### PR TITLE
Add routing instance as owner to nat pool in vs model

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
@@ -138,6 +138,7 @@ nat_pool
       natp_address
       | natp_description
       | natp_port
+      | natp_routing_instance
    )
 ;
 
@@ -207,6 +208,11 @@ natp_port
 natp_description
 :
    DESCRIPTION null_filler
+;
+
+natp_routing_instance
+:
+   ROUTING_INSTANCE name = variable
 ;
 
 proposal_set_type

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2406,6 +2406,14 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitNat_pool(Nat_poolContext ctx) {
+    // if not routing instance is configured for this nat, assign it to the default routing instance
+    if (_currentNatPool.getOwner() == null) {
+      RoutingInstance defaultRoutingInstance =
+          _configuration.getMasterLogicalSystem().getDefaultRoutingInstance();
+      _currentNatPool.setOwner(defaultRoutingInstance);
+      defaultRoutingInstance.getNatPools().put(_currentNatPoolName, _currentNatPool);
+    }
+
     _currentNatPool = null;
     _currentNatPoolName = null;
   }
@@ -4423,7 +4431,16 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       _w.redFlag("The routing instance " + ctx.name + " is not defined.");
       return;
     }
+
+    RoutingInstance defaultRoutingInstance =
+        _configuration.getMasterLogicalSystem().getDefaultRoutingInstance();
+    if (defaultRoutingInstance.getNatPools().containsKey(_currentNatPoolName)) {
+      defaultRoutingInstance.getNatPools().remove(_currentNatPoolName);
+    }
+
+    _currentNatPool.setOwner(ri);
     ri.getNatPools().put(_currentNatPoolName, _currentNatPool);
+    _currentNatPool.setOwner(ri);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -310,6 +310,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Nat_pool_default_port_r
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Nat_rule_setContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Natp_addressContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Natp_portContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Natp_routing_instanceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_areaContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_exportContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_reference_bandwidthContext;
@@ -1928,6 +1929,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   private NatPool _currentNatPool;
 
+  private String _currentNatPoolName;
+
   private NatRule _currentNatRule;
 
   private NatRuleSet _currentNatRuleSet;
@@ -2397,12 +2400,14 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void enterNat_pool(Nat_poolContext ctx) {
     String poolName = ctx.name.getText();
     _currentNatPool = _currentNat.getPools().computeIfAbsent(poolName, p -> new NatPool());
+    _currentNatPoolName = poolName;
     defineStructure(NAT_POOL, poolName, ctx);
   }
 
   @Override
   public void exitNat_pool(Nat_poolContext ctx) {
     _currentNatPool = null;
+    _currentNatPoolName = null;
   }
 
   @Override
@@ -4409,6 +4414,16 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     } else {
       _w.redFlag(ctx.getText() + " cannot be recognized");
     }
