### PR TITLE
compat bug fix

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -555,15 +555,30 @@ public class Parser extends CommonParser {
 
   public Rule LocationTerm() {
     return FirstOf(
-        LocationEnter(), LocationInterfaceDeprecated(), LocationInterface(), LocationParens());
+        LocationEnterDeprecated(),
+        LocationEnter(),
+        LocationInterfaceDeprecated(),
+        LocationInterface(),
+        LocationParens());
   }
 
   public Rule LocationEnter() {
     return Sequence(
-        FirstOf(IgnoreCase("@enter"), IgnoreCase("enter")),
+        IgnoreCase("@enter"),
         WhiteSpace(),
         "( ",
         LocationInterface(),
+        ") ",
+        push(new EnterLocationAstNode(pop())));
+  }
+
+  @Anchor(IGNORE)
+  public Rule LocationEnterDeprecated() {
+    return Sequence(
+        IgnoreCase("enter"),
+        WhiteSpace(),
+        "( ",
+        FirstOf(LocationInterfaceDeprecated(), LocationInterface()),
         ") ",
         push(new EnterLocationAstNode(pop())));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserLocationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserLocationTest.java
@@ -70,7 +70,6 @@ public class ParserLocationTest {
                         "@connectedTo",
                         "@deviceType",
                         "@enter",
-                        "enter",
                         "@interfaceGroup",
                         "@interfaceType",
                         "@role",
@@ -205,6 +204,18 @@ public class ParserLocationTest {
     String input = "[eth0/1]";
     InterfaceLocationAstNode expectedAst =
         InterfaceLocationAstNode.createFromInterface(new NameInterfaceAstNode("eth0/1"));
+
+    assertThat(ParserUtils.getAst(getRunner().run(input)), equalTo(expectedAst));
+    assertThat(ParserUtils.getAst(getRunner().run(" " + input + " ")), equalTo(expectedAst));
+  }
+
+  @Test
+  public void testParseLocationInterfaceDeprecatedInsideFunc() {
+    String input = "enter([ref.interfacegroup(sea, host-iface)])";
+    LocationAstNode expectedAst =
+        new EnterLocationAstNode(
+            InterfaceLocationAstNode.createFromInterface(
+                new InterfaceGroupInterfaceAstNode("sea", "host-iface")));
 
     assertThat(ParserUtils.getAst(getRunner().run(input)), equalTo(expectedAst));
     assertThat(ParserUtils.getAst(getRunner().run(" " + input + " ")), equalTo(expectedAst));


### PR DESCRIPTION
Support `enter([ref.interfacegroup(sea, host-iface)])`