### PR TITLE
Prepare ForwardingAnalysis for route-leaking and PBR

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysis.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysis.java
@@ -7,7 +7,10 @@ public interface ForwardingAnalysis {
   /** Mapping: hostname -&gt; inInterface -&gt; ipsToArpReplyTo */
   Map<String, Map<String, IpSpace>> getArpReplies();
 
-  /** Mapping: edge -&gt; dstIpsForWhichArpReplySent */
+  /**
+   * Mapping: hostname -&gt; vrfName -&gt; edge -&gt; dst IPs for which that vrf will forward out
+   * the source of the edge and receive an ARP reply from the target of the edge.
+   */
   Map<String, Map<String, Map<Edge, IpSpace>>> getArpTrueEdge();
 
   /** Mapping: hostname -&gt; vrfName -&gt; outInterface -&gt; dstIpsForWhichNoArpResponse */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysis.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysis.java
@@ -8,7 +8,7 @@ public interface ForwardingAnalysis {
   Map<String, Map<String, IpSpace>> getArpReplies();
 
   /** Mapping: edge -&gt; dstIpsForWhichArpReplySent */
-  Map<Edge, IpSpace> getArpTrueEdge();
+  Map<String, Map<String, Map<Edge, IpSpace>>> getArpTrueEdge();
 
   /** Mapping: hostname -&gt; vrfName -&gt; outInterface -&gt; dstIpsForWhichNoArpResponse */
   Map<String, Map<String, Map<String, IpSpace>>> getNeighborUnreachableOrExitsNetwork();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -399,8 +399,6 @@ public class ForwardingAnalysisImplTest {
             .setAddress(new InterfaceAddress(i2Ip, P1.getPrefixLength()))
             .build();
     Edge edge = Edge.of(c1.getHostname(), i1.getName(), c2.getHostname(), i2.getName());
-    Map<String, Configuration> configurations =
-        ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2);
     SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs =
         ImmutableSortedMap.of(
             c1.getHostname(),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -294,19 +294,26 @@ public class ForwardingAnalysisImplTest {
     IpSpace nextHopIpSpace = new MockIpSpace(1);
     IpSpace dstIpSpace = new MockIpSpace(2);
     Edge e1 = Edge.of("c1", "i1", "c2", "i2");
-    Map<Edge, IpSpace> arpTrueEdgeDestIp = ImmutableMap.of(e1, dstIpSpace);
-    Map<Edge, IpSpace> arpTrueEdgeNextHopIp = ImmutableMap.of(e1, nextHopIpSpace);
-    Map<Edge, IpSpace> result = computeArpTrueEdge(arpTrueEdgeDestIp, arpTrueEdgeNextHopIp);
+    Map<String, Map<String, Map<Edge, IpSpace>>> arpTrueEdgeDestIp =
+        ImmutableMap.of("c1", ImmutableMap.of("v1", ImmutableMap.of(e1, dstIpSpace)));
+    Map<String, Map<String, Map<Edge, IpSpace>>> arpTrueEdgeNextHopIp =
+        ImmutableMap.of("c1", ImmutableMap.of("v1", ImmutableMap.of(e1, nextHopIpSpace)));
+    Map<String, Map<String, Map<Edge, IpSpace>>> result =
+        computeArpTrueEdge(arpTrueEdgeDestIp, arpTrueEdgeNextHopIp);
 
     assertThat(
         result,
         hasEntry(
-            equalTo(e1),
-            isAclIpSpaceThat(
-                hasLines(
-                    containsInAnyOrder(
-                        AclIpSpaceLine.permit(nextHopIpSpace),
-                        AclIpSpaceLine.permit(dstIpSpace))))));
+            equalTo("c1"),
+            hasEntry(
+                equalTo("v1"),
+                hasEntry(
+                    equalTo(e1),
+                    isAclIpSpaceThat(
+                        hasLines(
+                            containsInAnyOrder(
+                                AclIpSpaceLine.permit(nextHopIpSpace),
+                                AclIpSpaceLine.permit(dstIpSpace))))))));
   }
 
   @Test
@@ -318,8 +325,6 @@ public class ForwardingAnalysisImplTest {
     Interface i1 = _ib.setOwner(c1).setVrf(vrf1).build();
     Ip i2Ip = Ip.create(P1.getStartIp().asLong() + 1);
     Interface i2 = _ib.setOwner(c2).setVrf(vrf2).build();
-    Map<String, Configuration> configs =
-        ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2);
     SortedMap<String, SortedMap<String, GenericRib<AbstractRoute>>> ribs =
         ImmutableSortedMap.of(
             c1.getHostname(),
@@ -336,8 +341,12 @@ public class ForwardingAnalysisImplTest {
                                 .build()))
                     .build()));
     Edge edge = Edge.of(c1.getHostname(), i1.getName(), c2.getHostname(), i2.getName());
