### PR TITLE
PHC: fix ICMP codes, add reasonable Flow defaults

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraintsUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraintsUtil.java
@@ -143,11 +143,15 @@ public class PacketHeaderConstraintsUtil {
     if (icmpTypes != null) {
       checkArgument(icmpTypes.isSingleton(), "Cannot construct flow with multiple ICMP types");
       builder.setIcmpType(icmpTypes.singletonValue());
+    } else if (builder.getIpProtocol() == IpProtocol.ICMP) {
+      builder.setIcmpType(8); // Default to Echo request for unconstrained, used for ICMP ping
     }
     IntegerSpace icmpCodes = constraints.getIcmpCodes();
     if (icmpCodes != null) {
       checkArgument(icmpCodes.isSingleton(), "Cannot construct flow with multiple ICMP codes");
-      builder.setIcmpType(icmpCodes.singletonValue());
+      builder.setIcmpCode(icmpCodes.singletonValue());
+    } else if (builder.getIpProtocol() == IpProtocol.ICMP) {
+      builder.setIcmpCode(0); // Default to Echo request for unconstrained, used for ICMP ping
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
@@ -10,6 +10,7 @@ import static org.batfish.datamodel.PacketHeaderConstraintsUtil.setIcmpValues;
 import static org.batfish.datamodel.PacketHeaderConstraintsUtil.setPacketLength;
 import static org.batfish.datamodel.PacketHeaderConstraintsUtil.setSrcPort;
 import static org.batfish.datamodel.PacketHeaderConstraintsUtil.setTcpFlags;
+import static org.batfish.datamodel.PacketHeaderConstraintsUtil.toFlow;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -61,6 +62,32 @@ public class PacketHeaderConstraintsUtilTest {
             UniverseIpSpace.INSTANCE,
             UniverseIpSpace.INSTANCE),
         equalTo(packet.getFactory().one()));
+  }
+
+  @Test
+  public void testSetIcmpCode() {
+    PacketHeaderConstraints phc =
+        PacketHeaderConstraints.builder()
+            .setIcmpCodes(IntegerSpace.of(1))
+            .setIcmpTypes(IntegerSpace.of(2))
+            .build();
+    Builder builder = Flow.builder();
+    setIcmpValues(phc, builder);
+    assertThat(builder.getIcmpCode(), equalTo(1));
+    assertThat(builder.getIcmpType(), equalTo(2));
+  }
+
+  /**
+   * Test that unconstrained ICMP type/code defaults to ICMP ping (echo request) if the ip protocol
+   * is ICMP.
+   */
+  @Test
+  public void testDefaultToIcmpPing() {
+    PacketHeaderConstraints phc =
+        PacketHeaderConstraints.builder().setIpProtocols(ImmutableSet.of(IpProtocol.ICMP)).build();
+    Builder builder = toFlow(phc);
+    assertThat(builder.getIcmpType(), equalTo(8));
+    assertThat(builder.getIcmpCode(), equalTo(0));
   }
 
   @Test


### PR DESCRIPTION
* Fix bug where we were setting types twice
* Default to ICMP ping when constructing flows.