### PR TITLE
InterfaceProperties: return incoming filter name

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
@@ -101,7 +101,7 @@ public class InterfacePropertySpecifier extends PropertySpecifier {
           // skip incoming filter
           .put(
               INCOMING_FILTER_NAME,
-              new PropertyDescriptor<>(Interface::getIncomingFilter, Schema.STRING))
+              new PropertyDescriptor<>(Interface::getIncomingFilterName, Schema.STRING))
           .put(INTERFACE_TYPE, new PropertyDescriptor<>(Interface::getInterfaceType, Schema.STRING))
           .put(MLAG_ID, new PropertyDescriptor<>(Interface::getMlagId, Schema.INTEGER))
           .put(MTU, new PropertyDescriptor<>(Interface::getMtu, Schema.INTEGER))

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
@@ -98,7 +98,7 @@ public class InterfacePropertySpecifier extends PropertySpecifier {
               HSRP_GROUPS,
               new PropertyDescriptor<>(Interface::getHsrpGroups, Schema.set(Schema.STRING)))
           .put(HSRP_VERSION, new PropertyDescriptor<>(Interface::getHsrpVersion, Schema.STRING))
-          // skip incoming filter
+          // use incomingFilterName instead of incomingFilter
           .put(
               INCOMING_FILTER_NAME,
               new PropertyDescriptor<>(Interface::getIncomingFilterName, Schema.STRING))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/InterfacePropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/InterfacePropertySpecifierTest.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.questions;
 
+import static org.batfish.datamodel.questions.InterfacePropertySpecifier.INCOMING_FILTER_NAME;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -9,6 +10,9 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import java.util.Iterator;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.IpAccessListLine;
 import org.junit.Test;
 
 public class InterfacePropertySpecifierTest {
@@ -47,5 +51,19 @@ public class InterfacePropertySpecifierTest {
 
     // should not match shorter
     assertThat(new InterfacePropertySpecifier(shorter).getMatchingProperties(), emptyIterable());
+  }
+
+  @Test
+  public void testIncomingFilterReturnsName() {
+    IpAccessList acl =
+        IpAccessList.builder()
+            .setName("MY_ACL")
+            .setLines(ImmutableList.of(IpAccessListLine.ACCEPT_ALL))
+            .build();
+    Interface i1 = Interface.builder().setName("i1").setIncomingFilter(acl).build();
+    i1.setInboundFilterName(acl.getName());
+    assertThat(
+        InterfacePropertySpecifier.JAVA_MAP.get(INCOMING_FILTER_NAME).getGetter().apply(i1),
+        equalTo(acl.getName()));
   }
 }


### PR DESCRIPTION
Return the name of the ACL/filter and not the contents