### PR TITLE
Flow: allow src/dst port to be null

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpace.java
@@ -895,14 +895,14 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
         && _dstProtocols.stream()
             .noneMatch(
                 dstProtocol ->
-                    dstProtocol.getPort() == flow.getDstPort()
+                    dstProtocol.getPort().equals(flow.getDstPort())
                         && dstProtocol.getIpProtocol() == flow.getIpProtocol())) {
       return false;
     }
     if (_notDstProtocols.stream()
         .anyMatch(
             notDstProtocol ->
-                notDstProtocol.getPort() == flow.getDstPort()
+                notDstProtocol.getPort().equals(flow.getDstPort())
                     && notDstProtocol.getIpProtocol() == flow.getIpProtocol())) {
       return false;
     }
@@ -960,12 +960,11 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
     }
     if (!_srcOrDstProtocols.isEmpty()) {
       IpProtocol flowProtocol = flow.getIpProtocol();
-      int flowDstPort = flow.getDstPort();
-      int flowSrcPort = flow.getSrcPort();
       if (_srcOrDstProtocols.stream()
           .noneMatch(
               protocol ->
-                  (protocol.getPort() == flowDstPort || protocol.getPort() == flowSrcPort)
+                  (protocol.getPort().equals(flow.getDstPort())
+                          || protocol.getPort().equals(flow.getSrcPort()))
                       && protocol.getIpProtocol() == flowProtocol)) {
         return false;
       }
@@ -987,14 +986,14 @@ public class HeaderSpace implements Serializable, Comparable<HeaderSpace> {
         && _srcProtocols.stream()
             .noneMatch(
                 srcProtocol ->
-                    srcProtocol.getPort() == flow.getSrcPort()
+                    srcProtocol.getPort().equals(flow.getSrcPort())
                         && srcProtocol.getIpProtocol() == flow.getIpProtocol())) {
       return false;
     }
     if (_notSrcProtocols.stream()
         .anyMatch(
             notSrcProtocol ->
-                notSrcProtocol.getPort() == flow.getSrcPort()
+                notSrcProtocol.getPort().equals(flow.getSrcPort())
                     && notSrcProtocol.getIpProtocol() == flow.getIpProtocol())) {
       return false;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SubRange.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SubRange.java
@@ -104,6 +104,11 @@ public final class SubRange implements Serializable, Comparable<SubRange> {
     return Objects.hash(_end, _start);
   }
 
+  /** Check whether a given integer belongs to this range. */
+  public boolean includes(@Nullable Integer integer) {
+    return integer != null && includes(integer.intValue());
+  }
+
   /** Check whether a given integer belongs to this range */
   public boolean includes(int integer) {
     return _start <= integer && integer <= _end;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -218,7 +218,7 @@ public final class AclTracer extends Evaluator {
         if (dstProtocol.getIpProtocol().equals(_flow.getIpProtocol())) {
           match = true;
           Integer dstPort = dstProtocol.getPort();
-          if (dstPort != null && !dstPort.equals(_flow.getDstPort())) {
+          if (!dstPort.equals(_flow.getDstPort())) {
             match = false;
           }
           if (match) {
@@ -236,7 +236,7 @@ public final class AclTracer extends Evaluator {
         if (notDstProtocol.getIpProtocol().equals(_flow.getIpProtocol())) {
           match = true;
           Integer dstPort = notDstProtocol.getPort();
-          if (dstPort != null && !dstPort.equals(_flow.getDstPort())) {
+          if (!dstPort.equals(_flow.getDstPort())) {
             match = false;
           }
           if (match) {
@@ -301,9 +301,7 @@ public final class AclTracer extends Evaluator {
         if (protocol.getIpProtocol().equals(_flow.getIpProtocol())) {
           match = true;
           Integer port = protocol.getPort();
-          if (port != null
-              && !port.equals(_flow.getDstPort())
-              && !port.equals(_flow.getSrcPort())) {
+          if (!port.equals(_flow.getDstPort()) && !port.equals(_flow.getSrcPort())) {
             match = false;
           }
           if (match) {
@@ -336,7 +334,7 @@ public final class AclTracer extends Evaluator {
         if (srcProtocol.getIpProtocol().equals(_flow.getIpProtocol())) {
           match = true;
           Integer srcPort = srcProtocol.getPort();
-          if (srcPort != null && !srcPort.equals(_flow.getSrcPort())) {
+          if (!srcPort.equals(_flow.getSrcPort())) {
             match = false;
           }
           if (match) {
@@ -354,7 +352,7 @@ public final class AclTracer extends Evaluator {
         if (notSrcProtocol.getIpProtocol().equals(_flow.getIpProtocol())) {
           match = true;
           Integer srcPort = notSrcProtocol.getPort();
-          if (srcPort != null && !srcPort.equals(_flow.getSrcPort())) {
+          if (!srcPort.equals(_flow.getSrcPort())) {
             match = false;
           }
           if (match) {

--- a/projects/batfish/src/main/java/org/batfish/datamodel/transformation/TransformationEvaluator.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/transformation/TransformationEvaluator.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.transformation;
 
+import static com.google.common.base.Verify.verifyNotNull;
 import static org.batfish.datamodel.FlowDiff.flowDiff;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -83,9 +84,9 @@ public class TransformationEvaluator {
     private int get(PortField field) {
       switch (field) {
         case DESTINATION:
-          return _flowBuilder.getDstPort();
+          return verifyNotNull(_flowBuilder.getDstPort(), "Missing destination port");
         case SOURCE:
-          return _flowBuilder.getSrcPort();
+          return verifyNotNull(_flowBuilder.getSrcPort(), "Missing source port");
         default:
           throw new IllegalArgumentException("unknown PortField " + field);
       }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1561,6 +1561,7 @@ public class CiscoGrammarTest {
             .setSrcIp(Ip.parse("1.1.1.1"))
             .setDstIp(Ip.parse("2.2.2.2"))
             .setIpProtocol(IpProtocol.TCP)
+            .setSrcPort(NamedPort.EPHEMERAL_LOWEST.number())
             .setDstPort(80)
             .setIngressNode("internet")
             .setTag("none")
@@ -1575,6 +1576,7 @@ public class CiscoGrammarTest {
             .setSrcIp(Ip.parse("1.1.1.2"))
             .setDstIp(Ip.parse("2.2.2.2"))
             .setIpProtocol(IpProtocol.TCP)
+            .setSrcPort(NamedPort.EPHEMERAL_LOWEST.number())
             .setDstPort(80)
             .setIngressNode("internet")
             .setTag("none")
@@ -1597,6 +1599,7 @@ public class CiscoGrammarTest {
             .setSrcIp(Ip.parse("1.1.1.1"))
             .setDstIp(Ip.parse("2.2.2.2"))
             .setIpProtocol(IpProtocol.TCP)
+            .setSrcPort(NamedPort.EPHEMERAL_LOWEST.number())
             .setDstPort(81)
             .setIngressNode("internet")
             .setTag("none")
@@ -1847,7 +1850,13 @@ public class CiscoGrammarTest {
             .setIcmpType(0)
             .build();
     Flow tcpFlow =
-        Flow.builder().setTag("").setIngressNode("").setIpProtocol(IpProtocol.TCP).build();
+        Flow.builder()
+            .setTag("")
+            .setIngressNode("")
+            .setIpProtocol(IpProtocol.TCP)
+            .setSrcPort(0)
+            .setDstPort(0)
+            .build();
 
     /* Confirm the used object groups have referrers */
     assertThat(ccae, hasNumReferrers(filename, PROTOCOL_OBJECT_GROUP, ogpIcmpName, 1));
@@ -2642,12 +2651,16 @@ public class CiscoGrammarTest {
             .setIngressNode(c.getHostname())
             .setTag("")
             .setIpProtocol(IpProtocol.TCP)
+            .setSrcPort(0)
+            .setDstPort(0)
             .build();
     Flow flowInspect =
         Flow.builder()
             .setIngressNode(c.getHostname())
             .setTag("")
             .setIpProtocol(IpProtocol.UDP)
+            .setSrcPort(0)
+            .setDstPort(0)
             .build();
     Flow flowDrop =
         Flow.builder()

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -19,6 +19,7 @@ import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.codehaus.jettison.json.JSONArray;
@@ -50,10 +51,8 @@ public class SecurityGroupsTest {
                 .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                 .build());
     _region = new Region("test");
-    _flowBuilder = Flow.builder();
-    _flowBuilder.setIngressNode("foo");
-    _flowBuilder.setTag("TEST");
-    _flowBuilder.setIpProtocol(IpProtocol.TCP);
+    _flowBuilder =
+        Flow.builder().setIngressNode("foo").setTag("TEST").setIpProtocol(IpProtocol.TCP);
   }
 
   @Test
@@ -290,10 +289,12 @@ public class SecurityGroupsTest {
         IpAccessList.builder().setName(TEST_ACL).setLines(outboundRules).build();
 
     // flow containing SYN and ~ACK should be rejected
-    _flowBuilder.setDstIp(Ip.parse("1.2.3.4"));
-    _flowBuilder.setSrcPort(22);
-    _flowBuilder.setTcpFlagsAck(0);
-    _flowBuilder.setTcpFlagsSyn(1);
+    _flowBuilder
+        .setDstIp(Ip.parse("1.2.3.4"))
+        .setSrcPort(22)
+        .setDstPort(NamedPort.EPHEMERAL_LOWEST.number())
+        .setTcpFlagsAck(0)
+        .setTcpFlagsSyn(1);
 
     assertThat(
         outFilter
@@ -315,10 +316,12 @@ public class SecurityGroupsTest {
         IpAccessList.builder().setName(TEST_ACL).setLines(outboundRules).build();
 
     // flow containing SYN and ACK should be accepted
-    _flowBuilder.setDstIp(Ip.parse("1.2.3.4"));
-    _flowBuilder.setSrcPort(22);
-    _flowBuilder.setTcpFlagsAck(1);
-    _flowBuilder.setTcpFlagsSyn(1);
+    _flowBuilder
+        .setDstIp(Ip.parse("1.2.3.4"))
+        .setSrcPort(22)
+        .setDstPort(NamedPort.EPHEMERAL_LOWEST.number())
+        .setTcpFlagsAck(1)
+        .setTcpFlagsSyn(1);
 
     assertThat(
         outFilter
@@ -340,10 +343,12 @@ public class SecurityGroupsTest {
         IpAccessList.builder().setName(TEST_ACL).setLines(outboundRules).build();
 
     // flow containing wrong destination IP should be rejected
-    _flowBuilder.setDstIp(Ip.parse("1.2.3.5"));
-    _flowBuilder.setSrcPort(22);
-    _flowBuilder.setTcpFlagsAck(1);
-    _flowBuilder.setTcpFlagsSyn(1);
+    _flowBuilder
+        .setDstIp(Ip.parse("1.2.3.5"))
+        .setSrcPort(22)
+        .setDstPort(NamedPort.EPHEMERAL_LOWEST.number())
+        .setTcpFlagsAck(1)
+        .setTcpFlagsSyn(1);
 
     assertThat(
         outFilter

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleSetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleSetTest.java
@@ -220,7 +220,13 @@ public class NatRuleSetTest {
                 null)
             .get();
 
-    Flow.Builder fb = Flow.builder().setIngressNode("ingressNode").setSrcIp(Ip.ZERO).setTag("tag");
+    Flow.Builder fb =
+        Flow.builder()
+            .setIngressNode("ingressNode")
+            .setSrcIp(Ip.ZERO)
+            .setSrcPort(0)
+            .setDstPort(0)
+            .setTag("tag");
 
     // doesn't match rule set
     TransformationResult result =

--- a/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersAnswerer.java
@@ -259,10 +259,10 @@ public class TestFiltersAnswerer extends Answerer {
     if (builder.getIpProtocol() == null || builder.getIpProtocol() == IpProtocol.IP) {
       builder.setIpProtocol(IpProtocol.TCP);
     }
-    if (builder.getDstPort() == 0) {
+    if (builder.getDstPort() == null) {
       builder.setDstPort(NamedPort.HTTP.number());
     }
-    if (builder.getSrcPort() == 0) {
+    if (builder.getSrcPort() == null) {
       builder.setSrcPort(NamedPort.EPHEMERAL_LOWEST.number());
     }
     return builder;

--- a/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswererHelper.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswererHelper.java
@@ -156,10 +156,10 @@ public final class TracerouteAnswererHelper {
     if (builder.getIpProtocol() == null || builder.getIpProtocol() == IpProtocol.IP) {
       builder.setIpProtocol(IpProtocol.UDP);
     }
-    if (builder.getDstPort() == 0) {
+    if (builder.getDstPort() == null) {
       builder.setDstPort(TRACEROUTE_PORT);
     }
-    if (builder.getSrcPort() == 0) {
+    if (builder.getSrcPort() == null) {
       builder.setSrcPort(NamedPort.EPHEMERAL_LOWEST.number());
     }
     return builder;


### PR DESCRIPTION
If the IP Protocol in question does not have them.

FWIW, I ran all unit tests in IntelliJ to make sure no `@Nonnull` annotations collided.