### PR TITLE
BGP admin cost defaults for Cumulus

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RoutingProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RoutingProtocol.java
@@ -120,9 +120,9 @@ public enum RoutingProtocol {
           case CISCO_IOS:
           case CISCO_IOS_XR:
           case CISCO_NX:
+          case CUMULUS_NCLU:
           case FORCE10:
           case FOUNDRY:
-            return 20;
           case F5:
           case F5_BIGIP_STRUCTURED:
             return 20;
@@ -247,9 +247,9 @@ public enum RoutingProtocol {
           case CISCO_IOS:
           case CISCO_IOS_XR:
           case CISCO_NX:
+          case CUMULUS_NCLU:
           case FORCE10:
           case FOUNDRY:
-            return 200;
           case F5:
           case F5_BIGIP_STRUCTURED:
             return 200;


### PR DESCRIPTION
Necessary to successfully generate data plane (no data plane support for BGP unnumbered yet).

Default costs based on https://support.cumulusnetworks.com/hc/en-us/articles/202917918-Routing-Preferences