### PR TITLE
Optimize get representative flows from bdd

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
@@ -1,6 +1,8 @@
 package org.batfish.common.bdd;
 
 import com.google.common.collect.ImmutableList;
+import io.opentracing.ActiveSpan;
+import io.opentracing.util.GlobalTracer;
 import java.util.List;
 import net.sf.javabdd.BDD;
 import org.batfish.common.BatfishException;
@@ -25,10 +27,14 @@ public final class BDDFlowConstraintGenerator {
   private BDD _tcpFlow;
 
   BDDFlowConstraintGenerator(BDDPacket pkt) {
-    _bddPacket = pkt;
-    _icmpFlow = computeICMPConstraint();
-    _udpFlow = computeUDPConstraint();
-    _tcpFlow = computeTCPConstraint();
+    try (ActiveSpan span =
+        GlobalTracer.get().buildSpan("construct BDDFlowConstraintGenerator").startActive()) {
+      assert span != null; // avoid unused warning
+      _bddPacket = pkt;
+      _icmpFlow = computeICMPConstraint();
+      _udpFlow = computeUDPConstraint();
+      _tcpFlow = computeTCPConstraint();
+    }
   }
 
   public BDD getUDPFlow() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
@@ -13,21 +13,17 @@ public class BDDRepresentativePicker {
   }
 
   public BDD pickRepresentative(BDD bdd) {
-    try (ActiveSpan span =
-        GlobalTracer.get().buildSpan("BDDRepresentativePicker.pickRepresentative").startActive()) {
-      assert span != null; // avoid unused warning
-      if (bdd.isZero()) {
-        return bdd;
-      }
-
-      for (BDD preferedBDD : _preference) {
-        BDD newBDD = preferedBDD.and(bdd);
-        if (!newBDD.isZero()) {
-          return newBDD.fullSatOne();
-        }
-      }
-
-      return bdd.fullSatOne();
+    if (bdd.isZero()) {
+      return bdd;
     }
+
+    for (BDD preferedBDD : _preference) {
+      BDD newBDD = preferedBDD.and(bdd);
+      if (!newBDD.isZero()) {
+        return newBDD.fullSatOne();
+      }
+    }
+
+    return bdd.fullSatOne();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
@@ -1,5 +1,7 @@
 package org.batfish.common.bdd;
 
+import io.opentracing.ActiveSpan;
+import io.opentracing.util.GlobalTracer;
 import java.util.List;
 import net.sf.javabdd.BDD;
 
@@ -11,17 +13,21 @@ public class BDDRepresentativePicker {
   }
 
   public BDD pickRepresentative(BDD bdd) {
-    if (bdd.isZero()) {
-      return bdd;
-    }
-
-    for (BDD preferedBDD : _preference) {
-      BDD newBDD = preferedBDD.and(bdd);
-      if (!newBDD.isZero()) {
-        return newBDD.fullSatOne();
+    try (ActiveSpan span =
+        GlobalTracer.get().buildSpan("BDDRepresentativePicker.pickRepresentative").startActive()) {
+      assert span != null; // avoid unused warning
+      if (bdd.isZero()) {
+        return bdd;
       }
-    }
 
-    return bdd.fullSatOne();
+      for (BDD preferedBDD : _preference) {
+        BDD newBDD = preferedBDD.and(bdd);
+        if (!newBDD.isZero()) {
+          return newBDD.fullSatOne();
+        }
+      }
+
+      return bdd.fullSatOne();
+    }
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
@@ -1,7 +1,5 @@
 package org.batfish.common.bdd;
 
-import io.opentracing.ActiveSpan;
-import io.opentracing.util.GlobalTracer;
 import java.util.List;
 import net.sf.javabdd.BDD;
 


### PR DESCRIPTION
1. More instrumentation of bdd loop detection;
2. Instead of constructing `BDDFlowConstraintGenerator` each time `BDDPacket.getFlow` is called, add a BDDFlowConstraintGenerator field in `BDDPacket` to reduce overhead.