### PR TITLE
Include L3 adjacency even if interface is not active

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -619,7 +619,7 @@ public final class TopologyUtil {
     configurations.forEach(
         (nodeName, node) -> {
           for (Interface iface : node.getAllInterfaces().values()) {
-            if (iface.isLoopback(node.getConfigurationFormat()) || !iface.getActive()) {
+            if (iface.isLoopback(node.getConfigurationFormat())) {
               continue;
             }
             for (InterfaceAddress address : iface.getAllAddresses()) {


### PR DESCRIPTION
If an interface is inactive, L3 adjacency is not created. This causes the SMT model to assume neighbor must be external to the network which is an incorrect assumption. The attached configs demonstrate a simple network with no external neighbors and a disabled interface where this improper assumption is made.


[configs.zip](https://github.com/batfish/batfish/files/3113403/configs.zip)
