### PR TITLE
Add message to no-redistribution parse warning

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -8509,7 +8509,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       settings.setDefaultInformationOriginate(true);
     }
     if (ctx.no_redistribution != null) {
-      todo(ctx);
+      todo(ctx, "Unsupported feature: no-redistribution");
       settings.setNoRedistribution(true);
     }
     if (ctx.no_summary != null) {
@@ -10350,6 +10350,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   private void todo(ParserRuleContext ctx) {
     _w.todo(ctx, getFullText(ctx), _parser);
+  }
+
+  private void todo(ParserRuleContext ctx, String message) {
+    _w.addWarning(ctx, getFullText(ctx), _parser, message);
   }
 
   private DiffieHellmanGroup toDhGroup(Dh_groupContext ctx) {

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -467,21 +467,21 @@
         "Line" : 34,
         "Text" : "area 0.0.0.0 nssa no-redistribution",
         "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
-        "Comment" : "This feature is not currently supported"
+        "Comment" : "Unsupported feature: no-redistribution"
       },
       {
         "Filename" : "configs/cisco_ospf",
         "Line" : 35,
         "Text" : "area 0.0.0.0 nssa no-redistribution no-summary",
         "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
-        "Comment" : "This feature is not currently supported"
+        "Comment" : "Unsupported feature: no-redistribution"
       },
       {
         "Filename" : "configs/cisco_ospf",
         "Line" : 36,
         "Text" : "area 0.0.0.0 nssa no-redistribution default-information-originate no-summary",
         "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
-        "Comment" : "This feature is not currently supported"
+        "Comment" : "Unsupported feature: no-redistribution"
       },
       {
         "Filename" : "configs/cisco_ospf",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -68316,19 +68316,19 @@
               "Text" : "area 0.0.0.0 filter-list prefix filterName out"
             },
             {
-              "Comment" : "This feature is not currently supported",
+              "Comment" : "Unsupported feature: no-redistribution",
               "Line" : 34,
               "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
               "Text" : "area 0.0.0.0 nssa no-redistribution"
             },
             {
-              "Comment" : "This feature is not currently supported",
+              "Comment" : "Unsupported feature: no-redistribution",
               "Line" : 35,
               "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
               "Text" : "area 0.0.0.0 nssa no-redistribution no-summary"
             },
             {
-              "Comment" : "This feature is not currently supported",
+              "Comment" : "Unsupported feature: no-redistribution",
               "Line" : 36,
               "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
               "Text" : "area 0.0.0.0 nssa no-redistribution default-information-originate no-summary"


### PR DESCRIPTION
Old warning message was the generic "This feature is not currently supported". Now it will say "Unsupported feature: no-redistribution" to indicate that other features configured on the same line are supported.