### PR TITLE
BDDFactory: fix type signature of setCacheRatio to be less confusing

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -38,16 +38,17 @@ public class BDDPacket {
   private static final int JFACTORY_INITIAL_NODE_TABLE_SIZE = 10000;
 
   /*
-   * Initial size of the BDD factory node cache. Automatically resized when the node table is,
-   * to preserve the cache ratio.
-   */
-  private static final int JFACTORY_INITIAL_NODE_CACHE_SIZE = 1000;
-
-  /*
    * The ratio of node table size to node cache size to preserve when resizing. The default
    * value is 0, which means never resize the cache.
    */
   private static final int JFACTORY_CACHE_RATIO = 64;
+
+  /*
+   * Initial size of the BDD factory node cache. Automatically resized when the node table is,
+   * to preserve the cache ratio.
+   */
+  private static final int JFACTORY_INITIAL_NODE_CACHE_SIZE =
+      (JFACTORY_INITIAL_NODE_TABLE_SIZE + JFACTORY_CACHE_RATIO - 1) / JFACTORY_CACHE_RATIO;
 
   private static final int DSCP_LENGTH = 6;
 

--- a/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDDFactory.java
@@ -337,8 +337,9 @@ public abstract class BDDFactory {
    * <p>Compare to bdd_setcacheratio.
    *
    * @param x cache ratio
+   * @return the previous cache ratio
    */
-  public abstract double setCacheRatio(double x);
+  public abstract int setCacheRatio(int x);
 
   /**
    * Sets the node table size.

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -5034,8 +5034,8 @@ public final class JFactory extends BDDFactory {
   }
 
   @Override
-  public double setCacheRatio(double x) {
-    return bdd_setcacheratio((int) (x * 100)) / 100.;
+  public int setCacheRatio(int r) {
+    return bdd_setcacheratio(r);
   }
 
   private int bdd_setcacheratio(int r) {

--- a/projects/bdd/src/main/java/net/sf/javabdd/MicroFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/MicroFactory.java
@@ -5498,8 +5498,8 @@ public class MicroFactory extends BDDFactory {
   }
 
   @Override
-  public double setCacheRatio(double x) {
-    return bdd_setcacheratio((int) (x * 100)) / 100.;
+  public int setCacheRatio(int r) {
+    return bdd_setcacheratio(r);
   }
 
   int bdd_setcacheratio(int r) {

--- a/projects/bdd/src/main/java/net/sf/javabdd/TestBDDFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/TestBDDFactory.java
@@ -496,9 +496,9 @@ public class TestBDDFactory extends BDDFactory {
   }
 
   @Override
-  public double setCacheRatio(double x) {
-    double r1 = f1.setCacheRatio(x);
-    double r2 = f2.setCacheRatio(x);
+  public int setCacheRatio(int r) {
+    int r1 = f1.setCacheRatio(r);
+    int r2 = f2.setCacheRatio(r);
     assertSame(r1 == r2, "setCacheRatio");
     return r1;
   }

--- a/projects/bdd/src/main/java/net/sf/javabdd/TypedBDDFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/TypedBDDFactory.java
@@ -133,8 +133,8 @@ public class TypedBDDFactory extends BDDFactory {
   }
 
   @Override
-  public double setCacheRatio(double x) {
-    return factory.setCacheRatio(x);
+  public int setCacheRatio(int r) {
+    return factory.setCacheRatio(r);
   }
 
   @Override


### PR DESCRIPTION
The old code would mysteriously interpret this as a number divided by 100. No idea why.

Caches were starting at size 10000 nodes 1000 cache entries, then being shrunk to 3 at the first resize (20000/6400 = 3).