### PR TITLE
canonical case for string literal suggestions

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
@@ -137,11 +137,7 @@ public final class ParboiledAutoComplete {
         */
         return ImmutableList.of(
             new AutocompleteSuggestion(
-                pm.getMatchPrefix() + pm.getMatchCompletion(),
-                true,
-                null,
-                RANK_STRING_LITERAL,
-                pm.getMatchStartIndex()));
+                pm.getMatch(), true, null, RANK_STRING_LITERAL, pm.getMatchStartIndex()));
       case EOI:
         return ImmutableList.of();
       case FILTER_NAME:
@@ -192,11 +188,7 @@ public final class ParboiledAutoComplete {
         */
         return ImmutableList.of(
             new AutocompleteSuggestion(
-                pm.getMatchPrefix() + pm.getMatchCompletion(),
-                true,
-                null,
-                RANK_STRING_LITERAL,
-                pm.getMatchStartIndex()));
+                pm.getMatch(), true, null, RANK_STRING_LITERAL, pm.getMatchStartIndex()));
       case VRF_NAME:
         return autoCompletePotentialMatch(pm, DEFAULT_RANK);
       case WHITESPACE:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParserUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParserUtils.java
@@ -123,7 +123,7 @@ final class ParserUtils {
   @VisibleForTesting
   static String getErrorString(PotentialMatch pm) {
     if (pm.getAnchorType().equals(Anchor.Type.STRING_LITERAL)) {
-      return String.format("'%s'", pm.getMatchCompletion());
+      return String.format("'%s'", pm.getMatch());
     }
     return String.format("%s", pm.getAnchorType());
   }
@@ -194,7 +194,7 @@ final class ParserUtils {
             new PotentialMatch(
                 pathAnchor.getAnchorType(),
                 matchPrefix,
-                fullToken.substring(matchPrefix.length()),
+                fullToken,
                 path.getElementAtLevel(pathAnchor.getLevel()).startIndex));
       } else {
         potentialMatches.add(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PotentialMatch.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PotentialMatch.java
@@ -9,20 +9,19 @@ class PotentialMatch {
   /** The type of completion this match indicates */
   private final Anchor.Type _anchorType;
 
-  /** The current rule would have matched if the input was followed by this */
-  private final String _matchCompletion;
+  /** The current rule would have matched if the input was this */
+  private final String _match;
 
-  /** What matched thus far when trying to match the current rule */
+  /** What the user entered */
   private final String _matchPrefix;
 
   /** Where in the input this match started */
   private final int _matchStartIndex;
 
-  PotentialMatch(
-      Anchor.Type anchorType, String matchPrefix, String matchCompletion, int matchStartIndex) {
+  PotentialMatch(Anchor.Type anchorType, String matchPrefix, String match, int matchStartIndex) {
     _anchorType = anchorType;
     _matchPrefix = matchPrefix;
-    _matchCompletion = matchCompletion;
+    _match = match;
     _matchStartIndex = matchStartIndex;
   }
 
@@ -32,7 +31,7 @@ class PotentialMatch {
       return false;
     }
     return Objects.equals(_anchorType, ((PotentialMatch) o)._anchorType)
-        && Objects.equals(_matchCompletion, ((PotentialMatch) o)._matchCompletion)
+        && Objects.equals(_match, ((PotentialMatch) o)._match)
         && Objects.equals(_matchPrefix, ((PotentialMatch) o)._matchPrefix)
         && Objects.equals(_matchStartIndex, ((PotentialMatch) o)._matchStartIndex);
   }
@@ -41,8 +40,8 @@ class PotentialMatch {
     return _anchorType;
   }
 
-  String getMatchCompletion() {
-    return _matchCompletion;
+  String getMatch() {
+    return _match;
   }
 
   String getMatchPrefix() {
@@ -55,7 +54,7 @@ class PotentialMatch {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_anchorType, _matchCompletion, _matchPrefix, _matchStartIndex);
+    return Objects.hash(_anchorType, _match, _matchPrefix, _matchStartIndex);
   }
 
   @Override
@@ -63,7 +62,7 @@ class PotentialMatch {
     return MoreObjects.toStringHelper(this.getClass())
         .add("anchorType", _anchorType)
         .add("matchingPrefix", _matchPrefix)
-        .add("matchingCompletion", _matchCompletion)
+        .add("matchingCompletion", _match)
         .add("matchStartIndex", _matchStartIndex)
         .toString();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
@@ -24,7 +24,7 @@ public class ParboiledAutoCompleteTest {
   private static ParboiledAutoComplete getTestPAC(String query) {
     return new ParboiledAutoComplete(
         TestParser.INSTANCE,
-        TestParser.INSTANCE.input(TestParser.INSTANCE.TestExpression()),
+        TestParser.INSTANCE.input(TestParser.INSTANCE.TestSpec()),
         TestParser.ANCHORS,
         "network",
         "snapshot",
@@ -39,7 +39,7 @@ public class ParboiledAutoCompleteTest {
       String query, CompletionMetadata completionMetadata) {
     return new ParboiledAutoComplete(
         TestParser.INSTANCE,
-        TestParser.INSTANCE.input(TestParser.INSTANCE.TestExpression()),
+        TestParser.INSTANCE.input(TestParser.INSTANCE.TestSpec()),
         TestParser.ANCHORS,
         "network",
         "snapshot",
@@ -53,7 +53,7 @@ public class ParboiledAutoCompleteTest {
   private static ParboiledAutoComplete getTestPAC(String query, ReferenceLibrary referenceLibrary) {
     return new ParboiledAutoComplete(
         TestParser.INSTANCE,
-        TestParser.INSTANCE.input(TestParser.INSTANCE.TestExpression()),
+        TestParser.INSTANCE.input(TestParser.INSTANCE.TestSpec()),
         TestParser.ANCHORS,
         "network",
         "snapshot",
@@ -255,7 +255,7 @@ public class ParboiledAutoCompleteTest {
 
     // first ensure that the query is valid input
     ParsingResult<?> result =
-        new ReportingParseRunner<>(TestParser.INSTANCE.input(TestParser.INSTANCE.TestExpression()))
+        new ReportingParseRunner<>(TestParser.INSTANCE.input(TestParser.INSTANCE.TestSpec()))
             .run(query);
     assertTrue(result.parseErrors.isEmpty());
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
@@ -268,7 +268,16 @@ public class ParboiledAutoCompleteTest {
 
   @Test
   public void testAutoCompletePotentialMatchStringLiteral() {
-    PotentialMatch pm = new PotentialMatch(Type.STRING_LITERAL, "pfx", "comp", 0);
+    PotentialMatch pm = new PotentialMatch(Type.STRING_LITERAL, "pfx", "pfxcomp", 0);
+    assertThat(
+        getTestPAC(null).autoCompletePotentialMatch(pm),
+        equalTo(ImmutableList.of(new AutocompleteSuggestion("pfxcomp", true, null, -1, 0))));
+  }
+
+  /** The suggestion should have the case in the grammar token independent of user input */
+  @Test
+  public void testAutoCompletePotentialMatchStringLiteralCasePreserve() {
+    PotentialMatch pm = new PotentialMatch(Type.STRING_LITERAL, "PfX", "pfxcomp", 0);
     assertThat(
         getTestPAC(null).autoCompletePotentialMatch(pm),
         equalTo(ImmutableList.of(new AutocompleteSuggestion("pfxcomp", true, null, -1, 0))));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
@@ -31,8 +31,7 @@ public class ParserUtilsTest {
   @org.junit.Rule public ExpectedException _thrown = ExpectedException.none();
 
   private static AbstractParseRunner<AstNode> getRunner() {
-    return new ReportingParseRunner<>(
-        TestParser.INSTANCE.input(TestParser.INSTANCE.TestExpression()));
+    return new ReportingParseRunner<>(TestParser.INSTANCE.input(TestParser.INSTANCE.TestSpec()));
   }
 
   /** These represent all the ways valid input can start */
@@ -209,6 +208,7 @@ public class ParserUtilsTest {
         equalTo(
             ImmutableSet.of(
                 new PotentialMatch(CHAR_LITERAL, "", ")", 8),
+                new PotentialMatch(CHAR_LITERAL, "", ",", 8),
                 new PotentialMatch(IP_ADDRESS, "1.1.1.1", null, 1),
                 new PotentialMatch(CHAR_LITERAL, "", "-", 8))));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
@@ -249,7 +249,7 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(STRING_LITERAL, "@specifi", "er", 0))));
+        equalTo(ImmutableSet.of(new PotentialMatch(STRING_LITERAL, "@specifi", "@specifier", 0))));
   }
 
   @Test
@@ -258,6 +258,15 @@ public class ParserUtilsTest {
     assertThat(
         getPotentialMatches(
             (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(STRING_LITERAL, "@", "specifier", 0))));
+        equalTo(ImmutableSet.of(new PotentialMatch(STRING_LITERAL, "@", "@specifier", 0))));
+  }
+
+  @Test
+  public void testGetPartialMatchesStringLiteralCasePreserve() {
+    ParsingResult<?> result = getRunner().run("@SPeciFi");
+    assertThat(
+        getPotentialMatches(
+            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
+        equalTo(ImmutableSet.of(new PotentialMatch(STRING_LITERAL, "@SPeciFi", "@specifier", 0))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/TestParser.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/TestParser.java
@@ -37,7 +37,7 @@ class TestParser extends CommonParser {
    */
 
   /* An Test expression is a comma-separated list of TestTerms */
-  public Rule TestExpression() {
+  public Rule TestSpec() {
     return Sequence(TestTerm(), WhiteSpace(), ZeroOrMore(", ", TestTerm(), WhiteSpace()));
   }
 
@@ -45,7 +45,7 @@ class TestParser extends CommonParser {
   public Rule TestTerm() {
     return FirstOf(
         TestParens(),
-        TestSpecifier(),
+        TestFunc(),
         TestNotOp(),
         TestIpRange(),
         TestIpAddress(),
@@ -55,10 +55,10 @@ class TestParser extends CommonParser {
   }
 
   public Rule TestParens() {
-    return Sequence("( ", TestTerm(), ") ");
+    return Sequence("( ", TestSpec(), ") ");
   }
 
-  public Rule TestSpecifier() {
+  public Rule TestFunc() {
     return Sequence("@specifier ", "( ", TestSpecifierInput(), ") ");
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/TestParser.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/TestParser.java
@@ -23,16 +23,16 @@ class TestParser extends CommonParser {
    * Test grammar
    *
    * <pre>
-   * testExpr := testTerm [, testTerm]*
+   * testSpec := testTerm [, testTerm]*
    *
-   * testTerm := @specifier(specifierInput)
-   *               | (testTerm)
+   * testTerm := @specifier(address-group, reference-book)
+   *               | (testSpec)
    *               | ! testTerm
-   *               | testBase
-   *
-   * specifierInput := REFERENCE_OBJECT_NAME_LITERAL
-   *
-   * testBase := IP_ADDRESS
+   *               | ip range
+   *               | ip address
+   *               | node name
+   *               | node name regex
+   *               | node name regex deprecated
    * </pre>
    */
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/TestParser.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/TestParser.java
@@ -59,7 +59,7 @@ class TestParser extends CommonParser {
   }
 
   public Rule TestFunc() {
-    return Sequence("@specifier ", "( ", TestSpecifierInput(), ") ");
+    return Sequence(IgnoreCase("@specifier"), WhiteSpace(), "( ", TestSpecifierInput(), ") ");
   }
 
   public Rule TestNotOp() {


### PR DESCRIPTION
The string literals suggested will be in canonical case independent of what the user entered. 

Before: autocomplete suggestion for 'tc' was 'tcP'
Now: autocomplete suggestion for 'tc' is 'TCP'

Includes #3444 

cc: @arifogel 