### PR TITLE
Clean up forwarding analysis

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -1044,7 +1044,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis {
                   Map<String, IpSpace> vrfIpSpaces2 = nodeIpSpace2.get(vrfEntry.getKey());
                   checkArgument(
                       vrfIpSpaces2.keySet().equals(vrfEntry.getValue().keySet()),
-                      "Can't merge with different interfaces in node %s VRF %s: %s and %s",
+                      "Can't union with different interfaces in node %s VRF %s: %s and %s",
                       nodeEntry.getKey(),
                       vrfEntry.getKey(),
                       vrfEntry.getValue().keySet(),

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -205,6 +205,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis {
       }
 
       // mapping: hostname -> interface -> ips belonging to a subnet of interface
+      // active interfaces only.
       Map<String, Map<String, IpSpace>> interfaceHostSubnetIps =
           computeInterfaceHostSubnetIps(configurations, /*excludeInactive=*/ true);
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -1208,40 +1208,36 @@ public class ForwardingAnalysisImplTest {
         computeInterfaceHostSubnetIps(configs, true),
         hasEntry(
             equalTo(c1.getHostname()),
-            hasEntry(
-                equalTo(vrf1.getName()),
-                allOf(
-                    hasEntry(
-                        equalTo(i1.getName()),
-                        allOf(
-                            not(containsIp(P1.getStartIp())),
-                            containsIp(Ip.create(P1.getStartIp().asLong() + 1)),
-                            containsIp(Ip.create(P1.getEndIp().asLong() - 1)),
-                            not(containsIp(P1.getEndIp())))),
-                    not(hasKey(i2.getName()))))));
+            allOf(
+                hasEntry(
+                    equalTo(i1.getName()),
+                    allOf(
+                        not(containsIp(P1.getStartIp())),
+                        containsIp(Ip.create(P1.getStartIp().asLong() + 1)),
+                        containsIp(Ip.create(P1.getEndIp().asLong() - 1)),
+                        not(containsIp(P1.getEndIp())))),
+                not(hasKey(i2.getName())))));
 
     // Test including inactive IPs.
     assertThat(
         computeInterfaceHostSubnetIps(configs, false),
         hasEntry(
             equalTo(c1.getHostname()),
-            hasEntry(
-                equalTo(vrf1.getName()),
-                allOf(
-                    hasEntry(
-                        equalTo(i1.getName()),
-                        allOf(
-                            not(containsIp(P1.getStartIp())),
-                            containsIp(Ip.create(P1.getStartIp().asLong() + 1)),
-                            containsIp(Ip.create(P1.getEndIp().asLong() - 1)),
-                            not(containsIp(P1.getEndIp())))),
-                    hasEntry(
-                        equalTo(i2.getName()),
-                        allOf(
-                            not(containsIp(P2.getStartIp())),
-                            containsIp(Ip.create(P2.getStartIp().asLong() + 1)),
-                            containsIp(Ip.create(P2.getEndIp().asLong() - 1)),
-                            not(containsIp(P2.getEndIp()))))))));
+            allOf(
+                hasEntry(
+                    equalTo(i1.getName()),
+                    allOf(
+                        not(containsIp(P1.getStartIp())),
+                        containsIp(Ip.create(P1.getStartIp().asLong() + 1)),
+                        containsIp(Ip.create(P1.getEndIp().asLong() - 1)),
+                        not(containsIp(P1.getEndIp())))),
+                hasEntry(
+                    equalTo(i2.getName()),
+                    allOf(
+                        not(containsIp(P2.getStartIp())),
+                        containsIp(Ip.create(P2.getStartIp().asLong() + 1)),
+                        containsIp(Ip.create(P2.getEndIp().asLong() - 1)),
+                        not(containsIp(P2.getEndIp())))))));
   }
 
   @Test
@@ -1255,7 +1251,7 @@ public class ForwardingAnalysisImplTest {
             .setVrf(vrf1)
             .setAddress(new InterfaceAddress(prefix.getStartIp(), prefix.getPrefixLength()))
             .build();
-    Map<String, Map<String, Map<String, IpSpace>>> interfaceHostSubnetIps =
+    Map<String, Map<String, IpSpace>> interfaceHostSubnetIps =
         computeInterfaceHostSubnetIps(configs, false);
 
     assertThat(
@@ -1263,10 +1259,8 @@ public class ForwardingAnalysisImplTest {
         hasEntry(
             equalTo(c1.getHostname()),
             hasEntry(
-                equalTo(vrf1.getName()),
-                hasEntry(
-                    equalTo(i1.getName()),
-                    allOf(containsIp(prefix.getStartIp()), containsIp(prefix.getEndIp()))))));
+                equalTo(i1.getName()),
+                allOf(containsIp(prefix.getStartIp()), containsIp(prefix.getEndIp())))));
   }
 
   @Test
