### PR TITLE
Juniper: stop warning on UDP netscreen options

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -3026,11 +3026,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   }
 
   @Override
-  public void exitSeso_udp(FlatJuniperParser.Seso_udpContext ctx) {
-    todo(ctx);
-  }
-
-  @Override
   public void enterSead_address_set(Sead_address_setContext ctx) {
     String name = ctx.name.getText();
     AddressBookEntry entry =


### PR DESCRIPTION
They're all statistics-based, and Batfish does not model that.