### PR TITLE
Cisco prefix-lists for BGP exports -> VI model

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -11,6 +11,7 @@ import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PAT
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENGTH;
 import static org.batfish.representation.cisco.CiscoConversions.convertCryptoMapSet;
 import static org.batfish.representation.cisco.CiscoConversions.generateAggregateRoutePolicy;
+import static org.batfish.representation.cisco.CiscoConversions.generateBgpExportPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.generateBgpImportPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.resolveIsakmpProfileIfaceNames;
 import static org.batfish.representation.cisco.CiscoConversions.resolveKeyringIfaceNames;
@@ -148,15 +149,12 @@ import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefix6Set;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
-import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.Not;
 import org.batfish.datamodel.routing_policy.expr.RouteIsClassful;
-import org.batfish.datamodel.routing_policy.expr.SelfNextHop;
 import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
 import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetMetric;
-import org.batfish.datamodel.routing_policy.statement.SetNextHop;
 import org.batfish.datamodel.routing_policy.statement.SetOrigin;
 import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
 import org.batfish.datamodel.routing_policy.statement.Statement;
@@ -307,7 +305,23 @@ public final class CiscoConfiguration extends VendorConfiguration {
   private static final int VLAN_NORMAL_MIN_CISCO = 2;
 
   public static String computeBgpCommonExportPolicyName(String vrf) {
-    return "~BGP_COMMON_EXPORT_POLICY:" + vrf + "~";
+    return String.format("~BGP_COMMON_EXPORT_POLICY:%s~", vrf);
+  }
+
+  public static String computeBgpDefaultRouteExportPolicyName(String vrf, String peer) {
+    return String.format("~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:%s:%s~", vrf, peer);
+  }
+
+  public static String computeBgpDefaultRouteGenerationPolicyName(String vrf, String peer) {
+    return String.format("~BGP_DEFAULT_ROUTE_GENERATION_POLICY:%s:%s~", vrf, peer);
+  }
+
+  public static String computeBgpPeerImportPolicyName(String vrf, String peer) {
+    return String.format("~BGP_PEER_IMPORT_POLICY:%s:%s~", vrf, peer);
+  }
+
+  public static String computeBgpPeerExportPolicyName(String vrf, String peer) {
+    return String.format("~BGP_PEER_EXPORT_POLICY:%s:%s~", vrf, peer);
   }
 
   public static String computeIcmpObjectGroupAclName(String name) {
@@ -1877,63 +1891,20 @@ public final class CiscoConfiguration extends VendorConfiguration {
       boolean ipv4 = lpg.getNeighborPrefix() != null;
       Ip updateSource = getUpdateSource(c, vrfName, lpg, updateSourceInterface, ipv4);
 
+      // Generate import and export policies
       String peerImportPolicyName = generateBgpImportPolicy(lpg, vrfName, c, _w);
-
-      String peerExportPolicyName =
-          "~BGP_PEER_EXPORT_POLICY:" + vrfName + ":" + lpg.getName() + "~";
-      RoutingPolicy peerExportPolicy = new RoutingPolicy(peerExportPolicyName, c);
-      c.getRoutingPolicies().put(peerExportPolicyName, peerExportPolicy);
-      if (lpg.getNextHopSelf() != null && lpg.getNextHopSelf()) {
-        peerExportPolicy.getStatements().add(new SetNextHop(SelfNextHop.getInstance(), false));
-      }
-      if (lpg.getRemovePrivateAs() != null && lpg.getRemovePrivateAs()) {
-        peerExportPolicy.getStatements().add(Statements.RemovePrivateAs.toStaticStatement());
-      }
-      Conjunction peerExportConditions = new Conjunction();
-      If peerExportConditional =
-          new If(
-              "peer-export policy main conditional: exitAccept if true / exitReject if false",
-              peerExportConditions,
-              ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
-              ImmutableList.of(Statements.ExitReject.toStaticStatement()));
-      peerExportPolicy.getStatements().add(peerExportConditional);
-      Disjunction localOrCommonOrigination = new Disjunction();
-      peerExportConditions.getConjuncts().add(localOrCommonOrigination);
-      localOrCommonOrigination.getDisjuncts().add(new CallExpr(bgpCommonExportPolicy.getName()));
-
-      // Add constraints on export routes from configured route-map or prefix-list. If both are
-      // configured, use route-map and warn. TODO support configuring route-map + prefix-list here.
-      String outboundPrefixListName = lpg.getOutboundPrefixList();
-      String outboundRouteMapName = lpg.getOutboundRouteMap();
-      if (outboundPrefixListName != null && outboundRouteMapName != null) {
-        _w.redFlag(
-            "Batfish does not support configuring both a route-map and a prefix-list for outgoing BGP routes."
-                + " When this occurs, the prefix-list will be ignored.");
-      }
-      if (outboundRouteMapName != null
-          && c.getRoutingPolicies().containsKey(outboundRouteMapName)) {
-        peerExportConditions.getConjuncts().add(new CallExpr(outboundRouteMapName));
-      } else if (outboundPrefixListName != null
-          && c.getRouteFilterLists().containsKey(outboundPrefixListName)) {
-        peerExportConditions
-            .getConjuncts()
-            .add(
-                new MatchPrefixSet(
-                    DestinationNetwork.instance(), new NamedPrefixSet(outboundPrefixListName)));
-      }
+      generateBgpExportPolicy(lpg, vrfName, c, _w);
 
       // set up default export policy for this peer group
       GeneratedRoute.Builder defaultRoute = null;
       GeneratedRoute6.Builder defaultRoute6;
       if (lpg.getDefaultOriginate()) {
-        String defaultRouteExportPolicyName;
-        defaultRouteExportPolicyName =
-            String.format("~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:%s:%s~", vrfName, lpg.getName());
-        RoutingPolicy defaultRouteExportPolicy = new RoutingPolicy(defaultRouteExportPolicyName, c);
-        c.getRoutingPolicies().put(defaultRouteExportPolicyName, defaultRouteExportPolicy);
-        defaultRouteExportPolicy
-            .getStatements()
-            .add(
+        String defaultRouteExportPolicyName =
+            computeBgpDefaultRouteExportPolicyName(vrfName, lpg.getName());
+        RoutingPolicy.builder()
+            .setOwner(c)
+            .setName(defaultRouteExportPolicyName)
+            .addStatement(
                 new If(
                     ipv4 ? MATCH_DEFAULT_ROUTE : MATCH_DEFAULT_ROUTE6,
                     ImmutableList.of(
@@ -1943,12 +1914,9 @@ public final class CiscoConfiguration extends VendorConfiguration {
                                     ? OriginType.IGP
                                     : OriginType.INCOMPLETE,
                                 null)),
-                        Statements.ReturnTrue.toStaticStatement())));
-        defaultRouteExportPolicy.getStatements().add(Statements.ReturnFalse.toStaticStatement());
-        localOrCommonOrigination
-            .getDisjuncts()
-            .add(new CallExpr(defaultRouteExportPolicy.getName()));
-
+                        Statements.ReturnTrue.toStaticStatement())))
+            .addStatement(Statements.ReturnFalse.toStaticStatement())
+            .build();
         defaultRoute = GeneratedRoute.builder();
         defaultRoute.setNetwork(Prefix.ZERO);
         defaultRoute.setAdmin(MAX_ADMINISTRATIVE_COST);
@@ -1970,16 +1938,17 @@ public final class CiscoConfiguration extends VendorConfiguration {
               new If(
                   ipv4 ? MATCH_DEFAULT_ROUTE : MATCH_DEFAULT_ROUTE6,
                   ImmutableList.of(Statements.ReturnTrue.toStaticStatement()));
-          RoutingPolicy defaultRouteGenerationPolicy =
-              new RoutingPolicy(
-                  "~BGP_DEFAULT_ROUTE_GENERATION_POLICY:" + vrfName + ":" + lpg.getName() + "~", c);
-          defaultRouteGenerationPolicy.getStatements().add(defaultRouteGenerationConditional);
-          c.getRoutingPolicies()
-              .put(defaultRouteGenerationPolicy.getName(), defaultRouteGenerationPolicy);
+          String defaultRouteGenerationPolicyName =
+              computeBgpDefaultRouteGenerationPolicyName(vrfName, lpg.getName());
+          RoutingPolicy.builder()
+              .setOwner(c)
+              .setName(defaultRouteGenerationPolicyName)
+              .addStatement(defaultRouteGenerationConditional)
+              .build();
           if (ipv4) {
-            defaultRoute.setGenerationPolicy(defaultRouteGenerationPolicy.getName());
+            defaultRoute.setGenerationPolicy(defaultRouteGenerationPolicyName);
           } else {
-            defaultRoute6.setGenerationPolicy(defaultRouteGenerationPolicy.getName());
+            defaultRoute6.setGenerationPolicy(defaultRouteGenerationPolicyName);
           }
         }
       }
