### PR TITLE
Add PERMIT_ALL to RouteFilterListLine, do minor cleanup

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterLine.java
@@ -1,33 +1,46 @@
 package org.batfish.datamodel;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** A line in a {@link RouteFilterList}. */
-public class RouteFilterLine implements Serializable {
+@ParametersAreNonnullByDefault
+public final class RouteFilterLine implements Serializable {
 
   private static final String PROP_ACTION = "action";
-
   private static final String PROP_LENGTH_RANGE = "lengthRange";
-
   private static final String PROP_IP_WILDCARD = "ipWildcard";
 
   private static final long serialVersionUID = 1L;
 
   private final LineAction _action;
-
   private final IpWildcard _ipWildcard;
-
   private final SubRange _lengthRange;
 
+  /** Route filter line that permits all routes */
+  public static final RouteFilterLine PERMIT_ALL =
+      new RouteFilterLine(
+          LineAction.PERMIT, Prefix.ZERO, new SubRange(0, Prefix.MAX_PREFIX_LENGTH));
+
   @JsonCreator
-  public RouteFilterLine(
-      @JsonProperty(PROP_ACTION) LineAction action,
-      @JsonProperty(PROP_IP_WILDCARD) IpWildcard ipWildcard,
-      @JsonProperty(PROP_LENGTH_RANGE) SubRange lengthRange) {
+  private static RouteFilterLine create(
+      @Nullable @JsonProperty(PROP_ACTION) LineAction action,
+      @Nullable @JsonProperty(PROP_IP_WILDCARD) IpWildcard ipWildcard,
+      @Nullable @JsonProperty(PROP_LENGTH_RANGE) SubRange lengthRange) {
+    checkArgument(action != null, "% is missing", PROP_ACTION);
+    checkArgument(ipWildcard != null, "% is missing", PROP_IP_WILDCARD);
+    checkArgument(lengthRange != null, "% is missing", PROP_LENGTH_RANGE);
+    return new RouteFilterLine(action, ipWildcard, lengthRange);
+  }
+
+  public RouteFilterLine(LineAction action, IpWildcard ipWildcard, SubRange lengthRange) {
     _action = action;
     _ipWildcard = ipWildcard;
     _lengthRange = lengthRange;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterLine.java
@@ -57,7 +57,7 @@ public final class RouteFilterLine implements Serializable {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (o == this) {
       return true;
     } else if (!(o instanceof RouteFilterLine)) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RouteFilterLineTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RouteFilterLineTest.java
@@ -1,0 +1,64 @@
+package org.batfish.datamodel;
+
+import static org.batfish.datamodel.RouteFilterLine.PERMIT_ALL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Test of {@link RouteFilterLine} */
+public class RouteFilterLineTest {
+  @Test
+  public void testEquals() {
+    RouteFilterLine rfl =
+        new RouteFilterLine(
+            LineAction.PERMIT, new IpWildcard(Ip.parse("1.1.1.1")), new SubRange(30, 32));
+    new EqualsTester()
+        .addEqualityGroup(
+            rfl,
+            rfl,
+            new RouteFilterLine(
+                LineAction.PERMIT, new IpWildcard(Ip.parse("1.1.1.1")), new SubRange(30, 32)))
+        .addEqualityGroup(
+            new RouteFilterLine(
+                LineAction.DENY, new IpWildcard(Ip.parse("1.1.1.1")), new SubRange(30, 32)))
+        .addEqualityGroup(
+            new RouteFilterLine(
+                LineAction.PERMIT, new IpWildcard(Ip.parse("2.2.2.2")), new SubRange(30, 32)))
+        .addEqualityGroup(
+            new RouteFilterLine(
+                LineAction.PERMIT, new IpWildcard(Ip.parse("2.2.2.2")), new SubRange(29, 32)))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    RouteFilterLine rfl =
+        new RouteFilterLine(
+            LineAction.PERMIT, new IpWildcard(Ip.parse("1.1.1.1")), new SubRange(30, 32));
+    assertThat(SerializationUtils.clone(rfl), equalTo(rfl));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    RouteFilterLine rfl =
+        new RouteFilterLine(
+            LineAction.PERMIT, new IpWildcard(Ip.parse("1.1.1.1")), new SubRange(30, 32));
+    assertThat(BatfishObjectMapper.clone(rfl, RouteFilterLine.class), equalTo(rfl));
+  }
+
+  @Test
+  public void testPermitAll() {
+    RouteFilterList rfl = new RouteFilterList("name", ImmutableList.of(PERMIT_ALL));
+    for (int prefixLen = 0; prefixLen <= Prefix.MAX_PREFIX_LENGTH; prefixLen++) {
+      assertTrue(rfl.permits(Prefix.create(Ip.parse("1.1.1.1"), prefixLen)));
+    }
+  }
+}


### PR DESCRIPTION
It's convenient to just have a line that permits all prefixes.
Added some tests while I was at it.