### PR TITLE
Cisco prefix-lists for BGP imports -> VI model

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1865,7 +1865,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       boolean ipv4 = lpg.getNeighborPrefix() != null;
       Ip updateSource = getUpdateSource(c, vrfName, lpg, updateSourceInterface, ipv4);
 
-      RoutingPolicy peerImportPolicy = generateBgpImportPolicy(lpg, vrfName, c, _w);
+      String peerImportPolicyName = generateBgpImportPolicy(lpg, vrfName, c, _w);
 
       String peerExportPolicyName =
           "~BGP_PEER_EXPORT_POLICY:" + vrfName + ":" + lpg.getName() + "~";
@@ -2017,8 +2017,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
           newNeighborBuilder.setGeneratedRoutes(ImmutableSet.of(defaultRoute.build()));
         }
         newNeighborBuilder.setGroup(lpg.getGroupName());
-        if (peerImportPolicy != null) {
-          newNeighborBuilder.setImportPolicy(peerImportPolicy.getName());
+        if (peerImportPolicyName != null) {
+          newNeighborBuilder.setImportPolicy(peerImportPolicyName);
         }
         newNeighborBuilder.setLocalAs(localAs);
         newNeighborBuilder.setLocalIp(updateSource);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -244,6 +244,47 @@ class CiscoConversions {
     return policy;
   }
 
+  @Nullable
+  static RoutingPolicy generateBgpImportPolicy(
+      LeafBgpPeerGroup lpg, String vrfName, Configuration c, Warnings w) {
+    // TODO Support filter-list and distribute-list
+    // https://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/5816-bgpfaq-5816.html
+
+    String inboundRouteMapName = lpg.getInboundRouteMap();
+    String inboundPrefixListName = lpg.getInboundPrefixList();
+
+    // TODO Support using both a route-map and a prefix-list in BGP import policies
+    if (inboundRouteMapName != null && inboundPrefixListName != null) {
+      w.redFlag(
+          "Batfish does not support configuring both a route-map and a prefix-list for incoming BGP routes. When this occurs, the prefix-list will be ignored.");
+    }
+
+    // Warnings for references to undefined route-maps and prefix-lists will be surfaced elsewhere.
+    if (inboundRouteMapName != null && c.getRoutingPolicies().containsKey(inboundRouteMapName)) {
+      // Inbound route-map is defined. Use that as the BGP import policy.
+      // TODO Ignore route-map if it has lines inapplicable to inbound BGP routes (e.g. match tag)
+      return c.getRoutingPolicies().get(inboundRouteMapName);
+    }
+    if (inboundPrefixListName != null
+        && c.getRouteFilterLists().containsKey(inboundPrefixListName)) {
+      // Inbound prefix-list is defined. Build an import policy around it.
+      String generatedImportPolicyName =
+          "~BGP_PEER_IMPORT_POLICY:" + vrfName + ":" + lpg.getName() + "~";
+      return RoutingPolicy.builder()
+          .setOwner(c)
+          .setName(generatedImportPolicyName)
+          .addStatement(
+              new If(
+                  new MatchPrefixSet(
+                      DestinationNetwork.instance(), new NamedPrefixSet(inboundPrefixListName)),
+                  ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
+                  ImmutableList.of(Statements.ExitReject.toStaticStatement())))
+          .build();
+    }
+    // Return null to indicate no constraints were imposed on inbound BGP routes.
+    return null;
+  }
+
   /**
    * Generates and returns a {@link Statement} that suppresses routes that are summarized by the
    * given set of {@link Prefix prefixes} configured as {@code summary-only}.

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -268,7 +268,6 @@ class CiscoConversions {
     // Warnings for references to undefined route-maps and prefix-lists will be surfaced elsewhere.
     if (inboundRouteMapName != null && c.getRoutingPolicies().containsKey(inboundRouteMapName)) {
       // Inbound route-map is defined. Use that as the BGP import policy.
-      // TODO Ignore route-map if it has lines inapplicable to inbound BGP routes (e.g. match tag)
       return inboundRouteMapName;
     }
     if (inboundPrefixListName != null

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -298,6 +298,7 @@ import org.batfish.datamodel.Line;
 import org.batfish.datamodel.LineType;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.NamedPort;
+import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.OspfInternalRoute;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Prefix6;
@@ -2081,6 +2082,40 @@ public class CiscoGrammarTest {
     assertThat(ccae, hasUndefinedReference(filename, PREFIX_LIST, "pre_list_undef1"));
     /* Route-map match context */
     assertThat(ccae, hasUndefinedReference(filename, PREFIX_LIST, "pre_list_undef2"));
+
+    // The defined inbound prefix-list should be converted to a BGP import policy
+    Ip peerAddress = Ip.parse("1.2.3.4");
+    Configuration c = batfish.loadConfigurations().get(hostname);
+    String generatedImportPolicyName =
+        String.format("~BGP_PEER_IMPORT_POLICY:%s:%s~", DEFAULT_VRF_NAME, peerAddress);
+    RoutingPolicy importPolicy = c.getRoutingPolicies().get(generatedImportPolicyName);
+    assertThat(importPolicy, notNullValue());
+
+    // Test that the generated import policy only permits 10.1.1.0/24, as expected
+    Prefix permittedPrefix = Prefix.parse("10.1.1.0/24");
+    BgpRoute.Builder r =
+        BgpRoute.builder()
+            .setOriginatorIp(peerAddress)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.IBGP);
+    BgpRoute permittedRoute = r.setNetwork(permittedPrefix).build();
+    BgpRoute unmatchedRoute = r.setNetwork(Prefix.parse("10.1.0.0/16")).build();
+    assertThat(
+        importPolicy.process(
+            permittedRoute,
+            permittedRoute.toBuilder(),
+            peerAddress,
+            DEFAULT_VRF_NAME,
+            Direction.IN),
+        equalTo(true));
+    assertThat(
+        importPolicy.process(
+            unmatchedRoute,
+            unmatchedRoute.toBuilder(),
+            peerAddress,
+            DEFAULT_VRF_NAME,
+            Direction.IN),
+        equalTo(false));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
@@ -217,9 +217,9 @@ public class CiscoConversionsTest {
         _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
     LeafBgpPeerGroup lpg = new IpBgpPeerGroup(Ip.parse("1.2.3.4"));
     Warnings w = new Warnings(true, true, true);
-    RoutingPolicy bgpImportPolicy = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
+    String bgpImportPolicyName = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
 
-    assertThat(bgpImportPolicy, nullValue());
+    assertThat(bgpImportPolicyName, nullValue());
     assertThat(w.getRedFlagWarnings(), empty());
   }
 
