### PR TITLE
Backlogged cleanup from RIB work

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRib.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRib.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedSet;
 
 public interface GenericRib<R extends AbstractRouteDecorator> extends Serializable {
 
@@ -25,8 +24,6 @@ public interface GenericRib<R extends AbstractRouteDecorator> extends Serializab
    * for which {@link AbstractRoute#getNonForwarding()} returns false.
    */
   Map<Prefix, IpSpace> getMatchingIps();
-
-  SortedSet<Prefix> getPrefixes();
 
   /**
    * Get all the IPs that match a forwarding route in the RIB.

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
@@ -117,11 +117,6 @@ public class MockRib implements GenericRib<AbstractRoute> {
   }
 
   @Override
-  public SortedSet<Prefix> getPrefixes() {
-    return _prefixes;
-  }
-
-  @Override
   public IpSpace getRoutableIps() {
     return _routableIps;
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -895,14 +895,14 @@ class IncrementalBdpEngine {
       int numBgpMultipathRibRoutes =
           nodes.values().stream()
               .flatMap(n -> n.getVirtualRouters().values().stream())
-              .mapToInt(vr -> vr.getBgpRib().getRoutes().size())
+              .mapToInt(vr -> vr.getBgpRib().getTypedRoutes().size())
               .sum();
       ae.getBgpMultipathRibRoutesByIteration()
           .put(dependentRoutesIterations, numBgpMultipathRibRoutes);
       int numMainRibRoutes =
           nodes.values().stream()
               .flatMap(n -> n.getVirtualRouters().values().stream())
-              .mapToInt(vr -> vr._mainRib.getRoutes().size())
+              .mapToInt(vr -> vr._mainRib.getTypedRoutes().size())
               .sum();
       ae.getMainRibRoutesByIteration().put(dependentRoutesIterations, numMainRibRoutes);
     }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
@@ -52,7 +52,7 @@ public class IncrementalDataPlanePlugin extends DataPlanePlugin {
         ((IncrementalDataPlane) answer._dataPlane)
             .getNodes().values().stream()
                 .flatMap(n -> n.getVirtualRouters().values().stream())
-                .mapToInt(vr -> vr._mainRib.getRoutes().size())
+                .mapToInt(vr -> vr._mainRib.getTypedRoutes().size())
                 .average()
                 .orElse(0.00d);
     _logger.infof(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -190,17 +190,11 @@ public class VirtualRouter implements Serializable {
   transient SortedMap<IsisEdge, Queue<RouteAdvertisement<IsisRoute>>> _isisIncomingRoutes;
 
   transient IsisLevelRib _isisL1Rib;
-
   transient IsisLevelRib _isisL2Rib;
-
   private transient IsisLevelRib _isisL1StagingRib;
-
   private transient IsisLevelRib _isisL2StagingRib;
-
   private transient IsisRib _isisRib;
-
   transient KernelRib _kernelRib;
-
   transient LocalRib _localRib;
 
   /** The finalized RIB, a combination different protocol RIBs */
@@ -212,16 +206,11 @@ public class VirtualRouter implements Serializable {
   @VisibleForTesting
   transient RibDelta.Builder<AnnotatedRoute<AbstractRoute>> _mainRibRouteDeltaBuilder;
 
-  @Nonnull private final Node _node;
-
   @Nonnull final String _name;
-
+  @Nonnull private final Node _node;
   transient OspfExternalType1Rib _ospfExternalType1Rib;
-
   transient OspfExternalType1Rib _ospfExternalType1StagingRib;
-
   transient OspfExternalType2Rib _ospfExternalType2Rib;
-
   transient OspfExternalType2Rib _ospfExternalType2StagingRib;
 
   @VisibleForTesting
@@ -229,23 +218,14 @@ public class VirtualRouter implements Serializable {
       _ospfExternalIncomingRoutes;
 
   transient OspfInterAreaRib _ospfInterAreaRib;
-
   transient OspfInterAreaRib _ospfInterAreaStagingRib;
-
   transient OspfIntraAreaRib _ospfIntraAreaRib;
-
   transient OspfIntraAreaRib _ospfIntraAreaStagingRib;
-
   transient OspfRib _ospfRib;
-
   transient RipInternalRib _ripInternalRib;
-
   transient RipInternalRib _ripInternalStagingRib;
-
   transient RipRib _ripRib;
-
   transient StaticRib _staticInterfaceRib;
-
   transient StaticRib _staticNextHopRib;
 
   /** FIB (forwarding information base) built from the main RIB */
@@ -2115,7 +2095,8 @@ public class VirtualRouter implements Serializable {
          */
         for (Prefix p : mainDelta.getPrefixes()) {
           preExportPolicyDeltaBuilder.add(
-              _bgpRib.getTypedRoutes(p).stream()
+              _bgpRib.getTypedRoutes().stream()
+                  .filter(r -> r.getNetwork().equals(p))
                   .map(r -> new AnnotatedRoute<AbstractRoute>(r, _name))
                   .collect(ImmutableSet.toImmutableSet()));
         }
@@ -2528,7 +2509,7 @@ public class VirtualRouter implements Serializable {
     }
 
     // Note prefixes we tried to originate
-    _mainRib.getRoutes().forEach(r -> _prefixTracer.originated(r.getNetwork()));
+    _mainRib.getTypedRoutes().forEach(r -> _prefixTracer.originated(r.getNetwork()));
 
     /*
      * Export route advertisements by looking at main RIB

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -141,16 +141,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   }
 
   @Override
-  public final SortedSet<Prefix> getPrefixes() {
-    SortedSet<Prefix> prefixes = new TreeSet<>();
-    Set<R> routes = getTypedRoutes();
-    for (R route : routes) {
-      prefixes.add(route.getNetwork());
-    }
-    return prefixes;
-  }
-
-  @Override
+  @Nonnull
   public Set<AbstractRoute> getRoutes() {
     return getTypedRoutes().stream()
         .map(AbstractRouteDecorator::getAbstractRoute)
@@ -158,18 +149,12 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   }
 
   @Override
+  @Nonnull
   public Set<R> getTypedRoutes() {
     if (_allRoutes == null) {
       _allRoutes = ImmutableSet.copyOf(_tree.getRoutes());
     }
     return _allRoutes;
-  }
-
-  public final Set<R> getTypedRoutes(Prefix p) {
-    // Collect routes that match the prefix
-    return getTypedRoutes().stream()
-        .filter(r -> r.getNetwork().equals(p))
-        .collect(ImmutableSet.toImmutableSet());
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -56,7 +56,7 @@ public class AbstractRibTest {
   public void testRibConstructor() {
     // Assertions: Ensure that a new rib is empty upon construction
     assertThat(_rib.getTypedRoutes(), empty());
-    assertThat(_rib.getTypedRoutes(), contains(_mostGeneralRoute));
+    assertThat(_rib.getTypedRoutes(), not(hasItem(_mostGeneralRoute)));
   }
 
   @Test
@@ -137,7 +137,7 @@ public class AbstractRibTest {
   public void testMultiOverlappingRouteAdd() {
     // Setup/Test: Add multiple routes with overlapping prefixes
     List<StaticRoute> routes = setupOverlappingRoutes();
-    assertThat(_rib.getTypedRoutes(), contains(routes));
+    assertThat(_rib.getTypedRoutes(), containsInAnyOrder(routes.toArray()));
   }
 
   /** Ensure that empty RIB doesn't have any prefix matches */

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/BgpRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/BgpRibTest.java
@@ -1,6 +1,7 @@
 package org.batfish.dataplane.rib;
 
 import static org.batfish.dataplane.ibdp.TestUtils.annotateRoute;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -13,7 +14,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -121,8 +121,8 @@ public class BgpRibTest {
     _multiPathRib.mergeRoute(worse);
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), equalTo(Collections.singleton(best)));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(best)));
+    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
   @Test
@@ -133,8 +133,8 @@ public class BgpRibTest {
     _multiPathRib.mergeRoute(worse);
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), equalTo(Collections.singleton(best)));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(best)));
+    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
   @Test
