### PR TITLE
Fix BDDInteger preconditions 

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
@@ -47,7 +47,7 @@ public final class BDDFlowConstraintGenerator {
   BDD computeICMPConstraint() {
     return _bddPacket
         .getIpProtocol()
-        .value(IpProtocol.ICMP.number())
+        .value(IpProtocol.ICMP)
         .and(
             _bddPacket
                 .getIcmpType()
@@ -70,7 +70,7 @@ public final class BDDFlowConstraintGenerator {
       result2 = result2.or(_bddPacket.getSrcPort().value(namedPort.number()));
     }
     result2 = _bddPacket.getDstPort().geq(NamedPort.EPHEMERAL_LOWEST.number()).and(result);
-    return _bddPacket.getIpProtocol().value(IpProtocol.TCP.number()).and(result.or(result2));
+    return _bddPacket.getIpProtocol().value(IpProtocol.TCP).and(result.or(result2));
   }
 
   // Get UDP packets for traceroute:
@@ -91,7 +91,7 @@ public final class BDDFlowConstraintGenerator {
             .and(_bddPacket.getSrcPort().leq(33534))
             .and(_bddPacket.getDstPort().geq(NamedPort.EPHEMERAL_LOWEST.number()));
 
-    return _bddPacket.getIpProtocol().value(IpProtocol.UDP.number()).and(bdd1.or(bdd2));
+    return _bddPacket.getIpProtocol().value(IpProtocol.UDP).and(bdd1.or(bdd2));
   }
 
   public List<BDD> generateFlowPreference(FlowPreference preference) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpCode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpCode.java
@@ -14,18 +14,26 @@ public final class BDDIcmpCode {
     _var = var;
   }
 
+  /** @return a constraint that the IcmpType have the specified value. */
   public BDD value(int icmpCode) {
     return icmpCode == IcmpCode.UNSET ? _var.getFactory().one() : _var.value(icmpCode);
   }
 
+  /**
+   * Extract the value from a satisfying assignment.
+   *
+   * @param satAssignment a satisfying assignment (i.e. produced by fullSat, allSat, etc)
+   */
   public int satAssignmentToValue(BDD satAssignment) {
     return _var.satAssignmentToLong(satAssignment).intValue();
   }
 
+  /** @return a constraint that the IcmpCode be greater than or equal to the specified value. */
   public BDD geq(int start) {
     return start == IcmpCode.UNSET ? _var.getFactory().one() : _var.geq(start);
   }
 
+  /** @return a constraint that the IcmpCode be less than or equal to the specified value. */
   public BDD leq(int end) {
     return end == IcmpCode.UNSET ? _var.getFactory().one() : _var.leq(end);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpCode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpCode.java
@@ -1,0 +1,32 @@
+package org.batfish.common.bdd;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import net.sf.javabdd.BDD;
+import org.batfish.datamodel.IcmpCode;
+
+/** Symbolic {@link IcmpCode} variable represented by an 8-bit BDD. */
+public final class BDDIcmpCode {
+  private final BDDInteger _var;
+
+  public BDDIcmpCode(BDDInteger var) {
+    checkArgument(var.getBitvec().length == 8, "IcmpCode field requires 8 bits");
+    _var = var;
+  }
+
+  public BDD value(int icmpCode) {
+    return icmpCode == IcmpCode.UNSET ? _var.getFactory().one() : _var.value(icmpCode);
+  }
+
+  public int satAssignmentToValue(BDD satAssignment) {
+    return _var.satAssignmentToLong(satAssignment).intValue();
+  }
+
+  public BDD geq(int start) {
+    return start == IcmpCode.UNSET ? _var.getFactory().one() : _var.geq(start);
+  }
+
+  public BDD leq(int end) {
+    return end == IcmpCode.UNSET ? _var.getFactory().one() : _var.leq(end);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpType.java
@@ -1,0 +1,31 @@
+package org.batfish.common.bdd;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import net.sf.javabdd.BDD;
+import org.batfish.datamodel.IcmpType;
+
+public class BDDIcmpType {
+  private final BDDInteger _var;
+
+  public BDDIcmpType(BDDInteger var) {
+    checkArgument(var.getBitvec().length == 8, "IcmpType field requires 8 bits");
+    _var = var;
+  }
+
+  public BDD value(int icmpType) {
+    return icmpType == IcmpType.UNSET ? _var.getFactory().one() : _var.value(icmpType);
+  }
+
+  public int satAssignmentToValue(BDD satAssignment) {
+    return _var.satAssignmentToLong(satAssignment).intValue();
+  }
+
+  public BDD geq(int start) {
+    return start == IcmpType.UNSET ? _var.getFactory().one() : _var.geq(start);
+  }
+
+  public BDD leq(int end) {
+    return end == IcmpType.UNSET ? _var.getFactory().one() : _var.leq(end);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpType.java
@@ -6,7 +6,7 @@ import net.sf.javabdd.BDD;
 import org.batfish.datamodel.IcmpType;
 
 /** Symbolic IcmpType variable represented by an 8-bit BDD. */
-public class BDDIcmpType {
+public final class BDDIcmpType {
   private final BDDInteger _var;
 
   public BDDIcmpType(BDDInteger var) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIcmpType.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import net.sf.javabdd.BDD;
 import org.batfish.datamodel.IcmpType;
 
+/** Symbolic IcmpType variable represented by an 8-bit BDD. */
 public class BDDIcmpType {
   private final BDDInteger _var;
 
@@ -13,18 +14,26 @@ public class BDDIcmpType {
     _var = var;
   }
 
+  /** @return a constraint that the IcmpType have the specified value. */
   public BDD value(int icmpType) {
     return icmpType == IcmpType.UNSET ? _var.getFactory().one() : _var.value(icmpType);
   }
 
+  /**
+   * Extract the value from a satisfying assignment.
+   *
+   * @param satAssignment a satisfying assignment (i.e. produced by fullSat, allSat, etc)
+   */
   public int satAssignmentToValue(BDD satAssignment) {
     return _var.satAssignmentToLong(satAssignment).intValue();
   }
 
+  /** @return a constraint that the IcmpType be greater than or equal to the specified value. */
   public BDD geq(int start) {
     return start == IcmpType.UNSET ? _var.getFactory().one() : _var.geq(start);
   }
 
+  /** @return a constraint that the IcmpType be less than or equal to the specified value. */
   public BDD leq(int end) {
     return end == IcmpType.UNSET ? _var.getFactory().one() : _var.leq(end);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
@@ -152,7 +152,7 @@ public class BDDInteger {
    */
   public BDD leq(long val) {
     checkArgument(val >= 0, "val is negative");
-    checkArgument(val < (1L << _bitvec.length), "val is out of range");
+    checkArgument(val < (1L << _bitvec.length), "val is out of range", val);
     long currentVal = val;
     BDD[] eq = new BDD[_bitvec.length];
     BDD[] less = new BDD[_bitvec.length];

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
@@ -131,8 +131,8 @@ public class BDDInteger {
    * Create a BDD representing the exact value
    */
   public BDD value(long val) {
-    checkArgument(val >= 0, "val is negative");
-    checkArgument(val < (1L << _bitvec.length), "val is out of range");
+    checkArgument(val >= 0, "value is negative");
+    checkArgument(val < (1L << _bitvec.length), "value %s is out of range", val);
     long currentVal = val;
     BDD bdd = _factory.one();
     for (int i = this._bitvec.length - 1; i >= 0; i--) {
@@ -151,8 +151,8 @@ public class BDDInteger {
    * Less than or equal to on integers
    */
   public BDD leq(long val) {
-    checkArgument(val >= 0, "val is negative");
-    checkArgument(val < (1L << _bitvec.length), "val is out of range", val);
+    checkArgument(val >= 0, "value is negative");
+    checkArgument(val < (1L << _bitvec.length), "value %s is out of range", val);
     long currentVal = val;
     BDD[] eq = new BDD[_bitvec.length];
     BDD[] less = new BDD[_bitvec.length];
@@ -177,8 +177,8 @@ public class BDDInteger {
    * Less than or equal to on integers
    */
   public BDD geq(long val) {
-    checkArgument(val >= 0, "val is negative");
-    checkArgument(val < (1L << _bitvec.length), "val is out of range");
+    checkArgument(val >= 0, "value is negative");
+    checkArgument(val < (1L << _bitvec.length), "value %s is out of range", val);
     long currentVal = val;
     BDD[] eq = new BDD[_bitvec.length];
     BDD[] greater = new BDD[_bitvec.length];

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
@@ -132,7 +132,7 @@ public class BDDInteger {
    */
   public BDD value(long val) {
     checkArgument(val >= 0, "val is negative");
-    checkArgument(val < (2L << _bitvec.length), "val is out of range");
+    checkArgument(val < (1L << _bitvec.length), "val is out of range");
     long currentVal = val;
     BDD bdd = _factory.one();
     for (int i = this._bitvec.length - 1; i >= 0; i--) {
@@ -152,7 +152,7 @@ public class BDDInteger {
    */
   public BDD leq(long val) {
     checkArgument(val >= 0, "val is negative");
-    checkArgument(val < (2L << _bitvec.length), "val is out of range");
+    checkArgument(val < (1L << _bitvec.length), "val is out of range");
     long currentVal = val;
     BDD[] eq = new BDD[_bitvec.length];
     BDD[] less = new BDD[_bitvec.length];
@@ -178,7 +178,7 @@ public class BDDInteger {
    */
   public BDD geq(long val) {
     checkArgument(val >= 0, "val is negative");
-    checkArgument(val < (2L << _bitvec.length), "val is out of range");
+    checkArgument(val < (1L << _bitvec.length), "val is out of range");
     long currentVal = val;
     BDD[] eq = new BDD[_bitvec.length];
     BDD[] greater = new BDD[_bitvec.length];

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIpProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIpProtocol.java
@@ -1,0 +1,25 @@
+package org.batfish.common.bdd;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import net.sf.javabdd.BDD;
+import org.batfish.datamodel.IpProtocol;
+
+/** Symbolic IpProtocol variable represented by an 8-bit BDD. */
+public final class BDDIpProtocol {
+  private final BDDInteger _var;
+
+  public BDDIpProtocol(BDDInteger var) {
+    checkArgument(var.getBitvec().length == 8, "IpProtocol field requires 8 bits");
+    _var = var;
+  }
+
+  public BDD value(IpProtocol v) {
+    // IP is a special case, meaning "any protocol". It's also an invalid value for _var
+    return v == IpProtocol.IP ? _var.getFactory().one() : _var.value(v.number());
+  }
+
+  public IpProtocol satAssignmentToValue(BDD satAssignment) {
+    return IpProtocol.fromNumber(_var.satAssignmentToLong(satAssignment).intValue());
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIpProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDIpProtocol.java
@@ -14,11 +14,17 @@ public final class BDDIpProtocol {
     _var = var;
   }
 
+  /** @return a constraint that the IpProtocol have the specified value. */
   public BDD value(IpProtocol v) {
     // IP is a special case, meaning "any protocol". It's also an invalid value for _var
     return v == IpProtocol.IP ? _var.getFactory().one() : _var.value(v.number());
   }
 
+  /**
+   * Extract the value from a satisfying assignment.
+   *
+   * @param satAssignment a satisfying assignment (i.e. produced by fullSat, allSat, etc)
+   */
   public IpProtocol satAssignmentToValue(BDD satAssignment) {
     return IpProtocol.fromNumber(_var.satAssignmentToLong(satAssignment).intValue());
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -21,7 +21,6 @@ import org.batfish.common.bdd.BDDFlowConstraintGenerator.FlowPreference;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowState;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.Prefix;
 
 /**
@@ -84,11 +83,11 @@ public class BDDPacket {
 
   private BDDInteger _fragmentOffset;
 
-  private BDDInteger _icmpCode;
+  private BDDIcmpCode _icmpCode;
 
-  private BDDInteger _icmpType;
+  private BDDIcmpType _icmpType;
 
-  private BDDInteger _ipProtocol;
+  private BDDIpProtocol _ipProtocol;
 
   private int _nextFreeBDDVarIdx = 0;
 
@@ -165,9 +164,9 @@ public class BDDPacket {
     _srcIp = allocateBDDInteger("srcIp", IP_LENGTH, false);
     _dstPort = allocateBDDInteger("dstPort", PORT_LENGTH, false);
     _srcPort = allocateBDDInteger("srcPort", PORT_LENGTH, false);
-    _ipProtocol = allocateBDDInteger("ipProtocol", IP_PROTOCOL_LENGTH, false);
-    _icmpCode = allocateBDDInteger("icmpCode", ICMP_CODE_LENGTH, false);
-    _icmpType = allocateBDDInteger("icmpType", ICMP_TYPE_LENGTH, false);
+    _ipProtocol = new BDDIpProtocol(allocateBDDInteger("ipProtocol", IP_PROTOCOL_LENGTH, false));
+    _icmpCode = new BDDIcmpCode(allocateBDDInteger("icmpCode", ICMP_CODE_LENGTH, false));
+    _icmpType = new BDDIcmpType(allocateBDDInteger("icmpType", ICMP_TYPE_LENGTH, false));
     _tcpAck = allocateBDDBit("tcpAck");
     _tcpCwr = allocateBDDBit("tcpCwr");
     _tcpEce = allocateBDDBit("tcpEce");
@@ -314,10 +313,9 @@ public class BDDPacket {
     fb.setSrcIp(Ip.create(_srcIp.satAssignmentToLong(satAssignment)));
     fb.setDstPort(_dstPort.satAssignmentToLong(satAssignment).intValue());
     fb.setSrcPort(_srcPort.satAssignmentToLong(satAssignment).intValue());
-    fb.setIpProtocol(
-        IpProtocol.fromNumber(_ipProtocol.satAssignmentToLong(satAssignment).intValue()));
-    fb.setIcmpCode(_icmpCode.satAssignmentToLong(satAssignment).intValue());
-    fb.setIcmpType(_icmpType.satAssignmentToLong(satAssignment).intValue());
+    fb.setIpProtocol(_ipProtocol.satAssignmentToValue(satAssignment));
+    fb.setIcmpCode(_icmpCode.satAssignmentToValue(satAssignment));
+    fb.setIcmpType(_icmpType.satAssignmentToValue(satAssignment));
     fb.setTcpFlagsAck(_tcpAck.and(satAssignment).isZero() ? 0 : 1);
     fb.setTcpFlagsCwr(_tcpCwr.and(satAssignment).isZero() ? 0 : 1);
     fb.setTcpFlagsEce(_tcpEce.and(satAssignment).isZero() ? 0 : 1);
@@ -373,27 +371,27 @@ public class BDDPacket {
     this._fragmentOffset = x;
   }
 
-  public BDDInteger getIcmpCode() {
+  public BDDIcmpCode getIcmpCode() {
     return _icmpCode;
   }
 
-  public void setIcmpCode(BDDInteger x) {
+  public void setIcmpCode(BDDIcmpCode x) {
     this._icmpCode = x;
   }
 
-  public BDDInteger getIcmpType() {
+  public BDDIcmpType getIcmpType() {
     return _icmpType;
   }
 
-  public void setIcmpType(BDDInteger x) {
+  public void setIcmpType(BDDIcmpType x) {
     this._icmpType = x;
   }
 
-  public BDDInteger getIpProtocol() {
+  public BDDIpProtocol getIpProtocol() {
     return _ipProtocol;
   }
 
-  public void setIpProtocol(BDDInteger x) {
+  public void setIpProtocol(BDDIpProtocol x) {
     this._ipProtocol = x;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/HeaderSpaceToBDD.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/HeaderSpaceToBDD.java
@@ -73,10 +73,7 @@ public final class HeaderSpaceToBDD {
     }
 
     return _bddOps.or(
-        ipProtocols.stream()
-            .map(IpProtocol::number)
-            .map(_bddPacket.getIpProtocol()::value)
-            .collect(Collectors.toList()));
+        ipProtocols.stream().map(_bddPacket.getIpProtocol()::value).collect(Collectors.toList()));
   }
 
   @VisibleForTesting
@@ -87,6 +84,38 @@ public final class HeaderSpaceToBDD {
     }
     return _bddOps.or(
         ranges.stream().map(range -> toBDD(range, var)).collect(ImmutableList.toImmutableList()));
+  }
+
+  @VisibleForTesting
+  @Nullable
+  BDD toBDD(@Nullable Set<SubRange> ranges, BDDIcmpCode var) {
+    if (ranges == null || ranges.isEmpty()) {
+      return null;
+    }
+    return _bddOps.or(
+        ranges.stream().map(range -> toBDD(range, var)).collect(ImmutableList.toImmutableList()));
+  }
+
+  @VisibleForTesting
+  @Nullable
+  BDD toBDD(@Nullable Set<SubRange> ranges, BDDIcmpType var) {
+    if (ranges == null || ranges.isEmpty()) {
+      return null;
+    }
+    return _bddOps.or(
+        ranges.stream().map(range -> toBDD(range, var)).collect(ImmutableList.toImmutableList()));
+  }
+
+  private BDD toBDD(SubRange range, BDDIcmpCode var) {
+    int start = range.getStart();
+    int end = range.getEnd();
+    return start == end ? var.value(start) : var.geq(start).and(var.leq(end));
+  }
+
+  private BDD toBDD(SubRange range, BDDIcmpType var) {
+    int start = range.getStart();
+    int end = range.getEnd();
+    return start == end ? var.value(start) : var.geq(start).and(var.leq(end));
   }
 
   @VisibleForTesting

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
@@ -7,9 +7,14 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Optional;
 import net.sf.javabdd.BDD;
+import net.sf.javabdd.BDDFactory;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class BDDIntegerTest {
+  @Rule public ExpectedException _exception = ExpectedException.none();
+
   @Test
   public void testSatAssignmentToLong() {
     BDDInteger dstIp = new BDDPacket().getDstIp();
@@ -45,5 +50,29 @@ public class BDDIntegerTest {
         dstIp.getValuesSatisfying(bdd, 10),
         containsInAnyOrder(
             0xFFFFFFFAL, 0xFFFFFFFBL, 0xFFFFFFFCL, 0xFFFFFFFDL, 0xFFFFFFFEL, 0xFFFFFFFFL));
+  }
+
+  @Test
+  public void testGeqOutOfRange() {
+    BDDFactory factory = BDDUtils.bddFactory(5);
+    BDDInteger var = BDDInteger.makeFromIndex(factory, 5, 0, false);
+    _exception.expect(IllegalArgumentException.class);
+    var.leq(32);
+  }
+
+  @Test
+  public void testLeqOutOfRange() {
+    BDDFactory factory = BDDUtils.bddFactory(5);
+    BDDInteger var = BDDInteger.makeFromIndex(factory, 5, 0, false);
+    _exception.expect(IllegalArgumentException.class);
+    var.leq(32);
+  }
+
+  @Test
+  public void testValueOutOfRange() {
+    BDDFactory factory = BDDUtils.bddFactory(5);
+    BDDInteger var = BDDInteger.makeFromIndex(factory, 5, 0, false);
+    _exception.expect(IllegalArgumentException.class);
+    var.value(32);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
@@ -57,6 +57,7 @@ public class BDDIntegerTest {
     BDDFactory factory = BDDUtils.bddFactory(5);
     BDDInteger var = BDDInteger.makeFromIndex(factory, 5, 0, false);
     _exception.expect(IllegalArgumentException.class);
+    _exception.expectMessage("value 32 is out of range");
     var.geq(32);
   }
 
@@ -65,6 +66,7 @@ public class BDDIntegerTest {
     BDDFactory factory = BDDUtils.bddFactory(5);
     BDDInteger var = BDDInteger.makeFromIndex(factory, 5, 0, false);
     _exception.expect(IllegalArgumentException.class);
+    _exception.expectMessage("value 32 is out of range");
     var.leq(32);
   }
 
@@ -73,6 +75,7 @@ public class BDDIntegerTest {
     BDDFactory factory = BDDUtils.bddFactory(5);
     BDDInteger var = BDDInteger.makeFromIndex(factory, 5, 0, false);
     _exception.expect(IllegalArgumentException.class);
+    _exception.expectMessage("value 32 is out of range");
     var.value(32);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
@@ -57,7 +57,7 @@ public class BDDIntegerTest {
     BDDFactory factory = BDDUtils.bddFactory(5);
     BDDInteger var = BDDInteger.makeFromIndex(factory, 5, 0, false);
     _exception.expect(IllegalArgumentException.class);
-    var.leq(32);
+    var.geq(32);
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
@@ -80,7 +80,7 @@ public class BDDPacketTest {
             .and(pkt.getDstPort().value(dstPort))
             .and(pkt.getIcmpCode().value(icmpCode))
             .and(pkt.getIcmpType().value(icmpType))
-            .and(pkt.getIpProtocol().value(ipProtocol.number()))
+            .and(pkt.getIpProtocol().value(ipProtocol))
             .and(pkt.getSrcIp().value(srcIp.asLong()))
             .and(pkt.getSrcPort().value(srcPort))
             .and(pkt.getTcpAck().not())
@@ -138,7 +138,7 @@ public class BDDPacketTest {
 
     BDD bdd = pkt.getDstIp().value(dstIp.asLong()).and(pkt.getSrcIp().value(srcIp.asLong()));
 
-    BDD icmpbdd = pkt.getIpProtocol().value(IpProtocol.ICMP.number());
+    BDD icmpbdd = pkt.getIpProtocol().value(IpProtocol.ICMP);
 
     bdd = bdd.and(icmpbdd.not());
 
@@ -159,9 +159,9 @@ public class BDDPacketTest {
 
     BDD bdd = pkt.getDstIp().value(dstIp.asLong()).and(pkt.getSrcIp().value(srcIp.asLong()));
 
-    BDD icmpbdd = pkt.getIpProtocol().value(IpProtocol.ICMP.number());
+    BDD icmpbdd = pkt.getIpProtocol().value(IpProtocol.ICMP);
 
-    BDD udpbdd = pkt.getIpProtocol().value(IpProtocol.UDP.number());
+    BDD udpbdd = pkt.getIpProtocol().value(IpProtocol.UDP);
 
     bdd = bdd.and(icmpbdd.not()).and(udpbdd.not());
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDRepresentativePickerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDRepresentativePickerTest.java
@@ -12,10 +12,10 @@ public class BDDRepresentativePickerTest {
   @Test
   public void testBDDRepresentativePicker1() {
     BDDPacket pkt = new BDDPacket();
-    BDD bdd1 = pkt.getIpProtocol().value(IpProtocol.UDP.number());
-    BDD bdd2 = pkt.getIpProtocol().value(IpProtocol.TCP.number());
+    BDD bdd1 = pkt.getIpProtocol().value(IpProtocol.UDP);
+    BDD bdd2 = pkt.getIpProtocol().value(IpProtocol.TCP);
     BDDRepresentativePicker picker = new BDDRepresentativePicker(ImmutableList.of(bdd1, bdd2));
-    BDD bdd = pkt.getIpProtocol().value(IpProtocol.UDP.number());
+    BDD bdd = pkt.getIpProtocol().value(IpProtocol.UDP);
     BDD pickedBDD = picker.pickRepresentative(bdd);
     // check pickedBDD is in bdd
     assertThat(pickedBDD.and(bdd), equalTo(pickedBDD));
@@ -24,10 +24,10 @@ public class BDDRepresentativePickerTest {
   @Test
   public void testBDDRepresentativePicker2() {
     BDDPacket pkt = new BDDPacket();
-    BDD bdd1 = pkt.getIpProtocol().value(IpProtocol.UDP.number());
-    BDD bdd2 = pkt.getIpProtocol().value(IpProtocol.TCP.number());
+    BDD bdd1 = pkt.getIpProtocol().value(IpProtocol.UDP);
+    BDD bdd2 = pkt.getIpProtocol().value(IpProtocol.TCP);
     BDDRepresentativePicker picker = new BDDRepresentativePicker(ImmutableList.of(bdd1, bdd2));
-    BDD bdd = pkt.getIpProtocol().value(IpProtocol.TCP.number());
+    BDD bdd = pkt.getIpProtocol().value(IpProtocol.TCP);
     BDD pickedBDD = picker.pickRepresentative(bdd);
     // check pickedBDD is in bdd
     assertThat(pickedBDD.and(bdd), equalTo(pickedBDD));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/HeaderSpaceToBDDTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/HeaderSpaceToBDDTest.java
@@ -153,8 +153,7 @@ public class HeaderSpaceToBDDTest {
     HeaderSpace headerSpace =
         HeaderSpace.builder().setIpProtocols(ImmutableList.of(proto1, proto2)).build();
     BDD bdd = _toBDD.toBDD(headerSpace);
-    BDD protoBDD =
-        _pkt.getIpProtocol().value(proto1.number()).or(_pkt.getIpProtocol().value(proto2.number()));
+    BDD protoBDD = _pkt.getIpProtocol().value(proto1).or(_pkt.getIpProtocol().value(proto2));
     assertThat(bdd, equalTo(protoBDD));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/BDDRoute.java
@@ -97,7 +97,7 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
    */
   public BDDRoute(Set<CommunityVar> comms) {
     int numVars = factory.varNum();
-    int numNeeded = 32 * 5 + 5 + comms.size() + 4;
+    int numNeeded = 32 * 5 + 6 + comms.size() + 4;
     if (numVars < numNeeded) {
       factory.setVarNum(numNeeded);
     }
@@ -121,9 +121,10 @@ public class BDDRoute implements IDeepCopy<BDDRoute> {
     _localPref = BDDInteger.makeFromIndex(factory, 32, idx, false);
     addBitNames("lp", 32, idx, false);
     idx += 32;
-    _prefixLength = BDDInteger.makeFromIndex(factory, 5, idx, true);
+    // need 6 bits for prefix length because there are 33 possible values, 0 - 32
+    _prefixLength = BDDInteger.makeFromIndex(factory, 6, idx, true);
     addBitNames("pfxLen", 5, idx, true);
-    idx += 5;
+    idx += 6;
     _prefix = BDDInteger.makeFromIndex(factory, 32, idx, true);
     addBitNames("pfx", 32, idx, true);
     idx += 32;

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/TransferBDD.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/TransferBDD.java
@@ -696,24 +696,20 @@ class TransferBDD {
    * is not modified, and thus will contain only the underlying variables:
    * [var(0), ..., var(n)]
    */
-  private BDD isRelevantFor(BDDRoute record, PrefixRange range) {
+  static BDD isRelevantFor(BDDRoute record, PrefixRange range) {
     Prefix p = range.getPrefix();
+    BDD prefixMatch = firstBitsEqual(record.getPrefix().getBitvec(), p, p.getPrefixLength());
+
+    BDDInteger prefixLength = record.getPrefixLength();
     SubRange r = range.getLengthRange();
-    int len = p.getPrefixLength();
     int lower = r.getStart();
     int upper = r.getEnd();
+    BDD lenMatch =
+        lower == upper
+            ? prefixLength.value(lower)
+            : prefixLength.geq(lower).and(prefixLength.leq(upper));
 
-    BDD lowerBitsMatch = firstBitsEqual(record.getPrefix().getBitvec(), p, len);
-    BDD acc = factory.zero();
-    if (lower == 0 && upper == 32) {
-      acc = factory.one();
-    } else {
-      for (int i = lower; i <= upper; i++) {
-        BDD equalLen = record.getPrefixLength().value(i);
-        acc = acc.or(equalLen);
-      }
-    }
-    return acc.and(lowerBitsMatch);
+    return lenMatch.and(prefixMatch);
   }
 
   /*

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
@@ -144,7 +144,7 @@ public final class SessionInstrumentationTest {
 
     // Setup filter BDDs
     {
-      _permitTcpBdd = PKT.getIpProtocol().value(IpProtocol.TCP.number());
+      _permitTcpBdd = PKT.getIpProtocol().value(IpProtocol.TCP);
       _filterBdds = ImmutableMap.of(FW, ImmutableMap.of(PERMIT_TCP, () -> _permitTcpBdd));
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/symbolic/bdd/TransferBDDTest.java
+++ b/projects/batfish/src/test/java/org/batfish/symbolic/bdd/TransferBDDTest.java
@@ -34,4 +34,17 @@ public class TransferBDDTest {
     assertTrue(matchingPrefix.and(len8).imp(notRangeBdd).isOne()); // prefix too short
     assertTrue(nonMatchingPrefix.and(len24).imp(notRangeBdd).isOne()); // prefix doesn't match
   }
+
+  @Test
+  public void testIsRelevantFor_range32() {
+    BDDRoute bddRoute = new BDDRoute(ImmutableSet.of());
+
+    PrefixRange range = new PrefixRange(Prefix.parse("0.0.0.0/0"), new SubRange(32, 32));
+    BDD rangeBdd = isRelevantFor(bddRoute, range);
+    BDD len0 = bddRoute.getPrefixLength().value(0);
+    BDD len32 = bddRoute.getPrefixLength().value(32);
+
+    assertTrue(len0.imp(rangeBdd.not()).isOne());
+    assertTrue(len32.imp(rangeBdd).isOne());
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/symbolic/bdd/TransferBDDTest.java
+++ b/projects/batfish/src/test/java/org/batfish/symbolic/bdd/TransferBDDTest.java
@@ -1,0 +1,37 @@
+package org.batfish.symbolic.bdd;
+
+import static org.batfish.symbolic.bdd.TransferBDD.isRelevantFor;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableSet;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.IpSpaceToBDD;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixRange;
+import org.batfish.datamodel.SubRange;
+import org.junit.Test;
+
+/** Tests for {@link TransferBDD}. */
+public class TransferBDDTest {
+  @Test
+  public void testIsRelevantFor() {
+    BDDRoute bddRoute = new BDDRoute(ImmutableSet.of());
+    IpSpaceToBDD ipSpaceToBDD = new IpSpaceToBDD(bddRoute.getPrefix());
+
+    PrefixRange range = new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(16, 24));
+    BDD rangeBdd = isRelevantFor(bddRoute, range);
+    BDD notRangeBdd = rangeBdd.not();
+
+    BDD matchingPrefix = ipSpaceToBDD.toBDD(Ip.parse("1.1.1.1"));
+    BDD nonMatchingPrefix = ipSpaceToBDD.toBDD(Ip.parse("2.2.2.2"));
+    BDD len24 = bddRoute.getPrefixLength().value(24);
+    BDD len8 = bddRoute.getPrefixLength().value(8);
+    BDD len32 = bddRoute.getPrefixLength().value(32);
+
+    assertTrue(matchingPrefix.and(len24).imp(rangeBdd).isOne());
+    assertTrue(matchingPrefix.and(len32).imp(notRangeBdd).isOne()); // prefix too long
+    assertTrue(matchingPrefix.and(len8).imp(notRangeBdd).isOne()); // prefix too short
+    assertTrue(nonMatchingPrefix.and(len24).imp(notRangeBdd).isOne()); // prefix doesn't match
+  }
+}

--- a/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswererTest.java
@@ -623,7 +623,7 @@ public class FilterLineReachabilityAnswererTest {
     BDD ddos2 = p.getSrcIp().value(Ip.parse("1.2.3.2").asLong());
     BDD ddos3 = p.getSrcIp().value(Ip.parse("1.2.3.3").asLong());
     // permit tcp any any eq ssh
-    BDD tcp = p.getIpProtocol().value(IpProtocol.TCP.number());
+    BDD tcp = p.getIpProtocol().value(IpProtocol.TCP);
     BDD ssh = tcp.and(p.getDstPort().value(22));
     // permit tcp any DST_IP eq ssh
     BDD selectiveSSH = ssh.and(p.getDstIp().value(Ip.parse("2.3.4.5").asLong()));
@@ -693,7 +693,7 @@ public class FilterLineReachabilityAnswererTest {
   public void testDifferentActionPreservation() {
     BDDPacket p = new BDDPacket();
     BDD slash32 = p.getDstIp().value(Ip.parse("1.2.3.4").asLong());
-    BDD tcp = p.getIpProtocol().value(IpProtocol.TCP.number());
+    BDD tcp = p.getIpProtocol().value(IpProtocol.TCP);
     BDD not80 = tcp.and(p.getDstPort().value(80).not());
 
     /*
@@ -722,7 +722,7 @@ public class FilterLineReachabilityAnswererTest {
   @Test
   public void testSameActionNotReported() {
     BDDPacket p = new BDDPacket();
-    BDD tcp = p.getIpProtocol().value(IpProtocol.TCP.number());
+    BDD tcp = p.getIpProtocol().value(IpProtocol.TCP);
     BDD tcpEstablished = p.getTcpAck().or(p.getTcpRst());
     BDD slash32 = p.getDstIp().value(Ip.parse("1.2.3.4").asLong());
     BDD port80 = p.getDstPort().value(80);


### PR DESCRIPTION
Preconditions on BDDInteger's methods value, leq, and geq were off-by-one. This meant that we were using invalid arguments for several BDDIntegers, causing silent failures. 

To fix BDDRoute.prefixLength, we need to allocate 6 bits instead of 5 (since 32 is a valid value).
To fix BDDPacket.ipProtocol, icmpCode, and icmpType, add a wrapper classes that correctly interpret the special value (outside the valid range of the underlying BDDInteger) for each class corresponding to unconstrained.