### PR TITLE
Specify interfaces by NodeInterfacePair

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/AllInterfacesInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/AllInterfacesInterfaceSpecifier.java
@@ -29,7 +29,7 @@ public final class AllInterfacesInterfaceSpecifier implements InterfaceSpecifier
     return ctxt.getConfigs().values().stream()
         .filter(c -> nodes.contains(c.getHostname()))
         .flatMap(c -> c.getAllInterfaces().values().stream())
-        .map(anInterface -> new NodeInterfacePair(anInterface))
+        .map(NodeInterfacePair::new)
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/AllInterfacesInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/AllInterfacesInterfaceSpecifier.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /** A {@link InterfaceSpecifier} that returns all interfaces. */
 @ParametersAreNonnullByDefault
@@ -25,10 +25,11 @@ public final class AllInterfacesInterfaceSpecifier implements InterfaceSpecifier
   }
 
   @Override
-  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+  public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     return ctxt.getConfigs().values().stream()
         .filter(c -> nodes.contains(c.getHostname()))
         .flatMap(c -> c.getAllInterfaces().values().stream())
+        .map(anInterface -> new NodeInterfacePair(anInterface))
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceSpecifier.java
@@ -1,7 +1,7 @@
 package org.batfish.specifier;
 
 import java.util.Set;
