### PR TITLE
Nonnull annotations for Cisco ACL fields

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -4260,7 +4260,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     return String.format("SECURITY_LEVEL_%s", securityLevel);
   }
 
-  private boolean isAclUsedForRouting(String aclName) {
+  private boolean isAclUsedForRouting(@Nonnull String aclName) {
     String currentMapName;
     for (Vrf vrf : _vrfs.values()) {
       // check ospf policies

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/ExtendedAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/ExtendedAccessList.java
@@ -3,30 +3,31 @@ package org.batfish.representation.cisco;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
 
 public class ExtendedAccessList implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private List<ExtendedAccessListLine> _lines;
-
-  private final String _name;
-
+  @Nonnull private List<ExtendedAccessListLine> _lines;
+  @Nonnull private final String _name;
   private StandardAccessList _parent;
 
-  public ExtendedAccessList(String id) {
+  public ExtendedAccessList(@Nonnull String id) {
     _name = id;
     _lines = new ArrayList<>();
   }
 
-  public void addLine(ExtendedAccessListLine all) {
-    _lines.add(all);
+  public void addLine(ExtendedAccessListLine line) {
+    _lines.add(line);
   }
 
+  @Nonnull
   public List<ExtendedAccessListLine> getLines() {
     return _lines;
   }
 
+  @Nonnull
   public String getName() {
     return _name;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/ExtendedAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/ExtendedAccessList.java
@@ -18,7 +18,7 @@ public class ExtendedAccessList implements Serializable {
     _lines = new ArrayList<>();
   }
 
-  public void addLine(ExtendedAccessListLine line) {
+  public void addLine(@Nonnull ExtendedAccessListLine line) {
     _lines.add(line);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/StandardAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/StandardAccessList.java
@@ -3,16 +3,16 @@ package org.batfish.representation.cisco;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
 
 public class StandardAccessList implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private List<StandardAccessListLine> _lines;
+  @Nonnull private List<StandardAccessListLine> _lines;
+  @Nonnull private final String _name;
 
-  private final String _name;
-
-  public StandardAccessList(String id) {
+  public StandardAccessList(@Nonnull String id) {
     _name = id;
     _lines = new ArrayList<>();
   }
@@ -21,10 +21,12 @@ public class StandardAccessList implements Serializable {
     _lines.add(all);
   }
 
+  @Nonnull
   public List<StandardAccessListLine> getLines() {
     return _lines;
   }
 
+  @Nonnull
   public String getName() {
     return _name;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/StandardAccessList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/StandardAccessList.java
@@ -17,8 +17,8 @@ public class StandardAccessList implements Serializable {
     _lines = new ArrayList<>();
   }
 
-  public void addLine(StandardAccessListLine all) {
-    _lines.add(all);
+  public void addLine(@Nonnull StandardAccessListLine line) {
+    _lines.add(line);
   }
 
   @Nonnull


### PR DESCRIPTION
Will make for cleaner code in forthcoming distribute-list PR.