### PR TITLE
Remove staging RIBs for OSPF

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -1034,19 +1034,6 @@ class IncrementalBdpEngine {
                 }
                 ospfInternalCompleted.incrementAndGet();
               });
-      AtomicInteger ospfInternalUnstageCompleted =
-          _newBatch.apply(
-              "Unstage OSPF Internal routes: iteration " + ospfInternalIterations, nodes.size());
-      nodes
-          .values()
-          .parallelStream()
-          .forEach(
-              n -> {
-                for (VirtualRouter vr : n.getVirtualRouters().values()) {
-                  vr.unstageOspfInternalRoutes();
-                }
-                ospfInternalUnstageCompleted.incrementAndGet();
-              });
     }
     AtomicInteger ospfInternalImportCompleted =
         _newBatch.apply("Import OSPF Internal routes", nodes.size());

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -218,9 +218,7 @@ public class VirtualRouter implements Serializable {
       _ospfExternalIncomingRoutes;
 
   transient OspfInterAreaRib _ospfInterAreaRib;
-  transient OspfInterAreaRib _ospfInterAreaStagingRib;
   transient OspfIntraAreaRib _ospfIntraAreaRib;
-  transient OspfIntraAreaRib _ospfIntraAreaStagingRib;
   transient OspfRib _ospfRib;
   transient RipInternalRib _ripInternalRib;
   transient RipInternalRib _ripInternalStagingRib;
@@ -642,7 +640,7 @@ public class VirtualRouter implements Serializable {
                     .setArea(areaNum)
                     .setNonRouting(true)
                     .build();
-        if (!_ospfInterAreaStagingRib.mergeRouteGetDelta(summaryRoute).isEmpty()) {
+        if (!_ospfInterAreaRib.mergeRouteGetDelta(summaryRoute).isEmpty()) {
           changed = true;
         }
       }
@@ -1280,9 +1278,7 @@ public class VirtualRouter implements Serializable {
     _ospfExternalType1StagingRib = new OspfExternalType1Rib(getHostname(), null);
     _ospfExternalType2StagingRib = new OspfExternalType2Rib(getHostname(), null);
     _ospfInterAreaRib = new OspfInterAreaRib();
-    _ospfInterAreaStagingRib = new OspfInterAreaRib();
     _ospfIntraAreaRib = new OspfIntraAreaRib();
-    _ospfIntraAreaStagingRib = new OspfIntraAreaRib();
     _ospfRib = new OspfRib();
 
     // RIP
@@ -1706,7 +1702,7 @@ public class VirtualRouter implements Serializable {
                 .setMetric(newCost)
                 .setArea(areaNum)
                 .build();
-    return _ospfInterAreaStagingRib.mergeRoute(newRoute);
+    return _ospfInterAreaRib.mergeRoute(newRoute);
   }
 
   private boolean propagateOspfInterAreaRouteFromIntraAreaRoute(
@@ -1829,7 +1825,7 @@ public class VirtualRouter implements Serializable {
       return false;
     }
     long metric = incrementalCost + area.getMetricOfDefaultRoute();
-    return _ospfInterAreaStagingRib.mergeRoute(
+    return _ospfInterAreaRib.mergeRoute(
         (OspfInterAreaRoute)
             OspfInternalRoute.builder()
                 .setProtocol(RoutingProtocol.OSPF_IA)
@@ -1884,8 +1880,7 @@ public class VirtualRouter implements Serializable {
                 .setMetric(newCost)
                 .setArea(linkAreaNum)
                 .build();
-    return neighborRoute.getArea() == linkAreaNum
-        && (_ospfIntraAreaStagingRib.mergeRoute(newRoute));
+    return neighborRoute.getArea() == linkAreaNum && (_ospfIntraAreaRib.mergeRoute(newRoute));
   }
 
   /**
@@ -2369,12 +2364,6 @@ public class VirtualRouter implements Serializable {
     _mainRibRouteDeltaBuilder.from(
         RibDelta.importRibDelta(_mainRib, ospfDeltaBuilder.build(), _name));
     return !d1.isEmpty() || !d2.isEmpty();
-  }
-
-  /** Merges staged OSPF internal routes into the "real" OSPF-internal RIBs */
-  void unstageOspfInternalRoutes() {
-    importRib(_ospfIntraAreaRib, _ospfIntraAreaStagingRib);
-    importRib(_ospfInterAreaRib, _ospfInterAreaStagingRib);
   }
 
   /** Merges staged RIP routes into the "real" RIP RIB */

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -402,9 +402,7 @@ public class VirtualRouterTest {
     assertThat(vr._ospfExternalType2Rib.getRoutes(), empty());
     assertThat(vr._ospfExternalType2StagingRib.getRoutes(), empty());
     assertThat(vr._ospfInterAreaRib.getRoutes(), empty());
-    assertThat(vr._ospfInterAreaStagingRib.getRoutes(), empty());
     assertThat(vr._ospfIntraAreaRib.getRoutes(), empty());
-    assertThat(vr._ospfIntraAreaStagingRib.getRoutes(), empty());
     assertThat(vr._ospfRib.getRoutes(), empty());
 
     // BGP ribs
@@ -473,9 +471,6 @@ public class VirtualRouterTest {
         exportingRouter.getConfiguration().getAllInterfaces().get(exportingRouterInterfaceName),
         adminCost);
 
-    assertThat(testRouter._ospfInterAreaStagingRib.getRoutes(), empty());
-    assertThat(testRouter._ospfIntraAreaStagingRib.getRoutes(), empty());
-
     // Flip interfaces on router 2 to be passive now
     testRouter
         .getConfiguration()
@@ -493,9 +488,6 @@ public class VirtualRouterTest {
         testRouter.getConfiguration().getAllInterfaces().firstEntry().getValue(),
         exportingRouter.getConfiguration().getAllInterfaces().get(exportingRouterInterfaceName),
         adminCost);
-
-    assertThat(testRouter._ospfInterAreaStagingRib.getRoutes(), empty());
-    assertThat(testRouter._ospfIntraAreaStagingRib.getRoutes(), empty());
   }
 
   /** Check that initialization of RIP internal routes happens correctly */
@@ -569,7 +561,7 @@ public class VirtualRouterTest {
                 .setMetric(metric + 10)
                 .setArea(area)
                 .build();
-    assertThat(vr._ospfInterAreaStagingRib.getTypedRoutes(), contains(expected));
+    assertThat(vr._ospfInterAreaRib.getTypedRoutes(), contains(expected));
   }
 
   /** Test that the static RIB correctly pulls static routes from the VRF */


### PR DESCRIPTION
No functional changes. Confirmed routes results are the same on a large & complex ospf network.