### PR TITLE
Fix OSPF redistribution in SMT formulation

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/EncoderSlice.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/EncoderSlice.java
@@ -714,7 +714,7 @@ class EncoderSlice {
           }
         }
 
-        if (proto.isOspf() && r.size() > 1 && exportGraphEdgeMap.size() > 0) {
+        if (proto.isOspf() && r.size() > 1 && !exportGraphEdgeMap.isEmpty()) {
           // Add the ospf redistributed record if needed
           String rname =
               String.format(

--- a/projects/batfish/src/main/java/org/batfish/symbolic/smt/EncoderSlice.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/smt/EncoderSlice.java
@@ -599,18 +599,6 @@ class EncoderSlice {
         // Add redistribution variables
         Set<Protocol> r = _logicalGraph.getRedistributedProtocols().get(router, proto);
         assert r != null;
-        if (proto.isOspf() && r.size() > 1) {
-          // Add the ospf redistributed record if needed
-          String rname =
-              String.format(
-                  "%d_%s%s_%s_%s",
-                  _encoder.getId(), _sliceName, router, proto.name(), "Redistributed");
-
-          SymbolicRoute rec =
-              new SymbolicRoute(this, rname, router, proto, _optimizations, null, false);
-          _ospfRedistributed.put(router, rec);
-          getAllSymbolicRecords().add(rec);
-        }
 
         Boolean useSingleExport =
             _optimizations.getSliceCanKeepSingleExportVar().get(router, proto);
@@ -724,6 +712,19 @@ class EncoderSlice {
             allEdges.addAll(exportEdgeList);
             es.add(allEdges);
           }
+        }
+
+        if (proto.isOspf() && r.size() > 1 && exportGraphEdgeMap.size() > 0) {
+          // Add the ospf redistributed record if needed
+          String rname =
+              String.format(
+                  "%d_%s%s_%s_%s",
+                  _encoder.getId(), _sliceName, router, proto.name(), "Redistributed");
+
+          SymbolicRoute rec =
+              new SymbolicRoute(this, rname, router, proto, _optimizations, null, false);
+          _ospfRedistributed.put(router, rec);
+          getAllSymbolicRecords().add(rec);
         }
       }
     }


### PR DESCRIPTION
OSPF redistribution variables should only be included in the SMT formulation if OSPF EXPORT variables exist for at least one interface. If OSPF does not export on any interfaces, then the redistribution variables for that interface will not appear in any predicate. Consequently, the solver will produce counterexamples with arbitrary values for the redistribution variables.