### PR TITLE
Juniper: disable for OSPF process and interface

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
@@ -39,6 +39,7 @@ import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasNativeVlan;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfArea;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfAreaName;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfCost;
+import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfEnabled;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfPointToPoint;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasSpeed;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasSwitchPortMode;
@@ -289,6 +290,14 @@ public final class InterfaceMatchers {
    */
   public static HasOspfCost hasOspfCost(Matcher<Integer> subMatcher) {
     return new HasOspfCost(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code expectedEnabledStatus} is the same as
+   * the interface's OSPF enabled status.
+   */
+  public static HasOspfEnabled hasOspfEnabled(boolean expectedEnabledStatus) {
+    return new HasOspfEnabled(equalTo(expectedEnabledStatus));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
@@ -292,12 +292,9 @@ public final class InterfaceMatchers {
     return new HasOspfCost(subMatcher);
   }
 
-  /**
-   * Provides a matcher that matches if the provided {@code expectedEnabledStatus} is the same as
-   * the interface's OSPF enabled status.
-   */
-  public static HasOspfEnabled hasOspfEnabled(boolean expectedEnabledStatus) {
-    return new HasOspfEnabled(equalTo(expectedEnabledStatus));
+  /** Provides an {@link Interface} matcher that matches if the interface has OSPF enabled. */
+  public static HasOspfEnabled hasOspfEnabled() {
+    return new HasOspfEnabled(equalTo(true));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
@@ -251,6 +251,17 @@ final class InterfaceMatchersImpl {
     }
   }
 
+  static final class HasOspfEnabled extends FeatureMatcher<Interface, Boolean> {
+    HasOspfEnabled(@Nonnull Matcher<? super Boolean> subMatcher) {
+      super(subMatcher, "an Interface with ospfEnabled:", "ospfEnabled");
+    }
+
+    @Override
+    protected Boolean featureValueOf(Interface actual) {
+      return actual.getOspfEnabled();
+    }
+  }
+
   static final class HasOspfPointToPoint extends FeatureMatcher<Interface, Boolean> {
     HasOspfPointToPoint(@Nonnull Matcher<? super Boolean> subMatcher) {
       super(subMatcher, "an Interface with ospfPointToPoint:", "ospfPointToPoint");

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_ospf.g4
@@ -28,6 +28,8 @@ o_common
 :
    apply
    | o_area
+   | o_disable
+   | o_enable
    | o_export
    | o_external_preference
    | o_import
@@ -36,6 +38,16 @@ o_common
    | o_reference_bandwidth
    | o_rib_group
    | o_traffic_engineering
+;
+
+o_disable
+:
+   DISABLE
+;
+
+o_enable
+:
+   ENABLE
 ;
 
 o_export
@@ -119,6 +131,7 @@ oa_interface
       apply
       | oai_dead_interval
       | oai_disable
+      | oai_enable
       | oai_hello_interval
       | oai_interface_type
       | oai_ldp_synchronization
@@ -186,6 +199,11 @@ oai_dead_interval
 oai_disable
 :
    DISABLE
+;
+
+oai_enable
+:
+   ENABLE
 ;
 
 oai_hello_interval

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -315,11 +315,15 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Natp_addressContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Natp_portContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Natp_routing_instanceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_areaContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_disableContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_enableContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_exportContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_reference_bandwidthContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oa_interfaceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oa_nssaContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oa_stubContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oai_disableContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oai_enableContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oai_interface_typeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oai_passiveContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oan_default_lsaContext;
@@ -4491,6 +4495,16 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   }
 
   @Override
+  public void exitO_disable(O_disableContext ctx) {
+    _currentRoutingInstance.setOspfDisable(true);
+  }
+
+  @Override
+  public void exitO_enable(O_enableContext ctx) {
+    _currentRoutingInstance.setOspfDisable(false);
+  }
+
+  @Override
   public void exitO_export(O_exportContext ctx) {
     String name = ctx.name.getText();
     _currentRoutingInstance.getOspfExportPolicies().add(name);
@@ -4528,6 +4542,16 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitOaa_restrict(FlatJuniperParser.Oaa_restrictContext ctx) {
     _currentAreaRangeRestrict = true;
+  }
+
+  @Override
+  public void exitOai_disable(Oai_disableContext ctx) {
+    _currentOspfInterface.setOspfDisable(true);
+  }
+
+  @Override
+  public void exitOai_enable(Oai_enableContext ctx) {
+    _currentOspfInterface.setOspfDisable(false);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -54,72 +54,40 @@ public class Interface implements Serializable {
   }
 
   private String _accessVlan;
-
   private boolean _active;
-
   private Set<Ip> _additionalArpIps;
-
   private final Set<InterfaceAddress> _allAddresses;
-
   // Dumb name to appease checkstyle
   private String _agg8023adInterface;
-
   private final Set<Ip> _allAddressIps;
-
   private final List<SubRange> _allowedVlans;
-
   private final List<String> _allowedVlanNames;
-
   private double _bandwidth;
-
   private String _description;
-
   private String _incomingFilter;
-
   private transient boolean _inherited;
-
   @Nonnull private final IsisInterfaceSettings _isisSettings;
-
   private IsoAddress _isoAddress;
-
   private Integer _mtu;
-
   private final String _name;
-
   @Nullable private Integer _nativeVlan;
-
   private Ip _ospfArea;
-
   private Integer _ospfCost;
-
   private int _ospfDeadInterval;
-
+  @Nullable private Boolean _ospfDisable;
   private int _ospfHelloMultiplier;
-
   private boolean _ospfPassive;
-
   private OspfInterfaceType _ospfInterfaceType;
-
   private String _outgoingFilter;
-
   private Interface _parent;
-
   private InterfaceAddress _preferredAddress;
-
   private InterfaceAddress _primaryAddress;
-
   @Nullable private String _redundantParentInterface;
-
   private String _routingInstance;
-
   private SwitchportMode _switchportMode;
-
   private SwitchportEncapsulationType _switchportTrunkEncapsulation;
-
   private final SortedMap<String, Interface> _units;
-
   private final SortedMap<Integer, VrrpGroup> _vrrpGroups;
-
   private Integer _tcpMss;
 
   public Interface(String name) {
@@ -223,6 +191,11 @@ public class Interface implements Serializable {
     return _ospfDeadInterval;
   }
 
+  @Nullable
+  public Boolean getOspfDisable() {
+    return _ospfDisable;
+  }
+
   public int getOspfHelloMultiplier() {
     return _ospfHelloMultiplier;
   }
@@ -293,6 +266,9 @@ public class Interface implements Serializable {
     }
     if (_ospfArea == null) {
       _ospfArea = _parent._ospfArea;
+    }
+    if (_ospfDisable == null) {
+      _ospfDisable = _parent._ospfDisable;
     }
   }
 
@@ -368,6 +344,10 @@ public class Interface implements Serializable {
 
   public void setOspfDeadInterval(int seconds) {
     _ospfDeadInterval = seconds;
+  }
+
+  public void setOspfDisable(boolean disable) {
+    _ospfDisable = disable;
   }
 
   public void setOspfHelloMultiplier(int multiplier) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -771,7 +771,11 @@ public final class JuniperConfiguration extends VendorConfiguration {
         .build();
   }
 
+  @Nullable
   private OspfProcess createOspfProcess(RoutingInstance routingInstance) {
+    if (firstNonNull(routingInstance.getOspfDisable(), Boolean.FALSE)) {
+      return null;
+    }
     OspfProcess newProc =
         OspfProcess.builder()
             // Use routing instance name since OSPF processes are not named
@@ -1050,7 +1054,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     long ospfAreaLong = ospfArea.asLong();
     org.batfish.datamodel.ospf.OspfArea.Builder newArea = newAreas.get(ospfAreaLong);
     newArea.addInterface(interfaceName);
-    newIface.setOspfEnabled(true);
+    newIface.setOspfEnabled(!firstNonNull(iface.getOspfDisable(), Boolean.FALSE));
     newIface.setOspfPassive(iface.getOspfPassive());
     Integer ospfCost = iface.getOspfCost();
     if (ospfCost == null && newIface.isLoopback(ConfigurationFormat.FLAT_JUNIPER)) {
@@ -2779,19 +2783,21 @@ public final class JuniperConfiguration extends VendorConfiguration {
                               riName,
                               _w))));
 
-      // create ospf process
+      // Create OSPF process (oproc will be null iff disable is configured at process level)
       if (ri.getOspfAreas().size() > 0) {
         OspfProcess oproc = createOspfProcess(ri);
-        vrf.setOspfProcess(oproc);
-        // add discard routes for OSPF summaries
-        oproc.getAreas().values().stream()
-            .flatMap(a -> a.getSummaries().entrySet().stream())
-            .forEach(
-                summaryEntry ->
-                    vrf.getGeneratedRoutes()
-                        .add(
-                            ospfSummaryToAggregateRoute(
-                                summaryEntry.getKey(), summaryEntry.getValue())));
+        if (oproc != null) {
+          vrf.setOspfProcess(oproc);
+          // add discard routes for OSPF summaries
+          oproc.getAreas().values().stream()
+              .flatMap(a -> a.getSummaries().entrySet().stream())
+              .forEach(
+                  summaryEntry ->
+                      vrf.getGeneratedRoutes()
+                          .add(
+                              ospfSummaryToAggregateRoute(
+                                  summaryEntry.getKey(), summaryEntry.getValue())));
+        }
       }
 
       // create is-is process

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
@@ -51,6 +51,7 @@ public class RoutingInstance implements Serializable {
   private final Map<String, NodeDevice> _nodeDevices;
   private Map<Long, OspfArea> _ospfAreas;
   private List<String> _ospfExportPolicies;
+  @Nullable private Boolean _ospfDisable;
   private double _ospfReferenceBandwidth;
   private final Map<String, RoutingInformationBase> _ribs;
   private Ip _routerId;
@@ -193,6 +194,11 @@ public class RoutingInstance implements Serializable {
     return _ospfExportPolicies;
   }
 
+  @Nullable
+  public Boolean getOspfDisable() {
+    return _ospfDisable;
+  }
+
   public double getOspfReferenceBandwidth() {
     return _ospfReferenceBandwidth;
   }
@@ -236,6 +242,10 @@ public class RoutingInstance implements Serializable {
   public void setHostname(String hostname) {
     checkNotNull(hostname, "'hostname' cannot be null");
     _hostname = hostname.toLowerCase();
+  }
+
+  public void setOspfDisable(boolean ospfDisable) {
+    _ospfDisable = ospfDisable;
   }
 
   public void setOspfReferenceBandwidth(double ospfReferenceBandwidth) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2019,15 +2019,35 @@ public final class FlatJuniperGrammarTest {
     // Interface ge-0/0/2.0 has disable set in OSPF config.
     Configuration config = parseConfig("ospf-interface-disable");
     assertThat(config.getVrfs().get(DEFAULT_VRF_NAME).getOspfProcess(), notNullValue());
-    assertThat(config.getActiveInterfaces().get("ge-0/0/1.0"), hasOspfEnabled(true));
-    assertThat(config.getActiveInterfaces().get("ge-0/0/2.0"), hasOspfEnabled(false));
+    assertThat(config.getActiveInterfaces().get("ge-0/0/1.0"), hasOspfEnabled());
+    assertThat(config.getActiveInterfaces().get("ge-0/0/2.0"), not(hasOspfEnabled()));
   }
 
   @Test
   public void testOspfDisable() throws IOException {
-    // Config has "set protocols ospf disable"; no VI OSPF process should be created
+    /*
+    - Default VRF has OSPF process disabled, with interface ge-0/0/0.0
+    - VRF INSTANCE_1 has OSPF process disabled, with interface ge-0/0/1.0
+    - VRF INSTANCE_2 has OSPF process disabled, then enabled, with interface ge-0/0/2.0
+    - VRF INSTANCE_3 has OSPF process enabled, then disabled, with interface ge-0/0/3.0
+     */
     Configuration config = parseConfig("ospf-disable");
+
+    // Default VRF: OSPF process should not be created
     assertThat(config.getVrfs().get(DEFAULT_VRF_NAME).getOspfProcess(), nullValue());
+    assertThat(config.getActiveInterfaces().get("ge-0/0/0.0"), not(hasOspfEnabled()));
+
+    // INSTANCE_1: OSPF process should not be created
+    assertThat(config.getVrfs().get("INSTANCE_1").getOspfProcess(), nullValue());
+    assertThat(config.getActiveInterfaces().get("ge-0/0/1.0"), not(hasOspfEnabled()));
+
+    // INSTANCE_2: OSPF process should be created and its interface enabled
+    assertThat(config.getVrfs().get("INSTANCE_2").getOspfProcess(), notNullValue());
+    assertThat(config.getActiveInterfaces().get("ge-0/0/2.0"), hasOspfEnabled());
+
+    // INSTANCE_3: OSPF process should not be created
+    assertThat(config.getVrfs().get("INSTANCE_3").getOspfProcess(), nullValue());
+    assertThat(config.getActiveInterfaces().get("ge-0/0/3.0"), not(hasOspfEnabled()));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -60,6 +60,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasNativeVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfAreaName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfCost;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfEnabled;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfPointToPoint;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSwitchPortMode;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasZoneName;
@@ -2010,6 +2011,23 @@ public final class FlatJuniperGrammarTest {
 
     OspfArea area2 = config.getDefaultVrf().getOspfProcess().getAreas().get(2L);
     assertThat(area2, not(hasInjectDefaultRoute()));
+  }
+
+  @Test
+  public void testOspfInterfaceDisable() throws IOException {
+    // Config has interfaces ge-0/0/1.0 and ge-0/0/2.0 configured in OSPF.
+    // Interface ge-0/0/2.0 has disable set in OSPF config.
+    Configuration config = parseConfig("ospf-interface-disable");
+    assertThat(config.getVrfs().get(DEFAULT_VRF_NAME).getOspfProcess(), notNullValue());
+    assertThat(config.getActiveInterfaces().get("ge-0/0/1.0"), hasOspfEnabled(true));
+    assertThat(config.getActiveInterfaces().get("ge-0/0/2.0"), hasOspfEnabled(false));
+  }
+
+  @Test
+  public void testOspfDisable() throws IOException {
+    // Config has "set protocols ospf disable"; no VI OSPF process should be created
+    Configuration config = parseConfig("ospf-disable");
+    assertThat(config.getVrfs().get(DEFAULT_VRF_NAME).getOspfProcess(), nullValue());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-disable
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-disable
@@ -1,0 +1,8 @@
+#
+set system host-name ospf-disable
+#
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.0/31
+#
+set protocols ospf area 0.0.0.0 interface ge-0/0/0.0
+set protocols ospf disable
+#

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-disable
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-disable
@@ -2,7 +2,26 @@
 set system host-name ospf-disable
 #
 set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.0/31
+set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.0/31
+set interfaces ge-0/0/2 unit 0 family inet address 10.0.2.0/31
+set interfaces ge-0/0/3 unit 0 family inet address 10.0.3.0/31
 #
 set protocols ospf area 0.0.0.0 interface ge-0/0/0.0
 set protocols ospf disable
+#
+set routing-instances INSTANCE_1 interface ge-0/0/1.0
+set routing-instances INSTANCE_1 protocols ospf area 0.0.0.0 interface ge-0/0/1.0
+set routing-instances INSTANCE_1 protocols ospf disable
+#
+# Should end up enabled
+set routing-instances INSTANCE_2 interface ge-0/0/2.0
+set routing-instances INSTANCE_2 protocols ospf area 0.0.0.0 interface ge-0/0/2.0
+set routing-instances INSTANCE_2 protocols ospf disable
+set routing-instances INSTANCE_2 protocols ospf enable
+#
+# Should end up disabled
+set routing-instances INSTANCE_3 interface ge-0/0/3.0
+set routing-instances INSTANCE_3 protocols ospf area 0.0.0.0 interface ge-0/0/3.0
+set routing-instances INSTANCE_3 protocols ospf enable
+set routing-instances INSTANCE_3 protocols ospf disable
 #

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-interface-disable
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-interface-disable
@@ -1,0 +1,9 @@
+#
+set system host-name ospf-interface-disable
+#
+set interfaces ge-0/0/1 unit 0 family inet address 1.0.0.0/24
+set interfaces ge-0/0/2 unit 0 family inet address 2.0.0.0/24
+#
+set protocols ospf area 0.0.0.0 interface ge-0/0/1.0
+set protocols ospf area 0.0.0.0 interface ge-0/0/2.0 disable
+#

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_ospf_disable
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_ospf_disable
@@ -1,0 +1,8 @@
+#
+set system host-name ospf-disable
+#
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.0/31
+#
+set protocols ospf area 0.0.0.0 interface ge-0/0/0.0
+set protocols ospf disable
+#

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -27067,6 +27067,117 @@
           }
         }
       },
+      "ospf-disable" : {
+        "configurationFormat" : "FLAT_JUNIPER",
+        "name" : "ospf-disable",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "SWITCH",
+        "interfaces" : {
+          "ge-0/0/0" : {
+            "name" : "ge-0/0/0",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "ge-0/0/0"
+            ],
+            "mtu" : 1500,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "ge-0/0/0.0" : {
+            "name" : "ge-0/0/0.0",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allPrefixes" : [
+              "10.0.0.0/31"
+            ],
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "ge-0/0/0.0"
+            ],
+            "mtu" : 1500,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "10.0.0.0/31",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOGICAL",
+            "vrf" : "default"
+          }
+        },
+        "vendorFamily" : {
+          "juniper" : {
+            "lines" : {
+              "auxiliary" : {
+                "name" : "auxiliary",
+                "aaaAuthenticationLoginList" : {
+                  "methods" : [
+                    "PASSWORD"
+                  ]
+                },
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "AUX"
+              },
+              "console" : {
+                "name" : "console",
+                "aaaAuthenticationLoginList" : {
+                  "methods" : [
+                    "PASSWORD"
+                  ]
+                },
+                "execTimeoutMinutes" : 0,
+                "execTimeoutSeconds" : 0,
+                "lineType" : "CON"
+              }
+            },
+            "systemAuthenticationOrder" : {
+              "methods" : [
+                "PASSWORD"
+              ]
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "interfaces" : [
+              "ge-0/0/0",
+              "ge-0/0/0.0"
+            ]
+          }
+        }
+      },
       "peer_template" : {
         "configurationFormat" : "CISCO_NX",
         "name" : "peer_template",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -778,6 +778,9 @@
         "openflow" : [
           "configs/openflow"
         ],
+        "ospf-disable" : [
+          "configs/juniper_ospf_disable"
+        ],
         "peer_template" : [
           "configs/peer_template"
         ],
@@ -1078,6 +1081,7 @@
         "configs/juniper_nat" : "PASSED",
         "configs/juniper_ntp" : "PASSED",
         "configs/juniper_ospf" : "PASSED",
+        "configs/juniper_ospf_disable" : "PASSED",
         "configs/juniper_ospf_stub_areas" : "PASSED",
         "configs/juniper_passwords" : "PASSED",
         "configs/juniper_policy_statement" : "PASSED",
@@ -60547,6 +60551,80 @@
             "  EOF:<EOF>)"
           ]
         },
+        "configs/juniper_ospf_disable" : {
+          "sentences" : [
+            "(flat_juniper_configuration",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_system",
+            "            SYSTEM:'system'",
+            "            (sy_host_name",
+            "              HOST_NAME:'host-name'",
+            "              (variable",
+            "                text = VARIABLE:'ospf-disable'))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_interfaces",
+            "            INTERFACES:'interfaces'",
+            "            (int_named",
+            "              (interface_id",
+            "                name = INTERFACE_NAME:'ge-0/0/0'  <== mode:M_Interface)",
+            "              (i_unit",
+            "                UNIT:'unit'",
+            "                num = DEC:'0'",
+            "                (i_common",
+            "                  (i_family",
+            "                    FAMILY:'family'",
+            "                    (if_inet",
+            "                      INET:'inet'",
+            "                      (ifi_address",
+            "                        ADDRESS:'address'",
+            "                        IP_PREFIX:'10.0.0.0/31'))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_protocols",
+            "            PROTOCOLS:'protocols'",
+            "            (p_ospf",
+            "              OSPF:'ospf'",
+            "              (o_common",
+            "                (o_area",
+            "                  AREA:'area'",
+            "                  area = IP_ADDRESS:'0.0.0.0'",
+            "                  (oa_interface",
+            "                    INTERFACE:'interface'",
+            "                    id = (interface_id",
+            "                      name = INTERFACE_NAME:'ge-0/0/0'  <== mode:M_Interface",
+            "                      PERIOD:'.'",
+            "                      unit = DEC:'0')",
+            "                    (apply)))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_protocols",
+            "            PROTOCOLS:'protocols'",
+            "            (p_ospf",
+            "              OSPF:'ospf'",
+            "              (o_common",
+            "                (o_disable",
+            "                  DISABLE:'disable')))))))",
+            "    NEWLINE:'\\n')",
+            "  EOF:<EOF>)"
+          ]
+        },
         "configs/juniper_ospf_stub_areas" : {
           "sentences" : [
             "(flat_juniper_configuration",
@@ -73383,6 +73461,7 @@
         "nxos_route_map_continue" : "PASSED",
         "nxos_system" : "PASSED",
         "openflow" : "PASSED",
+        "ospf-disable" : "PASSED",
         "peer_template" : "WARNINGS",
         "pim" : "PASSED",
         "pim_snooping" : "PASSED",
@@ -78403,6 +78482,22 @@
         },
         "configs/juniper_ntp" : { },
         "configs/juniper_ospf" : { },
+        "configs/juniper_ospf_disable" : {
+          "interface" : {
+            "ge-0/0/0" : {
+              "definitionLines" : [
+                4
+              ],
+              "numReferrers" : 1
+            },
+            "ge-0/0/0.0" : {
+              "definitionLines" : [
+                4
+              ],
+              "numReferrers" : 2
+            }
+          }
+        },
         "configs/juniper_ospf_stub_areas" : { },
         "configs/juniper_passwords" : { },
         "configs/juniper_policy_statement" : {
@@ -82786,6 +82881,23 @@
             }
           }
         },
+        "configs/juniper_ospf_disable" : {
+          "interface" : {
+            "ge-0/0/0" : {
+              "interface" : [
+                4
+              ]
+            },
+            "ge-0/0/0.0" : {
+              "interface" : [
+                4
+              ],
+              "ospf area interface" : [
+                6
+              ]
+            }
+          }
+        },
         "configs/juniper_policy_statement" : {
           "as-path" : {
             "ORIGINATED_IN_65535" : {
@@ -86226,6 +86338,7 @@
         "configs/juniper_nat" : "PASSED",
         "configs/juniper_ntp" : "PASSED",
         "configs/juniper_ospf" : "PASSED",
+        "configs/juniper_ospf_disable" : "PASSED",
         "configs/juniper_ospf_stub_areas" : "PASSED",
         "configs/juniper_passwords" : "PASSED",
         "configs/juniper_policy_statement" : "PASSED",


### PR DESCRIPTION
If `disable` is configured at the process level:
`set protocols ospf disable`
then the OSPF process is not created at all.

If `disable` is configured at the interface level:
`set protocols ospf area 0.0.0.0 interface ge-0/0/1.0 disable`
then the VI model remains the same except the existing field `Interface._ospfEnabled` is set to false. 

This matches the observed behavior documented [here](https://docs.google.com/document/d/1Xzzv579yhB0g-eypep8I8OZSfhhNEKvsRmdpBJ8MbMQ):
>OSPF is disabled on an interface if either the interface or the process has `disable` command configured.

Continues progress on #3443.