### PR TITLE
return full token

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
@@ -390,9 +390,6 @@ public final class AutoCompleteUtils {
    * Returns a list of suggestions based on query strings.
    *
    * <p>The search is case-insensitive
-   *
-   * <p>The returned list contains the tail of the match. If the query is "ab" and the matching
-   * string is "abcd", "cd" is returned.
    */
   @Nonnull
   public static List<AutocompleteSuggestion> stringAutoComplete(
@@ -403,7 +400,7 @@ public final class AutoCompleteUtils {
 
     return strings.stream()
         .filter(s -> s.toLowerCase().startsWith(testQuery))
-        .map(s -> new AutocompleteSuggestion(s.substring(testQuery.length()), false))
+        .map(s -> new AutocompleteSuggestion(s, false))
         .collect(ImmutableList.toImmutableList());
   }
 
@@ -413,9 +410,6 @@ public final class AutoCompleteUtils {
    * <p>The pairs are converted to "a,b" lowercase strings and the query is considered to be a
    * prefix over those strings. We assume that neither "a" not "b" contain whitespace, consistent
    * with valid names per {@link ReferenceLibrary#NAME_PATTERN}.
-   *
-   * <p>The returned list contains the tail of the matching pair. If the query is "aa" and a
-   * matching pair is "aa,bb", ",bb" is returned.
    */
   @Nonnull
   private static List<AutocompleteSuggestion> stringPairAutoComplete(
@@ -427,7 +421,7 @@ public final class AutoCompleteUtils {
     return pairs.stream()
         .map(p -> String.join(",", p.s1, p.s2).toLowerCase())
         .filter(p -> p.startsWith(testQuery))
-        .map(p -> new AutocompleteSuggestion(p.substring(testQuery.length()), false))
+        .map(p -> new AutocompleteSuggestion(p, false))
         .collect(ImmutableList.toImmutableList());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParserUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParserUtils.java
@@ -173,10 +173,7 @@ final class ParserUtils {
         continue;
       }
 
-      /*
-       The PotentialMatch object is straightforward given the anchor. Except that for string
-       literals, we remove the quotes inserted by parboiled.
-      */
+      // Build PotentialMatch objects from path anchor
       PathElement pathAnchor = pathAnchorOpt.get();
       String matchPrefix =
           error
@@ -187,6 +184,7 @@ final class ParserUtils {
 
       if (pathAnchor.getAnchorType() == STRING_LITERAL
           || pathAnchor.getAnchorType() == CHAR_LITERAL) {
+        // Remove quotes inserted by parboiled for completion suggestions
         String fullToken = path.getElementAtLevel(pathAnchor.getLevel()).matcher.getLabel();
         if (fullToken.length() >= 2) { // remove surrounding quotes
           fullToken = fullToken.substring(1, fullToken.length() - 1);
@@ -195,9 +193,15 @@ final class ParserUtils {
             new PotentialMatch(
                 pathAnchor.getAnchorType(),
                 matchPrefix,
-                fullToken.substring(matchPrefix.length())));
+                fullToken.substring(matchPrefix.length()),
+                path.getElementAtLevel(pathAnchor.getLevel()).startIndex));
       } else {
-        potentialMatches.add(new PotentialMatch(pathAnchor.getAnchorType(), matchPrefix, null));
+        potentialMatches.add(
+            new PotentialMatch(
+                pathAnchor.getAnchorType(),
+                matchPrefix,
+                null,
+                path.getElementAtLevel(pathAnchor.getLevel()).startIndex));
       }
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PotentialMatch.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PotentialMatch.java
@@ -15,10 +15,15 @@ class PotentialMatch {
   /** What matched thus far when trying to match the current rule */
   private final String _matchPrefix;
 
-  PotentialMatch(Anchor.Type anchorType, String matchPrefix, String matchCompletion) {
+  /** Where in the input this match started */
+  private final int _matchStartIndex;
+
+  PotentialMatch(
+      Anchor.Type anchorType, String matchPrefix, String matchCompletion, int matchStartIndex) {
     _anchorType = anchorType;
     _matchPrefix = matchPrefix;
     _matchCompletion = matchCompletion;
+    _matchStartIndex = matchStartIndex;
   }
 
   @Override
@@ -28,7 +33,8 @@ class PotentialMatch {
     }
     return Objects.equals(_anchorType, ((PotentialMatch) o)._anchorType)
         && Objects.equals(_matchCompletion, ((PotentialMatch) o)._matchCompletion)
-        && Objects.equals(_matchPrefix, ((PotentialMatch) o)._matchPrefix);
+        && Objects.equals(_matchPrefix, ((PotentialMatch) o)._matchPrefix)
+        && Objects.equals(_matchStartIndex, ((PotentialMatch) o)._matchStartIndex);
   }
 
   Anchor.Type getAnchorType() {
@@ -43,9 +49,13 @@ class PotentialMatch {
     return _matchPrefix;
   }
 
+  int getMatchStartIndex() {
+    return _matchStartIndex;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(_anchorType, _matchCompletion, _matchPrefix);
+    return Objects.hash(_anchorType, _matchCompletion, _matchPrefix, _matchStartIndex);
   }
 
   @Override
@@ -54,6 +64,7 @@ class PotentialMatch {
         .add("anchorType", _anchorType)
         .add("matchingPrefix", _matchPrefix)
         .add("matchingCompletion", _matchCompletion)
+        .add("matchStartIndex", _matchStartIndex)
         .toString();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AutoCompleteUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AutoCompleteUtilsTest.java
@@ -117,7 +117,7 @@ public class AutoCompleteUtilsTest {
             .stream()
             .map(AutocompleteSuggestion::getText)
             .collect(Collectors.toSet()),
-        equalTo(ImmutableSet.of("1,b1", "2,b2")));
+        equalTo(ImmutableSet.of("g1,b1", "g2,b2")));
 
     // 'g1' matches one pair
     assertThat(
@@ -133,7 +133,7 @@ public class AutoCompleteUtilsTest {
             .stream()
             .map(AutocompleteSuggestion::getText)
             .collect(Collectors.toSet()),
-        equalTo(ImmutableSet.of("b1")));
+        equalTo(ImmutableSet.of("g1,b1")));
   }
 
   @Test
@@ -272,7 +272,7 @@ public class AutoCompleteUtilsTest {
             .stream()
             .map(AutocompleteSuggestion::getText)
             .collect(Collectors.toSet()),
-        equalTo(ImmutableSet.of(".3.4", "3.4.5")));
+        equalTo(ImmutableSet.of("1.2.3.4", "1.23.4.5")));
   }
 
   @Test
@@ -379,7 +379,7 @@ public class AutoCompleteUtilsTest {
             .stream()
             .map(AutocompleteSuggestion::getText)
             .collect(Collectors.toSet()),
-        equalTo(ImmutableSet.of(".3.4/24")));
+        equalTo(ImmutableSet.of("1.2.3.4/24")));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
@@ -81,7 +81,7 @@ public class ParboiledAutoCompleteTest {
         equalTo(
             ImmutableSet.of(
                 new AutocompleteSuggestion(
-                    ".1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 5),
+                    "1.1.1.1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion(".", true, null, RANK_STRING_LITERAL, 5))));
   }
 
@@ -101,8 +101,10 @@ public class ParboiledAutoCompleteTest {
         ImmutableSet.copyOf(getTestPAC(query, completionMetadata).run()),
         equalTo(
             ImmutableSet.of(
-                new AutocompleteSuggestion("", true, null, AutocompleteSuggestion.DEFAULT_RANK, 7),
-                new AutocompleteSuggestion("0", true, null, AutocompleteSuggestion.DEFAULT_RANK, 7),
+                new AutocompleteSuggestion(
+                    "1.1.1.1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
+                new AutocompleteSuggestion(
+                    "1.1.1.10", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion("-", true, null, RANK_STRING_LITERAL, 7),
                 new AutocompleteSuggestion(",", true, null, RANK_STRING_LITERAL, 7))));
   }
@@ -121,9 +123,9 @@ public class ParboiledAutoCompleteTest {
         equalTo(
             ImmutableSet.of(
                 new AutocompleteSuggestion(
-                    "", true, null, AutocompleteSuggestion.DEFAULT_RANK, query.length()),
+                    "node1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion(
-                    "0", true, null, AutocompleteSuggestion.DEFAULT_RANK, query.length()),
+                    "node10", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion(",", true, null, RANK_STRING_LITERAL, query.length()))));
   }
 
@@ -140,9 +142,10 @@ public class ParboiledAutoCompleteTest {
         ImmutableSet.copyOf(getTestPAC(query, completionMetadata).run()),
         equalTo(
             ImmutableSet.of(
-                new AutocompleteSuggestion("\"", true, null, RANK_STRING_LITERAL, query.length()),
+                new AutocompleteSuggestion("\"", true, null, RANK_STRING_LITERAL, 6),
+                new AutocompleteSuggestion("\"node1\"", true, null, RANK_STRING_LITERAL, 0),
                 new AutocompleteSuggestion(
-                    "0", true, null, AutocompleteSuggestion.DEFAULT_RANK, query.length()))));
+                    "\"node10\"", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0))));
   }
 
   /** Test that we produce auto complete snapshot-based names even when we begin with a quote. */
@@ -192,7 +195,7 @@ public class ParboiledAutoCompleteTest {
         equalTo(
             ImmutableSet.of(
                 new AutocompleteSuggestion(
-                    "b1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 14))));
+                    "g1,b1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 11))));
   }
 
   /** Test that String literals are inserted before dynamic values */
@@ -246,15 +249,15 @@ public class ParboiledAutoCompleteTest {
 
   @Test
   public void testAutoCompletePotentialMatchStringLiteral() {
-    PotentialMatch pm = new PotentialMatch(Type.STRING_LITERAL, "pfx", "comp");
+    PotentialMatch pm = new PotentialMatch(Type.STRING_LITERAL, "pfx", "comp", 0);
     assertThat(
-        getTestPAC(null).autoCompletePotentialMatch(pm, 2),
-        equalTo(ImmutableList.of(new AutocompleteSuggestion("comp", true, null, -1, 2))));
+        getTestPAC(null).autoCompletePotentialMatch(pm),
+        equalTo(ImmutableList.of(new AutocompleteSuggestion("pfxcomp", true, null, -1, 0))));
   }
 
   @Test
   public void testAutoCompletePotentialMatchSkipLabel() {
-    PotentialMatch pm = new PotentialMatch(Type.IP_ADDRESS_MASK, "pfx", "comp");
-    assertThat(getTestPAC(null).autoCompletePotentialMatch(pm, 2), equalTo(ImmutableList.of()));
+    PotentialMatch pm = new PotentialMatch(Type.IP_ADDRESS_MASK, "pfx", "comp", 0);
+    assertThat(getTestPAC(null).autoCompletePotentialMatch(pm), equalTo(ImmutableList.of()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserFilterTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserFilterTest.java
@@ -93,9 +93,9 @@ public class ParserFilterTest {
         equalTo(
             ImmutableSet.of(
                 new AutocompleteSuggestion(
-                    "", true, null, AutocompleteSuggestion.DEFAULT_RANK, query.length()),
+                    "filter1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion(
-                    "1", true, null, AutocompleteSuggestion.DEFAULT_RANK, query.length()),
+                    "filter11", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion("\\", true, null, RANK_STRING_LITERAL, query.length()),
                 new AutocompleteSuggestion(",", true, null, RANK_STRING_LITERAL, query.length()),
                 new AutocompleteSuggestion("&", true, null, RANK_STRING_LITERAL, query.length()))));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserInterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserInterfaceTest.java
@@ -108,9 +108,9 @@ public class ParserInterfaceTest {
         equalTo(
             ImmutableSet.of(
                 new AutocompleteSuggestion(
-                    "", true, null, AutocompleteSuggestion.DEFAULT_RANK, query.length()),
+                    "iface1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion(
-                    "1", true, null, AutocompleteSuggestion.DEFAULT_RANK, query.length()),
+                    "iface11", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion("\\", true, null, RANK_STRING_LITERAL, query.length()),
                 new AutocompleteSuggestion(",", true, null, RANK_STRING_LITERAL, query.length()),
                 new AutocompleteSuggestion("&", true, null, RANK_STRING_LITERAL, query.length()))));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserIpSpaceTest.java
@@ -64,12 +64,14 @@ public class ParserIpSpaceTest {
         ImmutableSet.copyOf(pac.run()),
         equalTo(
             ImmutableSet.of(
-                new AutocompleteSuggestion("", true, null, AutocompleteSuggestion.DEFAULT_RANK, 7),
-                new AutocompleteSuggestion("0", true, null, AutocompleteSuggestion.DEFAULT_RANK, 7),
+                new AutocompleteSuggestion(
+                    "1.1.1.1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
+                new AutocompleteSuggestion(
+                    "1.1.1.10", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion("-", true, null, RANK_STRING_LITERAL, 7),
                 new AutocompleteSuggestion(":", true, null, RANK_STRING_LITERAL, 7),
                 new AutocompleteSuggestion("/", true, null, RANK_STRING_LITERAL, 7),
-                new AutocompleteSuggestion("/22", true, null, RANK_STRING_LITERAL, 7),
+                new AutocompleteSuggestion("1.1.1.1/22", true, null, RANK_STRING_LITERAL, 0),
                 new AutocompleteSuggestion(",", true, null, RANK_STRING_LITERAL, 7))));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserLocationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserLocationTest.java
@@ -112,9 +112,9 @@ public class ParserLocationTest {
         equalTo(
             ImmutableSet.of(
                 new AutocompleteSuggestion(
-                    "", true, null, AutocompleteSuggestion.DEFAULT_RANK, query.length()),
+                    "node1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion(
-                    "1", true, null, AutocompleteSuggestion.DEFAULT_RANK, query.length()),
+                    "node11", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion("\\", true, null, RANK_STRING_LITERAL, query.length()),
                 new AutocompleteSuggestion(",", true, null, RANK_STRING_LITERAL, query.length()),
                 new AutocompleteSuggestion("&", true, null, RANK_STRING_LITERAL, query.length()),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserNodeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserNodeTest.java
@@ -95,9 +95,9 @@ public class ParserNodeTest {
         equalTo(
             ImmutableSet.of(
                 new AutocompleteSuggestion(
-                    "", true, null, AutocompleteSuggestion.DEFAULT_RANK, query.length()),
+                    "node1", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion(
-                    "1", true, null, AutocompleteSuggestion.DEFAULT_RANK, query.length()),
+                    "node11", true, null, AutocompleteSuggestion.DEFAULT_RANK, 0),
                 new AutocompleteSuggestion("\\", true, null, RANK_STRING_LITERAL, query.length()),
                 new AutocompleteSuggestion(",", true, null, RANK_STRING_LITERAL, query.length()),
                 new AutocompleteSuggestion("&", true, null, RANK_STRING_LITERAL, query.length()))));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
@@ -36,15 +36,16 @@ public class ParserUtilsTest {
   }
 
   /** These represent all the ways valid input can start */
-  private Set<PotentialMatch> _validStarts =
-      ImmutableSet.of(
-          new PotentialMatch(STRING_LITERAL, "", "@specifier"),
-          new PotentialMatch(CHAR_LITERAL, "", "!"),
-          new PotentialMatch(IP_ADDRESS, "", null),
-          new PotentialMatch(NODE_NAME, "", null),
-          new PotentialMatch(CHAR_LITERAL, "", "\""),
-          new PotentialMatch(CHAR_LITERAL, "", "/"),
-          new PotentialMatch(CHAR_LITERAL, "", "("));
+  private static Set<PotentialMatch> getValidStarts(int matchStartIndex) {
+    return ImmutableSet.of(
+        new PotentialMatch(STRING_LITERAL, "", "@specifier", matchStartIndex),
+        new PotentialMatch(CHAR_LITERAL, "", "!", matchStartIndex),
+        new PotentialMatch(IP_ADDRESS, "", null, matchStartIndex),
+        new PotentialMatch(NODE_NAME, "", null, matchStartIndex),
+        new PotentialMatch(CHAR_LITERAL, "", "\"", matchStartIndex),
+        new PotentialMatch(CHAR_LITERAL, "", "/", matchStartIndex),
+        new PotentialMatch(CHAR_LITERAL, "", "(", matchStartIndex));
+  }
 
   @Test
   public void testConstructorPathElement() {
@@ -120,9 +121,9 @@ public class ParserUtilsTest {
 
   @Test
   public void testGetErrorString() {
-    assertThat(getErrorString(new PotentialMatch(STRING_LITERAL, "a", "b")), equalTo("'b'"));
+    assertThat(getErrorString(new PotentialMatch(STRING_LITERAL, "a", "b", 0)), equalTo("'b'"));
     assertThat(
-        getErrorString(new PotentialMatch(IP_ADDRESS, "", "b")), equalTo(IP_ADDRESS.toString()));
+        getErrorString(new PotentialMatch(IP_ADDRESS, "", "b", 0)), equalTo(IP_ADDRESS.toString()));
   }
 
   @Test
@@ -150,7 +151,7 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(_validStarts));
+        equalTo(getValidStarts(0)));
   }
 
   @Test
@@ -160,7 +161,7 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(_validStarts));
+        equalTo(getValidStarts(0)));
   }
 
   @Test
@@ -169,7 +170,7 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(IP_ADDRESS, "1.1.1.", null))));
+        equalTo(ImmutableSet.of(new PotentialMatch(IP_ADDRESS, "1.1.1.", null, 1))));
   }
 
   @Test
