### PR TITLE
Separate reverse pass transformation ranges by session out interface and next hop.

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDFirewallSessionTraceInfo.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDFirewallSessionTraceInfo.java
@@ -1,6 +1,7 @@
 package org.batfish.bddreachability;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.SOURCE_ORIGINATING_FROM_DEVICE;
 
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -27,6 +28,9 @@ final class BDDFirewallSessionTraceInfo {
       @Nullable String outgoingInterface,
       BDD sessionFlows,
       Transition transformation) {
+    checkArgument(
+        !SOURCE_ORIGINATING_FROM_DEVICE.equals(outgoingInterface),
+        "Use null instead of SOURCE_ORIGINATING_FROM_DEVICE for outgoingInterface");
     checkArgument(
         (outgoingInterface != null) || (nextHop == null),
         "If outgoingInterface is null, nextHop must be null");

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReverseTransformationRanges.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReverseTransformationRanges.java
@@ -1,12 +1,18 @@
 package org.batfish.bddreachability;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import net.sf.javabdd.BDD;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 interface BDDReverseTransformationRanges {
+  /** Invariant: if lastHop is nonnull, then inIface is nonnull. */
   @Nonnull
-  BDD reverseIncomingTransformationRange(String node, String iface);
+  BDD reverseIncomingTransformationRange(
+      String node, String iface, @Nullable String inIface, @Nullable NodeInterfacePair lastHop);
 
+  /** Invariant: if lastHop is nonnull, then inIface is nonnull. */
   @Nonnull
-  BDD reverseOutgoingTransformationRange(String node, String iface);
+  BDD reverseOutgoingTransformationRange(
+      String node, String iface, @Nullable String inIface, @Nullable NodeInterfacePair lastHop);
 }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReverseTransformationRangesImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReverseTransformationRangesImpl.java
@@ -2,6 +2,7 @@ package org.batfish.bddreachability;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
@@ -171,7 +172,8 @@ final class BDDReverseTransformationRangesImpl implements BDDReverseTransformati
     return _bddPacket.swapSourceAndDestinationFields(erased);
   }
 
