### PR TITLE
Stream cleanups throughout

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
@@ -152,7 +152,7 @@ public final class AutoCompleteUtils {
                   query,
                   completionMetadata.getInterfaces().stream()
                       .map(NodeInterfacePair::toString)
-                      .collect(Collectors.toSet()));
+                      .collect(ImmutableSet.toImmutableSet()));
           break;
         }
       case INTERFACE_GROUP_AND_BOOK:
@@ -160,12 +160,10 @@ public final class AutoCompleteUtils {
           checkReferenceLibrary(referenceLibrary, network);
           ImmutableSet<StringPair> pairs =
               referenceLibrary.getReferenceBooks().stream()
-                  .map(
+                  .flatMap(
                       b ->
                           b.getInterfaceGroups().stream()
-                              .map(ag -> new StringPair(ag.getName(), b.getName()))
-                              .collect(ImmutableSet.toImmutableSet()))
-                  .flatMap(Collection::stream)
+                              .map(ag -> new StringPair(ag.getName(), b.getName())))
                   .collect(ImmutableSet.toImmutableSet());
           suggestions = stringPairAutoComplete(query, pairs);
           break;
@@ -280,12 +278,8 @@ public final class AutoCompleteUtils {
           checkNodeRolesData(nodeRolesData, network);
           ImmutableSet<StringPair> pairs =
               nodeRolesData.getNodeRoleDimensions().stream()
-                  .map(
-                      d ->
-                          d.getRoles().stream()
-                              .map(r -> new StringPair(r.getName(), d.getName()))
-                              .collect(ImmutableSet.toImmutableSet()))
-                  .flatMap(Collection::stream)
+                  .flatMap(
+                      d -> d.getRoles().stream().map(r -> new StringPair(r.getName(), d.getName())))
                   .collect(ImmutableSet.toImmutableSet());
           suggestions = stringPairAutoComplete(query, pairs);
           break;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -309,11 +309,9 @@ public final class BgpTopologyUtils {
     Flow backwardFlow = fb.build();
     traces = tracerouteEngine.computeTraces(ImmutableSet.of(backwardFlow), false);
 
-    /*
-     * If backward traceroutes fail, do not consider the neighbor reachable
-     */
-    return !traces.get(backwardFlow).stream()
-        .filter(
+    // Consider neighbor reachable if any backward flow is accepted.
+    return traces.get(backwardFlow).stream()
+        .anyMatch(
             trace ->
                 trace.getDisposition() == FlowDisposition.ACCEPTED
                     && trace.getHops().size() > 0
@@ -322,9 +320,7 @@ public final class BgpTopologyUtils {
                         .get(trace.getHops().size() - 1)
                         .getNode()
                         .getName()
-                        .equals(initiator.getHostname()))
-        .collect(Collectors.toList())
-        .isEmpty();
+                        .equals(initiator.getHostname()));
   }
 
   private BgpTopologyUtils() {}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/PropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/PropertySpecifier.java
@@ -3,12 +3,12 @@ package org.batfish.datamodel.questions;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -73,7 +73,7 @@ public abstract class PropertySpecifier {
                             : e.toString());
         outputPropertyValue =
             targetSchema.getType() == Type.LIST
-                ? stream.collect(Collectors.toList())
+                ? stream.collect(ImmutableList.toImmutableList())
                 : stream.collect(ImmutableSet.toImmutableSet());
       }
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/TableDiff.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/table/TableDiff.java
@@ -76,11 +76,9 @@ public final class TableDiff {
     }
     String dhintText =
         "["
-            + String.join(
-                ", ",
-                diffColumnMetatadata.build().stream()
-                    .map(ColumnMetadata::getName)
-                    .collect(Collectors.toList()))
+            + diffColumnMetatadata.build().stream()
+                .map(ColumnMetadata::getName)
+                .collect(Collectors.joining(", "))
             + "]";
 
     // 2. Insert the key status column

--- a/projects/batfish/src/main/java/org/batfish/z3/NodContext.java
+++ b/projects/batfish/src/main/java/org/batfish/z3/NodContext.java
@@ -2,7 +2,6 @@ package org.batfish.z3;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.microsoft.z3.BitVecExpr;
 import com.microsoft.z3.BitVecSort;
@@ -104,8 +103,7 @@ public class NodContext {
                                 RelationCollector.collectRelations(program.getInput(), statement))
                         .map(Map::entrySet)
                         .flatMap(Collection::stream))
-            .collect(ImmutableSet.toImmutableSet())
-            .stream()
+            .distinct()
             .collect(
                 ImmutableMap.toImmutableMap(
                     Entry::getKey,

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1381,8 +1381,7 @@ public class WorkMgr extends AbstractCoordinator {
         String[] subdirEntryNames =
             CommonUtil.getEntries(entry).stream()
                 .map(subdirEntry -> subdirEntry.getFileName().toString())
-                .collect(Collectors.toList())
-                .toArray(new String[] {});
+                .toArray(String[]::new);
         retStringBuilder.append("/\n");
         // now append a maximum of MAX_SHOWN_SNAPSHOT_INFO_SUBDIR_ENTRIES
         for (int index = 0;

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/NetworkNodeRolesResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/NetworkNodeRolesResource.java
@@ -35,12 +35,12 @@ public final class NetworkNodeRolesResource {
     if (nodeRolesDataBean.roleDimensions == null) {
       return false;
     }
-    int uniqueSize =
+    long uniqueSize =
         nodeRolesDataBean.roleDimensions.stream()
             .map(bean -> bean.name)
             .map(String::toLowerCase)
-            .collect(ImmutableSet.toImmutableSet())
-            .size();
+            .distinct()
+            .count();
     return uniqueSize == nodeRolesDataBean.roleDimensions.size();
   }
 


### PR DESCRIPTION
Remove unnecessary intermediate collections

* `.collect(toSet()).stream()` -> `.distinct()`
* Use `Collectors.joining` where appropriate instead of list and then string utils
* Use `flatMap` where appropriate instead of list and then .stream()
* Use `.count()` instead of `.collect().size()`

And make a double-negative in BgpTopologyUtils much clearer.