### PR TITLE
JFactory: update cachesize on resize

### DIFF
--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -4078,6 +4078,8 @@ public final class JFactory extends BDDFactory {
       BddCache_resize(misccache, newcachesize);
       BddCache_resize(multiopcache, newcachesize);
       BddCache_resize(countcache, newcachesize);
+
+      cachesize = newcachesize;
     }
   }
 


### PR DESCRIPTION
Otherwise newly allocated caches will be sized to the initial
cache size until a nodes resize.