-    Map<Edge, Set<AbstractRoute>> routesWithDestIpEdge =
-        ImmutableMap.of(edge, ImmutableSet.of(new ConnectedRoute(P1, i1.getName())));
+    Map<String, Map<String, Map<Edge, Set<AbstractRoute>>>> routesWithDestIpEdge =
+        ImmutableMap.of(
+            c1.getHostname(),
+            ImmutableMap.of(
+                vrf1.getName(),
+                ImmutableMap.of(edge, ImmutableSet.of(new ConnectedRoute(P1, i1.getName())))));
     Map<String, Map<String, IpSpace>> arpReplies =
         ImmutableMap.of(
             c2.getHostname(),
@@ -346,16 +355,30 @@ public class ForwardingAnalysisImplTest {
                 AclIpSpace.permitting(i2Ip.toIpSpace())
                     .thenPermitting(P1.getEndIp().toIpSpace())
                     .build()));
-    Map<Edge, IpSpace> result =
-        computeArpTrueEdgeDestIp(
-            configs, computeMatchingIps(ribs), routesWithDestIpEdge, arpReplies);
+    Map<String, Map<String, Map<Edge, IpSpace>>> result =
+        computeArpTrueEdgeDestIp(computeMatchingIps(ribs), routesWithDestIpEdge, arpReplies);
 
     /* Respond to request for IP on i2. */
-    assertThat(result, hasEntry(equalTo(edge), containsIp(i2Ip)));
+    assertThat(
+        result,
+        hasEntry(
+            equalTo(c1.getHostname()),
+            hasEntry(equalTo(vrf1.getName()), hasEntry(equalTo(edge), containsIp(i2Ip)))));
     /* Do not make ARP request for IP matched by more specific route not going out i1.  */
-    assertThat(result, hasEntry(equalTo(edge), not(containsIp(P1.getEndIp()))));
+    assertThat(
+        result,
+        hasEntry(
+            equalTo(c1.getHostname()),
+            hasEntry(
+                equalTo(vrf1.getName()), hasEntry(equalTo(edge), not(containsIp(P1.getEndIp()))))));
     /* Do not receive response for IP i2 does not own. */
-    assertThat(result, hasEntry(equalTo(edge), not(containsIp(P1.getStartIp()))));
+    assertThat(
+        result,
+        hasEntry(
+            equalTo(c1.getHostname()),
+            hasEntry(
+                equalTo(vrf1.getName()),
+                hasEntry(equalTo(edge), not(containsIp(P1.getStartIp()))))));
   }
 
   @Test
@@ -393,29 +416,60 @@ public class ForwardingAnalysisImplTest {
                                 .thenPermitting(P1.toIpSpace())
                                 .build()))
                     .build()));
