### PR TITLE
Deprecate select JsonCreators

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraints.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraints.java
@@ -92,9 +92,9 @@ public class PacketHeaderConstraints {
   private static final IntegerSpace VALID_FRAGMENT_OFFSET =
       IntegerSpace.builder().including(Range.closed(0, 8191)).build(); // 13 bits
 
+  @Deprecated
   @JsonCreator
-  @VisibleForTesting
-  static PacketHeaderConstraints create(
+  private static PacketHeaderConstraints create(
       @Nullable @JsonProperty(PROP_DSCPS) IntegerSpace.Builder dscps,
       @Nullable @JsonProperty(PROP_ECNS) IntegerSpace.Builder ecns,
       @Nullable @JsonProperty(PROP_PACKET_LENGTHS) IntegerSpace.Builder packetLengths,


### PR DESCRIPTION
In practice, all JsonCreators should not be publicly accessible, but this is not
always the case. Take the ones where we've abused JsonNode for backwards compat
and ensure they are at least private and deprecated so that we get errors if
anyone tries to call them directly.