### PR TITLE
Robust parser and lexer non-recovery error behavior

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishCombinedParser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishCombinedParser.java
@@ -33,6 +33,8 @@ public abstract class BatfishCombinedParser<P extends BatfishParser, L extends B
 
   private BatfishParserErrorListener _parserErrorListener;
 
+  private boolean _recovery;
+
   private GrammarSettings _settings;
 
   private List<Integer> _tokenModes;
@@ -82,7 +84,7 @@ public abstract class BatfishCombinedParser<P extends BatfishParser, L extends B
       Class<L> lClass,
       String input,
       GrammarSettings settings,
-      BatfishANTLRErrorStrategy.BatfishANTLRErrorStrategyFactory batfishANTLRErrorStrategyFactor,
+      BatfishANTLRErrorStrategy.BatfishANTLRErrorStrategyFactory batfishANTLRErrorStrategyFactory,
       Set<Integer> separatorChars) {
     this(pClass, lClass, input, settings);
     /*
@@ -91,8 +93,9 @@ public abstract class BatfishCombinedParser<P extends BatfishParser, L extends B
      */
     if (!settings.getDisableUnrecognized()) {
       _parser.setInterpreter(new BatfishParserATNSimulator(_parser.getInterpreter()));
-      _parser.setErrorHandler(batfishANTLRErrorStrategyFactor.build(_input));
+      _parser.setErrorHandler(batfishANTLRErrorStrategyFactory.build(_input));
       _lexer.setRecoveryStrategy(new BatfishLexerRecoveryStrategy(_lexer, separatorChars));
+      _recovery = true;
     }
   }
 
@@ -144,6 +147,10 @@ public abstract class BatfishCombinedParser<P extends BatfishParser, L extends B
 
   public BatfishParserErrorListener getParserErrorListener() {
     return _parserErrorListener;
+  }
+
+  public boolean getRecovery() {
+    return _recovery;
   }
 
   public GrammarSettings getSettings() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishCombinedParser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishCombinedParser.java
@@ -149,6 +149,11 @@ public abstract class BatfishCombinedParser<P extends BatfishParser, L extends B
     return _parserErrorListener;
   }
 
