### PR TITLE
Yifei nat ruleset

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRuleSet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatRuleSet.java
@@ -102,7 +102,7 @@ public final class NatRuleSet implements Serializable, Comparable<NatRuleSet> {
       return Optional.empty();
     }
 
-    return rulesTransformation(nat, interfaceIp, andThen, orElse)
+    return rulesTransformation(nat, interfaceIp, andThen, null)
         .map(
             rulesTransformation ->
                 when(matchFromLocation).setAndThen(rulesTransformation).setOrElse(orElse).build());
@@ -115,7 +115,7 @@ public final class NatRuleSet implements Serializable, Comparable<NatRuleSet> {
    */
   public Optional<Transformation> toIncomingTransformation(
       Nat nat, Ip interfaceIp, @Nullable Transformation andThen, @Nullable Transformation orElse) {
-    return rulesTransformation(nat, interfaceIp, andThen, orElse);
+    return rulesTransformation(nat, interfaceIp, andThen, null);
   }
 
   private Optional<Transformation> rulesTransformation(

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4679,4 +4679,10 @@ public final class FlatJuniperGrammarTest {
     assertThat(pool0.getOwner(), equalTo("R1"));
     assertNull(pool1.getOwner());
   }
+
+  @Test
+  public void testNatRuleSet() {
+    JuniperConfiguration juniperConfiguration = parseJuniperConfig("juniper-nat-source-ruleset");
+    juniperConfiguration.getLogicalSystems();
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleSetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleSetTest.java
@@ -116,7 +116,7 @@ public class NatRuleSetTest {
                 when(matchDst(prefix2))
                     .apply(assignDestinationIp(poolStart, poolEnd))
                     .setAndThen(andThen)
-                    .setOrElse(orElse)
+                    .setOrElse(null)
                     .build())
             .build();
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-nat-ruleset
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-nat-ruleset
@@ -1,0 +1,20 @@
+#
+set system host-name juniper-nat-ruleset
+#
+set interfaces ge-0/0/0 unit 0 family inet address 1.0.0.1/24
+set interfaces ge-0/0/1 unit 0 family inet address 4.0.0.1/24
+#
+set security zones security-zone ZONE interfaces ge-0/0/0.0
+set security zones security-zone ZONE interfaces ge-0/0/1.0
+#
+set security nat source pool POOL address 10.10.10.10/24
+#
+set security nat source rule-set RULE-SET1 from interface ge-0/0/0.0
+set security nat source rule-set RULE-SET1 to interface ge-0/0/1.0
+set security nat source rule-set RULE-SET1 rule RULE1 match destination-address 1.1.1.1/24
+set security nat source rule-set RULE-SET1 rule RULE1 then source-nat pool POOL
+#
+set security nat source rule-set RULE-SET2 from zone ZONE
+set security nat source rule-set RULE-SET2 to interface ge-0/0/1.0
+set security nat source rule-set RULE-SET2 rule RULE2 match destination-address 0.0.0.0/0
+set security nat source rule-set RULE-SET2 rule RULE2 then source-nat pool POOL


### PR DESCRIPTION
In NAT, if a packet matches a rule set but no rules in the rule set match the packet, there will be no NAT for the packet (see https://www.inetzero.com/closer-look-at-static-nat/). Previously we applied the second rule set in such case. This PR fixes this bug.