### PR TITLE
OspfProcess: enforce presence of processId

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
@@ -69,7 +69,7 @@ public final class OspfProcess implements Serializable {
               _maxMetricSummaryNetworks,
               _maxMetricTransitLinks,
               _neighbors,
-              _processId,
+              _processId != null ? _processId : generateName(),
               _referenceBandwidth,
               _rfc1583Compatible,
               _routerId);
@@ -109,7 +109,7 @@ public final class OspfProcess implements Serializable {
       return this;
     }
 
-    public Builder setProcessId(@Nullable String processId) {
+    public Builder setProcessId(@Nonnull String processId) {
       _processId = processId;
       return this;
     }
@@ -183,32 +183,20 @@ public final class OspfProcess implements Serializable {
   }
 
   @Nonnull private SortedMap<Long, OspfArea> _areas;
-
   @Nullable private String _exportPolicy;
-
   @Nonnull private SortedSet<String> _exportPolicySources;
-
   @Nonnull private SortedSet<GeneratedRoute> _generatedRoutes;
-
   @Nullable private Long _maxMetricExternalNetworks;
-
   @Nullable private Long _maxMetricStubNetworks;
-
   @Nullable private Long _maxMetricSummaryNetworks;
-
   @Nullable private Long _maxMetricTransitLinks;
-
   private transient Map<IpLink, OspfNeighbor> _ospfNeighbors;
-
   /** Mapping from interface name to an OSPF config */
   @Nonnull private SortedMap<String, OspfNeighborConfig> _ospfNeighborConfigs;
 
-  @Nullable private String _processId;
-
+  @Nonnull private String _processId;
   @Nonnull private Double _referenceBandwidth;
-
   @Nullable private Boolean _rfc1583Compatible;
-
   @Nullable private Ip _routerId;
 
   @JsonCreator
@@ -226,6 +214,7 @@ public final class OspfProcess implements Serializable {
       @Nullable @JsonProperty(PROP_REFERENCE_BANDWIDTH) Double referenceBandwidth,
       @Nullable @JsonProperty(PROP_RFC1583) Boolean rfc1583Compatible,
       @Nullable @JsonProperty(PROP_ROUTER_ID) Ip routerId) {
+    checkArgument(processId != null, "Missing %s", PROP_PROCESS_ID);
     checkArgument(referenceBandwidth != null, "Missing %s", PROP_REFERENCE_BANDWIDTH);
     _areas = firstNonNull(areas, ImmutableSortedMap.of());
     _exportPolicy = exportPolicy;
@@ -342,7 +331,7 @@ public final class OspfProcess implements Serializable {
     return _ospfNeighborConfigs;
   }
 
-  @Nullable
+  @Nonnull
   @JsonProperty(PROP_PROCESS_ID)
   public String getProcessId() {
     return _processId;
@@ -447,14 +436,8 @@ public final class OspfProcess implements Serializable {
     _ospfNeighbors = ospfNeighbors;
   }
 
-  @JsonProperty(PROP_NEIGHBORS)
   void setOspfNeighborConfigs(Map<String, OspfNeighborConfig> ospfNeighborConfigs) {
     _ospfNeighborConfigs = ImmutableSortedMap.copyOf(ospfNeighborConfigs);
-  }
-
-  @JsonProperty(PROP_PROCESS_ID)
-  public void setProcessId(@Nullable String id) {
-    _processId = id;
   }
 
   public void setReferenceBandwidth(Double referenceBandwidth) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
@@ -194,7 +194,7 @@ public final class OspfProcess implements Serializable {
   /** Mapping from interface name to an OSPF config */
   @Nonnull private SortedMap<String, OspfNeighborConfig> _ospfNeighborConfigs;
 
-  @Nonnull private String _processId;
+  @Nonnull private final String _processId;
   @Nonnull private Double _referenceBandwidth;
   @Nullable private Boolean _rfc1583Compatible;
   @Nullable private Ip _routerId;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2477,6 +2477,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
       OspfProcess proc, String vrfName, Configuration c, CiscoConfiguration oldConfig) {
     org.batfish.datamodel.ospf.OspfProcess newProcess =
         org.batfish.datamodel.ospf.OspfProcess.builder()
+            .setProcessId(proc.getName())
             .setReferenceBandwidth(proc.getReferenceBandwidth())
             .build();
     org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
@@ -2489,8 +2490,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
       newProcess.setMaxMetricExternalNetworks(proc.getMaxMetricExternalLsa());
       newProcess.setMaxMetricSummaryNetworks(proc.getMaxMetricSummaryLsa());
     }
-
-    newProcess.setProcessId(proc.getName());
 
     // establish areas and associated interfaces
     Map<Long, OspfArea.Builder> areas = new HashMap<>();

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -770,6 +770,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
   private OspfProcess createOspfProcess(RoutingInstance routingInstance) {
     OspfProcess newProc =
         OspfProcess.builder()
+            // Use routing instance name since OSPF processes are not named
+            .setProcessId(routingInstance.getName())
             .setReferenceBandwidth(routingInstance.getOspfReferenceBandwidth())
             .build();
     String vrfName = routingInstance.getName();

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -273,10 +273,10 @@ public class EdgesAnswererTest {
 
   @Test
   public void testGetOspfEdges() {
-    OspfProcess ospf1 = OspfProcess.builder().setReferenceBandwidth(1e8).build();
-    OspfProcess ospf2 = OspfProcess.builder().setReferenceBandwidth(1e8).build();
-
     NetworkFactory nf = new NetworkFactory();
+    OspfProcess ospf1 = OspfProcess.builder(nf).setReferenceBandwidth(1e8).build();
+    OspfProcess ospf2 = OspfProcess.builder(nf).setReferenceBandwidth(1e8).build();
+
     OspfArea.builder(nf).setNumber(1L).setOspfProcess(ospf1).addInterface("int1").build();
     OspfArea.builder(nf).setNumber(1L).setOspfProcess(ospf2).addInterface("int2").build();
 

--- a/projects/question/src/test/java/org/batfish/question/ospfproperties/OspfPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfproperties/OspfPropertiesAnswererTest.java
@@ -22,10 +22,10 @@ public class OspfPropertiesAnswererTest {
 
   @Test
   public void getProperties() {
-    OspfProcess ospf1 = OspfProcess.builder().setReferenceBandwidth(1e8).build();
+    OspfProcess ospf1 =
+        OspfProcess.builder().setProcessId("uber-proc").setReferenceBandwidth(1e8).build();
     ospf1.setExportPolicy("my-policy");
     ospf1.setReferenceBandwidth(42.0);
-    ospf1.setProcessId("uber-proc");
 
     Vrf vrf1 = new Vrf("vrf1");
     vrf1.setOspfProcess(ospf1);

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -15841,6 +15841,7 @@
                   "vrf" : "default"
                 }
               },
+              "processId" : "default",
               "referenceBandwidth" : 1.0E9,
               "routerId" : "10.1.2.3"
             }
@@ -17752,6 +17753,7 @@
                 }
               },
               "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "default",
               "referenceBandwidth" : 1.0E9
             }
           }
@@ -20783,6 +20785,7 @@
                 }
               },
               "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
+              "processId" : "default",
               "referenceBandwidth" : 1.0E9
             }
           }


### PR DESCRIPTION
processId should always be set, as a precursor to supporting multi-ospf-process setups.