@@ -178,7 +179,7 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(_validStarts));
+        equalTo(getValidStarts(2)));
   }
 
   @Test
@@ -187,7 +188,7 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(_validStarts));
+        equalTo(getValidStarts(1)));
   }
 
   @Test
@@ -196,7 +197,7 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(_validStarts));
+        equalTo(getValidStarts(1)));
   }
 
   @Test
@@ -207,9 +208,9 @@ public class ParserUtilsTest {
             (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(
             ImmutableSet.of(
-                new PotentialMatch(CHAR_LITERAL, "", ")"),
-                new PotentialMatch(IP_ADDRESS, "1.1.1.1", null),
-                new PotentialMatch(CHAR_LITERAL, "", "-"))));
+                new PotentialMatch(CHAR_LITERAL, "", ")", 8),
+                new PotentialMatch(IP_ADDRESS, "1.1.1.1", null, 1),
+                new PotentialMatch(CHAR_LITERAL, "", "-", 8))));
   }
 
   @Test
@@ -220,8 +221,8 @@ public class ParserUtilsTest {
             (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
         equalTo(
             ImmutableSet.of(
-                new PotentialMatch(CHAR_LITERAL, "", "\""),
-                new PotentialMatch(NODE_NAME, "\"a", null))));
+                new PotentialMatch(CHAR_LITERAL, "", "\"", 2),
+                new PotentialMatch(NODE_NAME, "\"a", null, 0))));
   }
 
   @Test
@@ -230,7 +231,7 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(CHAR_LITERAL, "", "("))));
+        equalTo(ImmutableSet.of(new PotentialMatch(CHAR_LITERAL, "", "(", 10))));
   }
 
   @Test
@@ -239,7 +240,7 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(ADDRESS_GROUP_AND_BOOK, "", null))));
+        equalTo(ImmutableSet.of(new PotentialMatch(ADDRESS_GROUP_AND_BOOK, "", null, 11))));
   }
 
   @Test
@@ -248,7 +249,7 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(STRING_LITERAL, "@specifi", "er"))));
+        equalTo(ImmutableSet.of(new PotentialMatch(STRING_LITERAL, "@specifi", "er", 0))));
   }
 
   @Test
@@ -257,6 +258,6 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(STRING_LITERAL, "@", "specifier"))));
+        equalTo(ImmutableSet.of(new PotentialMatch(STRING_LITERAL, "@", "specifier", 0))));
   }
 }


### PR DESCRIPTION
When the autocomplete match is `abc` and the user has already typed `ab`, return `abc` as the suggestion instead of just `c`. In playing around with this stuff, it is more useful for the clients to see this. No other semantic change. 