+  }
+
+  @Override
+  public void exitNatp_routing_instance(Natp_routing_instanceContext ctx) {
+    RoutingInstance ri = _currentLogicalSystem.getRoutingInstances().get(ctx.name.getText());
+    if (ri == null) {
+      _w.redFlag("The routing instance " + ctx.name + " is not defined.");
+      return;
+    }
+    ri.getNatPools().put(_currentNatPoolName, _currentNatPool);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1929,8 +1929,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   private NatPool _currentNatPool;
 
-  private String _currentNatPoolName;
-
   private NatRule _currentNatRule;
 
   private NatRuleSet _currentNatRuleSet;
@@ -2400,22 +2398,12 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void enterNat_pool(Nat_poolContext ctx) {
     String poolName = ctx.name.getText();
     _currentNatPool = _currentNat.getPools().computeIfAbsent(poolName, p -> new NatPool());
-    _currentNatPoolName = poolName;
     defineStructure(NAT_POOL, poolName, ctx);
   }
 
   @Override
   public void exitNat_pool(Nat_poolContext ctx) {
-    // if not routing instance is configured for this nat, assign it to the default routing instance
-    if (_currentNatPool.getOwner() == null) {
-      RoutingInstance defaultRoutingInstance =
-          _configuration.getMasterLogicalSystem().getDefaultRoutingInstance();
-      _currentNatPool.setOwner(defaultRoutingInstance);
-      defaultRoutingInstance.getNatPools().put(_currentNatPoolName, _currentNatPool);
-    }
-
     _currentNatPool = null;
-    _currentNatPoolName = null;
   }
 
   @Override
@@ -4426,20 +4414,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitNatp_routing_instance(Natp_routing_instanceContext ctx) {
-    RoutingInstance ri = _currentLogicalSystem.getRoutingInstances().get(ctx.name.getText());
-    if (ri == null) {
-      _w.redFlag("The routing instance " + ctx.name + " is not defined.");
-      return;
-    }
-
-    RoutingInstance defaultRoutingInstance =
-        _configuration.getMasterLogicalSystem().getDefaultRoutingInstance();
-    if (defaultRoutingInstance.getNatPools().containsKey(_currentNatPoolName)) {
-      defaultRoutingInstance.getNatPools().remove(_currentNatPoolName);
-    }
-
-    _currentNatPool.setOwner(ri);
-    ri.getNatPools().put(_currentNatPoolName, _currentNatPool);
+    String ri = ctx.name.getText();
     _currentNatPool.setOwner(ri);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPool.java
@@ -17,7 +17,7 @@ public final class NatPool implements Serializable {
 
   private Ip _toAddress;
 
-  private RoutingInstance _owner;
+  @Nullable private String _owner;
 
   // null value means no pat is configured; source nat will apply pat and dest nat will not apply
   // pat by default
@@ -41,7 +41,7 @@ public final class NatPool implements Serializable {
   }
 
   @Nullable
-  public RoutingInstance getOwner() {
+  public String getOwner() {
     return _owner;
   }
 
@@ -62,7 +62,7 @@ public final class NatPool implements Serializable {
     _pat = pat;
   }
 
-  public void setOwner(RoutingInstance routingInstance) {
+  public void setOwner(String routingInstance) {
     _owner = routingInstance;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPool.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPool.java
@@ -17,6 +17,8 @@ public final class NatPool implements Serializable {
 
   private Ip _toAddress;
 
+  private RoutingInstance _owner;
+
   // null value means no pat is configured; source nat will apply pat and dest nat will not apply
   // pat by default
   @Nullable private PortAddressTranslation _pat;
@@ -25,6 +27,7 @@ public final class NatPool implements Serializable {
     _fromAddress = Prefix.ZERO.getStartIp();
     _toAddress = Prefix.ZERO.getEndIp();
     _pat = null;
+    _owner = null;
   }
 
   @Nonnull
@@ -35,6 +38,11 @@ public final class NatPool implements Serializable {
   @Nonnull
   public Ip getToAddress() {
     return _toAddress;
+  }
+
+  @Nullable
+  public RoutingInstance getOwner() {
+    return _owner;
   }
 
   @Nullable
@@ -52,5 +60,9 @@ public final class NatPool implements Serializable {
 
   public void setPortAddressTranslation(PortAddressTranslation pat) {
     _pat = pat;
+  }
+
+  public void setOwner(RoutingInstance routingInstance) {
+    _owner = routingInstance;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
@@ -56,7 +56,6 @@ public class RoutingInstance implements Serializable {
   private Ip _routerId;
   private SnmpServer _snmpServer;
   private final JuniperSystem _system;
-  private Map<String, NatPool> _natPools;
 
   public RoutingInstance(String name) {
     _aggregateRouteDefaults = initAggregateRouteDefaults();
@@ -76,7 +75,6 @@ public class RoutingInstance implements Serializable {
     _globalMasterInterface.setRoutingInstance(name);
     _name = name;
     _namedBgpGroups = new TreeMap<>();
-    _natPools = new TreeMap<>();
     _nodeDevices = new TreeMap<>();
     _ospfAreas = new TreeMap<>();
     _ospfExportPolicies = new LinkedList<>();
@@ -181,10 +179,6 @@ public class RoutingInstance implements Serializable {
 
   public Map<String, NamedBgpGroup> getNamedBgpGroups() {
     return _namedBgpGroups;
-  }
-
-  public Map<String, NatPool> getNatPools() {
-    return _natPools;
   }
 
   public Map<String, NodeDevice> getNodeDevices() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
@@ -56,6 +56,7 @@ public class RoutingInstance implements Serializable {
   private Ip _routerId;
   private SnmpServer _snmpServer;
   private final JuniperSystem _system;
+  private Map<String, NatPool> _natPools;
 
   public RoutingInstance(String name) {
     _aggregateRouteDefaults = initAggregateRouteDefaults();
@@ -75,6 +76,7 @@ public class RoutingInstance implements Serializable {
     _globalMasterInterface.setRoutingInstance(name);
     _name = name;
     _namedBgpGroups = new TreeMap<>();
+    _natPools = new TreeMap<>();
     _nodeDevices = new TreeMap<>();
     _ospfAreas = new TreeMap<>();
     _ospfExportPolicies = new LinkedList<>();
@@ -179,6 +181,10 @@ public class RoutingInstance implements Serializable {
 
   public Map<String, NamedBgpGroup> getNamedBgpGroups() {
     return _namedBgpGroups;
+  }
+
+  public Map<String, NatPool> getNatPools() {
+    return _natPools;
   }
 
   public Map<String, NodeDevice> getNodeDevices() {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4672,9 +4672,15 @@ public final class FlatJuniperGrammarTest {
 
   @Test
   public void testVrfSpecificPoolPortAddressTranslation() {
-    JuniperConfiguration juniperConfiguration = parseJuniperConfig("juniper-nat-pat");
+    JuniperConfiguration juniperConfiguration = parseJuniperConfig("juniper-nat-vrf");
     Nat sourceNat = juniperConfiguration.getMasterLogicalSystem().getNatSource();
     NatPool pool0 = sourceNat.getPools().get("POOL0");
     NatPool pool1 = sourceNat.getPools().get("POOL1");
+    assertThat(
+        pool0.getOwner(),
+        equalTo(juniperConfiguration.getMasterLogicalSystem().getRoutingInstances().get("R1")));
+    assertThat(
+        pool1.getOwner(),
+        equalTo(juniperConfiguration.getMasterLogicalSystem().getDefaultRoutingInstance()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4669,4 +4669,12 @@ public final class FlatJuniperGrammarTest {
     assertNotNull(pool5);
     assertNull(pool5.getPortAddressTranslation());
   }
+
+  @Test
+  public void testVrfSpecificPoolPortAddressTranslation() {
+    JuniperConfiguration juniperConfiguration = parseJuniperConfig("juniper-nat-pat");
+    Nat sourceNat = juniperConfiguration.getMasterLogicalSystem().getNatSource();
+    NatPool pool0 = sourceNat.getPools().get("POOL0");
+    NatPool pool1 = sourceNat.getPools().get("POOL1");
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4676,11 +4676,7 @@ public final class FlatJuniperGrammarTest {
     Nat sourceNat = juniperConfiguration.getMasterLogicalSystem().getNatSource();
     NatPool pool0 = sourceNat.getPools().get("POOL0");
     NatPool pool1 = sourceNat.getPools().get("POOL1");
-    assertThat(
-        pool0.getOwner(),
-        equalTo(juniperConfiguration.getMasterLogicalSystem().getRoutingInstances().get("R1")));
-    assertThat(
-        pool1.getOwner(),
-        equalTo(juniperConfiguration.getMasterLogicalSystem().getDefaultRoutingInstance()));
+    assertThat(pool0.getOwner(), equalTo("R1"));
+    assertNull(pool1.getOwner());
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-nat-vrf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-nat-vrf
@@ -1,0 +1,8 @@
+#
+set system host-name juniper-nat-vrf
+#
+set routing-instances R1 interface ge-0/0/1.0
+# vrf-specific pool
+set security nat source pool POOL0 routing-instance R1
+# default-vrf pool 
+set security nat source pool POOL1 description TEXT


### PR DESCRIPTION
A Juniper nat pool belongs to a routing instance. One can configure it by "et security nat source pool POOL routing-instance R1", otherwise a nat pool belongs to the default routing instance. A nat can use any pools no matter what routing instance it belongs to, so we only need to correctly parse the command and extract the information to vs model. 
1. Add `_owner` to `NatPool`
2. Trace all pools in a `RoutingInstance`
3. Parse the specific command above