### PR TITLE
Policy-based routing in traceroute engine

### DIFF
--- a/projects/allinone/BUILD
+++ b/projects/allinone/BUILD
@@ -167,6 +167,23 @@ junit_tests(
 )
 
 junit_tests(
+    name = "TraceroutePolicyBasedRoutingTest",
+    size = "small",
+    srcs = [
+        "src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java",
+    ],
+    deps = [
+        "//projects/batfish",
+        "//projects/batfish:batfish_testlib",
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:common_testlib",
+        "//projects/question",
+        "@guava//:compile",
+        "@hamcrest//:compile",
+    ],
+)
+
+junit_tests(
     name = "smt_tests",
     size = "small",
     srcs = glob([

--- a/projects/allinone/src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java
@@ -1,0 +1,200 @@
+package org.batfish.question.traceroute;
+
+import static org.batfish.common.util.TracePruner.DEFAULT_MAX_TRACES;
+import static org.batfish.datamodel.matchers.HopMatchers.hasOutputInterface;
+import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
+import static org.batfish.datamodel.matchers.TraceMatchers.hasLastHop;
+import static org.batfish.question.traceroute.TracerouteAnswerer.COL_TRACES;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.SortedMap;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.PacketHeaderConstraints;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.packet_policy.FibLookup;
+import org.batfish.datamodel.packet_policy.If;
+import org.batfish.datamodel.packet_policy.PacketMatchExpr;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.Return;
+import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.main.Batfish;
+import org.batfish.main.BatfishTestUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** End-to-end-ish tests of traceroute with policy-based routing */
+public class TraceroutePolicyBasedRoutingTest {
+
+  private static final String ROUTING_POLICY_NAME = "packetPolicy";
+  private static final String SOURCE_LOCATION_STR = "enter(c1[ingressInterface])";
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  /*
+   * Build a simple 1-node network with 2 VRFs
+   */
+  private static SortedMap<String, Configuration> pbrNetwork(boolean withPolicy) {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+
+    ImmutableSortedMap.Builder<String, Configuration> configs =
+        new ImmutableSortedMap.Builder<>(Comparator.naturalOrder());
+
+    Configuration c1 = cb.setHostname("c1").build();
+    configs.put(c1.getHostname(), c1);
+
+    Vrf v1 = nf.vrfBuilder().setOwner(c1).build();
+    Vrf v2 = nf.vrfBuilder().setOwner(c1).setName("otherVRF").build();
+
+    Interface ingressIface =
+        nf.interfaceBuilder()
+            .setAddress(new InterfaceAddress("1.1.1.1/31"))
+            .setOwner(c1)
+            .setVrf(v1)
+            .setName("ingressInterface")
+            .build();
+
+    if (withPolicy) {
+      ingressIface.setRoutingPolicy(ROUTING_POLICY_NAME);
+      // IF dst IP is 9.9.9.9 use PBR to do a lookup in V2, which will cause the packet to
+      // take a different exit interface
+      c1.setPacketPolicies(
+          ImmutableSortedMap.of(
+              ROUTING_POLICY_NAME,
+              new PacketPolicy(
+                  ROUTING_POLICY_NAME,
+                  ImmutableList.of(
+                      new If(
+                          new PacketMatchExpr(
+                              new MatchHeaderSpace(
+                                  HeaderSpace.builder()
+                                      .setDstIps(Ip.parse("9.9.9.9").toIpSpace())
+                                      .build())),
+                          ImmutableList.of(new Return(new FibLookup(v2.getName()))))),
+                  new Return(new FibLookup(v1.getName())))));
+      ingressIface.setRoutingPolicy(ROUTING_POLICY_NAME);
+    }
+
+    Interface i1 =
+        nf.interfaceBuilder()
+            .setAddress(new InterfaceAddress("2.2.2.1/24"))
+            .setOwner(c1)
+            .setVrf(v1)
+            .setName("i1")
+            .build();
+    Interface i2 =
+        nf.interfaceBuilder()
+            .setAddress(new InterfaceAddress("3.3.3.1/24"))
+            .setOwner(c1)
+            .setVrf(v2)
+            .setName("i2")
+            .build();
+
+    // Static routes. Different next hop interfaces in different VRFs
+    final Prefix prefixToMatch = Prefix.parse("9.9.9.0/24");
+    v1.setStaticRoutes(
+        ImmutableSortedSet.of(
+            StaticRoute.builder()
+                .setNetwork(prefixToMatch)
+                .setNextHopInterface(i1.getName())
+                .setAdmin(1)
+                .build()));
+    v2.setStaticRoutes(
+        ImmutableSortedSet.of(
+            StaticRoute.builder()
+                .setNetwork(prefixToMatch)
+                .setNextHopInterface(i2.getName())
+                .setAdmin(1)
+                .build()));
+
+    return configs.build();
+  }
+
+  @Test
+  public void testWithNoPolicy() throws IOException {
+    SortedMap<String, Configuration> configs = pbrNetwork(false);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
+    batfish.computeDataPlane();
+    PacketHeaderConstraints header =
+        PacketHeaderConstraints.builder().setSrcIp("1.1.1.222").setDstIp("9.9.9.9").build();
+
+    TracerouteQuestion question =
+        new TracerouteQuestion(SOURCE_LOCATION_STR, header, false, DEFAULT_MAX_TRACES);
+
+    TracerouteAnswerer answerer = new TracerouteAnswerer(question, batfish);
+    TableAnswerElement answer = (TableAnswerElement) answerer.answer();
+    assertThat(answer.getRows().getData(), hasSize(1));
+    assertThat(
+        answer.getRows().getData(),
+        everyItem(
+            hasColumn(
+                COL_TRACES,
+                everyItem(hasLastHop(hasOutputInterface(new NodeInterfacePair("c1", "i1")))),
+                Schema.set(Schema.TRACE))));
+  }
+
+  @Test
+  public void testMatchesPolicyIf() throws IOException {
+    SortedMap<String, Configuration> configs = pbrNetwork(true);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
+    batfish.computeDataPlane();
+    PacketHeaderConstraints header =
+        PacketHeaderConstraints.builder().setSrcIp("1.1.1.222").setDstIp("9.9.9.9").build();
+
+    TracerouteQuestion question =
+        new TracerouteQuestion(SOURCE_LOCATION_STR, header, false, DEFAULT_MAX_TRACES);
+
+    TracerouteAnswerer answerer = new TracerouteAnswerer(question, batfish);
+    TableAnswerElement answer = (TableAnswerElement) answerer.answer();
+    assertThat(answer.getRows().getData(), hasSize(1));
+    assertThat(
+        answer.getRows().getData(),
+        everyItem(
+            hasColumn(
+                COL_TRACES,
+                everyItem(hasLastHop(hasOutputInterface(new NodeInterfacePair("c1", "i2")))),
+                Schema.set(Schema.TRACE))));
+  }
+
+  @Test
+  public void testDoesNotMatchPolicyIf() throws IOException {
+    SortedMap<String, Configuration> configs = pbrNetwork(true);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
+    batfish.computeDataPlane();
+    PacketHeaderConstraints header =
+        PacketHeaderConstraints.builder().setSrcIp("1.1.1.222").setDstIp("9.9.9.233").build();
+
+    TracerouteQuestion question =
+        new TracerouteQuestion(SOURCE_LOCATION_STR, header, false, DEFAULT_MAX_TRACES);
+
+    TracerouteAnswerer answerer = new TracerouteAnswerer(question, batfish);
+    TableAnswerElement answer = (TableAnswerElement) answerer.answer();
+    assertThat(answer.getRows().getData(), hasSize(1));
+    assertThat(
+        answer.getRows().getData(),
+        everyItem(
+            hasColumn(
+                COL_TRACES,
+                everyItem(hasLastHop(hasOutputInterface(new NodeInterfacePair("c1", "i1")))),
+                Schema.set(Schema.TRACE))));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -9,6 +9,7 @@ import static org.batfish.datamodel.flow.FilterStep.FilterType.INGRESS_FILTER;
 import static org.batfish.datamodel.flow.FilterStep.FilterType.POST_TRANSFORMATION_INGRESS_FILTER;
 import static org.batfish.datamodel.flow.FilterStep.FilterType.PRE_TRANSFORMATION_EGRESS_FILTER;
 import static org.batfish.datamodel.flow.StepAction.DENIED;
+import static org.batfish.datamodel.flow.StepAction.PERMITTED;
 import static org.batfish.datamodel.flow.StepAction.TRANSMITTED;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.buildEnterSrcIfaceStep;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.createFilterStep;
@@ -49,6 +50,7 @@ import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.ExitOutputIfaceStep;
 import org.batfish.datamodel.flow.ExitOutputIfaceStep.ExitOutputIfaceStepDetail;
 import org.batfish.datamodel.flow.FilterStep;
+import org.batfish.datamodel.flow.FilterStep.FilterStepDetail;
 import org.batfish.datamodel.flow.FilterStep.FilterType;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
 import org.batfish.datamodel.flow.Hop;
@@ -66,6 +68,12 @@ import org.batfish.datamodel.flow.Step;
 import org.batfish.datamodel.flow.StepAction;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
+import org.batfish.datamodel.packet_policy.ActionVisitor;
+import org.batfish.datamodel.packet_policy.Drop;
+import org.batfish.datamodel.packet_policy.FibLookup;
+import org.batfish.datamodel.packet_policy.FlowEvaluator;
+import org.batfish.datamodel.packet_policy.FlowEvaluator.FlowResult;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
 import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.TransformationEvaluator;
@@ -291,6 +299,12 @@ class FlowTracer {
 
       // apply ingress filter
       Interface incomingInterface = _currentConfig.getAllInterfaces().get(_ingressInterface);
+      // if defined, use routing/packet policy applied to the interface
+      if (processPBR(incomingInterface)) {
+        return;
+      }
+
+      // if wasn't processed by packet policy, just apply ingress filter
       IpAccessList inputFilter = incomingInterface.getIncomingFilter();
       if (inputFilter != null) {
         if (applyFilter(inputFilter, INGRESS_FILTER) == DENIED) {
@@ -368,6 +382,90 @@ class FlowTracer {
     } finally {
       _breadcrumbs.pop();
     }
+  }
+
+  private boolean processPBR(Interface incomingInterface) {
+
+    // apply routing/packet policy applied to the interface, if defined.
+    String policyName = incomingInterface.getRoutingPolicyName();
+    if (policyName == null) {
+      return false;
+    }
+    PacketPolicy policy = _currentConfig.getPacketPolicies().get(policyName);
+    if (policy == null) {
+      return false;
+    }
+
+    FlowResult result = FlowEvaluator.evaluate(_currentFlow, incomingInterface.getName(), policy);
+    return new ActionVisitor<Boolean>() {
+
+      @Override
+      public Boolean visitDrop(Drop drop) {
+        _steps.add(new FilterStep(new FilterStepDetail(policy.getName(), INGRESS_FILTER), DENIED));
+        return true;
+      }
+
+      @Override
+      public Boolean visitFibLookup(FibLookup fibLookup) {
+        _steps.add(
+            new FilterStep(new FilterStepDetail(policy.getName(), INGRESS_FILTER), PERMITTED));
+        String lookupVrfName = fibLookup.getVrfName();
+        Ip dstIp = _currentFlow.getDstIp();
+
+        // Accept if the flow is destined for this vrf on this host.
+        String currentNodeName = _currentNode.getName();
+        if (_tracerouteContext.ownsIp(currentNodeName, _vrfName, dstIp)) {
+          buildAcceptTrace();
+          return true;
+        }
+
+        Fib fib = _tracerouteContext.getFib(currentNodeName, lookupVrfName);
+        // Sort so that resulting traces will be in sensible deterministic order
+        SortedSet<String> nextHopInterfaces =
+            ImmutableSortedSet.copyOf(fib.getNextHopInterfaces(dstIp));
+        if (nextHopInterfaces.isEmpty()) {
+          buildNoRouteTrace();
+          return true;
+        }
+
+        // Loop detection
+        Breadcrumb breadcrumb = new Breadcrumb(currentNodeName, _vrfName, _currentFlow);
+        if (_breadcrumbs.contains(breadcrumb)) {
+          buildLoopTrace();
+          return true;
+        }
+
+        _breadcrumbs.push(breadcrumb);
+        try {
+          _steps.add(buildRoutingStep(currentNodeName, dstIp));
+
+          Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopInterfacesByRoute =
+              fib.getNextHopInterfacesByRoute(dstIp);
+
+          // For every interface with a route to the dst IP
+          for (String nextHopInterfaceName : nextHopInterfaces) {
+            if (nextHopInterfaceName.equals(Interface.NULL_INTERFACE_NAME)) {
+              branch().buildNullRoutedTrace();
+              continue;
+            }
+
+            Interface nextHopInterface =
+                _currentConfig.getAllInterfaces().get(nextHopInterfaceName);
+
+            Multimap<Ip, AbstractRoute> resolvedNextHopIpRoutes =
+                resolveNextHopIpRoutes(nextHopInterfaceName, nextHopInterfacesByRoute);
+            resolvedNextHopIpRoutes
+                .asMap()
+                .forEach(
+                    (resolvedNextHopIp, routeCandidates) ->
+                        branch().forwardOutInterface(nextHopInterface, resolvedNextHopIp));
+          }
+        } finally {
+          _breadcrumbs.pop();
+        }
+        return true;
+      }
+    }.visit(result.getAction());
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -410,7 +410,7 @@ class FlowTracer {
         _steps.add(
             new FilterStep(new FilterStepDetail(policy.getName(), INGRESS_FILTER), PERMITTED));
         String lookupVrfName = fibLookup.getVrfName();
-        Ip dstIp = _currentFlow.getDstIp();
+        Ip dstIp = result.getFinalFlow().getDstIp();
 
         // Accept if the flow is destined for this vrf on this host.
         String currentNodeName = _currentNode.getName();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -348,14 +348,7 @@ class FlowTracer {
       return;
     }
 
-    // Loop detection
-    Breadcrumb breadcrumb = new Breadcrumb(currentNodeName, _vrfName, _currentFlow);
-    if (_breadcrumbs.contains(breadcrumb)) {
-      buildLoopTrace();
-      return;
-    }
-
-    fibLookup(dstIp, currentNodeName, fib, nextHopInterfaces, breadcrumb);
+    fibLookup(dstIp, currentNodeName, fib, nextHopInterfaces);
   }
 
   private boolean processPBR(Interface incomingInterface) {
@@ -402,25 +395,20 @@ class FlowTracer {
           return true;
         }
 
-        // Loop detection
-        Breadcrumb breadcrumb = new Breadcrumb(currentNodeName, _vrfName, _currentFlow);
-        if (_breadcrumbs.contains(breadcrumb)) {
-          buildLoopTrace();
-          return true;
-        }
-
-        fibLookup(dstIp, currentNodeName, fib, nextHopInterfaces, breadcrumb);
+        fibLookup(dstIp, currentNodeName, fib, nextHopInterfaces);
         return true;
       }
     }.visit(result.getAction());
   }
 
   private void fibLookup(
-      Ip dstIp,
-      String currentNodeName,
-      Fib fib,
-      SortedSet<String> nextHopInterfaces,
-      Breadcrumb breadcrumb) {
+      Ip dstIp, String currentNodeName, Fib fib, SortedSet<String> nextHopInterfaces) {
+    // Loop detection
+    Breadcrumb breadcrumb = new Breadcrumb(currentNodeName, _vrfName, _currentFlow);
+    if (_breadcrumbs.contains(breadcrumb)) {
+      buildLoopTrace();
+      return;
+    }
     _breadcrumbs.push(breadcrumb);
     try {
       _steps.add(buildRoutingStep(currentNodeName, dstIp));


### PR DESCRIPTION
* The policy-based pipeline preempts regular ingress filter
* Fib lookups can occur in a different VRF