### PR TITLE
BGP Communities: make comparable, keep backwards-compatible parsing

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/Community.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/Community.java
@@ -3,6 +3,8 @@ package org.batfish.datamodel.bgp.community;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
+import java.math.BigInteger;
+import javax.annotation.Nonnull;
 
 /**
  * Represents a BGP community value, which could be <a
@@ -10,23 +12,36 @@ import java.io.Serializable;
  * href="https://tools.ietf.org/html/rfc4360">extended</a> or <a
  * href="https://tools.ietf.org/html/rfc8092">large</a>
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    property = "type",
+    // Keep backwards-compatible with previous community implementation
+    defaultImpl = StandardCommunity.class)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = StandardCommunity.class, name = "standard"),
   @JsonSubTypes.Type(value = ExtendedCommunity.class, name = "extended"),
   @JsonSubTypes.Type(value = LargeCommunity.class, name = "large")
 })
-public interface Community extends Serializable {
+public interface Community extends Serializable, Comparable<Community> {
 
   /**
    * Whether this community is transitive (can traverse from autonomous system to autonomous system)
    */
   boolean isTransitive();
 
+  /**
+   * Return the community value as a {@link java.math.BigInteger} so it can be compared and ordered
+   * deterministically regardless of community type
+   */
+  @Nonnull
+  BigInteger asBigInt();
+
   /** Return a string representation of the community suitable for regex matching. */
+  @Nonnull
   String matchString();
 
   /** Return a string representation of the community in canonical form. */
   @Override
+  @Nonnull
   String toString();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/Community.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/Community.java
@@ -1,7 +1,6 @@
 package org.batfish.datamodel.bgp.community;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
 import java.math.BigInteger;
 import javax.annotation.Nonnull;
@@ -14,10 +13,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * href="https://tools.ietf.org/html/rfc4360">extended</a> or <a
  * href="https://tools.ietf.org/html/rfc8092">large</a>
  */
-@JsonTypeInfo(
-    use = JsonTypeInfo.Id.NAME,
-    // Keep backwards-compatible with previous community implementation
-    defaultImpl = StandardCommunity.class)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = StandardCommunity.class, name = "standard"),
   @JsonSubTypes.Type(value = ExtendedCommunity.class, name = "extended"),

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/Community.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/Community.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
 import java.math.BigInteger;
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * Represents a BGP community value, which could be <a
@@ -14,7 +15,6 @@ import javax.annotation.Nonnull;
  */
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
-    property = "type",
     // Keep backwards-compatible with previous community implementation
     defaultImpl = StandardCommunity.class)
 @JsonSubTypes({
@@ -22,26 +22,34 @@ import javax.annotation.Nonnull;
   @JsonSubTypes.Type(value = ExtendedCommunity.class, name = "extended"),
   @JsonSubTypes.Type(value = LargeCommunity.class, name = "large")
 })
