### PR TITLE
BDDReachability: use Table instead of nested Maps for transitions

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityUtils.java
@@ -5,16 +5,13 @@ import static com.google.common.collect.ImmutableTable.toImmutableTable;
 import com.google.common.collect.Streams;
 import com.google.common.collect.Table;
 import java.util.function.Function;
+import org.batfish.bddreachability.transition.Transitions;
 import org.batfish.z3.expr.StateExpr;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Utility methods for {@link BDDReachabilityAnalysis} and {@link BDDReachabilityAnalysisFactory}.
  */
 final class BDDReachabilityUtils {
-  private static final Logger logger = LoggerFactory.getLogger(BDDReachabilityUtils.class);
-
   static Table<StateExpr, StateExpr, Edge> computeForwardEdgeTable(Iterable<Edge> edges) {
     return Streams.stream(edges)
         .collect(
@@ -22,11 +19,10 @@ final class BDDReachabilityUtils {
                 Edge::getPreState,
                 Edge::getPostState,
                 Function.identity(),
-                (oldVal, newVal) -> {
-                  // The prior implementation using HashMap overwrote with new value. Keep that
-                  // behavior but warn.
-                  logger.warn("Overwriting old transition {} with {}", oldVal, newVal);
-                  return newVal;
-                }));
+                (oldVal, newVal) ->
+                    new Edge(
+                        oldVal.getPreState(),
+                        oldVal.getPostState(),
+                        Transitions.or(oldVal.getTransition(), newVal.getTransition()))));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityUtils.java
@@ -1,40 +1,32 @@
 package org.batfish.bddreachability;
 
-import static org.batfish.common.util.CommonUtil.toImmutableMap;
+import static com.google.common.collect.ImmutableTable.toImmutableTable;
 
-import com.google.common.collect.ImmutableMap;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
+import com.google.common.collect.Streams;
+import com.google.common.collect.Table;
+import java.util.function.Function;
 import org.batfish.z3.expr.StateExpr;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility methods for {@link BDDReachabilityAnalysis} and {@link BDDReachabilityAnalysisFactory}.
  */
 final class BDDReachabilityUtils {
-  static Map<StateExpr, Map<StateExpr, Edge>> computeForwardEdgeMap(Iterable<Edge> edges) {
-    Map<StateExpr, Map<StateExpr, Edge>> forwardEdges = new HashMap<>();
+  private static final Logger logger = LoggerFactory.getLogger(BDDReachabilityUtils.class);
 
-    edges.forEach(
-        edge ->
-            forwardEdges
-                .computeIfAbsent(edge.getPreState(), k -> new HashMap<>())
-                .put(edge.getPostState(), edge));
-
-    // freeze
-    return toImmutableMap(
-        forwardEdges, Entry::getKey, entry -> ImmutableMap.copyOf(entry.getValue()));
-  }
-
-  static Map<StateExpr, Map<StateExpr, Edge>> computeReverseEdgeMap(Iterable<Edge> edges) {
-    Map<StateExpr, Map<StateExpr, Edge>> reverseEdges = new HashMap<>();
-    edges.forEach(
-        edge ->
-            reverseEdges
-                .computeIfAbsent(edge.getPostState(), k -> new HashMap<>())
-                .put(edge.getPreState(), edge));
-    // freeze
-    return toImmutableMap(
-        reverseEdges, Entry::getKey, entry -> ImmutableMap.copyOf(entry.getValue()));
+  static Table<StateExpr, StateExpr, Edge> computeForwardEdgeTable(Iterable<Edge> edges) {
+    return Streams.stream(edges)
+        .collect(
+            toImmutableTable(
+                Edge::getPreState,
+                Edge::getPostState,
+                Function.identity(),
+                (oldVal, newVal) -> {
+                  // The prior implementation using HashMap overwrote with new value. Keep that
+                  // behavior but warn.
+                  logger.warn("Overwriting old transition {} with {}", oldVal, newVal);
+                  return newVal;
+                }));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
@@ -2,8 +2,7 @@ package org.batfish.bddreachability;
 
 import static org.batfish.bddreachability.BDDReachabilityAnalysis.fixpoint;
 import static org.batfish.bddreachability.BDDReachabilityAnalysis.toIngressLocation;
-import static org.batfish.bddreachability.BDDReachabilityUtils.computeForwardEdgeMap;
-import static org.batfish.bddreachability.BDDReachabilityUtils.computeReverseEdgeMap;
+import static org.batfish.bddreachability.BDDReachabilityUtils.computeForwardEdgeTable;
 import static org.batfish.bddreachability.TestNetwork.DST_PREFIX_1;
 import static org.batfish.bddreachability.TestNetwork.DST_PREFIX_2;
 import static org.batfish.bddreachability.TestNetwork.LINK_1_NETWORK;
@@ -23,6 +22,8 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -473,8 +474,9 @@ public final class BDDReachabilityAnalysisTest {
     Edge edgeAB = new Edge(a, b, bddAB);
     Edge edgeBC = new Edge(b, c, bddBC);
 
-    Map<StateExpr, Map<StateExpr, Edge>> forwardEdges =
-        computeForwardEdgeMap(ImmutableList.of(edgeAB, edgeBC));
+    Table<StateExpr, StateExpr, Edge> forwardEdges =
+        computeForwardEdgeTable(ImmutableList.of(edgeAB, edgeBC));
+    Table<StateExpr, StateExpr, Edge> reverseEdges = Tables.transpose(forwardEdges);
 
     // forward from a
     {
@@ -497,9 +499,6 @@ public final class BDDReachabilityAnalysisTest {
       fixpoint(forwardReachability, forwardEdges, Edge::traverseForward);
       assertThat(forwardReachability, equalTo(ImmutableMap.of(c, start)));
     }
-
-    Map<StateExpr, Map<StateExpr, Edge>> reverseEdges =
-        computeReverseEdgeMap(ImmutableList.of(edgeAB, edgeBC));
 
     // reverse from a
     {


### PR DESCRIPTION
Implemented the same under the hood.
Fewer copies.
Better interface.