### PR TITLE
Remove default generation policy for default-originate route

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -312,10 +312,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
     return String.format("~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:%s:%s~", vrf, peer);
   }
 
-  public static String computeBgpDefaultRouteGenerationPolicyName(String vrf, String peer) {
-    return String.format("~BGP_DEFAULT_ROUTE_GENERATION_POLICY:%s:%s~", vrf, peer);
-  }
-
   public static String computeBgpPeerImportPolicyName(String vrf, String peer) {
     return String.format("~BGP_PEER_IMPORT_POLICY:%s:%s~", vrf, peer);
   }
@@ -1914,23 +1910,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
             defaultRoute.setGenerationPolicy(defaultOriginateMapName);
           } else {
             defaultRoute6.setGenerationPolicy(defaultOriginateMapName);
-          }
-        } else {
-          If defaultRouteGenerationConditional =
-              new If(
-                  ipv4 ? MATCH_DEFAULT_ROUTE : MATCH_DEFAULT_ROUTE6,
-                  ImmutableList.of(Statements.ReturnTrue.toStaticStatement()));
-          String defaultRouteGenerationPolicyName =
-              computeBgpDefaultRouteGenerationPolicyName(vrfName, lpg.getName());
-          RoutingPolicy.builder()
-              .setOwner(c)
-              .setName(defaultRouteGenerationPolicyName)
-              .addStatement(defaultRouteGenerationConditional)
-              .build();
-          if (ipv4) {
-            defaultRoute.setGenerationPolicy(defaultRouteGenerationPolicyName);
-          } else {
-            defaultRoute6.setGenerationPolicy(defaultRouteGenerationPolicyName);
           }
         }
       }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-default-originate/configs/originator
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-default-originate/configs/originator
@@ -14,5 +14,3 @@ router bgp 1
  ! Inject default route
  neighbor 1.1.1.3 default-originate
 !
-ip route 0.0.0.0 0.0.0.0 Null0
-!

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -1298,60 +1298,6 @@
               }
             ]
           },
-          "~BGP_DEFAULT_ROUTE_GENERATION_POLICY:default:169.254.13.237~" : {
-            "name" : "~BGP_DEFAULT_ROUTE_GENERATION_POLICY:default:169.254.13.237~",
-            "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                  "comment" : "match default route",
-                  "prefix" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                  },
-                  "prefixSet" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                    "prefixSpace" : [
-                      "0.0.0.0/0"
-                    ]
-                  }
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnTrue"
-                  }
-                ]
-              }
-            ]
-          },
-          "~BGP_DEFAULT_ROUTE_GENERATION_POLICY:default:169.254.15.193~" : {
-            "name" : "~BGP_DEFAULT_ROUTE_GENERATION_POLICY:default:169.254.15.193~",
-            "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                  "comment" : "match default route",
-                  "prefix" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                  },
-                  "prefixSet" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                    "prefixSpace" : [
-                      "0.0.0.0/0"
-                    ]
-                  }
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnTrue"
-                  }
-                ]
-              }
-            ]
-          },
           "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.13.237~" : {
             "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.13.237~",
             "statements" : [
@@ -1885,7 +1831,6 @@
                       "administrativeCost" : 32767,
                       "asPath" : [ ],
                       "discard" : false,
-                      "generationPolicy" : "~BGP_DEFAULT_ROUTE_GENERATION_POLICY:default:169.254.13.237~",
                       "metric" : 0,
                       "network" : "0.0.0.0/0",
                       "nextHopIp" : "AUTO/NONE(-1l)"
@@ -1922,7 +1867,6 @@
                       "administrativeCost" : 32767,
                       "asPath" : [ ],
                       "discard" : false,
-                      "generationPolicy" : "~BGP_DEFAULT_ROUTE_GENERATION_POLICY:default:169.254.15.193~",
                       "metric" : 0,
                       "network" : "0.0.0.0/0",
                       "nextHopIp" : "AUTO/NONE(-1l)"


### PR DESCRIPTION
For generated routes spawned as a result of `neighbor a.b.c.d default-originate`, we were attaching a generation policy that effectively required the source node to have a default route in order to send the generated default route to its neighbor. In reality, the source node sends the generated default route unconditionally unless there is a route-map explicitly configured for it. Fixed by removing the generation policy we were creating in the absence of a route-map.