@@ -243,9 +243,12 @@ public class CiscoConversionsTest {
     LeafBgpPeerGroup lpg = new IpBgpPeerGroup(peerAddress);
     lpg.setInboundPrefixList(prefixListName);
     Warnings w = new Warnings(true, true, true);
-    RoutingPolicy bgpImportPolicy = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
-    assertThat(bgpImportPolicy, notNullValue());
+    String bgpImportPolicyName = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
+    assertThat(bgpImportPolicyName, notNullValue());
     assertThat(w.getRedFlagWarnings(), empty());
+
+    RoutingPolicy bgpImportPolicy = c.getRoutingPolicies().get(bgpImportPolicyName);
+    assertThat(bgpImportPolicy, notNullValue());
 
     // Test the generated policy against some routes
     BgpRoute.Builder r =
@@ -296,9 +299,10 @@ public class CiscoConversionsTest {
     lpg.setInboundRouteMap(routeMapName);
     Warnings w = new Warnings(true, true, true);
 
-    RoutingPolicy bgpImportPolicy = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
+    String bgpImportPolicyName = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
 
-    assertThat(bgpImportPolicy, equalTo(routeMap));
+    assertThat(bgpImportPolicyName, equalTo(routeMapName));
+    assertThat(c.getRoutingPolicies().get(bgpImportPolicyName), equalTo(routeMap));
     assertThat(w.getRedFlagWarnings(), empty());
   }
 
@@ -332,9 +336,10 @@ public class CiscoConversionsTest {
     lpg.setInboundRouteMap(routeMapName);
     Warnings w = new Warnings(true, true, true);
 
-    RoutingPolicy bgpImportPolicy = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
+    String bgpImportPolicyName = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
 
-    assertThat(bgpImportPolicy, equalTo(routeMap));
+    assertThat(bgpImportPolicyName, equalTo(routeMapName));
+    assertThat(c.getRoutingPolicies().get(bgpImportPolicyName), equalTo(routeMap));
     assertThat(w.getRedFlagWarnings(), hasSize(1));
     assertThat(
         w.getRedFlagWarnings().get(0).getText(),

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
@@ -1,10 +1,15 @@
 package org.batfish.representation.cisco;
 
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.Interface.INVALID_LOCAL_INTERFACE;
 import static org.batfish.representation.cisco.CiscoConversions.createAclWithSymmetricalLines;
+import static org.batfish.representation.cisco.CiscoConversions.generateBgpImportPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.getMatchingPsk;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
@@ -13,16 +18,30 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.batfish.common.Warnings;
+import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IkeKeyType;
 import org.batfish.datamodel.IkePhase1Key;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixRange;
+import org.batfish.datamodel.RouteFilterLine;
+import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.matchers.IkePhase1KeyMatchers;
+import org.batfish.datamodel.routing_policy.Environment.Direction;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -188,5 +207,139 @@ public class CiscoConversionsTest {
         getMatchingPsk(isakmpProfile, _warnings, ImmutableMap.of(IKE_PHASE1_KEY, ikePhase1Key));
 
     assertThat(matchingKey, is(nullValue()));
+  }
+
+  @Test
+  public void testGenerateBgpImportPolicyWithNoConstraints() {
+    // Create a BGP import policy from a peer group with no constraints on incoming routes.
+    // Resulting import policy should be null.
+    Configuration c =
+        _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    LeafBgpPeerGroup lpg = new IpBgpPeerGroup(Ip.parse("1.2.3.4"));
+    Warnings w = new Warnings(true, true, true);
+    RoutingPolicy bgpImportPolicy = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
+
+    assertThat(bgpImportPolicy, nullValue());
+    assertThat(w.getRedFlagWarnings(), empty());
+  }
+
+  @Test
+  public void testGenerateBgpImportPolicyWithPrefixList() {
+    // Set up a config with a prefix-list and create a BGP import policy from a peer group that uses
+    // that prefix-list to filter incoming routes. Resulting import policy should match prefix-list.
+    String prefixListName = "PREFIX_LIST";
+    Prefix permittedPrefix = Prefix.parse("1.1.1.0/24");
+    Prefix deniedPrefix = Prefix.parse("2.2.2.0/24");
+    Ip peerAddress = Ip.parse("1.2.3.4");
+    Configuration c =
+        _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    RouteFilterList prefixList =
+        new RouteFilterList(
+            prefixListName,
+            ImmutableList.of(
+                new RouteFilterLine(LineAction.PERMIT, PrefixRange.fromPrefix(permittedPrefix)),
+                new RouteFilterLine(LineAction.DENY, PrefixRange.fromPrefix(deniedPrefix))));
+    c.getRouteFilterLists().put(prefixListName, prefixList);
+    LeafBgpPeerGroup lpg = new IpBgpPeerGroup(peerAddress);
+    lpg.setInboundPrefixList(prefixListName);
+    Warnings w = new Warnings(true, true, true);
+    RoutingPolicy bgpImportPolicy = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
+    assertThat(bgpImportPolicy, notNullValue());
+    assertThat(w.getRedFlagWarnings(), empty());
+
+    // Test the generated policy against some routes
+    BgpRoute.Builder r =
+        BgpRoute.builder()
+            .setOriginatorIp(peerAddress)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.IBGP);
+    BgpRoute permittedRoute = r.setNetwork(permittedPrefix).build();
+    BgpRoute deniedRoute = r.setNetwork(deniedPrefix).build();
+    BgpRoute unmatchedRoute = r.setNetwork(Prefix.parse("3.3.3.0/24")).build();
+    assertThat(
+        bgpImportPolicy.process(
+            permittedRoute,
+            permittedRoute.toBuilder(),
+            peerAddress,
+            DEFAULT_VRF_NAME,
+            Direction.IN),
+        equalTo(true));
+    assertThat(
+        bgpImportPolicy.process(
+            deniedRoute, deniedRoute.toBuilder(), peerAddress, DEFAULT_VRF_NAME, Direction.IN),
+        equalTo(false));
+    assertThat(
+        bgpImportPolicy.process(
+            unmatchedRoute,
+            unmatchedRoute.toBuilder(),
+            peerAddress,
+            DEFAULT_VRF_NAME,
+            Direction.IN),
+        equalTo(false));
+  }
+
+  @Test
+  public void testGenerateBgpImportPolicyWithRouteMap() {
+    // Set up a config with a route-map and create a BGP import policy from a peer group that uses
+    // that route-map to filter incoming routes. Resulting import policy should match the route-map.
+    String routeMapName = "ROUTE_MAP";
+    Configuration c =
+        _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    RoutingPolicy routeMap =
+        RoutingPolicy.builder()
+            .setOwner(c)
+            .setName(routeMapName)
+            .addStatement(Statements.ExitReject.toStaticStatement())
+            .build();
+
+    LeafBgpPeerGroup lpg = new IpBgpPeerGroup(Ip.parse("1.2.3.4"));
+    lpg.setInboundRouteMap(routeMapName);
+    Warnings w = new Warnings(true, true, true);
+
+    RoutingPolicy bgpImportPolicy = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
+
+    assertThat(bgpImportPolicy, equalTo(routeMap));
+    assertThat(w.getRedFlagWarnings(), empty());
+  }
+
+  @Test
+  public void testGenerateBgpImportPolicyWithRouteMapAndPrefixList() {
+    // Set up a config with both a route-map and a prefix-list, and create a BGP import policy from
+    // a peer group that uses both to filter incoming routes. Resulting import policy should match
+    // the route-map, and a warning should be generated indicating the prefix-list was ignored.
+    String routeMapName = "ROUTE_MAP";
+    String prefixListName = "PREFIX_LIST";
+    Prefix permittedPrefix = Prefix.parse("1.1.1.0/24");
+    Prefix deniedPrefix = Prefix.parse("2.2.2.0/24");
+    Configuration c =
+        _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    RoutingPolicy routeMap =
+        RoutingPolicy.builder()
+            .setOwner(c)
+            .setName(routeMapName)
+            .addStatement(Statements.ExitReject.toStaticStatement())
+            .build();
+    RouteFilterList prefixList =
+        new RouteFilterList(
+            prefixListName,
+            ImmutableList.of(
+                new RouteFilterLine(LineAction.PERMIT, PrefixRange.fromPrefix(permittedPrefix)),
+                new RouteFilterLine(LineAction.DENY, PrefixRange.fromPrefix(deniedPrefix))));
+    c.getRouteFilterLists().put(prefixListName, prefixList);
+
+    LeafBgpPeerGroup lpg = new IpBgpPeerGroup(Ip.parse("1.2.3.4"));
+    lpg.setInboundPrefixList(prefixListName);
+    lpg.setInboundRouteMap(routeMapName);
+    Warnings w = new Warnings(true, true, true);
+
+    RoutingPolicy bgpImportPolicy = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
+
+    assertThat(bgpImportPolicy, equalTo(routeMap));
+    assertThat(w.getRedFlagWarnings(), hasSize(1));
+    assertThat(
+        w.getRedFlagWarnings().get(0).getText(),
+        equalTo(
+            "Batfish does not support configuring both a route-map and a prefix-list for incoming BGP routes."
+                + " When this occurs, the prefix-list will be ignored."));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-prefix-list
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-prefix-list
@@ -3,8 +3,9 @@ hostname ios-prefix-list
 !
 router bgp 64904
  router-id 11.11.11.11
- neighbor 1.2.3.4 prefix-list pre_list out
- neighbor 1.2.3.4 prefix-list pre_list_undef1 in
+ neighbor 1.2.3.4 remote-as 1234
+ neighbor 1.2.3.4 prefix-list pre_list in
+ neighbor 1.2.3.4 prefix-list pre_list_undef1 out
 !
 route-map STATIC_ONLY permit 10
   match ip address prefix-list pre_list


### PR DESCRIPTION
Generates a BGP import policy for peers with an import prefix-list configured. Until now, those prefix-lists were extracted but ignored.

Follow-up work:
- Get the prefix-list name to appear in the generated import policy's sources
- Support peers that use both an inbound route-map and an inbound prefix-list (right now we use the route-map and ignore the prefix-list)