### PR TITLE
Fix IPv6 detection for IOS flat BGP neighbors

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -2672,6 +2672,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void enterNeighbor_flat_rb_stanza(Neighbor_flat_rb_stanzaContext ctx) {
+    if (ctx.ip6 != null) {
+      // Remember we are in IPv6 context so that structure references are identified accordingly
+      _inIpv6BgpPeer = true;
+    }
     // do no further processing for unsupported address families / containers
     if (_currentPeerGroup == _dummyPeerGroup) {
       pushPeer(_dummyPeerGroup);
@@ -2699,7 +2703,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         pushPeer(_currentIpPeerGroup);
       }
     } else if (ctx.ip6 != null) {
-      _inIpv6BgpPeer = true;
       Ip6 ip6 = toIp6(ctx.ip6);
       Ipv6BgpPeerGroup pg6 = proc.getIpv6PeerGroups().get(ip6);
       if (pg6 == null) {

--- a/tests/parsing-tests/networks/unit-tests/configs/ios_bgp
+++ b/tests/parsing-tests/networks/unit-tests/configs/ios_bgp
@@ -3,8 +3,13 @@ hostname ios_bgp
 !
 router bgp 1
  neighbor 1.2.3.4 advertise-map ADVERTISE_MAP exist-map EXIST_MAP
+ neighbor 1::1 remote-as 2
  address-family ipv4
   neighbor UNDEFINED_PEER_GROUP activate
+ address-family vpnv6
+  neighbor 1::1 activate
+  neighbor 1::1 prefix-list VPNV6_PL in
+ exit-address-family
 !
 !
 

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -2553,6 +2553,18 @@
       },
       {
         "File_Name" : "configs/ios_bgp",
+        "Struct_Type" : "ipv6 prefix-list",
+        "Ref_Name" : "VPNV6_PL",
+        "Context" : "bgp inbound ipv6 prefix-list",
+        "Lines" : {
+          "filename" : "configs/ios_bgp",
+          "lines" : [
+            11
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/ios_bgp",
         "Struct_Type" : "route-map",
         "Ref_Name" : "ADVERTISE_MAP",
         "Context" : "bgp address-family aggregate-address advertise-map",
@@ -2595,7 +2607,7 @@
         "Lines" : {
           "filename" : "configs/ios_bgp",
           "lines" : [
-            7
+            8
           ]
         }
       },
@@ -4009,10 +4021,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 325 results",
+      "notes" : "Found 326 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 325
+      "numResults" : 326
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -4045,10 +4045,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 327 results",
+      "notes" : "Found 328 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 327
+      "numResults" : 328
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -46134,6 +46134,15 @@
             "                VARIABLE:'EXIST_MAP')",
             "              NEWLINE:'\\n'))))",
             "      (router_bgp_stanza_tail",
+            "        (neighbor_flat_rb_stanza",
+            "          NEIGHBOR:'neighbor'",
+            "          ip6 = IPV6_ADDRESS:'1::1'  <== mode:M_NEIGHBOR",
+            "          (remote_as_bgp_tail",
+            "            REMOTE_AS:'remote-as'",
+            "            remote = (bgp_asn",
+            "              asn = DEC:'2')",
+            "            NEWLINE:'\\n')))",
+            "      (router_bgp_stanza_tail",
             "        (address_family_rb_stanza",
             "          (address_family_header",
             "            ADDRESS_FAMILY:'address-family'",
@@ -46147,7 +46156,33 @@
             "              (activate_bgp_tail",
             "                ACTIVATE:'activate'",
             "                NEWLINE:'\\n')))",
-            "          (address_family_footer)))))",
+            "          (address_family_footer)))",
+            "      (router_bgp_stanza_tail",
+            "        (address_family_rb_stanza",
+            "          (address_family_header",
+            "            ADDRESS_FAMILY:'address-family'",
+            "            af = (bgp_address_family",
+            "              VPNV6:'vpnv6')",
+            "            NEWLINE:'\\n')",
+            "          (neighbor_flat_rb_stanza",
+            "            NEIGHBOR:'neighbor'",
+            "            ip6 = IPV6_ADDRESS:'1::1'  <== mode:M_NEIGHBOR",
+            "            (bgp_tail",
+            "              (activate_bgp_tail",
+            "                ACTIVATE:'activate'",
+            "                NEWLINE:'\\n')))",
+            "          (neighbor_flat_rb_stanza",
+            "            NEIGHBOR:'neighbor'",
+            "            ip6 = IPV6_ADDRESS:'1::1'  <== mode:M_NEIGHBOR",
+            "            (bgp_tail",
+            "              (prefix_list_bgp_tail",
+            "                PREFIX_LIST:'prefix-list'",
+            "                list_name = VARIABLE:'VPNV6_PL'  <== mode:M_Name",
+            "                IN:'in'",
+            "                NEWLINE:'\\n')))",
+            "          (address_family_footer",
+            "            EXIT_ADDRESS_FAMILY:'exit-address-family'",
+            "            NEWLINE:'\\n')))))",
             "  EOF:<EOF>)"
           ]
         },
@@ -78205,6 +78240,13 @@
           }
         },
         "configs/ios_bgp" : {
+          "ipv6 prefix-list" : {
+            "VPNV6_PL" : {
+              "bgp inbound ipv6 prefix-list" : [
+                11
+              ]
+            }
+          },
           "route-map" : {
             "ADVERTISE_MAP" : {
               "bgp address-family aggregate-address advertise-map" : [
@@ -78227,7 +78269,7 @@
           "undeclared bgp peer-group" : {
             "UNDEFINED_PEER_GROUP" : {
               "bgp peer-group referenced before defined" : [
-                7
+                8
               ]
             }
           }
@@ -80959,6 +81001,13 @@
           }
         },
         "configs/ios_bgp" : {
+          "ipv6 prefix-list" : {
+            "VPNV6_PL" : {
+              "bgp inbound ipv6 prefix-list" : [
+                11
+              ]
+            }
+          },
           "route-map" : {
             "ADVERTISE_MAP" : {
               "bgp address-family aggregate-address advertise-map" : [
@@ -80981,7 +81030,7 @@
           "undeclared bgp peer-group" : {
             "UNDEFINED_PEER_GROUP" : {
               "bgp peer-group referenced before defined" : [
-                7
+                8
               ]
             }
           }


### PR DESCRIPTION
- fix bug where unhandled dummy peer groups failed to properly maintain
  IPv6 context