### PR TITLE
Cleanup juniper format detection

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
@@ -47,7 +47,7 @@ public final class VendorConfigurationFormatDetector {
   private static final Pattern RANCID_FOUNDRY_PATTERN =
       Pattern.compile("(?m)^!RANCID-CONTENT-TYPE: foundry$");
   private static final Pattern RANCID_JUNIPER_PATTERN =
-      Pattern.compile("(?m)^!RANCID-CONTENT-TYPE: juniper$");
+      Pattern.compile("(?m)^[!#]RANCID-CONTENT-TYPE: juniper$");
   private static final Pattern RANCID_MRV_PATTERN =
       Pattern.compile("(?m)^!RANCID-CONTENT-TYPE: mrv$");
   private static final Pattern RANCID_PALO_ALTO_PATTERN =
@@ -229,13 +229,11 @@ public final class VendorConfigurationFormatDetector {
         || FLAT_JUNIPER_HOSTNAME_DECLARATION_PATTERN.matcher(_fileText).find(0)
         || (_fileText.contains("apply-groups") && SET_PATTERN.matcher(_fileText).find(0))) {
       return ConfigurationFormat.FLAT_JUNIPER;
-    } else if (_firstChar == '#'
-        || (_fileText.contains("version")
-            && _fileText.contains("system")
+    } else if (_fileText.contains("system")
             && _fileText.contains("{")
             && _fileText.contains("}")
             && _fileText.contains("host-name")
-            && _fileText.contains("interfaces"))
+            && _fileText.contains("interfaces")
         || fileTextMatches(JUNIPER_ACL_PATTERN)
         || fileTextMatches(JUNIPER_POLICY_OPTIONS_PATTERN)
         || fileTextMatches(JUNIPER_SNMP_PATTERN)) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -67,22 +67,25 @@ public class VendorConfigurationFormatDetectorTest {
     String firewall = "firewall {\n}\n";
     String policyOptions = "policy-options {\n}\n";
     String rancid = "!RANCID-CONTENT-TYPE: juniper\n!\nsomething {\n blah;\n}\n";
+    String rancid2 = "#RANCID-CONTENT-TYPE: juniper\n!\nsomething {\n blah;\n}\n";
     String snmp = "snmp {\n}\n";
 
     String flatHostname = "#\nset system host-name blah";
     String flatRancid = "!RANCID-CONTENT-TYPE: juniper\n!\nset blah\n";
+    String flatRancid2 = "#RANCID-CONTENT-TYPE: juniper\n!\nset blah\n";
     String flatSet = "#\nset apply-groups blah\n";
     String flattened = "####BATFISH FLATTENED JUNIPER CONFIG####\n";
 
     String flatSwitch = "set hostname\n";
 
     /* Confirm hierarchical configs are correctly identified */
-    for (String fileText : ImmutableList.of(firewall, policyOptions, rancid, snmp)) {
+    for (String fileText : ImmutableList.of(firewall, policyOptions, rancid, rancid2, snmp)) {
       assertThat(identifyConfigurationFormat(fileText), equalTo(JUNIPER));
     }
 
     /* Confirm flat (set-style) configs are correctly identified */
-    for (String fileText : ImmutableList.of(flatHostname, flatRancid, flatSet, flattened)) {
+    for (String fileText :
+        ImmutableList.of(flatHostname, flatRancid, flatRancid2, flatSet, flattened)) {
       assertThat(identifyConfigurationFormat(fileText), equalTo(FLAT_JUNIPER));
     }
 

--- a/projects/batfish/src/test/java/org/batfish/job/FlattenVendorConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/FlattenVendorConfigurationJobTest.java
@@ -9,6 +9,7 @@ import org.batfish.common.util.CommonUtil;
 import org.batfish.config.Settings;
 import org.junit.Test;
 
+/** Tests of {@link FlattenVendorConfigurationJob}. */
 public class FlattenVendorConfigurationJobTest {
   private static final String JUNIPER_TESTCONFIGS_PREFIX =
       "org/batfish/grammar/juniper/testconfigs/";

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/hierarchical
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/hierarchical
@@ -1,4 +1,4 @@
-# RANCID-CONTENT-TYPE: juniper
+#RANCID-CONTENT-TYPE: juniper
 system {
   host-name a.example.com;
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config
@@ -1,4 +1,4 @@
-#
+#RANCID-CONTENT-TYPE: juniper
 system {
     host-name nested-config;
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config-brackets
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config-brackets
@@ -1,4 +1,4 @@
-#
+#RANCID-CONTENT-TYPE: juniper
 security {
     policies {
         global {


### PR DESCRIPTION
1. Recognize newer RANCID which uses vendor-specific comments.
2. Relax _firstChar=# to mean juniper -- too broad.
3. Update tests to support recognition.