### PR TITLE
do not throw an exception in locationipspecifier

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationIpSpaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationIpSpaceSpecifier.java
@@ -1,7 +1,6 @@
 package org.batfish.specifier;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Objects;
 import java.util.Set;
@@ -56,7 +55,6 @@ public final class LocationIpSpaceSpecifier implements IpSpaceSpecifier {
 
   @Nonnull
   public static IpSpace computeIpSpace(Set<Location> locations, SpecifierContext ctxt) {
-    checkArgument(!locations.isEmpty(), "No such locations");
     return firstNonNull(
         AclIpSpace.union(
             InferFromLocationIpSpaceSpecifier.INSTANCE.resolve(locations, ctxt).getEntries()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/LocationIpSpaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/LocationIpSpaceSpecifierTest.java
@@ -1,6 +1,12 @@
 package org.batfish.specifier;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.batfish.datamodel.EmptyIpSpace;
+import org.batfish.specifier.IpSpaceAssignment.Entry;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -13,8 +19,10 @@ public class LocationIpSpaceSpecifierTest {
     MockSpecifierContext ctxt = MockSpecifierContext.builder().build();
     IpSpaceSpecifier specifier =
         new LocationIpSpaceSpecifier(new MockLocationSpecifier(ImmutableSet.of()));
-    _expectedException.expect(IllegalArgumentException.class);
-    _expectedException.expectMessage("No such locations");
-    specifier.resolve(ImmutableSet.of(), ctxt);
+    assertThat(
+        specifier.resolve(ImmutableSet.of(), ctxt),
+        equalTo(
+            IpSpaceAssignment.of(
+                ImmutableList.of(new Entry(EmptyIpSpace.INSTANCE, ImmutableSet.of())))));
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersAnswerer.java
@@ -283,14 +283,16 @@ public class TestFiltersAnswerer extends Answerer {
               .collect(ImmutableList.toImmutableList());
       checkArgument(
           nonEmptyIpSpaces.size() > 0,
-          "At least one destination IP is required, could not resolve any");
+          "Specified destination '%s' could not be resolved to any IP.",
+          headerDstIp);
       checkArgument(
           nonEmptyIpSpaces.size() == 1,
-          "Specified destination: %s, resolves to more than one IP",
-          headerDstIp);
+          "Specified destination '%s' resolves to more than one location/IP: %s",
+          headerDstIp,
+          nonEmptyIpSpaces);
       IpSpace space = nonEmptyIpSpaces.iterator().next().getIpSpace();
       Optional<Ip> dstIp = _ipSpaceRepresentative.getRepresentative(space);
-      checkArgument(dstIp.isPresent(), "Specified destination: %s has no IPs", headerDstIp);
+      checkArgument(dstIp.isPresent(), "Specified destination '%s' has no IPs", headerDstIp);
       builder.setDstIp(dstIp.get());
     } else {
       builder.setDstIp(DEFAULT_IP_ADDRESS);
@@ -315,16 +317,18 @@ public class TestFiltersAnswerer extends Answerer {
               .filter(e -> !e.getIpSpace().equals(EmptyIpSpace.INSTANCE))
               .collect(ImmutableList.toImmutableList());
       checkArgument(
-          nonEmptyIpSpaces.size() > 0, "At least one source IP is required, could not resolve any");
+          nonEmptyIpSpaces.size() > 0,
+          "Specified source '%s' could not be resolve to any IP.",
+          headerSrcIp);
       checkArgument(
           nonEmptyIpSpaces.size() == 1,
-          "Specified source IP %s resolves to more than one location/IP: %s",
+          "Specified source '%s' resolves to more than one location/IP: %s",
           headerSrcIp,
           nonEmptyIpSpaces);
       // Pick a representative from the remaining space
       IpSpace space = nonEmptyIpSpaces.iterator().next().getIpSpace();
       Optional<Ip> srcIp = _ipSpaceRepresentative.getRepresentative(space);
-      checkArgument(srcIp.isPresent(), "Specified source: %s has no IPs", headerSrcIp);
+      checkArgument(srcIp.isPresent(), "Specified source '%s' has no IPs", headerSrcIp);
       builder.setSrcIp(srcIp.get());
     } else if (srcLocation == null) {
       builder.setSrcIp(DEFAULT_IP_ADDRESS);

--- a/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswererHelper.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswererHelper.java
@@ -115,16 +115,18 @@ public final class TracerouteAnswererHelper {
               .filter(e -> !e.getIpSpace().equals(EmptyIpSpace.INSTANCE))
               .collect(ImmutableList.toImmutableList());
       checkArgument(
-          !nonEmptyIpSpaces.isEmpty(), "At least one source IP is required, could not resolve any");
+          !nonEmptyIpSpaces.isEmpty(),
+          "Specified source '%s' could not be resolved to any IP.",
+          headerSrcIp);
       checkArgument(
           nonEmptyIpSpaces.size() == 1,
-          "Specified source IP %s resolves to more than one location/IP: %s",
+          "Specified source '%s' resolves to more than one location/IP: %s",
           headerSrcIp,
           nonEmptyIpSpaces);
       IpSpace space = srcIps.getEntries().iterator().next().getIpSpace();
       Optional<Ip> srcIp = _ipSpaceRepresentative.getRepresentative(space);
       // Extra check to ensure that we actually got an IP
-      checkArgument(srcIp.isPresent(), "At least one source IP is required, could not resolve any");
+      checkArgument(srcIp.isPresent(), "Specified source '%s' has no IPs", headerSrcIp);
       builder.setSrcIp(srcIp.get());
     } else {
       // Use from source location to determine header Src IP
@@ -156,11 +158,11 @@ public final class TracerouteAnswererHelper {
     IpSpaceAssignment dstIps = dstIpSpecifier.resolve(ImmutableSet.of(), _specifierContext);
     checkArgument(
         dstIps.getEntries().size() == 1,
-        "Specified destination: %s, resolves to more than one IP",
+        "Specified destination '%s' resolves to more than one IP",
         headerDstIp);
     IpSpace space = dstIps.getEntries().iterator().next().getIpSpace();
     Optional<Ip> dstIp = _ipSpaceRepresentative.getRepresentative(space);
-    checkArgument(dstIp.isPresent(), "At least one destination IP is required");
+    checkArgument(dstIp.isPresent(), "Specified destination '%s' has no IPs.", headerDstIp);
     builder.setDstIp(dstIp.get());
   }
 


### PR DESCRIPTION
Necessary protections were already in place it seems for Testfilters and Traceroute. I tinkered with error messages. 

@anothermattbrown - based on a quick look, it seemed that reachability and searchfilters would do the right thing. could you please double check?