### PR TITLE
Juniper: don't try to generate transformations without an interface IP

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1643,7 +1643,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
   }
 
   private Transformation buildIncomingTransformation(Interface iface) {
-
     Nat dnat = _masterLogicalSystem.getNatDestination();
     if (dnat == null) {
       return null;


### PR DESCRIPTION
This prevents NPE when an interface has no IP.