@@ -2037,7 +2006,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       }
       newNeighborBuilder.setLocalAs(localAs);
       newNeighborBuilder.setLocalIp(updateSource);
-      newNeighborBuilder.setExportPolicy(peerExportPolicyName);
+      newNeighborBuilder.setExportPolicy(computeBgpPeerExportPolicyName(vrfName, lpg.getName()));
       newNeighborBuilder.setSendCommunity(lpg.getSendCommunity());
       newNeighborBuilder.build();
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1893,30 +1893,12 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
       // Generate import and export policies
       String peerImportPolicyName = generateBgpImportPolicy(lpg, vrfName, c, _w);
-      generateBgpExportPolicy(lpg, vrfName, c, _w);
+      generateBgpExportPolicy(lpg, vrfName, ipv4, c, _w);
 
-      // set up default export policy for this peer group
+      // If defaultOriginate is set, create default route for this peer group
       GeneratedRoute.Builder defaultRoute = null;
       GeneratedRoute6.Builder defaultRoute6;
       if (lpg.getDefaultOriginate()) {
-        String defaultRouteExportPolicyName =
-            computeBgpDefaultRouteExportPolicyName(vrfName, lpg.getName());
-        RoutingPolicy.builder()
-            .setOwner(c)
-            .setName(defaultRouteExportPolicyName)
-            .addStatement(
-                new If(
-                    ipv4 ? MATCH_DEFAULT_ROUTE : MATCH_DEFAULT_ROUTE6,
-                    ImmutableList.of(
-                        new SetOrigin(
-                            new LiteralOrigin(
-                                c.getConfigurationFormat() == ConfigurationFormat.CISCO_IOS
-                                    ? OriginType.IGP
-                                    : OriginType.INCOMPLETE,
-                                null)),
-                        Statements.ReturnTrue.toStaticStatement())))
-            .addStatement(Statements.ReturnFalse.toStaticStatement())
-            .build();
         defaultRoute = GeneratedRoute.builder();
         defaultRoute.setNetwork(Prefix.ZERO);
         defaultRoute.setAdmin(MAX_ADMINISTRATIVE_COST);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -4,6 +4,10 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Collections.singletonList;
 import static org.batfish.datamodel.Interface.INVALID_LOCAL_INTERFACE;
 import static org.batfish.datamodel.Interface.UNSET_LOCAL_INTERFACE;
+import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpCommonExportPolicyName;
+import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpDefaultRouteExportPolicyName;
+import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpPeerExportPolicyName;
+import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpPeerImportPolicyName;
 import static org.batfish.representation.cisco.CiscoConfiguration.computeProtocolObjectGroupAclName;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -92,8 +96,10 @@ import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.MatchProcessAsn;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
 import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.SelfNextHop;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetEigrpMetric;
+import org.batfish.datamodel.routing_policy.statement.SetNextHop;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.visitors.HeaderSpaceConverter;
@@ -273,8 +279,7 @@ class CiscoConversions {
     if (inboundPrefixListName != null
         && c.getRouteFilterLists().containsKey(inboundPrefixListName)) {
       // Inbound prefix-list is defined. Build an import policy around it.
-      String generatedImportPolicyName =
-          "~BGP_PEER_IMPORT_POLICY:" + vrfName + ":" + lpg.getName() + "~";
+      String generatedImportPolicyName = computeBgpPeerImportPolicyName(vrfName, lpg.getName());
       RoutingPolicy.builder()
           .setOwner(c)
           .setName(generatedImportPolicyName)
@@ -289,6 +294,60 @@ class CiscoConversions {
     }
     // Return null to indicate no constraints were imposed on inbound BGP routes.
     return null;
+  }
+
+  /**
+   * Creates a {@link RoutingPolicy} to be used as the BGP export policy for the given {@link
+   * LeafBgpPeerGroup}. The generated policy is added to the given configuration's routing policies.
+   */
+  static void generateBgpExportPolicy(
+      LeafBgpPeerGroup lpg, String vrfName, Configuration c, Warnings w) {
+    List<Statement> exportPolicyStatements = new ArrayList<>();
+    if (lpg.getNextHopSelf() != null && lpg.getNextHopSelf()) {
+      exportPolicyStatements.add(new SetNextHop(SelfNextHop.getInstance(), false));
+    }
+    if (lpg.getRemovePrivateAs() != null && lpg.getRemovePrivateAs()) {
+      exportPolicyStatements.add(Statements.RemovePrivateAs.toStaticStatement());
+    }
+
+    List<BooleanExpr> localOrCommonOriginationDisjuncts = new ArrayList<>();
+    localOrCommonOriginationDisjuncts.add(new CallExpr(computeBgpCommonExportPolicyName(vrfName)));
+    if (lpg.getDefaultOriginate()) {
+      localOrCommonOriginationDisjuncts.add(
+          new CallExpr(computeBgpDefaultRouteExportPolicyName(vrfName, lpg.getName())));
+    }
+
+    List<BooleanExpr> peerExportConjuncts = new ArrayList<>();
+    peerExportConjuncts.add(new Disjunction(localOrCommonOriginationDisjuncts));
+
+    // Add constraints on export routes from configured route-map or prefix-list. If both are
+    // configured, use route-map and warn. TODO support configuring route-map + prefix-list here.
+    String outboundPrefixListName = lpg.getOutboundPrefixList();
+    String outboundRouteMapName = lpg.getOutboundRouteMap();
+    if (outboundPrefixListName != null && outboundRouteMapName != null) {
+      w.redFlag(
+          "Batfish does not support configuring both a route-map and a prefix-list for outgoing BGP routes."
+              + " When this occurs, the prefix-list will be ignored.");
+    }
+    if (outboundRouteMapName != null && c.getRoutingPolicies().containsKey(outboundRouteMapName)) {
+      peerExportConjuncts.add(new CallExpr(outboundRouteMapName));
+    } else if (outboundPrefixListName != null
+        && c.getRouteFilterLists().containsKey(outboundPrefixListName)) {
+      peerExportConjuncts.add(
+          new MatchPrefixSet(
+              DestinationNetwork.instance(), new NamedPrefixSet(outboundPrefixListName)));
+    }
+    exportPolicyStatements.add(
+        new If(
+            "peer-export policy main conditional: exitAccept if true / exitReject if false",
+            new Conjunction(peerExportConjuncts),
+            ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
+            ImmutableList.of(Statements.ExitReject.toStaticStatement())));
+    RoutingPolicy.builder()
+        .setOwner(c)
+        .setName(computeBgpPeerExportPolicyName(vrfName, lpg.getName()))
+        .setStatements(exportPolicyStatements)
+        .build();
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsBgpPoliciesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsBgpPoliciesTest.java
@@ -137,8 +137,8 @@ public class CiscoConversionsBgpPoliciesTest {
             .setOriginatorIp(PEER_ADDRESS)
             .setOriginType(OriginType.IGP)
             .setProtocol(RoutingProtocol.IBGP);
-    BgpRoute permitted = r.setCommunities(ImmutableSet.of(10L)).build();
-    BgpRoute denied = r.setCommunities(ImmutableSet.of(20L)).build();
+    BgpRoute permitted = r.setCommunities(PERMITTED_COMMUNITY_SET).build();
+    BgpRoute denied = r.setCommunities(DENIED_COMMUNITY_SET).build();
     BgpRoute unmatched = r.setCommunities(ImmutableSet.of(30L)).build();
     assertThat(
         p.process(permitted, permitted.toBuilder(), PEER_ADDRESS, DEFAULT_VRF_NAME, direction),

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsBgpPoliciesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsBgpPoliciesTest.java
@@ -1,0 +1,299 @@
+package org.batfish.representation.cisco;
+
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpCommonExportPolicyName;
+import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpPeerExportPolicyName;
+import static org.batfish.representation.cisco.CiscoConversions.generateBgpExportPolicy;
+import static org.batfish.representation.cisco.CiscoConversions.generateBgpImportPolicy;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixRange;
+import org.batfish.datamodel.RouteFilterLine;
+import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.RoutingProtocol;
+import org.batfish.datamodel.routing_policy.Environment.Direction;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet;
+import org.batfish.datamodel.routing_policy.expr.MatchCommunitySet;
+import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.Statements;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link CiscoConversions} class */
+@RunWith(JUnit4.class)
+public class CiscoConversionsBgpPoliciesTest {
+
+  private static final Ip PEER_ADDRESS = Ip.parse("1.2.3.4");
+  private static final String PREFIX_LIST_NAME = "PREFIX_LIST";
+  private static final String ROUTE_MAP_NAME = "ROUTE_MAP";
+  private static final Prefix PERMITTED_PREFIX = Prefix.parse("1.1.1.0/24");
+  private static final Prefix DENIED_PREFIX = Prefix.parse("2.2.2.0/24");
+  private static final Set<Long> PERMITTED_COMMUNITY_SET = ImmutableSet.of(10L);
+  private static final Set<Long> DENIED_COMMUNITY_SET = ImmutableSet.of(20L);
+
+  private Configuration _c;
+  private Warnings _w;
+  private LeafBgpPeerGroup _peerGroup;
+
+  /**
+   * Initializes {@link #_c} to be a configuration that contains:
+   *
+   * <ul>
+   *   <li>a BGP common export policy that accepts all routes
+   *   <li>{@link RoutingPolicy} called {@link #ROUTE_MAP_NAME} that accepts routes with community
+   *       {@link #PERMITTED_COMMUNITY_SET} and denies routes with community {@link
+   *       #DENIED_COMMUNITY_SET}
+   *   <li>{@link RouteFilterList} called {@link #PREFIX_LIST_NAME} that accepts routes to {@link
+   *       #PERMITTED_PREFIX} and denies routes to {@link #DENIED_PREFIX}
+   * </ul>
+   */
+  @Before
+  public void before() {
+    _w = new Warnings(true, true, true);
+    _peerGroup = new IpBgpPeerGroup(PEER_ADDRESS);
+
+    NetworkFactory nf = new NetworkFactory();
+    _c = nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    RoutingPolicy.builder()
+        .setName(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
+        .setOwner(_c)
+        .addStatement(Statements.ReturnTrue.toStaticStatement())
+        .build();
+    RouteFilterList prefixList =
+        new RouteFilterList(
+            PREFIX_LIST_NAME,
+            ImmutableList.of(
+                new RouteFilterLine(LineAction.PERMIT, PrefixRange.fromPrefix(PERMITTED_PREFIX)),
+                new RouteFilterLine(LineAction.DENY, PrefixRange.fromPrefix(DENIED_PREFIX))));
+    _c.getRouteFilterLists().put(PREFIX_LIST_NAME, prefixList);
+    RoutingPolicy.builder()
+        .setOwner(_c)
+        .setName(ROUTE_MAP_NAME)
+        .addStatement(
+            new If(
+                new MatchCommunitySet(new LiteralCommunitySet(PERMITTED_COMMUNITY_SET)),
+                ImmutableList.of(Statements.ReturnTrue.toStaticStatement())))
+        .addStatement(
+            new If(
+                new MatchCommunitySet(new LiteralCommunitySet(DENIED_COMMUNITY_SET)),
+                ImmutableList.of(Statements.ReturnFalse.toStaticStatement())))
+        .addStatement(Statements.ReturnFalse.toStaticStatement())
+        .build();
+  }
+
+  /**
+   * Tests that the given {@link RoutingPolicy} permits route with prefix {@link #PERMITTED_PREFIX}
+   * and denies routes with prefix {@link #DENIED_PREFIX} or arbitrary other prefix.
+   */
+  private void testPolicyMatchesPrefixList(RoutingPolicy p, Direction direction) {
+    BgpRoute.Builder r =
+        BgpRoute.builder()
+            .setOriginatorIp(PEER_ADDRESS)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.IBGP);
+    BgpRoute permitted = r.setNetwork(PERMITTED_PREFIX).build();
+    BgpRoute denied = r.setNetwork(DENIED_PREFIX).build();
+    BgpRoute unmatched = r.setNetwork(Prefix.parse("3.3.3.0/24")).build();
+    assertThat(
+        p.process(permitted, permitted.toBuilder(), PEER_ADDRESS, DEFAULT_VRF_NAME, direction),
+        equalTo(true));
+    assertThat(
+        p.process(denied, denied.toBuilder(), PEER_ADDRESS, DEFAULT_VRF_NAME, direction),
+        equalTo(false));
+    assertThat(
+        p.process(unmatched, unmatched.toBuilder(), PEER_ADDRESS, DEFAULT_VRF_NAME, direction),
+        equalTo(false));
+  }
+
+  /**
+   * Tests that the given {@link RoutingPolicy} permits route with community {@link
+   * #PERMITTED_COMMUNITY_SET} and denies routes with community {@link #DENIED_COMMUNITY_SET} or
+   * arbitrary other community.
+   */
+  private void testPolicyMatchesRouteMap(RoutingPolicy p, Direction direction) {
+    BgpRoute.Builder r =
+        BgpRoute.builder()
+            .setNetwork(Prefix.parse("5.6.7.0/24"))
+            .setOriginatorIp(PEER_ADDRESS)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.IBGP);
+    BgpRoute permitted = r.setCommunities(ImmutableSet.of(10L)).build();
+    BgpRoute denied = r.setCommunities(ImmutableSet.of(20L)).build();
+    BgpRoute unmatched = r.setCommunities(ImmutableSet.of(30L)).build();
+    assertThat(
+        p.process(permitted, permitted.toBuilder(), PEER_ADDRESS, DEFAULT_VRF_NAME, direction),
+        equalTo(true));
+    assertThat(
+        p.process(denied, denied.toBuilder(), PEER_ADDRESS, DEFAULT_VRF_NAME, direction),
+        equalTo(false));
+    assertThat(
+        p.process(unmatched, unmatched.toBuilder(), PEER_ADDRESS, DEFAULT_VRF_NAME, direction),
+        equalTo(false));
+  }
+
+  @Test
+  public void testGenerateBgpImportPolicyWithNoConstraints() {
+    // Create a BGP import policy from a peer group with no constraints on incoming routes.
+    // Resulting import policy should be null.
+    String bgpImportPolicyName = generateBgpImportPolicy(_peerGroup, DEFAULT_VRF_NAME, _c, _w);
+    assertThat(bgpImportPolicyName, nullValue());
+    assertThat(_w.getRedFlagWarnings(), empty());
+  }
+
+  @Test
+  public void testGenerateBgpExportPolicyWithNoConstraints() {
+    // Create a BGP export policy from a peer group with no constraints on outgoing routes.
+    // Resulting export policy should accept any BGP routes.
+    _peerGroup.setDefaultOriginate(false);
+    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, _c, _w);
+    RoutingPolicy bgpExportPolicy =
+        _c.getRoutingPolicies()
+            .get(computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, _peerGroup.getName()));
+    assertThat(bgpExportPolicy, notNullValue());
+    assertThat(_w.getRedFlagWarnings(), empty());
+
+    BgpRoute.Builder r =
+        BgpRoute.builder()
+            .setOriginatorIp(PEER_ADDRESS)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.IBGP)
+            .setNetwork(Prefix.parse("5.6.7.0/24"));
+    assertThat(
+        bgpExportPolicy.process(r.build(), r, PEER_ADDRESS, DEFAULT_VRF_NAME, Direction.OUT),
+        equalTo(true));
+  }
+
+  @Test
+  public void testGenerateBgpImportPolicyWithPrefixList() {
+    // Create a BGP import policy from a peer group that uses the prefix-list to filter incoming
+    // routes. Resulting import policy should match prefix-list.
+    _peerGroup.setInboundPrefixList(PREFIX_LIST_NAME);
+    String bgpImportPolicyName = generateBgpImportPolicy(_peerGroup, DEFAULT_VRF_NAME, _c, _w);
+    assertThat(bgpImportPolicyName, notNullValue());
+    assertThat(_w.getRedFlagWarnings(), empty());
+
+    RoutingPolicy bgpImportPolicy = _c.getRoutingPolicies().get(bgpImportPolicyName);
+    assertThat(bgpImportPolicy, notNullValue());
+
+    // Test that the generated policy matches the prefix list
+    testPolicyMatchesPrefixList(bgpImportPolicy, Direction.IN);
+  }
+
+  @Test
+  public void testGenerateBgpExportPolicyWithPrefixList() {
+    // Create a BGP export policy from a peer group that uses the prefix-list to filter outgoing
+    // routes. Resulting export policy should match prefix-list.
+    _peerGroup.setDefaultOriginate(false);
+    _peerGroup.setOutboundPrefixList(PREFIX_LIST_NAME);
+    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, _c, _w);
+
+    RoutingPolicy bgpExportPolicy =
+        _c.getRoutingPolicies()
+            .get(computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, _peerGroup.getName()));
+    assertThat(bgpExportPolicy, notNullValue());
+    assertThat(_w.getRedFlagWarnings(), empty());
+
+    // Test that the generated policy matches the prefix list
+    testPolicyMatchesPrefixList(bgpExportPolicy, Direction.OUT);
+  }
+
+  @Test
+  public void testGenerateBgpImportPolicyWithRouteMap() {
+    // Create a BGP import policy from a peer group that uses the route-map to filter incoming
+    // routes. Resulting import policy should be the route-map.
+    _peerGroup.setInboundRouteMap(ROUTE_MAP_NAME);
+    String bgpImportPolicyName = generateBgpImportPolicy(_peerGroup, DEFAULT_VRF_NAME, _c, _w);
+
+    RoutingPolicy bgpImportPolicy = _c.getRoutingPolicies().get(bgpImportPolicyName);
+    assertThat(bgpImportPolicy, notNullValue());
+    assertThat(_w.getRedFlagWarnings(), empty());
+
+    // Test that the generated policy matches the route map
+    testPolicyMatchesRouteMap(bgpImportPolicy, Direction.IN);
+  }
+
+  @Test
+  public void testGenerateBgpExportPolicyWithRouteMap() {
+    // Create a BGP export policy from a peer group that uses the route-map to filter outgoing
+    // routes. Resulting export policy should match the route-map.
+    _peerGroup.setOutboundRouteMap(ROUTE_MAP_NAME);
+    _peerGroup.setDefaultOriginate(false);
+    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, _c, _w);
+
+    RoutingPolicy bgpExportPolicy =
+        _c.getRoutingPolicies()
+            .get(computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, _peerGroup.getName()));
+    assertThat(bgpExportPolicy, notNullValue());
+    assertThat(_w.getRedFlagWarnings(), empty());
+
+    // Test that the generated policy matches the route map
+    testPolicyMatchesRouteMap(bgpExportPolicy, Direction.OUT);
+  }
+
+  @Test
+  public void testGenerateBgpImportPolicyWithRouteMapAndPrefixList() {
+    // Create a BGP import policy from a peer group that uses both to filter incoming routes.
+    // Resulting import policy should be the route-map, and a warning should be generated indicating
+    // the prefix-list was ignored.
+    _peerGroup.setInboundPrefixList(PREFIX_LIST_NAME);
+    _peerGroup.setInboundRouteMap(ROUTE_MAP_NAME);
+    String bgpImportPolicyName = generateBgpImportPolicy(_peerGroup, DEFAULT_VRF_NAME, _c, _w);
+
+    RoutingPolicy bgpImportPolicy = _c.getRoutingPolicies().get(bgpImportPolicyName);
+    assertThat(bgpImportPolicy, notNullValue());
+    assertThat(_w.getRedFlagWarnings(), hasSize(1));
+    assertThat(
+        _w.getRedFlagWarnings().get(0).getText(),
+        equalTo(
+            "Batfish does not support configuring both a route-map and a prefix-list for incoming BGP routes."
+                + " When this occurs, the prefix-list will be ignored."));
+
+    // Test that the generated policy matches the route map
+    testPolicyMatchesRouteMap(bgpImportPolicy, Direction.IN);
+  }
+
+  @Test
+  public void testGenerateBgpExportPolicyWithRouteMapAndPrefixList() {
+    // Create a BGP export policy from a peer group that uses both to filter outgoing routes.
+    // Resulting export policy should match the route-map, and a warning should be generated
+    // indicating the prefix-list was ignored.
+    _peerGroup.setOutboundPrefixList(PREFIX_LIST_NAME);
+    _peerGroup.setOutboundRouteMap(ROUTE_MAP_NAME);
+    _peerGroup.setDefaultOriginate(false);
+    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, _c, _w);
+
+    RoutingPolicy bgpExportPolicy =
+        _c.getRoutingPolicies()
+            .get(computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, _peerGroup.getName()));
+    assertThat(bgpExportPolicy, notNullValue());
+    assertThat(_w.getRedFlagWarnings(), hasSize(1));
+    assertThat(
+        _w.getRedFlagWarnings().get(0).getText(),
+        equalTo(
+            "Batfish does not support configuring both a route-map and a prefix-list for outgoing BGP routes."
+                + " When this occurs, the prefix-list will be ignored."));
+
+    // Test that the generated policy matches the route map
+    testPolicyMatchesRouteMap(bgpExportPolicy, Direction.OUT);
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsBgpPoliciesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsBgpPoliciesTest.java
@@ -165,7 +165,7 @@ public class CiscoConversionsBgpPoliciesTest {
     // Create a BGP export policy from a peer group with no constraints on outgoing routes.
     // Resulting export policy should accept any BGP routes.
     _peerGroup.setDefaultOriginate(false);
-    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, _c, _w);
+    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, true, _c, _w);
     RoutingPolicy bgpExportPolicy =
         _c.getRoutingPolicies()
             .get(computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, _peerGroup.getName()));