-    Map<Edge, Set<AbstractRoute>> routesWithNextHopIpArpTrue =
+    Map<String, Map<String, Map<Edge, Set<AbstractRoute>>>> routesWithNextHopIpArpTrue =
         ImmutableMap.of(
-            edge,
-            ImmutableSet.of(
-                StaticRoute.builder()
-                    .setNetwork(P1)
-                    .setNextHopIp(P2.getStartIp())
-                    .setAdministrativeCost(1)
-                    .build()));
-    Map<Edge, IpSpace> result =
-        computeArpTrueEdgeNextHopIp(
-            configurations, computeMatchingIps(ribs), routesWithNextHopIpArpTrue);
+            c1.getHostname(),
+            ImmutableMap.of(
+                vrf1.getName(),
+                ImmutableMap.of(
+                    edge,
+                    ImmutableSet.of(
+                        StaticRoute.builder()
+                            .setNetwork(P1)
+                            .setNextHopIp(P2.getStartIp())
+                            .setAdministrativeCost(1)
+                            .build()))));
+    Map<String, Map<String, Map<Edge, IpSpace>>> result =
+        computeArpTrueEdgeNextHopIp(computeMatchingIps(ribs), routesWithNextHopIpArpTrue);
 
     /*
      * Respond for any destination IP in network not matching more specific route not going out i1.
      */
-    assertThat(result, hasEntry(equalTo(edge), containsIp(P1.getStartIp())));
-    assertThat(result, hasEntry(equalTo(edge), containsIp(i2Ip)));
+    assertThat(
+        result,
+        hasEntry(
+            equalTo(c1.getHostname()),
+            hasEntry(
+                equalTo(vrf1.getName()), hasEntry(equalTo(edge), containsIp(P1.getStartIp())))));
+
+    assertThat(
+        result,
+        hasEntry(
+            equalTo(c1.getHostname()),
+            hasEntry(equalTo(vrf1.getName()), hasEntry(equalTo(edge), containsIp(i2Ip)))));
+
     /* Do not respond for destination IP matching more specific route not going out i1 */
-    assertThat(result, hasEntry(equalTo(edge), not(containsIp(P1.getEndIp()))));
+    assertThat(
+        result,
+        hasEntry(
+            equalTo(c1.getHostname()),
+            hasEntry(
+                equalTo(vrf1.getName()), hasEntry(equalTo(edge), not(containsIp(P1.getEndIp()))))));
+
     /* Do not respond for destination IPs not matching route */
-    assertThat(result, hasEntry(equalTo(edge), not(containsIp(P2.getStartIp()))));
-    assertThat(result, hasEntry(equalTo(edge), not(containsIp(P2.getEndIp()))));
+    assertThat(
+        result,
+        hasEntry(
+            equalTo(c1.getHostname()),
+            hasEntry(
+                equalTo(vrf1.getName()),
+                hasEntry(equalTo(edge), not(containsIp(P2.getStartIp()))))));
+    assertThat(
+        result,
+        hasEntry(
+            equalTo(c1.getHostname()),
+            hasEntry(
+                equalTo(vrf1.getName()), hasEntry(equalTo(edge), not(containsIp(P2.getEndIp()))))));
   }
 
   @Test
@@ -860,10 +914,13 @@ public class ForwardingAnalysisImplTest {
         ImmutableMap.of(c1, ImmutableMap.of(v1, ImmutableMap.of(i1, ImmutableSet.of(r1))));
     Edge e1 = Edge.of(c1, i1, c2, i2);
     Topology topology = new Topology(ImmutableSortedSet.of(e1));
-    Map<Edge, Set<AbstractRoute>> result =
+    Map<String, Map<String, Map<Edge, Set<AbstractRoute>>>> result =
         computeRoutesWithDestIpEdge(topology, routesWhereDstIpCanBeArpIp);
 
-    assertThat(result, equalTo(ImmutableMap.of(e1, ImmutableSet.of(r1))));
+    assertThat(
+        result,
+        hasEntry(
+            equalTo(c1), hasEntry(equalTo(v1), equalTo(ImmutableMap.of(e1, ImmutableSet.of(r1))))));
   }
 
   @Test
@@ -1076,11 +1133,14 @@ public class ForwardingAnalysisImplTest {
                                 i1,
                                 ImmutableMap.of(r2.getNextHopIp(), ImmutableSet.of(ifaceRoute)))))
                     .build()));
