### PR TITLE
Juniper: parse and extract BGP top-level disable

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
@@ -104,6 +104,11 @@ b_description
    description
 ;
 
+b_disable
+:
+   DISABLE
+;
+
 b_disable_4byte_as
 :
    DISABLE_4BYTE_AS
@@ -486,6 +491,7 @@ p_bgp
    BGP
    (
       b_common
+      | b_disable
       | b_enable
       | b_group
       | b_neighbor

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -177,6 +177,8 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_authentication_keyCon
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_authentication_key_chainContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_clusterContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_descriptionContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_disableContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_enableContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_enforce_first_asContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_exportContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.B_groupContext;
@@ -3607,6 +3609,16 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitB_description(B_descriptionContext ctx) {
     _currentBgpGroup.setDescription(ctx.description().text.getText());
+  }
+
+  @Override
+  public void exitB_disable(B_disableContext ctx) {
+    _currentBgpGroup.setDisable(true);
+  }
+
+  @Override
+  public void exitB_enable(B_enableContext ctx) {
+    _currentBgpGroup.setDisable(false);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
@@ -14,59 +14,34 @@ public class BgpGroup implements Serializable {
     INTERNAL
   }
 
-  /** */
   private static final long serialVersionUID = 1L;
 
   private Boolean _advertiseExternal;
-
   private Boolean _advertiseInactive;
-
   private Boolean _advertisePeerAs;
-
   private BgpAuthenticationAlgorithm _authenticationAlgorithm;
-
   private String _authenticationKey;
-
   private String _authenticationKeyChainName;
-
   private Ip _clusterId;
-
   private String _description;
-
+  private Boolean _disable;
   private boolean _dynamic;
-
   private Boolean _ebgpMultihop;
-
   private Boolean _enforceFirstAs;
-
   private final List<String> _exportPolicies;
-
   protected String _groupName;
-
   private final List<String> _importPolicies;
-
   protected transient boolean _inherited;
-
   private boolean _ipv6;
-
   private Ip _localAddress;
-
   private Long _localAs;
-
   private Integer _loops;
-
   private Boolean _multipath;
-
   private Boolean _multipathMultipleAs;
-
   private BgpGroup _parent;
-
   private Long _peerAs;
-
   private Boolean _removePrivate;
-
   @Nullable private String _ribGroup;
-
   private BgpGroupType _type;
 
   public BgpGroup() {
@@ -104,6 +79,9 @@ public class BgpGroup implements Serializable {
       }
       if (_description == null) {
         _description = _parent._description;
+      }
+      if (_disable == null) {
+        _disable = _parent._disable;
       }
       if (_enforceFirstAs == null) {
         _enforceFirstAs = _parent._enforceFirstAs;
@@ -177,6 +155,10 @@ public class BgpGroup implements Serializable {
 
   public final String getDescription() {
     return _description;
+  }
+
+  public Boolean getDisable() {
+    return _disable;
   }
 
   public boolean getDynamic() {
@@ -278,6 +260,10 @@ public class BgpGroup implements Serializable {
 
   public final void setDescription(String description) {
     _description = description;
+  }
+
+  public void setDisable(boolean disable) {
+    _disable = disable;
   }
 
   public void setDynamic(boolean dynamic) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
@@ -24,7 +24,7 @@ public class BgpGroup implements Serializable {
   private String _authenticationKeyChainName;
   private Ip _clusterId;
   private String _description;
-  private Boolean _disable;
+  @Nullable private Boolean _disable;
   private boolean _dynamic;
   private Boolean _ebgpMultihop;
   private Boolean _enforceFirstAs;
@@ -157,6 +157,7 @@ public class BgpGroup implements Serializable {
     return _description;
   }
 
+  @Nullable
   public Boolean getDisable() {
     return _disable;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -270,7 +270,12 @@ public final class JuniperConfiguration extends VendorConfiguration {
     return authenticationKeyChains;
   }
 
+  @Nullable
   private BgpProcess createBgpProcess(RoutingInstance routingInstance) {
+    BgpGroup mg = routingInstance.getMasterBgpGroup();
+    if (firstNonNull(mg.getDisable(), Boolean.FALSE)) {
+      return null;
+    }
     initDefaultBgpExportPolicy();
     initDefaultBgpImportPolicy();
     String vrfName = routingInstance.getName();
@@ -284,7 +289,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
       }
     }
     proc.setRouterId(routerId);
-    BgpGroup mg = routingInstance.getMasterBgpGroup();
     boolean multipathEbgp = false;
     boolean multipathIbgp = false;
     boolean multipathMultipleAs = false;
@@ -332,9 +336,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
     for (Entry<Prefix, IpBgpGroup> e : routingInstance.getIpBgpGroups().entrySet()) {
       Prefix prefix = e.getKey();
       IpBgpGroup ig = e.getValue();
-      if (ig.getDisable() == Boolean.TRUE) {
-        continue;
-      }
       Builder<?, ?> neighbor;
       Long remoteAs = ig.getType() == BgpGroupType.INTERNAL ? ig.getLocalAs() : ig.getPeerAs();
       if (ig.getDynamic()) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -332,6 +332,9 @@ public final class JuniperConfiguration extends VendorConfiguration {
     for (Entry<Prefix, IpBgpGroup> e : routingInstance.getIpBgpGroups().entrySet()) {
       Prefix prefix = e.getKey();
       IpBgpGroup ig = e.getValue();
+      if (ig.getDisable() == Boolean.TRUE) {
+        continue;
+      }
       Builder<?, ?> neighbor;
       Long remoteAs = ig.getType() == BgpGroupType.INTERNAL ? ig.getLocalAs() : ig.getPeerAs();
       if (ig.getDynamic()) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -955,6 +955,14 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testBgpDisable() throws IOException {
+    // Config has "set protocols bgp disable"; no VI BGP process should be created
+    String hostname = "bgp_disable";
+    Configuration c = getBatfishForConfigurationNames(hostname).loadConfigurations().get(hostname);
+    assertThat(c.getVrfs().get(DEFAULT_VRF_NAME).getBgpProcess(), nullValue());
+  }
+
+  @Test
   public void testDefaultApplications() throws IOException {
     String hostname = "default-applications";
     Batfish batfish = getBatfishForConfigurationNames(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp_disable
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp_disable
@@ -1,4 +1,5 @@
 #
 set system host-name bgp_disable
 #
+set protocols bgp group GROUP peer-as 1
 set protocols bgp disable

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp_disable
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp_disable
@@ -1,0 +1,4 @@
+#
+set system host-name bgp_disable
+#
+set protocols bgp disable

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_bgp_disable
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_bgp_disable
@@ -1,4 +1,5 @@
 #
 set system host-name bgp-disable
 #
+set protocols bgp group GROUP peer-as 1
 set protocols bgp disable

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_bgp_disable
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_bgp_disable
@@ -1,0 +1,4 @@
+#
+set system host-name bgp-disable
+#
+set protocols bgp disable

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -2964,6 +2964,51 @@
           }
         }
       },
+      "bgp-disable" : {
+        "configurationFormat" : "FLAT_JUNIPER",
+        "name" : "bgp-disable",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "SWITCH",
+        "vendorFamily" : {
+          "juniper" : {
+            "lines" : {
+              "auxiliary" : {
+                "name" : "auxiliary",
+                "aaaAuthenticationLoginList" : {
+                  "methods" : [
+                    "PASSWORD"
+                  ]
+                },
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "console" : {
+                "name" : "console",
+                "aaaAuthenticationLoginList" : {
+                  "methods" : [
+                    "PASSWORD"
+                  ]
+                },
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              }
+            },
+            "systemAuthenticationOrder" : {
+              "methods" : [
+                "PASSWORD"
+              ]
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default"
+          }
+        }
+      },
       "bgp-enforce-first-as" : {
         "configurationFormat" : "FLAT_JUNIPER",
         "name" : "bgp-enforce-first-as",

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -2566,6 +2566,16 @@
       },
       {
         "Structure_Type" : "bgp group",
+        "Structure_Name" : "GROUP",
+        "Source_Lines" : {
+          "filename" : "configs/juniper_bgp_disable",
+          "lines" : [
+            4
+          ]
+        }
+      },
+      {
+        "Structure_Type" : "bgp group",
         "Structure_Name" : "someipv4bgpgroup",
         "Source_Lines" : {
           "filename" : "configs/juniper_bgp_remove_private_as",
@@ -3449,10 +3459,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 230 results",
+      "notes" : "Found 231 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 230
+      "numResults" : 231
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -55820,6 +55820,26 @@
             "            PROTOCOLS:'protocols'",
             "            (p_bgp",
             "              BGP:'bgp'",
+            "              (b_group",
+            "                GROUP:'group'",
+            "                name = (variable",
+            "                  text = VARIABLE:'GROUP'  <== mode:M_VarOrWildcard)",
+            "                (b_common",
+            "                  (b_peer_as",
+            "                    PEER_AS:'peer-as'",
+            "                    (bpa_as",
+            "                      asn = (bgp_asn",
+            "                        asn = DEC:'1'))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_protocols",
+            "            PROTOCOLS:'protocols'",
+            "            (p_bgp",
+            "              BGP:'bgp'",
             "              (b_disable",
             "                DISABLE:'disable'))))))",
             "    NEWLINE:'\\n')",
@@ -77977,7 +77997,16 @@
             }
           }
         },
-        "configs/juniper_bgp_disable" : { },
+        "configs/juniper_bgp_disable" : {
+          "bgp group" : {
+            "GROUP" : {
+              "definitionLines" : [
+                4
+              ],
+              "numReferrers" : 0
+            }
+          }
+        },
         "configs/juniper_bgp_enforce_fist_as" : {
           "bgp group" : {
             "MYGROUP" : {

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -141,6 +141,9 @@
         "bgp-allow" : [
           "configs/juniper_bgp_allow"
         ],
+        "bgp-disable" : [
+          "configs/juniper_bgp_disable"
+        ],
         "bgp-enforce-first-as" : [
           "configs/juniper_bgp_enforce_fist_as"
         ],
@@ -1062,6 +1065,7 @@
         "configs/juniper_bgp" : "PASSED",
         "configs/juniper_bgp_allow" : "PASSED",
         "configs/juniper_bgp_authentication" : "PASSED",
+        "configs/juniper_bgp_disable" : "PASSED",
         "configs/juniper_bgp_enforce_fist_as" : "PASSED",
         "configs/juniper_bgp_remove_private_as" : "PASSED",
         "configs/juniper_extended_community" : "PASSED",
@@ -55792,6 +55796,36 @@
             "  EOF:<EOF>)"
           ]
         },
+        "configs/juniper_bgp_disable" : {
+          "sentences" : [
+            "(flat_juniper_configuration",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_system",
+            "            SYSTEM:'system'",
+            "            (sy_host_name",
+            "              HOST_NAME:'host-name'",
+            "              (variable",
+            "                text = VARIABLE:'bgp-disable'))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_protocols",
+            "            PROTOCOLS:'protocols'",
+            "            (p_bgp",
+            "              BGP:'bgp'",
+            "              (b_disable",
+            "                DISABLE:'disable'))))))",
+            "    NEWLINE:'\\n')",
+            "  EOF:<EOF>)"
+          ]
+        },
         "configs/juniper_bgp_enforce_fist_as" : {
           "sentences" : [
             "(flat_juniper_configuration",
@@ -73119,6 +73153,7 @@
         "banner" : "PASSED",
         "banner_dos" : "PASSED",
         "bgp-allow" : "PASSED",
+        "bgp-disable" : "PASSED",
         "bgp-enforce-first-as" : "WARNINGS",
         "bgp_address_family" : "WARNINGS",
         "bgp_default_originate_policy" : "PASSED",
@@ -77942,6 +77977,7 @@
             }
           }
         },
+        "configs/juniper_bgp_disable" : { },
         "configs/juniper_bgp_enforce_fist_as" : {
           "bgp group" : {
             "MYGROUP" : {
@@ -86148,6 +86184,7 @@
         "configs/juniper_bgp" : "PASSED",
         "configs/juniper_bgp_allow" : "PASSED",
         "configs/juniper_bgp_authentication" : "PASSED",
+        "configs/juniper_bgp_disable" : "PASSED",
         "configs/juniper_bgp_enforce_fist_as" : "PASSED",
         "configs/juniper_bgp_remove_private_as" : "PASSED",
         "configs/juniper_extended_community" : "PASSED",


### PR DESCRIPTION
For now, disabled BGP processes will be left out of the VI model entirely, as per option 1 in #3443.