### PR TITLE
Cisco BGP default-originate export policies

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -311,8 +311,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
     return String.format("~BGP_COMMON_EXPORT_POLICY:%s~", vrf);
   }
 
-  public static String computeBgpDefaultRouteExportPolicyName(String vrf, String peer) {
-    return String.format("~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:%s:%s~", vrf, peer);
+  public static String computeBgpDefaultRouteExportPolicyName(boolean ipv4) {
+    return String.format("~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv%s~", ipv4 ? "4" : "6");
   }
 
   public static String computeBgpPeerImportPolicyName(String vrf, String peer) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -359,6 +359,12 @@ class CiscoConversions {
         .build();
   }
 
+  /**
+   * Initializes export policy for IPv4 or IPv6 default routes if it doesn't already exist. This
+   * policy is the same across BGP processes, so only one is created for each configuration.
+   *
+   * @param ipv4 Whether to initialize the IPv4 or IPv6 default route export policy
+   */
   static void initBgpDefaultRouteExportPolicy(boolean ipv4, Configuration c) {
     String defaultRouteExportPolicyName = computeBgpDefaultRouteExportPolicyName(ipv4);
     if (!c.getRoutingPolicies().containsKey(defaultRouteExportPolicyName)) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -321,9 +321,9 @@ class CiscoConversions {
     // If defaultOriginate is set, generate a default route export policy.
     // When exporting default route, can match this policy instead of the common export policy.
     if (lpg.getDefaultOriginate()) {
-      generateBgpDefaultRouteExportPolicy(lpg, vrfName, ipv4, c);
+      initBgpDefaultRouteExportPolicy(ipv4, c);
       localOrCommonOriginationDisjuncts.add(
-          new CallExpr(computeBgpDefaultRouteExportPolicyName(vrfName, lpg.getName())));
+          new CallExpr(computeBgpDefaultRouteExportPolicyName(ipv4)));
     }
 
     List<BooleanExpr> peerExportConjuncts = new ArrayList<>();
@@ -359,24 +359,26 @@ class CiscoConversions {
         .build();
   }
 
-  static void generateBgpDefaultRouteExportPolicy(
-      LeafBgpPeerGroup lpg, String vrfName, boolean ipv4, Configuration c) {
-    RoutingPolicy.builder()
-        .setOwner(c)
-        .setName(computeBgpDefaultRouteExportPolicyName(vrfName, lpg.getName()))
-        .addStatement(
-            new If(
-                ipv4 ? MATCH_DEFAULT_ROUTE : MATCH_DEFAULT_ROUTE6,
-                ImmutableList.of(
-                    new SetOrigin(
-                        new LiteralOrigin(
-                            c.getConfigurationFormat() == ConfigurationFormat.CISCO_IOS
-                                ? OriginType.IGP
-                                : OriginType.INCOMPLETE,
-                            null)),
-                    Statements.ReturnTrue.toStaticStatement())))
-        .addStatement(Statements.ReturnFalse.toStaticStatement())
-        .build();
+  static void initBgpDefaultRouteExportPolicy(boolean ipv4, Configuration c) {
+    String defaultRouteExportPolicyName = computeBgpDefaultRouteExportPolicyName(ipv4);
+    if (!c.getRoutingPolicies().containsKey(defaultRouteExportPolicyName)) {
+      RoutingPolicy.builder()
+          .setOwner(c)
+          .setName(defaultRouteExportPolicyName)
+          .addStatement(
+              new If(
+                  ipv4 ? MATCH_DEFAULT_ROUTE : MATCH_DEFAULT_ROUTE6,
+                  ImmutableList.of(
+                      new SetOrigin(
+                          new LiteralOrigin(
+                              c.getConfigurationFormat() == ConfigurationFormat.CISCO_IOS
+                                  ? OriginType.IGP
+                                  : OriginType.INCOMPLETE,
+                              null)),
+                      Statements.ReturnTrue.toStaticStatement())))
+          .addStatement(Statements.ReturnFalse.toStaticStatement())
+          .build();
+    }
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoNxConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoNxConversions.java
@@ -376,6 +376,10 @@ final class CiscoNxConversions {
     return newNeighborBuilder.build();
   }
 
+  /**
+   * Initializes export policy for default routes if it doesn't already exist. This policy is the
+   * same across BGP processes, so only one is created for each configuration.
+   */
   static void initBgpDefaultRouteExportPolicy(Configuration c) {
     String defaultRouteExportPolicyName = computeBgpDefaultRouteExportPolicyName(true);
     if (!c.getRoutingPolicies().containsKey(defaultRouteExportPolicyName)) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoNxConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoNxConversions.java
@@ -344,23 +344,8 @@ final class CiscoNxConversions {
     // If `default-originate [route-map NAME]` is configured for this neighbor, generate the
     // default route and inject it.
     if (naf4 != null && firstNonNull(naf4.getDefaultOriginate(), Boolean.FALSE)) {
-
-      String defaultRouteExportPolicyName;
-      defaultRouteExportPolicyName =
-          computeBgpDefaultRouteExportPolicyName(
-              vrf.getName(), dynamic ? prefix.toString() : prefix.getStartIp().toString());
-      RoutingPolicy defaultRouteExportPolicy = new RoutingPolicy(defaultRouteExportPolicyName, c);
-      c.getRoutingPolicies().put(defaultRouteExportPolicyName, defaultRouteExportPolicy);
-      defaultRouteExportPolicy
-          .getStatements()
-          .add(
-              new If(
-                  MATCH_DEFAULT_ROUTE,
-                  ImmutableList.of(
-                      new SetOrigin(new LiteralOrigin(OriginType.IGP, null)),
-                      Statements.ReturnTrue.toStaticStatement())));
-      defaultRouteExportPolicy.getStatements().add(Statements.ReturnFalse.toStaticStatement());
-      localOrCommonOrigination.add(new CallExpr(defaultRouteExportPolicy.getName()));
+      initBgpDefaultRouteExportPolicy(c);
+      localOrCommonOrigination.add(new CallExpr(computeBgpDefaultRouteExportPolicyName(true)));
 
       GeneratedRoute defaultRoute =
           GeneratedRoute.builder()
@@ -389,6 +374,23 @@ final class CiscoNxConversions {
     newNeighborBuilder.setExportPolicy(exportPolicy.getName());
 
     return newNeighborBuilder.build();
+  }
+
+  static void initBgpDefaultRouteExportPolicy(Configuration c) {
+    String defaultRouteExportPolicyName = computeBgpDefaultRouteExportPolicyName(true);
+    if (!c.getRoutingPolicies().containsKey(defaultRouteExportPolicyName)) {
+      RoutingPolicy.builder()
+          .setOwner(c)
+          .setName(defaultRouteExportPolicyName)
+          .addStatement(
+              new If(
+                  MATCH_DEFAULT_ROUTE,
+                  ImmutableList.of(
+                      new SetOrigin(new LiteralOrigin(OriginType.IGP, null)),
+                      Statements.ReturnTrue.toStaticStatement())))
+          .addStatement(Statements.ReturnFalse.toStaticStatement())
+          .build();
+    }
   }
 
   private static String getTextDesc(Ip ip, Vrf v) {

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -1298,46 +1298,8 @@
               }
             ]
           },
-          "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.13.237~" : {
-            "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.13.237~",
-            "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                  "comment" : "match default route",
-                  "prefix" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                  },
-                  "prefixSet" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                    "prefixSpace" : [
-                      "0.0.0.0/0"
-                    ]
-                  }
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
-                    "originType" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
-                      "originType" : "igp"
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnTrue"
-                  }
-                ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "ReturnFalse"
-              }
-            ]
-          },
-          "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.15.193~" : {
-            "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.15.193~",
+          "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~" : {
+            "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -1502,7 +1464,7 @@
                     },
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.13.237~"
+                      "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~"
                     }
                   ]
                 },
