### PR TITLE
CompareFilters: add ignoreComposites, fix reference bug

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/FilterQuestionUtils.java
+++ b/projects/question/src/main/java/org/batfish/question/FilterQuestionUtils.java
@@ -33,18 +33,19 @@ public final class FilterQuestionUtils {
 
   /** Get filters specified by the given filter specifier. */
   public static Multimap<String, String> getSpecifiedFilters(
-      Map<String, Configuration> configs,
+      SpecifierContext specifierContext,
       NodeSpecifier nodeSpecifier,
       FilterSpecifier filterSpecifier,
-      SpecifierContext specifierContext) {
+      boolean ignoreComposites) {
     Set<String> nodes = nodeSpecifier.resolve(specifierContext);
     ImmutableMultimap.Builder<String, String> filters = ImmutableMultimap.builder();
+    Map<String, Configuration> configs = specifierContext.getConfigs();
     nodes.stream()
         .map(configs::get)
         .forEach(
             config ->
-                filterSpecifier
-                    .resolve(config.getHostname(), specifierContext)
+                filterSpecifier.resolve(config.getHostname(), specifierContext).stream()
+                    .filter(f -> !ignoreComposites || !f.isComposite())
                     .forEach(filter -> filters.put(config.getHostname(), filter.getName())));
     return filters.build();
   }

--- a/projects/question/src/main/java/org/batfish/question/comparefilters/CompareFiltersQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/comparefilters/CompareFiltersQuestion.java
@@ -1,5 +1,7 @@
 package org.batfish.question.comparefilters;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -17,21 +19,26 @@ import org.batfish.specifier.SpecifierFactories;
 @ParametersAreNonnullByDefault
 public final class CompareFiltersQuestion extends Question {
   private static final String PROP_FILTERS = "filters";
+  private static final String PROP_IGNORE_COMPOSITES = "ignoreComposites";
   private static final String PROP_NODES = "nodes";
 
   private static final FilterSpecifier DEFAULT_FILTER_SPECIFIER =
       AllFiltersFilterSpecifier.INSTANCE;
+  private static final Boolean DEFAULT_IGNORE_COMPOSITES = Boolean.TRUE;
   private static final NodeSpecifier DEFAULT_NODE_SPECIFIER = AllNodesNodeSpecifier.INSTANCE;
 
   @Nullable private final String _filters;
+  private final boolean _ignoreComposites;
   @Nullable private final String _nodes;
 
   CompareFiltersQuestion() {
-    this(null, null);
+    this(null, null, null);
   }
 
-  CompareFiltersQuestion(@Nullable String filters, @Nullable String nodes) {
+  CompareFiltersQuestion(
+      @Nullable String filters, @Nullable Boolean ignoreComposites, @Nullable String nodes) {
     _filters = filters;
+    _ignoreComposites = firstNonNull(ignoreComposites, DEFAULT_IGNORE_COMPOSITES);
     _nodes = nodes;
     setDifferential(true);
   }
@@ -39,8 +46,9 @@ public final class CompareFiltersQuestion extends Question {
   @JsonCreator
   private static CompareFiltersQuestion jsonCreator(
       @JsonProperty(PROP_FILTERS) @Nullable String filters,
+      @JsonProperty(PROP_IGNORE_COMPOSITES) @Nullable Boolean ignoreComposites,
       @JsonProperty(PROP_NODES) @Nullable String nodes) {
-    return new CompareFiltersQuestion(filters, nodes);
+    return new CompareFiltersQuestion(filters, ignoreComposites, nodes);
   }
 
   @Override
@@ -63,6 +71,11 @@ public final class CompareFiltersQuestion extends Question {
   @JsonIgnore
   FilterSpecifier getFilterSpecifier() {
     return SpecifierFactories.getFilterSpecifierOrDefault(_filters, DEFAULT_FILTER_SPECIFIER);
+  }
+
+  @JsonProperty(PROP_IGNORE_COMPOSITES)
+  public boolean getIgnoreComposites() {
+    return _ignoreComposites;
   }
 
   @Nullable

--- a/questions/experimental/compareFilters.json
+++ b/questions/experimental/compareFilters.json
@@ -2,6 +2,7 @@
     "class": "org.batfish.question.comparefilters.CompareFiltersQuestion",
     "differential": true,
     "filters": "${filters}",
+    "ignoreComposites": "${ignoreComposites}",
     "nodes": "${nodes}",
     "instance": {
       "description": "Compares filters with the same name in the current and reference snapshots. Returns pairs of lines, one from each filter, that match the same flow(s) but treat them differently (i.e. one permits and the other denies the flow).",
@@ -21,6 +22,13 @@
                 "optional": true,
                 "type": "filter",
                 "displayName": "Filters"
+            },
+            "ignoreComposites": {
+                "description": "Whether to ignore filters that are composed of multiple filters defined in the configs",
+                "type": "boolean",
+                "optional": true,
+                "value": false,
+                "displayName": "Ignore composite filters"
             },
             "nodes": {
                 "description": "Only evaluate filters present on nodes matching this specifier",

--- a/questions/experimental/compareFilters.json
+++ b/questions/experimental/compareFilters.json
@@ -10,7 +10,8 @@
         "longDescription": "This question can be used to summarize how a filter has changed over time. In particular, it highlights differences that cause flows to be denied when they used to be permitted, or vice versa. The output is a table that includes pairs of lines, one from each version of the filter, that both match at least one common flow, and have different action (permit or deny).",
         "orderedVariableNames": [
             "nodes",
-            "filters"
+            "filters",
+            "ignoreComposites"
         ],
         "tags": [
             "dataPlane",

--- a/tests/questions/experimental/commands
+++ b/tests/questions/experimental/commands
@@ -22,7 +22,7 @@ test -raw tests/questions/experimental/bidirectionalTraceroute.ref validate-temp
 test -raw tests/questions/experimental/bidirectionalReachability.ref validate-template bidirectionalReachability headers={"dstIps" : "1.1.1.1/32"}, pathConstraints={"startLocation": "loc"}, returnFlowType="SUCCESS"
 
 # validate compareFilters
-test -raw tests/questions/experimental/compareFilters.ref validate-template compareFilters filters=".*", nodes=".*"
+test -raw tests/questions/experimental/compareFilters.ref validate-template compareFilters filters=".*", ignoreComposites=false, nodes=".*"
 
 # validate detectLoops
 test -raw tests/questions/experimental/detectLoops.ref validate-template detectLoops maxTraces=0

--- a/tests/questions/experimental/compareFilters.ref
+++ b/tests/questions/experimental/compareFilters.ref
@@ -1,6 +1,7 @@
 {
   "class" : "org.batfish.question.comparefilters.CompareFiltersQuestion",
   "filters" : ".*",
+  "ignoreComposites" : false,
   "nodes" : ".*",
   "differential" : true,
   "includeOneTableKeys" : true,
@@ -23,6 +24,13 @@
         "optional" : true,
         "type" : "filter",
         "value" : ".*"
+      },
+      "ignoreComposites" : {
+        "description" : "Whether to ignore filters that are composed of multiple filters defined in the configs",
+        "displayName" : "Ignore composite filters",
+        "optional" : true,
+        "type" : "boolean",
+        "value" : false
       },
       "nodes" : {
         "description" : "Only evaluate filters present on nodes matching this specifier",

--- a/tests/questions/experimental/compareFilters.ref
+++ b/tests/questions/experimental/compareFilters.ref
@@ -11,7 +11,8 @@
     "longDescription" : "This question can be used to summarize how a filter has changed over time. In particular, it highlights differences that cause flows to be denied when they used to be permitted, or vice versa. The output is a table that includes pairs of lines, one from each version of the filter, that both match at least one common flow, and have different action (permit or deny).",
     "orderedVariableNames" : [
       "nodes",
-      "filters"
+      "filters",
+      "ignoreComposites"
     ],
     "tags" : [
       "acl",


### PR DESCRIPTION
1. Add ignoreComposites flag, copied from filterLineReachability.json
2. Fix a bug in current/reference configs confusion. The issue stemmed from passing around
   redundant sources of truth that could conflict. Rewrote the code to prevent such confusion.