### PR TITLE
Implement PacketPolicyToBDD

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/PacketPolicyToBdd.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/PacketPolicyToBdd.java
@@ -151,7 +151,10 @@ class PacketPolicyToBdd {
 
     @Override
     public Void visitFibLookup(FibLookup fibLookup) {
-      _fibLookups.put(fibLookup, _fibLookups.getOrDefault(fibLookup, _zero).or(_constraint));
+      _fibLookups.compute(
+          fibLookup,
+          (k, oldConstraint) ->
+              oldConstraint == null ? _constraint : oldConstraint.or(_constraint));
       return null;
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/PacketPolicyToBdd.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/PacketPolicyToBdd.java
@@ -1,0 +1,159 @@
+package org.batfish.bddreachability;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDOps;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.IpAccessListToBdd;
+import org.batfish.datamodel.packet_policy.Action;
+import org.batfish.datamodel.packet_policy.ActionVisitor;
+import org.batfish.datamodel.packet_policy.BoolExpr;
+import org.batfish.datamodel.packet_policy.BoolExprVisitor;
+import org.batfish.datamodel.packet_policy.Drop;
+import org.batfish.datamodel.packet_policy.FibLookup;
+import org.batfish.datamodel.packet_policy.If;
+import org.batfish.datamodel.packet_policy.PacketMatchExpr;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.Return;
+import org.batfish.datamodel.packet_policy.StatementVisitor;
+
+/**
+ * Provides the ability to convert a {@link PacketPolicy} into sets of BDDs corresponding to a
+ * particular {@link Action policy action}.
+ */
+@ParametersAreNonnullByDefault
+class PacketPolicyToBdd {
+
+  @Nonnull private final BDDPacket _bddPacket;
+  @Nonnull private final BoolExprToBdd _boolExprToBdd;
+  @Nonnull private final BDD _zero;
+
+  @Nonnull private BDD _toDrop;
+  @Nonnull private final Map<FibLookup, BDD> _fibLookups;
+
+  /**
+   * Process a given {@link PacketPolicy} and return the {@link PacketPolicyToBdd} that expresses
+   * the conversion. Examine the result of the conversion using methods such as {@link #getToDrop()}
+   * and {@link #getFibLookups()}
+   */
+  public static PacketPolicyToBdd evaluate(
+      PacketPolicy policy, BDDPacket packet, IpAccessListToBdd ipAccessListToBdd) {
+    PacketPolicyToBdd evaluator = new PacketPolicyToBdd(packet, ipAccessListToBdd);
+    evaluator.process(policy);
+    return evaluator;
+  }
+
+  private PacketPolicyToBdd(BDDPacket packet, IpAccessListToBdd ipAccessListToBdd) {
+    _bddPacket = packet;
+    _boolExprToBdd = new BoolExprToBdd(ipAccessListToBdd);
+    _zero = _bddPacket.getFactory().zero();
+    _toDrop = _zero;
+    _fibLookups = new HashMap<>(0);
+  }
+
+  /** Process a given {@link PacketPolicy} */
+  private void process(PacketPolicy p) {
+    StatementToBdd stmtConverter = new StatementToBdd(_boolExprToBdd);
+    p.getStatements().forEach(stmtConverter::visit);
+
+    /* Handle the default action. Default action applies to the remaining packets,
+     * which can be expressed as the complement of the union of packets we have already accounted
+     * for.
+     */
+    new Collector(firstNonNull(BDDOps.orNull(_fibLookups.values()), _zero).or(_toDrop).not())
+        .visit(p.getDefaultAction().getAction());
+  }
+
+  /** Return the set of packets that is dropped by a policy */
+  public BDD getToDrop() {
+    return _toDrop;
+  }
+
+  /**
+   * Return the sets of packets that must be processed by destination-based forwarding pipeline
+   * (expressed as a {@link FibLookup} action).
+   */
+  public Map<FibLookup, BDD> getFibLookups() {
+    return _fibLookups;
+  }
+
+  /**
+   * Walks all the statements in the packet policy, statefully building up BDDs based on {@link
+   * BoolExpr}s that are encountered. When a {@link Return} is encountered, calls into a {@link
+   * Collector}
+   */
+  private final class StatementToBdd implements StatementVisitor<Void> {
+    private final BoolExprToBdd _boolExprToBdd;
+    private final BDD _identity;
+    private BDD _currentConstraint;
+
+    private StatementToBdd(BoolExprToBdd boolExprToBdd) {
+      _boolExprToBdd = boolExprToBdd;
+      _identity = _bddPacket.getFactory().one();
+      _currentConstraint = _identity;
+    }
+
+    @Override
+    public Void visitIf(If ifStmt) {
+      // Save existing constraint
+      BDD oldConstraint = _currentConstraint;
+      // Convert IF guard
+      BDD matchConstraint = _boolExprToBdd.visit(ifStmt.getMatchCondition());
+      _currentConstraint = _currentConstraint.and(matchConstraint);
+      // Process true statements
+      ifStmt.getTrueStatements().forEach(this::visit);
+      // If fell trough, constraint packets with complement of match condition and move on
+      _currentConstraint = oldConstraint.and(matchConstraint.not());
+      return null;
+    }
+
+    @Override
+    public Void visitReturn(Return returnStmt) {
+      new Collector(_currentConstraint).visit(returnStmt.getAction());
+      return null;
+    }
+  }
+
+  /** Converts boolean expressions to BDDs */
+  private static final class BoolExprToBdd implements BoolExprVisitor<BDD> {
+    private final IpAccessListToBdd _ipAccessListToBdd;
+
+    private BoolExprToBdd(IpAccessListToBdd ipAccessListToBdd) {
+      _ipAccessListToBdd = ipAccessListToBdd;
+    }
+
+    @Override
+    public BDD visitPacketMatchExpr(PacketMatchExpr expr) {
+      return _ipAccessListToBdd.toBdd(expr.getExpr());
+    }
+  }
+
+  /**
+   * Updates set of packets associated with a particular action (i.e., {@link #_toDrop} and {@link
+   * #_fibLookups})
+   */
+  private final class Collector implements ActionVisitor<Void> {
+    private final BDD _constraint;
+
+    private Collector(BDD constraint) {
+      _constraint = constraint;
+    }
+
+    @Override
+    public Void visitDrop(Drop drop) {
+      _toDrop = _toDrop.or(_constraint);
+      return null;
+    }
+
+    @Override
+    public Void visitFibLookup(FibLookup fibLookup) {
+      _fibLookups.put(fibLookup, _fibLookups.getOrDefault(fibLookup, _zero).or(_constraint));
+      return null;
+    }
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/PacketPolicyToBdd.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/PacketPolicyToBdd.java
@@ -12,7 +12,6 @@ import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.IpAccessListToBdd;
 import org.batfish.datamodel.packet_policy.Action;
 import org.batfish.datamodel.packet_policy.ActionVisitor;
-import org.batfish.datamodel.packet_policy.BoolExpr;
 import org.batfish.datamodel.packet_policy.BoolExprVisitor;
 import org.batfish.datamodel.packet_policy.Drop;
 import org.batfish.datamodel.packet_policy.FibLookup;
@@ -83,8 +82,8 @@ class PacketPolicyToBdd {
   }
 
   /**
-   * Walks all the statements in the packet policy, statefully building up BDDs based on {@link
-   * BoolExpr}s that are encountered. When a {@link Return} is encountered, calls into a {@link
+   * Walks all the statements in the packet policy, statefully building up BDDs based on boolean
+   * expressions that are encountered. When a {@link Return} is encountered, calls into a {@link
    * Collector}
    */
   private final class StatementToBdd implements StatementVisitor<Void> {

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/PacketPolicyToBddTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/PacketPolicyToBddTest.java
@@ -3,8 +3,8 @@ package org.batfish.bddreachability;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -52,7 +52,7 @@ public class PacketPolicyToBddTest {
             _bddPacket,
             _ipAccessListToBdd);
     // Everything is dropped
-    assertThat(evaluator.getToDrop(), equalTo(_bddPacket.getFactory().one()));
+    assertTrue(evaluator.getToDrop().isOne());
     assertThat(evaluator.getFibLookups(), anEmptyMap());
   }
 
@@ -67,7 +67,7 @@ public class PacketPolicyToBddTest {
             _bddPacket,
             _ipAccessListToBdd);
     // Everything is looked up in "vrf"
-    assertThat(evaluator.getToDrop(), equalTo(_bddPacket.getFactory().zero()));
+    assertTrue(evaluator.getToDrop().isZero());
     assertThat(evaluator.getFibLookups(), aMapWithSize(1));
     assertThat(
         evaluator.getFibLookups(), hasEntry(new FibLookup("vrf"), _bddPacket.getFactory().one()));
@@ -103,7 +103,7 @@ public class PacketPolicyToBddTest {
     BDD dstIpBdd = new IpSpaceToBDD(_bddPacket.getDstIp()).toBDD(dstIps);
 
     // Nothing to Drop
-    assertThat(evaluator.getToDrop(), equalTo(_bddPacket.getFactory().zero()));
+    assertTrue(evaluator.getToDrop().isZero());
     assertThat(evaluator.getFibLookups(), aMapWithSize(3));
     // Inner if captures 10.0.0.0/8, vrf 1
     assertThat(evaluator.getFibLookups(), hasEntry(new FibLookup(vrf1), dstIpBdd));

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/PacketPolicyToBddTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/PacketPolicyToBddTest.java
@@ -1,0 +1,116 @@
+package org.batfish.bddreachability;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.common.bdd.IpAccessListToBdd;
+import org.batfish.common.bdd.IpAccessListToBddImpl;
+import org.batfish.common.bdd.IpSpaceToBDD;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.packet_policy.Drop;
+import org.batfish.datamodel.packet_policy.FibLookup;
+import org.batfish.datamodel.packet_policy.If;
+import org.batfish.datamodel.packet_policy.PacketMatchExpr;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.Return;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PacketPolicyToBddTest {
+
+  private BDDPacket _bddPacket;
+  private IpAccessListToBdd _ipAccessListToBdd;
+
+  @Before
+  public void setUp() {
+    _bddPacket = new BDDPacket();
+    _ipAccessListToBdd =
+        new IpAccessListToBddImpl(
+            _bddPacket,
+            BDDSourceManager.forInterfaces(_bddPacket, ImmutableSet.of()),
+            ImmutableMap.of(),
+            ImmutableMap.of());
+  }
+
+  @Test
+  public void testDefaultAction() {
+    PacketPolicyToBdd evaluator =
+        PacketPolicyToBdd.evaluate(
+            new PacketPolicy("name", ImmutableList.of(), new Return(Drop.instance())),
+            _bddPacket,
+            _ipAccessListToBdd);
+    // Everything is dropped
+    assertThat(evaluator.getToDrop(), equalTo(_bddPacket.getFactory().one()));
+    assertThat(evaluator.getFibLookups(), anEmptyMap());
+  }
+
+  @Test
+  public void testReturn() {
+    PacketPolicyToBdd evaluator =
+        PacketPolicyToBdd.evaluate(
+            new PacketPolicy(
+                "name",
+                ImmutableList.of(new Return(new FibLookup("vrf"))),
+                new Return(Drop.instance())),
+            _bddPacket,
+            _ipAccessListToBdd);
+    // Everything is looked up in "vrf"
+    assertThat(evaluator.getToDrop(), equalTo(_bddPacket.getFactory().zero()));
+    assertThat(evaluator.getFibLookups(), aMapWithSize(1));
+    assertThat(
+        evaluator.getFibLookups(), hasEntry(new FibLookup("vrf"), _bddPacket.getFactory().one()));
+  }
+
+  @Test
+  public void testNestedIfs() {
+    String vrf1 = "vrf1";
+    String vrf2 = "vrf2";
+    String vrf3 = "vrf3";
+
+    Prefix dstIps = Prefix.parse("10.0.0.0/8");
+    If innerIf =
+        new If(
+            new PacketMatchExpr(
+                new MatchHeaderSpace(HeaderSpace.builder().setDstIps(dstIps.toIpSpace()).build())),
+            ImmutableList.of(new Return(new FibLookup(vrf1))));
+    If outerIf =
+        new If(
+            new PacketMatchExpr(
+                new MatchHeaderSpace(
+                    HeaderSpace.builder().setDstIps(UniverseIpSpace.INSTANCE).build())),
+            ImmutableList.of(innerIf, new Return(new FibLookup(vrf2))));
+    PacketPolicyToBdd evaluator =
+        PacketPolicyToBdd.evaluate(
+            new PacketPolicy(
+                "name",
+                ImmutableList.of(outerIf, new Return(new FibLookup(vrf3))),
+                new Return(Drop.instance())),
+            _bddPacket,
+            _ipAccessListToBdd);
+
+    BDD dstIpBdd = new IpSpaceToBDD(_bddPacket.getDstIp()).toBDD(dstIps);
+
+    // Nothing to Drop
+    assertThat(evaluator.getToDrop(), equalTo(_bddPacket.getFactory().zero()));
+    assertThat(evaluator.getFibLookups(), aMapWithSize(3));
+    // Inner if captures 10.0.0.0/8, vrf 1
+    assertThat(evaluator.getFibLookups(), hasEntry(new FibLookup(vrf1), dstIpBdd));
+    // Outer if captures everything else, vrf 2
+    assertThat(evaluator.getFibLookups(), hasEntry(new FibLookup(vrf2), dstIpBdd.not()));
+    // Last statement captures no packets, but is visited in the evaluation
+    assertThat(
+        evaluator.getFibLookups(), hasEntry(new FibLookup(vrf3), _bddPacket.getFactory().zero()));
+  }
+}


### PR DESCRIPTION
Enable conversion of packet policies to BDDs.
Since so far packet policies don't support transformations, we can
efficiently compact them into BDDs corresponding to dropped packets
and packets forwarded per VRF.

not plugged in anywhere yet