### PR TITLE
Add an LpmRoutes question

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/lpmroutes/LpmRoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/lpmroutes/LpmRoutesAnswerer.java
@@ -1,0 +1,122 @@
+package org.batfish.question.lpmroutes;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.regex.Pattern;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Answerer;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.AbstractRouteDecorator;
+import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.answers.AnswerElement;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.datamodel.table.ColumnMetadata;
+import org.batfish.datamodel.table.Row;
+import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.datamodel.table.TableMetadata;
+
+/** An answerer for {@link LpmRoutesQuestion} */
+@ParametersAreNonnullByDefault
+public class LpmRoutesAnswerer extends Answerer {
+
+  static final String COL_NODE = "Node";
+  static final String COL_VRF = "VRF";
+  static final String COL_IP = "Ip";
+  static final String COL_NETWORK = "Network";
+  static final String COL_NUM_ROUTES = "Num_Routes";
+
+  private final Map<String, ColumnMetadata> _columnMap;
+
+  public LpmRoutesAnswerer(Question question, IBatfish batfish) {
+    super(question, batfish);
+    _columnMap = getMetadata().toColumnMap();
+  }
+
+  @Override
+  public AnswerElement answer() {
+    LpmRoutesQuestion q = (LpmRoutesQuestion) _question;
+    TableAnswerElement answer = new TableAnswerElement(getMetadata());
+    answer.postProcessAnswer(
+        _question,
+        getRows(
+            _batfish.loadDataPlane().getRibs(),
+            q.getIp(),
+            q.getNodeSpecifier().resolve(_batfish.specifierContext()),
+            Pattern.compile(q.getVrfs()),
+            _columnMap));
+    return answer;
+  }
+
+  @VisibleForTesting
+  static <T extends AbstractRouteDecorator> List<Row> getRows(
+      SortedMap<String, SortedMap<String, GenericRib<T>>> ribs,
+      Ip ip,
+      Set<String> nodes,
+      Pattern vrfRegex,
+      Map<String, ColumnMetadata> columnMap) {
+
+    ImmutableList.Builder<Row> builder = ImmutableList.builder();
+    for (Entry<String, SortedMap<String, GenericRib<T>>> nodeEntry : ribs.entrySet()) {
+      if (!nodes.contains(nodeEntry.getKey())) {
+        continue;
+      }
+
+      for (Entry<String, GenericRib<T>> vrfEntry : nodeEntry.getValue().entrySet()) {
+        if (!vrfRegex.matcher(vrfEntry.getKey()).matches()) {
+          continue;
+        }
+
+        toRow(
+                vrfEntry.getValue().longestPrefixMatch(ip),
+                nodeEntry.getKey(),
+                vrfEntry.getKey(),
+                ip,
+                columnMap)
+            .ifPresent(builder::add);
+      }
+    }
+    return builder.build();
+  }
+
+  @VisibleForTesting
+  static <T extends AbstractRouteDecorator> Optional<Row> toRow(
+      Set<T> routes, String node, String vrf, Ip ip, Map<String, ColumnMetadata> columnMap) {
+    if (routes.isEmpty()) {
+      return Optional.empty();
+    }
+    Prefix network = routes.iterator().next().getNetwork();
+    return Optional.of(
+        Row.builder(columnMap)
+            .put(COL_NODE, new Node(node))
+            .put(COL_VRF, vrf)
+            .put(COL_IP, ip)
+            .put(COL_NETWORK, network)
+            .put(COL_NUM_ROUTES, routes.size())
+            .build());
+  }
+
+  private static TableMetadata getMetadata() {
+    return new TableMetadata(getColumnMetadata());
+  }
+
+  @VisibleForTesting
+  static List<ColumnMetadata> getColumnMetadata() {
+    return ImmutableList.<ColumnMetadata>builder()
+        .add(new ColumnMetadata(COL_NODE, Schema.NODE, "Node", true, false))
+        .add(new ColumnMetadata(COL_VRF, Schema.STRING, "Node", true, false))
+        .add(new ColumnMetadata(COL_IP, Schema.IP, "Node", true, false))
+        .add(new ColumnMetadata(COL_NETWORK, Schema.PREFIX, "Node", false, true))
+        .add(new ColumnMetadata(COL_NUM_ROUTES, Schema.INTEGER, "Node", false, true))
+        .build();
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/lpmroutes/LpmRoutesQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/lpmroutes/LpmRoutesQuestion.java
@@ -1,0 +1,112 @@
+package org.batfish.question.lpmroutes;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.question.routes.RoutesQuestion.RibProtocol;
+import org.batfish.specifier.AllNodesNodeSpecifier;
+import org.batfish.specifier.NodeSpecifier;
+import org.batfish.specifier.SpecifierFactories;
+
+/**
+ * Retrieves a longest prefix match for a given {@link Ip} address. Can be done is a
+ * protocol-specific RIB supported by {@link RibProtocol}.
+ */
+@ParametersAreNonnullByDefault
+public class LpmRoutesQuestion extends Question {
+
+  private static final String PROP_IP = "ip";
+  private static final String PROP_NODES = "nodes";
+  private static final String PROP_RIB = "rib";
+  private static final String PROP_VRFS = "vrfs";
+  private static final String VRFS_ALL = ".*";
+
+  @Nonnull private final Ip _ip;
+  @Nullable private final String _nodes;
+  @Nonnull private final String _vrfs;
+  @Nonnull private final RibProtocol _ribProtocol;
+
+  /**
+   * Create a new question.
+   *
+   * @param ip the IP address to do longest prefix match on
+   * @param nodes input to a {@link NodeSpecifier} for filtering nodes
+   * @param vrfs regex for VRF filtering
+   * @param ribProtocol the {@link RibProtocol} for which to retrieve the RIBs.
+   */
+  public LpmRoutesQuestion(Ip ip, @Nullable String nodes, String vrfs, RibProtocol ribProtocol) {
+    checkArgument(
+        ribProtocol == RibProtocol.MAIN,
+        "Unsupported RIB %s. Only %s is supported at this time",
+        ribProtocol,
+        RibProtocol.MAIN);
+    _ip = ip;
+    _nodes = nodes;
+    _vrfs = vrfs;
+    _ribProtocol = ribProtocol;
+  }
+
+  LpmRoutesQuestion() {
+    // Choose an arbitrary public IP
+    this(Ip.parse("8.8.8.8"), null, VRFS_ALL, RibProtocol.MAIN);
+  }
+
+  @JsonCreator
+  private static LpmRoutesQuestion jsonCreator(
+      @Nullable @JsonProperty(PROP_IP) Ip ip,
+      @Nullable @JsonProperty(PROP_NODES) String nodes,
+      @Nullable @JsonProperty(PROP_VRFS) String vrfs,
+      @Nullable @JsonProperty(PROP_RIB) RibProtocol protocol) {
+    checkArgument(ip != null, "Missing %s", PROP_IP);
+    return new LpmRoutesQuestion(
+        ip, nodes, firstNonNull(vrfs, VRFS_ALL), firstNonNull(protocol, RibProtocol.MAIN));
+  }
+
+  @Override
+  public boolean getDataPlane() {
+    return true;
+  }
+
+  @JsonProperty(PROP_IP)
+  @Nonnull
+  public Ip getIp() {
+    return _ip;
+  }
+
+  @JsonProperty(PROP_NODES)
+  @Nullable
+  private String getNodes() {
+    return _nodes;
+  }
+
+  @JsonProperty(PROP_VRFS)
+  @Nonnull
+  public String getVrfs() {
+    return _vrfs;
+  }
+
+  @JsonProperty(PROP_RIB)
+  @Nonnull
+  public RibProtocol getRibProtocol() {
+    return _ribProtocol;
+  }
+
+  @Override
+  public String getName() {
+    return "lpmRoutes";
+  }
+
+  @Nonnull
+  @JsonIgnore
+  public NodeSpecifier getNodeSpecifier() {
+    return SpecifierFactories.getNodeSpecifierOrDefault(_nodes, AllNodesNodeSpecifier.INSTANCE);
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/lpmroutes/LpmRoutesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/lpmroutes/LpmRoutesQuestionPlugin.java
@@ -1,0 +1,21 @@
+package org.batfish.question.lpmroutes;
+
+import com.google.auto.service.AutoService;
+import org.batfish.common.Answerer;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.plugin.Plugin;
+import org.batfish.datamodel.questions.Question;
+import org.batfish.question.QuestionPlugin;
+
+@AutoService(Plugin.class)
+public class LpmRoutesQuestionPlugin extends QuestionPlugin {
+  @Override
+  protected Answerer createAnswerer(Question question, IBatfish batfish) {
+    return new LpmRoutesAnswerer(question, batfish);
+  }
+
+  @Override
+  protected Question createQuestion() {
+    return new LpmRoutesQuestion();
+  }
+}

--- a/projects/question/src/test/java/org/batfish/question/lpmroutes/LpmRoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/lpmroutes/LpmRoutesAnswererTest.java
@@ -1,0 +1,137 @@
+package org.batfish.question.lpmroutes;
+
+import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
+import static org.batfish.question.lpmroutes.LpmRoutesAnswerer.COL_IP;
+import static org.batfish.question.lpmroutes.LpmRoutesAnswerer.COL_NETWORK;
+import static org.batfish.question.lpmroutes.LpmRoutesAnswerer.COL_NODE;
+import static org.batfish.question.lpmroutes.LpmRoutesAnswerer.COL_NUM_ROUTES;
+import static org.batfish.question.lpmroutes.LpmRoutesAnswerer.COL_VRF;
+import static org.batfish.question.lpmroutes.LpmRoutesAnswerer.getColumnMetadata;
+import static org.batfish.question.lpmroutes.LpmRoutesAnswerer.getRows;
+import static org.batfish.question.lpmroutes.LpmRoutesAnswerer.toRow;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
+import java.util.List;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.MockRib;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.answers.Schema;
+import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.table.ColumnMetadata;
+import org.batfish.datamodel.table.Row;
+import org.junit.Test;
+
+/** Tests for {@link LpmRoutesAnswerer} */
+public class LpmRoutesAnswererTest {
+
+  private static MockRib getMockRib(Ip ip) {
+    return MockRib.builder()
+        .setLongestPrefixMatchResults(
+            ImmutableMap.of(
+                ip,
+                ImmutableSet.of(
+                    new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Eth0"),
+                    new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Eth1"))))
+        .build();
+  }
+
+  @Test
+  public void testGetColumnMetadata() {
+    List<ColumnMetadata> metadata = getColumnMetadata();
+    assertThat(
+        metadata,
+        equalTo(
+            ImmutableList.of(
+                new ColumnMetadata(COL_NODE, Schema.NODE, "Node", true, false),
+                new ColumnMetadata(COL_VRF, Schema.STRING, "Node", true, false),
+                new ColumnMetadata(COL_IP, Schema.IP, "Node", true, false),
+                new ColumnMetadata(COL_NETWORK, Schema.PREFIX, "Node", false, true),
+                new ColumnMetadata(COL_NUM_ROUTES, Schema.INTEGER, "Node", false, true))));
+  }
+
+  @Test
+  public void testToRow() {
+    final ImmutableMap<String, ColumnMetadata> columnMap =
+        getColumnMetadata().stream()
+            .collect(ImmutableMap.toImmutableMap(ColumnMetadata::getName, Function.identity()));
+    Row row =
+        toRow(
+                ImmutableSet.of(
+                    new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Eth0"),
+                    new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Eth1")),
+                "node1",
+                "vrf",
+                Ip.parse("1.1.1.1"),
+                columnMap)
+            .get();
+    assertThat(
+        row,
+        equalTo(
+            Row.builder(columnMap)
+                .put(COL_NODE, new Node("node1"))
+                .put(COL_VRF, "vrf")
+                .put(COL_IP, Ip.parse("1.1.1.1"))
+                .put(COL_NETWORK, Prefix.parse("1.1.1.0/24"))
+                .put(COL_NUM_ROUTES, 2)
+                .build()));
+  }
+
+  @Test
+  public void testFilteringByNodes() {
+    final ImmutableMap<String, ColumnMetadata> columnMap =
+        getColumnMetadata().stream()
+            .collect(ImmutableMap.toImmutableMap(ColumnMetadata::getName, Function.identity()));
+
+    final Ip lpmIp = Ip.parse("1.1.1.1");
+    List<Row> rows =
+        getRows(
+            ImmutableSortedMap.of(
+                "node1",
+                ImmutableSortedMap.of("vrf1", getMockRib(lpmIp)),
+                "node2",
+                ImmutableSortedMap.of("vrf2", getMockRib(lpmIp))),
+            lpmIp,
+            ImmutableSet.of("node2"),
+            Pattern.compile(".*"),
+            columnMap);
+
+    assertThat(rows, contains(hasColumn(COL_NODE, equalTo(new Node("node2")), Schema.NODE)));
+  }
+
+  @Test
+  public void testFilteringByVrfs() {
+    final ImmutableMap<String, ColumnMetadata> columnMap =
+        getColumnMetadata().stream()
+            .collect(ImmutableMap.toImmutableMap(ColumnMetadata::getName, Function.identity()));
+
+    final Ip lpmIp = Ip.parse("1.1.1.1");
+    List<Row> rows =
+        getRows(
+            ImmutableSortedMap.of(
+                "node1",
+                ImmutableSortedMap.of("vrf1", getMockRib(lpmIp)),
+                "node2",
+                ImmutableSortedMap.of("vrf2", getMockRib(lpmIp))),
+            lpmIp,
+            ImmutableSet.of("node1", "node2"),
+            Pattern.compile("vrf1"),
+            columnMap);
+
+    assertThat(
+        rows,
+        contains(
+            allOf(
+                hasColumn(COL_NODE, equalTo(new Node("node1")), Schema.NODE),
+                hasColumn(COL_VRF, equalTo("vrf1"), Schema.STRING))));
+  }
+}

--- a/questions/stable/lpmRoutes.json
+++ b/questions/stable/lpmRoutes.json
@@ -1,0 +1,37 @@
+{
+    "class": "org.batfish.question.lpmroutes.LpmRoutesQuestion",
+    "differential": false,
+    "instance": {
+        "description": "Show routes which are longest prefix match for a given IP address",
+        "instanceName": "lpmRoutes",
+        "longDescription": "Return longest prefix match routes for a given IP in the RIBs of specified node/VRF.",
+        "tags": [
+            "dataPlane",
+            "route"
+        ],
+        "variables": {
+            "ip": {
+                "description": "IP address to run LPM on",
+                "type": "ip",
+                "optional": false,
+                "displayName": "IP Address"
+            },
+            "nodes": {
+                "description": "Examine routes on nodes matching this specifier",
+                "type": "nodeSpec",
+                "value": ".*",
+                "displayName": "Nodes"
+            },
+            "vrfs": {
+                "description": "Examine routes on VRFs matching this name or regex",
+                "type": "vrf",
+                "value": ".*",
+                "displayName": "VRFs"
+            }
+        }
+    },
+    "ip": "${ip}",
+    "nodes": "${nodes}",
+    "rib": "main",
+    "vrfs": "${vrfs}"
+}

--- a/questions/stable/lpmRoutes.json
+++ b/questions/stable/lpmRoutes.json
@@ -28,7 +28,12 @@
                 "value": ".*",
                 "displayName": "VRFs"
             }
-        }
+        },
+        "orderedVariableNames": [
+            "ip",
+            "nodes",
+            "vrfs"
+        ]
     },
     "ip": "${ip}",
     "nodes": "${nodes}",

--- a/tests/questions/stable/commands
+++ b/tests/questions/stable/commands
@@ -21,6 +21,9 @@ test -raw tests/questions/stable/edges.ref validate-template edges edgeType="bgp
 # validate ipsecSessionStatus
 test -raw tests/questions/stable/ipsecSessionStatus.ref validate-template ipsecSessionStatus nodes="n1", remoteNodes="n2", status=".*"
 
+# validate lpmRoutes
+test -raw tests/questions/stable/lpmRoutes.ref validate-template lpmRoutes ip="1.1.1.1", nodes="n1", vrfs="default"
+
 # validate parseWarning
 test -raw tests/questions/stable/parseWarning.ref validate-template parseWarning aggregateDuplicates=true
 

--- a/tests/questions/stable/lpmRoutes.ref
+++ b/tests/questions/stable/lpmRoutes.ref
@@ -1,0 +1,41 @@
+{
+  "class" : "org.batfish.question.lpmroutes.LpmRoutesQuestion",
+  "ip" : "1.1.1.1",
+  "nodes" : "n1",
+  "rib" : "MAIN",
+  "vrfs" : "default",
+  "differential" : false,
+  "includeOneTableKeys" : true,
+  "instance" : {
+    "description" : "Show routes which are longest prefix match for a given IP address",
+    "instanceName" : "qname",
+    "longDescription" : "Return longest prefix match routes for a given IP in the RIBs of specified node/VRF.",
+    "tags" : [
+      "dataPlane",
+      "route"
+    ],
+    "variables" : {
+      "ip" : {
+        "description" : "IP address to run LPM on",
+        "displayName" : "IP Address",
+        "optional" : false,
+        "type" : "ip",
+        "value" : "1.1.1.1"
+      },
+      "nodes" : {
+        "description" : "Examine routes on nodes matching this specifier",
+        "displayName" : "Nodes",
+        "optional" : false,
+        "type" : "nodeSpec",
+        "value" : "n1"
+      },
+      "vrfs" : {
+        "description" : "Examine routes on VRFs matching this name or regex",
+        "displayName" : "VRFs",
+        "optional" : false,
+        "type" : "vrf",
+        "value" : "default"
+      }
+    }
+  }
+}

--- a/tests/questions/stable/lpmRoutes.ref
+++ b/tests/questions/stable/lpmRoutes.ref
@@ -10,6 +10,11 @@
     "description" : "Show routes which are longest prefix match for a given IP address",
     "instanceName" : "qname",
     "longDescription" : "Return longest prefix match routes for a given IP in the RIBs of specified node/VRF.",
+    "orderedVariableNames" : [
+      "ip",
+      "nodes",
+      "vrfs"
+    ],
     "tags" : [
       "dataPlane",
       "route"


### PR DESCRIPTION
Allows running longest prefix match for a given IP on the main RIBs of
all nodes/vrfs

The `rib` parameter is for now hidden from the template. Needs more changes to DP interface to get the right RIBs.