@@ -205,7 +205,7 @@ public class CiscoConversionsBgpPoliciesTest {
     // routes. Resulting export policy should match prefix-list.
     _peerGroup.setDefaultOriginate(false);
     _peerGroup.setOutboundPrefixList(PREFIX_LIST_NAME);
-    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, _c, _w);
+    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, true, _c, _w);
 
     RoutingPolicy bgpExportPolicy =
         _c.getRoutingPolicies()
@@ -238,7 +238,7 @@ public class CiscoConversionsBgpPoliciesTest {
     // routes. Resulting export policy should match the route-map.
     _peerGroup.setOutboundRouteMap(ROUTE_MAP_NAME);
     _peerGroup.setDefaultOriginate(false);
-    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, _c, _w);
+    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, true, _c, _w);
 
     RoutingPolicy bgpExportPolicy =
         _c.getRoutingPolicies()
@@ -280,7 +280,7 @@ public class CiscoConversionsBgpPoliciesTest {
     _peerGroup.setOutboundPrefixList(PREFIX_LIST_NAME);
     _peerGroup.setOutboundRouteMap(ROUTE_MAP_NAME);
     _peerGroup.setDefaultOriginate(false);
-    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, _c, _w);
+    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, true, _c, _w);
 
     RoutingPolicy bgpExportPolicy =
         _c.getRoutingPolicies()

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
@@ -1,15 +1,10 @@
 package org.batfish.representation.cisco;
 
