### PR TITLE
Return compact JSON from v2 service

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
@@ -39,7 +39,7 @@ public final class BatfishObjectMapper {
   private static final ObjectWriter VERBOSE_WRITER = VERBOSE_MAPPER.writer(PRETTY_PRINTER);
 
   /**
-   * Returns a {@link ObjectMapper} configured to Batfish JSON standards. The JSON produced is not
+   * Returns an {@link ObjectMapper} configured to Batfish JSON standards. The JSON produced is not
    * pretty-printed but does include empty lists and null values.
    */
   public static ObjectMapper alwaysMapper() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
@@ -19,8 +19,10 @@ import org.batfish.common.util.serialization.BatfishThirdPartySerializationModul
 public final class BatfishObjectMapper {
   private static final ObjectMapper MAPPER = baseMapper();
 
-  private static final ObjectWriter ALWAYS_WRITER =
-      baseMapper().setSerializationInclusion(Include.ALWAYS).writer();
+  private static final ObjectMapper ALWAYS_MAPPER =
+      baseMapper().setSerializationInclusion(Include.ALWAYS);
+
+  private static final ObjectWriter ALWAYS_WRITER = ALWAYS_MAPPER.writer();
 
   private static final ObjectWriter WRITER = MAPPER.writer();
 
@@ -35,6 +37,14 @@ public final class BatfishObjectMapper {
           .setSerializationInclusion(Include.ALWAYS);
 
   private static final ObjectWriter VERBOSE_WRITER = VERBOSE_MAPPER.writer(PRETTY_PRINTER);
+
+  /**
+   * Returns a {@link ObjectMapper} configured to Batfish JSON standards. The JSON produced is not
+   * pretty-printed but does include empty lists and null values.
+   */
+  public static ObjectMapper alwaysMapper() {
+    return ALWAYS_MAPPER;
+  }
 
   /**
    * Returns a {@link ObjectMapper} configured to Batfish JSON standards. The JSON produced is not

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
@@ -19,10 +19,8 @@ import org.batfish.common.util.serialization.BatfishThirdPartySerializationModul
 public final class BatfishObjectMapper {
   private static final ObjectMapper MAPPER = baseMapper();
 
-  private static final ObjectMapper ALWAYS_MAPPER =
-      baseMapper().setSerializationInclusion(Include.ALWAYS);
-
-  private static final ObjectWriter ALWAYS_WRITER = ALWAYS_MAPPER.writer();
+  private static final ObjectWriter ALWAYS_WRITER =
+      baseMapper().setSerializationInclusion(Include.ALWAYS).writer();
 
   private static final ObjectWriter WRITER = MAPPER.writer();
 
@@ -32,19 +30,9 @@ public final class BatfishObjectMapper {
       baseMapper().enable(SerializationFeature.INDENT_OUTPUT).writer(PRETTY_PRINTER);
 
   private static final ObjectMapper VERBOSE_MAPPER =
-      baseMapper()
-          .enable(SerializationFeature.INDENT_OUTPUT)
-          .setSerializationInclusion(Include.ALWAYS);
+      baseMapper().setSerializationInclusion(Include.ALWAYS);
 
   private static final ObjectWriter VERBOSE_WRITER = VERBOSE_MAPPER.writer(PRETTY_PRINTER);
-
-  /**
-   * Returns an {@link ObjectMapper} configured to Batfish JSON standards. The JSON produced
-   * includes empty lists and null values and is not pretty-printed.
-   */
-  public static ObjectMapper alwaysMapper() {
-    return ALWAYS_MAPPER;
-  }
 
   /**
    * Returns a {@link ObjectMapper} configured to Batfish JSON standards. The JSON produced is not
@@ -84,7 +72,7 @@ public final class BatfishObjectMapper {
 
   /**
    * Returns a {@link ObjectMapper} configured to Batfish JSON standards. Relative to {@link
-   * #mapper()}, it indents the JSON and includes null values and empty lists.
+   * #mapper()}, it includes null values and empty lists.
    */
   public static ObjectMapper verboseMapper() {
     return VERBOSE_MAPPER;
@@ -92,7 +80,7 @@ public final class BatfishObjectMapper {
 
   /**
    * Returns a {@link ObjectWriter} configured to Batfish JSON standards. The JSON produced is
-   * verbosely pretty-printed; all fields are included.
+   * verbosely but not pretty printed (including all fields).
    *
    * @see BatfishObjectMapper#writer()
    * @see BatfishObjectMapper#prettyWriter()

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
@@ -39,8 +39,8 @@ public final class BatfishObjectMapper {
   private static final ObjectWriter VERBOSE_WRITER = VERBOSE_MAPPER.writer(PRETTY_PRINTER);
 
   /**
-   * Returns an {@link ObjectMapper} configured to Batfish JSON standards. The JSON produced is not
-   * pretty-printed but does include empty lists and null values.
+   * Returns an {@link ObjectMapper} configured to Batfish JSON standards. The JSON produced
+   * includes empty lists and null values and is not pretty-printed.
    */
   public static ObjectMapper alwaysMapper() {
     return ALWAYS_MAPPER;

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/ServiceObjectMapper.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/ServiceObjectMapper.java
@@ -14,6 +14,6 @@ public class ServiceObjectMapper implements ContextResolver<ObjectMapper> {
 
   @Override
   public ObjectMapper getContext(Class<?> type) {
-    return BatfishObjectMapper.alwaysMapper();
+    return BatfishObjectMapper.verboseMapper();
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/ServiceObjectMapper.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/ServiceObjectMapper.java
@@ -14,6 +14,6 @@ public class ServiceObjectMapper implements ContextResolver<ObjectMapper> {
 
   @Override
   public ObjectMapper getContext(Class<?> type) {
-    return BatfishObjectMapper.verboseMapper();
+    return BatfishObjectMapper.alwaysMapper();
   }
 }


### PR DESCRIPTION
* Update `verboseMapper` to no longer print pretty JSON
  * This is used for service v2 APIs

Previously, listing containers would result in:
```
> curl -XGET --header "X-Batfish-Apikey: 00000000000000000000000000000000" --header "X-Batfish-Version: 0.36.0" http://localhost:9996/v2/containers
[ {
  "name" : "network",
  "testrigs" : [ ],
  "analysis" : null
} ]
```
now, it results in:
```
> curl -XGET --header "X-Batfish-Apikey: 00000000000000000000000000000000" --header "X-Batfish-Version: 0.36.0" http://localhost:9996/v2/containers
[{"name":"network","testrigs":[],"analysis":null}]
```

Fixes #3607