### PR TITLE
Make AsPath.empty() a singleton

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 public final class AsPath implements Serializable, Comparable<AsPath> {
 
   private static final long serialVersionUID = 1L;
+  private static final AsPath EMPTY = new AsPath(ImmutableList.of());
 
   /**
    * Returns true iff the provided AS number is reserved for private use by RFC 6696:
@@ -57,7 +58,7 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
 
   /** Create and return a new empty {@link AsPath}. */
   public static AsPath empty() {
-    return AsPath.of(ImmutableList.of());
+    return EMPTY;
   }
 
   /** Create and return a new {@link AsPath} of length 1 using the given {@link AsSet}. */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
@@ -68,6 +68,9 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
 
   /** Create and return a new {@link AsPath} of the given {@link AsSet AsSets}. */
   public static AsPath of(List<AsSet> asSets) {
+    if (asSets.isEmpty()) {
+      return empty();
+    }
     ImmutableList<AsSet> immutableValue = ImmutableList.copyOf(asSets);
     try {
       return CACHE.get(immutableValue, () -> new AsPath(immutableValue));


### PR DESCRIPTION
It was showing up on cpu profiling when creating bgp route builder (which we do a lot) and was a really easy fix.