### PR TITLE
Revert "Remove staging RIBs for OSPF (#3398)"

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -1034,6 +1034,19 @@ class IncrementalBdpEngine {
                 }
                 ospfInternalCompleted.incrementAndGet();
               });
+      AtomicInteger ospfInternalUnstageCompleted =
+          _newBatch.apply(
+              "Unstage OSPF Internal routes: iteration " + ospfInternalIterations, nodes.size());
+      nodes
+          .values()
+          .parallelStream()
+          .forEach(
+              n -> {
+                for (VirtualRouter vr : n.getVirtualRouters().values()) {
+                  vr.unstageOspfInternalRoutes();
+                }
+                ospfInternalUnstageCompleted.incrementAndGet();
+              });
     }
     AtomicInteger ospfInternalImportCompleted =
         _newBatch.apply("Import OSPF Internal routes", nodes.size());

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -402,7 +402,9 @@ public class VirtualRouterTest {
     assertThat(vr._ospfExternalType2Rib.getRoutes(), empty());
     assertThat(vr._ospfExternalType2StagingRib.getRoutes(), empty());
     assertThat(vr._ospfInterAreaRib.getRoutes(), empty());
+    assertThat(vr._ospfInterAreaStagingRib.getRoutes(), empty());
     assertThat(vr._ospfIntraAreaRib.getRoutes(), empty());
+    assertThat(vr._ospfIntraAreaStagingRib.getRoutes(), empty());
     assertThat(vr._ospfRib.getRoutes(), empty());
 
     // BGP ribs
@@ -471,6 +473,9 @@ public class VirtualRouterTest {
         exportingRouter.getConfiguration().getAllInterfaces().get(exportingRouterInterfaceName),
         adminCost);
 
+    assertThat(testRouter._ospfInterAreaStagingRib.getRoutes(), empty());
+    assertThat(testRouter._ospfIntraAreaStagingRib.getRoutes(), empty());
+
     // Flip interfaces on router 2 to be passive now
     testRouter
         .getConfiguration()
@@ -488,6 +493,9 @@ public class VirtualRouterTest {
         testRouter.getConfiguration().getAllInterfaces().firstEntry().getValue(),
         exportingRouter.getConfiguration().getAllInterfaces().get(exportingRouterInterfaceName),
         adminCost);
+
+    assertThat(testRouter._ospfInterAreaStagingRib.getRoutes(), empty());
+    assertThat(testRouter._ospfIntraAreaStagingRib.getRoutes(), empty());
   }
 
   /** Check that initialization of RIP internal routes happens correctly */
@@ -561,7 +569,7 @@ public class VirtualRouterTest {
                 .setMetric(metric + 10)
                 .setArea(area)
                 .build();
-    assertThat(vr._ospfInterAreaRib.getTypedRoutes(), contains(expected));
+    assertThat(vr._ospfInterAreaStagingRib.getTypedRoutes(), contains(expected));
   }
 
   /** Test that the static RIB correctly pulls static routes from the VRF */


### PR DESCRIPTION
This reverts commit 92237cb98464cac5a8dcdbdd795a3404308ab878.

RIBs aren't synchronized. :facepalm: