### PR TITLE
Simplify BgpSessionQuestion.matchesType()

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswerer.java
@@ -137,12 +137,7 @@ public abstract class BgpSessionAnswerer extends Answerer {
         return false;
       }
     }
-    String typeName = (String) row.get(COL_SESSION_TYPE, Schema.STRING);
-    SessionType type = typeName == null ? null : SessionType.valueOf(typeName);
-    if (!question.matchesType(type)) {
-      return false;
-    }
-    return true;
+    return question.matchesType((String) row.get(COL_SESSION_TYPE, Schema.STRING));
   }
 
   public abstract List<Row> getRows(BgpSessionQuestion question);

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionQuestion.java
@@ -77,11 +77,8 @@ public abstract class BgpSessionQuestion extends Question {
     return status != null && _status.matcher(status.toString()).matches();
   }
 
-  boolean matchesType(SessionType type) {
-    if (_type.pattern().equals(MATCH_ALL)) {
-      return true;
-    }
-    return type != null && _type.matcher(type.toString()).matches();
+  boolean matchesType(@Nullable String type) {
+    return _type.pattern().equals(MATCH_ALL) || (type != null && _type.matcher(type).matches());
   }
 
   @Nullable


### PR DESCRIPTION
No point in converting String to SessionType only to immediately convert back to String. No functional change.