### PR TITLE
OspfProcess: enforce correctly initialized areas

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
@@ -247,6 +247,11 @@ public final class OspfProcess implements Serializable {
                 computeDefaultAdminCosts(ConfigurationFormat.CISCO_IOS)));
     checkArgument(_adminCosts.keySet().containsAll(REQUIRES_ADMIN));
     _areas = firstNonNull(areas, ImmutableSortedMap.of());
+    // Ensure area numbers match up
+    checkArgument(
+        _areas.entrySet().stream()
+            .allMatch(entry -> entry.getKey() == entry.getValue().getAreaNumber()),
+        "Area number does not match up with map key");
     _exportPolicy = exportPolicy;
     _exportPolicySources = firstNonNull(exportPolicySources, ImmutableSortedSet.of());
     _generatedRoutes = firstNonNull(generatedRoutes, ImmutableSortedSet.of());
@@ -427,6 +432,11 @@ public final class OspfProcess implements Serializable {
   }
 
   public void setAreas(SortedMap<Long, OspfArea> areas) {
+    // Ensure area numbers match up
+    checkArgument(
+        areas.entrySet().stream()
+            .allMatch(entry -> entry.getKey() == entry.getValue().getAreaNumber()),
+        "Area number does not match up with map key");
     _areas = areas;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfProcessTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfProcessTest.java
@@ -82,4 +82,25 @@ public class OspfProcessTest {
     // Compute values for passive interfaces
     assertThat(i3.getOspfCost(), equalTo(100));
   }
+
+  @Test
+  public void setAreasMismatchedNumbers() {
+    final NetworkFactory networkFactory = new NetworkFactory();
+    OspfProcess proc =
+        OspfProcess.builder(networkFactory).setProcessId("1").setReferenceBandwidth(10e8).build();
+    _thrown.expect(IllegalArgumentException.class);
+    proc.setAreas(
+        ImmutableSortedMap.of(1L, OspfArea.builder(networkFactory).setNumber(2L).build()));
+  }
+
+  @Test
+  public void setAreasMismatchedNumbersOnBuild() {
+    final NetworkFactory networkFactory = new NetworkFactory();
+    _thrown.expect(IllegalArgumentException.class);
+    OspfProcess.builder(networkFactory)
+        .setProcessId("1")
+        .setReferenceBandwidth(10e8)
+        .setAreas(ImmutableSortedMap.of(1L, OspfArea.builder(networkFactory).setNumber(2L).build()))
+        .build();
+  }
 }

--- a/projects/question/src/test/java/org/batfish/question/ospfprocess/OspfProcessConfigAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfprocess/OspfProcessConfigAnswererTest.java
@@ -50,7 +50,8 @@ public class OspfProcessConfigAnswererTest {
     nf.ospfProcessBuilder()
         .setProcessId("ospf_1")
         .setAreas(
-            ImmutableSortedMap.of(1L, nf.ospfAreaBuilder().setInjectDefaultRoute(true).build()))
+            ImmutableSortedMap.of(
+                1L, nf.ospfAreaBuilder().setNumber(1).setInjectDefaultRoute(true).build()))
         .setExportPolicySources(ImmutableSortedSet.of("export_policy_source"))
         .setExportPolicyName("export_policy")
         .setReferenceBandwidth(12d)
@@ -91,7 +92,8 @@ public class OspfProcessConfigAnswererTest {
         nf.ospfProcessBuilder()
             .setProcessId("ospf_1")
             .setAreas(
-                ImmutableSortedMap.of(1L, nf.ospfAreaBuilder().setInjectDefaultRoute(true).build()))
+                ImmutableSortedMap.of(
+                    1L, nf.ospfAreaBuilder().setNumber(1).setInjectDefaultRoute(true).build()))
             .setExportPolicySources(ImmutableSortedSet.of("export_policy_source"))
             .setExportPolicyName("export_policy")
             .setReferenceBandwidth(12d)


### PR DESCRIPTION
Keys must match the area number stored in OspfArea