+  /**
+   * Returns {@code true} iff this is grammar uses custom recovery infrastructure, e.g. via {@link
+   * BatfishANTLRErrorStrategy}. For non-recovery-based grammars, this should return {@code false}
+   * even when unrecognized lines are allowed.
+   */
   public boolean getRecovery() {
     return _recovery;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParserErrorListener.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishParserErrorListener.java
@@ -46,12 +46,24 @@ public class BatfishParserErrorListener extends BatfishGrammarErrorListener {
 
   public void syntaxError(
       ParserRuleContext ctx, Object offendingSymbol, int line, int charPositionInLine, String msg) {
-    if (!_settings.getDisableUnrecognized()) {
+    if (!_settings.getDisableUnrecognized() && _combinedParser.getRecovery()) {
+      // recovery should have added error node for parse tree listener, so we can stop here
       return;
     }
     BatfishParser parser = _combinedParser.getParser();
     List<String> ruleNames = Arrays.asList(parser.getRuleNames());
     String ruleStack = ctx.toString(ruleNames);
+    String text = _combinedParser.getInput();
+    String[] lines = text.split("\n", -1);
+    Token offendingToken = (Token) offendingSymbol;
+    int errorLineIndex = offendingToken.getLine() - 1;
+    if (!_settings.getDisableUnrecognized()) {
+      // no recovery, so have to store error node for parse tree listener to process later
+      ctx.addErrorNode(
+          parser.createErrorNode(
+              ctx, new UnrecognizedLineToken(lines[errorLineIndex], line, ruleStack)));
+      return;
+    }
     List<Token> tokens = _combinedParser.getTokens().getTokens();
     int startTokenIndex = parser.getInputStream().index();
     StringBuilder sb = new StringBuilder();
@@ -65,7 +77,6 @@ public class BatfishParserErrorListener extends BatfishGrammarErrorListener {
             + ": "
             + msg
             + "\n");
-    Token offendingToken = (Token) offendingSymbol;
     String offendingTokenText = printToken(offendingToken);
     sb.append("Offending Token: " + offendingTokenText + "\n");
     sb.append("Error parsing top (leftmost) parser rule in stack: '" + ruleStack + "'.\n");
@@ -101,9 +112,6 @@ public class BatfishParserErrorListener extends BatfishGrammarErrorListener {
     }
 
     // collect context from text
-    String text = _combinedParser.getInput();
-    String[] lines = text.split("\n", -1);
-    int errorLineIndex = offendingToken.getLine() - 1;
     int errorContextStartLine = Math.max(errorLineIndex - _settings.getMaxParserContextLines(), 0);
     sb.append("Error context lines:\n");
     for (int i = errorContextStartLine; i < errorLineIndex; i++) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/GrammarSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/GrammarSettings.java
@@ -4,10 +4,10 @@ package org.batfish.grammar;
 public interface GrammarSettings {
 
   /**
-   * Controls whether or not unrecognized lines will trigger recovery mode wherein they are
-   * collected and ignored, i.e. they do not trigger a crash.
-   *
-   * @return true iff recovery from unrecognized lines is disabled
+   * When {@code true}, unrecognized lines will trigger a crash. When {@code false}, custom recovery
+   * via {@link BatfishANTLRErrorStrategy} will be performed for supported grammars; for other
+   * grammars, vanilla ANTLR recovery will be performed and syntax errors logged via {@link
+   * BatfishParserErrorListener} and {@link BatfishLexerErrorListener}.
    */
   boolean getDisableUnrecognized();
 

--- a/projects/batfish-common-protocol/src/test/antlr4/org/batfish/grammar/recovery/RecoveryLexer.g4
+++ b/projects/batfish-common-protocol/src/test/antlr4/org/batfish/grammar/recovery/RecoveryLexer.g4
@@ -27,6 +27,11 @@ INNER
    'inner'
 ;
 
+OTHER
+:
+  'other'
+;
+
 SIMPLE
 :
    'simple'

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/BatfishLexerErrorListenerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/BatfishLexerErrorListenerTest.java
@@ -1,0 +1,37 @@
+package org.batfish.grammar;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.batfish.common.util.CommonUtil;
+import org.batfish.grammar.recovery.NonRecoveryCombinedParser;
+import org.batfish.grammar.recovery.RecoveryExtractor;
+import org.batfish.grammar.recovery.RecoveryParser.RecoveryContext;
+import org.junit.Test;
+
+/* Test of {@link BatfishLexerErrorListener} */
+public final class BatfishLexerErrorListenerTest {
+
+  @Test
+  public void testNonRecoveryLexerErrorNode() {
+    String recoveryText = CommonUtil.readResource("org/batfish/grammar/non_recovery_lexer_error");
+    GrammarSettings settings = new MockGrammarSettings(false, 0, 0, 0, false, false, false, false);
+    NonRecoveryCombinedParser cp = new NonRecoveryCombinedParser(recoveryText, settings);
+    RecoveryContext ctx = cp.parse();
+    RecoveryExtractor extractor = new RecoveryExtractor();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(cp);
+    walker.walk(extractor, ctx);
+
+    assertThat(extractor.getFirstErrorLine(), equalTo(2));
+    assertThat(extractor.getNumSimpleStatements(), equalTo(1));
+    /*
+     * There should be 4 lexer errors for the word 'error':
+     * 'er' (requires two chars since 'en...' is valid
+     * 'r' (nothing starts with 'r')
+     * 'o' (nothing starts with 'o')
+     * 'r' (nothing starts with 'r')
+     */
+    assertThat(extractor.getNumErrorNodes(), equalTo(4));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/BatfishParserErrorListenerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/BatfishParserErrorListenerTest.java
@@ -1,0 +1,32 @@
+package org.batfish.grammar;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.batfish.common.util.CommonUtil;
+import org.batfish.grammar.recovery.NonRecoveryCombinedParser;
+import org.batfish.grammar.recovery.RecoveryExtractor;
+import org.batfish.grammar.recovery.RecoveryParser.RecoveryContext;
+import org.junit.Test;
+
+/* Test of {@link BatfishLexerErrorListener} */
+public final class BatfishParserErrorListenerTest {
+
+  @Test
+  public void testNonRecoveryParserErrorNode() {
+    String recoveryText = CommonUtil.readResource("org/batfish/grammar/non_recovery_parser_error");
+    GrammarSettings settings = new MockGrammarSettings(false, 0, 0, 0, false, false, false, false);
+    NonRecoveryCombinedParser cp = new NonRecoveryCombinedParser(recoveryText, settings);
+    RecoveryContext ctx = cp.parse();
+    RecoveryExtractor extractor = new RecoveryExtractor();
+    ParseTreeWalker walker = new BatfishParseTreeWalker(cp);
+    walker.walk(extractor, ctx);
+
+    // There should be 1 parser error for the token OTHER:'other' on the 2nd line:
+    assertThat(extractor.getFirstErrorLine(), equalTo(2));
+    assertThat(extractor.getNumErrorNodes(), equalTo(1));
+    // The block statement following the error should be processed
+    assertThat(extractor.getNumBlockStatements(), equalTo(1));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/recovery/NonRecoveryCombinedParser.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/grammar/recovery/NonRecoveryCombinedParser.java
@@ -1,0 +1,22 @@
+package org.batfish.grammar.recovery;
+
+import org.batfish.grammar.BatfishCombinedParser;
+import org.batfish.grammar.GrammarSettings;
+import org.batfish.grammar.recovery.RecoveryParser.RecoveryContext;
+
+/**
+ * A {@link BatfishCombinedParser} that uses recovery grammar but disables recovery. Used for
+ * testing best-effort BatfishLexerErrorListener and BatfishParserErrorListener error handling.
+ */
+public final class NonRecoveryCombinedParser
+    extends BatfishCombinedParser<RecoveryParser, RecoveryLexer> {
+
+  public NonRecoveryCombinedParser(String input, GrammarSettings settings) {
+    super(RecoveryParser.class, RecoveryLexer.class, input, settings);
+  }
+
+  @Override
+  public RecoveryContext parse() {
+    return _parser.recovery();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/resources/org/batfish/grammar/non_recovery_lexer_error
+++ b/projects/batfish-common-protocol/src/test/resources/org/batfish/grammar/non_recovery_lexer_error
@@ -1,0 +1,4 @@
+### Unrecognized. Tests expect line 2 of this file to be result in syntax error, keep it that way.
+error
+### Valid: statement->simple_statement
+simple simple simple

--- a/projects/batfish-common-protocol/src/test/resources/org/batfish/grammar/non_recovery_parser_error
+++ b/projects/batfish-common-protocol/src/test/resources/org/batfish/grammar/non_recovery_parser_error
@@ -1,0 +1,4 @@
+### Unrecognized. Tests expect line 2 of this file to be result in syntax error, keep it that way.
+simple other simple
+### Valid: statement->block_statement
+block


### PR DESCRIPTION
- Don't silently drop errors when disableUnrecognized is true
- New behavior approximates what recovery does by adding error nodes