### PR TITLE
migrate testfilters to use grammar-based nodes input

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersAnswerer.java
@@ -206,7 +206,7 @@ public class TestFiltersAnswerer extends Answerer {
     TestFiltersQuestion question = (TestFiltersQuestion) _question;
     Map<String, Configuration> configurations = _batfish.loadConfigurations();
     SortedSet<String> includeNodes =
-        ImmutableSortedSet.copyOf(question.getNodes().getMatchingNodes(_batfish));
+        ImmutableSortedSet.copyOf(question.getNodeSpecifier().resolve(_batfish.specifierContext()));
     FilterSpecifier filterSpecifier = question.getFilterSpecifier();
 
     Multiset<Row> rows = HashMultiset.create();

--- a/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersQuestion.java
@@ -9,11 +9,12 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.PacketHeaderConstraints;
 import org.batfish.datamodel.questions.FiltersSpecifier;
-import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.specifier.AllInterfacesLocationSpecifier;
+import org.batfish.specifier.AllNodesNodeSpecifier;
 import org.batfish.specifier.FilterSpecifier;
 import org.batfish.specifier.LocationSpecifier;
+import org.batfish.specifier.NodeSpecifier;
 import org.batfish.specifier.ShorthandFilterSpecifier;
 import org.batfish.specifier.SpecifierFactories;
 
@@ -30,16 +31,16 @@ public class TestFiltersQuestion extends Question {
 
   @Nullable private final String _filters;
   @Nonnull private final PacketHeaderConstraints _headers;
-  @Nonnull private final NodesSpecifier _nodes;
+  @Nullable private final String _nodes;
   @Nullable private final String _startLocation;
 
   @JsonCreator
   public TestFiltersQuestion(
-      @JsonProperty(PROP_NODES) NodesSpecifier nodes,
+      @JsonProperty(PROP_NODES) String nodes,
       @JsonProperty(PROP_FILTERS) String filters,
       @JsonProperty(PROP_HEADERS) PacketHeaderConstraints headers,
       @JsonProperty(PROP_START_LOCATION) String startLocation) {
-    _nodes = nodes == null ? NodesSpecifier.ALL : nodes;
+    _nodes = nodes;
     _filters = filters;
     _headers = firstNonNull(headers, PacketHeaderConstraints.unconstrained());
     _startLocation = startLocation;
@@ -50,6 +51,7 @@ public class TestFiltersQuestion extends Question {
     return false;
   }
 
+  @Nullable
   @JsonProperty(PROP_FILTERS)
   private String getFilters() {
     return _filters;
@@ -63,6 +65,12 @@ public class TestFiltersQuestion extends Question {
   }
 
   @Nonnull
+  @JsonIgnore
+  public NodeSpecifier getNodeSpecifier() {
+    return SpecifierFactories.getNodeSpecifierOrDefault(_nodes, AllNodesNodeSpecifier.INSTANCE);
+  }
+
+  @Nonnull
   @JsonProperty(PROP_HEADERS)
   public PacketHeaderConstraints getHeaders() {
     return _headers;
@@ -73,8 +81,9 @@ public class TestFiltersQuestion extends Question {
     return "testFilters";
   }
 
+  @Nullable
   @JsonProperty(PROP_NODES)
-  public NodesSpecifier getNodes() {
+  public String getNodes() {
     return _nodes;
   }
 

--- a/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
@@ -40,7 +40,6 @@ import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.matchers.PermittedByIpAccessListLineMatchers;
 import org.batfish.datamodel.pojo.Node;
-import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.Rows;
 import org.batfish.datamodel.table.TableAnswerElement;
@@ -257,8 +256,7 @@ public class TestFiltersAnswererTest {
         new MockBatfish(ImmutableSortedMap.of(c1.getHostname(), c1, c2.getHostname(), c2));
 
     // Test that filtering by node gives only that node's ACLs
-    TestFiltersQuestion question =
-        new TestFiltersQuestion(new NodesSpecifier(c1.getHostname()), null, null, null);
+    TestFiltersQuestion question = new TestFiltersQuestion(c1.getHostname(), null, null, null);
     TestFiltersAnswerer answerer = new TestFiltersAnswerer(question, batfish);
     Rows rows = answerer.answer().getRows();
 
@@ -278,7 +276,7 @@ public class TestFiltersAnswererTest {
     }
 
     // Test that filtering by both gives only the one matching ACL
-    question = new TestFiltersQuestion(new NodesSpecifier(c1.getHostname()), "acl1", null, null);
+    question = new TestFiltersQuestion(c1.getHostname(), "acl1", null, null);
     answerer = new TestFiltersAnswerer(question, batfish);
     rows = answerer.answer().getRows();
 
@@ -293,8 +291,7 @@ public class TestFiltersAnswererTest {
         new MockBatfish(configs, MockSpecifierContext.builder().setConfigs(configs).build());
 
     // Test that exception is thrown if no nodes match
-    TestFiltersQuestion question =
-        new TestFiltersQuestion(new NodesSpecifier("fake_node"), null, null, null);
+    TestFiltersQuestion question = new TestFiltersQuestion("fake_node", null, null, null);
     TestFiltersAnswerer answerer = new TestFiltersAnswerer(question, batfish);
 
     _thrown.expect(BatfishException.class);
@@ -311,7 +308,7 @@ public class TestFiltersAnswererTest {
 
     // Test that exception is thrown if node is found, but no filters match
     TestFiltersQuestion question =
-        new TestFiltersQuestion(new NodesSpecifier(c1.getHostname()), "fake_filter", null, null);
+        new TestFiltersQuestion(c1.getHostname(), "fake_filter", null, null);
     TestFiltersAnswerer answerer = new TestFiltersAnswerer(question, batfish);
 
     _thrown.expect(BatfishException.class);

--- a/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersQuestionTest.java
@@ -68,6 +68,6 @@ public class TestFiltersQuestionTest {
         BatfishObjectMapper.mapper().readValue(serialized, TestFiltersQuestion.class);
 
     assertThat(q.getFilterSpecifier(), notNullValue());
-    assertThat(q.getNodes(), notNullValue());
+    assertThat(q.getNodeSpecifier(), notNullValue());
   }
 }


### PR DESCRIPTION
NodesSpecifier (really old one) is buried deep into our psyche. I'll send a series of small PRs (at least at first) to move us off it. 