-  private BDD sourceAndLastHopConstraint(
+  @VisibleForTesting
+  BDD sourceAndLastHopConstraint(
       String node, @Nullable String inIface, @Nullable NodeInterfacePair lastHop) {
     checkArgument(inIface != null || lastHop == null, "Can't have a lastHop without an inIface");
     BDDSourceManager srcMgr = _srcManagers.get(node);

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
@@ -7,6 +7,8 @@ import static org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchers.ha
 import static org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchers.hasSessionFlows;
 import static org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchers.hasTransformation;
 import static org.batfish.bddreachability.BDDReachabilityAnalysisSessionFactory.computeInitializedSesssions;
+import static org.batfish.bddreachability.BDDReverseTransformationRangesImpl.TransformationType.INCOMING;
+import static org.batfish.bddreachability.BDDReverseTransformationRangesImpl.TransformationType.OUTGOING;
 import static org.batfish.bddreachability.transition.Transitions.compose;
 import static org.batfish.bddreachability.transition.Transitions.constraint;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -358,16 +360,17 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
     BDDReverseTransformationRanges transformationRanges =
         new MockBDDReverseTransformationRanges(
             PKT.getFactory().zero(),
-            // incoming transformation ranges
             ImmutableMap.of(
-                new Key(FW, FWI1, FWI1, NEXT_HOP_R1I1), r1I1IncomingTransformationRange,
-                new Key(FW, FWI1, FWI1, NEXT_HOP_R2I1), r2I1IncomingTransformationRange),
+                // incoming transformation ranges
+                new Key(FW, FWI1, INCOMING, FWI1, NEXT_HOP_R1I1),
+                r1I1IncomingTransformationRange,
+                new Key(FW, FWI1, INCOMING, FWI1, NEXT_HOP_R2I1),
+                r2I1IncomingTransformationRange,
 
-            // outgoing transformation ranges
-            ImmutableMap.of(
-                new Key(FW, FWI3, FWI1, NEXT_HOP_R1I1),
+                // outgoing transformation ranges
+                new Key(FW, FWI3, OUTGOING, FWI1, NEXT_HOP_R1I1),
                 r1I1OutgoingingTransformationRange,
-                new Key(FW, FWI3, FWI1, NEXT_HOP_R2I1),
+                new Key(FW, FWI3, OUTGOING, FWI1, NEXT_HOP_R2I1),
                 r2I1OutgoingingTransformationRange));
 
     Map<String, List<BDDFirewallSessionTraceInfo>> sessions =

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
@@ -1,5 +1,7 @@
 package org.batfish.bddreachability;
 
+import static org.batfish.bddreachability.BDDReverseTransformationRangesImpl.TransformationType.INCOMING;
+import static org.batfish.bddreachability.BDDReverseTransformationRangesImpl.TransformationType.OUTGOING;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
@@ -16,6 +18,7 @@ import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.HeaderSpaceToBDD;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
@@ -39,7 +42,6 @@ public class BDDReverseTransformationRangesImplTest {
   private Map<String, Configuration> _configs;
   private Interface.Builder _ib;
   private HeaderSpaceToBDD _headerSpaceToBDD;
-  private Map<String, BDDSourceManager> _srcManagers;
   private LastHopOutgoingInterfaceManager _lastHopManager;
 
   @Before
@@ -55,8 +57,6 @@ public class BDDReverseTransformationRangesImplTest {
     _ib = nf.interfaceBuilder().setOwner(config).setVrf(vrf).setActive(true);
     _configs = ImmutableMap.of(HOSTNAME, config);
     _headerSpaceToBDD = new HeaderSpaceToBDD(_bddPacket, ImmutableMap.of());
-    _srcManagers =
-        ImmutableMap.of(HOSTNAME, BDDSourceManager.forInterfaces(_bddPacket, ImmutableSet.of()));
     _lastHopManager = new LastHopOutgoingInterfaceManager(_bddPacket, _configs, ImmutableSet.of());
   }
 
@@ -68,9 +68,12 @@ public class BDDReverseTransformationRangesImplTest {
 
     Interface iface = _ib.build();
 
+    Map<String, BDDSourceManager> srcManagers =
+        BDDSourceManager.forNetwork(_bddPacket, _configs, true);
+
     BDDReverseTransformationRangesImpl ranges =
         new BDDReverseTransformationRangesImpl(
-            _configs, ImmutableMap.of(), _bddPacket, null, _srcManagers, _lastHopManager);
+            _configs, ImmutableMap.of(), _bddPacket, null, srcManagers, _lastHopManager);
 
     assertTrue(
         ranges.reverseIncomingTransformationRange(HOSTNAME, iface.getName(), null, null).isZero());
@@ -83,8 +86,8 @@ public class BDDReverseTransformationRangesImplTest {
     Interface iface = _ib.build();
     String iName = iface.getName();
 
-    // reinitialize source managers with new interface
-    _srcManagers = BDDSourceManager.forNetwork(_bddPacket, _configs, true);
+    Map<String, BDDSourceManager> srcManagers =
+        BDDSourceManager.forNetwork(_bddPacket, _configs, true);
 
     BDD fwdPreInBdd = _headerSpaceToBDD.getDstIpSpaceToBdd().toBDD(Ip.parse("1.1.1.1"));
     BDD bwdPreInBdd = _headerSpaceToBDD.getSrcIpSpaceToBdd().toBDD(Ip.parse("1.1.1.1"));
@@ -96,7 +99,7 @@ public class BDDReverseTransformationRangesImplTest {
     {
       BDDReverseTransformationRangesImpl ranges =
           new BDDReverseTransformationRangesImpl(
-              _configs, forwardReach, _bddPacket, null, _srcManagers, _lastHopManager);
+              _configs, forwardReach, _bddPacket, null, srcManagers, _lastHopManager);
       assertThat(
           ranges.reverseIncomingTransformationRange(HOSTNAME, iface.getName(), iName, null),
           equalTo(bwdPreInBdd));
@@ -119,7 +122,7 @@ public class BDDReverseTransformationRangesImplTest {
               forwardReach,
               _bddPacket,
               ImmutableMap.of(HOSTNAME, ImmutableMap.of(aclName, () -> fwdAclBdd)),
-              _srcManagers,
+              srcManagers,
               _lastHopManager);
       assertThat(
           ranges.reverseIncomingTransformationRange(HOSTNAME, iName, iName, null),
@@ -131,6 +134,9 @@ public class BDDReverseTransformationRangesImplTest {
   public void testOutgoingTransformationRange() {
     Interface iface = _ib.build();
     String iName = iface.getName();
+
+    Map<String, BDDSourceManager> srcManagers =
+        BDDSourceManager.forNetwork(_bddPacket, _configs, true);
 
     BDD fwdPreOutEdge1Bdd = _headerSpaceToBDD.getDstIpSpaceToBdd().toBDD(Ip.parse("1.1.1.1"));
     BDD fwdPreOutEdge2Bdd = _headerSpaceToBDD.getDstIpSpaceToBdd().toBDD(Ip.parse("1.1.1.2"));
@@ -153,7 +159,7 @@ public class BDDReverseTransformationRangesImplTest {
     {
       BDDReverseTransformationRangesImpl ranges =
           new BDDReverseTransformationRangesImpl(
-              _configs, forwardReach, _bddPacket, null, _srcManagers, _lastHopManager);
+              _configs, forwardReach, _bddPacket, null, srcManagers, _lastHopManager);
       assertThat(
           ranges.reverseOutgoingTransformationRange(HOSTNAME, iName, null, null), equalTo(reach));
     }
@@ -175,7 +181,7 @@ public class BDDReverseTransformationRangesImplTest {
               forwardReach,
               _bddPacket,
               ImmutableMap.of(HOSTNAME, ImmutableMap.of(aclName, () -> fwdAclBdd)),
-              _srcManagers,
+              srcManagers,
               _lastHopManager);
       assertThat(
           ranges.reverseOutgoingTransformationRange(HOSTNAME, iName, null, null),
@@ -189,8 +195,8 @@ public class BDDReverseTransformationRangesImplTest {
     Interface iface = _ib.build();
     String iName = iface.getName();
 
-    // reinitialize source managers with new interface
-    _srcManagers = BDDSourceManager.forNetwork(_bddPacket, _configs, true);
+    Map<String, BDDSourceManager> srcManagers =
+        BDDSourceManager.forNetwork(_bddPacket, _configs, true);
 
     // make the node a session node.
     iface.setFirewallSessionInterfaceInfo(
@@ -201,10 +207,9 @@ public class BDDReverseTransformationRangesImplTest {
             _bddPacket,
             _configs,
             ImmutableSet.of(
-                new org.batfish.datamodel.Edge(
-                    new NodeInterfacePair("A", "A"), new NodeInterfacePair(HOSTNAME, iName))));
+                new Edge(new NodeInterfacePair("A", "A"), new NodeInterfacePair(HOSTNAME, iName))));
 
-    BDD srcBdd = _srcManagers.get(HOSTNAME).getSourceInterfaceBDD(iName);
+    BDD srcBdd = srcManagers.get(HOSTNAME).getSourceInterfaceBDD(iName);
     BDD lastHopBdd = _lastHopManager.getNoLastHopOutgoingInterfaceBdd(HOSTNAME, iName);
     BDD reach = srcBdd.and(lastHopBdd);
 
@@ -217,7 +222,7 @@ public class BDDReverseTransformationRangesImplTest {
 
     BDDReverseTransformationRangesImpl ranges =
         new BDDReverseTransformationRangesImpl(
-            _configs, forwardReach, _bddPacket, null, _srcManagers, _lastHopManager);
+            _configs, forwardReach, _bddPacket, null, srcManagers, _lastHopManager);
     assertTrue(ranges.reverseOutgoingTransformationRange(HOSTNAME, iName, iName, null).isOne());
     assertTrue(ranges.reverseIncomingTransformationRange(HOSTNAME, iName, iName, null).isOne());
   }
@@ -228,8 +233,9 @@ public class BDDReverseTransformationRangesImplTest {
     String iName = iface.getName();
 
     // reinitialize source managers with new interface
-    _srcManagers = BDDSourceManager.forNetwork(_bddPacket, _configs, true);
-    BDDSourceManager srcManager = _srcManagers.get(HOSTNAME);
+    Map<String, BDDSourceManager> srcManagers =
+        BDDSourceManager.forNetwork(_bddPacket, _configs, true);
+    BDDSourceManager srcManager = srcManagers.get(HOSTNAME);
 
     String neighbor1 = "neighbor1";
     String neighbor2 = "neighbor2";
@@ -241,12 +247,12 @@ public class BDDReverseTransformationRangesImplTest {
             _bddPacket,
             _configs,
             ImmutableSet.of(
-                new org.batfish.datamodel.Edge(lastHop1, new NodeInterfacePair(HOSTNAME, iName)),
-                new org.batfish.datamodel.Edge(lastHop2, new NodeInterfacePair(HOSTNAME, iName))));
+                new Edge(lastHop1, new NodeInterfacePair(HOSTNAME, iName)),
+                new Edge(lastHop2, new NodeInterfacePair(HOSTNAME, iName))));
 
     BDDReverseTransformationRangesImpl ranges =
         new BDDReverseTransformationRangesImpl(
-            _configs, ImmutableMap.of(), _bddPacket, null, _srcManagers, _lastHopManager);
+            _configs, ImmutableMap.of(), _bddPacket, null, srcManagers, _lastHopManager);
 
     assertThat(
         ranges.sourceAndLastHopConstraint(HOSTNAME, null, null),
@@ -285,11 +291,14 @@ public class BDDReverseTransformationRangesImplTest {
     String inIface = "inIface";
     NodeInterfacePair lastHop = new NodeInterfacePair("lastHopNode", "lastHopIface");
     new EqualsTester()
-        .addEqualityGroup(new Key(node, iface, inIface, null), new Key(node, iface, inIface, null))
-        .addEqualityGroup(new Key("", iface, inIface, null))
-        .addEqualityGroup(new Key(node, "", inIface, null))
-        .addEqualityGroup(new Key(node, iface, null, null))
-        .addEqualityGroup(new Key(node, iface, inIface, lastHop))
+        .addEqualityGroup(
+            new Key(node, iface, OUTGOING, inIface, null),
+            new Key(node, iface, OUTGOING, inIface, null))
+        .addEqualityGroup(new Key("", iface, OUTGOING, inIface, null))
+        .addEqualityGroup(new Key(node, "", OUTGOING, inIface, null))
+        .addEqualityGroup(new Key(node, iface, INCOMING, inIface, null))
+        .addEqualityGroup(new Key(node, iface, OUTGOING, null, null))
+        .addEqualityGroup(new Key(node, iface, OUTGOING, inIface, lastHop))
         .testEquals();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/MockBDDReverseTransformationRanges.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/MockBDDReverseTransformationRanges.java
@@ -2,30 +2,36 @@ package org.batfish.bddreachability;
 
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import net.sf.javabdd.BDD;
+import org.batfish.bddreachability.BDDReverseTransformationRangesImpl.Key;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 
 final class MockBDDReverseTransformationRanges implements BDDReverseTransformationRanges {
-  private final Map<NodeInterfacePair, BDD> _incomingTransformationRanges;
-  private final Map<NodeInterfacePair, BDD> _outgoingTransformationRanges;
+  private final Map<Key, BDD> _incomingTransformationRanges;
+  private final Map<Key, BDD> _outgoingTransformationRanges;
   private final BDD _zero;
 
   MockBDDReverseTransformationRanges(
       BDD zero,
-      Map<NodeInterfacePair, BDD> incomingTransformationRanges,
-      Map<NodeInterfacePair, BDD> outgoingTransformationRanges) {
+      Map<Key, BDD> incomingTransformationRanges,
+      Map<Key, BDD> outgoingTransformationRanges) {
     _zero = zero;
     _incomingTransformationRanges = incomingTransformationRanges;
     _outgoingTransformationRanges = outgoingTransformationRanges;
   }
 
   @Override
-  public @Nonnull BDD reverseIncomingTransformationRange(String node, String iface) {
-    return _incomingTransformationRanges.getOrDefault(new NodeInterfacePair(node, iface), _zero);
+  public @Nonnull BDD reverseIncomingTransformationRange(
+      String node, String iface, @Nullable String inIface, @Nullable NodeInterfacePair lastHop) {
+    return _incomingTransformationRanges.getOrDefault(
+        new Key(node, iface, inIface, lastHop), _zero);
   }
 
   @Override
-  public @Nonnull BDD reverseOutgoingTransformationRange(String node, String iface) {
-    return _outgoingTransformationRanges.getOrDefault(new NodeInterfacePair(node, iface), _zero);
+  public @Nonnull BDD reverseOutgoingTransformationRange(
+      String node, String iface, @Nullable String inIface, @Nullable NodeInterfacePair lastHop) {
+    return _outgoingTransformationRanges.getOrDefault(
+        new Key(node, iface, inIface, lastHop), _zero);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/MockBDDReverseTransformationRanges.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/MockBDDReverseTransformationRanges.java
@@ -1,5 +1,9 @@
 package org.batfish.bddreachability;
 
+import static org.batfish.bddreachability.BDDReverseTransformationRangesImpl.TransformationType.INCOMING;
+import static org.batfish.bddreachability.BDDReverseTransformationRangesImpl.TransformationType.OUTGOING;
+
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -8,30 +12,23 @@ import org.batfish.bddreachability.BDDReverseTransformationRangesImpl.Key;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 
 final class MockBDDReverseTransformationRanges implements BDDReverseTransformationRanges {
-  private final Map<Key, BDD> _incomingTransformationRanges;
-  private final Map<Key, BDD> _outgoingTransformationRanges;
+  private final Map<Key, BDD> _ranges;
   private final BDD _zero;
 
-  MockBDDReverseTransformationRanges(
-      BDD zero,
-      Map<Key, BDD> incomingTransformationRanges,
-      Map<Key, BDD> outgoingTransformationRanges) {
+  MockBDDReverseTransformationRanges(BDD zero, Map<Key, BDD> ranges) {
     _zero = zero;
-    _incomingTransformationRanges = incomingTransformationRanges;
-    _outgoingTransformationRanges = outgoingTransformationRanges;
+    _ranges = ImmutableMap.copyOf(ranges);
   }
 
   @Override
   public @Nonnull BDD reverseIncomingTransformationRange(
       String node, String iface, @Nullable String inIface, @Nullable NodeInterfacePair lastHop) {
-    return _incomingTransformationRanges.getOrDefault(
-        new Key(node, iface, inIface, lastHop), _zero);
+    return _ranges.getOrDefault(new Key(node, iface, INCOMING, inIface, lastHop), _zero);
   }
 
   @Override
   public @Nonnull BDD reverseOutgoingTransformationRange(
       String node, String iface, @Nullable String inIface, @Nullable NodeInterfacePair lastHop) {
-    return _outgoingTransformationRanges.getOrDefault(
-        new Key(node, iface, inIface, lastHop), _zero);
+    return _ranges.getOrDefault(new Key(node, iface, OUTGOING, inIface, lastHop), _zero);
   }
 }


### PR DESCRIPTION
The ranges of return-pass sessions depend on the session's out interface and next-hop. In particular, the range should be limited to return-pass flows corresponding to forward-pass flows that entered the session node on that interface, coming from that hop.