### PR TITLE
Add PAT in session transformation in traceroute for return flows

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
@@ -8,6 +8,7 @@ import static org.batfish.datamodel.flow.StepAction.NEIGHBOR_UNREACHABLE;
 import static org.batfish.datamodel.flow.StepAction.RECEIVED;
 import static org.batfish.datamodel.transformation.Transformation.always;
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
+import static org.batfish.datamodel.transformation.TransformationStep.assignSourcePort;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -229,11 +230,23 @@ public final class TracerouteUtils {
       transformationStepsBuilder.add(assignSourceIp(origDstIp, origDstIp));
     }
 
+    Integer origDstPort = inputFlow.getDstPort();
+    if (!origDstPort.equals(currentFlow.getDstPort())) {
+      transformationStepsBuilder.add(assignSourcePort(origDstPort, origDstPort));
+    }
+
     Ip origSrcIp = inputFlow.getSrcIp();
     if (!origSrcIp.equals(currentFlow.getSrcIp())) {
       transformationStepsBuilder.add(
           org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp(
               origSrcIp, origSrcIp));
+    }
+
+    Integer origSrcPort = inputFlow.getSrcPort();
+    if (!origSrcPort.equals(currentFlow.getSrcPort())) {
+      transformationStepsBuilder.add(
+          org.batfish.datamodel.transformation.TransformationStep.assignDestinationPort(
+              origSrcPort, origSrcPort));
     }
 
     List<org.batfish.datamodel.transformation.TransformationStep> transformationSteps =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -39,6 +39,7 @@ import static org.batfish.datamodel.transformation.Noop.NOOP_SOURCE_NAT;
 import static org.batfish.datamodel.transformation.Transformation.always;
 import static org.batfish.datamodel.transformation.Transformation.when;
 import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp;
+import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationPort;
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourcePort;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.getFinalActionForDisposition;
@@ -1452,7 +1453,8 @@ public class TracerouteEngineImplTest {
     Ip poolIp = Ip.parse("4.4.4.4");
     ib.setName(i4Name)
         .setAddress(new InterfaceAddress("1.1.4.1/24"))
-        .setOutgoingTransformation(always().apply(assignSourceIp(poolIp, poolIp)).build())
+        .setOutgoingTransformation(
+            always().apply(assignSourceIp(poolIp, poolIp), assignSourcePort(2000, 2000)).build())
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
                 ImmutableSet.of(i4Name), incomingAclName, outgoingAclName))
@@ -1583,7 +1585,7 @@ public class TracerouteEngineImplTest {
                           .setSrcIp(dstIp)
                           .setSrcPort(dstPort)
                           .setDstIp(poolIp)
-                          .setDstPort(srcPort)
+                          .setDstPort(2000)
                           .setTag("TAG")
                           .build()),
                   hasNewFirewallSessions(
@@ -1593,8 +1595,12 @@ public class TracerouteEngineImplTest {
                               i1Name,
                               null,
                               ImmutableSet.of(i4Name),
-                              match5Tuple(dstIp, dstPort, poolIp, srcPort, ipProtocol),
-                              always().apply(assignDestinationIp(srcIp, srcIp)).build()))))));
+                              match5Tuple(dstIp, dstPort, poolIp, 2000, ipProtocol),
+                              always()
+                                  .apply(
+                                      assignDestinationIp(srcIp, srcIp),
+                                      assignDestinationPort(srcPort, srcPort))
+                                  .build()))))));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteUtilsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteUtilsTest.java
@@ -1,14 +1,22 @@
 package org.batfish.dataplane.traceroute;
 
+import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp;
+import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationPort;
+import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
+import static org.batfish.datamodel.transformation.TransformationStep.assignSourcePort;
 import static org.batfish.dataplane.traceroute.TracerouteUtils.getTcpFlagsForReverse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.TcpFlags;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
+import org.batfish.datamodel.transformation.Transformation;
 import org.junit.Test;
 
 /** Tests for {@link TracerouteUtils}. */
@@ -127,5 +135,55 @@ public final class TracerouteUtilsTest {
     assertFalse(reverseTcpFlags.getEce());
     assertFalse(reverseTcpFlags.getPsh());
     assertFalse(reverseTcpFlags.getCwr());
+  }
+
+  @Test
+  public void testSessionTransformation() {
+    Ip srcIp1 = Ip.parse("1.1.1.1");
+    Ip dstIp1 = Ip.parse("2.2.2.2");
+    int srcPort1 = 10001;
+    int dstPort1 = 10002;
+    Ip srcIp2 = Ip.parse("3.3.3.3");
+    Ip dstIp2 = Ip.parse("4.4.4.4");
+    int srcPort2 = 10003;
+    int dstPort2 = 10004;
+
+    Flow inputFlow =
+        Flow.builder()
+            .setIngressNode("inNode")
+            .setIngressInterface("inInterf")
+            .setTag("tag")
+            .setDstIp(dstIp1)
+            .setSrcIp(srcIp1)
+            .setDstPort(dstPort1)
+            .setSrcPort(srcPort1)
+            .setIpProtocol(IpProtocol.TCP)
+            .build();
+    Flow currentFlow =
+        Flow.builder()
+            .setIngressNode("inNode")
+            .setIngressInterface("inInterf")
+            .setTag("tag")
+            .setDstIp(dstIp2)
+            .setSrcIp(srcIp2)
+            .setDstPort(dstPort2)
+            .setSrcPort(srcPort2)
+            .setIpProtocol(IpProtocol.TCP)
+            .build();
+
+    Transformation transformation = TracerouteUtils.sessionTransformation(inputFlow, currentFlow);
+
+    assertThat(
+        transformation,
+        equalTo(
+            new Transformation(
+                AclLineMatchExprs.TRUE,
+                ImmutableList.of(
+                    assignSourceIp(dstIp1, dstIp1),
+                    assignSourcePort(dstPort1, dstPort1),
+                    assignDestinationIp(srcIp1, srcIp1),
+                    assignDestinationPort(srcPort1, srcPort1)),
+                null,
+                null)));
   }
 }


### PR DESCRIPTION
When a flow is applied PAT, the session should remember the transformation so that the return flow can be transformed correctly.