@@ -144,8 +144,8 @@ public class BgpRibTest {
     _multiPathRib.mergeRoute(worse);
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), equalTo(Collections.singleton(best)));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(best)));
+    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
   @Test
@@ -156,8 +156,8 @@ public class BgpRibTest {
     _multiPathRib.mergeRoute(worse);
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), equalTo(Collections.singleton(best)));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(best)));
+    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
   @Test
@@ -169,12 +169,12 @@ public class BgpRibTest {
     _multiPathRib.mergeRoute(worst);
     _multiPathRib.mergeRoute(medium);
 
-    assertThat(_multiPathRib.getRoutes(), equalTo(Collections.singleton(medium)));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(medium)));
+    assertThat(_multiPathRib.getRoutes(), contains(medium));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(medium));
 
     _multiPathRib.mergeRoute(best);
-    assertThat(_multiPathRib.getRoutes(), equalTo(Collections.singleton(best)));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(best)));
+    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
   @Test
@@ -185,8 +185,8 @@ public class BgpRibTest {
     _multiPathRib.mergeRoute(worse);
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), equalTo(Collections.singleton(best)));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(best)));
+    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
   @Test
@@ -197,8 +197,8 @@ public class BgpRibTest {
     _multiPathRib.mergeRoute(worse);
     _multiPathRib.mergeRoute(best);
 
-    assertThat(_multiPathRib.getRoutes(), equalTo(Collections.singleton(best)));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(best)));
+    assertThat(_multiPathRib.getRoutes(), contains(best));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(best));
   }
 
   @Test
@@ -225,8 +225,8 @@ public class BgpRibTest {
 
     rib.mergeRoute(worse);
     rib.mergeRoute(best);
-    assertThat(rib.getRoutes(), equalTo(Collections.singleton(best)));
-    assertThat(rib.getBestPathRoutes(), equalTo(Collections.singleton(best)));
+    assertThat(rib.getRoutes(), contains(best));
+    assertThat(rib.getBestPathRoutes(), contains(best));
   }
 
   @Test
