### PR TITLE
Cisco_interface.g4: add parsing for nxos route-pref and tag inline

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -10896,6 +10896,11 @@ ROUTE_POLICY
    'route-policy'
 ;
 
+ROUTE_PREFERENCE
+:
+   'route-preference'
+;
+
 ROUTE_REFLECTOR_CLIENT
 :
    'route-reflector-client'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -265,19 +265,16 @@ if_ip_access_group
 
 if_ip_address
 :
+   (IP | IPV4) ADDRESS
+   VIRTUAL?
    (
-      IP
-      | IPV4
-   ) ADDRESS VIRTUAL?
-   (
-      (
-         ip = IP_ADDRESS subnet = IP_ADDRESS
-      )
+      ip = IP_ADDRESS subnet = IP_ADDRESS
       | prefix = IP_PREFIX
    )
-   (
-      STANDBY standby_address = IP_ADDRESS
-   )? NEWLINE
+   (STANDBY standby_address = IP_ADDRESS)?
+   (ROUTE_PREFERENCE pref=DEC)?
+   (TAG tag=DEC)?
+   NEWLINE
 ;
 
 if_ip_address_dhcp

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -6056,6 +6056,12 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         currentInterface.setStandbyAddress(standbyAddress);
       }
     }
+    if (ctx.ROUTE_PREFERENCE() != null) {
+      todo(ctx, "Unsupported: route-preference declared in interface IP address");
+    }
+    if (ctx.TAG() != null) {
+      todo(ctx, "Unsupported: tag declared in interface IP address");
+    }
   }
 
   @Override

--- a/tests/parsing-tests/networks/unit-tests/configs/nxos_interface
+++ b/tests/parsing-tests/networks/unit-tests/configs/nxos_interface
@@ -3,6 +3,7 @@ hostname nxos_interface
 feature privilege
 !
 interface Ethernet0/0
+ ip address 1.2.3.4/24 route-preference 10 tag 12345
  link debounce link-up time 0
  linkdebounce time 100
  mdix auto

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -26805,6 +26805,9 @@
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
+            "allPrefixes" : [
+              "1.2.3.4/24"
+            ],
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E9,
@@ -26817,6 +26820,7 @@
             "ospfHelloMultiplier" : 0,
             "ospfPassive" : false,
             "ospfPointToPoint" : false,
+            "prefix" : "1.2.3.4/24",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -2206,6 +2206,20 @@
         "Comment" : "This feature is not currently supported"
       },
       {
+        "Filename" : "configs/nxos_interface",
+        "Line" : 6,
+        "Text" : "ip address 1.2.3.4/24 route-preference 10 tag 12345",
+        "Parser_Context" : "[if_ip_address if_inner s_interface stanza cisco_configuration]",
+        "Comment" : "Unsupported: route-preference declared in interface IP address"
+      },
+      {
+        "Filename" : "configs/nxos_interface",
+        "Line" : 6,
+        "Text" : "ip address 1.2.3.4/24 route-preference 10 tag 12345",
+        "Parser_Context" : "[if_ip_address if_inner s_interface stanza cisco_configuration]",
+        "Comment" : "Unsupported: tag declared in interface IP address"
+      },
+      {
         "Filename" : "configs/peer_template",
         "Line" : 24,
         "Text" : "allowas-in 1",
@@ -2249,10 +2263,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 315 results",
+      "notes" : "Found 317 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 315
+      "numResults" : 317
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -67942,6 +67942,16 @@
             "            low = DEC:'0'  <== mode:M_Interface)))",
             "      NEWLINE:'\\n'  <== mode:M_Interface",
             "      (if_inner",
+            "        (if_ip_address",
+            "          IP:'ip'",
+            "          ADDRESS:'address'",
+            "          prefix = IP_PREFIX:'1.2.3.4/24'",
+            "          ROUTE_PREFERENCE:'route-preference'",
+            "          pref = DEC:'10'",
+            "          TAG:'tag'",
+            "          tag = DEC:'12345'",
+            "          NEWLINE:'\\n'))",
+            "      (if_inner",
             "        (if_null_block",
             "          LINK:'link'",
             "          VARIABLE:'debounce'",
@@ -73931,6 +73941,22 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "apply-groups statement at path: 'system tacplus-server 1.2.3.4' refers to non-existent group: 'bippety'\n"
+            }
+          ]
+        },
+        "configs/nxos_interface" : {
+          "Parse warnings" : [
+            {
+              "Comment" : "Unsupported: route-preference declared in interface IP address",
+              "Line" : 6,
+              "Parser_Context" : "[if_ip_address if_inner s_interface stanza cisco_configuration]",
+              "Text" : "ip address 1.2.3.4/24 route-preference 10 tag 12345"
+            },
+            {
+              "Comment" : "Unsupported: tag declared in interface IP address",
+              "Line" : 6,
+              "Parser_Context" : "[if_ip_address if_inner s_interface stanza cisco_configuration]",
+              "Text" : "ip address 1.2.3.4/24 route-preference 10 tag 12345"
             }
           ]
         },
@@ -80032,14 +80058,15 @@
                 5,
                 6,
                 7,
-                8
+                8,
+                9
               ],
               "numReferrers" : 1
             },
             "nve1" : {
               "definitionLines" : [
-                10,
-                11
+                11,
+                12
               ],
               "numReferrers" : 1
             }
@@ -84598,7 +84625,7 @@
             },
             "nve1" : {
               "interface" : [
-                10
+                11
               ]
             }
           }


### PR DESCRIPTION
Mark unsupported for now, implementation pending.