### PR TITLE
Refactor question resource

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionResource.java
@@ -2,6 +2,7 @@ package org.batfish.coordinator.resources;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.ws.rs.DELETE;
@@ -28,7 +29,7 @@ public final class QuestionResource {
   }
 
   @DELETE
-  public Response deleteQuestion() {
+  public @Nonnull Response deleteQuestion() {
     if (!Main.getWorkMgr().delQuestion(_network, _questionName, _analysis)) {
       return Response.status(Status.NOT_FOUND).build();
     }
@@ -36,7 +37,7 @@ public final class QuestionResource {
   }
 
   @GET
-  public Response getQuestion() {
+  public @Nonnull Response getQuestion() {
     String result = Main.getWorkMgr().getQuestion(_network, _questionName, _analysis);
     if (result == null) {
       return Response.status(Status.NOT_FOUND).build();
@@ -45,7 +46,7 @@ public final class QuestionResource {
   }
 
   @PUT
-  public Response putQuestion(String questionJson) {
+  public @Nonnull Response putQuestion(String questionJson) {
     if (_analysis != null) {
       Main.getWorkMgr()
           .configureAnalysis(

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionResource.java
@@ -11,10 +11,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.batfish.coordinator.Main;
 
-/**
- * This resource provided functionality for storing and retrieving user-defined data at the snapshot
- * level.
- */
+/** Resource for handling requests about specific ad-hoc or analysis questions */
 @ParametersAreNonnullByDefault
 public final class QuestionResource {
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionResource.java
@@ -11,7 +11,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.batfish.coordinator.Main;
 
-/** Resource for handling requests about specific ad-hoc or analysis questions */
+/** Resource for handling requests about a specific ad-hoc or analysis question */
 @ParametersAreNonnullByDefault
 public final class QuestionResource {
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionResource.java
@@ -1,0 +1,66 @@
+package org.batfish.coordinator.resources;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.batfish.coordinator.Main;
+
+/**
+ * This resource provided functionality for storing and retrieving user-defined data at the snapshot
+ * level.
+ */
+@ParametersAreNonnullByDefault
+public final class QuestionResource {
+
+  private final String _analysis;
+
+  private final String _network;
+
+  private final String _questionName;
+
+  public QuestionResource(String network, @Nullable String analysis, String questionName) {
+    _analysis = analysis;
+    _network = network;
+    _questionName = questionName;
+  }
+
+  @DELETE
+  public Response deleteQuestion() {
+    if (!Main.getWorkMgr().delQuestion(_network, _questionName, _analysis)) {
+      return Response.status(Status.NOT_FOUND).build();
+    }
+    return Response.ok().build();
+  }
+
+  @GET
+  public Response getQuestion() {
+    String result = Main.getWorkMgr().getQuestion(_network, _questionName, _analysis);
+    if (result == null) {
+      return Response.status(Status.NOT_FOUND).build();
+    }
+    return Response.ok().entity(result).build();
+  }
+
+  @PUT
+  public Response putQuestion(String questionJson) {
+    if (_analysis != null) {
+      Main.getWorkMgr()
+          .configureAnalysis(
+              _network,
+              false,
+              _analysis,
+              ImmutableMap.of(_questionName, questionJson),
+              ImmutableList.of(),
+              false);
+    } else if (!Main.getWorkMgr().uploadQuestion(_network, _questionName, questionJson)) {
+      return Response.status(Status.NOT_FOUND).build();
+    }
+    return Response.ok().build();
+  }
+}

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionsResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionsResource.java
@@ -1,14 +1,10 @@
 package org.batfish.coordinator.resources;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.util.SortedSet;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -36,22 +32,8 @@ public final class QuestionsResource {
   }
 
   @Path("/{question}")
-  @DELETE
-  public Response deleteQuestion(@PathParam("question") String question) {
-    if (!Main.getWorkMgr().delQuestion(_network, question, _analysis)) {
-      return Response.status(Status.NOT_FOUND).build();
-    }
-    return Response.ok().build();
-  }
-
-  @Path("/{question}")
-  @GET
-  public Response getQuestion(@PathParam("question") String question) {
-    String result = Main.getWorkMgr().getQuestion(_network, question, _analysis);
-    if (result == null) {
-      return Response.status(Status.NOT_FOUND).build();
-    }
-    return Response.ok().entity(result).build();
+  public QuestionResource question(@PathParam("question") String question) {
+    return new QuestionResource(_network, _analysis, question);
   }
 
   @GET
@@ -64,23 +46,5 @@ public final class QuestionsResource {
       return Response.status(Status.NOT_FOUND).build();
     }
     return Response.ok().entity(result).build();
-  }
-
-  @Path("/{question}")
-  @PUT
-  public Response putQuestion(@PathParam("question") String question, String questionJson) {
-    if (_analysis != null) {
-      Main.getWorkMgr()
-          .configureAnalysis(
-              _network,
-              false,
-              _analysis,
-              ImmutableMap.of(question, questionJson),
-              ImmutableList.of(),
-              false);
-    } else if (!Main.getWorkMgr().uploadQuestion(_network, question, questionJson)) {
-      return Response.status(Status.NOT_FOUND).build();
-    }
-    return Response.ok().build();
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionsResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionsResource.java
@@ -1,6 +1,7 @@
 package org.batfish.coordinator.resources;
 
 import java.util.SortedSet;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.ws.rs.Consumes;
@@ -26,18 +27,18 @@ public final class QuestionsResource {
    * Question resource for a given network and analysis. If analysis is {@code null}, resource is
    * for interacting with ad-hoc questions for the network.
    */
-  public QuestionsResource(String network, @Nullable String analysis) {
+  public @Nonnull QuestionsResource(String network, @Nullable String analysis) {
     _network = network;
     _analysis = analysis;
   }
 
   @Path("/{question}")
-  public QuestionResource question(@PathParam("question") String question) {
+  public @Nonnull QuestionResource question(@PathParam("question") String question) {
     return new QuestionResource(_network, _analysis, question);
   }
 
   @GET
-  public Response getQuestions() {
+  public @Nonnull Response getQuestions() {
     SortedSet<String> result =
         _analysis != null
             ? Main.getWorkMgr().listAnalysisQuestions(_network, _analysis)

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionsResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/QuestionsResource.java
@@ -27,7 +27,7 @@ public final class QuestionsResource {
    * Question resource for a given network and analysis. If analysis is {@code null}, resource is
    * for interacting with ad-hoc questions for the network.
    */
-  public @Nonnull QuestionsResource(String network, @Nullable String analysis) {
+  public QuestionsResource(String network, @Nullable String analysis) {
     _network = network;
     _analysis = analysis;
   }


### PR DESCRIPTION
Split `QuestionResource` into its own class, out of `QuestionsResource` (similar to how we handle network and snapshot resources)
