### PR TITLE
JFactory: only clear the cache if there are some free nodes

### DIFF
--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -3128,10 +3128,14 @@ public final class JFactory extends BDDFactory {
       }
     }
 
-    if (FLUSH_CACHE_ON_GC) {
-      bdd_operator_reset();
-    } else {
-      bdd_operator_clean();
+    if (bddfreenum > 0) {
+      // Don't reset or clean caches if we didn't free any nodes.
+
+      if (FLUSH_CACHE_ON_GC) {
+        bdd_operator_reset();
+      } else {
+        bdd_operator_clean();
+      }
     }
 
     c2 = System.currentTimeMillis();


### PR DESCRIPTION
Otherwise, there's no need to do so -- we didn't invalidate any BDDs.