### PR TITLE
Arista OSPF default route redistribution

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -307,6 +307,7 @@ import org.batfish.datamodel.LineType;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.OspfExternalType2Route;
 import org.batfish.datamodel.OspfIntraAreaRoute;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Prefix6;
@@ -5360,5 +5361,37 @@ public class CiscoGrammarTest {
         ccae, not(hasUndefinedReference(filename, NETWORK_OBJECT_GROUP, "source-real-group")));
     assertThat(ccae, hasUndefinedReference(filename, NETWORK_OBJECT, "undef-source-mapped"));
     assertThat(ccae, hasUndefinedReference(filename, NETWORK_OBJECT, "undef-source-real"));
+  }
+
+  @Test
+  public void testAristaDefaultRouteRedistribution() throws IOException {
+    final String receiver = "ios_receiver";
+    final String advertiser = "arista_advertiser";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationText(
+                    TESTRIGS_PREFIX + "arista-redistribute-default-route",
+                    ImmutableList.of(advertiser, receiver))
+                .build(),
+            _folder);
+
+    batfish.computeDataPlane();
+    Set<AbstractRoute> routes =
+        batfish.loadDataPlane().getRibs().get(receiver).get(DEFAULT_VRF_NAME).getRoutes();
+
+    assertThat(
+        routes,
+        hasItem(
+            OspfExternalType2Route.builder()
+                .setNetwork(Prefix.ZERO)
+                .setNextHopIp(Ip.parse("1.2.3.5"))
+                .setArea(1)
+                .setCostToAdvertiser(1)
+                .setAdvertiser(advertiser)
+                .setAdmin(110)
+                .setMetric(1)
+                .setLsaMetric(1)
+                .build()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -5363,6 +5363,10 @@ public class CiscoGrammarTest {
     assertThat(ccae, hasUndefinedReference(filename, NETWORK_OBJECT, "undef-source-real"));
   }
 
+  /**
+   * Ensure that Arista redistributes a static default route even though default-originate is not
+   * explicitly specified in the config
+   */
   @Test
   public void testAristaDefaultRouteRedistribution() throws IOException {
     final String receiver = "ios_receiver";

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-redistribute-default-route/configs/arista_advertiser
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-redistribute-default-route/configs/arista_advertiser
@@ -1,0 +1,17 @@
+! Command: show running-config
+! device: localhost (vEOS, EOS-4.18.10M)
+!
+! boot system flash:/vEOS-lab.swi
+!
+hostname arista_advertiser
+!
+interface Ethernet1
+   no switchport
+   ip address 1.2.3.5/24
+   ip ospf 1 area 1
+!
+ip route 0.0.0.0/0 Null0
+!
+router ospf 1
+   redistribute static
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-redistribute-default-route/configs/ios_receiver
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-redistribute-default-route/configs/ios_receiver
@@ -1,0 +1,12 @@
+!
+! Last configuration change at 23:52:11 UTC Fri Apr 12 2019
+!
+hostname ios_receiver
+!
+interface GigabitEthernet1/0
+ ip address 1.2.3.4 255.255.255.0
+ negotiation auto
+!
+router ospf 1
+ network 1.2.3.0 0.0.0.255 area 0.0.0.1
+!


### PR DESCRIPTION
Unlike Cisco, Arista allows redistributing of default routes into OSPF via `redistribute <protocol>` command