### PR TITLE
OSPF NSSA setting to suppress type 7 LSAs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/NssaSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/NssaSettings.java
@@ -13,8 +13,8 @@ public class NssaSettings implements Serializable {
   public static class Builder {
 
     private OspfDefaultOriginateType _defaultOriginateType;
-
     private boolean _suppressType3;
+    private boolean _suppressType7;
 
     private Builder() {}
 
@@ -31,11 +31,16 @@ public class NssaSettings implements Serializable {
       _suppressType3 = suppressType3;
       return this;
     }
+
+    public Builder setSuppressType7(boolean suppressType7) {
+      _suppressType7 = suppressType7;
+      return this;
+    }
   }
 
   private static final String PROP_DEFAULT_ORIGINATE_TYPE = "defaultOriginateType";
-
   private static final String PROP_SUPPRESS_TYPE3 = "suppressType3";
+  private static final String PROP_SUPPRESS_TYPE7 = "suppressType7";
 
   private static final long serialVersionUID = 1L;
 
@@ -44,20 +49,23 @@ public class NssaSettings implements Serializable {
   }
 
   private final OspfDefaultOriginateType _defaultOriginateType;
-
   private final boolean _suppressType3;
+  private final boolean _suppressType7;
 
-  public NssaSettings(Builder builder) {
+  private NssaSettings(Builder builder) {
     _defaultOriginateType = builder._defaultOriginateType;
     _suppressType3 = builder._suppressType3;
+    _suppressType7 = builder._suppressType7;
   }
 
   @JsonCreator
   private NssaSettings(
       @JsonProperty(PROP_DEFAULT_ORIGINATE_TYPE) OspfDefaultOriginateType defaultOriginateType,
-      @JsonProperty(PROP_SUPPRESS_TYPE3) boolean suppressType3) {
+      @JsonProperty(PROP_SUPPRESS_TYPE3) boolean suppressType3,
+      @JsonProperty(PROP_SUPPRESS_TYPE7) boolean suppressType7) {
     _defaultOriginateType = firstNonNull(defaultOriginateType, OspfDefaultOriginateType.NONE);
     _suppressType3 = suppressType3;
+    _suppressType7 = suppressType7;
   }
 
   @JsonProperty(PROP_DEFAULT_ORIGINATE_TYPE)
@@ -68,5 +76,10 @@ public class NssaSettings implements Serializable {
   @JsonProperty(PROP_SUPPRESS_TYPE3)
   public boolean getSuppressType3() {
     return _suppressType3;
+  }
+
+  @JsonProperty(PROP_SUPPRESS_TYPE7)
+  public boolean getSuppressType7() {
+    return _suppressType7;
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/NssaSettingsMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/NssaSettingsMatchers.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.matchers.NssaSettingsMatchersImpl.HasDefaultOriginateType;
 import org.batfish.datamodel.matchers.NssaSettingsMatchersImpl.HasSuppressType3;
+import org.batfish.datamodel.matchers.NssaSettingsMatchersImpl.HasSuppressType7;
 import org.batfish.datamodel.ospf.NssaSettings;
 import org.batfish.datamodel.ospf.OspfDefaultOriginateType;
 import org.hamcrest.Matcher;
@@ -43,6 +44,14 @@ public final class NssaSettingsMatchers {
    */
   public static @Nonnull Matcher<NssaSettings> hasSuppressType3(boolean expectedSuppressType3) {
     return new HasSuppressType3(equalTo(expectedSuppressType3));
+  }
+
+  /**
+   * Provides a matcher that matches if the the {@link NssaSettings}'s suppressType7 is {@code
+   * expectedSuppressType7}.
+   */
+  public static @Nonnull Matcher<NssaSettings> hasSuppressType7(boolean expectedSuppressType7) {
+    return new HasSuppressType7(equalTo(expectedSuppressType7));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/NssaSettingsMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/NssaSettingsMatchersImpl.java
@@ -31,5 +31,16 @@ final class NssaSettingsMatchersImpl {
     }
   }
 
+  static final class HasSuppressType7 extends FeatureMatcher<NssaSettings, Boolean> {
+    HasSuppressType7(@Nonnull Matcher<? super Boolean> subMatcher) {
+      super(subMatcher, "An NssaSettings with suppressType7:", "suppressType7");
+    }
+
+    @Override
+    protected Boolean featureValueOf(NssaSettings actual) {
+      return actual.getSuppressType7();
+    }
+  }
+
   private NssaSettingsMatchersImpl() {}
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -2260,6 +2260,14 @@ public class VirtualRouter implements Serializable {
         continue;
       }
 
+      // If we're in an ABR that suppresses type 7 LSAs, do not propagate external routes to NSSAs
+      if (_vrf.getOspfProcess().isAreaBorderRouter()
+          && localArea.getNssa() != null
+          && localArea.getNssa().getSuppressType7()
+          && localArea.getStubType() == StubType.NSSA) {
+        continue;
+      }
+
       // Get remote VirtualRouter
       VirtualRouter remoteVr =
           allNodes

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -8509,7 +8509,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       settings.setDefaultInformationOriginate(true);
     }
     if (ctx.no_redistribution != null) {
-      todo(ctx, "Unsupported feature: no-redistribution");
       settings.setNoRedistribution(true);
     }
     if (ctx.no_summary != null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2704,6 +2704,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                 ? OspfDefaultOriginateType.INTER_AREA
                 : OspfDefaultOriginateType.NONE)
         .setSuppressType3(nssaSettings.getNoSummary())
+        .setSuppressType7(nssaSettings.getNoRedistribution())
         .build();
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -123,6 +123,7 @@ import static org.batfish.datamodel.matchers.MlagMatchers.hasPeerAddress;
 import static org.batfish.datamodel.matchers.MlagMatchers.hasPeerInterface;
 import static org.batfish.datamodel.matchers.NssaSettingsMatchers.hasDefaultOriginateType;
 import static org.batfish.datamodel.matchers.NssaSettingsMatchers.hasSuppressType3;
+import static org.batfish.datamodel.matchers.NssaSettingsMatchers.hasSuppressType7;
 import static org.batfish.datamodel.matchers.OrMatchExprMatchers.hasDisjuncts;
 import static org.batfish.datamodel.matchers.OrMatchExprMatchers.isOrMatchExprThat;
 import static org.batfish.datamodel.matchers.OspfAreaMatchers.hasNssa;
@@ -3586,7 +3587,7 @@ public class CiscoGrammarTest {
     // Sanity check: ensure the ABR does not have suppressType7 set for area 1
     OspfArea abrToArea1 =
         abr.getVrfs().get(DEFAULT_VRF_NAME).getInterfaces().get("Ethernet1").getOspfArea();
-    assertThat(abrToArea1.getNssa().getSuppressType7(), equalTo(false));
+    assertThat(abrToArea1.getNssa(), hasSuppressType7(false));
 
     batfish.computeDataPlane();
     DataPlane dp = batfish.loadDataPlane();
@@ -3618,7 +3619,7 @@ public class CiscoGrammarTest {
 
     // This time the ABR should have suppressType7 set for area 1
     abrToArea1 = abr.getVrfs().get(DEFAULT_VRF_NAME).getInterfaces().get("Ethernet1").getOspfArea();
-    assertThat(abrToArea1.getNssa().getSuppressType7(), equalTo(true));
+    assertThat(abrToArea1.getNssa(), hasSuppressType7(true));
 
     batfish.computeDataPlane();
     dp = batfish.loadDataPlane();

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ospf-no-redistribution/configs/ios-abr
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ospf-no-redistribution/configs/ios-abr
@@ -1,0 +1,21 @@
+!
+hostname ios-abr
+!
+!
+interface Loopback1
+ ip address 10.10.10.10 255.255.255.255
+!
+! To area 0
+interface Ethernet0
+ ip address 2.2.2.1 255.255.255.0
+!
+! To area 1
+interface Ethernet1
+ ip address 1.1.1.1 255.255.255.0
+!
+router ospf 1
+ network 2.2.0.0 0.0.255.255 area 0
+ network 1.1.0.0 0.0.255.255 area 1
+ area 1 nssa
+ redistribute connected subnets
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ospf-no-redistribution/configs/ios-abr-no-redistribution
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ospf-no-redistribution/configs/ios-abr-no-redistribution
@@ -1,0 +1,21 @@
+!
+hostname ios-abr-no-redistribution
+!
+!
+interface Loopback1
+ ip address 10.10.10.10 255.255.255.255
+!
+! To area 0
+interface Ethernet0
+ ip address 2.2.2.1 255.255.255.0
+!
+! To area 1
+interface Ethernet1
+ ip address 1.1.1.1 255.255.255.0
+!
+router ospf 1
+ network 2.2.0.0 0.0.255.255 area 0
+ network 1.1.0.0 0.0.255.255 area 1
+ area 1 nssa no-redistribution
+ redistribute connected subnets
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ospf-no-redistribution/configs/ios-area-0
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ospf-no-redistribution/configs/ios-area-0
@@ -1,0 +1,9 @@
+!
+hostname ios-area-0
+!
+interface Ethernet0/0
+ ip address 2.2.2.2 255.255.255.0
+!
+router ospf 1
+ network 2.2.0.0 0.0.255.255 area 0
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ospf-no-redistribution/configs/ios-area-1-nssa
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ospf-no-redistribution/configs/ios-area-1-nssa
@@ -1,0 +1,10 @@
+!
+hostname ios-area-1-nssa
+!
+interface Ethernet1
+ ip address 1.1.1.2 255.255.255.0
+!
+router ospf 1
+ network 1.1.0.0 0.0.255.255 area 1
+ area 1 nssa
+!

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -10312,7 +10312,8 @@
                   "name" : 0,
                   "nssa" : {
                     "defaultOriginateType" : "INTER_AREA",
-                    "suppressType3" : true
+                    "suppressType3" : true,
+                    "suppressType7" : true
                   },
                   "stubType" : "NSSA",
                   "summaries" : {
@@ -16461,7 +16462,8 @@
                   "name" : 66051,
                   "nssa" : {
                     "defaultOriginateType" : "INTER_AREA",
-                    "suppressType3" : true
+                    "suppressType3" : true,
+                    "suppressType7" : false
                   },
                   "stubType" : "NSSA",
                   "summaries" : {

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -464,27 +464,6 @@
       },
       {
         "Filename" : "configs/cisco_ospf",
-        "Line" : 34,
-        "Text" : "area 0.0.0.0 nssa no-redistribution",
-        "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
-        "Comment" : "Unsupported feature: no-redistribution"
-      },
-      {
-        "Filename" : "configs/cisco_ospf",
-        "Line" : 35,
-        "Text" : "area 0.0.0.0 nssa no-redistribution no-summary",
-        "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
-        "Comment" : "Unsupported feature: no-redistribution"
-      },
-      {
-        "Filename" : "configs/cisco_ospf",
-        "Line" : 36,
-        "Text" : "area 0.0.0.0 nssa no-redistribution default-information-originate no-summary",
-        "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
-        "Comment" : "Unsupported feature: no-redistribution"
-      },
-      {
-        "Filename" : "configs/cisco_ospf",
         "Line" : 53,
         "Text" : "distribute-list aclin in",
         "Parser_Context" : "[ro_distribute_list s_router_ospf stanza cisco_configuration]",
@@ -2081,10 +2060,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 291 results",
+      "notes" : "Found 288 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 291
+      "numResults" : 288
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -68316,24 +68316,6 @@
               "Text" : "area 0.0.0.0 filter-list prefix filterName out"
             },
             {
-              "Comment" : "Unsupported feature: no-redistribution",
-              "Line" : 34,
-              "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
-              "Text" : "area 0.0.0.0 nssa no-redistribution"
-            },
-            {
-              "Comment" : "Unsupported feature: no-redistribution",
-              "Line" : 35,
-              "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
-              "Text" : "area 0.0.0.0 nssa no-redistribution no-summary"
-            },
-            {
-              "Comment" : "Unsupported feature: no-redistribution",
-              "Line" : 36,
-              "Parser_Context" : "[ro_area_nssa s_router_ospf stanza cisco_configuration]",
-              "Text" : "area 0.0.0.0 nssa no-redistribution default-information-originate no-summary"
-            },
-            {
               "Comment" : "This feature is not currently supported",
               "Line" : 53,
               "Parser_Context" : "[ro_distribute_list s_router_ospf stanza cisco_configuration]",


### PR DESCRIPTION
Also adds extraction for Cisco `no-redistribution` to use this new infrastructure.