### PR TITLE
Add ordered variable names to bidirectional traceroute

### DIFF
--- a/questions/experimental/bidirectionalTraceroute.json
+++ b/questions/experimental/bidirectionalTraceroute.json
@@ -9,6 +9,12 @@
         "description": "Trace the path(s) for the specified flow, along with path(s) for reverse flows.",
         "instanceName": "bidirectionalTraceroute",
         "longDescription": "This question performs a virtual traceroute in the network from a starting node. A destination IP and ingress (source) node must be specified. Other IP headers are given default values if unspecified.\nIf the trace succeeds, a traceroute is performed in the reverse direction.",
+        "orderedVariableNames": [
+            "startLocation",
+            "headers",
+            "maxTraces",
+            "ignoreFilters"
+        ],
         "tags": [
             "dataPlane",
             "reachability",

--- a/tests/questions/experimental/bidirectionalTraceroute.ref
+++ b/tests/questions/experimental/bidirectionalTraceroute.ref
@@ -12,6 +12,12 @@
     "description" : "Trace the path(s) for the specified flow, along with path(s) for reverse flows.",
     "instanceName" : "qname",
     "longDescription" : "This question performs a virtual traceroute in the network from a starting node. A destination IP and ingress (source) node must be specified. Other IP headers are given default values if unspecified.\nIf the trace succeeds, a traceroute is performed in the reverse direction.",
+    "orderedVariableNames" : [
+      "startLocation",
+      "headers",
+      "maxTraces",
+      "ignoreFilters"
+    ],
     "tags" : [
       "dataPlane",
       "reachability",

--- a/tests/questions/test_questions.py
+++ b/tests/questions/test_questions.py
@@ -106,7 +106,6 @@ NO_ORDERED_VARIABLE_NAMES_QUESTIONS = {
     'questions/experimental/bgpProcessConfiguration.json',
     'questions/experimental/bgpSessionCompatibility.json',
     'questions/experimental/bgpSessionStatus.json',
-    'questions/experimental/bidirectionalTraceroute.json',
     'questions/experimental/differentialReachability.json',
     'questions/experimental/filterLineReachability.json',
     'questions/experimental/filterTable.json',


### PR DESCRIPTION
This PR adds `orderedVariableNames` to bidirectional traceroute to match the ordering in regular traceroute.