### PR TITLE
Small BGP peer config & topology changes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPassivePeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPassivePeerConfig.java
@@ -139,13 +139,8 @@ public final class BgpPassivePeerConfig extends BgpPeerConfig {
     _peerPrefix = peerPrefix;
   }
 
-  /** Check whether a connection from a peer with a given AS number will be accepted. */
-  public boolean canConnect(@Nullable Long asNumber) {
-    return _remoteAsns.equals(ALL_AS_NUMBERS)
-        || (asNumber != null && _remoteAsns.contains(asNumber));
-  }
-
-  public boolean canConnect(@Nonnull Ip address) {
+  /** Check whether this peer's remote prefix contains the given IP. */
+  public boolean hasCompatibleRemotePrefix(@Nonnull Ip address) {
     return _peerPrefix != null && _peerPrefix.containsIp(address);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
@@ -150,6 +150,12 @@ public abstract class BgpPeerConfig implements Serializable {
     _sendCommunity = sendCommunity;
   }
 
+  /** Check whether the given AS number matches this peer's remote AS numbers. */
+  public boolean hasCompatibleRemoteAsns(@Nullable Long asNumber) {
+    return _remoteAsns.equals(ALL_AS_NUMBERS)
+        || (asNumber != null && _remoteAsns.contains(asNumber));
+  }
+
   @JsonProperty(PROP_ADDITIONAL_PATHS_RECEIVE)
   public boolean getAdditionalPathsReceive() {
     return _additionalPathsReceive;


### PR DESCRIPTION
- Rename `canConnect()` methods to be more obvious
- Move one of them to `BgpPeerConfig` since it's useful for all BGP peers, not just dynamic
- Simplify `BgpTopology.bgpCandidatePassesSanityChecks()`