### PR TITLE
Preserve OspfRib external routes across IBDP iterations

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -2496,6 +2496,8 @@ public class VirtualRouter implements Serializable {
      */
     importRib(_ospfRib, _ospfIntraAreaRib);
     importRib(_ospfRib, _ospfInterAreaRib);
+    importRib(_ospfRib, _ospfExternalType1Rib);
+    importRib(_ospfRib, _ospfExternalType2Rib);
     /*
      * Re-add independent RIP routes to ripRib for tie-breaking
      */


### PR DESCRIPTION
Fixes a bug where the main RIB could end up with multiple OSPF external routes to the same prefix with different costs to advertiser.

This happened because the OSPF RIB cleared its external routes at the beginning of each new iteration, so when a new external route was merged into the OSPF RIB in `unstageOspfExternalRoutes()`, the resulting delta would never have a `REPLACE` advertisement. That delta is then merged into the main RIB, so if the main RIB already had an OSPF external route that matched the new route's destination and metric, it wouldn't get replaced.