### PR TITLE
Endpoint IPs in BgpSessionProperties

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
@@ -54,11 +54,13 @@ public final class BgpSessionProperties {
     return SessionType.isEbgp(_sessionType);
   }
 
+  /** IP of local peer for this session */
   @Nonnull
   public Ip getTailIp() {
     return _tailIp;
   }
 
+  /** IP of remote peer for this session */
   @Nonnull
   public Ip getHeadIp() {
     return _headIp;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
@@ -9,16 +9,22 @@ public final class BgpSessionProperties {
   private final boolean _additionalPaths;
   private final boolean _advertiseExternal;
   private final boolean _advertiseInactive;
+  @Nonnull private final Ip _initiatorIp;
+  @Nonnull private final Ip _listenerIp;
   private final SessionType _sessionType;
 
   private BgpSessionProperties(
       boolean additionalPaths,
       boolean advertiseExternal,
       boolean advertiseInactive,
+      @Nonnull Ip initiatorIp,
+      @Nonnull Ip listenerIp,
       SessionType sessionType) {
     _additionalPaths = additionalPaths;
     _advertiseExternal = advertiseExternal;
     _advertiseInactive = advertiseInactive;
+    _initiatorIp = initiatorIp;
+    _listenerIp = listenerIp;
     _sessionType = sessionType;
   }
 
@@ -48,6 +54,16 @@ public final class BgpSessionProperties {
     return SessionType.isEbgp(_sessionType);
   }
 
+  @Nonnull
+  public Ip getInitiatorIp() {
+    return _initiatorIp;
+  }
+
+  @Nonnull
+  public Ip getListenerIp() {
+    return _listenerIp;
+  }
+
   /** Return this session's {@link SessionType}. */
   public SessionType getSessionType() {
     return _sessionType;
@@ -65,6 +81,15 @@ public final class BgpSessionProperties {
       @Nonnull BgpActivePeerConfig initiator,
       @Nonnull BgpPeerConfig listener,
       boolean reverseDirection) {
+    Ip initiatorIp = initiator.getLocalIp();
+    Ip listenerIp = listener.getLocalIp();
+    if (listenerIp == null || listenerIp == Ip.AUTO) {
+      // Initiator must be active; determine listener's IP from initiator
+      listenerIp = initiator.getPeerAddress();
+    }
+    assert initiatorIp != null;
+    assert listenerIp != null;
+
     SessionType sessionType = getSessionType(initiator);
     return new BgpSessionProperties(
         !SessionType.isEbgp(sessionType)
@@ -73,27 +98,24 @@ public final class BgpSessionProperties {
             && initiator.getAdditionalPathsSelectAll(),
         SessionType.isEbgp(sessionType) && initiator.getAdvertiseInactive(),
         !SessionType.isEbgp(sessionType) && initiator.getAdvertiseExternal(),
+        reverseDirection ? listenerIp : initiatorIp,
+        reverseDirection ? initiatorIp : listenerIp,
         sessionType);
   }
 
   /**
-   * Determine what type of session the peer is configured to establish.
+   * Determine what type of session {@code initiator} is configured to establish.
    *
-   * @param initiator the configuration of connection initiator.
+   * @param initiator the {@link BgpActivePeerConfig} representing the connection initiator.
    * @return a {@link SessionType} the initiator is configured to establish.
    */
   public static @Nonnull SessionType getSessionType(BgpActivePeerConfig initiator) {
-    SessionType sessionType = SessionType.UNSET;
-    if (initiator.getLocalAs() != null && !initiator.getRemoteAsns().isEmpty()) {
-      if (initiator.getRemoteAsns().equals(LongSpace.of(initiator.getLocalAs()))) {
-        sessionType = SessionType.IBGP;
-      } else if (initiator.getEbgpMultihop()) {
-        sessionType = SessionType.EBGP_MULTIHOP;
-      } else {
-        sessionType = SessionType.EBGP_SINGLEHOP;
-      }
+    if (initiator.getLocalAs() == null || initiator.getRemoteAsns().isEmpty()) {
+      return SessionType.UNSET;
     }
-    return sessionType;
+    return initiator.getRemoteAsns().equals(LongSpace.of(initiator.getLocalAs()))
+        ? SessionType.IBGP
+        : initiator.getEbgpMultihop() ? SessionType.EBGP_MULTIHOP : SessionType.EBGP_SINGLEHOP;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
@@ -9,22 +9,22 @@ public final class BgpSessionProperties {
   private final boolean _additionalPaths;
   private final boolean _advertiseExternal;
   private final boolean _advertiseInactive;
-  @Nonnull private final Ip _initiatorIp;
-  @Nonnull private final Ip _listenerIp;
+  @Nonnull private final Ip _tailIp;
+  @Nonnull private final Ip _headIp;
   private final SessionType _sessionType;
 
   private BgpSessionProperties(
       boolean additionalPaths,
       boolean advertiseExternal,
       boolean advertiseInactive,
-      @Nonnull Ip initiatorIp,
-      @Nonnull Ip listenerIp,
+      @Nonnull Ip tailIp,
+      @Nonnull Ip headIp,
       SessionType sessionType) {
     _additionalPaths = additionalPaths;
     _advertiseExternal = advertiseExternal;
     _advertiseInactive = advertiseInactive;
-    _initiatorIp = initiatorIp;
-    _listenerIp = listenerIp;
+    _tailIp = tailIp;
+    _headIp = headIp;
     _sessionType = sessionType;
   }
 
@@ -55,13 +55,13 @@ public final class BgpSessionProperties {
   }
 
   @Nonnull
-  public Ip getInitiatorIp() {
-    return _initiatorIp;
+  public Ip getTailIp() {
+    return _tailIp;
   }
 
   @Nonnull
-  public Ip getListenerIp() {
-    return _listenerIp;
+  public Ip getHeadIp() {
+    return _headIp;
   }
 
   /** Return this session's {@link SessionType}. */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -230,31 +230,27 @@ public final class BgpTopologyUtils {
   /**
    * Check if a bgp peer is reachable to establish a session
    *
-   * <p><b>Warning:</b> Notion of directionality is important here, we are assuming {@code src} is
-   * initiating the connection according to its local configuration
+   * <p><b>Warning:</b> Notion of directionality is important here, we are assuming {@code
+   * initiator} is initiating the connection according to its local configuration
+   *
+   * <p>Assumes {@code initiator}'s local IP and peer address have already been confirmed nonnull.
    */
   @VisibleForTesting
   public static boolean isReachableBgpNeighbor(
-      @Nonnull BgpPeerConfigId initiator,
-      @Nonnull BgpPeerConfigId listener,
-      @Nonnull BgpActivePeerConfig src,
+      @Nonnull BgpPeerConfigId initiatorId,
+      @Nonnull BgpPeerConfigId listenerId,
+      @Nonnull BgpActivePeerConfig initiator,
       @Nonnull TracerouteEngine tracerouteEngine) {
-    Ip srcAddress = src.getLocalIp();
-    Ip dstAddress = src.getPeerAddress();
-    if (dstAddress == null) {
-      return false;
-    }
-
     // we do a bidirectional traceroute only from the initiator to the listener since the other
     // direction will be checked once we pick up the listener as the source. This is consistent with
     // the directional nature of BGP graph
     return canInitiateBgpSession(
-        initiator.getHostname(),
-        initiator.getVrfName(),
-        srcAddress,
-        dstAddress,
-        listener.getHostname(),
-        SessionType.isEbgp(BgpSessionProperties.getSessionType(src)) && !src.getEbgpMultihop(),
+        initiatorId.getHostname(),
+        initiatorId.getVrfName(),
+        initiator.getLocalIp(),
+        initiator.getPeerAddress(),
+        listenerId.getHostname(),
+        BgpSessionProperties.getSessionType(initiator) == SessionType.EBGP_SINGLEHOP,
         tracerouteEngine);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -2714,8 +2714,8 @@ public class VirtualRouter implements Serializable {
    * @param ourConfig {@link BgpPeerConfig} that sends the route
    * @param remoteConfig {@link BgpPeerConfig} that will be receiving the route
    * @param allNodes all nodes in the network
-   * @param sessionProperties {@link BgpSessionProperties} representing the <em>incoming</em> edge
-   *     on which this route arrived
+   * @param sessionProperties {@link BgpSessionProperties} representing the <em>incoming</em> edge:
+   *     i.e. the edge from {@code remoteConfig} to {@code ourConfig}
    * @return The transformed route as a {@link BgpRoute}, or {@code null} if the route should not be
    *     exported.
    */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1465,8 +1465,8 @@ public class VirtualRouter implements Serializable {
       BgpSessionProperties sessionProperties =
           getBgpSessionProperties(bgpTopology, new BgpEdgeId(remoteConfigId, ourConfigId));
       BgpPeerConfig ourBgpConfig = requireNonNull(nc.getBgpPeerConfig(e.getKey().dst()));
-      // sessionProperties represents the incoming edge, so its fromIp is the remote peer's IP
-      Ip remoteIp = sessionProperties.getFromIp();
+      // sessionProperties represents the incoming edge, so its tailIp is the remote peer's IP
+      Ip remoteIp = sessionProperties.getTailIp();
 
       BgpRib targetRib = sessionProperties.isEbgp() ? _ebgpStagingRib : _ibgpStagingRib;
       Builder<AnnotatedRoute<AbstractRoute>> perNeighborDeltaForRibGroups = RibDelta.builder();
@@ -2749,8 +2749,8 @@ public class VirtualRouter implements Serializable {
       return null;
     }
 
-    // sessionProperties represents the incoming edge, so its fromIp is the remote peer's IP
-    Ip remoteIp = sessionProperties.getFromIp();
+    // sessionProperties represents the incoming edge, so its tailIp is the remote peer's IP
+    Ip remoteIp = sessionProperties.getTailIp();
 
     // Process transformed outgoing route by the export policy
     boolean shouldExport =

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1465,7 +1465,8 @@ public class VirtualRouter implements Serializable {
       BgpSessionProperties sessionProperties =
           getBgpSessionProperties(bgpTopology, new BgpEdgeId(remoteConfigId, ourConfigId));
       BgpPeerConfig ourBgpConfig = requireNonNull(nc.getBgpPeerConfig(e.getKey().dst()));
-      BgpPeerConfig remoteBgpConfig = requireNonNull(nc.getBgpPeerConfig(e.getKey().src()));
+      // sessionProperties represents the incoming edge, so its fromIp is the remote peer's IP
+      Ip remoteIp = sessionProperties.getFromIp();
 
       BgpRib targetRib = sessionProperties.isEbgp() ? _ebgpStagingRib : _ibgpStagingRib;
       Builder<AnnotatedRoute<AbstractRoute>> perNeighborDeltaForRibGroups = RibDelta.builder();
@@ -1494,7 +1495,7 @@ public class VirtualRouter implements Serializable {
                 importPolicy.process(
                     remoteRoute,
                     transformedIncomingRouteBuilder,
-                    remoteBgpConfig.getLocalIp(),
+                    remoteIp,
                     ourConfigId.getRemotePeerPrefix(),
                     _name,
                     IN);
@@ -1505,7 +1506,7 @@ public class VirtualRouter implements Serializable {
           _prefixTracer.filtered(
               remoteRoute.getNetwork(),
               ourConfigId.getHostname(),
-              remoteBgpConfig.getLocalIp(),
+              remoteIp,
               remoteConfigId.getVrfName(),
               importPolicyName,
               IN);
@@ -1530,7 +1531,7 @@ public class VirtualRouter implements Serializable {
           _prefixTracer.installed(
               transformedIncomingRoute.getNetwork(),
               remoteConfigId.getHostname(),
-              remoteBgpConfig.getLocalIp(),
+              remoteIp,
               remoteConfigId.getVrfName(),
               importPolicyName);
         }
@@ -2713,6 +2714,8 @@ public class VirtualRouter implements Serializable {
    * @param ourConfig {@link BgpPeerConfig} that sends the route
    * @param remoteConfig {@link BgpPeerConfig} that will be receiving the route
    * @param allNodes all nodes in the network
+   * @param sessionProperties {@link BgpSessionProperties} representing the <em>incoming</em> edge
+   *     on which this route arrived
    * @return The transformed route as a {@link BgpRoute}, or {@code null} if the route should not be
    *     exported.
    */
@@ -2746,12 +2749,15 @@ public class VirtualRouter implements Serializable {
       return null;
     }
 
+    // sessionProperties represents the incoming edge, so its fromIp is the remote peer's IP
+    Ip remoteIp = sessionProperties.getFromIp();
+
     // Process transformed outgoing route by the export policy
     boolean shouldExport =
         exportPolicy.process(
             exportCandidate,
             transformedOutgoingRouteBuilder,
-            remoteConfig.getLocalIp(),
+            remoteIp,
             ourConfigId.getRemotePeerPrefix(),
             ourConfigId.getVrfName(),
             Direction.OUT);
@@ -2762,7 +2768,7 @@ public class VirtualRouter implements Serializable {
       _prefixTracer.filtered(
           exportCandidate.getNetwork(),
           requireNonNull(remoteVr).getHostname(),
-          remoteConfig.getLocalIp(),
+          remoteIp,
           remoteConfigId.getVrfName(),
           ourConfig.getExportPolicy(),
           Direction.OUT);
@@ -2778,7 +2784,7 @@ public class VirtualRouter implements Serializable {
     _prefixTracer.sentTo(
         transformedOutgoingRoute.getNetwork(),
         requireNonNull(remoteVr).getHostname(),
-        remoteConfig.getLocalIp(),
+        remoteIp,
         remoteConfigId.getVrfName(),
         ourConfig.getExportPolicy());
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -51,8 +51,8 @@ public class BgpProtocolHelper {
 
     BgpRoute.Builder transformedOutgoingRouteBuilder = new BgpRoute.Builder();
 
-    // sessionProperties represents incoming edge, so fromNeighbor's IP is its toIp
-    Ip fromNeighborIp = sessionProperties.getToIp();
+    // sessionProperties represents incoming edge, so fromNeighbor's IP is its headIp
+    Ip fromNeighborIp = sessionProperties.getHeadIp();
 
     // Set the tag
     transformedOutgoingRouteBuilder.setTag(route.getTag());

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -33,6 +33,11 @@ public class BgpProtocolHelper {
   /**
    * Perform BGP export transformations on a given route when sending an advertisement from {@code
    * fromNeighbor} to {@code toNeighbor} before export policy is applied.
+   *
+   * @param fromNeighbor {@link BgpPeerConfig} exporting {@code route}
+   * @param toNeighbor {@link BgpPeerConfig} to which to export {@code route}
+   * @param sessionProperties {@link BgpSessionProperties} representing the <em>incoming</em> edge:
+   *     i.e. the edge from {@code toNeighbor} to {@code fromNeighbor}
    */
   @Nullable
   public static BgpRoute.Builder transformBgpRoutePreExport(
@@ -46,10 +51,13 @@ public class BgpProtocolHelper {
 
     BgpRoute.Builder transformedOutgoingRouteBuilder = new BgpRoute.Builder();
 
+    // sessionProperties represents incoming edge, so fromNeighbor's IP is its toIp
+    Ip fromNeighborIp = sessionProperties.getToIp();
+
     // Set the tag
     transformedOutgoingRouteBuilder.setTag(route.getTag());
 
-    transformedOutgoingRouteBuilder.setReceivedFromIp(fromNeighbor.getLocalIp());
+    transformedOutgoingRouteBuilder.setReceivedFromIp(fromNeighborIp);
     RoutingProtocol remoteRouteProtocol = route.getProtocol();
 
     boolean remoteRouteIsBgp =
@@ -173,7 +181,7 @@ public class BgpProtocolHelper {
     Ip nextHopIp;
     long localPreference;
     if (sessionProperties.isEbgp() || !remoteRouteIsBgp) {
-      nextHopIp = fromNeighbor.getLocalIp();
+      nextHopIp = fromNeighborIp;
       localPreference = BgpRoute.DEFAULT_LOCAL_PREFERENCE;
     } else {
       nextHopIp = route.getNextHopIp();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
@@ -86,8 +86,18 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
         _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
     Configuration c2 =
         _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
-    _fromNeighbor = _nf.bgpNeighborBuilder().setLocalAs(AS1).setRemoteAs(ibgp ? AS1 : AS2).build();
-    _toNeighbor = _nf.bgpNeighborBuilder().setLocalAs(ibgp ? AS1 : AS2).setRemoteAs(AS1).build();
+    _fromNeighbor =
+        _nf.bgpNeighborBuilder()
+            .setLocalAs(AS1)
+            .setRemoteAs(ibgp ? AS1 : AS2)
+            .setLocalIp(SOURCE_IP)
+            .build();
+    _toNeighbor =
+        _nf.bgpNeighborBuilder()
+            .setLocalAs(ibgp ? AS1 : AS2)
+            .setRemoteAs(AS1)
+            .setLocalIp(DEST_IP)
+            .build();
     _sessionProperties = BgpSessionProperties.from(_fromNeighbor, _toNeighbor, false);
     _fromVrf = _nf.vrfBuilder().setOwner(c1).build();
     _nf.bgpProcessBuilder().setVrf(_fromVrf).setRouterId(SOURCE_IP).build();

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ibgp-no-update-source/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ibgp-no-update-source/configs/r1
@@ -1,0 +1,19 @@
+hostname r1
+!
+interface Loopback0
+   ip address 1.1.1.1/32
+!
+interface Ethernet1
+   ip address 10.0.0.1/24
+!
+!
+! Missing update-source
+router bgp 1
+   router-id 1.1.1.1
+   redistribute static
+   neighbor 2.2.2.2 remote-as 1
+!
+ip route 2.2.2.2/32 10.0.0.2
+ip route 7.7.7.7/32 Null0
+!
+end

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ibgp-no-update-source/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ibgp-no-update-source/configs/r2
@@ -1,0 +1,19 @@
+hostname r2
+!
+interface Loopback0
+   ip address 2.2.2.2/32
+!
+interface Ethernet1
+   ip address 10.0.0.2/24
+!
+!
+router bgp 1
+   router-id 2.2.2.2
+   redistribute static
+   neighbor 1.1.1.1 remote-as 1
+   neighbor 1.1.1.1 update-source Loopback0
+!
+ip route 1.1.1.1/32 10.0.0.1
+ip route 8.8.8.8/32 Null0
+!
+end


### PR DESCRIPTION
Allows active peers with null local IPs into the established BGP topology. This fixes a bug where sessions between two active iBGP or eBGP multi-hop peers would not come up if one peer was missing a local IP, even though the other peer should still be able to initiate a session.

This change broke assumptions in BDP that BGP peers' local IPs would be nonnull, so added nonnull head and tail IPs to BgpSessionProperties. BDP now uses BgpSessionProperties as source of truth for endpoint IPs.