@@ -1278,8 +1272,8 @@ public class ForwardingAnalysisImplTest {
 
     Map<String, Map<String, Map<String, IpSpace>>> arpFalseDestIp =
         ImmutableMap.of(c1, ImmutableMap.of(vrf1, ImmutableMap.of(i1, EmptyIpSpace.INSTANCE)));
-    Map<String, Map<String, Map<String, IpSpace>>> interfaceHostSubnetIps =
-        ImmutableMap.of(c1, ImmutableMap.of(vrf1, ImmutableMap.of(i1, ip.toIpSpace())));
+    Map<String, Map<String, IpSpace>> interfaceHostSubnetIps =
+        ImmutableMap.of(c1, ImmutableMap.of(i1, ip.toIpSpace()));
     IpSpace ownedIps = EmptyIpSpace.INSTANCE;
 
     Map<String, Map<String, Map<String, IpSpace>>> result =
@@ -1299,8 +1293,8 @@ public class ForwardingAnalysisImplTest {
 
     Map<String, Map<String, Map<String, IpSpace>>> arpFalseDestIp =
         ImmutableMap.of(c1, ImmutableMap.of(vrf1, ImmutableMap.of(i1, ip.toIpSpace())));
-    Map<String, Map<String, Map<String, IpSpace>>> interfaceHostSubnetIps =
-        ImmutableMap.of(c1, ImmutableMap.of(vrf1, ImmutableMap.of(i1, EmptyIpSpace.INSTANCE)));
+    Map<String, Map<String, IpSpace>> interfaceHostSubnetIps =
+        ImmutableMap.of(c1, ImmutableMap.of(i1, EmptyIpSpace.INSTANCE));
     IpSpace ownedIps = EmptyIpSpace.INSTANCE;
 
     Map<String, Map<String, Map<String, IpSpace>>> result =
@@ -1320,8 +1314,8 @@ public class ForwardingAnalysisImplTest {
 
     Map<String, Map<String, Map<String, IpSpace>>> arpFalseDestIp =
         ImmutableMap.of(c1, ImmutableMap.of(vrf1, ImmutableMap.of(i1, ip.toIpSpace())));
-    Map<String, Map<String, Map<String, IpSpace>>> interfaceHostSubnetIps =
-        ImmutableMap.of(c1, ImmutableMap.of(vrf1, ImmutableMap.of(i1, ip.toIpSpace())));
+    Map<String, Map<String, IpSpace>> interfaceHostSubnetIps =
+        ImmutableMap.of(c1, ImmutableMap.of(i1, ip.toIpSpace()));
     IpSpace ownedIps = EmptyIpSpace.INSTANCE;
 
     Map<String, Map<String, Map<String, IpSpace>>> result =
@@ -1400,15 +1394,13 @@ public class ForwardingAnalysisImplTest {
     IpSpace internalIps = internalIpsBuilder.build();
     IpSpace externalIps = internalIps.complement();
 
-    Map<String, Map<String, Map<String, IpSpace>>> interfaceHostSubnetIps;
+    Map<String, Map<String, IpSpace>> interfaceHostSubnetIps;
     if (isDstIpInSubnet) {
       interfaceHostSubnetIps =
-          ImmutableMap.of(
-              CONFIG1, ImmutableMap.of(VRF1, ImmutableMap.of(INTERFACE1, dstPrefix.toIpSpace())));
+          ImmutableMap.of(CONFIG1, ImmutableMap.of(INTERFACE1, dstPrefix.toIpSpace()));
     } else {
       interfaceHostSubnetIps =
-          ImmutableMap.of(
-              CONFIG1, ImmutableMap.of(VRF1, ImmutableMap.of(INTERFACE1, EmptyIpSpace.INSTANCE)));
+          ImmutableMap.of(CONFIG1, ImmutableMap.of(INTERFACE1, EmptyIpSpace.INSTANCE));
     }
 
     Map<String, Map<String, Map<String, IpSpace>>> arpFalse =


### PR DESCRIPTION
- computeArpRepliesByInterface: handle case when nothing is forwarded
  out an interface.
- computeInterfaceArpReplies: exclude null_interface from the map.
- interfaceHostSubnetIps: don't group by VRF.
- computeDeliveredToSubnet: base map on arpFalseDestIps; remove
  nested-map intersection.
- Delete nested-map intersection; inline merge into union.
- Enforce equal key sets in nested-map union