### PR TITLE
Fix NPE when BGP cluster ID is null

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -57,6 +58,7 @@ public class BgpProcess implements Serializable {
     public Set<Long> get() {
       return _activeNeighbors.values().stream()
           .map(BgpPeerConfig::getClusterId)
+          .filter(Objects::nonNull)
           .collect(ImmutableSet.toImmutableSet());
     }
   }


### PR DESCRIPTION
Doesn't seem important to include `null` in the set of collected cluster IDs, because `ClusterIdsSupplier.get()` is only called once, and that's to check if the set has any cluster ID in common with another set that can't include `null`.