### PR TITLE
BGP unnumbered peers and sessions in BGP topology

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfigId.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfigId.java
@@ -116,15 +116,14 @@ public final class BgpPeerConfigId implements Comparable<BgpPeerConfigId> {
 
   @Override
   public int compareTo(@Nonnull BgpPeerConfigId o) {
-    Comparator<BgpPeerConfigId> baseComparator =
-        Comparator.comparing(BgpPeerConfigId::getHostname)
-            .thenComparing(BgpPeerConfigId::getVrfName)
-            .thenComparing(BgpPeerConfigId::getType);
-
-    // Need to compare whichever is nonnull of peer interface or remote prefix.
-    return _remotePeerPrefix != null
-        ? baseComparator.thenComparing(BgpPeerConfigId::getRemotePeerPrefix).compare(this, o)
-        : baseComparator.thenComparing(BgpPeerConfigId::getPeerInterface).compare(this, o);
+    return Comparator.comparing(BgpPeerConfigId::getHostname)
+        .thenComparing(BgpPeerConfigId::getVrfName)
+        .thenComparing(BgpPeerConfigId::getType)
+        .thenComparing(
+            BgpPeerConfigId::getRemotePeerPrefix, Comparator.nullsLast(Prefix::compareTo))
+        .thenComparing(
+            BgpPeerConfigId::getPeerInterface, Comparator.nullsLast(Comparator.naturalOrder()))
+        .compare(this, o);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfigId.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfigId.java
@@ -85,9 +85,9 @@ public final class BgpPeerConfigId implements Comparable<BgpPeerConfigId> {
   }
 
   /**
-   * The interface of this peer ID, or null if it does not represent a {@link
-   * BgpUnnumberedPeerConfig}. By contract, exactly one of _peerInterface and {@link
-   * #_remotePeerPrefix} is defined.
+   * The interface of this peer ID, or {@code null} iff it does not represent a {@link
+   * BgpUnnumberedPeerConfig}. Exactly one of {@link #getPeerInterface()} and {@link
+   * #getRemotePeerPrefix()} is nonnull.
    */
   @Nullable
   @JsonProperty(PROP_INTERFACE)
@@ -96,8 +96,9 @@ public final class BgpPeerConfigId implements Comparable<BgpPeerConfigId> {
   }
 
   /**
-   * The remote prefix of this peer ID, or null if it represents a {@link BgpUnnumberedPeerConfig}.
-   * By contract, exactly one of {@link #_peerInterface} and _remotePeerPrefix is defined.
+   * The remote prefix of this peer ID, or {@code null} iff it represents a {@link
+   * BgpUnnumberedPeerConfig}. Exactly one of {@link #getPeerInterface()} and {@link
+   * #getRemotePeerPrefix()} is nonnull.
    */
   @Nullable
   @JsonProperty(PROP_PREFIX)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
@@ -80,14 +80,12 @@ public final class BgpSessionProperties {
    *     (listener to initiator) rather than forwards direction (initiator to listener)
    */
   public static BgpSessionProperties from(
-      @Nonnull BgpActivePeerConfig initiator,
-      @Nonnull BgpPeerConfig listener,
-      boolean reverseDirection) {
+      @Nonnull BgpPeerConfig initiator, @Nonnull BgpPeerConfig listener, boolean reverseDirection) {
     Ip initiatorIp = initiator.getLocalIp();
     Ip listenerIp = listener.getLocalIp();
     if (listenerIp == null || listenerIp == Ip.AUTO) {
       // Initiator must be active; determine listener's IP from initiator
-      listenerIp = initiator.getPeerAddress();
+      listenerIp = ((BgpActivePeerConfig) initiator).getPeerAddress();
     }
     assert initiatorIp != null;
     assert listenerIp != null;
@@ -108,10 +106,10 @@ public final class BgpSessionProperties {
   /**
    * Determine what type of session {@code initiator} is configured to establish.
    *
-   * @param initiator the {@link BgpActivePeerConfig} representing the connection initiator.
+   * @param initiator the {@link BgpPeerConfig} representing the connection initiator.
    * @return a {@link SessionType} the initiator is configured to establish.
    */
-  public static @Nonnull SessionType getSessionType(BgpActivePeerConfig initiator) {
+  public static @Nonnull SessionType getSessionType(BgpPeerConfig initiator) {
     if (initiator.getLocalAs() == null || initiator.getRemoteAsns().isEmpty()) {
       return SessionType.UNSET;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
@@ -84,7 +84,10 @@ public final class BgpSessionProperties {
     Ip initiatorIp = initiator.getLocalIp();
     Ip listenerIp = listener.getLocalIp();
     if (listenerIp == null || listenerIp == Ip.AUTO) {
-      // Initiator must be active; determine listener's IP from initiator
+      // Determine listener's IP from initiator.
+      // Listener must be active or dynamic, because unnumbered peers always have localIP defined.
+      // Therefore initiator must be active since unnumbered peers only peer with each other.
+      assert initiator instanceof BgpActivePeerConfig;
       listenerIp = ((BgpActivePeerConfig) initiator).getPeerAddress();
     }
     assert initiatorIp != null;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkConfigurations.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkConfigurations.java
@@ -41,6 +41,10 @@ public final class NetworkConfigurations {
     return Optional.ofNullable(_configurations.get(hostname));
   }
 
+  /**
+   * Returns a {@link BgpPeerConfig} matching the given {@code id} if one exists, otherwise {@code
+   * null}.
+   */
   @Nullable
   public BgpPeerConfig getBgpPeerConfig(BgpPeerConfigId id) {
     switch (id.getType()) {
@@ -55,6 +59,10 @@ public final class NetworkConfigurations {
     }
   }
 
+  /**
+   * Returns a {@link BgpPassivePeerConfig} matching the given {@code id} if one exists, otherwise
+   * {@code null}.
+   */
   @Nullable
   public BgpPassivePeerConfig getBgpDynamicPeerConfig(BgpPeerConfigId id) {
     if (id.getRemotePeerPrefix() == null) {
@@ -67,6 +75,10 @@ public final class NetworkConfigurations {
         .orElse(null);
   }
 
+  /**
+   * Returns a {@link BgpActivePeerConfig} matching the given {@code id} if one exists, otherwise
+   * {@code null}.
+   */
   @Nullable
   public BgpActivePeerConfig getBgpPointToPointPeerConfig(BgpPeerConfigId id) {
     if (id.getRemotePeerPrefix() == null) {
@@ -79,6 +91,10 @@ public final class NetworkConfigurations {
         .orElse(null);
   }
 
+  /**
+   * Returns a {@link BgpUnnumberedPeerConfig} matching the given {@code id} if one exists,
+   * otherwise {@code null}.
+   */
   @Nullable
   public BgpUnnumberedPeerConfig getBgpUnnumberedPeerConfig(BgpPeerConfigId id) {
     if (id.getPeerInterface() == null) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -282,7 +282,7 @@ public final class BgpTopologyUtils {
 
   /**
    * Check if {@code candidateId} represents a candidate with a valid configuration and compatible
-   * local/remote AS and local/remote IP to peer with {@code neighbor}.
+   * local/remote AS and local/remote IP to peer with active peer {@code neighbor}.
    */
   private static boolean bgpCandidatePassesSanityChecks(
       @Nonnull BgpActivePeerConfig neighbor,
@@ -320,7 +320,7 @@ public final class BgpTopologyUtils {
 
   /**
    * Check if {@code candidateId} represents a BGP unnumbered peer with a valid configuration and
-   * compatible local/remote AS to peer with {@code neighbor}.
+   * compatible local/remote AS to peer with BGP unnumbered peer {@code neighbor}.
    */
   private static boolean bgpCandidatePassesSanityChecks(
       @Nonnull BgpUnnumberedPeerConfig neighbor,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -268,8 +268,6 @@ public final class BgpTopologyUtils {
    */
   private static boolean bgpConfigPassesSanityChecks(
       BgpPeerConfig config, String hostname, Map<Ip, Set<String>> ipOwners) {
-
-    // TODO:
     if (config instanceof BgpUnnumberedPeerConfig) {
       return true;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -21,13 +21,16 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.plugin.TracerouteEngine;
+import org.batfish.common.topology.Layer2Topology;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
+import org.batfish.datamodel.BgpPeerConfigId.BgpPeerConfigType;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.BgpSessionProperties.SessionType;
+import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
@@ -37,6 +40,7 @@ import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Hop;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
@@ -45,8 +49,8 @@ import org.batfish.datamodel.flow.TraceAndReverseFlow;
 public final class BgpTopologyUtils {
   /**
    * Compute the BGP topology -- a network of {@link BgpPeerConfig}s connected by {@link
-   * BgpSessionProperties}s. See {@link #initBgpTopology(Map, Map, boolean, boolean,
-   * TracerouteEngine)} for more details.
+   * BgpSessionProperties}. See {@link #initBgpTopology(Map, Map, boolean, boolean,
+   * TracerouteEngine, Layer2Topology)} for more details.
    *
    * @param configurations configuration keyed by hostname
    * @param ipOwners Ip owners (see {@link
@@ -60,12 +64,13 @@ public final class BgpTopologyUtils {
       Map<String, Configuration> configurations,
       Map<Ip, Set<String>> ipOwners,
       boolean keepInvalid) {
-    return initBgpTopology(configurations, ipOwners, keepInvalid, false, null);
+    // TODO Include layer 2 topology later for BGP unnumbered sessions in BgpSession questions.
+    return initBgpTopology(configurations, ipOwners, keepInvalid, false, null, null);
   }
 
   /**
    * Compute the BGP topology -- a network of {@link BgpPeerConfigId}s connected by {@link
-   * BgpSessionProperties}s.
+   * BgpSessionProperties}.
    *
    * @param configurations node configurations, keyed by hostname
    * @param ipOwners network Ip owners (see {@link
@@ -78,6 +83,8 @@ public final class BgpTopologyUtils {
    *     {@code keepInvalid=false}, which only does filters invalid neighbors at the control-plane
    *     level
    * @param tracerouteEngine an instance of {@link TracerouteEngine} for doing reachability checks.
+   * @param layer2Topology {@link Layer2Topology} of the network, for checking BGP unnumbered
+   *     reachability.
    * @return A graph ({@link Network}) representing all BGP peerings.
    */
   public static ValueGraph<BgpPeerConfigId, BgpSessionProperties> initBgpTopology(
@@ -85,7 +92,8 @@ public final class BgpTopologyUtils {
       Map<Ip, Set<String>> ipOwners,
       boolean keepInvalid,
       boolean checkReachability,
-      @Nullable TracerouteEngine tracerouteEngine) {
+      @Nullable TracerouteEngine tracerouteEngine,
+      @Nullable Layer2Topology layer2Topology) {
     checkArgument(
         !checkReachability || tracerouteEngine != null,
         "Cannot check reachability without a traceroute engine");
@@ -110,6 +118,8 @@ public final class BgpTopologyUtils {
             // nothing to do if no bgp process on this VRF
             continue;
           }
+
+          // Active and dynamic peers
           for (Entry<Prefix, ? extends BgpPeerConfig> entry :
               Iterables.concat(
                   proc.getActiveNeighbors().entrySet(), proc.getPassiveNeighbors().entrySet())) {
@@ -125,59 +135,125 @@ public final class BgpTopologyUtils {
                     hostname, vrf.getName(), prefix, bgpPeerConfig instanceof BgpPassivePeerConfig);
             graph.addNode(neighborID);
           }
+
+          // Unnumbered BGP peers: map of interface name to BgpUnnumberedPeerConfig
+          proc.getInterfaceNeighbors().entrySet().stream()
+              .filter(
+                  e -> keepInvalid || bgpConfigPassesSanityChecks(e.getValue(), hostname, ipOwners))
+              .forEach(
+                  e -> graph.addNode(new BgpPeerConfigId(hostname, vrf.getName(), e.getKey())));
         }
       }
 
       // Second pass: add edges to the graph. Note, these are directed edges.
       for (BgpPeerConfigId neighborId : graph.nodes()) {
-        if (neighborId.isDynamic()) {
-          // Passive end of the peering cannot initiate a connection
-          continue;
+        switch (neighborId.getType()) {
+          case DYNAMIC:
+            // Passive end of the peering cannot initiate a connection
+            continue;
+          case ACTIVE:
+            addActivePeerEdges(
+                neighborId,
+                graph,
+                networkConfigurations,
+                ipOwners,
+                checkReachability,
+                tracerouteEngine);
+            break;
+          case UNNUMBERED:
+            // Can't infer BGP unnumbered connectivity without layer 2 topology
+            if (layer2Topology != null) {
+              addUnnumberedPeerEdges(neighborId, graph, networkConfigurations, layer2Topology);
+            }
+            break;
+          default:
+            throw new IllegalArgumentException(
+                String.format("Unrecognized peer type: %s", neighborId));
         }
-        BgpActivePeerConfig neighbor =
-            networkConfigurations.getBgpPointToPointPeerConfig(neighborId);
-        if (neighbor == null
-            || neighbor.getLocalIp() == null
-            || neighbor.getLocalAs() == null
-            || neighbor.getPeerAddress() == null
-            || neighbor.getRemoteAsns().isEmpty()) {
-          continue;
-        }
-        // Find nodes that own the neighbor's peer address
-        Set<String> possibleHostnames = ipOwners.get(neighbor.getPeerAddress());
-        if (possibleHostnames == null) {
-          continue;
-        }
-
-        Set<BgpPeerConfigId> alreadyEstablished = graph.adjacentNodes(neighborId);
-        graph.nodes().stream()
-            .filter(
-                candidateId ->
-                    // If edge is already established (i.e., we already found that candidate can
-                    // initiate the session), don't bother checking in this direction
-                    !alreadyEstablished.contains(candidateId)
-                        // Ensure candidate has compatible local/remote IP, AS, & hostname
-                        && bgpCandidatePassesSanityChecks(
-                            neighbor, candidateId, possibleHostnames, networkConfigurations)
-                        // If checking reachability, ensure candidate is reachable
-                        && (!checkReachability
-                            || isReachableBgpNeighbor(
-                                neighborId, candidateId, neighbor, tracerouteEngine)))
-            .forEach(
-                remoteId -> {
-                  // Session will be established. Add edges between neighbor and remote peer.
-                  BgpPeerConfig remotePeer =
-                      Objects.requireNonNull(networkConfigurations.getBgpPeerConfig(remoteId));
-                  BgpSessionProperties edgeToCandidate =
-                      BgpSessionProperties.from(neighbor, remotePeer, false);
-                  BgpSessionProperties edgeFromCandidate =
-                      BgpSessionProperties.from(neighbor, remotePeer, true);
-                  graph.putEdgeValue(neighborId, remoteId, edgeToCandidate);
-                  graph.putEdgeValue(remoteId, neighborId, edgeFromCandidate);
-                });
       }
       return ImmutableValueGraph.copyOf(graph);
     }
+  }
+
+  private static void addActivePeerEdges(
+      BgpPeerConfigId neighborId,
+      MutableValueGraph<BgpPeerConfigId, BgpSessionProperties> graph,
+      NetworkConfigurations nc,
+      Map<Ip, Set<String>> ipOwners,
+      boolean checkReachability,
+      TracerouteEngine tracerouteEngine) {
+    BgpActivePeerConfig neighbor = nc.getBgpPointToPointPeerConfig(neighborId);
+    if (neighbor == null
+        || neighbor.getLocalIp() == null
+        || neighbor.getLocalAs() == null
+        || neighbor.getPeerAddress() == null
+        || neighbor.getRemoteAsns().isEmpty()) {
+      return;
+    }
+    // Find nodes that own the neighbor's peer address
+    Set<String> possibleHostnames = ipOwners.get(neighbor.getPeerAddress());
+    if (possibleHostnames == null) {
+      return;
+    }
+
+    Set<BgpPeerConfigId> alreadyEstablished = graph.adjacentNodes(neighborId);
+    graph.nodes().stream()
+        .filter(
+            candidateId ->
+                // If edge is already established (i.e., we already found that candidate can
+                // initiate the session), don't bother checking in this direction
+                !alreadyEstablished.contains(candidateId)
+                    // Ensure candidate has compatible local/remote IP, AS, & hostname
+                    && bgpCandidatePassesSanityChecks(neighbor, candidateId, possibleHostnames, nc)
+                    // If checking reachability, ensure candidate is reachable
+                    && (!checkReachability
+                        || isReachableBgpNeighbor(
+                            neighborId, candidateId, neighbor, tracerouteEngine)))
+        .forEach(remoteId -> addEdges(neighbor, neighborId, remoteId, graph, nc));
+  }
+
+  private static void addUnnumberedPeerEdges(
+      BgpPeerConfigId neighborId,
+      MutableValueGraph<BgpPeerConfigId, BgpSessionProperties> graph,
+      NetworkConfigurations nc,
+      @Nonnull Layer2Topology layer2Topology) {
+    // neighbor will be null if neighborId has no peer interface defined
+    BgpUnnumberedPeerConfig neighbor = nc.getBgpUnnumberedPeerConfig(neighborId);
+    if (neighbor == null || neighbor.getLocalAs() == null || neighbor.getRemoteAsns().isEmpty()) {
+      return;
+    }
+
+    Set<BgpPeerConfigId> alreadyEstablished = graph.adjacentNodes(neighborId);
+    NodeInterfacePair peerNip =
+        new NodeInterfacePair(neighborId.getHostname(), neighborId.getPeerInterface());
+    graph.nodes().stream()
+        .filter(
+            candidateId ->
+                // If edge is already established (i.e., we already found that candidate can
+                // initiate the session), don't bother checking in this direction
+                !alreadyEstablished.contains(candidateId)
+                    //  Ensure candidate is unnumbered and has compatible local/remote AS
+                    && bgpCandidatePassesSanityChecks(neighbor, candidateId, nc)
+                    // Check layer 2 connectivity
+                    && layer2Topology.inSameBroadcastDomain(
+                        peerNip,
+                        new NodeInterfacePair(
+                            candidateId.getHostname(), candidateId.getPeerInterface())))
+        .forEach(remoteId -> addEdges(neighbor, neighborId, remoteId, graph, nc));
+  }
+
+  /** Adds edges in {@code graph} between the given {@link BgpPeerConfigId}s in both directions. */
+  private static void addEdges(
+      BgpPeerConfig p1,
+      BgpPeerConfigId id1,
+      BgpPeerConfigId id2,
+      MutableValueGraph<BgpPeerConfigId, BgpSessionProperties> graph,
+      NetworkConfigurations networkConfigurations) {
+    BgpPeerConfig remotePeer = Objects.requireNonNull(networkConfigurations.getBgpPeerConfig(id2));
+    BgpSessionProperties edgeToCandidate = BgpSessionProperties.from(p1, remotePeer, false);
+    BgpSessionProperties edgeFromCandidate = BgpSessionProperties.from(p1, remotePeer, true);
+    graph.putEdgeValue(id1, id2, edgeToCandidate);
+    graph.putEdgeValue(id2, id1, edgeFromCandidate);
   }
 
   /**
@@ -192,6 +268,12 @@ public final class BgpTopologyUtils {
    */
   private static boolean bgpConfigPassesSanityChecks(
       BgpPeerConfig config, String hostname, Map<Ip, Set<String>> ipOwners) {
+
+    // TODO:
+    if (config instanceof BgpUnnumberedPeerConfig) {
+      return true;
+    }
+
     Ip localIp = config.getLocalIp();
     return localIp == null
         || localIp.equals(Ip.AUTO) // dynamic
@@ -199,31 +281,55 @@ public final class BgpTopologyUtils {
   }
 
   /**
-   * Check if the given combo of BGP peer configs can agree on their respective BGP local/remote AS
-   * number configurations.
+   * Check if {@code candidateId} represents a candidate with a valid configuration and compatible
+   * local/remote AS and local/remote IP to peer with {@code neighbor}.
    */
   private static boolean bgpCandidatePassesSanityChecks(
       @Nonnull BgpActivePeerConfig neighbor,
       @Nonnull BgpPeerConfigId candidateId,
       @Nonnull Set<String> possibleHostnames,
       @Nonnull NetworkConfigurations nc) {
-    BgpPeerConfig candidate = nc.getBgpPeerConfig(candidateId);
     if (!possibleHostnames.contains(candidateId.getHostname())
-        || candidate == null
+        // Unnumbered configs only form sessions with each other
+        || candidateId.getType() == BgpPeerConfigType.UNNUMBERED) {
+      return false;
+    }
+    // Ensure candidate exists and has compatible local and remote AS
+    BgpPeerConfig candidate = nc.getBgpPeerConfig(candidateId);
+    if (candidate == null
         || !neighbor.hasCompatibleRemoteAsns(candidate.getLocalAs())
         || !candidate.hasCompatibleRemoteAsns(neighbor.getLocalAs())) {
       return false;
     }
-    if (candidateId.isDynamic()) {
-      return ((BgpPassivePeerConfig) candidate).hasCompatibleRemotePrefix(neighbor.getLocalIp());
-    } else {
-      // If candidate has no local IP, we can still initiate unless session is EBGP single-hop.
-      return (Objects.equals(neighbor.getPeerAddress(), candidate.getLocalIp())
-              || (candidate.getLocalIp() == null
-                  && BgpSessionProperties.getSessionType(neighbor) != SessionType.EBGP_SINGLEHOP))
-          && Objects.equals(
-              neighbor.getLocalIp(), ((BgpActivePeerConfig) candidate).getPeerAddress());
+    switch (candidateId.getType()) {
+      case DYNAMIC:
+        return ((BgpPassivePeerConfig) candidate).hasCompatibleRemotePrefix(neighbor.getLocalIp());
+      case ACTIVE:
+        // If candidate has no local IP, we can still initiate unless session is EBGP single-hop.
+        return (Objects.equals(neighbor.getPeerAddress(), candidate.getLocalIp())
+                || (candidate.getLocalIp() == null
+                    && BgpSessionProperties.getSessionType(neighbor) != SessionType.EBGP_SINGLEHOP))
+            && Objects.equals(
+                neighbor.getLocalIp(), ((BgpActivePeerConfig) candidate).getPeerAddress());
+      default:
+        // Already checked it wasn't unnumbered
+        throw new IllegalArgumentException(
+            String.format("Unrecognized peer type: %s", candidateId.getType()));
     }
+  }
+
+  /**
+   * Check if {@code candidateId} represents a BGP unnumbered peer with a valid configuration and
+   * compatible local/remote AS to peer with {@code neighbor}.
+   */
+  private static boolean bgpCandidatePassesSanityChecks(
+      @Nonnull BgpUnnumberedPeerConfig neighbor,
+      @Nonnull BgpPeerConfigId candidateId,
+      @Nonnull NetworkConfigurations nc) {
+    BgpPeerConfig candidate = nc.getBgpPeerConfig(candidateId);
+    return candidate instanceof BgpUnnumberedPeerConfig
+        && neighbor.hasCompatibleRemoteAsns(candidate.getLocalAs())
+        && candidate.hasCompatibleRemoteAsns(neighbor.getLocalAs());
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
@@ -17,6 +17,7 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
+import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.answers.Schema;
 
@@ -104,14 +105,13 @@ public class BgpPeerPropertySpecifier extends PropertySpecifier {
 
   @VisibleForTesting
   static boolean getIsPassive(@Nonnull BgpPeerConfig peer) {
-    if (peer instanceof BgpActivePeerConfig) {
+    if (peer instanceof BgpActivePeerConfig || peer instanceof BgpUnnumberedPeerConfig) {
       return false;
     }
     if (peer instanceof BgpPassivePeerConfig) {
       return true;
     }
-    throw new IllegalArgumentException(
-        String.format("Peer is neither Active nor Passive: %s", peer));
+    throw new IllegalArgumentException(String.format("Unrecognized peer type: %s", peer));
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpPeerConfigIdTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpPeerConfigIdTest.java
@@ -1,0 +1,61 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import java.util.List;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Tests of {@link BgpPeerConfigId} */
+public class BgpPeerConfigIdTest {
+
+  @Test
+  public void testEquals() {
+    BgpPeerConfigId id = new BgpPeerConfigId("c1", "vrf1", Prefix.ZERO, false);
+    new EqualsTester()
+        .addEqualityGroup(id, id, new BgpPeerConfigId("c1", "vrf1", Prefix.ZERO, false))
+        .addEqualityGroup(new BgpPeerConfigId("c2", "vrf1", Prefix.ZERO, false))
+        .addEqualityGroup(new BgpPeerConfigId("c1", "vrf2", Prefix.ZERO, false))
+        .addEqualityGroup(new BgpPeerConfigId("c1", "vrf1", Prefix.parse("1.1.1.1/24"), false))
+        .addEqualityGroup(new BgpPeerConfigId("c1", "vrf1", Prefix.ZERO, true))
+        .addEqualityGroup(new BgpPeerConfigId("c1", "vrf1", "peerIface"))
+        .addEqualityGroup(new BgpPeerConfigId("c1", "vrf1", "peerIface2"))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    BgpPeerConfigId id = new BgpPeerConfigId("c1", "vrf1", Prefix.ZERO, false);
+    assertThat(BatfishObjectMapper.clone(id, BgpPeerConfigId.class), equalTo(id));
+  }
+
+  @Test
+  public void testCompareTo() {
+    List<BgpPeerConfigId> ordered =
+        ImmutableList.of(
+            new BgpPeerConfigId("c0", "vrf0", Prefix.ZERO, false),
+            new BgpPeerConfigId("c1", "vrf0", Prefix.ZERO, false),
+            new BgpPeerConfigId("c1", "vrf1", Prefix.ZERO, false),
+            new BgpPeerConfigId("c1", "vrf1", Prefix.parse("1.1.1.1/24"), false),
+            new BgpPeerConfigId("c1", "vrf1", Prefix.parse("1.1.1.1/24"), true),
+            new BgpPeerConfigId("c2", "vrf1", Prefix.parse("1.1.1.1/24"), true),
+            new BgpPeerConfigId("c2", "vrf2", Prefix.parse("1.1.1.1/24"), true),
+            new BgpPeerConfigId("c2", "vrf2", Prefix.parse("2.2.2.2/24"), true),
+            new BgpPeerConfigId("c2", "vrf2", "iface"),
+            new BgpPeerConfigId("c3", "vrf2", "iface"),
+            new BgpPeerConfigId("c3", "vrf3", "iface"),
+            new BgpPeerConfigId("c3", "vrf3", "iface2"));
+    for (int i = 0; i < ordered.size(); i++) {
+      for (int j = 0; j < ordered.size(); j++) {
+        assertThat(
+            Integer.signum(ordered.get(i).compareTo(ordered.get(j))),
+            equalTo(Integer.signum(i - j)));
+      }
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifierTest.java
@@ -1,18 +1,20 @@
 package org.batfish.datamodel.questions;
 
 import static org.batfish.datamodel.questions.BgpPeerPropertySpecifier.getIsPassive;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
+import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.junit.Test;
 
 public class BgpPeerPropertySpecifierTest {
 
   @Test
   public void getIsPassiveTest() {
-    assertThat(getIsPassive(BgpActivePeerConfig.builder().build()), equalTo(false));
-    assertThat(getIsPassive(BgpPassivePeerConfig.builder().build()), equalTo(true));
+    assertFalse(getIsPassive(BgpActivePeerConfig.builder().build()));
+    assertFalse(getIsPassive(BgpUnnumberedPeerConfig.builder().setPeerInterface("i").build()));
+    assertTrue(getIsPassive(BgpPassivePeerConfig.builder().build()));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -31,6 +31,7 @@ import org.batfish.common.BatfishLogger;
 import org.batfish.common.BdpOscillationException;
 import org.batfish.common.Version;
 import org.batfish.common.plugin.DataPlanePlugin.ComputeDataPlaneResult;
+import org.batfish.common.topology.Layer2Topology;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.BgpPeerConfigId;
@@ -131,6 +132,7 @@ class IncrementalBdpEngine {
   ComputeDataPlaneResult computeDataPlane(
       Map<String, Configuration> configurations,
       Topology topology,
+      @Nullable Layer2Topology layer2Topology,
       OspfTopology ospfTopology,
       Set<BgpAdvertisement> externalAdverts) {
     try (ActiveSpan span = GlobalTracer.get().buildSpan("Compute Data Plane").startActive()) {
@@ -191,7 +193,8 @@ class IncrementalBdpEngine {
                   ipOwners,
                   false,
                   true,
-                  new TracerouteEngineImpl(partialDataplane));
+                  new TracerouteEngineImpl(partialDataplane),
+                  layer2Topology);
 
           boolean isOscillating =
               computeNonMonotonicPortionOfDataPlane(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
@@ -46,6 +46,7 @@ public class IncrementalDataPlanePlugin extends DataPlanePlugin {
         _engine.computeDataPlane(
             configurations,
             topology,
+            _batfish.getLayer2Topology(),
             _batfish.getTopologyProvider().getOspfTopology(_batfish.getNetworkSnapshot()),
             externalAdverts);
     double averageRoutes =

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
@@ -46,7 +46,10 @@ public class IncrementalDataPlanePlugin extends DataPlanePlugin {
         _engine.computeDataPlane(
             configurations,
             topology,
-            _batfish.getLayer2Topology(),
+            _batfish
+                .getTopologyProvider()
+                .getLayer2Topology(_batfish.getNetworkSnapshot())
+                .orElse(null),
             _batfish.getTopologyProvider().getOspfTopology(_batfish.getNetworkSnapshot()),
             externalAdverts);
     double averageRoutes =

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -403,7 +403,7 @@ public class VirtualRouter implements Serializable {
       _bgpIncomingRoutes = ImmutableSortedMap.of();
     } else {
       _bgpIncomingRoutes =
-          Stream.concat(
+          Streams.concat(
                   _vrf.getBgpProcess().getActiveNeighbors().entrySet().stream()
                       .map(
                           e ->
@@ -412,7 +412,9 @@ public class VirtualRouter implements Serializable {
                   _vrf.getBgpProcess().getPassiveNeighbors().entrySet().stream()
                       .map(
                           e ->
-                              new BgpPeerConfigId(getHostname(), _vrf.getName(), e.getKey(), true)))
+                              new BgpPeerConfigId(getHostname(), _vrf.getName(), e.getKey(), true)),
+                  _vrf.getBgpProcess().getInterfaceNeighbors().keySet().stream()
+                      .map(iface -> new BgpPeerConfigId(getHostname(), _vrf.getName(), iface)))
               .filter(bgpTopology.nodes()::contains)
               .flatMap(
                   dst ->
@@ -578,7 +580,7 @@ public class VirtualRouter implements Serializable {
       }
 
       Ip srcIp = advert.getSrcIp();
-      // TODO: support passive bgp connections
+      // TODO: support passive and unnumbered bgp connections
       Prefix srcPrefix = Prefix.create(srcIp, Prefix.MAX_PREFIX_LENGTH);
       BgpPeerConfig neighbor = _vrf.getBgpProcess().getActiveNeighbors().get(srcPrefix);
       if (neighbor == null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpIpv4UnicastAddressFamily.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpIpv4UnicastAddressFamily.java
@@ -3,6 +3,7 @@ package org.batfish.representation.cumulus;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.Prefix;
 
@@ -17,7 +18,7 @@ public class BgpIpv4UnicastAddressFamily implements Serializable {
 
   public BgpIpv4UnicastAddressFamily() {
     _networks = new HashMap<>();
-    _redistributionPolicies = new HashMap<>();
+    _redistributionPolicies = new TreeMap<>();
   }
 
   public @Nonnull Map<Prefix, BgpNetwork> getNetworks() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -3,6 +3,7 @@ package org.batfish.representation.cumulus;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Comparator.naturalOrder;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
+import static org.batfish.representation.cumulus.CumulusRoutingProtocol.toViProtocol;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
@@ -140,11 +141,10 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
   private void addInterfaceNeighbor(
       String peerInterface,
       BgpInterfaceNeighbor neighbor,
-      long localAs,
+      @Nullable Long localAs,
       BgpVrf bgpVrf,
       org.batfish.datamodel.BgpProcess newProc) {
     String vrfName = bgpVrf.getVrfName();
-    Ip updateSource = BgpProcess.BGP_UNNUMBERED_IP;
 
     RoutingPolicy.Builder peerExportPolicy =
         RoutingPolicy.builder()
@@ -170,7 +170,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
             .setBgpProcess(newProc)
             .setExportPolicy(peerExportPolicy.build().getName())
             .setLocalAs(localAs)
-            .setLocalIp(updateSource)
+            .setLocalIp(BgpProcess.BGP_UNNUMBERED_IP)
             .setPeerInterface(peerInterface)
             .setRemoteAsns(computeRemoteAsns(neighbor, localAs));
     builder.build();
@@ -247,18 +247,20 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
             });
   }
 
-  private @Nonnull LongSpace computeRemoteAsns(BgpInterfaceNeighbor neighbor, long localAs) {
-    switch (neighbor.getRemoteAsType()) {
-      case EXPLICIT:
-        return LongSpace.of(neighbor.getRemoteAs());
-      case EXTERNAL:
-        return BgpPeerConfig.ALL_AS_NUMBERS.difference(LongSpace.of(localAs));
-      case INTERNAL:
-        return LongSpace.of(localAs);
-      default:
-        throw new IllegalArgumentException(
-            String.format("Invalid remote-as type: %s", neighbor.getRemoteAsType()));
+  private @Nonnull LongSpace computeRemoteAsns(
+      BgpInterfaceNeighbor neighbor, @Nullable Long localAs) {
+    if (neighbor.getRemoteAsType() == RemoteAsType.EXPLICIT) {
+      Long remoteAs = neighbor.getRemoteAs();
+      return remoteAs == null ? LongSpace.EMPTY : LongSpace.of(remoteAs);
+    } else if (localAs == null) {
+      return LongSpace.EMPTY;
+    } else if (neighbor.getRemoteAsType() == RemoteAsType.EXTERNAL) {
+      return BgpPeerConfig.ALL_AS_NUMBERS.difference(LongSpace.of(localAs));
+    } else if (neighbor.getRemoteAsType() == RemoteAsType.INTERNAL) {
+      return LongSpace.of(localAs);
     }
+    throw new IllegalArgumentException(
+        String.format("Invalid remote-as type: %s", neighbor.getRemoteAsType()));
   }
 
   private void convertBgpProcess() {
@@ -575,7 +577,6 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
    */
   private @Nullable org.batfish.datamodel.BgpProcess toBgpProcess(String vrfName, BgpVrf bgpVrf) {
     org.batfish.datamodel.BgpProcess newProc = new org.batfish.datamodel.BgpProcess();
-    long localAs = bgpVrf.getAutonomousSystem();
     Ip routerId = bgpVrf.getRouterId();
     if (routerId == null) {
       _w.redFlag(
@@ -609,23 +610,26 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
     // Finally, the export policy ends with returning false: do not export unmatched routes.
     bgpCommonExportPolicy.addStatement(Statements.ReturnFalse.toStaticStatement()).build();
 
-    // Export connected routes that should be redistributed.
-    BgpRedistributionPolicy redistributeProtocolPolicy =
-        bgpVrf.getIpv4Unicast().getRedistributionPolicies().get(CumulusRoutingProtocol.CONNECTED);
-    if (redistributeProtocolPolicy != null) {
+    // Export routes that should be redistributed.
+    for (BgpRedistributionPolicy redistributeProtocolPolicy :
+        bgpVrf.getIpv4Unicast().getRedistributionPolicies().values()) {
+
+      // Get a match expression for the protocol to be redistributed
+      CumulusRoutingProtocol protocol = redistributeProtocolPolicy.getProtocol();
+      MatchProtocol matchProtocol = new MatchProtocol(toViProtocol(protocol));
+
+      // Create a WithEnvironmentExpr with the redistribution route-map, if one is defined
       BooleanExpr weInterior = BooleanExprs.TRUE;
-      Conjunction exportProtocolConditions = new Conjunction();
-      exportProtocolConditions.setComment("Redistribute connected routes into BGP");
-      exportProtocolConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.CONNECTED));
       String mapName = redistributeProtocolPolicy.getRouteMap();
-      if (mapName != null) {
-        RouteMap redistributeProtocolRouteMap = _routeMaps.get(mapName);
-        if (redistributeProtocolRouteMap != null) {
-          weInterior = new CallExpr(mapName);
-        }
+      if (mapName != null && _routeMaps.keySet().contains(mapName)) {
+        weInterior = new CallExpr(mapName);
       }
       BooleanExpr we = bgpRedistributeWithEnvironmentExpr(weInterior, OriginType.INCOMPLETE);
-      exportProtocolConditions.getConjuncts().add(we);
+
+      // Export routes that match the protocol and WithEnvironmentExpr
+      Conjunction exportProtocolConditions = new Conjunction(ImmutableList.of(matchProtocol, we));
+      exportProtocolConditions.setComment(
+          String.format("Redistribute %s routes into BGP", protocol));
       exportConditions.add(exportProtocolConditions);
     }
 
@@ -667,7 +671,8 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
         .getInterfaceNeighbors()
         .forEach(
             (peerInterface, neighbor) ->
-                addInterfaceNeighbor(peerInterface, neighbor, localAs, bgpVrf, newProc));
+                addInterfaceNeighbor(
+                    peerInterface, neighbor, bgpVrf.getAutonomousSystem(), bgpVrf, newProc));
 
     return newProc;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusRoutingProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusRoutingProtocol.java
@@ -1,22 +1,20 @@
 package org.batfish.representation.cumulus;
 
-import javax.annotation.Nonnull;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.Set;
 import org.batfish.datamodel.RoutingProtocol;
 
 public enum CumulusRoutingProtocol {
   CONNECTED,
   STATIC;
 
-  @Nonnull
-  public static RoutingProtocol toViProtocol(@Nonnull CumulusRoutingProtocol protocol) {
-    switch (protocol) {
-      case CONNECTED:
-        return RoutingProtocol.CONNECTED;
-      case STATIC:
-        return RoutingProtocol.STATIC;
-      default:
-        throw new IllegalArgumentException(
-            String.format("Unrecognized Cumulus routing protocol: %s", protocol));
-    }
-  }
+  /**
+   * Maps each {@link CumulusRoutingProtocol} to the set of {@link RoutingProtocol}s it includes.
+   */
+  public static final Map<CumulusRoutingProtocol, Set<RoutingProtocol>> VI_PROTOCOLS_MAP =
+      ImmutableMap.of(
+          CONNECTED, ImmutableSet.of(RoutingProtocol.CONNECTED),
+          STATIC, ImmutableSet.of(RoutingProtocol.STATIC));
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusRoutingProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusRoutingProtocol.java
@@ -1,6 +1,22 @@
 package org.batfish.representation.cumulus;
 
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.RoutingProtocol;
+
 public enum CumulusRoutingProtocol {
   CONNECTED,
-  STATIC
+  STATIC;
+
+  @Nonnull
+  public static RoutingProtocol toViProtocol(@Nonnull CumulusRoutingProtocol protocol) {
+    switch (protocol) {
+      case CONNECTED:
+        return RoutingProtocol.CONNECTED;
+      case STATIC:
+        return RoutingProtocol.STATIC;
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unrecognized Cumulus routing protocol: %s", protocol));
+    }
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpTest.java
@@ -408,6 +408,7 @@ public class EigrpTest {
         engine.computeDataPlane(
                 configurations,
                 topology,
+                null,
                 computeOspfTopology(NetworkConfigurations.of(configurations), topology),
                 Collections.emptySet())
             ._dataPlane;

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -379,6 +379,7 @@ public class IncrementalDataPlanePluginTest {
         engine.computeDataPlane(
             ImmutableMap.of(c.getHostname(), c),
             topology,
+            null,
             OspfTopology.empty(),
             Collections.emptySet());
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -150,7 +150,7 @@ public class IsisTest {
     Topology topology = TopologyUtil.synthesizeL3Topology(configurations);
     return (IncrementalDataPlane)
         engine.computeDataPlane(
-                configurations, topology, OspfTopology.empty(), Collections.emptySet())
+                configurations, topology, null, OspfTopology.empty(), Collections.emptySet())
             ._dataPlane;
   }
 
@@ -428,7 +428,7 @@ public class IsisTest {
     IncrementalDataPlane dp =
         (IncrementalDataPlane)
             engine.computeDataPlane(
-                    configurations, topology, OspfTopology.empty(), Collections.emptySet())
+                    configurations, topology, null, OspfTopology.empty(), Collections.emptySet())
                 ._dataPlane;
     return dp;
   }
@@ -594,7 +594,7 @@ public class IsisTest {
     Topology topology = TopologyUtil.synthesizeL3Topology(configurations);
     return (IncrementalDataPlane)
         engine.computeDataPlane(
-                configurations, topology, OspfTopology.empty(), Collections.emptySet())
+                configurations, topology, null, OspfTopology.empty(), Collections.emptySet())
             ._dataPlane;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -269,6 +269,7 @@ public class OspfTest {
             engine.computeDataPlane(
                     configurations,
                     topology,
+                    null,
                     computeOspfTopology(NetworkConfigurations.of(configurations), topology),
                     Collections.emptySet())
                 ._dataPlane;
@@ -466,6 +467,7 @@ public class OspfTest {
             engine.computeDataPlane(
                     configurations,
                     topology,
+                    null,
                     computeOspfTopology(NetworkConfigurations.of(configurations), topology),
                     Collections.emptySet())
                 ._dataPlane;

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
@@ -225,6 +225,7 @@ public class RouteReflectionTest {
         engine.computeDataPlane(
             configurations,
             topology,
+            null,
             OspfTopology.empty(),
             ImmutableSet.of(
                 _ab.setAsPath(AsPath.ofSingletonAsSets(1L))
@@ -353,6 +354,7 @@ public class RouteReflectionTest {
             engine.computeDataPlane(
                     configurations,
                     topology,
+                    null,
                     OspfTopology.empty(),
                     ImmutableSet.of(
                         _ab.setAsPath(AsPath.ofSingletonAsSets(1L))

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -7,6 +7,7 @@ import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasLocalAs;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasRemoteAs;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasInterfaceNeighbors;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasRouterId;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpRouteThat;
 import static org.batfish.datamodel.matchers.BgpUnnumberedPeerConfigMatchers.hasPeerInterface;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasHostname;
@@ -42,6 +43,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
@@ -57,12 +59,16 @@ import com.google.common.collect.Range;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.config.Settings;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.AsPath;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.Configuration;
@@ -87,8 +93,10 @@ import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.vendor_family.cumulus.InterfaceClagSettings;
+import org.batfish.dataplane.ibdp.IncrementalDataPlane;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.TestrigText;
 import org.batfish.representation.cumulus.BgpInterfaceNeighbor;
 import org.batfish.representation.cumulus.BgpL2vpnEvpnAddressFamily;
 import org.batfish.representation.cumulus.BgpProcess;
@@ -112,6 +120,7 @@ import org.junit.rules.TemporaryFolder;
 
 public final class CumulusNcluGrammarTest {
   private static final String TESTCONFIGS_PREFIX = "org/batfish/grammar/cumulus_nclu/testconfigs/";
+  private static final String TESTRIGS_PREFIX = "org/batfish/grammar/cumulus_nclu/testrigs/";
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
   @Rule public ExpectedException _thrown = ExpectedException.none();
@@ -191,6 +200,84 @@ public final class CumulusNcluGrammarTest {
     VendorConfiguration vc = extractor.getVendorConfiguration();
     assertThat(vc, instanceOf(CumulusNcluConfiguration.class));
     return (CumulusNcluConfiguration) vc;
+  }
+
+  @Test
+  public void testEbgpUnnumbered() throws IOException {
+    /*
+    node1 and node2 should have an eBGP unnumbered session between them. Both redistribute static
+    routes. node1 has static route 5.5.5.5/32 and node2 has static route 6.6.6.6/32, so should see
+    BGP routes on both to the other's static network.
+     */
+    String testrigName = "bgp-unnumbered";
+    String NODE1 = "node1";
+    String NODE2 = "node2";
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationText(TESTRIGS_PREFIX + testrigName, ImmutableSet.of(NODE1, NODE2))
+                .setLayer1TopologyText(TESTRIGS_PREFIX + testrigName)
+                .build(),
+            _folder);
+
+    // Sanity check configured peers
+    Map<String, Configuration> configs = batfish.loadConfigurations();
+    BgpUnnumberedPeerConfig.Builder peerBuilder =
+        BgpUnnumberedPeerConfig.builder()
+            .setLocalIp(BGP_UNNUMBERED_IP)
+            .setPeerInterface("swp1")
+            .setExportPolicy(computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, "swp1"));
+    Map<String, BgpUnnumberedPeerConfig> expectedPeers1 =
+        ImmutableMap.of(
+            "swp1",
+            peerBuilder
+                .setLocalAs(65100L)
+                .setRemoteAsns(BgpPeerConfig.ALL_AS_NUMBERS.difference(LongSpace.of(65100L)))
+                .build());
+    Map<String, BgpUnnumberedPeerConfig> expectedPeers2 =
+        ImmutableMap.of(
+            "swp1",
+            peerBuilder
+                .setLocalAs(65101L)
+                .setRemoteAsns(BgpPeerConfig.ALL_AS_NUMBERS.difference(LongSpace.of(65101L)))
+                .build());
+    assertThat(
+        configs.get(NODE1),
+        hasVrf(DEFAULT_VRF_NAME, hasBgpProcess(hasInterfaceNeighbors(equalTo(expectedPeers1)))));
+    assertThat(
+        configs.get(NODE2),
+        hasVrf(DEFAULT_VRF_NAME, hasBgpProcess(hasInterfaceNeighbors(equalTo(expectedPeers2)))));
+
+    // Ensure reachability between nodes
+    batfish.computeDataPlane();
+    IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane();
+    Set<AbstractRoute> n1Routes = dp.getRibs().get(NODE1).get(DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> n2Routes = dp.getRibs().get(NODE2).get(DEFAULT_VRF_NAME).getRoutes();
+
+    BgpRoute.Builder routeBuilder =
+        BgpRoute.builder()
+            .setNextHopIp(BGP_UNNUMBERED_IP)
+            .setReceivedFromIp(BGP_UNNUMBERED_IP)
+            .setOriginType(OriginType.INCOMPLETE)
+            .setProtocol(RoutingProtocol.BGP)
+            .setSrcProtocol(RoutingProtocol.BGP)
+            .setLocalPreference(100)
+            .setAdmin(20);
+    BgpRoute expectedRoute1 =
+        routeBuilder
+            .setNetwork(Prefix.parse("6.6.6.6/32"))
+            .setAsPath(AsPath.ofSingletonAsSets(65101L))
+            .setOriginatorIp(Ip.parse("192.0.2.2"))
+            .build();
+    BgpRoute expectedRoute2 =
+        routeBuilder
+            .setNetwork(Prefix.parse("5.5.5.5/32"))
+            .setAsPath(AsPath.ofSingletonAsSets(65100L))
+            .setOriginatorIp(Ip.parse("192.0.2.1"))
+            .build();
+
+    assertThat(n1Routes, hasItem(isBgpRouteThat(equalTo(expectedRoute1))));
+    assertThat(n2Routes, hasItem(isBgpRouteThat(equalTo(expectedRoute2))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -210,12 +210,12 @@ public final class CumulusNcluGrammarTest {
     BGP routes on both to the other's static network.
      */
     String testrigName = "bgp-unnumbered";
-    String NODE1 = "node1";
-    String NODE2 = "node2";
+    String node1 = "node1";
+    String node2 = "node2";
     Batfish batfish =
         BatfishTestUtils.getBatfishFromTestrigText(
             TestrigText.builder()
-                .setConfigurationText(TESTRIGS_PREFIX + testrigName, ImmutableSet.of(NODE1, NODE2))
+                .setConfigurationText(TESTRIGS_PREFIX + testrigName, ImmutableSet.of(node1, node2))
                 .setLayer1TopologyText(TESTRIGS_PREFIX + testrigName)
                 .build(),
             _folder);
@@ -242,17 +242,17 @@ public final class CumulusNcluGrammarTest {
                 .setRemoteAsns(BgpPeerConfig.ALL_AS_NUMBERS.difference(LongSpace.of(65101L)))
                 .build());
     assertThat(
-        configs.get(NODE1),
+        configs.get(node1),
         hasVrf(DEFAULT_VRF_NAME, hasBgpProcess(hasInterfaceNeighbors(equalTo(expectedPeers1)))));
     assertThat(
-        configs.get(NODE2),
+        configs.get(node2),
         hasVrf(DEFAULT_VRF_NAME, hasBgpProcess(hasInterfaceNeighbors(equalTo(expectedPeers2)))));
 
     // Ensure reachability between nodes
     batfish.computeDataPlane();
     IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane();
-    Set<AbstractRoute> n1Routes = dp.getRibs().get(NODE1).get(DEFAULT_VRF_NAME).getRoutes();
-    Set<AbstractRoute> n2Routes = dp.getRibs().get(NODE2).get(DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> n1Routes = dp.getRibs().get(node1).get(DEFAULT_VRF_NAME).getRoutes();
+    Set<AbstractRoute> n2Routes = dp.getRibs().get(node2).get(DEFAULT_VRF_NAME).getRoutes();
 
     BgpRoute.Builder routeBuilder =
         BgpRoute.builder()

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testrigs/bgp-unnumbered/configs/node1
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testrigs/bgp-unnumbered/configs/node1
@@ -3,14 +3,12 @@ net del all
 net add hostname node1
 #
 net add bgp autonomous-system 65100
-net add bgp ipv4 unicast network 192.0.2.1/30
 net add bgp ipv4 unicast redistribute static
 net add bgp neighbor swp1 interface remote-as external
 net add bgp router-id 192.0.2.1
 #
 # Interfaces
-net add loopback lo ip address 10.0.0.1/32
-net add interface swp1 ip address 10.0.0.1/24
+net add interface swp1
 net add interface swp2 ip address 10.1.0.1/24
 #
 # Static route

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testrigs/bgp-unnumbered/configs/node1
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testrigs/bgp-unnumbered/configs/node1
@@ -1,0 +1,19 @@
+net del all
+#
+net add hostname node1
+#
+net add bgp autonomous-system 65100
+net add bgp ipv4 unicast network 192.0.2.1/30
+net add bgp ipv4 unicast redistribute static
+net add bgp neighbor swp1 interface remote-as external
+net add bgp router-id 192.0.2.1
+#
+# Interfaces
+net add loopback lo ip address 10.0.0.1/32
+net add interface swp1 ip address 10.0.0.1/24
+net add interface swp2 ip address 10.1.0.1/24
+#
+# Static route
+net add routing route 5.5.5.5/32 10.1.0.1
+#
+net commit

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testrigs/bgp-unnumbered/configs/node2
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testrigs/bgp-unnumbered/configs/node2
@@ -3,14 +3,12 @@ net del all
 net add hostname node2
 #
 net add bgp autonomous-system 65101
-net add bgp ipv4 unicast network 192.0.2.2/30
 net add bgp ipv4 unicast redistribute static
 net add bgp neighbor swp1 interface remote-as external
 net add bgp router-id 192.0.2.2
 #
 # Interfaces
-net add loopback lo ip address 10.0.0.1/32
-net add interface swp1 ip address 10.0.0.2/24
+net add interface swp1
 net add interface swp2 ip address 10.2.0.1/24
 #
 # Static route

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testrigs/bgp-unnumbered/configs/node2
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testrigs/bgp-unnumbered/configs/node2
@@ -1,0 +1,19 @@
+net del all
+#
+net add hostname node2
+#
+net add bgp autonomous-system 65101
+net add bgp ipv4 unicast network 192.0.2.2/30
+net add bgp ipv4 unicast redistribute static
+net add bgp neighbor swp1 interface remote-as external
+net add bgp router-id 192.0.2.2
+#
+# Interfaces
+net add loopback lo ip address 10.0.0.1/32
+net add interface swp1 ip address 10.0.0.2/24
+net add interface swp2 ip address 10.2.0.1/24
+#
+# Static route
+net add routing route 6.6.6.6/32 10.2.0.1
+#
+net commit

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testrigs/bgp-unnumbered/layer1_topology.json
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testrigs/bgp-unnumbered/layer1_topology.json
@@ -1,0 +1,24 @@
+{
+    "edges": [
+        {
+            "node1": {
+                "hostname": "node1",
+                "interfaceName": "swp1"
+            },
+            "node2": {
+                "hostname": "node2",
+                "interfaceName": "swp1"
+            }
+        },
+        {
+            "node1": {
+                "hostname": "node2",
+                "interfaceName": "swp1"
+            },
+            "node2": {
+                "hostname": "node1",
+                "interfaceName": "swp1"
+            }
+        }
+    ]
+}

--- a/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
@@ -913,7 +913,8 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
       if (!_remoteBgpNeighborsInitialized) {
         Map<Ip, Set<String>> ipOwners = TopologyUtil.computeIpNodeOwners(configurations, true);
         _bgpTopology =
-            BgpTopologyUtils.initBgpTopology(configurations, ipOwners, false, false, null);
+            BgpTopologyUtils.initBgpTopology(
+                configurations, ipOwners, false, false, null, _batfish.getLayer2Topology());
         _remoteBgpNeighborsInitialized = true;
       }
     }

--- a/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/NeighborsQuestionPlugin.java
@@ -913,8 +913,7 @@ public class NeighborsQuestionPlugin extends QuestionPlugin {
       if (!_remoteBgpNeighborsInitialized) {
         Map<Ip, Set<String>> ipOwners = TopologyUtil.computeIpNodeOwners(configurations, true);
         _bgpTopology =
-            BgpTopologyUtils.initBgpTopology(
-                configurations, ipOwners, false, false, null, _batfish.getLayer2Topology());
+            BgpTopologyUtils.initBgpTopology(configurations, ipOwners, false, false, null, null);
         _remoteBgpNeighborsInitialized = true;
       }
     }

--- a/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
@@ -220,15 +220,14 @@ public class VIModelQuestionPlugin extends QuestionPlugin {
       Topology topology = _batfish.getEnvironmentTopology();
       Map<Ip, Set<String>> ipOwners = TopologyUtil.computeIpNodeOwners(configs, true);
       _batfish.initRemoteRipNeighbors(configs, ipOwners, topology);
-      Layer2Topology layer2Topology = _batfish.getLayer2Topology();
 
       return new VIModelAnswerElement(
           configs,
-          getBgpEdges(configs, ipOwners, layer2Topology),
+          getBgpEdges(configs, ipOwners),
           getEigrpEdges(configs, topology),
           getIsisEdges(configs, topology),
           _batfish.getLayer1Topology(),
-          layer2Topology,
+          _batfish.getLayer2Topology(),
           getLayer3Edges(configs, topology),
           getOspfEdges(
               _batfish.getTopologyProvider().getOspfTopology(_batfish.getNetworkSnapshot())),
@@ -236,11 +235,9 @@ public class VIModelQuestionPlugin extends QuestionPlugin {
     }
 
     private static SortedSet<VerboseBgpEdge> getBgpEdges(
-        Map<String, Configuration> configs,
-        Map<Ip, Set<String>> ipOwners,
-        Layer2Topology layer2Topology) {
+        Map<String, Configuration> configs, Map<Ip, Set<String>> ipOwners) {
       ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
-          BgpTopologyUtils.initBgpTopology(configs, ipOwners, false, false, null, layer2Topology);
+          BgpTopologyUtils.initBgpTopology(configs, ipOwners, false, false, null, null);
       SortedSet<VerboseBgpEdge> bgpEdges = new TreeSet<>(VERBOSE_BGP_EDGE_COMPARATOR);
       for (EndpointPair<BgpPeerConfigId> session : bgpTopology.edges()) {
         BgpPeerConfigId bgpPeerConfigId = session.source();

--- a/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
@@ -220,14 +220,15 @@ public class VIModelQuestionPlugin extends QuestionPlugin {
       Topology topology = _batfish.getEnvironmentTopology();
       Map<Ip, Set<String>> ipOwners = TopologyUtil.computeIpNodeOwners(configs, true);
       _batfish.initRemoteRipNeighbors(configs, ipOwners, topology);
+      Layer2Topology layer2Topology = _batfish.getLayer2Topology();
 
       return new VIModelAnswerElement(
           configs,
-          getBgpEdges(configs, ipOwners),
+          getBgpEdges(configs, ipOwners, layer2Topology),
           getEigrpEdges(configs, topology),
           getIsisEdges(configs, topology),
           _batfish.getLayer1Topology(),
-          _batfish.getLayer2Topology(),
+          layer2Topology,
           getLayer3Edges(configs, topology),
           getOspfEdges(
               _batfish.getTopologyProvider().getOspfTopology(_batfish.getNetworkSnapshot())),
@@ -235,9 +236,11 @@ public class VIModelQuestionPlugin extends QuestionPlugin {
     }
 
     private static SortedSet<VerboseBgpEdge> getBgpEdges(
-        Map<String, Configuration> configs, Map<Ip, Set<String>> ipOwners) {
+        Map<String, Configuration> configs,
+        Map<Ip, Set<String>> ipOwners,
+        Layer2Topology layer2Topology) {
       ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
-          BgpTopologyUtils.initBgpTopology(configs, ipOwners, false, false, null);
+          BgpTopologyUtils.initBgpTopology(configs, ipOwners, false, false, null, layer2Topology);
       SortedSet<VerboseBgpEdge> bgpEdges = new TreeSet<>(VERBOSE_BGP_EDGE_COMPARATOR);
       for (EndpointPair<BgpPeerConfigId> session : bgpTopology.edges()) {
         BgpPeerConfigId bgpPeerConfigId = session.source();

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswerer.java
@@ -23,6 +23,7 @@ import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.BgpSessionProperties.SessionType;
+import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LongSpace;
@@ -84,7 +85,8 @@ public class BgpSessionCompatibilityAnswerer extends BgpSessionAnswerer {
             .map(
                 neighbor -> {
                   BgpPeerConfig bpc = getBgpPeerConfig(configurations, neighbor);
-                  if (bpc instanceof BgpPassivePeerConfig) {
+                  if (bpc instanceof BgpPassivePeerConfig
+                      || bpc instanceof BgpUnnumberedPeerConfig) {
                     return null;
                   } else if (!(bpc instanceof BgpActivePeerConfig)) {
                     throw new BatfishException(

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
@@ -23,6 +23,7 @@ import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.BgpSessionProperties.SessionType;
+import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LongSpace;
@@ -80,17 +81,18 @@ public class BgpSessionStatusAnswerer extends BgpSessionAnswerer {
     ValueGraph<BgpPeerConfigId, BgpSessionProperties> configuredBgpTopology =
         BgpTopologyUtils.initBgpTopology(configurations, ipOwners, true);
 
-    ValueGraph<BgpPeerConfigId, BgpSessionProperties> establishedBgpTopology;
-    establishedBgpTopology =
+    // TODO Use layer 2 topology to include BGP unnumbered sessions
+    ValueGraph<BgpPeerConfigId, BgpSessionProperties> establishedBgpTopology =
         BgpTopologyUtils.initBgpTopology(
-            configurations, ipOwners, false, true, _batfish.getTracerouteEngine());
+            configurations, ipOwners, false, true, _batfish.getTracerouteEngine(), null);
 
     Stream<Row> activePeerRows =
         configuredBgpTopology.nodes().stream()
             .map(
                 neighbor -> {
                   BgpPeerConfig bpc = getBgpPeerConfig(configurations, neighbor);
-                  if (bpc instanceof BgpPassivePeerConfig) {
+                  if (bpc instanceof BgpPassivePeerConfig
+                      || bpc instanceof BgpUnnumberedPeerConfig) {
                     return null;
                   } else if (!(bpc instanceof BgpActivePeerConfig)) {
                     throw new BatfishException(

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -124,9 +124,9 @@ public class EdgesAnswerer extends Answerer {
     Map<Ip, Set<String>> ipOwners = TopologyUtil.computeIpNodeOwners(configurations, true);
     switch (edgeType) {
       case BGP:
+        // TODO Include layer 2 topology and test BGP unnumbered edges
         ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
-            BgpTopologyUtils.initBgpTopology(
-                configurations, ipOwners, false, false, null, _batfish.getLayer2Topology());
+            BgpTopologyUtils.initBgpTopology(configurations, ipOwners, false, false, null, null);
         return getBgpEdges(configurations, includeNodes, includeRemoteNodes, bgpTopology);
       case EIGRP:
         Network<EigrpInterface, EigrpEdge> eigrpTopology =

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -125,7 +125,8 @@ public class EdgesAnswerer extends Answerer {
     switch (edgeType) {
       case BGP:
         ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
-            BgpTopologyUtils.initBgpTopology(configurations, ipOwners, false, false, null);
+            BgpTopologyUtils.initBgpTopology(
+                configurations, ipOwners, false, false, null, _batfish.getLayer2Topology());
         return getBgpEdges(configurations, includeNodes, includeRemoteNodes, bgpTopology);
       case EIGRP:
         Network<EigrpInterface, EigrpEdge> eigrpTopology =

--- a/tests/basic/neighbors.ref
+++ b/tests/basic/neighbors.ref
@@ -39,9 +39,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as1border1",
           "prefix" : "10.12.11.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -74,9 +74,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2border1",
           "prefix" : "10.12.11.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -117,9 +117,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as1border2",
           "prefix" : "10.13.22.3/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -152,9 +152,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as3border2",
           "prefix" : "10.13.22.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -195,9 +195,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2border1",
           "prefix" : "10.12.11.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -230,9 +230,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as1border1",
           "prefix" : "10.12.11.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -273,9 +273,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2border2",
           "prefix" : "10.23.21.3/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -308,9 +308,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as3border1",
           "prefix" : "10.23.21.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -351,9 +351,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dept1",
           "prefix" : "2.34.101.3/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -386,9 +386,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dist1",
           "prefix" : "2.34.101.4/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -429,9 +429,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dept1",
           "prefix" : "2.34.201.3/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -464,9 +464,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dist2",
           "prefix" : "2.34.201.4/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -507,9 +507,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dist1",
           "prefix" : "2.34.101.4/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -542,9 +542,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dept1",
           "prefix" : "2.34.101.3/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -585,9 +585,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dist2",
           "prefix" : "2.34.201.4/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -620,9 +620,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dept1",
           "prefix" : "2.34.201.3/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -663,9 +663,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as3border1",
           "prefix" : "10.23.21.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -698,9 +698,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2border2",
           "prefix" : "10.23.21.3/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -741,9 +741,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as3border2",
           "prefix" : "10.13.22.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -776,9 +776,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as1border2",
           "prefix" : "10.13.22.3/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       }
@@ -814,9 +814,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as1border1",
           "prefix" : "1.10.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -842,9 +842,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as1core1",
           "prefix" : "1.1.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -878,9 +878,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as1border2",
           "prefix" : "1.10.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -906,9 +906,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as1core1",
           "prefix" : "1.2.2.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -942,9 +942,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as1core1",
           "prefix" : "1.1.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -970,9 +970,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as1border1",
           "prefix" : "1.10.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1006,9 +1006,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as1core1",
           "prefix" : "1.2.2.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1034,9 +1034,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as1border2",
           "prefix" : "1.10.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1070,9 +1070,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2border1",
           "prefix" : "2.1.2.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1098,9 +1098,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core1",
           "prefix" : "2.1.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1134,9 +1134,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2border1",
           "prefix" : "2.1.2.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1162,9 +1162,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core2",
           "prefix" : "2.1.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1198,9 +1198,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2border2",
           "prefix" : "2.1.2.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1226,9 +1226,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core1",
           "prefix" : "2.1.1.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1262,9 +1262,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2border2",
           "prefix" : "2.1.2.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1290,9 +1290,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core2",
           "prefix" : "2.1.1.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1326,9 +1326,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core1",
           "prefix" : "2.1.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1354,9 +1354,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2border1",
           "prefix" : "2.1.2.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1390,9 +1390,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core1",
           "prefix" : "2.1.1.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1418,9 +1418,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2border2",
           "prefix" : "2.1.2.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1454,9 +1454,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core1",
           "prefix" : "2.1.3.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1482,9 +1482,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dist1",
           "prefix" : "2.1.2.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1518,9 +1518,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core1",
           "prefix" : "2.1.3.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1546,9 +1546,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dist2",
           "prefix" : "2.1.2.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1582,9 +1582,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core2",
           "prefix" : "2.1.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1610,9 +1610,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2border1",
           "prefix" : "2.1.2.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1646,9 +1646,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core2",
           "prefix" : "2.1.1.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1674,9 +1674,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2border2",
           "prefix" : "2.1.2.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1710,9 +1710,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core2",
           "prefix" : "2.1.3.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1738,9 +1738,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dist1",
           "prefix" : "2.1.2.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1774,9 +1774,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core2",
           "prefix" : "2.1.3.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1802,9 +1802,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dist2",
           "prefix" : "2.1.2.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1838,9 +1838,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dist1",
           "prefix" : "2.1.2.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1866,9 +1866,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core1",
           "prefix" : "2.1.3.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1902,9 +1902,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dist1",
           "prefix" : "2.1.2.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1930,9 +1930,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core2",
           "prefix" : "2.1.3.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -1966,9 +1966,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dist2",
           "prefix" : "2.1.2.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -1994,9 +1994,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core1",
           "prefix" : "2.1.3.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -2030,9 +2030,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2dist2",
           "prefix" : "2.1.2.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -2058,9 +2058,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as2core2",
           "prefix" : "2.1.3.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -2094,9 +2094,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as3border1",
           "prefix" : "3.10.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -2122,9 +2122,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as3core1",
           "prefix" : "3.1.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -2158,9 +2158,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as3border2",
           "prefix" : "3.10.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -2186,9 +2186,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as3core1",
           "prefix" : "3.2.2.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -2222,9 +2222,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as3core1",
           "prefix" : "3.1.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -2250,9 +2250,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as3border1",
           "prefix" : "3.10.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       },
@@ -2286,9 +2286,9 @@
           "sendCommunity" : true
         },
         "node1SessionId" : {
-          "dynamic" : false,
           "hostname" : "as3core1",
           "prefix" : "3.2.2.2/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         },
         "node2Session" : {
@@ -2314,9 +2314,9 @@
           "sendCommunity" : true
         },
         "node2SessionId" : {
-          "dynamic" : false,
           "hostname" : "as3border2",
           "prefix" : "3.10.1.1/32",
+          "type" : "ACTIVE",
           "vrf" : "default"
         }
       }

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -33,9 +33,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as1border1",
             "prefix" : "1.10.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -61,9 +61,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as1core1",
             "prefix" : "1.1.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -104,9 +104,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as1border1",
             "prefix" : "10.12.11.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -139,9 +139,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2border1",
             "prefix" : "10.12.11.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -175,9 +175,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as1border2",
             "prefix" : "1.10.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -203,9 +203,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as1core1",
             "prefix" : "1.2.2.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -246,9 +246,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as1border2",
             "prefix" : "10.13.22.3/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -281,9 +281,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as3border2",
             "prefix" : "10.13.22.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -317,9 +317,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as1core1",
             "prefix" : "1.1.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -345,9 +345,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as1border1",
             "prefix" : "1.10.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -381,9 +381,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as1core1",
             "prefix" : "1.2.2.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -409,9 +409,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as1border2",
             "prefix" : "1.10.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -445,9 +445,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2border1",
             "prefix" : "2.1.2.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -473,9 +473,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core1",
             "prefix" : "2.1.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -509,9 +509,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2border1",
             "prefix" : "2.1.2.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -537,9 +537,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core2",
             "prefix" : "2.1.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -580,9 +580,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2border1",
             "prefix" : "10.12.11.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -615,9 +615,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as1border1",
             "prefix" : "10.12.11.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -651,9 +651,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2border2",
             "prefix" : "2.1.2.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -679,9 +679,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core1",
             "prefix" : "2.1.1.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -715,9 +715,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2border2",
             "prefix" : "2.1.2.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -743,9 +743,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core2",
             "prefix" : "2.1.1.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -786,9 +786,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2border2",
             "prefix" : "10.23.21.3/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -821,9 +821,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as3border1",
             "prefix" : "10.23.21.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -857,9 +857,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core1",
             "prefix" : "2.1.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -885,9 +885,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2border1",
             "prefix" : "2.1.2.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -921,9 +921,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core1",
             "prefix" : "2.1.1.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -949,9 +949,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2border2",
             "prefix" : "2.1.2.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -985,9 +985,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core1",
             "prefix" : "2.1.3.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1013,9 +1013,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dist1",
             "prefix" : "2.1.2.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1049,9 +1049,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core1",
             "prefix" : "2.1.3.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1077,9 +1077,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dist2",
             "prefix" : "2.1.2.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1113,9 +1113,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core2",
             "prefix" : "2.1.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1141,9 +1141,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2border1",
             "prefix" : "2.1.2.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1177,9 +1177,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core2",
             "prefix" : "2.1.1.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1205,9 +1205,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2border2",
             "prefix" : "2.1.2.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1241,9 +1241,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core2",
             "prefix" : "2.1.3.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1269,9 +1269,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dist1",
             "prefix" : "2.1.2.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1305,9 +1305,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core2",
             "prefix" : "2.1.3.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1333,9 +1333,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dist2",
             "prefix" : "2.1.2.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1376,9 +1376,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dept1",
             "prefix" : "2.34.101.3/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1411,9 +1411,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dist1",
             "prefix" : "2.34.101.4/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1454,9 +1454,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dept1",
             "prefix" : "2.34.201.3/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1489,9 +1489,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dist2",
             "prefix" : "2.34.201.4/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1525,9 +1525,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dist1",
             "prefix" : "2.1.2.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1553,9 +1553,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core1",
             "prefix" : "2.1.3.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1589,9 +1589,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dist1",
             "prefix" : "2.1.2.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1617,9 +1617,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core2",
             "prefix" : "2.1.3.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1660,9 +1660,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dist1",
             "prefix" : "2.34.101.4/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1695,9 +1695,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dept1",
             "prefix" : "2.34.101.3/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1731,9 +1731,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dist2",
             "prefix" : "2.1.2.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1759,9 +1759,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core1",
             "prefix" : "2.1.3.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1795,9 +1795,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dist2",
             "prefix" : "2.1.2.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1823,9 +1823,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2core2",
             "prefix" : "2.1.3.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1866,9 +1866,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dist2",
             "prefix" : "2.34.201.4/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1901,9 +1901,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2dept1",
             "prefix" : "2.34.201.3/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -1937,9 +1937,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as3border1",
             "prefix" : "3.10.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -1965,9 +1965,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as3core1",
             "prefix" : "3.1.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -2008,9 +2008,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as3border1",
             "prefix" : "10.23.21.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -2043,9 +2043,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as2border2",
             "prefix" : "10.23.21.3/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -2079,9 +2079,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as3border2",
             "prefix" : "3.10.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -2107,9 +2107,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as3core1",
             "prefix" : "3.2.2.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -2150,9 +2150,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as3border2",
             "prefix" : "10.13.22.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -2185,9 +2185,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as1border2",
             "prefix" : "10.13.22.3/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -2221,9 +2221,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as3core1",
             "prefix" : "3.1.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -2249,9 +2249,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as3border1",
             "prefix" : "3.10.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         },
@@ -2285,9 +2285,9 @@
             "sendCommunity" : true
           },
           "node1SessionId" : {
-            "dynamic" : false,
             "hostname" : "as3core1",
             "prefix" : "3.2.2.2/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           },
           "node2Session" : {
@@ -2313,9 +2313,9 @@
             "sendCommunity" : true
           },
           "node2SessionId" : {
-            "dynamic" : false,
             "hostname" : "as3border2",
             "prefix" : "3.10.1.1/32",
+            "type" : "ACTIVE",
             "vrf" : "default"
           }
         }

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -13830,14 +13830,14 @@
                   "disjuncts" : [
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "comment" : "Redistribute STATIC routes into BGP",
+                      "comment" : "Redistribute CONNECTED routes into BGP",
                       "conjuncts" : [
                         {
                           "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
                           "disjuncts" : [
                             {
                               "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                              "protocol" : "static"
+                              "protocol" : "connected"
                             }
                           ]
                         },
@@ -13877,14 +13877,14 @@
                     },
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "comment" : "Redistribute CONNECTED routes into BGP",
+                      "comment" : "Redistribute STATIC routes into BGP",
                       "conjuncts" : [
                         {
                           "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
                           "disjuncts" : [
                             {
                               "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                              "protocol" : "connected"
+                              "protocol" : "static"
                             }
                           ]
                         },

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -13682,7 +13682,7 @@
                   "disjuncts" : [
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "comment" : "Redistribute connected routes into BGP",
+                      "comment" : "Redistribute CONNECTED routes into BGP",
                       "conjuncts" : [
                         {
                           "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
@@ -13825,11 +13825,53 @@
                   "disjuncts" : [
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "comment" : "Redistribute connected routes into BGP",
+                      "comment" : "Redistribute CONNECTED routes into BGP",
                       "conjuncts" : [
                         {
                           "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
                           "protocol" : "connected"
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "incomplete"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "comment" : "Redistribute STATIC routes into BGP",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                          "protocol" : "static"
                         },
                         {
                           "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -13685,8 +13685,13 @@
                       "comment" : "Redistribute CONNECTED routes into BGP",
                       "conjuncts" : [
                         {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                          "protocol" : "connected"
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                          "disjuncts" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                              "protocol" : "connected"
+                            }
+                          ]
                         },
                         {
                           "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
@@ -13825,11 +13830,16 @@
                   "disjuncts" : [
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "comment" : "Redistribute CONNECTED routes into BGP",
+                      "comment" : "Redistribute STATIC routes into BGP",
                       "conjuncts" : [
                         {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                          "protocol" : "connected"
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                          "disjuncts" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                              "protocol" : "static"
+                            }
+                          ]
                         },
                         {
                           "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
@@ -13867,11 +13877,16 @@
                     },
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                      "comment" : "Redistribute STATIC routes into BGP",
+                      "comment" : "Redistribute CONNECTED routes into BGP",
                       "conjuncts" : [
                         {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                          "protocol" : "static"
+                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                          "disjuncts" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                              "protocol" : "connected"
+                            }
+                          ]
                         },
                         {
                           "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",


### PR DESCRIPTION
Adds unnumbered BGP peers to the BGP topology, and adds edges between them as appropriate IF a layer 2 topology is present.

So far, the questions that use BGP topology should be unaffected because they do not supply a layer 2 topology, so they will use a BGP topology with no edges between unnumbered peers.