-public interface Community extends Serializable, Comparable<Community> {
+@ParametersAreNonnullByDefault
+public abstract class Community implements Serializable, Comparable<Community> {
+
+  private static final long serialVersionUID = 1L;
 
   /**
    * Whether this community is transitive (can traverse from autonomous system to autonomous system)
    */
-  boolean isTransitive();
+  public abstract boolean isTransitive();
 
   /**
    * Return the community value as a {@link java.math.BigInteger} so it can be compared and ordered
    * deterministically regardless of community type
    */
   @Nonnull
-  BigInteger asBigInt();
+  public abstract BigInteger asBigInt();
 
   /** Return a string representation of the community suitable for regex matching. */
   @Nonnull
-  String matchString();
+  public abstract String matchString();
 
   /** Return a string representation of the community in canonical form. */
   @Override
   @Nonnull
-  String toString();
+  public abstract String toString();
+
+  @Override
+  public int compareTo(Community o) {
+    return asBigInt().compareTo(o.asBigInt());
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/Community.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/Community.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
 import java.math.BigInteger;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
@@ -47,6 +48,12 @@ public abstract class Community implements Serializable, Comparable<Community> {
   @Override
   @Nonnull
   public abstract String toString();
+
+  @Override
+  public abstract boolean equals(@Nullable Object obj);
+
+  @Override
+  public abstract int hashCode();
 
   @Override
   public int compareTo(Community o) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
+import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -197,6 +198,7 @@ public final class ExtendedCommunity implements Community {
     return Objects.hash(_type, _subType, _globalAdministrator, _localAdministrator);
   }
 
+  @Nonnull
   @Override
   public String matchString() {
     if (_regexStr == null) {
@@ -222,5 +224,21 @@ public final class ExtendedCommunity implements Community {
               + _localAdministrator;
     }
     return _str;
+  }
+
+  @Nonnull
+  @Override
+  public BigInteger asBigInt() {
+    int gaOffset = _type == 0x00 || _type == 0x40 ? 8 : 16;
+    return BigInteger.valueOf(_type)
+        .shiftLeft(56)
+        .or(BigInteger.valueOf(_subType).shiftLeft(48))
+        .or(BigInteger.valueOf(_globalAdministrator).shiftLeft(gaOffset))
+        .or(BigInteger.valueOf(_localAdministrator));
+  }
+
+  @Override
+  public int compareTo(Community o) {
+    return asBigInt().compareTo(o.asBigInt());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
@@ -20,7 +20,7 @@ import org.batfish.datamodel.Ip;
  * href="https://tools.ietf.org/html/rfc4360">RFC4360</a>
  */
 @ParametersAreNonnullByDefault
-public final class ExtendedCommunity implements Community {
+public final class ExtendedCommunity extends Community {
 
   private static final long serialVersionUID = 1L;
 
@@ -229,16 +229,11 @@ public final class ExtendedCommunity implements Community {
   @Nonnull
   @Override
   public BigInteger asBigInt() {
-    int gaOffset = _type == 0x00 || _type == 0x40 ? 8 : 16;
+    int gaOffset = _type == 0x00 || _type == 0x40 ? 32 : 16;
     return BigInteger.valueOf(_type)
         .shiftLeft(56)
         .or(BigInteger.valueOf(_subType).shiftLeft(48))
         .or(BigInteger.valueOf(_globalAdministrator).shiftLeft(gaOffset))
         .or(BigInteger.valueOf(_localAdministrator));
-  }
-
-  @Override
-  public int compareTo(Community o) {
-    return asBigInt().compareTo(o.asBigInt());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/LargeCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/LargeCommunity.java
@@ -3,7 +3,9 @@ package org.batfish.datamodel.bgp.community;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.math.BigInteger;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -14,7 +16,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public final class LargeCommunity implements Community {
 
-  private static final long serialVersionUID = -1;
+  private static final long serialVersionUID = 1L;
 
   private final long _globalAdministrator;
   private final long _localData1;
@@ -76,6 +78,7 @@ public final class LargeCommunity implements Community {
     return false;
   }
 
+  @Nonnull
   @Override
   public String matchString() {
     return toString();
@@ -100,11 +103,26 @@ public final class LargeCommunity implements Community {
     return Objects.hash(_globalAdministrator, _localData1, _localData2);
   }
 
+  @Nonnull
   @Override
   public String toString() {
     if (_str == null) {
       _str = _globalAdministrator + ":" + _localData1 + ":" + _localData2;
     }
     return _str;
+  }
+
+  @Nonnull
+  @Override
+  public BigInteger asBigInt() {
+    return BigInteger.valueOf(_globalAdministrator)
+        .shiftLeft(64)
+        .or(BigInteger.valueOf(_localData1).shiftLeft(32))
+        .or(BigInteger.valueOf(_localData2));
+  }
+
+  @Override
+  public int compareTo(Community o) {
+    return asBigInt().compareTo(o.asBigInt());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/LargeCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/LargeCommunity.java
@@ -14,7 +14,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * href="https://tools.ietf.org/html/rfc8092">RFC8092</a>
  */
 @ParametersAreNonnullByDefault
-public final class LargeCommunity implements Community {
+public final class LargeCommunity extends Community {
 
   private static final long serialVersionUID = 1L;
 
@@ -119,10 +119,5 @@ public final class LargeCommunity implements Community {
         .shiftLeft(64)
         .or(BigInteger.valueOf(_localData1).shiftLeft(32))
         .or(BigInteger.valueOf(_localData2));
-  }
-
-  @Override
-  public int compareTo(Community o) {
-    return asBigInt().compareTo(o.asBigInt());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/StandardCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/StandardCommunity.java
@@ -14,7 +14,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * A standard BGP community, as defined in <a href="https://tools.ietf.org/html/rfc1997">RFC1197</a>
  */
 @ParametersAreNonnullByDefault
-public final class StandardCommunity implements Community {
+public final class StandardCommunity extends Community {
   private static final long serialVersionUID = 1L;
 
   private long _value;
@@ -128,10 +128,5 @@ public final class StandardCommunity implements Community {
   @Override
   public BigInteger asBigInt() {
     return BigInteger.valueOf(_value);
-  }
-
-  @Override
-  public int compareTo(Community o) {
-    return asBigInt().compareTo(o.asBigInt());
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/StandardCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/StandardCommunity.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigInteger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -27,16 +29,32 @@ public final class StandardCommunity implements Community {
   }
 
   @JsonCreator
-  private static StandardCommunity create(@Nullable String value) {
-    checkArgument(value != null, "Standard community string must not be null");
-    return parse(value);
+  private static StandardCommunity create(@Nullable JsonNode value) {
+    // Keep this creator backwards compatible with previous communities implementation
+    checkArgument(value != null && !value.isNull(), "Standard community string must not be null");
+    if (value.isTextual()) {
+      return parse(value.textValue());
+    } else if (value.isInt() || value.isLong()) {
+      return StandardCommunity.of(value.longValue());
+    } else if (value.isArray()
+        && value.has(0)
+        && value.get(0).textValue().equalsIgnoreCase("standard")) {
+      return parse(value.get(1).textValue());
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Invalid standard community value: %s", value));
+    }
   }
 
   @Nonnull
   public static StandardCommunity parse(String value) {
     String[] parts = value.split(":");
-    checkArgument(parts.length == 2, "Invalid standard community string: %s", value);
-    return of(Integer.parseUnsignedInt(parts[0]), Integer.parseUnsignedInt(parts[1]));
+    checkArgument(parts.length <= 2, "Invalid standard community string: %s", value);
+    if (parts.length == 2) {
+      return of(Integer.parseUnsignedInt(parts[0]), Integer.parseUnsignedInt(parts[1]));
+    } else {
+      return of(Long.parseUnsignedLong(value));
+    }
   }
 
   @Nonnull
@@ -48,7 +66,17 @@ public final class StandardCommunity implements Community {
   public static StandardCommunity of(int high, int low) {
     checkArgument(low >= 0 && low <= 0xFFFF, "Invalid low value: %d", low);
     checkArgument(high >= 0 && high <= 0xFFFF, "Invalid high value: %d", low);
-    return new StandardCommunity(high << 16 | low);
+    return new StandardCommunity((long) high << 16 | low);
+  }
+
+  /** Return the lower 16 bits of the community value as an integer */
+  public int low() {
+    return (int) (_value & 0xFFFF);
+  }
+
+  /** Return the lower 16 bits of the community value as an integer */
+  public int high() {
+    return (int) (_value >> 16);
   }
 
   @Override
@@ -57,11 +85,18 @@ public final class StandardCommunity implements Community {
     return false;
   }
 
+  @Nonnull
   @Override
   public String matchString() {
     return toString();
   }
 
+  /** Return this community's value as a long */
+  public long asLong() {
+    return _value;
+  }
+
+  @Nonnull
   @Override
   @JsonValue
   public String toString() {
@@ -87,5 +122,16 @@ public final class StandardCommunity implements Community {
   public int hashCode() {
     // Inline Long hashcode for speed
     return (int) (_value ^ (_value >>> 32));
+  }
+
+  @Nonnull
+  @Override
+  public BigInteger asBigInt() {
+    return BigInteger.valueOf(_value);
+  }
+
+  @Override
+  public int compareTo(Community o) {
+    return asBigInt().compareTo(o.asBigInt());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/ExtendedCommunityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/ExtendedCommunityTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.testing.EqualsTester;
 import java.io.IOException;
+import java.math.BigInteger;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
@@ -147,5 +148,24 @@ public final class ExtendedCommunityTest {
     assertThat(ExtendedCommunity.parse("origin:1L:1").toString(), equalTo("515:1L:1"));
     assertThat(ExtendedCommunity.parse("origin:1:1").toString(), equalTo("3:1:1"));
     assertThat(ExtendedCommunity.parse("origin:0.0.0.0:1").toString(), equalTo("259:0L:1"));
+  }
+
+  @Test
+  public void testToBigInt() {
+    assertThat(ExtendedCommunity.of(0, 0, 0).asBigInt(), equalTo(BigInteger.ZERO));
+    assertThat(
+        ExtendedCommunity.of((0x40 << 8) + 1, 65535, 4294967295L).asBigInt(),
+        equalTo(
+            BigInteger.valueOf(16385)
+                .shiftLeft(48)
+                .or(BigInteger.valueOf(65535).shiftLeft(32))
+                .or(BigInteger.valueOf(4294967295L))));
+    assertThat(
+        ExtendedCommunity.of((0x41 << 8) + 1, 4294967295L, 65535).asBigInt(),
+        equalTo(
+            BigInteger.valueOf(16641)
+                .shiftLeft(48)
+                .or(BigInteger.valueOf(4294967295L).shiftLeft(16))
+                .or(BigInteger.valueOf(65535))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/LargeCommunityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/LargeCommunityTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 
 import com.google.common.testing.EqualsTester;
+import java.math.BigInteger;
 import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Rule;
 import org.junit.Test;
@@ -102,5 +103,16 @@ public class LargeCommunityTest {
     LargeCommunity lc = LargeCommunity.parse("large:1:2:3");
     assertThat(lc.toString(), equalTo("1:2:3"));
     assertThat(lc.matchString(), equalTo(lc.toString()));
+  }
+
+  @Test
+  public void testToBigInt() {
+    assertThat(
+        LargeCommunity.of(4294967295L, 4294967294L, 4294967293L).asBigInt(),
+        equalTo(
+            BigInteger.valueOf(4294967295L)
+                .shiftLeft(64)
+                .or(BigInteger.valueOf(4294967294L).shiftLeft(32))
+                .or(BigInteger.valueOf(4294967293L))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/StandardCommunityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/StandardCommunityTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertFalse;
 
 import com.google.common.testing.EqualsTester;
 import java.io.IOException;
+import java.math.BigInteger;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Rule;
@@ -131,5 +132,25 @@ public class StandardCommunityTest {
   @Test
   public void testNotTransitive() {
     assertFalse(StandardCommunity.of(1, 1).isTransitive());
+  }
+
+  @Test
+  public void testToBigInt() {
+    assertThat(StandardCommunity.of(0).asBigInt(), equalTo(BigInteger.ZERO));
+    assertThat(
+        StandardCommunity.of(65535, 65535).asBigInt(), equalTo(BigInteger.valueOf(4294967295L)));
+  }
+
+  @Test
+  public void testAsLong() {
+    StandardCommunity c = StandardCommunity.of(65535, 65534);
+    assertThat(c.asLong(), equalTo((long) 65535 << 16 | 65534));
+  }
+
+  @Test
+  public void testHighAndLow() {
+    StandardCommunity c = StandardCommunity.of(65535, 65534);
+    assertThat(c.high(), equalTo(65535));
+    assertThat(c.low(), equalTo(65534));
   }
 }


### PR DESCRIPTION
1. Of course we put communities into a whole bunch of sorted sets, so making comparable.
2. Default JSON parsing to standard communities, to avoid breaking user-facing APIs (e.g., testPolicies question)
3. Add utility methods to StandardCommunities such as getting long/high/low values.