-    Map<Edge, Set<AbstractRoute>> result =
+    Map<String, Map<String, Map<Edge, Set<AbstractRoute>>>> result =
         computeRoutesWithNextHopIpArpTrue(fibs, topology, arpReplies, routesWithNextHop);
 
     /* Only the route with the next hop ip that gets a reply should be present. */
-    assertThat(result, equalTo(ImmutableMap.of(e1, ImmutableSet.of(r1))));
+    assertThat(
+        result,
+        equalTo(
+            ImmutableMap.of(c1, ImmutableMap.of(v1, ImmutableMap.of(e1, ImmutableSet.of(r1))))));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockForwardingAnalysis.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockForwardingAnalysis.java
@@ -14,7 +14,7 @@ public class MockForwardingAnalysis implements ForwardingAnalysis {
             String, Map<String, Map<AbstractRoute, Map<String, Map<ArpIpChoice, Set<IpSpace>>>>>>
         _arpRequests;
 
-    private Map<Edge, IpSpace> _arpTrueEdge;
+    private Map<String, Map<String, Map<Edge, IpSpace>>> _arpTrueEdge;
 
     private Map<String, Map<String, Map<String, IpSpace>>> _neighborUnreachableOrExitsNetwork;
 
@@ -47,7 +47,7 @@ public class MockForwardingAnalysis implements ForwardingAnalysis {
       return this;
     }
 
-    public Builder setArpTrueEdge(Map<Edge, IpSpace> arpTrueEdge) {
+    public Builder setArpTrueEdge(Map<String, Map<String, Map<Edge, IpSpace>>> arpTrueEdge) {
       _arpTrueEdge = arpTrueEdge;
       return this;
     }
@@ -79,7 +79,7 @@ public class MockForwardingAnalysis implements ForwardingAnalysis {
           String, Map<String, Map<AbstractRoute, Map<String, Map<ArpIpChoice, Set<IpSpace>>>>>>
       _arpRequests;
 
-  private final Map<Edge, IpSpace> _arpTrueEdge;
+  private final Map<String, Map<String, Map<Edge, IpSpace>>> _arpTrueEdge;
 
   private final Map<String, Map<String, Map<String, IpSpace>>> _neighborUnreachableOrExitsNetwork;
 
@@ -108,7 +108,7 @@ public class MockForwardingAnalysis implements ForwardingAnalysis {
   }
 
   @Override
-  public Map<Edge, IpSpace> getArpTrueEdge() {
+  public Map<String, Map<String, Map<Edge, IpSpace>>> getArpTrueEdge() {
     return _arpTrueEdge;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -138,8 +138,8 @@ public final class BDDReachabilityAnalysisFactory {
   private final Map<String, Map<String, Supplier<BDD>>> _aclPermitBDDs;
 
   /*
-   * edge --> set of packets that will flow out the edge successfully, including that the
-   * neighbor will respond to ARP.
+   * node -> vrf -> edge -> set of packets that vrf will forward out that edge successfully,
+   * including that the neighbor will respond to ARP.
    */
   private final Map<String, Map<String, Map<org.batfish.datamodel.Edge, BDD>>> _arpTrueEdgeBDDs;
 

--- a/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/z3/SynthesizerInputImplTest.java
@@ -226,7 +226,12 @@ public class SynthesizerInputImplTest {
         _inputBuilder
             .setForwardingAnalysis(
                 MockForwardingAnalysis.builder()
-                    .setArpTrueEdge(ImmutableMap.of(edge1, ipSpace1, edge2, ipSpace2))
+                    .setArpTrueEdge(
+                        ImmutableMap.of(
+                            srcNode.getHostname(),
+                            ImmutableMap.of(
+                                srcVrf.getName(),
+                                ImmutableMap.of(edge1, ipSpace1, edge2, ipSpace2))))
                     .build())
             .setTopology(new Topology(ImmutableSortedSet.of(edge1, edge2)))
             .build();


### PR DESCRIPTION
ForwardingAnalysis currently assumes that only the VRF that owns an
interface can forward traffic out that interface. Route-leaking and PBR
violate that assumption. This change (at least partially) removes it.