@@ -1536,7 +1498,7 @@
                     },
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:default:169.254.15.193~"
+                      "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~"
                     }
                   ]
                 },

--- a/tests/parsing-tests/networks/unit-tests/configs/cisco_bgp
+++ b/tests/parsing-tests/networks/unit-tests/configs/cisco_bgp
@@ -45,6 +45,7 @@ router bgp 1
    network 192.168.1.3/11
    aggregate-address 192.168.0.0/16 summary-only attribute-map AGGREGATE-MAP
    redistribute connected route-map CONNECTED-TO-BGP
+   default-originate
 !
 route-map ospfv3_map permit 10
 !

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -6610,6 +6610,44 @@
               }
             ]
           },
+          "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~" : {
+            "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                    "originType" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                      "originType" : "igp"
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
           "~BGP_PEER_EXPORT_POLICY:aVrfWithInnerStatements:10.0.1.2~" : {
             "name" : "~BGP_PEER_EXPORT_POLICY:aVrfWithInnerStatements:10.0.1.2~",
             "statements" : [
@@ -6623,8 +6661,17 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:aVrfWithInnerStatements~"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:aVrfWithInnerStatements~"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                      "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~"
+                    }
+                  ]
                 },
                 "trueStatements" : [
                   {
@@ -6685,6 +6732,17 @@
                   "exportPolicySources" : [
                     "AGGREGATE-MAP",
                     "CONNECTED-TO-BGP"
+                  ],
+                  "generatedRoutes" : [
+                    {
+                      "class" : "org.batfish.datamodel.GeneratedRoute",
+                      "administrativeCost" : 32767,
+                      "asPath" : [ ],
+                      "discard" : false,
+                      "metric" : 0,
+                      "network" : "0.0.0.0/0",
+                      "nextHopIp" : "AUTO/NONE(-1l)"
+                    }
                   ],
                   "localAs" : 1,
                   "peerAddress" : "10.0.1.2",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -15316,6 +15316,10 @@
             "              ROUTE_MAP:'route-map'",
             "              map = (variable",
             "                VARIABLE:'CONNECTED-TO-BGP'  <== mode:M_RouteMap)",
+            "              NEWLINE:'\\n'))",
+            "          (bgp_tail",
+            "            (default_originate_bgp_tail",
+            "              DEFAULT_ORIGINATE:'default-originate'",
             "              NEWLINE:'\\n'))))))",
             "  (stanza",
             "    (route_map_stanza",
@@ -72689,25 +72693,25 @@
           "route-map" : {
             "AGGREGATE-MAP" : {
               "definitionLines" : [
-                53
+                54
               ],
               "numReferrers" : 1
             },
             "CONNECTED-TO-BGP" : {
               "definitionLines" : [
-                51
+                52
               ],
               "numReferrers" : 1
             },
             "UNSUPP-MAP" : {
               "definitionLines" : [
-                55
+                56
               ],
               "numReferrers" : 1
             },
             "ospfv3_map" : {
               "definitionLines" : [
-                49
+                50
               ],
               "numReferrers" : 1
             }


### PR DESCRIPTION
Currently every BGP peer with default-originate configured gets its own generated default-originate export policy. However, these policies only vary based on address family and configuration format. Now each configuration will have at most two default-originate export policies (one for IPv4 peers and one for IPv6).