### PR TITLE
Cisco: properly identify portchannel subinterfaces

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -704,7 +704,12 @@ public final class Interface extends ComparableStructure<String> {
     } else if (name.startsWith("nve")) {
       return InterfaceType.VLAN;
     } else if (name.startsWith("Port-Channel")) {
-      return InterfaceType.AGGREGATED;
+      if (name.contains(".")) {
+        // Subinterface of a port channel
+        return InterfaceType.AGGREGATE_CHILD;
+      } else {
+        return InterfaceType.AGGREGATED;
+      }
     } else if (name.startsWith("POS")) {
       return InterfaceType.PHYSICAL;
     } else if (name.startsWith("Serial")) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -89,6 +89,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasEigrp;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasEncapsulationVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasHsrpGroup;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasHsrpVersion;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInterfaceType;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasIsis;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMlagId;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
@@ -296,6 +297,7 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
@@ -5610,5 +5612,15 @@ public class CiscoGrammarTest {
                 .setMetric(1)
                 .setLsaMetric(1)
                 .build()));
+  }
+
+  @Test
+  public void testPortchannelSubinterfaceIsUp() throws IOException {
+    Configuration config = parseConfig("ios-portchannel-subinterface");
+    assertThat(
+        config,
+        hasInterface(
+            "Port-Channel1.1",
+            allOf(hasInterfaceType(InterfaceType.AGGREGATE_CHILD), isActive(true))));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-portchannel-subinterface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-portchannel-subinterface
@@ -1,0 +1,9 @@
+!
+hostname ios-portchannel-subinterface
+!
+interface Ethernet1
+  no shutdown
+  channel-group 1
+interface Port-Channel1
+  description foo
+interface Port-Channel1.1


### PR DESCRIPTION
Give them correct type so that they are not disabled for lack of dependencies.
Note: this does not add a bind dependency to the parent interface (future work)