### PR TITLE
Make hostname in Isp conf case-insensitive

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/ModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/ModelingUtils.java
@@ -122,7 +122,7 @@ public final class ModelingUtils {
             .map(BorderInterfaceInfo::getBorderInterface)
             .collect(
                 Collectors.groupingBy(
-                    NodeInterfacePair::getHostname,
+                    nodeInterfacePair -> nodeInterfacePair.getHostname().toLowerCase(),
                     Collectors.mapping(NodeInterfacePair::getInterface, Collectors.toSet())));
 
     Map<Long, IspInfo> asnToIspInfos = new HashMap<>();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/ModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/ModelingUtils.java
@@ -28,6 +28,7 @@ import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DeviceType;
+import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
@@ -37,7 +38,6 @@ import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Vrf;
-import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.isp_configuration.BorderInterfaceInfo;
 import org.batfish.datamodel.isp_configuration.IspConfiguration;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
@@ -123,7 +123,9 @@ public final class ModelingUtils {
             .collect(
                 Collectors.groupingBy(
                     nodeInterfacePair -> nodeInterfacePair.getHostname().toLowerCase(),
-                    Collectors.mapping(NodeInterfacePair::getInterface, Collectors.toSet())));
+                    Collectors.mapping(
+                        nodeInterfacePair -> nodeInterfacePair.getInterface().toLowerCase(),
+                        Collectors.toSet())));
 
     Map<Long, IspInfo> asnToIspInfos = new HashMap<>();
 
