### PR TITLE
AclIpSpace: simplify input, cache hashCode

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpSpaceToBDD.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpSpaceToBDD.java
@@ -138,9 +138,12 @@ public class IpSpaceToBDD implements GenericIpSpaceVisitor<BDD> {
   public BDD visitAclIpSpace(AclIpSpace aclIpSpace) {
     BDD bdd = _zero;
     for (AclIpSpaceLine aclIpSpaceLine : Lists.reverse(aclIpSpace.getLines())) {
-      bdd =
-          visit(aclIpSpaceLine.getIpSpace())
-              .ite(aclIpSpaceLine.getAction() == LineAction.PERMIT ? _one : _zero, bdd);
+      BDD line = visit(aclIpSpaceLine.getIpSpace());
+      if (aclIpSpaceLine.getAction() == LineAction.PERMIT) {
+        bdd = line.or(bdd);
+      } else {
+        bdd = line.not().and(bdd);
+      }
     }
     return bdd;
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MemoizedIpSpaceToBDDTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MemoizedIpSpaceToBDDTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 public class MemoizedIpSpaceToBDDTest {
   private static final IpSpace IP1_IP_SPACE = Ip.parse("1.1.1.1").toIpSpace();
   private static final IpSpace IP2_IP_SPACE = Ip.parse("2.2.2.2").toIpSpace();
-  private static final AclIpSpace ACL_IP_SPACE =
+  private static final IpSpace ACL_IP_SPACE =
       AclIpSpace.builder().thenPermitting(IP1_IP_SPACE).thenPermitting(IP2_IP_SPACE).build();
 
   private MemoizedIpSpaceToBDD _toBdd;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
@@ -14,7 +14,7 @@ public class AclIpSpaceTest {
   /*
    * Permit everything in 1.1.0.0/16 except for 1.1.1.0/24.
    */
-  private static final AclIpSpace _aclIpSpace =
+  private static final IpSpace _aclIpSpace =
       AclIpSpace.builder()
           .thenRejecting(Prefix.parse("1.1.1.0/24").toIpSpace())
           .thenPermitting(Prefix.parse("1.1.0.0/16").toIpSpace())
@@ -55,14 +55,14 @@ public class AclIpSpaceTest {
 
   @Test
   public void testStopWhenEmpty() {
-    AclIpSpace space =
+    IpSpace space =
         AclIpSpace.builder()
             .thenPermitting(Prefix.parse("1.2.3.4/32").toIpSpace())
             .thenRejecting(UniverseIpSpace.INSTANCE)
             .thenPermitting(Prefix.parse("2.0.0.0/8").toIpSpace())
             .build();
 
-    AclIpSpace expected =
+    IpSpace expected =
         AclIpSpace.builder()
             .thenPermitting(Prefix.parse("1.2.3.4/32").toIpSpace())
             .thenRejecting(UniverseIpSpace.INSTANCE)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -8,13 +8,13 @@ import static org.batfish.datamodel.matchers.DataModelMatchers.isPermittedByIpAc
 import static org.batfish.datamodel.matchers.DataModelMatchers.isPermittedByNamedIpSpace;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.batfish.datamodel.AclIpSpace;
-import org.batfish.datamodel.AclIpSpaceLine;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.HeaderSpace;
@@ -24,6 +24,7 @@ import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceMetadata;
 import org.batfish.datamodel.IpSpaceReference;
+import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.matchers.DeniedByIpAccessListLineMatchers;
 import org.batfish.datamodel.matchers.PermittedByAclIpSpaceLineMatchers;
@@ -59,7 +60,11 @@ public class AclTracerTest {
 
   @Test
   public void testDefaultDeniedByNamedAclIpSpace() {
-    AclIpSpace aclIpSpace = AclIpSpace.DENY_ALL;
+    IpSpace aclIpSpace =
+        AclIpSpace.permitting(Ip.parse("255.255.255.255").toIpSpace())
+            .thenPermitting(Ip.parse("255.255.255.254").toIpSpace())
+            .build();
+    assertThat(aclIpSpace, instanceOf(AclIpSpace.class));
     IpAccessList acl =
         IpAccessList.builder()
             .setName(ACL_NAME)
@@ -148,7 +153,12 @@ public class AclTracerTest {
 
   @Test
   public void testDeniedByNamedAclIpSpaceLine() {
-    AclIpSpace aclIpSpace = AclIpSpace.of(AclIpSpaceLine.DENY_ALL);
+    IpSpace aclIpSpace =
+        AclIpSpace.permitting(Ip.parse("255.255.255.255").toIpSpace())
+            .thenPermitting(Ip.parse("255.255.255.254").toIpSpace())
+            .build();
+    assertThat(aclIpSpace, instanceOf(AclIpSpace.class));
+
     IpAccessList acl =
         IpAccessList.builder()
             .setName(ACL_NAME)
@@ -200,7 +210,12 @@ public class AclTracerTest {
 
   @Test
   public void testDeniedByUnnamedAclIpSpace() {
-    AclIpSpace aclIpSpace = AclIpSpace.DENY_ALL;
+    IpSpace aclIpSpace =
+        AclIpSpace.permitting(Ip.parse("255.255.255.255").toIpSpace())
+            .thenPermitting(Ip.parse("255.255.255.254").toIpSpace())
+            .build();
+    assertThat(aclIpSpace, instanceOf(AclIpSpace.class));
+
     IpAccessList acl =
         IpAccessList.builder()
             .setName(ACL_NAME)
@@ -266,7 +281,12 @@ public class AclTracerTest {
 
   @Test
   public void testPermittedByNamedAclIpSpaceLine() {
-    AclIpSpace aclIpSpace = AclIpSpace.PERMIT_ALL;
+    IpSpace aclIpSpace =
+        AclIpSpace.permitting(Prefix.parse("1.0.0.0/1").toIpSpace())
+            .thenPermitting(Prefix.parse("0.0.0.0/1").toIpSpace())
+            .build();
+    assertThat(aclIpSpace, instanceOf(AclIpSpace.class));
+
     IpAccessList acl =
         IpAccessList.builder()
             .setName(ACL_NAME)
@@ -335,7 +355,12 @@ public class AclTracerTest {
 
   @Test
   public void testPermittedByUnnamedAclIpSpace() {
-    AclIpSpace aclIpSpace = AclIpSpace.PERMIT_ALL;
+    IpSpace aclIpSpace =
+        AclIpSpace.permitting(Prefix.parse("0.0.0.0/1").toIpSpace())
+            .thenPermitting(Prefix.parse("1.0.0.0/1").toIpSpace())
+            .build();
+    assertThat(aclIpSpace, instanceOf(AclIpSpace.class));
+
     IpAccessList acl =
         IpAccessList.builder()
             .setName(ACL_NAME)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceDereferencerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceDereferencerTest.java
@@ -30,14 +30,15 @@ public class IpSpaceDereferencerTest {
   public void testAclIpSpace() {
     IpSpaceDereferencer dereferencer = new IpSpaceDereferencer(NAMED_IP_SPACES);
     AclIpSpace input =
-        AclIpSpace.builder()
-            .thenPermitting(new IpSpaceReference("empty"))
-            .thenRejecting(new IpSpaceReference("prefix"))
-            .thenPermitting(new IpSpaceReference("namedIp"))
-            .thenRejecting(UniverseIpSpace.INSTANCE)
-            .build();
+        (AclIpSpace)
+            AclIpSpace.builder()
+                .thenPermitting(new IpSpaceReference("empty"))
+                .thenRejecting(new IpSpaceReference("prefix"))
+                .thenPermitting(new IpSpaceReference("namedIp"))
+                .thenRejecting(UniverseIpSpace.INSTANCE)
+                .build();
 
-    AclIpSpace expected =
+    IpSpace expected =
         AclIpSpace.builder()
             .thenPermitting(NAMED_IP_SPACES.get("empty"))
             .thenRejecting(NAMED_IP_SPACES.get("prefix"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceDescriberTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceDescriberTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import org.batfish.datamodel.AclIpSpace;
-import org.batfish.datamodel.AclIpSpaceLine;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
@@ -49,10 +48,12 @@ public final class IpSpaceDescriberTest {
 
   @Test
   public void testVisitAclIpSpace() {
-    IpSpace lineIpSpace = UniverseIpSpace.INSTANCE;
+    IpSpace lineIpSpace = Ip.parse("1.2.3.4").toIpSpace();
+    IpSpace line2IpSpace = Ip.parse("1.2.3.5").toIpSpace();
     String lineIpSpaceName = "lineIpSpace";
     IpSpaceMetadata lineIpSpaceMetadata = new IpSpaceMetadata("line_space_name", "line_space_type");
-    IpSpace ipSpace = AclIpSpace.of(AclIpSpaceLine.permit(lineIpSpace));
+    IpSpace ipSpace =
+        AclIpSpace.builder().thenPermitting(lineIpSpace).thenPermitting(line2IpSpace).build();
     IpSpaceDescriber describerWithMetadata =
         new IpSpaceDescriber(
             new AclTracer(
@@ -70,10 +71,10 @@ public final class IpSpaceDescriberTest {
                 ImmutableMap.of(lineIpSpaceName, lineIpSpace),
                 ImmutableMap.of(lineIpSpaceName, lineIpSpaceMetadata)));
 
-    assertThat(ipSpace.accept(_describerNoNamesNorMetadata), equalTo("[0: universe]"));
+    assertThat(ipSpace.accept(_describerNoNamesNorMetadata), equalTo("[0: 1.2.3.4, 1: 1.2.3.5]"));
     assertThat(
         ipSpace.accept(describerWithLineMetadata),
-        equalTo("[0: 'line_space_type' named 'line_space_name']"));
+        equalTo("[0: 'line_space_type' named 'line_space_name', 1: 1.2.3.5]"));
     assertThat(ipSpace.accept(describerWithMetadata), equalTo(TEST_METADATA_DESCRIPTION));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/datamodel/visitors/IpSpaceRenamerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/visitors/IpSpaceRenamerTest.java
@@ -53,7 +53,7 @@ public class IpSpaceRenamerTest {
 
   @Test
   public void testAclIpSpace() {
-    AclIpSpace input =
+    IpSpace input =
         AclIpSpace.builder()
             .thenPermitting(IP_IP_SPACE)
             .thenRejecting(PREFIX_IP_SPACE)
@@ -61,7 +61,7 @@ public class IpSpaceRenamerTest {
             .thenRejecting(IP_WILDCARD_IP_SPACE)
             .thenPermitting(IP_WILDCARD_SET_IP_SPACE)
             .build();
-    AclIpSpace output =
+    IpSpace output =
         AclIpSpace.builder()
             .thenPermitting(IP_IP_SPACE)
             .thenRejecting(PREFIX_IP_SPACE)


### PR DESCRIPTION
AclIpSpace is one source of perf issues. Simplify it during building when
possible -- especially single-entry AclIpSpaces are fairly common.
Secondly, cache the hashCode on demand, as for large AclIpSpaces hashing can
be expensive, and we stick them in maps.