### PR TITLE
AclIpSpace: flatten if possible during union

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclIpSpaceTest.java
@@ -54,6 +54,15 @@ public class AclIpSpaceTest {
   }
 
   @Test
+  public void testUnionNested() {
+    IpIpSpace a = Ip.parse("1.2.3.4").toIpSpace();
+    IpIpSpace b = Ip.parse("1.2.3.5").toIpSpace();
+    IpIpSpace c = Ip.parse("1.2.3.6").toIpSpace();
+    assertThat(union(a, b, c), equalTo(union(union(a, b), c)));
+    assertThat(union(a, b, c), equalTo(union(a, union(b, c))));
+  }
+
+  @Test
   public void testStopWhenEmpty() {
     IpSpace space =
         AclIpSpace.builder()

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -20491,23 +20491,15 @@
                         {
                           "action" : "PERMIT",
                           "ipSpace" : {
-                            "class" : "org.batfish.datamodel.AclIpSpace",
-                            "lines" : [
-                              {
-                                "action" : "PERMIT",
-                                "ipSpace" : {
-                                  "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                                  "ipWildcard" : "1.2.3.4"
-                                }
-                              },
-                              {
-                                "action" : "PERMIT",
-                                "ipSpace" : {
-                                  "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                                  "ipWildcard" : "1.2.3.5"
-                                }
-                              }
-                            ]
+                            "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                            "ipWildcard" : "1.2.3.4"
+                          }
+                        },
+                        {
+                          "action" : "PERMIT",
+                          "ipSpace" : {
+                            "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                            "ipWildcard" : "1.2.3.5"
                           }
                         },
                         {
@@ -20597,23 +20589,15 @@
                           {
                             "action" : "PERMIT",
                             "ipSpace" : {
-                              "class" : "org.batfish.datamodel.AclIpSpace",
-                              "lines" : [
-                                {
-                                  "action" : "PERMIT",
-                                  "ipSpace" : {
-                                    "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                                    "ipWildcard" : "1.2.3.4"
-                                  }
-                                },
-                                {
-                                  "action" : "PERMIT",
-                                  "ipSpace" : {
-                                    "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                                    "ipWildcard" : "1.2.3.5"
-                                  }
-                                }
-                              ]
+                              "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                              "ipWildcard" : "1.2.3.4"
+                            }
+                          },
+                          {
+                            "action" : "PERMIT",
+                            "ipSpace" : {
+                              "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                              "ipWildcard" : "1.2.3.5"
                             }
                           },
                           {


### PR DESCRIPTION
Makes `union(union(a, b), c)` equivalent to `union(a, b, c)` instead of nested.