### PR TITLE
cleanup Routing policy environment

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -337,6 +337,11 @@ public final class BgpRoute extends AbstractRoute {
       boolean nonForwarding,
       boolean nonRouting) {
     super(network, admin, nonRouting, nonForwarding);
+    checkArgument(
+        protocol == RoutingProtocol.BGP
+            || protocol == RoutingProtocol.IBGP
+            || protocol == RoutingProtocol.AGGREGATE,
+        "Invalid BgpRoute protocol");
     _asPath = firstNonNull(asPath, AsPath.empty());
     _clusterList =
         clusterList == null ? ImmutableSortedSet.of() : ImmutableSortedSet.copyOf(clusterList);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
@@ -1,5 +1,9 @@
 package org.batfish.datamodel.routing_policy;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.AbstractRoute;
@@ -7,17 +11,36 @@ import org.batfish.datamodel.AbstractRoute6;
 import org.batfish.datamodel.AbstractRouteBuilder;
 import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.AsPathAccessList;
+import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.CommunityList;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Ip6AccessList;
+import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.Route6FilterList;
+import org.batfish.datamodel.RouteFilterList;
 
 public class Environment {
 
-  public static Builder builder(@Nonnull Configuration c) {
-    return new Builder(c);
+  public static Builder builder(@Nonnull Configuration c, String vrf) {
+    ConfigurationFormat format = c.getConfigurationFormat();
+    return new Builder()
+        .setAsPathAccessLists(c.getAsPathAccessLists())
+        .setBgpProcess(c.getVrfs().get(vrf).getBgpProcess())
+        .setCommunityLists(c.getCommunityLists())
+        .setIpAccessLists(c.getIpAccessLists())
+        .setIp6AccessLists(c.getIp6AccessLists())
+        .setRouteFilterLists(c.getRouteFilterLists())
+        .setRoute6FilterLists(c.getRoute6FilterLists())
+        .setRoutingPolicies(c.getRoutingPolicies())
+        .setUseOutputAttributes(
+            format == ConfigurationFormat.JUNIPER
+                || format == ConfigurationFormat.JUNIPER_SWITCH
+                || format == ConfigurationFormat.FLAT_JUNIPER);
   }
 
   public enum Direction {
@@ -25,13 +48,17 @@ public class Environment {
     OUT
   }
 
+  private final Map<String, AsPathAccessList> _asPathAccessLists;
+
+  private BgpProcess _bgpProcess;
+
   private boolean _buffered;
 
   private boolean _callExprContext;
 
   private boolean _callStatementContext;
 
-  @Nonnull private final Configuration _configuration;
+  private final Map<String, CommunityList> _communityLists;
 
   private boolean _defaultAction;
 
@@ -43,6 +70,10 @@ public class Environment {
 
   private BgpRoute.Builder _intermediateBgpAttributes;
 
+  private final Map<String, IpAccessList> _ipAccessLists;
+
+  private final Map<String, Ip6AccessList> _ip6AccessLists;
+
   private boolean _localDefaultAction;
 
   private final AbstractRoute _originalRoute;
@@ -51,68 +82,89 @@ public class Environment {
 
   private final AbstractRouteBuilder<?, ?> _outputRoute;
 
+  private final Map<String, RoutingPolicy> _routingPolicies;
+
   @Nullable private final Ip _peerAddress;
 
   @Nullable private final Prefix _peerPrefix;
 
   private boolean _readFromIntermediateBgpAttributes;
 
+  private final Map<String, Route6FilterList> _route6FilterLists;
+
+  private final Map<String, RouteFilterList> _routeFilterLists;
+
   @Nullable private final String _routeSourceVrf;
 
   private final boolean _useOutputAttributes;
-
-  private final Vrf _vrf;
 
   private boolean _writeToIntermediateBgpAttributes;
 
   private Boolean _suppressed;
 
   private Environment(
+      Map<String, AsPathAccessList> asPathAccessLists,
+      BgpProcess bgpProcess,
       boolean buffered,
       boolean callExprContext,
       boolean callStatementContext,
-      @Nonnull Configuration configuration,
+      Map<String, CommunityList> communityLists,
       boolean defaultAction,
       String defaultPolicy,
       Direction direction,
       boolean error,
       BgpRoute.Builder intermediateBgpAttributes,
+      Map<String, IpAccessList> ipAccessLists,
+      Map<String, Ip6AccessList> ip6AccessLists,
       boolean localDefaultAction,
+      Map<String, RoutingPolicy> routingPolicies,
       AbstractRouteDecorator originalRoute,
       @Nullable AbstractRoute6 originalRoute6,
       AbstractRouteBuilder<?, ?> outputRoute,
       @Nullable Ip peerAddress,
       @Nullable Prefix peerPrefix,
       boolean readFromIntermediateBgpAttributes,
-      Vrf vrf,
+      Map<String, Route6FilterList> route6FilterLists,
+      Map<String, RouteFilterList> routeFilterLists,
+      boolean useOutputAttributes,
       boolean writeToIntermediateBgpAttributes) {
+    _asPathAccessLists = asPathAccessLists;
+    _bgpProcess = bgpProcess;
     _buffered = buffered;
     _callExprContext = callExprContext;
     _callStatementContext = callStatementContext;
-    _configuration = configuration;
+    _communityLists = communityLists;
     _defaultAction = defaultAction;
     _defaultPolicy = defaultPolicy;
     _direction = direction;
     _error = error;
     _intermediateBgpAttributes = intermediateBgpAttributes;
+    _ipAccessLists = ipAccessLists;
+    _ip6AccessLists = ip6AccessLists;
     _localDefaultAction = localDefaultAction;
+    _routingPolicies = routingPolicies;
     _originalRoute = originalRoute == null ? null : originalRoute.getAbstractRoute();
     _originalRoute6 = originalRoute6;
     _outputRoute = outputRoute;
     _peerAddress = peerAddress;
     _peerPrefix = peerPrefix;
     _readFromIntermediateBgpAttributes = readFromIntermediateBgpAttributes;
+    _route6FilterLists = route6FilterLists;
+    _routeFilterLists = routeFilterLists;
     _routeSourceVrf =
         originalRoute instanceof AnnotatedRoute
             ? ((AnnotatedRoute<?>) originalRoute).getSourceVrf()
             : null;
-    ConfigurationFormat format = configuration.getConfigurationFormat();
-    _useOutputAttributes =
-        format == ConfigurationFormat.JUNIPER
-            || format == ConfigurationFormat.JUNIPER_SWITCH
-            || format == ConfigurationFormat.FLAT_JUNIPER;
-    _vrf = vrf;
+    _useOutputAttributes = useOutputAttributes;
     _writeToIntermediateBgpAttributes = writeToIntermediateBgpAttributes;
+  }
+
+  public Map<String, AsPathAccessList> getAsPathAccessLists() {
+    return _asPathAccessLists;
+  }
+
+  public BgpProcess getBgpProcess() {
+    return _bgpProcess;
   }
 
   public boolean getBuffered() {
@@ -127,9 +179,8 @@ public class Environment {
     return _callStatementContext;
   }
 
-  @Nonnull
-  public Configuration getConfiguration() {
-    return _configuration;
+  public Map<String, CommunityList> getCommunityLists() {
+    return _communityLists;
   }
 
   public boolean getDefaultAction() {
@@ -152,8 +203,20 @@ public class Environment {
     return _intermediateBgpAttributes;
   }
 
+  public Map<String, Ip6AccessList> getIp6AccessLists() {
+    return _ip6AccessLists;
+  }
+
+  public Map<String, IpAccessList> getIpAccessLists() {
+    return _ipAccessLists;
+  }
+
   public boolean getLocalDefaultAction() {
     return _localDefaultAction;
+  }
+
+  public Map<String, RoutingPolicy> getRoutingPolicies() {
+    return _routingPolicies;
   }
 
   public AbstractRoute getOriginalRoute() {
@@ -183,16 +246,20 @@ public class Environment {
     return _readFromIntermediateBgpAttributes;
   }
 
+  public Map<String, Route6FilterList> getRoute6FilterLists() {
+    return _route6FilterLists;
+  }
+
+  public Map<String, RouteFilterList> getRouteFilterLists() {
+    return _routeFilterLists;
+  }
+
   public String getRouteSourceVrf() {
     return _routeSourceVrf;
   }
 
   public boolean getUseOutputAttributes() {
     return _useOutputAttributes;
-  }
-
-  public Vrf getVrf() {
-    return _vrf;
   }
 
   public boolean getWriteToIntermediateBgpAttributes() {
@@ -240,27 +307,42 @@ public class Environment {
   }
 
   public static final class Builder {
+    private Map<String, AsPathAccessList> _asPathAccessLists;
+    private BgpProcess _bgpProcess;
     private boolean _buffered;
     private boolean _callExprContext;
     private boolean _callStatementContext;
-    private Configuration _configuration;
+    private Map<String, CommunityList> _communityLists;
     private boolean _defaultAction;
     private String _defaultPolicy;
     private Direction _direction;
     private boolean _error;
     private BgpRoute.Builder _intermediateBgpAttributes;
+    private Map<String, Ip6AccessList> _ip6AccessLists;
+    private Map<String, IpAccessList> _ipAccessLists;
     private boolean _localDefaultAction;
+    private Map<String, RoutingPolicy> _routingPolicies;
     private AbstractRouteDecorator _originalRoute;
     private AbstractRoute6 _originalRoute6;
     private AbstractRouteBuilder<?, ?> _outputRoute;
     @Nullable private Ip _peerAddress;
     @Nullable private Prefix _peerPrefix;
     private boolean _readFromIntermediateBgpAttributes;
-    private String _vrf;
+    private Map<String, Route6FilterList> _route6FilterLists;
+    private Map<String, RouteFilterList> _routeFilterLists;
+    private boolean _useOutputAttributes;
     private boolean _writeToIntermediateBgpAttributes;
 
-    private Builder(Configuration c) {
-      _configuration = c;
+    private Builder() {}
+
+    public Builder setAsPathAccessLists(Map<String, AsPathAccessList> asPathAccessLists) {
+      _asPathAccessLists = ImmutableMap.copyOf(asPathAccessLists);
+      return this;
+    }
+
+    public Builder setBgpProcess(BgpProcess bgpProcess) {
+      _bgpProcess = bgpProcess;
+      return this;
     }
 
     public Builder setBuffered(boolean buffered) {
@@ -278,8 +360,8 @@ public class Environment {
       return this;
     }
 
-    public Builder setConfiguration(Configuration configuration) {
-      _configuration = configuration;
+    public Builder setCommunityLists(Map<String, CommunityList> communityLists) {
+      _communityLists = ImmutableMap.copyOf(communityLists);
       return this;
     }
 
@@ -308,8 +390,23 @@ public class Environment {
       return this;
     }
 
+    public Builder setIp6AccessLists(Map<String, Ip6AccessList> ip6AccessLists) {
+      _ip6AccessLists = ImmutableMap.copyOf(ip6AccessLists);
+      return this;
+    }
+
+    public Builder setIpAccessLists(Map<String, IpAccessList> ipAccessLists) {
+      _ipAccessLists = ImmutableMap.copyOf(ipAccessLists);
+      return this;
+    }
+
     public Builder setLocalDefaultAction(boolean localDefaultAction) {
       _localDefaultAction = localDefaultAction;
+      return this;
+    }
+
+    public Builder setRoutingPolicies(Map<String, RoutingPolicy> routingPolicies) {
+      _routingPolicies = ImmutableMap.copyOf(routingPolicies);
       return this;
     }
 
@@ -343,37 +440,53 @@ public class Environment {
       return this;
     }
 
-    public Builder setVrf(String vrf) {
-      _vrf = vrf;
-      return this;
-    }
-
     public Builder setWriteToIntermediateBgpAttributes(boolean writeToIntermediateBgpAttributes) {
       _writeToIntermediateBgpAttributes = writeToIntermediateBgpAttributes;
       return this;
     }
 
     public Environment build() {
-      Vrf vrf = _configuration.getVrfs().get(_vrf);
       return new Environment(
+          firstNonNull(_asPathAccessLists, ImmutableMap.of()),
+          _bgpProcess,
           _buffered,
           _callExprContext,
           _callStatementContext,
-          _configuration,
+          firstNonNull(_communityLists, ImmutableMap.of()),
           _defaultAction,
           _defaultPolicy,
           _direction,
           _error,
           _intermediateBgpAttributes,
+          firstNonNull(_ipAccessLists, ImmutableMap.of()),
+          firstNonNull(_ip6AccessLists, ImmutableMap.of()),
           _localDefaultAction,
+          firstNonNull(_routingPolicies, ImmutableMap.of()),
           _originalRoute,
           _originalRoute6,
           _outputRoute,
           _peerAddress,
           _peerPrefix,
           _readFromIntermediateBgpAttributes,
-          vrf,
+          firstNonNull(_route6FilterLists, ImmutableMap.of()),
+          firstNonNull(_routeFilterLists, ImmutableMap.of()),
+          _useOutputAttributes,
           _writeToIntermediateBgpAttributes);
+    }
+
+    public Builder setRoute6FilterLists(Map<String, Route6FilterList> route6FilterLists) {
+      _route6FilterLists = ImmutableMap.copyOf(route6FilterLists);
+      return this;
+    }
+
+    public Builder setRouteFilterLists(Map<String, RouteFilterList> routeFilterLists) {
+      _routeFilterLists = ImmutableMap.copyOf(routeFilterLists);
+      return this;
+    }
+
+    public Builder setUseOutputAttributes(boolean useOutputAttributes) {
+      _useOutputAttributes = useOutputAttributes;
+      return this;
     }
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
@@ -25,12 +25,14 @@ import org.batfish.datamodel.Route6FilterList;
 import org.batfish.datamodel.RouteFilterList;
 
 public class Environment {
-
-  public static Builder builder(@Nonnull Configuration c, String vrf) {
+  /**
+   * Initalizes an {@link Environment} builder using a {@link Configuration} as the source of
+   * several fields.
+   */
+  public static Builder builder(@Nonnull Configuration c) {
     ConfigurationFormat format = c.getConfigurationFormat();
     return new Builder()
         .setAsPathAccessLists(c.getAsPathAccessLists())
-        .setBgpProcess(c.getVrfs().get(vrf).getBgpProcess())
         .setCommunityLists(c.getCommunityLists())
         .setIpAccessLists(c.getIpAccessLists())
         .setIp6AccessLists(c.getIp6AccessLists())
@@ -41,6 +43,15 @@ public class Environment {
             format == ConfigurationFormat.JUNIPER
                 || format == ConfigurationFormat.JUNIPER_SWITCH
                 || format == ConfigurationFormat.FLAT_JUNIPER);
+  }
+
+  /**
+   * Initalizes an {@link Environment} builder using a {@link Configuration} and a {@link
+   * org.batfish.datamodel.Vrf} as the source of several fields. The vrf determines which {@link
+   * BgpProcess} to put into the environment.
+   */
+  public static Builder builder(@Nonnull Configuration c, String vrf) {
+    return builder(c).setBgpProcess(c.getVrfs().get(vrf).getBgpProcess());
   }
 
   public enum Direction {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
@@ -1,7 +1,6 @@
 package org.batfish.datamodel.routing_policy;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -200,10 +199,9 @@ public class RoutingPolicy implements Serializable {
   }
 
   /**
-   * Must provide one of peerAddress or peerPrefix.
-   *
    * @param peerAddress The address of a known peer.
    * @param peerPrefix The address of an unknown peer. Used for dynamic BGP.
+   * @return True if the policy accepts the route.
    */
   public boolean process(
       AbstractRouteDecorator inputRoute,
@@ -212,8 +210,6 @@ public class RoutingPolicy implements Serializable {
       @Nullable Prefix peerPrefix,
       String vrf,
       Direction direction) {
-    checkArgument(
-        peerAddress != null || peerPrefix != null, "Need either peerAddress or peerPrefix.");
     checkState(_owner != null, "Cannot evaluate routing policy without a Configuration");
     Environment environment =
         Environment.builder(_owner, vrf)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
@@ -200,7 +200,7 @@ public class RoutingPolicy implements Serializable {
   }
 
   /**
-   * Must provide one of peerAddress or peerPrefix, but not both.
+   * Must provide one of peerAddress or peerPrefix.
    *
    * @param peerAddress The address of a known peer.
    * @param peerPrefix The address of an unknown peer. Used for dynamic BGP.
@@ -213,8 +213,7 @@ public class RoutingPolicy implements Serializable {
       String vrf,
       Direction direction) {
     checkArgument(
-        peerAddress == null ^ peerPrefix == null,
-        "Must provide one of peerAddress or peerPrefix, but not both.");
+        peerAddress != null || peerPrefix != null, "Need either peerAddress or peerPrefix.");
     checkState(_owner != null, "Cannot evaluate routing policy without a Configuration");
     Environment environment =
         Environment.builder(_owner, vrf)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/AutoAs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/AutoAs.java
@@ -29,7 +29,7 @@ public class AutoAs extends AsExpr {
 
   @Override
   public long evaluate(Environment environment) {
-    BgpProcess proc = environment.getVrf().getBgpProcess();
+    BgpProcess proc = environment.getBgpProcess();
     if (proc == null) {
       throw new BatfishException("Expected BGP process");
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CallExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/CallExpr.java
@@ -53,8 +53,7 @@ public final class CallExpr extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    RoutingPolicy policy =
-        environment.getConfiguration().getRoutingPolicies().get(_calledPolicyName);
+    RoutingPolicy policy = environment.getRoutingPolicies().get(_calledPolicyName);
     if (policy == null) {
       environment.setError(true);
       return new Result(false);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIp6AccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIp6AccessList.java
@@ -29,7 +29,7 @@ public final class MatchIp6AccessList extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    Ip6AccessList list = environment.getConfiguration().getIp6AccessLists().get(_list);
+    Ip6AccessList list = environment.getIp6AccessLists().get(_list);
     if (list != null) {
       // TODO
     } else {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchIpAccessList.java
@@ -29,7 +29,7 @@ public final class MatchIpAccessList extends BooleanExpr {
 
   @Override
   public Result evaluate(Environment environment) {
-    IpAccessList list = environment.getConfiguration().getIpAccessLists().get(_list);
+    IpAccessList list = environment.getIpAccessLists().get(_list);
     if (list != null) {
       // TODO
     } else {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedAsPathSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedAsPathSet.java
@@ -48,7 +48,7 @@ public final class NamedAsPathSet extends AsPathSetExpr {
 
   @Override
   public boolean matches(Environment environment) {
-    AsPathAccessList list = environment.getConfiguration().getAsPathAccessLists().get(_name);
+    AsPathAccessList list = environment.getAsPathAccessLists().get(_name);
     if (list != null) {
       boolean match = false;
       AsPath inputAsPath = null;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedCommunitySet.java
@@ -81,11 +81,7 @@ public class NamedCommunitySet extends CommunitySetExpr {
 
   @Override
   public boolean matchCommunity(Environment environment, long community) {
-    return environment
-        .getConfiguration()
-        .getCommunityLists()
-        .get(_name)
-        .matchCommunity(environment, community);
+    return environment.getCommunityLists().get(_name).matchCommunity(environment, community);
   }
 
   @Override
@@ -100,6 +96,6 @@ public class NamedCommunitySet extends CommunitySetExpr {
   }
 
   private @Nonnull CommunitySetExpr resolve(@Nonnull Environment environment) {
-    return requireNonNull(environment.getConfiguration().getCommunityLists().get(_name));
+    return requireNonNull(environment.getCommunityLists().get(_name));
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedPrefix6Set.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedPrefix6Set.java
@@ -57,7 +57,7 @@ public final class NamedPrefix6Set extends Prefix6SetExpr {
 
   @Override
   public boolean matches(Prefix6 prefix, Environment environment) {
-    Route6FilterList list = environment.getConfiguration().getRoute6FilterLists().get(_name);
+    Route6FilterList list = environment.getRoute6FilterLists().get(_name);
     if (list != null) {
       return list.permits(prefix);
     } else {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedPrefixSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NamedPrefixSet.java
@@ -55,7 +55,7 @@ public final class NamedPrefixSet extends PrefixSetExpr {
 
   @Override
   public boolean matches(Prefix prefix, Environment environment) {
-    RouteFilterList list = environment.getConfiguration().getRouteFilterLists().get(_name);
+    RouteFilterList list = environment.getRouteFilterLists().get(_name);
     if (list != null) {
       return list.permits(prefix);
     } else {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
@@ -31,10 +31,9 @@ public class SelfNextHop extends NextHopExpr {
     if (peerPrefix == null) {
       return null;
     }
-    BgpPeerConfig neighbor =
-        environment.getVrf().getBgpProcess().getActiveNeighbors().get(peerPrefix);
+    BgpPeerConfig neighbor = environment.getBgpProcess().getActiveNeighbors().get(peerPrefix);
     if (neighbor == null) {
-      neighbor = environment.getVrf().getBgpProcess().getPassiveNeighbors().get(peerPrefix);
+      neighbor = environment.getBgpProcess().getPassiveNeighbors().get(peerPrefix);
     }
     if (neighbor == null) {
       return null;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/CallStatement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/CallStatement.java
@@ -70,8 +70,7 @@ public class CallStatement extends Statement {
 
   @Override
   public Result execute(Environment environment) {
-    RoutingPolicy policy =
-        environment.getConfiguration().getRoutingPolicies().get(_calledPolicyName);
+    RoutingPolicy policy = environment.getRoutingPolicies().get(_calledPolicyName);
     if (policy == null) {
       environment.setError(true);
       return Result.builder().setBooleanValue(false).build();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChainTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChainTest.java
@@ -86,7 +86,7 @@ public class ConjunctionChainTest {
     c.setVrfs(
         ImmutableMap.of(Configuration.DEFAULT_VRF_NAME, new Vrf(Configuration.DEFAULT_VRF_NAME)));
     c.setRoutingPolicies(policies);
-    return Environment.builder(c)
+    return Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
         .setDefaultPolicy(defaultPolicy)
         .setOriginalRoute(route)
         .setOutputRoute(route.toBuilder())
@@ -124,8 +124,9 @@ public class ConjunctionChainTest {
         new ConjunctionChain(ImmutableList.of(BooleanExprs.TRUE, BooleanExprs.FALSE));
     Result result =
         cc.evaluate(
-            Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
-                .setVrf(Configuration.DEFAULT_VRF_NAME)
+            Environment.builder(
+                    new Configuration("host", ConfigurationFormat.JUNIPER),
+                    Configuration.DEFAULT_VRF_NAME)
                 .build());
     assertThat(result, equalTo(new Result(false, false, false, false)));
 
@@ -134,8 +135,9 @@ public class ConjunctionChainTest {
     cc = new ConjunctionChain(ImmutableList.of(BooleanExprs.TRUE, BooleanExprs.TRUE));
     result =
         cc.evaluate(
-            Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
-                .setVrf(Configuration.DEFAULT_VRF_NAME)
+            Environment.builder(
+                    new Configuration("host", ConfigurationFormat.JUNIPER),
+                    Configuration.DEFAULT_VRF_NAME)
                 .build());
     assertThat(result, equalTo(new Result(true, false, false, false)));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChainTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChainTest.java
@@ -124,10 +124,7 @@ public class ConjunctionChainTest {
         new ConjunctionChain(ImmutableList.of(BooleanExprs.TRUE, BooleanExprs.FALSE));
     Result result =
         cc.evaluate(
-            Environment.builder(
-                    new Configuration("host", ConfigurationFormat.JUNIPER),
-                    Configuration.DEFAULT_VRF_NAME)
-                .build());
+            Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER)).build());
     assertThat(result, equalTo(new Result(false, false, false, false)));
 
     // result._return should not be true here because if there were more policies in the chain, it
@@ -135,10 +132,7 @@ public class ConjunctionChainTest {
     cc = new ConjunctionChain(ImmutableList.of(BooleanExprs.TRUE, BooleanExprs.TRUE));
     result =
         cc.evaluate(
-            Environment.builder(
-                    new Configuration("host", ConfigurationFormat.JUNIPER),
-                    Configuration.DEFAULT_VRF_NAME)
-                .build());
+            Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER)).build());
     assertThat(result, equalTo(new Result(true, false, false, false)));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ExplicitAsPathSetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ExplicitAsPathSetTest.java
@@ -27,7 +27,7 @@ public class ExplicitAsPathSetTest {
     Configuration c = cb.build();
     c.setVrfs(
         ImmutableMap.of(Configuration.DEFAULT_VRF_NAME, new Vrf(Configuration.DEFAULT_VRF_NAME)));
-    return Environment.builder(c)
+    return Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
         .setOriginalRoute(
             BgpRoute.builder()
                 .setOriginatorIp(Ip.ZERO)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChainTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChainTest.java
@@ -105,19 +105,13 @@ public class FirstMatchChainTest {
         new FirstMatchChain(ImmutableList.of(BooleanExprs.FALSE, BooleanExprs.TRUE));
     Result result =
         fmc.evaluate(
-            Environment.builder(
-                    new Configuration("host", ConfigurationFormat.JUNIPER),
-                    Configuration.DEFAULT_VRF_NAME)
-                .build());
+            Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER)).build());
     assertThat(result, equalTo(new Result(false, false, false, false)));
 
     fmc = new FirstMatchChain(ImmutableList.of(BooleanExprs.TRUE, BooleanExprs.FALSE));
     result =
         fmc.evaluate(
-            Environment.builder(
-                    new Configuration("host", ConfigurationFormat.JUNIPER),
-                    Configuration.DEFAULT_VRF_NAME)
-                .build());
+            Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER)).build());
     assertThat(result, equalTo(new Result(true, false, false, false)));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChainTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChainTest.java
@@ -68,7 +68,7 @@ public class FirstMatchChainTest {
     c.setVrfs(
         ImmutableMap.of(Configuration.DEFAULT_VRF_NAME, new Vrf(Configuration.DEFAULT_VRF_NAME)));
     c.setRoutingPolicies(policies);
-    return Environment.builder(c)
+    return Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
         .setDefaultPolicy(defaultPolicy)
         .setOutputRoute(route.toBuilder())
         .build();
@@ -105,16 +105,18 @@ public class FirstMatchChainTest {
         new FirstMatchChain(ImmutableList.of(BooleanExprs.FALSE, BooleanExprs.TRUE));
     Result result =
         fmc.evaluate(
-            Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
-                .setVrf(Configuration.DEFAULT_VRF_NAME)
+            Environment.builder(
+                    new Configuration("host", ConfigurationFormat.JUNIPER),
+                    Configuration.DEFAULT_VRF_NAME)
                 .build());
     assertThat(result, equalTo(new Result(false, false, false, false)));
 
     fmc = new FirstMatchChain(ImmutableList.of(BooleanExprs.TRUE, BooleanExprs.FALSE));
     result =
         fmc.evaluate(
-            Environment.builder(new Configuration("host", ConfigurationFormat.JUNIPER))
-                .setVrf(Configuration.DEFAULT_VRF_NAME)
+            Environment.builder(
+                    new Configuration("host", ConfigurationFormat.JUNIPER),
+                    Configuration.DEFAULT_VRF_NAME)
                 .build());
     assertThat(result, equalTo(new Result(true, false, false, false)));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchProtocolTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchProtocolTest.java
@@ -63,7 +63,7 @@ public class MatchProtocolTest {
             .setSystemId("invalidSystemId");
 
     MatchProtocol mp = new MatchProtocol(RoutingProtocol.ISIS_ANY);
-    Environment.Builder eb = Environment.builder(c).setVrf(Configuration.DEFAULT_VRF_NAME);
+    Environment.Builder eb = Environment.builder(c, Configuration.DEFAULT_VRF_NAME);
 
     assertTrue(
         "Matches ISIS_L1",

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/NamedCommunitySetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/NamedCommunitySetTest.java
@@ -44,7 +44,7 @@ public final class NamedCommunitySetTest {
             false);
     c.getCommunityLists().put(COMMUNITY_LIST_NAME, referent);
     nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME).setOwner(c).build();
-    _env = Environment.builder(c).setVrf(Configuration.DEFAULT_VRF_NAME).build();
+    _env = Environment.builder(c, Configuration.DEFAULT_VRF_NAME).build();
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassfulTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassfulTest.java
@@ -21,7 +21,7 @@ public class RouteIsClassfulTest {
   private static boolean evaluateIsClassful(Prefix network) {
     Configuration c = new Configuration("host", ConfigurationFormat.CISCO_IOS);
     ConnectedRoute route = new ConnectedRoute(network, "Ethernet0");
-    Environment env = Environment.builder(c).setVrf("vrf").setOriginalRoute(route).build();
+    Environment env = Environment.builder(c, "vrf").setOriginalRoute(route).build();
     Result res = RouteIsClassful.instance().evaluate(env);
     return res.getBooleanValue();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassfulTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/RouteIsClassfulTest.java
@@ -21,7 +21,7 @@ public class RouteIsClassfulTest {
   private static boolean evaluateIsClassful(Prefix network) {
     Configuration c = new Configuration("host", ConfigurationFormat.CISCO_IOS);
     ConnectedRoute route = new ConnectedRoute(network, "Ethernet0");
-    Environment env = Environment.builder(c, "vrf").setOriginalRoute(route).build();
+    Environment env = Environment.builder(c).setOriginalRoute(route).build();
     Result res = RouteIsClassful.instance().evaluate(env);
     return res.getBooleanValue();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/PrependAsPathTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/PrependAsPathTest.java
@@ -22,7 +22,7 @@ public class PrependAsPathTest {
 
   private static Environment newTestEnvironment(BgpRoute.Builder outputRoute) {
     Configuration c = new Configuration("host", ConfigurationFormat.CISCO_IOS);
-    return Environment.builder(c).setVrf("vrf").setOutputRoute(outputRoute).build();
+    return Environment.builder(c, "vrf").setOutputRoute(outputRoute).build();
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/PrependAsPathTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/PrependAsPathTest.java
@@ -22,7 +22,7 @@ public class PrependAsPathTest {
 
   private static Environment newTestEnvironment(BgpRoute.Builder outputRoute) {
     Configuration c = new Configuration("host", ConfigurationFormat.CISCO_IOS);
-    return Environment.builder(c, "vrf").setOutputRoute(outputRoute).build();
+    return Environment.builder(c).setOutputRoute(outputRoute).build();
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/GeneratedRouteHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/GeneratedRouteHelperTest.java
@@ -15,6 +15,7 @@ import org.batfish.datamodel.GeneratedRoute.Builder;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.junit.Before;
@@ -80,6 +81,7 @@ public class GeneratedRouteHelperTest {
             .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
             .setHostname("n1")
             .build();
+    Vrf vrf = nf.vrfBuilder().setOwner(c).build();
 
     RoutingPolicy policy =
         nf.routingPolicyBuilder()
@@ -102,7 +104,7 @@ public class GeneratedRouteHelperTest {
                         .setMetric(0L)
                         .setTag(1)
                         .build())),
-            "vrf");
+            vrf.getName());
 
     assertThat(newRoute, notNullValue());
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishGrammarTest.java
@@ -286,10 +286,9 @@ public final class F5BigipImishGrammarTest {
       assertTrue(
           commonExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(bgpRouteAllowedByPeerPolicy)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
       BgpRoute outputRoute = outputBuilder.build();
@@ -302,10 +301,9 @@ public final class F5BigipImishGrammarTest {
       assertTrue(
           peerExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(bgpRouteAllowedByPeerPolicy)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
       BgpRoute outputRoute = outputBuilder.build();
@@ -318,10 +316,9 @@ public final class F5BigipImishGrammarTest {
       assertTrue(
           commonExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(bgpRouteAllowedOnlyByCommonPolicy)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
     }
@@ -332,10 +329,9 @@ public final class F5BigipImishGrammarTest {
       assertFalse(
           peerExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(bgpRouteAllowedOnlyByCommonPolicy)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
     }
@@ -346,10 +342,9 @@ public final class F5BigipImishGrammarTest {
       assertFalse(
           commonExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(connectedRoute)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
     }
@@ -360,10 +355,9 @@ public final class F5BigipImishGrammarTest {
       assertFalse(
           peerExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(connectedRoute)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
     }
@@ -374,10 +368,9 @@ public final class F5BigipImishGrammarTest {
       assertTrue(
           commonExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(kernelRoute)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
       BgpRoute outputRoute = outputBuilder.build();
@@ -390,10 +383,9 @@ public final class F5BigipImishGrammarTest {
       assertTrue(
           peerExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(kernelRoute)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
       BgpRoute outputRoute = outputBuilder.build();
@@ -444,9 +436,8 @@ public final class F5BigipImishGrammarTest {
         c.getRoutingPolicies()
             .get(acceptAllName)
             .call(
-                Environment.builder(c)
+                Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                     .setDirection(Direction.OUT)
-                    .setVrf(Configuration.DEFAULT_VRF_NAME)
                     .setOriginalRoute(
                         new ConnectedRoute(Prefix.strict("10.0.0.0/24"), "/Common/outint"))
                     .build())
@@ -460,9 +451,8 @@ public final class F5BigipImishGrammarTest {
     assertTrue(
         "rm1 denies prefix 10.0.0.0/24 (via 10)",
         !rm1.call(
-                Environment.builder(c)
+                Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                     .setDirection(Direction.OUT)
-                    .setVrf(Configuration.DEFAULT_VRF_NAME)
                     .setOriginalRoute(
                         new ConnectedRoute(Prefix.strict("10.0.0.0/24"), "/Common/outint"))
                     .build())
@@ -477,10 +467,9 @@ public final class F5BigipImishGrammarTest {
             .setOriginType(OriginType.INCOMPLETE)
             .setProtocol(RoutingProtocol.BGP);
     Environment acceptedPrefixEnvironment =
-        Environment.builder(c)
+        Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
             .setDirection(Direction.OUT)
             .setOutputRoute(outputRoute)
-            .setVrf(Configuration.DEFAULT_VRF_NAME)
             .setOriginalRoute(acceptedRoute)
             .build();
     Result acceptedBy20 = rm1.call(acceptedPrefixEnvironment);
@@ -497,9 +486,8 @@ public final class F5BigipImishGrammarTest {
     assertTrue(
         "rm1 rejects prefix 10.0.2.0/24 (no matching entry)",
         !rm1.call(
-                Environment.builder(c)
+                Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                     .setDirection(Direction.OUT)
-                    .setVrf(Configuration.DEFAULT_VRF_NAME)
                     .setOriginalRoute(
                         new ConnectedRoute(Prefix.strict("10.0.2.0/24"), "/Common/outint"))
                     .build())

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredGrammarTest.java
@@ -341,10 +341,9 @@ public final class F5BigipStructuredGrammarTest {
       assertTrue(
           commonExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(bgpRouteAllowedByPeerPolicy)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
       BgpRoute outputRoute = outputBuilder.build();
@@ -357,10 +356,9 @@ public final class F5BigipStructuredGrammarTest {
       assertTrue(
           peerExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(bgpRouteAllowedByPeerPolicy)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
       BgpRoute outputRoute = outputBuilder.build();
@@ -373,10 +371,9 @@ public final class F5BigipStructuredGrammarTest {
       assertTrue(
           commonExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(bgpRouteAllowedOnlyByCommonPolicy)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
     }
@@ -387,10 +384,9 @@ public final class F5BigipStructuredGrammarTest {
       assertFalse(
           peerExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(bgpRouteAllowedOnlyByCommonPolicy)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
     }
@@ -401,10 +397,9 @@ public final class F5BigipStructuredGrammarTest {
       assertFalse(
           commonExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(connectedRoute)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
     }
@@ -415,10 +410,9 @@ public final class F5BigipStructuredGrammarTest {
       assertFalse(
           peerExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(connectedRoute)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
     }
@@ -429,10 +423,9 @@ public final class F5BigipStructuredGrammarTest {
       assertTrue(
           commonExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(kernelRoute)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
       BgpRoute outputRoute = outputBuilder.build();
@@ -445,10 +438,9 @@ public final class F5BigipStructuredGrammarTest {
       assertTrue(
           peerExportPolicy
               .call(
-                  Environment.builder(c)
+                  Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                       .setOriginalRoute(kernelRoute)
                       .setOutputRoute(outputBuilder)
-                      .setVrf(Configuration.DEFAULT_VRF_NAME)
                       .build())
               .getBooleanValue());
       BgpRoute outputRoute = outputBuilder.build();
@@ -995,9 +987,8 @@ public final class F5BigipStructuredGrammarTest {
         c.getRoutingPolicies()
             .get(acceptAllName)
             .call(
-                Environment.builder(c)
+                Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                     .setDirection(Direction.OUT)
-                    .setVrf(Configuration.DEFAULT_VRF_NAME)
                     .setOriginalRoute(
                         new ConnectedRoute(Prefix.strict("10.0.0.0/24"), "/Common/outint"))
                     .build())
@@ -1011,9 +1002,8 @@ public final class F5BigipStructuredGrammarTest {
     assertTrue(
         "rm1 denies prefix 10.0.0.0/24 (via 10)",
         !rm1.call(
-                Environment.builder(c)
+                Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                     .setDirection(Direction.OUT)
-                    .setVrf(Configuration.DEFAULT_VRF_NAME)
                     .setOriginalRoute(
                         new ConnectedRoute(Prefix.strict("10.0.0.0/24"), "/Common/outint"))
                     .build())
@@ -1028,10 +1018,9 @@ public final class F5BigipStructuredGrammarTest {
             .setOriginType(OriginType.INCOMPLETE)
             .setProtocol(RoutingProtocol.BGP);
     Environment acceptedPrefixEnvironment =
-        Environment.builder(c)
+        Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
             .setDirection(Direction.OUT)
             .setOutputRoute(outputRoute)
-            .setVrf(Configuration.DEFAULT_VRF_NAME)
             .setOriginalRoute(acceptedRoute)
             .build();
     Result acceptedBy20 = rm1.call(acceptedPrefixEnvironment);
@@ -1048,9 +1037,8 @@ public final class F5BigipStructuredGrammarTest {
     assertTrue(
         "rm1 rejects prefix 10.0.2.0/24 (no matching entry)",
         !rm1.call(
-                Environment.builder(c)
+                Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
                     .setDirection(Direction.OUT)
-                    .setVrf(Configuration.DEFAULT_VRF_NAME)
                     .setOriginalRoute(
                         new ConnectedRoute(Prefix.strict("10.0.2.0/24"), "/Common/outint"))
                     .build())

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/AsPathRegexTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/AsPathRegexTest.java
@@ -35,7 +35,7 @@ public class AsPathRegexTest {
     Configuration c = cb.build();
     c.setVrfs(
         ImmutableMap.of(Configuration.DEFAULT_VRF_NAME, new Vrf(Configuration.DEFAULT_VRF_NAME)));
-    return Environment.builder(c)
+    return Environment.builder(c, Configuration.DEFAULT_VRF_NAME)
         .setOriginalRoute(
             BgpRoute.builder()
                 .setOriginatorIp(Ip.ZERO)

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2057,7 +2057,7 @@ public final class FlatJuniperGrammarTest {
             .setAdministrativeCost(1)
             .build();
 
-    Environment.Builder eb = Environment.builder(c, "vrf1").setDirection(Direction.IN);
+    Environment.Builder eb = Environment.builder(c).setDirection(Direction.IN);
     policyPreference.call(
         eb.setOriginalRoute(staticRoute).setOutputRoute(OspfExternalType2Route.builder()).build());
 
@@ -2068,8 +2068,6 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testPsPreferenceStructure() throws IOException {
     Configuration c = parseConfig("policy-statement-preference");
-
-    Environment.Builder eb = Environment.builder(c, "vrf1").setDirection(Direction.IN);
 
     RoutingPolicy policyPreference = c.getRoutingPolicies().get("preference");
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2057,8 +2057,7 @@ public final class FlatJuniperGrammarTest {
             .setAdministrativeCost(1)
             .build();
 
-    Environment.Builder eb = Environment.builder(c).setDirection(Direction.IN);
-    eb.setVrf("vrf1");
+    Environment.Builder eb = Environment.builder(c, "vrf1").setDirection(Direction.IN);
     policyPreference.call(
         eb.setOriginalRoute(staticRoute).setOutputRoute(OspfExternalType2Route.builder()).build());
 
@@ -2070,8 +2069,7 @@ public final class FlatJuniperGrammarTest {
   public void testPsPreferenceStructure() throws IOException {
     Configuration c = parseConfig("policy-statement-preference");
 
-    Environment.Builder eb = Environment.builder(c).setDirection(Direction.IN);
-    eb.setVrf("vrf1");
+    Environment.Builder eb = Environment.builder(c, "vrf1").setDirection(Direction.IN);
 
     RoutingPolicy policyPreference = c.getRoutingPolicies().get("preference");
 
@@ -2864,8 +2862,7 @@ public final class FlatJuniperGrammarTest {
           c.getRoutingPolicies()
               .get("POLICY-NAME")
               .call(
-                  Environment.builder(c)
-                      .setVrf(DEFAULT_VRF_NAME)
+                  Environment.builder(c, DEFAULT_VRF_NAME)
                       .setOriginalRoute(new ConnectedRoute(p, "nextHop"))
                       .build());
       assertThat(result.getBooleanValue(), equalTo(true));
@@ -2876,8 +2873,7 @@ public final class FlatJuniperGrammarTest {
         c.getRoutingPolicies()
             .get("POLICY-NAME")
             .call(
-                Environment.builder(c)
-                    .setVrf(DEFAULT_VRF_NAME)
+                Environment.builder(c, DEFAULT_VRF_NAME)
                     .setOriginalRoute(
                         StaticRoute.builder()
                             .setAdministrativeCost(0)
@@ -2891,8 +2887,7 @@ public final class FlatJuniperGrammarTest {
         c.getRoutingPolicies()
             .get("POLICY-NAME")
             .call(
-                Environment.builder(c)
-                    .setVrf(DEFAULT_VRF_NAME)
+                Environment.builder(c, DEFAULT_VRF_NAME)
                     .setOriginalRoute(new ConnectedRoute(Prefix.parse("3.3.3.0/24"), "nextHop"))
                     .build());
     assertThat(result.getBooleanValue(), equalTo(false));
@@ -2936,8 +2931,7 @@ public final class FlatJuniperGrammarTest {
     assertThat(result.getBooleanValue(), equalTo(false));
     result =
         familyPolicy.call(
-            Environment.builder(c)
-                .setVrf(DEFAULT_VRF_NAME)
+            Environment.builder(c, DEFAULT_VRF_NAME)
                 .setOriginalRoute6(new GeneratedRoute6(Prefix6.ZERO))
                 .build());
     assertThat(result.getBooleanValue(), equalTo(true));
@@ -3060,20 +3054,20 @@ public final class FlatJuniperGrammarTest {
     srb = StaticRoute.builder().setAdministrativeCost(100).setNetwork(testPrefix);
     result =
         tagPolicy.call(
-            Environment.builder(c).setVrf(DEFAULT_VRF_NAME).setOutputRoute(srb.setTag(1)).build());
+            Environment.builder(c, DEFAULT_VRF_NAME).setOutputRoute(srb.setTag(1)).build());
     assertThat(result.getBooleanValue(), equalTo(true));
     result =
         tagPolicy.call(
-            Environment.builder(c).setVrf(DEFAULT_VRF_NAME).setOutputRoute(srb.setTag(2)).build());
+            Environment.builder(c, DEFAULT_VRF_NAME).setOutputRoute(srb.setTag(2)).build());
     assertThat(result.getBooleanValue(), equalTo(true));
     result =
         tagPolicy.call(
-            Environment.builder(c).setVrf(DEFAULT_VRF_NAME).setOutputRoute(srb.setTag(3)).build());
+            Environment.builder(c, DEFAULT_VRF_NAME).setOutputRoute(srb.setTag(3)).build());
     assertThat(result.getBooleanValue(), equalTo(false));
   }
 
   private static Environment envWithRoute(Configuration c, AbstractRoute route) {
-    return Environment.builder(c).setVrf(DEFAULT_VRF_NAME).setOriginalRoute(route).build();
+    return Environment.builder(c, DEFAULT_VRF_NAME).setOriginalRoute(route).build();
   }
 
   @Test
@@ -3269,7 +3263,6 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testLocalRouteExportBgp() throws IOException {
     Configuration c = parseConfig("local-route-export-bgp");
-    Environment.Builder eb = Environment.builder(c).setDirection(Direction.OUT);
 
     String peer1Vrf = "peer1Vrf";
     RoutingPolicy peer1RejectAllLocal =
@@ -3291,7 +3284,7 @@ public final class FlatJuniperGrammarTest {
     LocalRoute localRouteLan = new LocalRoute(new InterfaceAddress("10.0.1.0/30"), "ge-0/0/1.0");
 
     // Peer policies should reject local routes not exported by their VRFs
-    eb.setVrf(peer1Vrf);
+    Environment.Builder eb = Environment.builder(c, peer1Vrf).setDirection(Direction.OUT);
     assertThat(
         peer1RejectAllLocal
             .call(eb.setOriginalRoute(localRoutePtp).setOutputRoute(new BgpRoute.Builder()).build())
@@ -3303,7 +3296,7 @@ public final class FlatJuniperGrammarTest {
             .getBooleanValue(),
         equalTo(false));
 
-    eb.setVrf(peer2Vrf);
+    eb = Environment.builder(c, peer2Vrf).setDirection(Direction.OUT);
     assertThat(
         peer2RejectPtpLocal
             .call(eb.setOriginalRoute(localRoutePtp).setOutputRoute(new BgpRoute.Builder()).build())
@@ -3315,7 +3308,7 @@ public final class FlatJuniperGrammarTest {
             .getBooleanValue(),
         equalTo(true));
 
-    eb.setVrf(peer3Vrf);
+    eb = Environment.builder(c, peer3Vrf).setDirection(Direction.OUT);
     assertThat(
         peer3RejectLanLocal
             .call(eb.setOriginalRoute(localRoutePtp).setOutputRoute(new BgpRoute.Builder()).build())
@@ -3327,7 +3320,7 @@ public final class FlatJuniperGrammarTest {
             .getBooleanValue(),
         equalTo(false));
 
-    eb.setVrf(peer4Vrf);
+    eb = Environment.builder(c, peer4Vrf).setDirection(Direction.OUT);
     assertThat(
         peer4AllowAllLocal
             .call(eb.setOriginalRoute(localRoutePtp).setOutputRoute(new BgpRoute.Builder()).build())
@@ -3343,7 +3336,6 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testLocalRouteExportOspf() throws IOException {
     Configuration c = parseConfig("local-route-export-ospf");
-    Environment.Builder eb = Environment.builder(c).setDirection(Direction.OUT);
 
     String vrf1 = "vrf1";
     RoutingPolicy vrf1RejectAllLocal =
@@ -3364,7 +3356,7 @@ public final class FlatJuniperGrammarTest {
     LocalRoute localRouteLan = new LocalRoute(new InterfaceAddress("10.0.1.0/30"), "ge-0/0/1.0");
 
     // Peer policies should reject local routes not exported by their VRFs
-    eb.setVrf(vrf1);
+    Environment.Builder eb = Environment.builder(c, vrf1).setDirection(Direction.OUT);
     assertThat(
         vrf1RejectAllLocal
             .call(
@@ -3382,7 +3374,7 @@ public final class FlatJuniperGrammarTest {
             .getBooleanValue(),
         equalTo(false));
 
-    eb.setVrf(vrf2);
+    eb = Environment.builder(c, vrf2).setDirection(Direction.OUT);
     assertThat(
         vrf2RejectPtpLocal
             .call(
@@ -3400,7 +3392,7 @@ public final class FlatJuniperGrammarTest {
             .getBooleanValue(),
         equalTo(true));
 
-    eb.setVrf(vrf3);
+    eb = Environment.builder(c, vrf3).setDirection(Direction.OUT);
     assertThat(
         vrf3RejectLanLocal
             .call(
@@ -3418,7 +3410,7 @@ public final class FlatJuniperGrammarTest {
             .getBooleanValue(),
         equalTo(false));
 
-    eb.setVrf(vrf4);
+    eb = Environment.builder(c, vrf4).setDirection(Direction.OUT);
     assertThat(
         vrf4AllowAllLocal
             .call(
@@ -3980,7 +3972,6 @@ public final class FlatJuniperGrammarTest {
   @Test
   public void testRoutingPolicy() throws IOException {
     Configuration c = parseConfig("routing-policy");
-    Environment.Builder eb = Environment.builder(c).setDirection(Direction.IN);
 
     RoutingPolicy policyExact = c.getRoutingPolicies().get("route-filter-exact");
     RoutingPolicy policyLonger = c.getRoutingPolicies().get("route-filter-longer");
@@ -4006,7 +3997,7 @@ public final class FlatJuniperGrammarTest {
     ConnectedRoute connectedRouteMaskInvalidLength =
         new ConnectedRoute(Prefix.parse("1.9.3.9/17"), "nhinttest");
 
-    eb.setVrf("vrf1");
+    Environment.Builder eb = Environment.builder(c, "vrf1").setDirection(Direction.IN);
 
     assertThat(
         policyExact.call(eb.setOriginalRoute(connectedRouteExact).build()).getBooleanValue(),
@@ -4202,8 +4193,7 @@ public final class FlatJuniperGrammarTest {
               .getRoutingPolicies()
               .get("POLICY-NAME")
               .call(
-                  Environment.builder(config)
-                      .setVrf(DEFAULT_VRF_NAME)
+                  Environment.builder(config, DEFAULT_VRF_NAME)
                       .setOriginalRoute(new ConnectedRoute(p, "iface"))
                       .build());
       assertThat(result.getBooleanValue(), equalTo(true));
@@ -4215,8 +4205,7 @@ public final class FlatJuniperGrammarTest {
             .getRoutingPolicies()
             .get("POLICY-NAME")
             .call(
-                Environment.builder(config)
-                    .setVrf(DEFAULT_VRF_NAME)
+                Environment.builder(config, DEFAULT_VRF_NAME)
                     .setOriginalRoute(new ConnectedRoute(Prefix.parse("3.3.3.3/24"), "iface"))
                     .build());
     assertThat(result.getBooleanValue(), equalTo(false));
@@ -4227,8 +4216,7 @@ public final class FlatJuniperGrammarTest {
             .getRoutingPolicies()
             .get("POLICY-NAME")
             .call(
-                Environment.builder(config)
-                    .setVrf(DEFAULT_VRF_NAME)
+                Environment.builder(config, DEFAULT_VRF_NAME)
                     .setOriginalRoute(
                         StaticRoute.builder()
                             .setNextHopInterface("iface")

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsBgpPoliciesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsBgpPoliciesTest.java
@@ -99,6 +99,7 @@ public class CiscoConversionsBgpPoliciesTest {
                 ImmutableList.of(Statements.ReturnFalse.toStaticStatement())))
         .addStatement(Statements.ReturnFalse.toStaticStatement())
         .build();
+    nf.vrfBuilder().setOwner(_c).setName(Configuration.DEFAULT_VRF_NAME).build();
   }
 
   /**


### PR DESCRIPTION
Remove Configuration and Vrf from the environment. Instead, store the parts of those that we actually need. Now the Environment builder factory method initializes the builder by setting the properties that come from config and vrf.