### PR TITLE
Traceroute: move off of RIB

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Fib.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Fib.java
@@ -11,8 +11,13 @@ public interface Fib extends Serializable {
   @Nonnull
   Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> getNextHopInterfaces();
 
-  /** Set of interfaces used to forward traffic destined to this IP. */
+  /**
+   * Set of interfaces used to forward traffic destined to this IP.
+   *
+   * @deprecated in favor of more general {@link Fib#get(Ip)}
+   */
   @Nonnull
+  @Deprecated
   Set<String> getNextHopInterfaces(Ip ip);
 
   /**
@@ -23,8 +28,11 @@ public interface Fib extends Serializable {
 
   /**
    * Mapping: matching route -&gt; nexthopinterface -&gt; resolved nextHopIP -&gt; interfaceRoutes
+   *
+   * @deprecated in favor of more general {@link Fib#get(Ip)}
    */
   @Nonnull
+  @Deprecated
   Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> getNextHopInterfacesByRoute(
       Ip dstIp);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -280,6 +280,7 @@ public final class FibImpl implements Fib {
   }
 
   @Override
+  @Deprecated
   public @Nonnull Set<String> getNextHopInterfaces(Ip ip) {
     return get(ip).stream().map(FibEntry::getInterfaceName).collect(ImmutableSet.toImmutableSet());
   }
@@ -291,6 +292,7 @@ public final class FibImpl implements Fib {
   }
 
   @Override
+  @Deprecated
   public @Nonnull Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>
       getNextHopInterfacesByRoute(Ip dstIp) {
     return get(dstIp).stream()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockFib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockFib.java
@@ -1,6 +1,9 @@
 package org.batfish.datamodel;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -18,11 +21,14 @@ public class MockFib implements Fib {
 
     private Map<String, Set<AbstractRoute>> _routesByNextHopInterface;
 
+    private Map<Ip, Set<FibEntry>> _fibEntries;
+
     private Builder() {
       _nextHopInterfaces = ImmutableMap.of();
       _nextHopInterfacesByIp = ImmutableMap.of();
       _nextHopInterfacesByRoute = ImmutableMap.of();
       _routesByNextHopInterface = ImmutableMap.of();
+      _fibEntries = ImmutableMap.of();
     }
 
     public MockFib build() {
@@ -35,12 +41,14 @@ public class MockFib implements Fib {
       return this;
     }
 
+    @Deprecated
     public Builder setNextHopInterfacesByIp(
         @Nonnull Map<Ip, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopInterfacesByIp) {
       _nextHopInterfacesByIp = nextHopInterfacesByIp;
       return this;
     }
 
+    @Deprecated
     public Builder setNextHopInterfacesByRoute(
         @Nonnull
             Map<Ip, Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>>
@@ -52,6 +60,11 @@ public class MockFib implements Fib {
     public Builder setRoutesByNextHopInterface(
         @Nonnull Map<String, Set<AbstractRoute>> routesByNextHopInterface) {
       _routesByNextHopInterface = routesByNextHopInterface;
+      return this;
+    }
+
+    public Builder setFibEntries(@Nonnull Map<Ip, Set<FibEntry>> fibEntries) {
+      _fibEntries = fibEntries;
       return this;
     }
   }
@@ -72,11 +85,14 @@ public class MockFib implements Fib {
 
   private final Map<String, Set<AbstractRoute>> _routesByNextHopInterface;
 
+  private Map<Ip, Set<FibEntry>> _fibEntries;
+
   private MockFib(Builder builder) {
     _nextHopInterfaces = ImmutableMap.copyOf(builder._nextHopInterfaces);
     _nextHopInterfacesByIp = ImmutableMap.copyOf(builder._nextHopInterfacesByIp);
     _nextHopInterfacesByRoute = ImmutableMap.copyOf(builder._nextHopInterfacesByRoute);
     _routesByNextHopInterface = ImmutableMap.copyOf(builder._routesByNextHopInterface);
+    _fibEntries = ImmutableMap.copyOf(builder._fibEntries);
   }
 
   @Override
@@ -86,6 +102,7 @@ public class MockFib implements Fib {
   }
 
   @Override
+  @Deprecated
   public @Nonnull Set<String> getNextHopInterfaces(Ip ip) {
     return _nextHopInterfacesByIp.getOrDefault(ip, ImmutableMap.of()).keySet();
   }
@@ -93,10 +110,11 @@ public class MockFib implements Fib {
   @Nonnull
   @Override
   public Set<FibEntry> get(Ip ip) {
-    throw new UnsupportedOperationException();
+    return firstNonNull(_fibEntries.get(ip), ImmutableSet.of());
   }
 
   @Override
+  @Deprecated
   public @Nonnull Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>
       getNextHopInterfacesByRoute(Ip dstIp) {
     return _nextHopInterfacesByRoute.get(dstIp);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FibEntryMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FibEntryMatchers.java
@@ -1,0 +1,15 @@
+package org.batfish.datamodel.matchers;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.batfish.datamodel.FibEntry;
+import org.batfish.datamodel.matchers.FibEntryMatchersImpl.HasInterface;
+
+/** Matchers for {@link FibEntry} */
+public final class FibEntryMatchers {
+  public static HasInterface hasInterface(String interfaceName) {
+    return new HasInterface(equalTo(interfaceName));
+  }
+
+  private FibEntryMatchers() {}
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FibEntryMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/FibEntryMatchersImpl.java
@@ -1,0 +1,22 @@
+package org.batfish.datamodel.matchers;
+
+import org.batfish.datamodel.FibEntry;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+final class FibEntryMatchersImpl {
+
+  static final class HasInterface extends FeatureMatcher<FibEntry, String> {
+
+    public HasInterface(Matcher<? super String> subMatcher) {
+      super(subMatcher, "A FibEntry with: nextHopInterface", "nextHopInterface");
+    }
+
+    @Override
+    protected String featureValueOf(FibEntry fibEntry) {
+      return fibEntry.getInterfaceName();
+    }
+  }
+
+  private FibEntryMatchersImpl() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/ExitPoint.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/ExitPoint.java
@@ -1,0 +1,63 @@
+package org.batfish.dataplane.traceroute;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.FibEntry;
+import org.batfish.datamodel.Ip;
+
+/**
+ * A flow exit point out of a device. A combination of the IP to arp for and the interface name to
+ * use.
+ */
+@ParametersAreNonnullByDefault
+final class ExitPoint {
+  @Nonnull private final Ip _arpIp;
+  @Nonnull private final String _interfaceName;
+
+  ExitPoint(Ip arpIp, String interfaceName) {
+    _arpIp = arpIp;
+    _interfaceName = interfaceName;
+  }
+
+  static ExitPoint from(FibEntry fibEntry) {
+    return new ExitPoint(fibEntry.getArpIP(), fibEntry.getInterfaceName());
+  }
+
+  @Nonnull
+  public Ip getArpIP() {
+    return _arpIp;
+  }
+
+  @Nonnull
+  public String getInterfaceName() {
+    return _interfaceName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ExitPoint)) {
+      return false;
+    }
+    ExitPoint exitPoint = (ExitPoint) o;
+    return Objects.equals(_arpIp, exitPoint._arpIp)
+        && Objects.equals(_interfaceName, exitPoint._interfaceName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_arpIp, _interfaceName);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("arpIp", _arpIp)
+        .add("interfaceName", _interfaceName)
+        .toString();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -9,34 +9,36 @@ import static org.batfish.datamodel.flow.FilterStep.FilterType.INGRESS_FILTER;
 import static org.batfish.datamodel.flow.FilterStep.FilterType.POST_TRANSFORMATION_INGRESS_FILTER;
 import static org.batfish.datamodel.flow.FilterStep.FilterType.PRE_TRANSFORMATION_EGRESS_FILTER;
 import static org.batfish.datamodel.flow.StepAction.DENIED;
+import static org.batfish.datamodel.flow.StepAction.FORWARDED;
 import static org.batfish.datamodel.flow.StepAction.PERMITTED;
 import static org.batfish.datamodel.flow.StepAction.TRANSMITTED;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.buildEnterSrcIfaceStep;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.createFilterStep;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.getFinalActionForDisposition;
-import static org.batfish.dataplane.traceroute.TracerouteUtils.resolveNextHopIpRoutes;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.returnFlow;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.sessionTransformation;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Multimap;
+import com.google.common.collect.ImmutableSortedMap;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.Stack;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Fib;
+import org.batfish.datamodel.FibEntry;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
@@ -339,16 +341,8 @@ class FlowTracer {
       return;
     }
 
-    Fib fib = _tracerouteContext.getFib(currentNodeName, _vrfName);
-    // Sort so that resulting traces will be in sensible deterministic order
-    SortedSet<String> nextHopInterfaces =
-        ImmutableSortedSet.copyOf(fib.getNextHopInterfaces(dstIp));
-    if (nextHopInterfaces.isEmpty()) {
-      buildNoRouteTrace();
-      return;
-    }
-
-    fibLookup(dstIp, currentNodeName, fib, nextHopInterfaces);
+    Fib fib = _tracerouteContext.getFib(currentNodeName, _vrfName).get();
+    fibLookup(dstIp, currentNodeName, fib);
   }
 
   private boolean processPBR(Interface incomingInterface) {
@@ -386,23 +380,14 @@ class FlowTracer {
           return true;
         }
 
-        Fib fib = _tracerouteContext.getFib(currentNodeName, lookupVrfName);
-        // Sort so that resulting traces will be in sensible deterministic order
-        SortedSet<String> nextHopInterfaces =
-            ImmutableSortedSet.copyOf(fib.getNextHopInterfaces(dstIp));
-        if (nextHopInterfaces.isEmpty()) {
-          buildNoRouteTrace();
-          return true;
-        }
-
-        fibLookup(dstIp, currentNodeName, fib, nextHopInterfaces);
+        Fib fib = _tracerouteContext.getFib(currentNodeName, lookupVrfName).get();
+        fibLookup(dstIp, currentNodeName, fib);
         return true;
       }
     }.visit(result.getAction());
   }
 
-  private void fibLookup(
-      Ip dstIp, String currentNodeName, Fib fib, SortedSet<String> nextHopInterfaces) {
+  private void fibLookup(Ip dstIp, String currentNodeName, Fib fib) {
     // Loop detection
     Breadcrumb breadcrumb = new Breadcrumb(currentNodeName, _vrfName, _currentFlow);
     if (_breadcrumbs.contains(breadcrumb)) {
@@ -411,27 +396,35 @@ class FlowTracer {
     }
     _breadcrumbs.push(breadcrumb);
     try {
-      _steps.add(buildRoutingStep(currentNodeName, dstIp));
+      Set<FibEntry> fibEntries = fib.get(dstIp);
 
-      Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopInterfacesByRoute =
-          fib.getNextHopInterfacesByRoute(dstIp);
+      if (fibEntries.isEmpty()) {
+        buildNoRouteTrace();
+        return;
+      }
+
+      _steps.add(buildRoutingStep(fibEntries));
+
+      // Group traces by outgoing interface (we do not want extra branching if there is branching
+      // in FIB resolution)
+      SortedMap<ExitPoint, Set<FibEntry>> groupedByExitPoint =
+          // Sort so that resulting traces will be in sensible deterministic order
+          ImmutableSortedMap.copyOf(
+              fibEntries.stream()
+                  .collect(Collectors.groupingBy(ExitPoint::from, Collectors.toSet())),
+              Comparator.comparing(ExitPoint::getInterfaceName).thenComparing(ExitPoint::getArpIP));
 
       // For every interface with a route to the dst IP
-      for (String nextHopInterfaceName : nextHopInterfaces) {
-        if (nextHopInterfaceName.equals(Interface.NULL_INTERFACE_NAME)) {
+      for (ExitPoint exitPoint : groupedByExitPoint.keySet()) {
+        if (exitPoint.getInterfaceName().equals(Interface.NULL_INTERFACE_NAME)) {
           branch().buildNullRoutedTrace();
           continue;
         }
 
-        Interface nextHopInterface = _currentConfig.getAllInterfaces().get(nextHopInterfaceName);
-
-        Multimap<Ip, AbstractRoute> resolvedNextHopIpRoutes =
-            resolveNextHopIpRoutes(nextHopInterfaceName, nextHopInterfacesByRoute);
-        resolvedNextHopIpRoutes
-            .asMap()
-            .forEach(
-                (resolvedNextHopIp, routeCandidates) ->
-                    branch().forwardOutInterface(nextHopInterface, resolvedNextHopIp));
+        branch()
+            .forwardOutInterface(
+                _currentConfig.getAllInterfaces().get(exitPoint.getInterfaceName()),
+                exitPoint.getArpIP());
       }
     } finally {
       _breadcrumbs.pop();
@@ -446,14 +439,20 @@ class FlowTracer {
         .build();
   }
 
-  @Nonnull
-  private RoutingStep buildRoutingStep(String currentNodeName, Ip dstIp) {
+  private RoutingStep buildRoutingStep(Set<FibEntry> fibEntries) {
     List<RouteInfo> matchedRibRouteInfo =
-        _tracerouteContext.longestPrefixMatch(currentNodeName, _vrfName, dstIp);
-
+        fibEntries.stream()
+            .map(FibEntry::getTopLevelRoute)
+            .map(rc -> new RouteInfo(rc.getProtocol(), rc.getNetwork(), rc.getNextHopIp()))
+            .sorted(
+                Comparator.comparing(RouteInfo::getNetwork)
+                    .thenComparing(RouteInfo::getNextHopIp)
+                    .thenComparing(RouteInfo::getProtocol))
+            .distinct()
+            .collect(ImmutableList.toImmutableList());
     return RoutingStep.builder()
         .setDetail(RoutingStepDetail.builder().setRoutes(matchedRibRouteInfo).build())
-        .setAction(StepAction.FORWARDED)
+        .setAction(FORWARDED)
         .build();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -3,7 +3,6 @@ package org.batfish.dataplane.traceroute;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.buildSessionsByIngressInterface;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.validateInputs;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
@@ -11,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -18,7 +18,6 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import org.batfish.common.BatfishException;
-import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Fib;
@@ -29,7 +28,6 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
 import org.batfish.datamodel.flow.Hop;
-import org.batfish.datamodel.flow.RouteInfo;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
 
@@ -143,21 +141,12 @@ public class TracerouteEngineImplContext {
     return _configurations;
   }
 
-  Fib getFib(String node, String vrf) {
-    return _fibs.get(node).get(vrf);
+  Optional<Fib> getFib(String node, String vrf) {
+    return Optional.ofNullable(_fibs.getOrDefault(node, ImmutableMap.of()).get(vrf));
   }
 
   boolean getIgnoreFilters() {
     return _ignoreFilters;
-  }
-
-  List<RouteInfo> longestPrefixMatch(String node, String vrf, Ip ip) {
-    return _dataPlane.getRibs().get(node).get(vrf).longestPrefixMatch(ip).stream()
-        .map(AnnotatedRoute::getRoute)
-        .sorted()
-        .map(rc -> new RouteInfo(rc.getProtocol(), rc.getNetwork(), rc.getNextHopIp()))
-        .distinct()
-        .collect(ImmutableList.toImmutableList());
   }
 
   Collection<FirewallSessionTraceInfo> getSessions(String node, String inputIface) {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
@@ -13,16 +13,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.FilterResult;
 import org.batfish.datamodel.Flow;
@@ -33,7 +30,6 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.Route;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.EnterInputIfaceStep;
 import org.batfish.datamodel.flow.EnterInputIfaceStep.EnterInputIfaceStepDetail;
@@ -201,34 +197,6 @@ public final class TracerouteUtils {
                         builder.put(
                             new NodeInterfacePair(session.getHostname(), incomingIface), session)));
     return builder.build();
-  }
-
-  @Nonnull
-  static Multimap<Ip, AbstractRoute> resolveNextHopIpRoutes(
-      String nextHopInterfaceName,
-      Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> nextHopInterfacesByRoute) {
-    TreeMultimap<Ip, AbstractRoute> resolvedNextHopWithRoutes = TreeMultimap.create();
-
-    // Loop over all matching routes that use nextHopInterfaceName as one of the next hop
-    // interfaces.
-    for (Entry<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> e :
-        nextHopInterfacesByRoute.entrySet()) {
-      Map<Ip, Set<AbstractRoute>> finalNextHops = e.getValue().get(nextHopInterfaceName);
-      if (finalNextHops == null || finalNextHops.isEmpty()) {
-        continue;
-      }
-
-      AbstractRoute routeCandidate = e.getKey();
-      Ip nextHopIp = routeCandidate.getNextHopIp();
-      if (nextHopIp.equals(Route.UNSET_ROUTE_NEXT_HOP_IP)) {
-        resolvedNextHopWithRoutes.put(nextHopIp, routeCandidate);
-      } else {
-        for (Ip resolvedNextHopIp : finalNextHops.keySet()) {
-          resolvedNextHopWithRoutes.put(resolvedNextHopIp, routeCandidate);
-        }
-      }
-    }
-    return resolvedNextHopWithRoutes;
   }
 
   @Nullable

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/ExitPointTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/ExitPointTest.java
@@ -1,0 +1,41 @@
+package org.batfish.dataplane.traceroute;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.FibEntry;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.junit.Test;
+
+/** Tests of {@link ExitPoint} */
+public class ExitPointTest {
+  @Test
+  public void testEquals() {
+    ExitPoint ep = new ExitPoint(Ip.parse("1.1.1.1"), "eth0");
+    new EqualsTester()
+        .addEqualityGroup(ep, ep, new ExitPoint(Ip.parse("1.1.1.1"), "eth0"))
+        .addEqualityGroup(new ExitPoint(Ip.parse("1.1.1.2"), "eth0"))
+        .addEqualityGroup(new ExitPoint(Ip.parse("1.1.1.1"), "eth1"))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testFromFibEntry() {
+    assertThat(
+        ExitPoint.from(
+            new FibEntry(
+                Ip.parse("1.1.1.1"),
+                "eth0",
+                ImmutableList.of(
+                    ConnectedRoute.builder()
+                        .setNextHopInterface("eth0")
+                        .setNetwork(Prefix.parse("1.1.1.0/24"))
+                        .build()))),
+        equalTo(new ExitPoint(Ip.parse("1.1.1.1"), "eth0")));
+  }
+}


### PR DESCRIPTION
1. Stop using RIBs in traceroute computation, move to FIBs
2. Stop using and deprecate some FIB APIs that use maps of maps of maps
3. Stop doing meet-in-the-middle resolution in traceroute. Just get all FIB entries, then group them as desired (which is by exit point: combination of ARP IP and Interface)