### PR TITLE
Do not limit interfaces to a VRF when computing dispositions

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Fib.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Fib.java
@@ -26,6 +26,10 @@ public interface Fib extends Serializable {
   @Nonnull
   Set<FibEntry> get(Ip ip);
 
+  /** Return the set of all entries */
+  @Nonnull
+  Set<FibEntry> allEntries();
+
   /**
    * Mapping: matching route -&gt; nexthopinterface -&gt; resolved nextHopIP -&gt; interfaceRoutes
    *
@@ -36,6 +40,8 @@ public interface Fib extends Serializable {
   Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>> getNextHopInterfacesByRoute(
       Ip dstIp);
 
+  /** @deprecated in favor of more general {@link Fib#get(Ip)} */
   @Nonnull
+  @Deprecated
   Map<String, Set<AbstractRoute>> getRoutesByNextHopInterface();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -80,7 +80,7 @@ public final class FibImpl implements Fib {
   /** This trie is the source of truth for all resolved FIB routes */
   @Nonnull private final PrefixTrieMultiMap<FibEntry> _root;
 
-  private transient Supplier<Map<AbstractRoute, Set<FibEntry>>> _entries;
+  private transient Supplier<Set<FibEntry>> _entries;
   private transient Supplier<Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>>
       _nextHopInterfaces;
 
@@ -112,13 +112,13 @@ public final class FibImpl implements Fib {
                         Collectors.mapping(FibEntry::getResolvedToRoute, Collectors.toSet())))));
   }
 
-  private Map<AbstractRoute, Set<FibEntry>> computeEntries() {
-    return _root.getAllElements().stream()
-        .collect(Collectors.groupingBy(FibEntry::getTopLevelRoute, Collectors.toSet()));
+  private Set<FibEntry> computeEntries() {
+    return _root.getAllElements();
   }
 
   @Nonnull
-  public Map<AbstractRoute, Set<FibEntry>> getEntries() {
+  @Override
+  public Set<FibEntry> allEntries() {
     return _entries.get();
   }
 
@@ -307,6 +307,7 @@ public final class FibImpl implements Fib {
   }
 
   @Override
+  @Deprecated
   public @Nonnull Map<String, Set<AbstractRoute>> getRoutesByNextHopInterface() {
     Map<String, ImmutableSet.Builder<AbstractRoute>> routesByNextHopInterface = new HashMap<>();
     getNextHopInterfaces()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -59,7 +59,7 @@ public class ForwardingAnalysisImplTest {
 
   private Interface.Builder _ib;
 
-  private Map<String, Map<String, Set<Interface>>> _fibInterfaces;
+  private Map<String, Map<String, Set<String>>> _fibInterfaces;
 
   private Map<String, Map<String, Set<Ip>>> _interfaceOwnedIps = ImmutableMap.of();
 
@@ -1362,9 +1362,8 @@ public class ForwardingAnalysisImplTest {
                     ImmutableList.of(new ConnectedRoute(i1.getPrimaryNetwork(), i1.getName())))));
 
     // Test:
-    Map<String, Map<String, Set<Interface>>> fibInterfaces =
+    Map<String, Map<String, Set<String>>> fibInterfaces =
         computeFibInterfaces(
-            ImmutableMap.of(hostname, c1),
             ImmutableMap.of(
                 hostname,
                 ImmutableMap.of(
@@ -1374,8 +1373,10 @@ public class ForwardingAnalysisImplTest {
                     MockFib.builder().setFibEntries(fibEntryMap).build())));
 
     // Both vrf1 and vrf2 can go out to i1
-    assertThat(fibInterfaces.get(hostname).get(v1.getName()), equalTo(ImmutableSet.of(i1)));
-    assertThat(fibInterfaces.get(hostname).get(v2.getName()), equalTo(ImmutableSet.of(i1)));
+    assertThat(
+        fibInterfaces.get(hostname).get(v1.getName()), equalTo(ImmutableSet.of(i1.getName())));
+    assertThat(
+        fibInterfaces.get(hostname).get(v2.getName()), equalTo(ImmutableSet.of(i1.getName())));
   }
 
   enum NextHopIpStatus {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockFib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockFib.java
@@ -57,6 +57,7 @@ public class MockFib implements Fib {
       return this;
     }
 
+    @Deprecated
     public Builder setRoutesByNextHopInterface(
         @Nonnull Map<String, Set<AbstractRoute>> routesByNextHopInterface) {
       _routesByNextHopInterface = routesByNextHopInterface;
@@ -95,6 +96,14 @@ public class MockFib implements Fib {
     _fibEntries = ImmutableMap.copyOf(builder._fibEntries);
   }
 
+  @Nonnull
+  @Override
+  public Set<FibEntry> allEntries() {
+    return _fibEntries.values().stream()
+        .flatMap(Set::stream)
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
   @Override
   public @Nonnull Map<AbstractRoute, Map<String, Map<Ip, Set<AbstractRoute>>>>
       getNextHopInterfaces() {
@@ -121,6 +130,7 @@ public class MockFib implements Fib {
   }
 
   @Override
+  @Deprecated
   public @Nonnull Map<String, Set<AbstractRoute>> getRoutesByNextHopInterface() {
     return _routesByNextHopInterface;
   }


### PR DESCRIPTION
Since VRF leaking + PBR there is no longer an invariant that a flow exits out of the same VRF as it arrived on (or the lookup was done in).