### PR TITLE
BGP topology: cross-check with IP owners consistently

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -207,13 +207,15 @@ public final class BgpTopologyUtils {
       @Nonnull BgpPeerConfigId candidateId,
       @Nonnull Set<String> possibleHostnames,
       @Nonnull NetworkConfigurations nc) {
+    if (!possibleHostnames.contains(candidateId.getHostname())) {
+      return false;
+    }
     if (candidateId.isDynamic()) {
       BgpPassivePeerConfig candidate = nc.getBgpDynamicPeerConfig(candidateId);
       return candidate != null
           && candidate.canConnect(neighbor.getLocalAs())
           && neighbor.getRemoteAsns().contains(candidate.getLocalAs())
-          && candidate.canConnect(neighbor.getLocalIp())
-          && possibleHostnames.contains(candidateId.getHostname());
+          && candidate.canConnect(neighbor.getLocalIp());
     } else {
       BgpActivePeerConfig candidate = nc.getBgpPointToPointPeerConfig(candidateId);
       return candidate != null


### PR DESCRIPTION
Fixes issue where active peers can appear compatible with active remote peers missing their local IP when the remote peer's node does not own the local peer's remote IP.