### PR TITLE
F5 BIG-IP parsing fixes and validation

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/BUILD
@@ -10,6 +10,7 @@ java_library(
     ],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
+        "//projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/parsing:f5_bigip_imish_base_parser",
         "@antlr4_runtime//:compile",
     ],
 )

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/F5BigipImishParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/F5BigipImishParser.g4
@@ -5,7 +5,7 @@ import
 F5BigipImish_common, F5BigipImish_access_list, F5BigipImish_bgp, F5BigipImish_route_map;
 
 options {
-  superClass = 'org.batfish.grammar.BatfishParser';
+  superClass = 'org.batfish.grammar.f5_bigip_imish.parsing.F5BigipImishBaseParser';
   tokenVocab = F5BigipImishLexer;
 }
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/F5BigipImish_access_list.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/F5BigipImish_access_list.g4
@@ -9,7 +9,7 @@ options {
 ip_spec
 :
   ANY
-  | prefix = IP_PREFIX
+  | prefix = ip_prefix
 ;
 
 s_access_list

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/F5BigipImish_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/F5BigipImish_bgp.g4
@@ -91,7 +91,7 @@ rbn_null
 
 rbn_remote_as
 :
-  REMOTE_AS remoteas = uint64 NEWLINE
+  REMOTE_AS remoteas = uint32 NEWLINE
 ;
 
 rbn_route_map_out
@@ -117,7 +117,7 @@ rb_redistribute_kernel
 
 s_router_bgp
 :
-  ROUTER BGP localas = uint64 NEWLINE
+  ROUTER BGP localas = uint32 NEWLINE
   (
     rb_bgp_always_compare_med
     | rb_bgp_deterministic_med

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/F5BigipImish_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/F5BigipImish_common.g4
@@ -4,6 +4,11 @@ options {
   tokenVocab = F5BigipImishLexer;
 }
 
+ip_prefix
+:
+  IP_PREFIX
+;
+
 line_action
 :
   DENY
@@ -17,12 +22,9 @@ null_rest_of_line
 
 uint32
 :
-  DEC
-;
+  d = DEC
+  {isUint32($d)}?
 
-uint64
-:
-  DEC
 ;
 
 word

--- a/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/parsing/BUILD
+++ b/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/parsing/BUILD
@@ -1,0 +1,14 @@
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "f5_bigip_imish_base_parser",
+    srcs = [
+        ":F5BigipImishBaseParser.java",
+    ],
+    deps = [
+        "//projects/batfish-common-protocol:parser_common",
+        "@antlr4_runtime//:compile",
+        "@com_google_guava_guava//jar",
+        "@jsr305//:compile",
+    ],
+)

--- a/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/parsing/F5BigipImishBaseParser.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/parsing/F5BigipImishBaseParser.java
@@ -1,0 +1,34 @@
+package org.batfish.grammar.f5_bigip_imish.parsing;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
+import org.batfish.grammar.BatfishParser;
+
+/**
+ * F5 BIG-IP imish parser base class providing validation functionality on top of {@link
+ * BatfishParser}.
+ */
+@ParametersAreNonnullByDefault
+public abstract class F5BigipImishBaseParser extends BatfishParser {
+
+  public F5BigipImishBaseParser(TokenStream input) {
+    super(input);
+  }
+
+  /**
+   * Returns {@code true} iff {@code t}'s text represents a valid unsigned 32-bit integer in base
+   * 10.
+   */
+  protected static boolean isUint32(Token t) {
+    try {
+      Long val = Long.parseLong(t.getText(), 10);
+      checkArgument(val == (val & 0xFFFFFFFFL));
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredConfigurationBuilder.java
@@ -597,13 +597,13 @@ public class F5BigipStructuredConfigurationBuilder extends F5BigipStructuredPars
   @Override
   public void enterNrpe_entry(Nrpe_entryContext ctx) {
     _currentPrefixListEntry =
-        _currentPrefixList.getEntries().computeIfAbsent(toInteger(ctx.num), PrefixListEntry::new);
+        _currentPrefixList.getEntries().computeIfAbsent(toLong(ctx.num), PrefixListEntry::new);
   }
 
   @Override
   public void enterNrre_entry(Nrre_entryContext ctx) {
     _currentRouteMapEntry =
-        _currentRouteMap.getEntries().computeIfAbsent(toInteger(ctx.num), RouteMapEntry::new);
+        _currentRouteMap.getEntries().computeIfAbsent(toLong(ctx.num), RouteMapEntry::new);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/PrefixList.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/PrefixList.java
@@ -12,7 +12,7 @@ public final class PrefixList implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private final @Nonnull SortedMap<Integer, PrefixListEntry> _entries;
+  private final @Nonnull SortedMap<Long, PrefixListEntry> _entries;
 
   private final @Nonnull String _name;
 
@@ -21,7 +21,7 @@ public final class PrefixList implements Serializable {
     _entries = new TreeMap<>();
   }
 
-  public @Nonnull SortedMap<Integer, PrefixListEntry> getEntries() {
+  public @Nonnull SortedMap<Long, PrefixListEntry> getEntries() {
     return _entries;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/PrefixListEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/PrefixListEntry.java
@@ -21,13 +21,13 @@ public final class PrefixListEntry implements Serializable {
 
   private @Nullable SubRange _lengthRange;
 
-  private final int _num;
+  private final long _num;
 
   private @Nullable Prefix _prefix;
 
   private @Nullable Prefix6 _prefix6;
 
-  public PrefixListEntry(int num) {
+  public PrefixListEntry(long num) {
     _num = num;
   }
 
@@ -67,7 +67,7 @@ public final class PrefixListEntry implements Serializable {
     return _lengthRange;
   }
 
-  public int getNum() {
+  public long getNum() {
     return _num;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/RouteMap.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/RouteMap.java
@@ -12,7 +12,7 @@ public final class RouteMap implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private SortedMap<Integer, RouteMapEntry> _entries;
+  private SortedMap<Long, RouteMapEntry> _entries;
 
   private final @Nonnull String _name;
 
@@ -21,7 +21,7 @@ public final class RouteMap implements Serializable {
     _name = name;
   }
 
-  public SortedMap<Integer, RouteMapEntry> getEntries() {
+  public SortedMap<Long, RouteMapEntry> getEntries() {
     return _entries;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/RouteMapEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/RouteMapEntry.java
@@ -17,10 +17,10 @@ public final class RouteMapEntry implements Serializable {
   private @Nullable LineAction _action;
   private @Nullable MatchAccessList _matchAccessList;
   private @Nullable RouteMapMatchPrefixList _matchPrefixList;
-  private final int _num;
+  private final long _num;
   private @Nullable RouteMapSetCommunity _setCommunity;
 
-  public RouteMapEntry(int num) {
+  public RouteMapEntry(long num) {
     _num = num;
   }
 
@@ -41,7 +41,7 @@ public final class RouteMapEntry implements Serializable {
     return _matchPrefixList;
   }
 
-  public int getNum() {
+  public long getNum() {
     return _num;
   }
 

--- a/tests/parsing-tests/networks/unit-tests/configs/f5_bigip_imish_malformed
+++ b/tests/parsing-tests/networks/unit-tests/configs/f5_bigip_imish_malformed
@@ -5,17 +5,10 @@ sys global-settings {
 }
 
 !
-route-map invalid permit 1000000000000000000000
-!
-router bgp 1000000000000000000000
- ! don't crash
- neighbor 1.1.1.1 remote-as 1
-!
 router bgp 1
  neighbor undeclared description hello
  neighbor 3.3.3.3 remote-as 2
  neighbor 3.3.3.3 peer-group undefined-peer-group
- neighbor 4.4.4.4 remote-as 1000000000000000000000
  neighbor undeclared-peer-group remote-as 3
  neighbor 2::2 remote-as 4
  neighbor 2::2 route-map rm1 out

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -2308,7 +2308,7 @@
         "Lines" : {
           "filename" : "configs/f5_bigip_imish_malformed",
           "lines" : [
-            21
+            14
           ]
         }
       },
@@ -2320,7 +2320,7 @@
         "Lines" : {
           "filename" : "configs/f5_bigip_imish_malformed",
           "lines" : [
-            22
+            15
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -42465,41 +42465,15 @@
             "        BRACE_RIGHT:'}'",
             "        NEWLINE:'\\n\\n')))",
             "  (imish_chunk",
-            "    IMISH_CHUNK:'!\\nroute-map invalid permit 1000000000000000000000\\n!\\nrouter bgp 1000000000000000000000\\n ! don't crash\\n neighbor 1.1.1.1 remote-as 1\\n!\\nrouter bgp 1\\n neighbor undeclared description hello\\n neighbor 3.3.3.3 remote-as 2\\n neighbor 3.3.3.3 peer-group undefined-peer-group\\n neighbor 4.4.4.4 remote-as 1000000000000000000000\\n neighbor undeclared-peer-group remote-as 3\\n neighbor 2::2 remote-as 4\\n neighbor 2::2 route-map rm1 out\\n neighbor undeclared-peer-group route-map rm1 out\\n!\\nend\\n\\n\\n')",
+            "    IMISH_CHUNK:'!\\nrouter bgp 1\\n neighbor undeclared description hello\\n neighbor 3.3.3.3 remote-as 2\\n neighbor 3.3.3.3 peer-group undefined-peer-group\\n neighbor undeclared-peer-group remote-as 3\\n neighbor 2::2 remote-as 4\\n neighbor 2::2 route-map rm1 out\\n neighbor undeclared-peer-group route-map rm1 out\\n!\\nend\\n\\n\\n')",
             "  EOF:<EOF>)",
             "(f5_bigip_imish_configuration",
             "  (statement",
-            "    (s_route_map",
-            "      ROUTE_MAP:'route-map'",
-            "      name = (word",
-            "        WORD:'invalid')",
-            "      action = (line_action",
-            "        PERMIT:'permit')",
-            "      num = (uint32",
-            "        DEC:'1000000000000000000000')",
-            "      NEWLINE:'\\n'))",
-            "  (statement",
             "    (s_router_bgp",
             "      ROUTER:'router'",
             "      BGP:'bgp'",
-            "      localas = (uint64",
-            "        DEC:'1000000000000000000000')",
-            "      NEWLINE:'\\n'",
-            "      (rb_neighbor_ipv4",
-            "        NEIGHBOR:'neighbor'",
-            "        ip = IP_ADDRESS:'1.1.1.1'",
-            "        (rbn_common",
-            "          (rbn_remote_as",
-            "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'1')",
-            "            NEWLINE:'\\n')))))",
-            "  (statement",
-            "    (s_router_bgp",
-            "      ROUTER:'router'",
-            "      BGP:'bgp'",
-            "      localas = (uint64",
-            "        DEC:'1')",
+            "      localas = (uint32",
+            "        d = DEC:'1')",
             "      NEWLINE:'\\n'",
             "      (rb_neighbor_peer_group",
             "        NEIGHBOR:'neighbor'",
@@ -42516,8 +42490,8 @@
             "        (rbn_common",
             "          (rbn_remote_as",
             "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'2')",
+            "            remoteas = (uint32",
+            "              d = DEC:'2')",
             "            NEWLINE:'\\n')))",
             "      (rb_neighbor_ipv4",
             "        NEIGHBOR:'neighbor'",
@@ -42527,15 +42501,6 @@
             "          name = (peer_group_name",
             "            WORD:'undefined-peer-group')",
             "          NEWLINE:'\\n'))",
-            "      (rb_neighbor_ipv4",
-            "        NEIGHBOR:'neighbor'",
-            "        ip = IP_ADDRESS:'4.4.4.4'",
-            "        (rbn_common",
-            "          (rbn_remote_as",
-            "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'1000000000000000000000')",
-            "            NEWLINE:'\\n')))",
             "      (rb_neighbor_peer_group",
             "        NEIGHBOR:'neighbor'",
             "        name = (peer_group_name",
@@ -42543,8 +42508,8 @@
             "        (rbn_common",
             "          (rbn_remote_as",
             "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'3')",
+            "            remoteas = (uint32",
+            "              d = DEC:'3')",
             "            NEWLINE:'\\n')))",
             "      (rb_neighbor_ipv6",
             "        NEIGHBOR:'neighbor'",
@@ -42552,8 +42517,8 @@
             "        (rbn_common",
             "          (rbn_remote_as",
             "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'4')",
+            "            remoteas = (uint32",
+            "              d = DEC:'4')",
             "            NEWLINE:'\\n')))",
             "      (rb_neighbor_ipv6",
             "        NEIGHBOR:'neighbor'",
@@ -46491,7 +46456,8 @@
             "      action = (line_action",
             "        PERMIT:'permit')",
             "      src = (ip_spec",
-            "        prefix = IP_PREFIX:'192.0.2.0/24')",
+            "        prefix = (ip_prefix",
+            "          IP_PREFIX:'192.0.2.0/24'))",
             "      NEWLINE:'\\n'))",
             "  (statement",
             "    (s_null",
@@ -46522,8 +46488,8 @@
             "    (s_router_bgp",
             "      ROUTER:'router'",
             "      BGP:'bgp'",
-            "      localas = (uint64",
-            "        DEC:'65500')",
+            "      localas = (uint32",
+            "        d = DEC:'65500')",
             "      NEWLINE:'\\n'",
             "      (rb_bgp_always_compare_med",
             "        BGP:'bgp'",
@@ -46603,8 +46569,8 @@
             "        (rbn_common",
             "          (rbn_remote_as",
             "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'555')",
+            "            remoteas = (uint32",
+            "              d = DEC:'555')",
             "            NEWLINE:'\\n')))",
             "      (rb_neighbor_ipv6",
             "        NEIGHBOR:'neighbor'",
@@ -46612,8 +46578,8 @@
             "        (rbn_common",
             "          (rbn_remote_as",
             "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'555')",
+            "            remoteas = (uint32",
+            "              d = DEC:'555')",
             "            NEWLINE:'\\n')))",
             "      (rb_neighbor_ipv6",
             "        NEIGHBOR:'neighbor'",
@@ -46621,8 +46587,8 @@
             "        (rbn_common",
             "          (rbn_remote_as",
             "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'555')",
+            "            remoteas = (uint32",
+            "              d = DEC:'555')",
             "            NEWLINE:'\\n')))",
             "      (rb_neighbor_ipv6",
             "        NEIGHBOR:'neighbor'",
@@ -46630,8 +46596,8 @@
             "        (rbn_common",
             "          (rbn_remote_as",
             "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'555')",
+            "            remoteas = (uint32",
+            "              d = DEC:'555')",
             "            NEWLINE:'\\n')))",
             "      (rb_neighbor_ipv6",
             "        NEIGHBOR:'neighbor'",
@@ -46639,8 +46605,8 @@
             "        (rbn_common",
             "          (rbn_remote_as",
             "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'555')",
+            "            remoteas = (uint32",
+            "              d = DEC:'555')",
             "            NEWLINE:'\\n')))",
             "      (rb_neighbor_ipv6",
             "        NEIGHBOR:'neighbor'",
@@ -46648,8 +46614,8 @@
             "        (rbn_common",
             "          (rbn_remote_as",
             "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'555')",
+            "            remoteas = (uint32",
+            "              d = DEC:'555')",
             "            NEWLINE:'\\n')))",
             "      (rb_neighbor_ipv6",
             "        NEIGHBOR:'neighbor'",
@@ -46657,8 +46623,8 @@
             "        (rbn_common",
             "          (rbn_remote_as",
             "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'555')",
+            "            remoteas = (uint32",
+            "              d = DEC:'555')",
             "            NEWLINE:'\\n')))",
             "      (rb_neighbor_ipv4",
             "        NEIGHBOR:'neighbor'",
@@ -46666,8 +46632,8 @@
             "        (rbn_common",
             "          (rbn_remote_as",
             "            REMOTE_AS:'remote-as'",
-            "            remoteas = (uint64",
-            "              DEC:'65501')",
+            "            remoteas = (uint32",
+            "              d = DEC:'65501')",
             "            NEWLINE:'\\n')))",
             "      (rb_neighbor_ipv4",
             "        NEIGHBOR:'neighbor'",
@@ -46723,7 +46689,7 @@
             "      action = (line_action",
             "        PERMIT:'permit')",
             "      num = (uint32",
-            "        DEC:'1')",
+            "        d = DEC:'1')",
             "      NEWLINE:'\\n'",
             "      (rm_match",
             "        MATCH:'match'",
@@ -46750,7 +46716,7 @@
             "      action = (line_action",
             "        DENY:'deny')",
             "      num = (uint32",
-            "        DEC:'2')",
+            "        d = DEC:'2')",
             "      NEWLINE:'\\n'))",
             "  (statement",
             "    (s_line",
@@ -46758,7 +46724,7 @@
             "      (l_con",
             "        CON:'con'",
             "        num = (uint32",
-            "          DEC:'0')",
+            "          d = DEC:'0')",
             "        NEWLINE:'\\n'",
             "        (l_login",
             "          LOGIN:'login'",
@@ -46769,9 +46735,9 @@
             "      (l_vty",
             "        VTY:'vty'",
             "        low = (uint32",
-            "          DEC:'0')",
+            "          d = DEC:'0')",
             "        high = (uint32",
-            "          DEC:'39')",
+            "          d = DEC:'39')",
             "        NEWLINE:'\\n'",
             "        (l_login",
             "          LOGIN:'login'",
@@ -72461,35 +72427,11 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Could not convert to Integer: 1000000000000000000000"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Invalid entry number: '1000000000000000000000' in: 'route-map invalid permit 1000000000000000000000\n"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not convert to Long: 1000000000000000000000"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Invalid local-as: '1000000000000000000000' in: 'router bgp 1000000000000000000000\n ! don't crash\n neighbor 1.1.1.1 remote-as 1\n"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
               "text" : "Cannot add description to non-existent neighbor: 'undeclared' in: 'neighbor undeclared description hello\n'"
             },
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Cannot assign bgp neighbor to non-existent peer-group: 'undefined-peer-group' in: 'neighbor 3.3.3.3 peer-group undefined-peer-group\n'"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Could not convert to Long: 1000000000000000000000"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Invalid remote-as: '1000000000000000000000' in: 'remote-as 1000000000000000000000\n"
             },
             {
               "tag" : "MISCELLANEOUS",
@@ -77129,21 +77071,15 @@
         },
         "configs/f5_bigip_imish_malformed" : {
           "bgp neighbor" : {
-            "1.1.1.1" : {
-              "definitionLines" : [
-                12
-              ],
-              "numReferrers" : 1
-            },
             "2::2" : {
               "definitionLines" : [
-                20
+                13
               ],
               "numReferrers" : 1
             },
             "3.3.3.3" : {
               "definitionLines" : [
-                16
+                10
               ],
               "numReferrers" : 1
             }
@@ -77151,15 +77087,14 @@
           "bgp process" : {
             "1" : {
               "definitionLines" : [
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
                 14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22
+                15
               ],
               "numReferrers" : 1
             }
@@ -82909,43 +82844,38 @@
         },
         "configs/f5_bigip_imish_malformed" : {
           "bgp neighbor" : {
-            "1.1.1.1" : {
-              "bgp neighbor self-reference" : [
-                12
-              ]
-            },
             "2::2" : {
               "bgp neighbor self-reference" : [
-                20
+                13
               ]
             },
             "3.3.3.3" : {
               "bgp neighbor self-reference" : [
-                16
+                10
               ]
             }
           },
           "bgp process" : {
             "1" : {
               "bgp process self-reference" : [
-                14
+                8
               ]
             }
           },
           "peer-group" : {
             "undefined-peer-group" : {
               "neighbor peer-group" : [
-                17
+                11
               ]
             }
           },
           "route-map" : {
             "rm1" : {
               "bgp neighbor address-family ipv6 route-map out" : [
-                21
+                14
               ],
               "neighbor peer-group route-map out" : [
-                22
+                15
               ]
             }
           }
@@ -86116,10 +86046,10 @@
           "route-map" : {
             "rm1" : {
               "bgp neighbor address-family ipv6 route-map out" : [
-                21
+                14
               ],
               "neighbor peer-group route-map out" : [
-                22
+                15
               ]
             }
           }


### PR DESCRIPTION
- validation for imish parser
- use correct integer sizes
- avoid passing tokens to conversion functions in imish extraction
- remove unnecessary validation during extraction