@@ -263,9 +265,12 @@ public final class ModelingUtils {
       Map<Long, IspInfo> allIspInfos) {
 
     // collecting InterfaceAddresses for interfaces
+    Map<String, Interface> caseInsensitiveIfaces =
+        configuration.getAllInterfaces().entrySet().stream()
+            .collect(Collectors.toMap(entry -> entry.getKey().toLowerCase(), Entry::getValue));
     Map<Ip, InterfaceAddress> ipToInterfaceAddresses =
         interfaces.stream()
-            .map(iface -> configuration.getAllInterfaces().get(iface))
+            .map(caseInsensitiveIfaces::get)
             .filter(Objects::nonNull)
             .flatMap(iface -> iface.getAllAddresses().stream())
             .collect(ImmutableMap.toImmutableMap(InterfaceAddress::getIp, Function.identity()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -698,15 +698,15 @@ public final class TopologyUtilTest {
   public void testIncompleteLyaer1TopologyHandlingIsp() {
     /*
      * Connectivity between border routers and generated ISP nodes
-     * Expected: H1 <=> B1 <=> INTERNET <=> B2 <=> H2
-     * Provided: H1 <=> B1   B2 <=> H2
-     * Use case: B1 and B2 are declared as border routers; topological connectivity should be
+     * Expected: h1 <=> b1 <=> INTERNET <=> b2 <=> h2
+     * Provided: h1 <=> b1   b2 <=> h2
+     * Use case: b1 and b2 are declared as border routers; topological connectivity should be
      *           synthesized via generated ISP nodes
      */
-    String b1Name = "B1";
-    String b2Name = "B2";
-    String h1Name = "H1";
-    String h2Name = "H2";
+    String b1Name = "b1";
+    String b2Name = "b2";
+    String h1Name = "h1";
+    String h2Name = "h2";
 
     String i1Name = "i1";
     String i2Name = "i2";
@@ -728,16 +728,16 @@ public final class TopologyUtilTest {
 
     Configuration cH1 = _cb.setHostname(h1Name).build();
     Vrf vH1 = _vb.setOwner(cH1).build();
-    _ib.setOwner(cH1).setVrf(vH1).setName(i1Name).build(); // H1 => B1
+    _ib.setOwner(cH1).setVrf(vH1).setName(i1Name).build(); // h1 => b1
 
     Configuration cH2 = _cb.setHostname(h2Name).build();
     Vrf vH2 = _vb.setOwner(cH2).build();
-    _ib.setOwner(cH2).setVrf(vH2).setName(i1Name).build(); // H2 => B2
+    _ib.setOwner(cH2).setVrf(vH2).setName(i1Name).build(); // h2 => b2
 
     Configuration cB1 = _cb.setHostname(b1Name).build();
     Vrf vB1 = _vb.setOwner(cB1).build();
-    _ib.setOwner(cB1).setVrf(vB1).setName(i1Name).build(); // B1 => H1
-    _ib.setName(i2Name).setAddress(b1i2Address).build(); // B1 => INTERNET
+    _ib.setOwner(cB1).setVrf(vB1).setName(i1Name).build(); // b1 => h1
+    _ib.setName(i2Name).setAddress(b1i2Address).build(); // b1 => INTERNET
     BgpProcess b1Proc =
         _nf.bgpProcessBuilder().setRouterId(b1i2Address.getIp()).setVrf(vB1).build();
     _nf.bgpNeighborBuilder()
@@ -750,7 +750,7 @@ public final class TopologyUtilTest {
 
     Configuration cB2 = _cb.setHostname(b2Name).build();
     Vrf vB2 = _vb.setOwner(cB2).build();
-    _ib.setOwner(cB2).setVrf(vB2).setName(i1Name).setAddress(null).build(); // B2 => H2
+    _ib.setOwner(cB2).setVrf(vB2).setName(i1Name).setAddress(null).build(); // b2 => h2
     _ib.setName(i2Name).setAddress(b2i2Address).build(); // B2 => INTERNET
     BgpProcess b2Proc =
         _nf.bgpProcessBuilder().setRouterId(b2i2Address.getIp()).setVrf(vB2).build();
@@ -825,10 +825,10 @@ public final class TopologyUtilTest {
                         || explicitNodes.contains(edge.getNode2()))
             .collect(ImmutableSet.toImmutableSet()),
         containsInAnyOrder(
-            both(hasHead(l3B1)).and(hasNode1(in(ispNodes))), // INTERNET => B1
-            both(hasTail(l3B1)).and(hasNode2(in(ispNodes))), // B1 => INTERNET
-            both(hasHead(l3B2)).and(hasNode1(in(ispNodes))), // INTERNET => B2
-            both(hasTail(l3B2)).and(hasNode2(in(ispNodes))))); // B2 => INTERNET
+            both(hasHead(l3B1)).and(hasNode1(in(ispNodes))), // INTERNET => b1
+            both(hasTail(l3B1)).and(hasNode2(in(ispNodes))), // b1 => INTERNET
+            both(hasHead(l3B2)).and(hasNode1(in(ispNodes))), // INTERNET => b2
+            both(hasTail(l3B2)).and(hasNode2(in(ispNodes))))); // b2 => INTERNET
 
     // Layer-3 topology should also contain other synthetic edges for the modeled ISPs
     assertThat(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/ModelingUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/ModelingUtilsTest.java
@@ -295,7 +295,7 @@ public class ModelingUtilsTest {
         cb.setHostname("conf").setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
     nf.vrfBuilder().setName(DEFAULT_VRF_NAME).setOwner(configuration).build();
     nf.interfaceBuilder()
-        .setName("interface")
+        .setName("Interface")
         .setOwner(configuration)
         .setAddress(new InterfaceAddress(Ip.parse("2.2.2.2"), 24))
         .build();
@@ -315,7 +315,7 @@ public class ModelingUtilsTest {
             ImmutableMap.of(configuration.getHostname(), configuration),
             new IspConfiguration(
                 ImmutableList.of(
-                    new BorderInterfaceInfo(new NodeInterfacePair("CoNf", "interface"))),
+                    new BorderInterfaceInfo(new NodeInterfacePair("CoNf", "InTeRfAcE"))),
                 IspFilter.ALLOW_ALL),
             new BatfishLogger("output", false));
 


### PR DESCRIPTION
Batfish preserves the Interface name case so that is still case sensitive