### PR TITLE
OspfNeighborId: take into account processId

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfNeighborConfigId.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfNeighborConfigId.java
@@ -14,11 +14,22 @@ public final class OspfNeighborConfigId implements Serializable {
 
   private final String _hostname;
   private final String _vrfName;
+  private final String _procName;
   private final String _interfaceName;
 
-  public OspfNeighborConfigId(String hostname, String vrfName, String interfaceName) {
+  /**
+   * Create a new unique identifier for an OSPF process
+   *
+   * @param hostname the hostname on which the neighbor exists
+   * @param vrfName the name of a VRF on which the neighbor exists
+   * @param procName the name of OSPF process on which the neighbor exists
+   * @param interfaceName the interface name
+   */
+  public OspfNeighborConfigId(
+      String hostname, String vrfName, String procName, String interfaceName) {
     _hostname = hostname;
     _vrfName = vrfName;
+    _procName = procName;
     _interfaceName = interfaceName;
   }
 
@@ -28,6 +39,10 @@ public final class OspfNeighborConfigId implements Serializable {
 
   public String getVrfName() {
     return _vrfName;
+  }
+
+  public String getProcName() {
+    return _procName;
   }
 
   public String getInterfaceName() {
@@ -49,6 +64,7 @@ public final class OspfNeighborConfigId implements Serializable {
     OspfNeighborConfigId other = (OspfNeighborConfigId) o;
     return Objects.equals(_hostname, other._hostname)
         && Objects.equals(_vrfName, other._vrfName)
+        && Objects.equals(_procName, other._procName)
         && Objects.equals(_interfaceName, other._interfaceName);
   }
 
@@ -62,6 +78,7 @@ public final class OspfNeighborConfigId implements Serializable {
     return MoreObjects.toStringHelper(this)
         .add("hostname", _hostname)
         .add("vrfName", _vrfName)
+        .add("procName", _procName)
         .add("intefaceName", _interfaceName)
         .toString();
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfTopologyUtils.java
@@ -204,7 +204,8 @@ public final class OspfTopologyUtils {
           }
 
           graph.addNode(
-              new OspfNeighborConfigId(config.getHostname(), vrf.getName(), iface.get().getName()));
+              new OspfNeighborConfigId(
+                  config.getHostname(), vrf.getName(), proc.getProcessId(), iface.get().getName()));
         }
       }
     }
@@ -225,7 +226,9 @@ public final class OspfTopologyUtils {
                 .getInterface(remoteNodeInterface.getHostname(), remoteNodeInterface.getInterface())
                 .orElse(null);
 
-        if (remoteInterface == null || !remoteInterface.getActive()) {
+        if (remoteInterface == null
+            || !remoteInterface.getActive()
+            || remoteInterface.getOspfProcess() == null) {
           continue;
         }
 
@@ -233,6 +236,7 @@ public final class OspfTopologyUtils {
             new OspfNeighborConfigId(
                 remoteNodeInterface.getHostname(),
                 remoteInterface.getVrfName(),
+                remoteInterface.getOspfProcess(),
                 remoteNodeInterface.getInterface());
         getSessionIfCompatible(configId, remoteConfigId, networkConfigurations)
             .ifPresent(s -> graph.putEdgeValue(configId, remoteConfigId, s));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfNeighborConfigIdTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfNeighborConfigIdTest.java
@@ -13,17 +13,19 @@ public class OspfNeighborConfigIdTest {
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new OspfNeighborConfigId("h", "v", "i"), new OspfNeighborConfigId("h", "v", "i"))
-        .addEqualityGroup(new OspfNeighborConfigId("h2", "v", "i"))
-        .addEqualityGroup(new OspfNeighborConfigId("h", "v2", "i"))
-        .addEqualityGroup(new OspfNeighborConfigId("h", "v", "i2"))
+            new OspfNeighborConfigId("h", "v", "p", "i"),
+            new OspfNeighborConfigId("h", "v", "p", "i"))
+        .addEqualityGroup(new OspfNeighborConfigId("h2", "v", "p", "i"))
+        .addEqualityGroup(new OspfNeighborConfigId("h", "v2", "p", "i"))
+        .addEqualityGroup(new OspfNeighborConfigId("h", "v", "p2", "i"))
+        .addEqualityGroup(new OspfNeighborConfigId("h", "v", "p", "i2"))
         .addEqualityGroup(new Object())
         .testEquals();
   }
 
   @Test
   public void testJavaSerialization() {
-    OspfNeighborConfigId cid = new OspfNeighborConfigId("h", "v", "i");
+    OspfNeighborConfigId cid = new OspfNeighborConfigId("h", "v", "p", "i");
     assertThat(SerializationUtils.clone(cid), equalTo(cid));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfTopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfTopologyTest.java
@@ -19,10 +19,10 @@ public class OspfTopologyTest {
   public void testEquals() {
     MutableValueGraph<OspfNeighborConfigId, OspfSessionProperties> g1 =
         ValueGraphBuilder.directed().build();
-    g1.addNode(new OspfNeighborConfigId("h1", "vrf1", "i1"));
+    g1.addNode(new OspfNeighborConfigId("h1", "vrf1", "p", "i1"));
     MutableValueGraph<OspfNeighborConfigId, OspfSessionProperties> g2 =
         ValueGraphBuilder.from(g1).build();
-    g2.addNode(new OspfNeighborConfigId("h2", "vrf2", "i2"));
+    g2.addNode(new OspfNeighborConfigId("h2", "vrf2", "p", "i2"));
     new EqualsTester()
         .addEqualityGroup(OspfTopology.empty())
         .addEqualityGroup(new OspfTopology(g1), new OspfTopology(g1))
@@ -39,21 +39,21 @@ public class OspfTopologyTest {
 
   @Test
   public void testGetNeighborsNonExistentNode() {
-    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "i1");
+    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "p", "i1");
     assertThat(OspfTopology.empty().neighbors(n), empty());
   }
 
   @Test
   public void testGetIncomingEdgesNonExistentNode() {
-    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "i1");
+    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "p", "i1");
     assertThat(OspfTopology.empty().incomingEdges(n), empty());
   }
 
   @Test
   public void testGetIncomingEdges() {
     // Setup: small topo with one edge
-    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "i1");
-    OspfNeighborConfigId n2 = new OspfNeighborConfigId("h2", "vrf2", "i2");
+    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "p", "i1");
+    OspfNeighborConfigId n2 = new OspfNeighborConfigId("h2", "vrf2", "p2", "i2");
     MutableValueGraph<OspfNeighborConfigId, OspfSessionProperties> graph =
         ValueGraphBuilder.directed().build();
     graph.addNode(n);
@@ -71,8 +71,8 @@ public class OspfTopologyTest {
 
   @Test
   public void testEdgeIdEquals() {
-    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "i1");
-    OspfNeighborConfigId n2 = new OspfNeighborConfigId("h2", "vrf2", "i2");
+    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "p", "i1");
+    OspfNeighborConfigId n2 = new OspfNeighborConfigId("h2", "vrf2", "p", "i2");
     new EqualsTester()
         .addEqualityGroup(OspfTopology.makeEdge(n, n2), OspfTopology.makeEdge(n, n2))
         .addEqualityGroup(OspfTopology.makeEdge(n, n))
@@ -83,8 +83,8 @@ public class OspfTopologyTest {
 
   @Test
   public void testEdgeIdReverse() {
-    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "i1");
-    OspfNeighborConfigId n2 = new OspfNeighborConfigId("h2", "vrf2", "i2");
+    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "p", "i1");
+    OspfNeighborConfigId n2 = new OspfNeighborConfigId("h2", "vrf2", "p", "i2");
     EdgeId edgeId = OspfTopology.makeEdge(n, n2);
     assertThat(edgeId.reverse(), equalTo(OspfTopology.makeEdge(n2, n)));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfTopologyUtilsTest.java
@@ -20,9 +20,9 @@ public class OspfTopologyUtilsTest {
     // Setup
     MutableValueGraph<OspfNeighborConfigId, OspfSessionProperties> graph =
         ValueGraphBuilder.directed().allowsSelfLoops(false).build();
-    OspfNeighborConfigId n1 = new OspfNeighborConfigId("h1", "v", "i");
-    OspfNeighborConfigId n2 = new OspfNeighborConfigId("h2", "v", "i");
-    OspfNeighborConfigId n3 = new OspfNeighborConfigId("h3", "v", "i");
+    OspfNeighborConfigId n1 = new OspfNeighborConfigId("h1", "v", "p", "i");
+    OspfNeighborConfigId n2 = new OspfNeighborConfigId("h2", "v", "p", "i");
+    OspfNeighborConfigId n3 = new OspfNeighborConfigId("h3", "v", "p", "i");
     graph.addNode(n1);
     graph.addNode(n2);
     graph.addNode(n3);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -439,7 +439,10 @@ public class VirtualRouter implements Serializable {
                     topology
                         .incomingEdges(
                             new OspfNeighborConfigId(
-                                _node.getConfiguration().getHostname(), _name, interfaceName))
+                                _node.getConfiguration().getHostname(),
+                                _name,
+                                proc.getProcessId(),
+                                interfaceName))
                         .stream())
             .collect(
                 ImmutableSortedMap.toImmutableSortedMap(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpTest.java
@@ -250,9 +250,10 @@ public class EigrpTest {
 
     Interface.Builder nib = nf.interfaceBuilder().setOspfCost(1);
 
-    OspfProcess.Builder opb = nf.ospfProcessBuilder();
+    OspfProcess.Builder opb = nf.ospfProcessBuilder().setProcessId("1");
     OspfArea.Builder oab = nf.ospfAreaBuilder().setNumber(area);
-    Interface.Builder oib = nf.interfaceBuilder().setOspfCost(1).setOspfEnabled(true);
+    Interface.Builder oib =
+        nf.interfaceBuilder().setOspfCost(1).setOspfProcess("1").setOspfEnabled(true);
 
     /* Configuration 1 */
     Configuration c1 = buildConfiguration(R1, eib, epb, oib, opb, nib);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -164,10 +164,10 @@ public class OspfTest {
     Vrf v1 = vb.setOwner(c1).build();
     RoutingPolicy c1ExportPolicy =
         rpb.setOwner(c1).setStatements(getExportPolicyStatements(C1_L1_ADDRESS)).build();
-    OspfProcess op1 = opb.setVrf(v1).setExportPolicy(c1ExportPolicy).build();
+    OspfProcess op1 = opb.setVrf(v1).setProcessId("1").setExportPolicy(c1ExportPolicy).build();
     OspfArea oa1a = oaba.setOspfProcess(op1).build();
     OspfArea oa1b = areaA == areaB ? oa1a : oabb.setOspfProcess(op1).build();
-    ib.setOwner(c1).setVrf(v1).setOspfArea(oa1a);
+    ib.setOwner(c1).setVrf(v1).setOspfArea(oa1a).setOspfProcess("1");
     ib.setOspfPassive(true).setName(l0Name).setAddress(C1_L0_ADDRESS).build();
     ib.setOspfEnabled(false)
         .setOspfPassive(false)
@@ -320,6 +320,7 @@ public class OspfTest {
             .setOspfCost(10)
             .setOspfEnabled(true)
             .setOspfPointToPoint(true)
+            .setOspfProcess("1")
             .setBandwidth(100E6);
     OspfProcess.Builder opb = nf.ospfProcessBuilder().setProcessId("1");
     OspfArea.Builder oab = nf.ospfAreaBuilder();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/topology/OspfTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/topology/OspfTopologyTest.java
@@ -80,6 +80,7 @@ public class OspfTopologyTest {
             .setOwner(c1)
             .setOspfEnabled(true)
             .setOspfPassive(true)
+            .setOspfProcess("1")
             .setName("i12")
             .build();
 
@@ -89,6 +90,7 @@ public class OspfTopologyTest {
             .setOwner(c1)
             .setOspfEnabled(true)
             .setOspfPassive(false)
+            .setOspfProcess("1")
             .setName("i13")
             .build();
 
@@ -98,6 +100,7 @@ public class OspfTopologyTest {
             .setOwner(c1)
             .setOspfEnabled(true)
             .setOspfPassive(false)
+            .setOspfProcess("1")
             .setActive(false)
             .setName("i14")
             .build();
@@ -117,6 +120,7 @@ public class OspfTopologyTest {
             .setOwner(c2)
             .setOspfEnabled(true)
             .setOspfPassive(false)
+            .setOspfProcess("1")
             .setName("i21")
             .build();
     oab.setInterfaces(Collections.singleton(i21.getName())).setOspfProcess(proc2).build();
@@ -131,6 +135,7 @@ public class OspfTopologyTest {
             .setOwner(c3)
             .setOspfEnabled(true)
             .setOspfPassive(false)
+            .setOspfProcess("1")
             .setName("i31")
             .build();
     oab.setInterfaces(Collections.singleton(i31.getName())).setOspfProcess(proc3).build();
@@ -145,6 +150,7 @@ public class OspfTopologyTest {
             .setOwner(c4)
             .setOspfEnabled(true)
             .setOspfPassive(false)
+            .setOspfProcess("1")
             .setName("i41")
             .build();
     oab.setInterfaces(Collections.singleton(i41.getName())).setOspfProcess(proc4).build();
@@ -164,9 +170,9 @@ public class OspfTopologyTest {
 
     // Active neighbor relationship
     final OspfNeighborConfigId r1i13 =
-        new OspfNeighborConfigId("r1", Configuration.DEFAULT_VRF_NAME, "i13");
+        new OspfNeighborConfigId("r1", Configuration.DEFAULT_VRF_NAME, "1", "i13");
     final OspfNeighborConfigId r3i31 =
-        new OspfNeighborConfigId("r3", Configuration.DEFAULT_VRF_NAME, "i31");
+        new OspfNeighborConfigId("r3", Configuration.DEFAULT_VRF_NAME, "1", "i31");
     assertThat(topology.neighbors(r1i13), equalTo(ImmutableSet.of(r3i31)));
     assertThat(topology.neighbors(r3i31), equalTo(ImmutableSet.of(r1i13)));
     assertThat(
@@ -178,16 +184,20 @@ public class OspfTopologyTest {
 
     // Everyone else has no neighbors
     assertThat(
-        topology.neighbors(new OspfNeighborConfigId("r1", Configuration.DEFAULT_VRF_NAME, "i12")),
+        topology.neighbors(
+            new OspfNeighborConfigId("r1", Configuration.DEFAULT_VRF_NAME, "p", "i12")),
         empty());
     assertThat(
-        topology.neighbors(new OspfNeighborConfigId("r1", Configuration.DEFAULT_VRF_NAME, "i14")),
+        topology.neighbors(
+            new OspfNeighborConfigId("r1", Configuration.DEFAULT_VRF_NAME, "p", "i14")),
         empty());
     assertThat(
-        topology.neighbors(new OspfNeighborConfigId("r2", Configuration.DEFAULT_VRF_NAME, "i21")),
+        topology.neighbors(
+            new OspfNeighborConfigId("r2", Configuration.DEFAULT_VRF_NAME, "p", "i21")),
         empty());
     assertThat(
-        topology.neighbors(new OspfNeighborConfigId("r4", Configuration.DEFAULT_VRF_NAME, "i41")),
+        topology.neighbors(
+            new OspfNeighborConfigId("r4", Configuration.DEFAULT_VRF_NAME, "p", "i41")),
         empty());
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -302,7 +302,9 @@ public class EdgesAnswerer extends Answerer {
             .forEach(
                 interfaceName ->
                     topology
-                        .neighbors(new OspfNeighborConfigId(hostname, vrf.getName(), interfaceName))
+                        .neighbors(
+                            new OspfNeighborConfigId(
+                                hostname, vrf.getName(), proc.getProcessId(), interfaceName))
                         .stream()
                         .filter(n -> includeRemoteNodes.contains(n.getHostname()))
                         .forEach(

--- a/projects/question/src/main/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswerer.java
@@ -95,7 +95,8 @@ public class OspfSessionCompatibilityAnswerer extends Answerer {
                     .forEach(
                         iface -> {
                           OspfNeighborConfigId ospfNeighborConfigId =
-                              new OspfNeighborConfigId(node, vrf.getName(), iface);
+                              new OspfNeighborConfigId(
+                                  node, vrf.getName(), ospfProcess.getProcessId(), iface);
                           Set<OspfNeighborConfigId> filteredNeighbors =
                               ospfTopology.neighbors(ospfNeighborConfigId).stream()
                                   .filter(

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -287,8 +287,12 @@ public class EdgesAnswererTest {
 
     _host1.setVrfs(ImmutableSortedMap.of("vrf1", vrf1));
     _host2.setVrfs(ImmutableSortedMap.of("vrf2", vrf2));
-    _host1.getAllInterfaces().get("int1").setVrf(vrf1);
-    _host2.getAllInterfaces().get("int2").setVrf(vrf2);
+    Interface i1 = _host1.getAllInterfaces().get("int1");
+    i1.setVrf(vrf1);
+    i1.setOspfProcess(ospf1.getProcessId());
+    Interface i2 = _host2.getAllInterfaces().get("int2");
+    i2.setVrf(vrf2);
+    i2.setOspfProcess(ospf2.getProcessId());
 
     OspfTopologyUtils.initNeighborConfigs(NetworkConfigurations.of(_configurations));
     // Need edges to be bi-directional

--- a/projects/question/src/test/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswererTest.java
@@ -72,6 +72,7 @@ public class OspfSessionCompatibilityAnswererTest {
         .setName("int_u")
         .setVrf(vrfU)
         .setOwner(configurationU)
+        .setOspfProcess("U")
         .build();
 
     nf.interfaceBuilder()
@@ -79,10 +80,12 @@ public class OspfSessionCompatibilityAnswererTest {
         .setName("int_v")
         .setVrf(vrfV)
         .setOwner(configurationV)
+        .setOspfProcess("V")
         .build();
 
     nf.ospfProcessBuilder()
         .setVrf(vrfU)
+        .setProcessId("U")
         .setNeighbors(
             ImmutableMap.of(
                 "int_u",
@@ -95,6 +98,7 @@ public class OspfSessionCompatibilityAnswererTest {
         .build();
     nf.ospfProcessBuilder()
         .setVrf(vrfV)
+        .setProcessId("V")
         .setNeighbors(
             ImmutableMap.of(
                 "int_v",
@@ -112,8 +116,8 @@ public class OspfSessionCompatibilityAnswererTest {
         ValueGraphBuilder.directed().allowsSelfLoops(false).build();
 
     ospfGraph.putEdgeValue(
-        new OspfNeighborConfigId("configuration_u", "vrf_u", "int_u"),
-        new OspfNeighborConfigId("configuration_v", "vrf_v", "int_v"),
+        new OspfNeighborConfigId("configuration_u", "vrf_u", "U", "int_u"),
+        new OspfNeighborConfigId("configuration_v", "vrf_v", "V", "int_v"),
         new OspfSessionProperties(new IpLink(Ip.parse("1.1.1.2"), Ip.parse("1.1.1.3"))));
     _ospfTopology = new OspfTopology(ImmutableValueGraph.copyOf(ospfGraph));
   }


### PR DESCRIPTION
For proper topology establishment in the presence of multiple OSPF processes. 