### PR TITLE
 Cisco BGP policy extractions: warning and comment

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -5242,6 +5242,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitDistribute_list_bgp_tail(Distribute_list_bgp_tailContext ctx) {
+    // Note: Mutually exclusive with Prefix_list_bgp_tail
+    // https://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/5816-bgpfaq-5816.html
     todo(ctx);
   }
 
@@ -5821,6 +5823,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         BGP_NEIGHBOR_FILTER_AS_PATH_ACCESS_LIST,
         ctx.getStart().getLine());
     // TODO: Handle filter-list in batfish
+    todo(ctx);
   }
 
   @Override

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -212,6 +212,27 @@
       },
       {
         "Filename" : "configs/cisco_bgp",
+        "Line" : 10,
+        "Text" : "filter-list 10 out",
+        "Parser_Context" : "[filter_list_bgp_tail neighbor_flat_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+        "Comment" : "This feature is not currently supported"
+      },
+      {
+        "Filename" : "configs/cisco_bgp",
+        "Line" : 14,
+        "Text" : "filter-list 20 in",
+        "Parser_Context" : "[filter_list_bgp_tail neighbor_flat_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+        "Comment" : "This feature is not currently supported"
+      },
+      {
+        "Filename" : "configs/cisco_bgp",
+        "Line" : 18,
+        "Text" : "filter-list 40 in",
+        "Parser_Context" : "[filter_list_bgp_tail neighbor_flat_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+        "Comment" : "This feature is not currently supported"
+      },
+      {
+        "Filename" : "configs/cisco_bgp",
         "Line" : 29,
         "Text" : "redistribute ospf abc",
         "Parser_Context" : "[redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
@@ -2060,10 +2081,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 288 results",
+      "notes" : "Found 291 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 288
+      "numResults" : 291
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -67965,6 +67965,24 @@
           "Parse warnings" : [
             {
               "Comment" : "This feature is not currently supported",
+              "Line" : 10,
+              "Parser_Context" : "[filter_list_bgp_tail neighbor_flat_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+              "Text" : "filter-list 10 out"
+            },
+            {
+              "Comment" : "This feature is not currently supported",
+              "Line" : 14,
+              "Parser_Context" : "[filter_list_bgp_tail neighbor_flat_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+              "Text" : "filter-list 20 in"
+            },
+            {
+              "Comment" : "This feature is not currently supported",
+              "Line" : 18,
+              "Parser_Context" : "[filter_list_bgp_tail neighbor_flat_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
+              "Text" : "filter-list 40 in"
+            },
+            {
+              "Comment" : "This feature is not currently supported",
               "Line" : 29,
               "Parser_Context" : "[redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
               "Text" : "redistribute ospf abc"


### PR DESCRIPTION
- Add unsupported warning for `neighbor 1.2.3.4 filter-list ...`. Filter-lists should have an impact on BGP import/export policies and they currently don't.
- Add comment in extraction method for `neighbor 1.2.3.4 distribute-list ...` to ensure that when support is added for distribute-lists, it is correctly implemented to be mutually exclusive with `neighbor 1.2.3.4 prefix-list ...` (see note about distribute-lists [here](https://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/5816-bgpfaq-5816.html#anc3); also linked in comment).