### PR TITLE
Juniper: cleanup TCP netscreen grammar and warnings

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
@@ -1281,17 +1281,17 @@ seso_tcp
 :
    TCP
    (
-      FIN_NO_ACK
-      | LAND
+      sesot_fin_no_ack
+      | sesot_land
       | sesot_port_scan
       | sesot_syn_ack_ack_proxy
-      | SYN_FIN
+      | sesot_syn_fin
       | sesot_syn_flood
-      | SYN_FRAG
-      | TCP_NO_FLAG
+      | sesot_syn_frag
+      | sesot_tcp_no_flag
       | sesot_tcp_sweep
-      | WINNUKE
-   )+
+      | sesot_winnuke
+   )
 ;
 
 seso_udp
@@ -1379,6 +1379,16 @@ sesop6_user_option
    USER_DEFINED_OPTION_TYPE type_low=DEC (TO type_high=DEC)?
 ;
 
+sesot_fin_no_ack
+:
+   FIN_NO_ACK
+;
+
+sesot_land
+:
+   LAND
+;
+
 sesot_port_scan
 :
    PORT_SCAN threshold
@@ -1387,6 +1397,11 @@ sesot_port_scan
 sesot_syn_ack_ack_proxy
 :
    SYN_ACK_ACK_PROXY threshold
+;
+
+sesot_syn_fin
+:
+   SYN_FIN
 ;
 
 sesot_syn_flood
@@ -1402,9 +1417,24 @@ sesot_syn_flood
   )
 ;
 
+sesot_syn_frag
+:
+   SYN_FRAG
+;
+
+sesot_tcp_no_flag
+:
+   TCP_NO_FLAG
+;
+
 sesot_tcp_sweep
 :
    TCP_SWEEP threshold
+;
+
+sesot_winnuke
+:
+   WINNUKE
 ;
 
 sesots_alarm_thred

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -508,6 +508,12 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sepctxpm_source_address
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sepctxpm_source_identityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sepctxpt_denyContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sepctxpt_permitContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sesot_fin_no_ackContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sesot_landContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sesot_syn_finContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sesot_syn_fragContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sesot_tcp_no_flagContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sesot_winnukeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sez_security_zoneContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sezs_address_bookContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sezs_host_inbound_trafficContext;
@@ -2986,16 +2992,36 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   }
 
   @Override
-  public void exitSeso_tcp(FlatJuniperParser.Seso_tcpContext ctx) {
-    if (!ctx.TCP_NO_FLAG().isEmpty()) {
-      _currentScreen.getScreenOptions().add(TcpNoFlag.INSTANCE);
-    } else if (!ctx.SYN_FIN().isEmpty()) {
-      _currentScreen.getScreenOptions().add(TcpSynFin.INSTANCE);
-    } else if (!ctx.FIN_NO_ACK().isEmpty()) {
-      _currentScreen.getScreenOptions().add(TcpFinNoAck.INSTANCE);
-    } else {
-      todo(ctx);
-    }
+  public void exitSesot_fin_no_ack(Sesot_fin_no_ackContext ctx) {
+    _currentScreen.getScreenOptions().add(TcpFinNoAck.INSTANCE);
+  }
+
+  @Override
+  public void exitSesot_land(Sesot_landContext ctx) {
+    // Batfish has no way to express SourceIp == DestIp.
+    todo(ctx, "Unsupported netscreen option");
+  }
+
+  @Override
+  public void exitSesot_syn_fin(Sesot_syn_finContext ctx) {
+    _currentScreen.getScreenOptions().add(TcpSynFin.INSTANCE);
+  }
+
+  @Override
+  public void exitSesot_syn_frag(Sesot_syn_fragContext ctx) {
+    // Batfish does not currently model the IP fragmentation bits.
+    todo(ctx, "Unsupported netscreen option");
+  }
+
+  @Override
+  public void exitSesot_tcp_no_flag(Sesot_tcp_no_flagContext ctx) {
+    _currentScreen.getScreenOptions().add(TcpNoFlag.INSTANCE);
+  }
+
+  @Override
+  public void exitSesot_winnuke(Sesot_winnukeContext ctx) {
+    // Batfish does not currently support transformation in filters.
+    todo(ctx, "Unsupported netscreen option");
   }
 
   @Override
@@ -6112,6 +6138,10 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   private void todo(ParserRuleContext ctx) {
     _w.todo(ctx, getFullText(ctx), _parser);
+  }
+
+  private void todo(ParserRuleContext ctx, String message) {
+    _w.addWarning(ctx, getFullText(ctx), _parser, message);
   }
 
   private Family toFamily(F_familyContext ctx) {

--- a/tests/parsing-tests/srx-testbed.ref
+++ b/tests/parsing-tests/srx-testbed.ref
@@ -825,7 +825,8 @@
             "                  text = UNTRUST_SCREEN:'untrust-screen')",
             "                (seso_tcp",
             "                  TCP:'tcp'",
-            "                  LAND:'land')))))))",
+            "                  (sesot_land",
+            "                    LAND:'land'))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line",
             "    SET:'set'",
@@ -3235,7 +3236,8 @@
             "                  text = UNTRUST_SCREEN:'untrust-screen')",
             "                (seso_tcp",
             "                  TCP:'tcp'",
-            "                  LAND:'land')))))))",
+            "                  (sesot_land",
+            "                    LAND:'land'))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line",
             "    SET:'set'",
@@ -5154,7 +5156,8 @@
             "                  text = UNTRUST_SCREEN:'untrust-screen')",
             "                (seso_tcp",
             "                  TCP:'tcp'",
-            "                  LAND:'land')))))))",
+            "                  (sesot_land",
+            "                    LAND:'land'))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line",
             "    SET:'set'",
@@ -6050,40 +6053,10 @@
               "Text" : "ip tear-drop"
             },
             {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 42,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood alarm-threshold 1024"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 43,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood attack-threshold 200"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 44,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood source-threshold 1024"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 45,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood destination-threshold 2048"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 46,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood timeout 20"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
+              "Comment" : "Unsupported netscreen option",
               "Line" : 47,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp land"
+              "Parser_Context" : "[sesot_land seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "land"
             }
           ]
         },
@@ -6108,40 +6081,10 @@
               "Text" : "ip tear-drop"
             },
             {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 42,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood alarm-threshold 1024"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 43,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood attack-threshold 200"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 44,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood source-threshold 1024"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 45,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood destination-threshold 2048"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 46,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood timeout 20"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
+              "Comment" : "Unsupported netscreen option",
               "Line" : 47,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp land"
+              "Parser_Context" : "[sesot_land seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "land"
             }
           ]
         },
@@ -6166,40 +6109,10 @@
               "Text" : "ip tear-drop"
             },
             {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 43,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood alarm-threshold 1024"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 44,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood attack-threshold 200"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 45,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood source-threshold 1024"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 46,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood destination-threshold 2048"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 47,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp syn-flood timeout 20"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
+              "Comment" : "Unsupported netscreen option",
               "Line" : 48,
-              "Parser_Context" : "[seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "tcp land"
+              "Parser_Context" : "[sesot_land seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "land"
             }
           ]
         }


### PR DESCRIPTION
* drop incorrect `+` from grammar
* be consistent: either have subrules or literals, but not both
* add warnings with message for unsupported netscreen options we could/should support
* stop warning about netscreen options related to rate, as Batfish does not model that.