### PR TITLE
cache bdd_correctify.

### DIFF
--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -1218,7 +1218,7 @@ public final class JFactory extends BDDFactory {
     }
 
     entry = BddCache_lookupI(replacecache, REPLACEHASH(replaceid, r));
-    if (entry.a == r && entry.b == -1 && entry.c == replaceid) {
+    if (entry.a == r && entry.c == replaceid) {
       if (CACHESTATS) {
         cachestats.opHit++;
       }
@@ -1252,7 +1252,6 @@ public final class JFactory extends BDDFactory {
       cachestats.opOverwrite++;
     }
     entry.a = r;
-    entry.b = -1; // this identifies the entry as being for replace
     entry.c = replaceid;
     entry.res = res;
 
@@ -1260,10 +1259,10 @@ public final class JFactory extends BDDFactory {
   }
 
   /**
-   * This is similar to {@link JFactory::bdd_makenode} -- it returns a BDD that branches at the
-   * input level with the input low and high nodes. The difference between this and bdd_makenode is
-   * that bdd_makenode requires level to be strictly less than LEVEL(l) and LEVEL(r), where this
-   * does not. The base case of bdd_correctify is when that is true -- then it simply delegates to
+   * This is similar to {@link JFactory#bdd_makenode} -- it returns a BDD that branches at the input
+   * level with the input low and high nodes. The difference between this and bdd_makenode is that
+   * bdd_makenode requires level to be strictly less than LEVEL(l) and LEVEL(r), where this does
+   * not. The base case of bdd_correctify is when that is true -- then it simply delegates to
    * bdd_makenode.
    *
    * @param level The level to branch on.
@@ -2483,6 +2482,12 @@ public final class JFactory extends BDDFactory {
       return BDDZERO;
     }
 
+    // compose_rec uses replacecache
+    if (replacecache == null) {
+      replacecache = BddCacheI_init(cachesize);
+    }
+
+    // compose_rec can call ite_rec, which uses applycache
     if (applycache == null) {
       applycache = BddCacheI_init(cachesize);
     }

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -1287,7 +1287,7 @@ public final class JFactory extends BDDFactory {
       cachestats.opOverwrite++;
     }
     entry.a = level;
-    entry.b = l; // this identifies the entry as being for replace
+    entry.b = l; // l is always >=0, which identifies the entry as being for correctify
     entry.c = r;
     entry.res = res;
 

--- a/projects/bdd/src/test/java/net/sf/javabdd/bdd/BasicTests.java
+++ b/projects/bdd/src/test/java/net/sf/javabdd/bdd/BasicTests.java
@@ -592,6 +592,39 @@ public class BasicTests extends BDDTestCase {
     }
   }
 
+  public void testCompose() {
+    reset();
+    assertTrue(hasNext());
+    while (hasNext()) {
+      BDDFactory bdd = next();
+      if (bdd.varNum() < 4) {
+        bdd.setVarNum(4);
+      }
+      BDD a = bdd.ithVar(0);
+      BDD b = bdd.ithVar(1);
+      BDD c = bdd.ithVar(2);
+      BDD d = bdd.ithVar(3);
+
+      BDD xorCD = c.xor(d);
+
+      // b doesn't occur in a
+      BDD res = a.compose(xorCD, b.var());
+      assert res.equals(a);
+
+      res = b.compose(xorCD, b.var());
+      assert res.equals(xorCD);
+
+      res = b.not().compose(xorCD, b.var());
+      assert res.equals(xorCD.not());
+
+      res = a.and(b).compose(xorCD, b.var());
+      assert res.equals(a.and(xorCD));
+
+      res = a.diff(b).compose(xorCD, b.var());
+      assert res.equals(a.diff(xorCD));
+    }
+  }
+
   void tEnsureCapacity() {
     reset();
     assertTrue(hasNext());


### PR DESCRIPTION
This makes replace significantly faster. correctify calls are cached in
the replacecache, so we need to disambiguate with replace calls. Replace
doesn't use the entries' b field, so we mark replace calls by storing -1
in b. Correctify stores a node id in b, which is always >= 0.