@@ -278,7 +278,7 @@ public class BgpRibTest {
     _multiPathRib.mergeRoute(_rb.setOriginatorIp(Ip.parse("2.2.2.3")).build());
     _multiPathRib.mergeRoute(bestPath);
     assertThat(_multiPathRib.getRoutes(), hasSize(3));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(bestPath)));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(bestPath));
   }
 
   @Test
@@ -297,7 +297,7 @@ public class BgpRibTest {
     _multiPathRib.mergeRoute(best);
 
     assertThat(_multiPathRib.getRoutes(), hasSize(3));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(earliest)));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(earliest));
   }
 
   @Test
@@ -309,7 +309,7 @@ public class BgpRibTest {
     _multiPathRib.mergeRoute(_rb.setClusterList(ImmutableSortedSet.of(22L, 33L)).build());
 
     assertThat(_multiPathRib.getRoutes(), hasSize(3));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(bestPath)));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(bestPath));
   }
 
   @Test
@@ -320,7 +320,7 @@ public class BgpRibTest {
     _multiPathRib.mergeRoute(bestPath);
 
     assertThat(_multiPathRib.getRoutes(), hasSize(3));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(bestPath)));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(bestPath));
   }
 
   @Test
@@ -331,7 +331,7 @@ public class BgpRibTest {
     _multiPathRib.mergeRoute(bestPath);
 
     assertThat(_multiPathRib.getRoutes(), hasSize(1));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(bestPath)));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(bestPath));
   }
 
   @Test
@@ -345,8 +345,8 @@ public class BgpRibTest {
     BgpRoute bestPath = _rb.setLocalPreference(1000).build();
     _multiPathRib.mergeRoute(bestPath);
 
-    assertThat(_multiPathRib.getRoutes(), equalTo(Collections.singleton(bestPath)));
-    assertThat(_multiPathRib.getBestPathRoutes(), equalTo(Collections.singleton(bestPath)));
+    assertThat(_multiPathRib.getRoutes(), contains(bestPath));
+    assertThat(_multiPathRib.getBestPathRoutes(), contains(bestPath));
   }
 
   @Test
@@ -357,8 +357,8 @@ public class BgpRibTest {
     bestPathRib.mergeRoute(_rb.setReceivedFromIp(Ip.parse("2.2.2.3")).build());
     bestPathRib.mergeRoute(bestPath);
 
-    assertThat(bestPathRib.getRoutes(), equalTo(Collections.singleton(bestPath)));
-    assertThat(bestPathRib.getBestPathRoutes(), equalTo(Collections.singleton(bestPath)));
+    assertThat(bestPathRib.getRoutes(), contains(bestPath));
+    assertThat(bestPathRib.getBestPathRoutes(), contains(bestPath));
   }
 
   @Test
@@ -384,7 +384,7 @@ public class BgpRibTest {
     BgpRoute bestPath = _rb.setLocalPreference(200).build();
     _bestPathRib.mergeRoute(bestPath);
 
-    assertThat(_bestPathRib.getRoutes(), equalTo(Collections.singleton(bestPath)));
+    assertThat(_bestPathRib.getRoutes(), contains(bestPath));
   }
 
   @Test
@@ -394,7 +394,7 @@ public class BgpRibTest {
     BgpRoute bestPath = _rb.setOriginatorIp(Ip.parse("1.1.0.1")).build();
     _bestPathRib.mergeRoute(bestPath);
 
-    assertThat(_bestPathRib.getRoutes(), equalTo(Collections.singleton(bestPath)));
+    assertThat(_bestPathRib.getRoutes(), contains(bestPath));
   }
 
   @Test
@@ -404,7 +404,7 @@ public class BgpRibTest {
     BgpRoute bestPath = _rb.setReceivedFromIp(Ip.parse("1.1.0.1")).build();
     _bestPathRib.mergeRoute(bestPath);
 
-    assertThat(_bestPathRib.getRoutes(), equalTo(Collections.singleton(bestPath)));
+    assertThat(_bestPathRib.getRoutes(), contains(bestPath));
   }
 
   @Test
@@ -415,7 +415,7 @@ public class BgpRibTest {
     // Oldest route should win despite newer having lower in Originator IP
     _bestPathRib.mergeRoute(_rb.setOriginatorIp(Ip.parse("1.1.0.1")).build());
 
-    assertThat(_bestPathRib.getRoutes(), equalTo(Collections.singleton(bestPath)));
+    assertThat(_bestPathRib.getRoutes(), contains(bestPath));
   }
 
   //////////////////////////////////////////////////////////////////////////////////

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AbstractRouteDecorator;
@@ -486,11 +485,6 @@ public class RoutesAnswererTest {
 
     @Override
     public Map<Prefix, IpSpace> getMatchingIps() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SortedSet<Prefix> getPrefixes() {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Stuff I managed not to blob into #3180.
- Delete unused GenericRib method `getPrefixes()`
- Remove `AbstractRoute.getTypedRoutes(Prefix p)` as it was only used once; just use `getTypedRoutes()` and filter instead
- Favor `getTypedRoutes()` over `getRoutes()` in places where it doesn't matter which is used, because typed routes are memoized (`getRoutes()` has to stream and recollect)
- Big pile of test simplification and cleanup