-import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.Interface.INVALID_LOCAL_INTERFACE;
 import static org.batfish.representation.cisco.CiscoConversions.createAclWithSymmetricalLines;
-import static org.batfish.representation.cisco.CiscoConversions.generateBgpImportPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.getMatchingPsk;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
@@ -18,30 +13,16 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.batfish.common.Warnings;
-import org.batfish.datamodel.BgpRoute;
-import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IkeKeyType;
 import org.batfish.datamodel.IkePhase1Key;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.NetworkFactory;
-import org.batfish.datamodel.OriginType;
-import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.PrefixRange;
-import org.batfish.datamodel.RouteFilterLine;
-import org.batfish.datamodel.RouteFilterList;
-import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.matchers.IkePhase1KeyMatchers;
-import org.batfish.datamodel.routing_policy.Environment.Direction;
-import org.batfish.datamodel.routing_policy.RoutingPolicy;
-import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -207,144 +188,5 @@ public class CiscoConversionsTest {
         getMatchingPsk(isakmpProfile, _warnings, ImmutableMap.of(IKE_PHASE1_KEY, ikePhase1Key));
 
     assertThat(matchingKey, is(nullValue()));
-  }
-
-  @Test
-  public void testGenerateBgpImportPolicyWithNoConstraints() {
-    // Create a BGP import policy from a peer group with no constraints on incoming routes.
-    // Resulting import policy should be null.
-    Configuration c =
-        _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
-    LeafBgpPeerGroup lpg = new IpBgpPeerGroup(Ip.parse("1.2.3.4"));
-    Warnings w = new Warnings(true, true, true);
-    String bgpImportPolicyName = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
-
-    assertThat(bgpImportPolicyName, nullValue());
-    assertThat(w.getRedFlagWarnings(), empty());
-  }
-
-  @Test
-  public void testGenerateBgpImportPolicyWithPrefixList() {
-    // Set up a config with a prefix-list and create a BGP import policy from a peer group that uses
-    // that prefix-list to filter incoming routes. Resulting import policy should match prefix-list.
-    String prefixListName = "PREFIX_LIST";
-    Prefix permittedPrefix = Prefix.parse("1.1.1.0/24");
-    Prefix deniedPrefix = Prefix.parse("2.2.2.0/24");
-    Ip peerAddress = Ip.parse("1.2.3.4");
-    Configuration c =
-        _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
-    RouteFilterList prefixList =
-        new RouteFilterList(
-            prefixListName,
-            ImmutableList.of(
-                new RouteFilterLine(LineAction.PERMIT, PrefixRange.fromPrefix(permittedPrefix)),
-                new RouteFilterLine(LineAction.DENY, PrefixRange.fromPrefix(deniedPrefix))));
-    c.getRouteFilterLists().put(prefixListName, prefixList);
-    LeafBgpPeerGroup lpg = new IpBgpPeerGroup(peerAddress);
-    lpg.setInboundPrefixList(prefixListName);
-    Warnings w = new Warnings(true, true, true);
-    String bgpImportPolicyName = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
-    assertThat(bgpImportPolicyName, notNullValue());
-    assertThat(w.getRedFlagWarnings(), empty());
-
-    RoutingPolicy bgpImportPolicy = c.getRoutingPolicies().get(bgpImportPolicyName);
-    assertThat(bgpImportPolicy, notNullValue());
-
-    // Test the generated policy against some routes
-    BgpRoute.Builder r =
-        BgpRoute.builder()
-            .setOriginatorIp(peerAddress)
-            .setOriginType(OriginType.IGP)
-            .setProtocol(RoutingProtocol.IBGP);
-    BgpRoute permittedRoute = r.setNetwork(permittedPrefix).build();
-    BgpRoute deniedRoute = r.setNetwork(deniedPrefix).build();
-    BgpRoute unmatchedRoute = r.setNetwork(Prefix.parse("3.3.3.0/24")).build();
-    assertThat(
-        bgpImportPolicy.process(
-            permittedRoute,
-            permittedRoute.toBuilder(),
-            peerAddress,
-            DEFAULT_VRF_NAME,
-            Direction.IN),
-        equalTo(true));
-    assertThat(
-        bgpImportPolicy.process(
-            deniedRoute, deniedRoute.toBuilder(), peerAddress, DEFAULT_VRF_NAME, Direction.IN),
-        equalTo(false));
-    assertThat(
-        bgpImportPolicy.process(
-            unmatchedRoute,
-            unmatchedRoute.toBuilder(),
-            peerAddress,
-            DEFAULT_VRF_NAME,
-            Direction.IN),
-        equalTo(false));
-  }
-
-  @Test
-  public void testGenerateBgpImportPolicyWithRouteMap() {
-    // Set up a config with a route-map and create a BGP import policy from a peer group that uses
-    // that route-map to filter incoming routes. Resulting import policy should match the route-map.
-    String routeMapName = "ROUTE_MAP";
-    Configuration c =
-        _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
-    RoutingPolicy routeMap =
-        RoutingPolicy.builder()
-            .setOwner(c)
-            .setName(routeMapName)
-            .addStatement(Statements.ExitReject.toStaticStatement())
-            .build();
-
-    LeafBgpPeerGroup lpg = new IpBgpPeerGroup(Ip.parse("1.2.3.4"));
-    lpg.setInboundRouteMap(routeMapName);
-    Warnings w = new Warnings(true, true, true);
-
-    String bgpImportPolicyName = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
-
-    assertThat(bgpImportPolicyName, equalTo(routeMapName));
-    assertThat(c.getRoutingPolicies().get(bgpImportPolicyName), equalTo(routeMap));
-    assertThat(w.getRedFlagWarnings(), empty());
-  }
-
-  @Test
-  public void testGenerateBgpImportPolicyWithRouteMapAndPrefixList() {
-    // Set up a config with both a route-map and a prefix-list, and create a BGP import policy from
-    // a peer group that uses both to filter incoming routes. Resulting import policy should match
-    // the route-map, and a warning should be generated indicating the prefix-list was ignored.
-    String routeMapName = "ROUTE_MAP";
-    String prefixListName = "PREFIX_LIST";
-    Prefix permittedPrefix = Prefix.parse("1.1.1.0/24");
-    Prefix deniedPrefix = Prefix.parse("2.2.2.0/24");
-    Configuration c =
-        _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
-    RoutingPolicy routeMap =
-        RoutingPolicy.builder()
-            .setOwner(c)
-            .setName(routeMapName)
-            .addStatement(Statements.ExitReject.toStaticStatement())
-            .build();
-    RouteFilterList prefixList =
-        new RouteFilterList(
-            prefixListName,
-            ImmutableList.of(
-                new RouteFilterLine(LineAction.PERMIT, PrefixRange.fromPrefix(permittedPrefix)),
-                new RouteFilterLine(LineAction.DENY, PrefixRange.fromPrefix(deniedPrefix))));
-    c.getRouteFilterLists().put(prefixListName, prefixList);
-
-    LeafBgpPeerGroup lpg = new IpBgpPeerGroup(Ip.parse("1.2.3.4"));
-    lpg.setInboundPrefixList(prefixListName);
-    lpg.setInboundRouteMap(routeMapName);
-    Warnings w = new Warnings(true, true, true);
-
-    String bgpImportPolicyName = generateBgpImportPolicy(lpg, DEFAULT_VRF_NAME, c, w);
-
-    assertThat(bgpImportPolicyName, equalTo(routeMapName));
-    assertThat(c.getRoutingPolicies().get(bgpImportPolicyName), equalTo(routeMap));
-    assertThat(w.getRedFlagWarnings(), hasSize(1));
-    assertThat(
-        w.getRedFlagWarnings().get(0).getText(),
-        equalTo(
-            "Batfish does not support configuring both a route-map and a prefix-list for incoming BGP routes."
-                + " When this occurs, the prefix-list will be ignored."));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-prefix-list
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-prefix-list
@@ -5,7 +5,10 @@ router bgp 64904
  router-id 11.11.11.11
  neighbor 1.2.3.4 remote-as 1234
  neighbor 1.2.3.4 prefix-list pre_list in
- neighbor 1.2.3.4 prefix-list pre_list_undef1 out
+ neighbor 1.2.3.4 prefix-list pre_list out
+!
+! For testing undefined prefix-list in BGP neighbor context
+ neighbor 5.6.7.8 prefix-list pre_list_undef1 out
 !
 route-map STATIC_ONLY permit 10
   match ip address prefix-list pre_list


### PR DESCRIPTION
Adds a MatchPrefixList to BGP export policy for peers with an export prefix-list configured. Until now, those prefix-lists were extracted but ignored.

Follow-up work:
- Get the prefix-list name to appear in the generated export policy's sources
- Support peers that use both an outbound route-map and an outbound prefix-list (right now we use the route-map and ignore the prefix-list)