### PR TITLE
OspfRoutingProcess: collect to set

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -702,7 +702,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
                 r.toBuilder()
                     .setRoute(r.getRoute().toBuilder().setNextHopIp(nextHopIp).build())
                     .build())
-        .collect(ImmutableList.toImmutableList());
+        .collect(ImmutableSet.toImmutableSet());
   }
 
   /** Send out inter-area routes from a regular (non-ABR) router to a neighbor */
@@ -751,7 +751,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
                             .setNextHopIp(nextHopIp)
                             .build())
                     .build())
-        .collect(ImmutableList.toImmutableList());
+        .collect(ImmutableSet.toImmutableSet());
   }
 
   /** Send out inter-area routes from an ABR to a neighbor */
@@ -797,7 +797,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
                     nextHopIp,
                     _process.getMaxMetricSummaryNetworks()),
                 computeDefaultInterAreaRouteToInject(edgeId, areaConfig, nextHopIp))
-            .collect(ImmutableList.toImmutableList()));
+            .collect(ImmutableSet.toImmutableSet()));
   }
 
   /**
@@ -1195,7 +1195,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
                               .build())
                   .build();
             })
-        .collect(ImmutableList.toImmutableList());
+        .collect(ImmutableSet.toImmutableSet());
   }
 
   /**
@@ -1226,7 +1226,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
                               .build())
                   .build();
             })
-        .collect(ImmutableList.toImmutableList());
+        .collect(ImmutableSet.toImmutableSet());
   }
 
   /**
@@ -1388,7 +1388,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
             r -> areaConfig.getStubType() == StubType.NONE || !r.getNetwork().equals(Prefix.ZERO))
         .filter(clazz::isInstance)
         .map(r -> new RouteAdvertisement<>(clazz.cast(r)))
-        .collect(ImmutableList.toImmutableList());
+        .collect(ImmutableSet.toImmutableSet());
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -798,7 +798,7 @@ public class OspfRoutingProcessTest {
     // Going to area 0
     assertThat(
         _routingProcess.transformType1RoutesOnExport(routes, AREA0_CONFIG),
-        equalTo(ImmutableList.of(new RouteAdvertisement<>(builder.setArea(0).build()))));
+        contains(new RouteAdvertisement<>(builder.setArea(0).build())));
 
     // Going from area 0 to some area
     assertThat(
@@ -806,9 +806,7 @@ public class OspfRoutingProcessTest {
             ImmutableList.of(
                 new RouteAdvertisement<>((OspfExternalType1Route) builder.setArea(0).build())),
             ospfArea),
-        equalTo(
-            ImmutableList.of(
-                new RouteAdvertisement<>(builder.setArea(ospfArea.getAreaNumber()).build()))));
+        contains(new RouteAdvertisement<>(builder.setArea(ospfArea.getAreaNumber()).build())));
 
     // Generated locally, going to some area
     assertThat(
@@ -817,9 +815,7 @@ public class OspfRoutingProcessTest {
                 new RouteAdvertisement<>(
                     (OspfExternalType1Route) builder.setArea(OspfRoute.NO_AREA).build())),
             ospfArea),
-        equalTo(
-            ImmutableList.of(
-                new RouteAdvertisement<>(builder.setArea(ospfArea.getAreaNumber()).build()))));
+        contains(new RouteAdvertisement<>(builder.setArea(ospfArea.getAreaNumber()).build())));
 
     // In the same area
     assertThat(
@@ -828,9 +824,7 @@ public class OspfRoutingProcessTest {
                 new RouteAdvertisement<>(
                     (OspfExternalType1Route) builder.setArea(ospfArea.getAreaNumber()).build())),
             ospfArea),
-        equalTo(
-            ImmutableList.of(
-                new RouteAdvertisement<>(builder.setArea(ospfArea.getAreaNumber()).build()))));
+        contains(new RouteAdvertisement<>(builder.setArea(ospfArea.getAreaNumber()).build())));
 
     // Going across two non-zero areas: not allowed
     assertThat(
@@ -869,15 +863,14 @@ public class OspfRoutingProcessTest {
     // Override for routes transiting across areas
     assertThat(
         routingProcess.transformType1RoutesOnExport(routes, AREA0_CONFIG),
-        equalTo(
-            ImmutableList.of(
-                new RouteAdvertisement<>(
-                    (OspfExternalType1Route)
-                        builder
-                            .setCostToAdvertiser(overrideMetric)
-                            .setMetric(overrideMetric + 10) // + LsaMetric
-                            .setArea(0)
-                            .build()))));
+        contains(
+            new RouteAdvertisement<>(
+                (OspfExternalType1Route)
+                    builder
+                        .setCostToAdvertiser(overrideMetric)
+                        .setMetric(overrideMetric + 10) // + LsaMetric
+                        .setArea(0)
+                        .build())));
 
     // No override for locally generated routes
     assertThat(
@@ -886,9 +879,7 @@ public class OspfRoutingProcessTest {
                 new RouteAdvertisement<>(
                     (OspfExternalType1Route) builder.setArea(OspfRoute.NO_AREA).build())),
             AREA0_CONFIG),
-        equalTo(
-            ImmutableList.of(
-                new RouteAdvertisement<>((OspfExternalType1Route) builder.setArea(0).build()))));
+        contains(new RouteAdvertisement<>((OspfExternalType1Route) builder.setArea(0).build())));
   }
 
   @Test
@@ -906,14 +897,14 @@ public class OspfRoutingProcessTest {
         ImmutableList.of(new RouteAdvertisement<>((OspfExternalType2Route) builder.build()));
     assertThat(
         _routingProcess.transformType2RoutesOnExport(routes, AREA0_CONFIG),
-        equalTo(ImmutableList.of(new RouteAdvertisement<>(builder.setArea(1).build()))));
+        contains(new RouteAdvertisement<>(builder.setArea(1).build())));
     assertThat(
         _routingProcess.transformType2RoutesOnExport(
             ImmutableList.of(
                 new RouteAdvertisement<>(
                     (OspfExternalType2Route) builder.setArea(OspfRoute.NO_AREA).build())),
             AREA0_CONFIG),
-        equalTo(ImmutableList.of(new RouteAdvertisement<>(builder.setArea(0).build()))));
+        contains(new RouteAdvertisement<>(builder.setArea(0).build())));
   }
 
   @Test


### PR DESCRIPTION
This helps reduce memory pressure when computing dataplane on certain networks