### PR TITLE
Juniper: cleanup ICMP netscreen grammar and warnings

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_security.g4
@@ -1243,12 +1243,12 @@ seso_icmp
    ICMP
    (
       sesoi_flood
-      | FRAGMENT
-      | ICMPV6_MALFORMED
+      | sesoi_fragment
+      | sesoi_icmpv6_malformed
       | sesoi_ip_sweep
-      | LARGE
-      | PING_DEATH
-   )+
+      | sesoi_large
+      | sesoi_ping_death
+   )
 ;
 
 seso_ip
@@ -1315,9 +1315,29 @@ sesoi_flood
    FLOOD threshold
 ;
 
+sesoi_fragment
+:
+   FRAGMENT
+;
+
+sesoi_icmpv6_malformed
+:
+   ICMPV6_MALFORMED
+;
+
 sesoi_ip_sweep
 :
    IP_SWEEP threshold
+;
+
+sesoi_large
+:
+   LARGE
+;
+
+sesoi_ping_death
+:
+   PING_DEATH
 ;
 
 sesop_ipv6_extension_header

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -509,6 +509,9 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sepctxpm_source_address
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sepctxpm_source_identityContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sepctxpt_denyContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sepctxpt_permitContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sesoi_fragmentContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sesoi_largeContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sesoi_ping_deathContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sesot_fin_no_ackContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sesot_landContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Sesot_syn_finContext;
@@ -2975,21 +2978,29 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   }
 
   @Override
-  public void exitSeso_icmp(FlatJuniperParser.Seso_icmpContext ctx) {
-    if (!ctx.LARGE().isEmpty()) {
-      _currentScreen.getScreenOptions().add(IcmpLarge.INSTANCE);
-    } else {
-      todo(ctx);
-    }
-  }
-
-  @Override
   public void exitSeso_ip(FlatJuniperParser.Seso_ipContext ctx) {
     if (!ctx.UNKNOWN_PROTOCOL().isEmpty()) {
       _currentScreen.getScreenOptions().add(IpUnknownProtocol.INSTANCE);
     } else {
       todo(ctx);
     }
+  }
+
+  @Override
+  public void exitSesoi_fragment(Sesoi_fragmentContext ctx) {
+    // Batfish does not currently model the IP fragmentation bits.
+    todo(ctx, "Unsupported netscreen ICMP option");
+  }
+
+  @Override
+  public void exitSesoi_large(Sesoi_largeContext ctx) {
+    _currentScreen.getScreenOptions().add(IcmpLarge.INSTANCE);
+  }
+
+  @Override
+  public void exitSesoi_ping_death(Sesoi_ping_deathContext ctx) {
+    // Batfish does not currently model the IP fragmentation bits needed for this.
+    todo(ctx, "Unsupported netscreen ICMP option");
   }
 
   @Override
@@ -3000,7 +3011,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitSesot_land(Sesot_landContext ctx) {
     // Batfish has no way to express SourceIp == DestIp.
-    todo(ctx, "Unsupported netscreen option");
+    todo(ctx, "Unsupported netscreen TCP option");
   }
 
   @Override
@@ -3011,7 +3022,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitSesot_syn_frag(Sesot_syn_fragContext ctx) {
     // Batfish does not currently model the IP fragmentation bits.
-    todo(ctx, "Unsupported netscreen option");
+    todo(ctx, "Unsupported netscreen TCP option");
   }
 
   @Override
@@ -3022,7 +3033,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitSesot_winnuke(Sesot_winnukeContext ctx) {
     // Batfish does not currently support transformation in filters.
-    todo(ctx, "Unsupported netscreen option");
+    todo(ctx, "Unsupported netscreen TCP option");
   }
 
   @Override

--- a/tests/parsing-tests/srx-testbed.ref
+++ b/tests/parsing-tests/srx-testbed.ref
@@ -669,7 +669,8 @@
             "                  text = UNTRUST_SCREEN:'untrust-screen')",
             "                (seso_icmp",
             "                  ICMP:'icmp'",
-            "                  PING_DEATH:'ping-death')))))))",
+            "                  (sesoi_ping_death",
+            "                    PING_DEATH:'ping-death'))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line",
             "    SET:'set'",
@@ -3080,7 +3081,8 @@
             "                  text = UNTRUST_SCREEN:'untrust-screen')",
             "                (seso_icmp",
             "                  ICMP:'icmp'",
-            "                  PING_DEATH:'ping-death')))))))",
+            "                  (sesoi_ping_death",
+            "                    PING_DEATH:'ping-death'))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line",
             "    SET:'set'",
@@ -5000,7 +5002,8 @@
             "                  text = UNTRUST_SCREEN:'untrust-screen')",
             "                (seso_icmp",
             "                  ICMP:'icmp'",
-            "                  PING_DEATH:'ping-death')))))))",
+            "                  (sesoi_ping_death",
+            "                    PING_DEATH:'ping-death'))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line",
             "    SET:'set'",
@@ -6035,10 +6038,10 @@
         "configs/junos-srx-1.cfg" : {
           "Parse warnings" : [
             {
-              "Comment" : "This feature is not currently supported",
+              "Comment" : "Unsupported netscreen ICMP option",
               "Line" : 39,
-              "Parser_Context" : "[seso_icmp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "icmp ping-death"
+              "Parser_Context" : "[sesoi_ping_death seso_icmp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "ping-death"
             },
             {
               "Comment" : "This feature is not currently supported",
@@ -6053,7 +6056,7 @@
               "Text" : "ip tear-drop"
             },
             {
-              "Comment" : "Unsupported netscreen option",
+              "Comment" : "Unsupported netscreen TCP option",
               "Line" : 47,
               "Parser_Context" : "[sesot_land seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "land"
@@ -6063,10 +6066,10 @@
         "configs/junos-srx-2.cfg" : {
           "Parse warnings" : [
             {
-              "Comment" : "This feature is not currently supported",
+              "Comment" : "Unsupported netscreen ICMP option",
               "Line" : 39,
-              "Parser_Context" : "[seso_icmp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "icmp ping-death"
+              "Parser_Context" : "[sesoi_ping_death seso_icmp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "ping-death"
             },
             {
               "Comment" : "This feature is not currently supported",
@@ -6081,7 +6084,7 @@
               "Text" : "ip tear-drop"
             },
             {
-              "Comment" : "Unsupported netscreen option",
+              "Comment" : "Unsupported netscreen TCP option",
               "Line" : 47,
               "Parser_Context" : "[sesot_land seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "land"
@@ -6091,10 +6094,10 @@
         "configs/junos-srx-3.cfg" : {
           "Parse warnings" : [
             {
-              "Comment" : "This feature is not currently supported",
+              "Comment" : "Unsupported netscreen ICMP option",
               "Line" : 40,
-              "Parser_Context" : "[seso_icmp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
-              "Text" : "icmp ping-death"
+              "Parser_Context" : "[sesoi_ping_death seso_icmp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
+              "Text" : "ping-death"
             },
             {
               "Comment" : "This feature is not currently supported",
@@ -6109,7 +6112,7 @@
               "Text" : "ip tear-drop"
             },
             {
-              "Comment" : "Unsupported netscreen option",
+              "Comment" : "Unsupported netscreen TCP option",
               "Line" : 48,
               "Parser_Context" : "[sesot_land seso_tcp ses_ids_option se_screen s_security s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "land"


### PR DESCRIPTION
Same as #3312 , for ICMP.

Reword the message to include the type (ICMP/TCP/etc.)