-import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /** An abstract specification of a set of interfaces in the network. */
 public interface InterfaceSpecifier {
@@ -10,5 +10,5 @@ public interface InterfaceSpecifier {
    *
    * @param ctxt Information about the network that may be used to determine match.
    */
-  Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt);
+  Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceSpecifierFilterSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceSpecifierFilterSpecifier.java
@@ -1,12 +1,15 @@
 package org.batfish.specifier;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /** A {@link FilterSpecifier} based on an {@link InterfaceSpecifier}. */
 @ParametersAreNonnullByDefault
@@ -45,7 +48,10 @@ public final class InterfaceSpecifierFilterSpecifier implements FilterSpecifier 
 
   @Override
   public Set<IpAccessList> resolve(String node, SpecifierContext ctxt) {
+    Map<String, Interface> ifaces = ctxt.getConfigs().get(node).getAllInterfaces();
     return _interfaceSpecifier.resolve(ImmutableSet.of(node), ctxt).stream()
+        .map(NodeInterfacePair::getInterface)
+        .map(ifaces::get)
         .map(
             iface ->
                 _type == Type.IN_FILTER ? iface.getIncomingFilter() : iface.getOutgoingFilter())

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceSpecifierInterfaceLocationSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceSpecifierInterfaceLocationSpecifier.java
@@ -36,7 +36,7 @@ public class InterfaceSpecifierInterfaceLocationSpecifier implements LocationSpe
   @Override
   public Set<Location> resolve(SpecifierContext ctxt) {
     return _interfaceSpecifier.resolve(ctxt.getConfigs().keySet(), ctxt).stream()
-        .map(iface -> new InterfaceLocation(iface.getOwner().getHostname(), iface.getName()))
+        .map(iface -> new InterfaceLocation(iface.getHostname(), iface.getInterface()))
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceWithConnectedIpsSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceWithConnectedIpsSpecifier.java
@@ -18,6 +18,7 @@ import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /** An {@link InterfaceSpecifier} that resolves interfaces connected to a given {@link IpSpace}. */
 public final class InterfaceWithConnectedIpsSpecifier implements InterfaceSpecifier {
@@ -59,11 +60,12 @@ public final class InterfaceWithConnectedIpsSpecifier implements InterfaceSpecif
   }
 
   @Override
-  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+  public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     return ctxt.getConfigs().values().stream()
         .filter(c -> nodes.contains(c.getHostname()))
         .flatMap(c -> c.getAllInterfaces().values().stream().filter(Interface::getActive))
         .filter(i -> i.getAllAddresses().stream().anyMatch(this::interfaceAddressMatchesIpSpace))
+        .map(anInterface -> new NodeInterfacePair(anInterface))
         .collect(ImmutableSet.toImmutableSet());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceWithConnectedIpsSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceWithConnectedIpsSpecifier.java
@@ -65,7 +65,7 @@ public final class InterfaceWithConnectedIpsSpecifier implements InterfaceSpecif
         .filter(c -> nodes.contains(c.getHostname()))
         .flatMap(c -> c.getAllInterfaces().values().stream().filter(Interface::getActive))
         .filter(i -> i.getAllAddresses().stream().anyMatch(this::interfaceAddressMatchesIpSpace))
-        .map(anInterface -> new NodeInterfacePair(anInterface))
+        .map(NodeInterfacePair::new)
         .collect(ImmutableSet.toImmutableSet());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NameInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NameInterfaceSpecifier.java
@@ -42,7 +42,7 @@ public final class NameInterfaceSpecifier implements InterfaceSpecifier {
         .map(c -> c.getAllInterfaces().values())
         .flatMap(Collection::stream)
         .filter(iface -> iface.getName().equalsIgnoreCase(_name))
-        .map(anInterface -> new NodeInterfacePair(anInterface))
+        .map(NodeInterfacePair::new)
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NameInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NameInterfaceSpecifier.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /** A {@link InterfaceSpecifier} that matches interface names (case insensitive). */
 @ParametersAreNonnullByDefault
@@ -36,12 +36,13 @@ public final class NameInterfaceSpecifier implements InterfaceSpecifier {
   }
 
   @Override
-  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+  public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     return ctxt.getConfigs().values().stream()
         .filter(c -> nodes.contains(c.getHostname()))
         .map(c -> c.getAllInterfaces().values())
         .flatMap(Collection::stream)
         .filter(iface -> iface.getName().equalsIgnoreCase(_name))
+        .map(anInterface -> new NodeInterfacePair(anInterface))
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NameRegexInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NameRegexInterfaceSpecifier.java
@@ -43,7 +43,7 @@ public final class NameRegexInterfaceSpecifier implements InterfaceSpecifier {
         .map(c -> c.getAllInterfaces().values())
         .flatMap(Collection::stream)
         .filter(iface -> _pattern.matcher(iface.getName()).matches())
-        .map(anInterface -> new NodeInterfacePair(anInterface))
+        .map(NodeInterfacePair::new)
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NameRegexInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NameRegexInterfaceSpecifier.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /** A {@link InterfaceSpecifier} that matches regex pattern over interface names. */
 @ParametersAreNonnullByDefault
@@ -37,12 +37,13 @@ public final class NameRegexInterfaceSpecifier implements InterfaceSpecifier {
   }
 
   @Override
-  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+  public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     return ctxt.getConfigs().values().stream()
         .filter(c -> nodes.contains(c.getHostname()))
         .map(c -> c.getAllInterfaces().values())
         .flatMap(Collection::stream)
         .filter(iface -> _pattern.matcher(iface.getName()).matches())
+        .map(anInterface -> new NodeInterfacePair(anInterface))
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NodeSpecifierInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/NodeSpecifierInterfaceSpecifier.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Set;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /**
  * An {@link InterfaceSpecifier} that yields {@link Interface}s based on a {@code NodeSpecifier}.
@@ -34,9 +35,10 @@ public class NodeSpecifierInterfaceSpecifier implements InterfaceSpecifier {
   }
 
   @Override
-  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+  public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     return Sets.intersection(_nodeSpecifier.resolve(ctxt), nodes).stream()
         .flatMap(n -> ctxt.getConfigs().get(n).getAllInterfaces().values().stream())
+        .map(NodeInterfacePair::new)
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ReferenceInterfaceGroupInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ReferenceInterfaceGroupInterfaceSpecifier.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
-import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.referencelibrary.InterfaceGroup;
 
@@ -41,7 +40,7 @@ public final class ReferenceInterfaceGroupInterfaceSpecifier implements Interfac
   }
 
   @Override
-  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+  public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     InterfaceGroup interfaceGroup =
         ctxt.getReferenceBook(_bookName)
             .orElseThrow(
@@ -55,16 +54,11 @@ public final class ReferenceInterfaceGroupInterfaceSpecifier implements Interfac
                             + "' not found in ReferenceBook '"
                             + _bookName
                             + "'"));
-
     return nodes.stream()
         .map(n -> ctxt.getConfigs().get(n).getAllInterfaces().values())
         .flatMap(Collection::stream)
-        // we have a stream of Interfaces now
-        .filter(
-            v ->
-                interfaceGroup
-                    .getInterfaces()
-                    .contains(new NodeInterfacePair(v.getOwner().getHostname(), v.getName())))
+        .map(anInterface -> new NodeInterfacePair(anInterface))
+        .filter(interfaceGroup.getInterfaces()::contains)
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ReferenceInterfaceGroupInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ReferenceInterfaceGroupInterfaceSpecifier.java
@@ -57,7 +57,7 @@ public final class ReferenceInterfaceGroupInterfaceSpecifier implements Interfac
     return nodes.stream()
         .map(n -> ctxt.getConfigs().get(n).getAllInterfaces().values())
         .flatMap(Collection::stream)
-        .map(anInterface -> new NodeInterfacePair(anInterface))
+        .map(NodeInterfacePair::new)
         .filter(interfaceGroup.getInterfaces()::contains)
         .collect(ImmutableSet.toImmutableSet());
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/TypesInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/TypesInterfaceSpecifier.java
@@ -10,8 +10,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /**
  * An {@link InterfaceSpecifier} that specifies interfaces by {@link InterfaceType type}. Uses a
@@ -34,13 +34,14 @@ public final class TypesInterfaceSpecifier implements InterfaceSpecifier {
   }
 
   @Override
-  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+  public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     Map<String, Configuration> configs = ctxt.getConfigs();
 
     return nodes.stream()
         .map(configs::get)
         .flatMap(config -> config.getAllInterfaces().values().stream())
         .filter(iface -> _interfaceTypes.contains(iface.getInterfaceType()))
+        .map(anInterface -> new NodeInterfacePair(anInterface))
         .collect(ImmutableSet.toImmutableSet());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/TypesInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/TypesInterfaceSpecifier.java
@@ -41,7 +41,7 @@ public final class TypesInterfaceSpecifier implements InterfaceSpecifier {
         .map(configs::get)
         .flatMap(config -> config.getAllInterfaces().values().stream())
         .filter(iface -> _interfaceTypes.contains(iface.getInterfaceType()))
-        .map(anInterface -> new NodeInterfacePair(anInterface))
+        .map(NodeInterfacePair::new)
         .collect(ImmutableSet.toImmutableSet());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameInterfaceSpecifier.java
@@ -4,14 +4,14 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
-import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /**
  * An {@link InterfaceSpecifier} for interfaces that belong to a VRF name. The name matching is
  * case-insensitive.
  */
 public final class VrfNameInterfaceSpecifier implements InterfaceSpecifier {
-  String _name;
+  private final String _name;
 
   public VrfNameInterfaceSpecifier(String name) {
     _name = name;
@@ -35,7 +35,7 @@ public final class VrfNameInterfaceSpecifier implements InterfaceSpecifier {
   }
 
   @Override
-  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+  public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     return nodes.stream()
         .map(n -> ctxt.getConfigs().get(n).getVrfs().values())
         .flatMap(Collection::stream)
@@ -43,6 +43,7 @@ public final class VrfNameInterfaceSpecifier implements InterfaceSpecifier {
         .filter(v -> v.getName().equalsIgnoreCase(_name))
         .map(v -> v.getInterfaces().values())
         .flatMap(Collection::stream)
+        .map(anInterface -> new NodeInterfacePair(anInterface))
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameInterfaceSpecifier.java
@@ -43,7 +43,7 @@ public final class VrfNameInterfaceSpecifier implements InterfaceSpecifier {
         .filter(v -> v.getName().equalsIgnoreCase(_name))
         .map(v -> v.getInterfaces().values())
         .flatMap(Collection::stream)
-        .map(anInterface -> new NodeInterfacePair(anInterface))
+        .map(NodeInterfacePair::new)
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameRegexInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameRegexInterfaceSpecifier.java
@@ -44,7 +44,7 @@ public final class VrfNameRegexInterfaceSpecifier implements InterfaceSpecifier 
         .filter(v -> _pattern.matcher(v.getName()).matches())
         .map(v -> v.getInterfaces().values())
         .flatMap(Collection::stream)
-        .map(anInterface -> new NodeInterfacePair(anInterface))
+        .map(NodeInterfacePair::new)
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameRegexInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameRegexInterfaceSpecifier.java
@@ -5,14 +5,14 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /**
  * An {@link InterfaceSpecifier} specifying interfaces that belong to VRFs with names matching the
  * input regex.
  */
 public final class VrfNameRegexInterfaceSpecifier implements InterfaceSpecifier {
-  Pattern _pattern;
+  private final Pattern _pattern;
 
   public VrfNameRegexInterfaceSpecifier(Pattern pattern) {
     _pattern = pattern;
@@ -36,7 +36,7 @@ public final class VrfNameRegexInterfaceSpecifier implements InterfaceSpecifier 
   }
 
   @Override
-  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+  public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     return nodes.stream()
         .map(n -> ctxt.getConfigs().get(n).getVrfs().values())
         .flatMap(Collection::stream)
@@ -44,6 +44,7 @@ public final class VrfNameRegexInterfaceSpecifier implements InterfaceSpecifier 
         .filter(v -> _pattern.matcher(v.getName()).matches())
         .map(v -> v.getInterfaces().values())
         .flatMap(Collection::stream)
+        .map(anInterface -> new NodeInterfacePair(anInterface))
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ZoneNameInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ZoneNameInterfaceSpecifier.java
@@ -55,7 +55,7 @@ public final class ZoneNameInterfaceSpecifier implements InterfaceSpecifier {
             .collect(ImmutableSet.toImmutableSet());
     return config.getAllInterfaces().values().stream()
         .filter(i -> interfaceNamesInMatchingZones.contains(i.getName()))
-        .map(anInterface -> new NodeInterfacePair(anInterface))
+        .map(NodeInterfacePair::new)
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ZoneNameInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ZoneNameInterfaceSpecifier.java
@@ -5,7 +5,8 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Zone;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /**
  * An {@link InterfaceSpecifier} for interfaces that belong to a Zone name. Name matching is case
@@ -36,7 +37,7 @@ public final class ZoneNameInterfaceSpecifier implements InterfaceSpecifier {
   }
 
   @Override
-  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+  public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     return nodes.stream()
         .map(n -> resolve(n, ctxt))
         .flatMap(Collection::stream)
@@ -44,16 +45,17 @@ public final class ZoneNameInterfaceSpecifier implements InterfaceSpecifier {
   }
 
   // This helper could be avoided if Zones stored Interfaces and not (just) interface names
-  private Set<Interface> resolve(String node, SpecifierContext ctxt) {
+  private Set<NodeInterfacePair> resolve(String node, SpecifierContext ctxt) {
     Configuration config = ctxt.getConfigs().get(node);
     Set<String> interfaceNamesInMatchingZones =
         config.getZones().values().stream()
             .filter(z -> z.getName().equalsIgnoreCase(_name))
-            .map(z -> z.getInterfaces())
+            .map(Zone::getInterfaces)
             .flatMap(Collection::stream)
             .collect(ImmutableSet.toImmutableSet());
     return config.getAllInterfaces().values().stream()
         .filter(i -> interfaceNamesInMatchingZones.contains(i.getName()))
+        .map(anInterface -> new NodeInterfacePair(anInterface))
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ZoneNameRegexInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ZoneNameRegexInterfaceSpecifier.java
@@ -6,7 +6,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Zone;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /**
  * An {@link InterfaceSpecifier} specifying interfaces that belong to Zones with names matching the
@@ -37,7 +38,7 @@ public final class ZoneNameRegexInterfaceSpecifier implements InterfaceSpecifier
   }
 
   @Override
-  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+  public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     return nodes.stream()
         .map(n -> resolve(n, ctxt))
         .flatMap(Collection::stream)
@@ -45,16 +46,17 @@ public final class ZoneNameRegexInterfaceSpecifier implements InterfaceSpecifier
   }
 
   // This helper could be avoided if Zones stored Interfaces and not (just) interface names
-  private Set<Interface> resolve(String node, SpecifierContext ctxt) {
+  private Set<NodeInterfacePair> resolve(String node, SpecifierContext ctxt) {
     Configuration config = ctxt.getConfigs().get(node);
     Set<String> interfaceNamesInMatchingZones =
         config.getZones().values().stream()
             .filter(z -> _pattern.matcher(z.getName()).matches())
-            .map(z -> z.getInterfaces())
+            .map(Zone::getInterfaces)
             .flatMap(Collection::stream)
             .collect(ImmutableSet.toImmutableSet());
     return config.getAllInterfaces().values().stream()
         .filter(i -> interfaceNamesInMatchingZones.contains(i.getName()))
+        .map(anInterface -> new NodeInterfacePair(anInterface))
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ZoneNameRegexInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ZoneNameRegexInterfaceSpecifier.java
@@ -56,7 +56,7 @@ public final class ZoneNameRegexInterfaceSpecifier implements InterfaceSpecifier
             .collect(ImmutableSet.toImmutableSet());
     return config.getAllInterfaces().values().stream()
         .filter(i -> interfaceNamesInMatchingZones.contains(i.getName()))
-        .map(anInterface -> new NodeInterfacePair(anInterface))
+        .map(NodeInterfacePair::new)
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifier.java
@@ -74,7 +74,7 @@ final class ParboiledInterfaceSpecifier implements InterfaceSpecifier {
     }
 
     @Override
-    public Set<Interface> visitInterfaceWithNodeInterfaceAstNode(
+    public Set<NodeInterfacePair> visitInterfaceWithNodeInterfaceAstNode(
         InterfaceWithNodeInterfaceAstNode interfaceWithNodeInterfaceAstNode) {
       return Sets.intersection(
           new NodeSpecifierInterfaceSpecifier(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifier.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.specifier.InterfaceSpecifier;
 import org.batfish.specifier.InterfaceWithConnectedIpsSpecifier;
 import org.batfish.specifier.NameInterfaceSpecifier;
@@ -24,7 +24,7 @@ final class ParboiledInterfaceSpecifier implements InterfaceSpecifier {
 
   @ParametersAreNonnullByDefault
   private final class InterfaceAstNodeToInterfaces
-      implements InterfaceAstNodeVisitor<Set<Interface>> {
+      implements InterfaceAstNodeVisitor<Set<NodeInterfacePair>> {
     private final SpecifierContext _ctxt;
     private final Set<String> _nodes;
 
@@ -35,7 +35,7 @@ final class ParboiledInterfaceSpecifier implements InterfaceSpecifier {
 
     @Nonnull
     @Override
-    public Set<Interface> visitConnectedToInterfaceAstNode(
+    public Set<NodeInterfacePair> visitConnectedToInterfaceAstNode(
         ConnectedToInterfaceAstNode connectedToInterfaceAstNode) {
       return new InterfaceWithConnectedIpsSpecifier(
               connectedToInterfaceAstNode
@@ -46,7 +46,7 @@ final class ParboiledInterfaceSpecifier implements InterfaceSpecifier {
 
     @Nonnull
     @Override
-    public Set<Interface> visitDifferenceInterfaceAstNode(
+    public Set<NodeInterfacePair> visitDifferenceInterfaceAstNode(
         DifferenceInterfaceAstNode differenceInterfaceAstNode) {
       return Sets.difference(
           differenceInterfaceAstNode.getLeft().accept(this),
@@ -55,7 +55,7 @@ final class ParboiledInterfaceSpecifier implements InterfaceSpecifier {
 
     @Nonnull
     @Override
-    public Set<Interface> visitInterfaceGroupInterfaceAstNode(
+    public Set<NodeInterfacePair> visitInterfaceGroupInterfaceAstNode(
         InterfaceGroupInterfaceAstNode interfaceGroupInterfaceAstNode) {
       return new ReferenceInterfaceGroupInterfaceSpecifier(
               interfaceGroupInterfaceAstNode.getInterfaceGroup(),
@@ -65,7 +65,7 @@ final class ParboiledInterfaceSpecifier implements InterfaceSpecifier {
 
     @Nonnull
     @Override
-    public Set<Interface> visitIntersectionInterfaceAstNode(
+    public Set<NodeInterfacePair> visitIntersectionInterfaceAstNode(
         IntersectionInterfaceAstNode intersectionInterfaceAstNode) {
       return Sets.intersection(
           intersectionInterfaceAstNode.getLeft().accept(this),
@@ -74,13 +74,14 @@ final class ParboiledInterfaceSpecifier implements InterfaceSpecifier {
 
     @Nonnull
     @Override
-    public Set<Interface> visitNameInterfaceNode(NameInterfaceAstNode nameInterfaceAstNode) {
+    public Set<NodeInterfacePair> visitNameInterfaceNode(
+        NameInterfaceAstNode nameInterfaceAstNode) {
       return new NameInterfaceSpecifier(nameInterfaceAstNode.getName()).resolve(_nodes, _ctxt);
     }
 
     @Nonnull
     @Override
-    public Set<Interface> visitNameRegexInterfaceAstNode(
+    public Set<NodeInterfacePair> visitNameRegexInterfaceAstNode(
         NameRegexInterfaceAstNode nameRegexInterfaceAstNode) {
       return new NameRegexInterfaceSpecifier(nameRegexInterfaceAstNode.getPattern())
           .resolve(_nodes, _ctxt);
@@ -88,14 +89,16 @@ final class ParboiledInterfaceSpecifier implements InterfaceSpecifier {
 
     @Nonnull
     @Override
-    public Set<Interface> visitTypeInterfaceNode(TypeInterfaceAstNode typeInterfaceAstNode) {
+    public Set<NodeInterfacePair> visitTypeInterfaceNode(
+        TypeInterfaceAstNode typeInterfaceAstNode) {
       return new TypesInterfaceSpecifier(ImmutableSet.of(typeInterfaceAstNode.getInterfaceType()))
           .resolve(_nodes, _ctxt);
     }
 
     @Nonnull
     @Override
-    public Set<Interface> visitUnionInterfaceAstNode(UnionInterfaceAstNode unionInterfaceAstNode) {
+    public Set<NodeInterfacePair> visitUnionInterfaceAstNode(
+        UnionInterfaceAstNode unionInterfaceAstNode) {
       return Sets.union(
           unionInterfaceAstNode.getLeft().accept(this),
           unionInterfaceAstNode.getRight().accept(this));
@@ -103,13 +106,15 @@ final class ParboiledInterfaceSpecifier implements InterfaceSpecifier {
 
     @Nonnull
     @Override
-    public Set<Interface> visitVrfInterfaceAstNode(VrfInterfaceAstNode vrfInterfaceAstNode) {
+    public Set<NodeInterfacePair> visitVrfInterfaceAstNode(
+        VrfInterfaceAstNode vrfInterfaceAstNode) {
       return new VrfNameInterfaceSpecifier(vrfInterfaceAstNode.getVrfName()).resolve(_nodes, _ctxt);
     }
 
     @Nonnull
     @Override
-    public Set<Interface> visitZoneInterfaceAstNode(ZoneInterfaceAstNode zoneInterfaceAstNode) {
+    public Set<NodeInterfacePair> visitZoneInterfaceAstNode(
+        ZoneInterfaceAstNode zoneInterfaceAstNode) {
       return new ZoneNameInterfaceSpecifier(zoneInterfaceAstNode.getZoneName())
           .resolve(_nodes, _ctxt);
     }
@@ -138,7 +143,7 @@ final class ParboiledInterfaceSpecifier implements InterfaceSpecifier {
   }
 
   @Override
-  public Set<Interface> resolve(Set<String> nodes, SpecifierContext ctxt) {
+  public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     return _ast.accept(new InterfaceAstNodeToInterfaces(nodes, ctxt));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/InterfaceWithConnectedIpsSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/InterfaceWithConnectedIpsSpecifierTest.java
@@ -15,6 +15,7 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.specifier.InterfaceWithConnectedIpsSpecifier.Factory;
 import org.junit.Rule;
 import org.junit.Test;
@@ -96,17 +97,17 @@ public class InterfaceWithConnectedIpsSpecifierTest {
     assertThat(
         new InterfaceWithConnectedIpsSpecifier(Ip.parse("1.2.3.4").toIpSpace())
             .resolve(ImmutableSet.of("node1", "node2"), ctxt),
-        equalTo(ImmutableSet.of(iface11, iface2)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(iface11), new NodeInterfacePair(iface2))));
 
     assertThat(
         new InterfaceWithConnectedIpsSpecifier(Ip.parse("1.2.3.8").toIpSpace())
             .resolve(ImmutableSet.of("node1", "node2"), ctxt),
-        equalTo(ImmutableSet.of(iface11)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(iface11))));
 
     assertThat(
         new InterfaceWithConnectedIpsSpecifier(Ip.parse("2.3.4.5").toIpSpace())
             .resolve(ImmutableSet.of("node1", "node2"), ctxt),
-        equalTo(ImmutableSet.of(iface12)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(iface12))));
 
     assertThat(
         new InterfaceWithConnectedIpsSpecifier(Prefix.parse("3.0.0.0/24").toIpSpace())

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/NameInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/NameInterfaceSpecifierTest.java
@@ -1,6 +1,8 @@
 package org.batfish.specifier;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
@@ -9,6 +11,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.junit.Test;
 
 public class NameInterfaceSpecifierTest {
@@ -35,20 +38,19 @@ public class NameInterfaceSpecifierTest {
 
     assertThat(
         new NameInterfaceSpecifier("iface1").resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of(iface1node1)));
+        contains(new NodeInterfacePair(iface1node1)));
 
     assertThat(
         new NameInterfaceSpecifier("iface1").resolve(ImmutableSet.of("node1", "node2"), ctxt),
-        equalTo(ImmutableSet.of(iface1node1, iface1node2)));
+        containsInAnyOrder(new NodeInterfacePair(iface1node1), new NodeInterfacePair(iface1node2)));
 
     // bad name
     assertThat(
-        new NameInterfaceSpecifier("iface").resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of()));
+        new NameInterfaceSpecifier("iface").resolve(ImmutableSet.of("node1"), ctxt), empty());
 
     // case insensitive
     assertThat(
         new NameInterfaceSpecifier("IfACe1").resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of(iface1node1)));
+        contains(new NodeInterfacePair(iface1node1)));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/NameRegexInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/NameRegexInterfaceSpecifierTest.java
@@ -1,6 +1,8 @@
 package org.batfish.specifier;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
@@ -10,6 +12,7 @@ import java.util.regex.Pattern;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.junit.Test;
 
 public class NameRegexInterfaceSpecifierTest {
@@ -37,17 +40,17 @@ public class NameRegexInterfaceSpecifierTest {
     assertThat(
         new NameRegexInterfaceSpecifier(Pattern.compile(".*1"))
             .resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of(iface1node1)));
+        contains(new NodeInterfacePair(iface1node1)));
 
     assertThat(
         new NameRegexInterfaceSpecifier(Pattern.compile("iface1.*"))
             .resolve(ImmutableSet.of("node1", "node2"), ctxt),
-        equalTo(ImmutableSet.of(iface1node1, iface1node2)));
+        containsInAnyOrder(new NodeInterfacePair(iface1node1), new NodeInterfacePair(iface1node2)));
 
     // bad regex
     assertThat(
         new NameRegexInterfaceSpecifier(Pattern.compile("iface"))
             .resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of()));
+        empty());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/NodeSpecifierInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/NodeSpecifierInterfaceSpecifierTest.java
@@ -1,6 +1,7 @@
 package org.batfish.specifier;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
@@ -9,6 +10,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.junit.Test;
 
 public class NodeSpecifierInterfaceSpecifierTest {
@@ -37,12 +39,12 @@ public class NodeSpecifierInterfaceSpecifierTest {
     assertThat(
         new NodeSpecifierInterfaceSpecifier(new NameNodeSpecifier("node1"))
             .resolve(ImmutableSet.of("node1", "node2"), ctxt),
-        equalTo(ImmutableSet.of(iface1node1, iface2node1)));
+        containsInAnyOrder(new NodeInterfacePair(iface1node1), new NodeInterfacePair(iface2node1)));
 
     // no common nodes
     assertThat(
         new NodeSpecifierInterfaceSpecifier(new NameNodeSpecifier("node1"))
             .resolve(ImmutableSet.of("node2"), ctxt),
-        equalTo(ImmutableSet.of()));
+        empty());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/ReferenceInterfaceGroupInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/ReferenceInterfaceGroupInterfaceSpecifierTest.java
@@ -1,6 +1,6 @@
 package org.batfish.specifier;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -52,6 +52,6 @@ public class ReferenceInterfaceGroupInterfaceSpecifierTest {
     assertThat(
         new ReferenceInterfaceGroupInterfaceSpecifier("group", "refbook")
             .resolve(ImmutableSet.of(node1.getHostname()), ctxt),
-        equalTo(ImmutableSet.of(iface11)));
+        contains(new NodeInterfacePair(iface11)));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TypesInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TypesInterfaceSpecifierTest.java
@@ -13,6 +13,7 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -82,26 +83,39 @@ public class TypesInterfaceSpecifierTest {
     new TypesInterfaceSpecifier(Pattern.compile("bad regex"));
   }
 
-  private Set<Interface> specifiedInterfaces(String regex) {
+  private static Set<NodeInterfacePair> specifiedInterfaces(String regex) {
     return new TypesInterfaceSpecifier(Pattern.compile(regex, Pattern.CASE_INSENSITIVE))
         .resolve(ImmutableSet.of(HOSTNAME), CTXT);
   }
 
   @Test
   public void test() {
-    assertThat(specifiedInterfaces("a.*"), equalTo(ImmutableSet.of(AGGREGATED)));
-    assertThat(specifiedInterfaces("l.*"), equalTo(ImmutableSet.of(LOOPBACK)));
-    assertThat(specifiedInterfaces("n.*"), equalTo(ImmutableSet.of(NULL)));
-    assertThat(specifiedInterfaces("p.*"), equalTo(ImmutableSet.of(PHYSICAL)));
-    assertThat(specifiedInterfaces("r.*"), equalTo(ImmutableSet.of(REDUNDANT)));
-    assertThat(specifiedInterfaces("t.*"), equalTo(ImmutableSet.of(TUNNEL)));
-    assertThat(specifiedInterfaces("u.*"), equalTo(ImmutableSet.of(UNKNOWN)));
-    assertThat(specifiedInterfaces("vlan"), equalTo(ImmutableSet.of(VLAN)));
-    assertThat(specifiedInterfaces("vpn"), equalTo(ImmutableSet.of(VPN)));
+    assertThat(
+        specifiedInterfaces("a.*"), equalTo(ImmutableSet.of(new NodeInterfacePair(AGGREGATED))));
+    assertThat(
+        specifiedInterfaces("l.*"), equalTo(ImmutableSet.of(new NodeInterfacePair(LOOPBACK))));
+    assertThat(specifiedInterfaces("n.*"), equalTo(ImmutableSet.of(new NodeInterfacePair(NULL))));
+    assertThat(
+        specifiedInterfaces("p.*"), equalTo(ImmutableSet.of(new NodeInterfacePair(PHYSICAL))));
+    assertThat(
+        specifiedInterfaces("r.*"), equalTo(ImmutableSet.of(new NodeInterfacePair(REDUNDANT))));
+    assertThat(specifiedInterfaces("t.*"), equalTo(ImmutableSet.of(new NodeInterfacePair(TUNNEL))));
+    assertThat(
+        specifiedInterfaces("u.*"), equalTo(ImmutableSet.of(new NodeInterfacePair(UNKNOWN))));
+    assertThat(specifiedInterfaces("vlan"), equalTo(ImmutableSet.of(new NodeInterfacePair(VLAN))));
+    assertThat(specifiedInterfaces("vpn"), equalTo(ImmutableSet.of(new NodeInterfacePair(VPN))));
     assertThat(
         specifiedInterfaces(".*"),
         equalTo(
             ImmutableSet.of(
-                AGGREGATED, LOOPBACK, NULL, PHYSICAL, REDUNDANT, TUNNEL, UNKNOWN, VLAN, VPN)));
+                new NodeInterfacePair(AGGREGATED),
+                new NodeInterfacePair(LOOPBACK),
+                new NodeInterfacePair(NULL),
+                new NodeInterfacePair(PHYSICAL),
+                new NodeInterfacePair(REDUNDANT),
+                new NodeInterfacePair(TUNNEL),
+                new NodeInterfacePair(UNKNOWN),
+                new NodeInterfacePair(VLAN),
+                new NodeInterfacePair(VPN))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/VrfNameInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/VrfNameInterfaceSpecifierTest.java
@@ -1,6 +1,8 @@
 package org.batfish.specifier;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
@@ -10,6 +12,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.junit.Test;
 
 public class VrfNameInterfaceSpecifierTest {
@@ -46,24 +49,22 @@ public class VrfNameInterfaceSpecifierTest {
     // vrf1 on node1 should yield one interface
     assertThat(
         new VrfNameInterfaceSpecifier("vrf1").resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of(iface11)));
+        contains(new NodeInterfacePair(iface11)));
 
     // vrf1 on node1, node2 should yield one interface
     assertThat(
         new VrfNameInterfaceSpecifier("vrf1").resolve(ImmutableSet.of("node1", "node2"), ctxt),
-        equalTo(ImmutableSet.of(iface11, iface2)));
+        containsInAnyOrder(new NodeInterfacePair(iface11), new NodeInterfacePair(iface2)));
 
     // case insensitivity
     assertThat(
         new VrfNameInterfaceSpecifier("VrF1").resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of(iface11)));
+        contains(new NodeInterfacePair(iface11)));
 
     // bad names
     assertThat(
-        new VrfNameInterfaceSpecifier("vrf").resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of()));
+        new VrfNameInterfaceSpecifier("vrf").resolve(ImmutableSet.of("node1"), ctxt), empty());
     assertThat(
-        new VrfNameInterfaceSpecifier("v.*").resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of()));
+        new VrfNameInterfaceSpecifier("v.*").resolve(ImmutableSet.of("node1"), ctxt), empty());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/VrfNameRegexInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/VrfNameRegexInterfaceSpecifierTest.java
@@ -11,6 +11,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.junit.Test;
 
 public class VrfNameRegexInterfaceSpecifierTest {
@@ -44,6 +45,6 @@ public class VrfNameRegexInterfaceSpecifierTest {
     assertThat(
         new VrfNameRegexInterfaceSpecifier(Pattern.compile("vrf1"))
             .resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of(iface11)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(iface11))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/ZoneNameInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/ZoneNameInterfaceSpecifierTest.java
@@ -11,6 +11,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Zone;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.junit.Test;
 
 public class ZoneNameInterfaceSpecifierTest {
@@ -46,17 +47,21 @@ public class ZoneNameInterfaceSpecifierTest {
     // zone1 on node1 should only return two interfaces
     assertThat(
         new ZoneNameInterfaceSpecifier("zone1").resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of(iface11, iface12)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(iface11), new NodeInterfacePair(iface12))));
 
     // case insensitivity
     assertThat(
         new ZoneNameInterfaceSpecifier("ZoNe1").resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of(iface11, iface12)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(iface11), new NodeInterfacePair(iface12))));
 
     // zone1 on both nodes should only return three interfaces
     assertThat(
         new ZoneNameInterfaceSpecifier("zone1").resolve(ImmutableSet.of("node1", "node2"), ctxt),
-        equalTo(ImmutableSet.of(iface11, iface12, iface2)));
+        equalTo(
+            ImmutableSet.of(
+                new NodeInterfacePair(iface11),
+                new NodeInterfacePair(iface12),
+                new NodeInterfacePair(iface2))));
 
     // empty set with invalid zone names
     assertThat(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/ZoneNameRegexInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/ZoneNameRegexInterfaceSpecifierTest.java
@@ -12,6 +12,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Zone;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.junit.Test;
 
 public class ZoneNameRegexInterfaceSpecifierTest {
@@ -48,13 +49,17 @@ public class ZoneNameRegexInterfaceSpecifierTest {
     assertThat(
         new ZoneNameRegexInterfaceSpecifier(Pattern.compile("zone1"))
             .resolve(ImmutableSet.of("node1"), ctxt),
-        equalTo(ImmutableSet.of(iface11, iface12)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(iface11), new NodeInterfacePair(iface12))));
 
     // zone1 on both nodes should only return three interfaces
     assertThat(
         new ZoneNameRegexInterfaceSpecifier(Pattern.compile("zone1"))
             .resolve(ImmutableSet.of("node1", "node2"), ctxt),
-        equalTo(ImmutableSet.of(iface11, iface12, iface2)));
+        equalTo(
+            ImmutableSet.of(
+                new NodeInterfacePair(iface11),
+                new NodeInterfacePair(iface12),
+                new NodeInterfacePair(iface2))));
 
     // empty set with invalid zone name
     assertThat(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifierTest.java
@@ -1,5 +1,8 @@
 package org.batfish.specifier.parboiled;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -85,7 +88,7 @@ public class ParboiledInterfaceSpecifierTest {
     assertThat(
         new ParboiledInterfaceSpecifier(new InterfaceGroupInterfaceAstNode(interfaceGroup, book))
             .resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface11))));
+        contains(new NodeInterfacePair(_iface11)));
   }
 
   @Test
@@ -97,7 +100,7 @@ public class ParboiledInterfaceSpecifierTest {
                     new NameNodeAstNode(_node1.getHostname()),
                     new NameRegexInterfaceAstNode(".*2")))
             .resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(_iface12)));
+        contains(new NodeInterfacePair(_iface12)));
   }
 
   @Test
@@ -108,13 +111,13 @@ public class ParboiledInterfaceSpecifierTest {
                 new IntersectionInterfaceAstNode(
                     new NameRegexInterfaceAstNode("iface1.*"), new NameInterfaceAstNode("iface11")))
             .resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface11))));
+        contains(new NodeInterfacePair(_iface11)));
     assertThat(
         new ParboiledInterfaceSpecifier(
                 new IntersectionInterfaceAstNode(
                     new NameInterfaceAstNode("iface2"), new NameRegexInterfaceAstNode("iface1.*")))
             .resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of()));
+        empty());
   }
 
   @Test
@@ -122,12 +125,12 @@ public class ParboiledInterfaceSpecifierTest {
     build();
     assertThat(
         new ParboiledInterfaceSpecifier(new NameInterfaceAstNode("iface11")).resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface11))));
+        contains(new NodeInterfacePair(_iface11)));
     // This regex looking name below should not match anything
     assertThat(
         new ParboiledInterfaceSpecifier(new NameInterfaceAstNode("iface1.*"))
             .resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of()));
+        empty());
   }
 
   @Test
@@ -136,7 +139,7 @@ public class ParboiledInterfaceSpecifierTest {
     assertThat(
         new ParboiledInterfaceSpecifier(new NameRegexInterfaceAstNode("iface.*2"))
             .resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface12), new NodeInterfacePair(_iface2))));
+        containsInAnyOrder(new NodeInterfacePair(_iface12), new NodeInterfacePair(_iface2)));
   }
 
   @Test
@@ -146,7 +149,7 @@ public class ParboiledInterfaceSpecifierTest {
     build();
     assertThat(
         new ParboiledInterfaceSpecifier(new TypeInterfaceAstNode("vpn")).resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface12))));
+        contains(new NodeInterfacePair(_iface12)));
   }
 
   @Test
@@ -157,7 +160,7 @@ public class ParboiledInterfaceSpecifierTest {
                 new UnionInterfaceAstNode(
                     new NameInterfaceAstNode("iface11"), new NameInterfaceAstNode("iface2")))
             .resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface11), new NodeInterfacePair(_iface2))));
+        containsInAnyOrder(new NodeInterfacePair(_iface11), new NodeInterfacePair(_iface2)));
   }
 
   @Test
@@ -169,7 +172,7 @@ public class ParboiledInterfaceSpecifierTest {
     _node1.setVrfs(ImmutableMap.of("node1", vrf1));
     assertThat(
         new ParboiledInterfaceSpecifier(new VrfInterfaceAstNode("vrf1")).resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface11))));
+        contains(new NodeInterfacePair(_iface11)));
   }
 
   @Test
@@ -181,6 +184,6 @@ public class ParboiledInterfaceSpecifierTest {
     build();
     assertThat(
         new ParboiledInterfaceSpecifier(new ZoneInterfaceAstNode("zone1")).resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface11), new NodeInterfacePair(_iface2))));
+        containsInAnyOrder(new NodeInterfacePair(_iface11), new NodeInterfacePair(_iface2)));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifierTest.java
@@ -59,7 +59,7 @@ public class ParboiledInterfaceSpecifierTest {
                 new DifferenceInterfaceAstNode(
                     new NameRegexInterfaceAstNode("iface1.*"), new NameInterfaceAstNode("iface11")))
             .resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(_iface12)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface12))));
     assertThat(
         new ParboiledInterfaceSpecifier(
                 new DifferenceInterfaceAstNode(
@@ -85,7 +85,7 @@ public class ParboiledInterfaceSpecifierTest {
     assertThat(
         new ParboiledInterfaceSpecifier(new InterfaceGroupInterfaceAstNode(interfaceGroup, book))
             .resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(_iface11)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface11))));
   }
 
   @Test
@@ -96,7 +96,7 @@ public class ParboiledInterfaceSpecifierTest {
                 new IntersectionInterfaceAstNode(
                     new NameRegexInterfaceAstNode("iface1.*"), new NameInterfaceAstNode("iface11")))
             .resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(_iface11)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface11))));
     assertThat(
         new ParboiledInterfaceSpecifier(
                 new IntersectionInterfaceAstNode(
@@ -110,7 +110,7 @@ public class ParboiledInterfaceSpecifierTest {
     build();
     assertThat(
         new ParboiledInterfaceSpecifier(new NameInterfaceAstNode("iface11")).resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(_iface11)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface11))));
     // This regex looking name below should not match anything
     assertThat(
         new ParboiledInterfaceSpecifier(new NameInterfaceAstNode("iface1.*"))
@@ -124,7 +124,7 @@ public class ParboiledInterfaceSpecifierTest {
     assertThat(
         new ParboiledInterfaceSpecifier(new NameRegexInterfaceAstNode("iface.*2"))
             .resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(_iface12, _iface2)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface12), new NodeInterfacePair(_iface2))));
   }
 
   @Test
@@ -134,7 +134,7 @@ public class ParboiledInterfaceSpecifierTest {
     build();
     assertThat(
         new ParboiledInterfaceSpecifier(new TypeInterfaceAstNode("vpn")).resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(_iface12)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface12))));
   }
 
   @Test
@@ -145,7 +145,7 @@ public class ParboiledInterfaceSpecifierTest {
                 new UnionInterfaceAstNode(
                     new NameInterfaceAstNode("iface11"), new NameInterfaceAstNode("iface2")))
             .resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(_iface11, _iface2)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface11), new NodeInterfacePair(_iface2))));
   }
 
   @Test
@@ -157,7 +157,7 @@ public class ParboiledInterfaceSpecifierTest {
     _node1.setVrfs(ImmutableMap.of("node1", vrf1));
     assertThat(
         new ParboiledInterfaceSpecifier(new VrfInterfaceAstNode("vrf1")).resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(_iface11)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface11))));
   }
 
   @Test
@@ -169,6 +169,6 @@ public class ParboiledInterfaceSpecifierTest {
     build();
     assertThat(
         new ParboiledInterfaceSpecifier(new ZoneInterfaceAstNode("zone1")).resolve(_nodes, _ctxt),
-        equalTo(ImmutableSet.of(_iface11, _iface2)));
+        equalTo(ImmutableSet.of(new NodeInterfacePair(_iface11), new NodeInterfacePair(_iface2))));
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/OspfStatusQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/OspfStatusQuestionPlugin.java
@@ -140,7 +140,7 @@ public class OspfStatusQuestionPlugin extends QuestionPlugin {
 
       for (String hostname : includeNodes) {
         Configuration c = configurations.get(hostname);
-        Set<Interface> includeInterfaces =
+        Set<NodeInterfacePair> includeInterfaces =
             question
                 .getInterfaceSpecifier()
                 .resolve(ImmutableSet.of(hostname), _batfish.specifierContext());
@@ -148,7 +148,7 @@ public class OspfStatusQuestionPlugin extends QuestionPlugin {
           for (Entry<String, Interface> e2 : vrf.getInterfaces().entrySet()) {
             String interfaceName = e2.getKey();
             Interface iface = e2.getValue();
-            if (includeInterfaces.contains(iface)) {
+            if (includeInterfaces.contains(new NodeInterfacePair(iface))) {
               if (iface.getSwitchport()) {
                 // it's a layer2 interface
                 conditionalAdd(

--- a/projects/question/src/main/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswerer.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
 import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.collections.NodeInterfacePair;
@@ -135,9 +136,13 @@ public class InterfacePropertiesAnswerer extends Answerer {
       boolean excludeShutInterfaces,
       Map<String, ColumnMetadata> columns) {
     Multiset<Row> rows = HashMultiset.create();
+    Map<String, Configuration> configs = ctxt.getConfigs();
 
     for (String nodeName : nodeSpecifier.resolve(ctxt)) {
-      for (Interface iface : interfaceSpecifier.resolve(ImmutableSet.of(nodeName), ctxt)) {
+      for (NodeInterfacePair ifaceId :
+          interfaceSpecifier.resolve(ImmutableSet.of(nodeName), ctxt)) {
+        Interface iface =
+            configs.get(ifaceId.getHostname()).getAllInterfaces().get(ifaceId.getInterface());
         if (excludeShutInterfaces && !iface.getActive()) {
           continue;
         }

--- a/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/specifiers/SpecifiersAnswerer.java
@@ -8,11 +8,9 @@ import java.util.Objects;
 import java.util.Set;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
-import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.table.ColumnMetadata;
@@ -105,10 +103,9 @@ public final class SpecifiersAnswerer extends Answerer {
     InterfaceSpecifier interfaceSpecifier = question.getInterfaceSpecifier();
     Set<String> nodes = question.getNodeSpecifier().resolve(context);
 
-    Set<Interface> interfaces = interfaceSpecifier.resolve(nodes, context);
-    for (Interface iface : interfaces) {
-      table.addRow(Row.of(columnMap, COL_INTERFACE, new NodeInterfacePair(iface)));
-    }
+    interfaceSpecifier
+        .resolve(nodes, context)
+        .forEach(iface -> table.addRow(Row.of(columnMap, COL_INTERFACE, iface)));
 
     return table;
   }

--- a/projects/question/src/main/java/org/batfish/question/switchedvlanproperties/SwitchedVlanPropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/switchedvlanproperties/SwitchedVlanPropertiesAnswerer.java
@@ -67,10 +67,11 @@ public final class SwitchedVlanPropertiesAnswerer extends Answerer {
       Map<Integer, ImmutableSet.Builder<NodeInterfacePair>> switchedVlanInterfaces,
       ImmutableMap.Builder<Integer, Integer> vlanVnisBuilder) {
     addVlanVnis(c, vlans, switchedVlanInterfaces, vlanVnisBuilder);
+    Set<NodeInterfacePair> specifiedInterfaces =
+        interfacesSpecifier.resolve(ImmutableSet.of(c.getHostname()), ctxt);
     for (Interface iface : c.getAllInterfaces().values()) {
       tryAddInterfaceToVlans(
-          ctxt,
-          interfacesSpecifier,
+          specifiedInterfaces,
           excludeShutInterfaces,
           vlans,
           switchedVlanInterfaces,
@@ -208,14 +209,13 @@ public final class SwitchedVlanPropertiesAnswerer extends Answerer {
 
   @VisibleForTesting
   static void tryAddInterfaceToVlans(
-      SpecifierContext ctxt,
-      InterfaceSpecifier interfacesSpecifier,
+      Set<NodeInterfacePair> specifiedInterfaces,
       boolean excludeShutInterfaces,
       IntegerSpace vlans,
-      Map<Integer, ImmutableSet.Builder<NodeInterfacePair>> switchedVlanInterfaces,
+      Map<Integer, Builder<NodeInterfacePair>> switchedVlanInterfaces,
       String node,
       Interface iface) {
-    if (!interfacesSpecifier.resolve(ImmutableSet.of(node), ctxt).contains(iface)
+    if (!specifiedInterfaces.contains(new NodeInterfacePair(iface))
         || (excludeShutInterfaces && !iface.getActive())
         || (iface.getInterfaceType() != InterfaceType.VLAN
             && !Boolean.TRUE.equals(iface.getSwitchport()))) {


### PR DESCRIPTION
InterfaceSpecifier used to return a set of Interfaces, which is known
to be dangerous due to Interface's strange definition of equals. Use
NodeInterfacePair to identify interfaces instead.

Also factored out a repeated call to InterfaceSpecifier::resolve in
SwitchedVlanPropertiesAnswerer, and cleaned up
SwitchedVlanPropertiesAnswererTest.

cc @dhalperi @progwriter 