### PR TITLE
Arista BGP default-originate route-map

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -317,7 +317,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
     return String.format("~BGP_COMMON_EXPORT_POLICY:%s~", vrf);
   }
 
-  public static String computeBgpDefaultRouteExportPolicyName(boolean ipv4) {
+  public static String computeBgpDefaultRouteExportPolicyName(
+      boolean ipv4, String vrf, String peer) {
+    return String.format(
+        "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv%s:%s:%s~", ipv4 ? "4" : "6", vrf, peer);
+  }
+
+  public static String computeNxosBgpDefaultRouteExportPolicyName(boolean ipv4) {
     return String.format("~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv%s~", ipv4 ? "4" : "6");
   }
 
@@ -1873,9 +1879,20 @@ public final class CiscoConfiguration extends VendorConfiguration {
       boolean ipv4 = lpg.getNeighborPrefix() != null;
       Ip updateSource = getUpdateSource(c, vrfName, lpg, updateSourceInterface, ipv4);
 
+      // Get default-originate generation policy (if Cisco) or export policy (if Arista)
+      String defaultRouteExportMap = null;
+      String defaultOriginateGenerationMap = null;
+      if (lpg.getDefaultOriginate()) {
+        if (c.getConfigurationFormat() == ConfigurationFormat.ARISTA) {
+          defaultRouteExportMap = lpg.getDefaultOriginateMap();
+        } else {
+          defaultOriginateGenerationMap = lpg.getDefaultOriginateMap();
+        }
+      }
+
       // Generate import and export policies
       String peerImportPolicyName = generateBgpImportPolicy(lpg, vrfName, c, _w);
-      generateBgpExportPolicy(lpg, vrfName, ipv4, c, _w);
+      generateBgpExportPolicy(lpg, vrfName, ipv4, defaultRouteExportMap, c, _w);
 
       // If defaultOriginate is set, create default route for this peer group
       GeneratedRoute.Builder defaultRoute = null;
@@ -1888,14 +1905,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
         defaultRoute6.setNetwork(Prefix6.ZERO);
         defaultRoute6.setAdmin(MAX_ADMINISTRATIVE_COST);
 
-        String defaultOriginateMapName = lpg.getDefaultOriginateMap();
-        if (defaultOriginateMapName != null
-            && c.getRoutingPolicies().containsKey(defaultOriginateMapName)) {
+        if (defaultOriginateGenerationMap != null
+            && c.getRoutingPolicies().containsKey(defaultOriginateGenerationMap)) {
           // originate contingent on generation policy
           if (ipv4) {
-            defaultRoute.setGenerationPolicy(defaultOriginateMapName);
+            defaultRoute.setGenerationPolicy(defaultOriginateGenerationMap);
           } else {
-            defaultRoute6.setGenerationPolicy(defaultOriginateMapName);
+            defaultRoute6.setGenerationPolicy(defaultOriginateGenerationMap);
           }
         }
       }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1880,11 +1880,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
       Ip updateSource = getUpdateSource(c, vrfName, lpg, updateSourceInterface, ipv4);
 
       // Get default-originate generation policy (if Cisco) or export policy (if Arista)
-      String defaultRouteExportMap = null;
+      String defaultOriginateExportMap = null;
       String defaultOriginateGenerationMap = null;
       if (lpg.getDefaultOriginate()) {
         if (c.getConfigurationFormat() == ConfigurationFormat.ARISTA) {
-          defaultRouteExportMap = lpg.getDefaultOriginateMap();
+          defaultOriginateExportMap = lpg.getDefaultOriginateMap();
         } else {
           defaultOriginateGenerationMap = lpg.getDefaultOriginateMap();
         }
@@ -1892,7 +1892,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
       // Generate import and export policies
       String peerImportPolicyName = generateBgpImportPolicy(lpg, vrfName, c, _w);
-      generateBgpExportPolicy(lpg, vrfName, ipv4, defaultRouteExportMap, c, _w);
+      generateBgpExportPolicy(lpg, vrfName, ipv4, defaultOriginateExportMap, c, _w);
 
       // If defaultOriginate is set, create default route for this peer group
       GeneratedRoute.Builder defaultRoute = null;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -103,6 +103,7 @@ import org.batfish.datamodel.routing_policy.expr.MatchProcessAsn;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
 import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.SelfNextHop;
+import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetEigrpMetric;
 import org.batfish.datamodel.routing_policy.statement.SetNextHop;
@@ -426,7 +427,7 @@ class CiscoConversions {
       defaultRouteExportStatements =
           ImmutableList.of(
               setOrigin,
-              new If(new CallExpr(defaultOriginateExportMapName), ImmutableList.of()),
+              new CallStatement(defaultOriginateExportMapName),
               Statements.ReturnTrue.toStaticStatement());
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -322,7 +322,12 @@ class CiscoConversions {
    * LeafBgpPeerGroup}. The generated policy is added to the given configuration's routing policies.
    */
   static void generateBgpExportPolicy(
-      LeafBgpPeerGroup lpg, String vrfName, boolean ipv4, Configuration c, Warnings w) {
+      LeafBgpPeerGroup lpg,
+      String vrfName,
+      boolean ipv4,
+      @Nullable String defaultOriginateExportRouteMapName,
+      Configuration c,
+      Warnings w) {
     List<Statement> exportPolicyStatements = new ArrayList<>();
     if (lpg.getNextHopSelf() != null && lpg.getNextHopSelf()) {
       exportPolicyStatements.add(new SetNextHop(SelfNextHop.getInstance(), false));
@@ -335,11 +340,12 @@ class CiscoConversions {
     // this policy and get exported without going through the rest of the export policy.
     // TODO Verify that nextHopSelf and removePrivateAs settings apply to default-originate route.
     if (lpg.getDefaultOriginate()) {
-      initBgpDefaultRouteExportPolicy(ipv4, c);
+      initBgpDefaultRouteExportPolicy(
+          vrfName, lpg.getName(), ipv4, defaultOriginateExportRouteMapName, c);
       exportPolicyStatements.add(
           new If(
               "Export default route from peer with default-originate configured",
-              new CallExpr(computeBgpDefaultRouteExportPolicyName(ipv4)),
+              new CallExpr(computeBgpDefaultRouteExportPolicyName(ipv4, vrfName, lpg.getName())),
               singletonList(Statements.ReturnTrue.toStaticStatement()),
               ImmutableList.of()));
     }
@@ -392,30 +398,50 @@ class CiscoConversions {
    * policy is the same across BGP processes, so only one is created for each configuration.
    *
    * @param ipv4 Whether to initialize the IPv4 or IPv6 default route export policy
+   * @param defaultOriginateExportMapName Name of route-map to apply to generated route before
+   *     export. This is an Arista-specific concept and <a
+   *     href=https://www.arista.com/en/um-eos/eos-section-32-4-bgp-commands#ww1116958>does not
+   *     affect whether the route will be exported</a>.
    */
-  static void initBgpDefaultRouteExportPolicy(boolean ipv4, Configuration c) {
-    String defaultRouteExportPolicyName = computeBgpDefaultRouteExportPolicyName(ipv4);
-    if (!c.getRoutingPolicies().containsKey(defaultRouteExportPolicyName)) {
-      RoutingPolicy.builder()
-          .setOwner(c)
-          .setName(defaultRouteExportPolicyName)
-          .addStatement(
-              new If(
-                  new Conjunction(
-                      ImmutableList.of(
-                          ipv4 ? MATCH_DEFAULT_ROUTE : MATCH_DEFAULT_ROUTE6,
-                          new MatchProtocol(RoutingProtocol.AGGREGATE))),
-                  ImmutableList.of(
-                      new SetOrigin(
-                          new LiteralOrigin(
-                              c.getConfigurationFormat() == ConfigurationFormat.CISCO_IOS
-                                  ? OriginType.IGP
-                                  : OriginType.INCOMPLETE,
-                              null)),
-                      Statements.ReturnTrue.toStaticStatement())))
-          .addStatement(Statements.ReturnFalse.toStaticStatement())
-          .build();
+  static void initBgpDefaultRouteExportPolicy(
+      String vrfName,
+      String peerName,
+      boolean ipv4,
+      @Nullable String defaultOriginateExportMapName,
+      Configuration c) {
+    SetOrigin setOrigin =
+        new SetOrigin(
+            new LiteralOrigin(
+                c.getConfigurationFormat() == ConfigurationFormat.CISCO_IOS
+                    ? OriginType.IGP
+                    : OriginType.INCOMPLETE,
+                null));
+    List<Statement> defaultRouteExportStatements;
+    if (defaultOriginateExportMapName == null
+        // TODO Test behavior if route-map is undefined
+        || !c.getRoutingPolicies().keySet().contains(defaultOriginateExportMapName)) {
+      defaultRouteExportStatements =
+          ImmutableList.of(setOrigin, Statements.ReturnTrue.toStaticStatement());
+    } else {
+      defaultRouteExportStatements =
+          ImmutableList.of(
+              setOrigin,
+              new If(new CallExpr(defaultOriginateExportMapName), ImmutableList.of()),
+              Statements.ReturnTrue.toStaticStatement());
     }
+
+    RoutingPolicy.builder()
+        .setOwner(c)
+        .setName(computeBgpDefaultRouteExportPolicyName(ipv4, vrfName, peerName))
+        .addStatement(
+            new If(
+                new Conjunction(
+                    ImmutableList.of(
+                        ipv4 ? MATCH_DEFAULT_ROUTE : MATCH_DEFAULT_ROUTE6,
+                        new MatchProtocol(RoutingProtocol.AGGREGATE))),
+                defaultRouteExportStatements))
+        .addStatement(Statements.ReturnFalse.toStaticStatement())
+        .build();
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoNxConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoNxConversions.java
@@ -6,8 +6,8 @@ import static org.batfish.datamodel.routing_policy.statement.Statements.RemovePr
 import static org.batfish.representation.cisco.CiscoConfiguration.MATCH_DEFAULT_ROUTE;
 import static org.batfish.representation.cisco.CiscoConfiguration.MAX_ADMINISTRATIVE_COST;
 import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpCommonExportPolicyName;
-import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpDefaultRouteExportPolicyName;
 import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpPeerExportPolicyName;
+import static org.batfish.representation.cisco.CiscoConfiguration.computeNxosBgpDefaultRouteExportPolicyName;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -344,7 +344,7 @@ final class CiscoNxConversions {
       exportStatements.add(
           new If(
               "Export default route from peer with default-originate configured",
-              new CallExpr(computeBgpDefaultRouteExportPolicyName(true)),
+              new CallExpr(computeNxosBgpDefaultRouteExportPolicyName(true)),
               singletonList(Statements.ReturnTrue.toStaticStatement()),
               ImmutableList.of()));
 
@@ -392,7 +392,7 @@ final class CiscoNxConversions {
    * same across BGP processes, so only one is created for each configuration.
    */
   static void initBgpDefaultRouteExportPolicy(Configuration c) {
-    String defaultRouteExportPolicyName = computeBgpDefaultRouteExportPolicyName(true);
+    String defaultRouteExportPolicyName = computeNxosBgpDefaultRouteExportPolicyName(true);
     if (!c.getRoutingPolicies().containsKey(defaultRouteExportPolicyName)) {
       RoutingPolicy.builder()
           .setOwner(c)

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsBgpPoliciesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsBgpPoliciesTest.java
@@ -166,7 +166,7 @@ public class CiscoConversionsBgpPoliciesTest {
     // Create a BGP export policy from a peer group with no constraints on outgoing routes.
     // Resulting export policy should accept any BGP routes.
     _peerGroup.setDefaultOriginate(false);
-    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, true, _c, _w);
+    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, true, null, _c, _w);
     RoutingPolicy bgpExportPolicy =
         _c.getRoutingPolicies()
             .get(computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, _peerGroup.getName()));
@@ -206,7 +206,7 @@ public class CiscoConversionsBgpPoliciesTest {
     // routes. Resulting export policy should match prefix-list.
     _peerGroup.setDefaultOriginate(false);
     _peerGroup.setOutboundPrefixList(PREFIX_LIST_NAME);
-    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, true, _c, _w);
+    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, true, null, _c, _w);
 
     RoutingPolicy bgpExportPolicy =
         _c.getRoutingPolicies()
@@ -239,7 +239,7 @@ public class CiscoConversionsBgpPoliciesTest {
     // routes. Resulting export policy should match the route-map.
     _peerGroup.setOutboundRouteMap(ROUTE_MAP_NAME);
     _peerGroup.setDefaultOriginate(false);
-    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, true, _c, _w);
+    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, true, null, _c, _w);
 
     RoutingPolicy bgpExportPolicy =
         _c.getRoutingPolicies()
@@ -281,7 +281,7 @@ public class CiscoConversionsBgpPoliciesTest {
     _peerGroup.setOutboundPrefixList(PREFIX_LIST_NAME);
     _peerGroup.setOutboundRouteMap(ROUTE_MAP_NAME);
     _peerGroup.setDefaultOriginate(false);
-    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, true, _c, _w);
+    generateBgpExportPolicy(_peerGroup, DEFAULT_VRF_NAME, true, null, _c, _w);
 
     RoutingPolicy bgpExportPolicy =
         _c.getRoutingPolicies()

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-bgp-default-originate/configs/arista-originator
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-bgp-default-originate/configs/arista-originator
@@ -1,0 +1,19 @@
+boot system flash this-is-an-arista-device.swi
+!
+hostname arista-originator
+!
+interface Loopback0
+ ip address 1.1.1.1/32
+!
+interface Eth0
+ ip address 10.1.1.1/24
+!
+router bgp 1
+ router-id 1.1.1.1
+ neighbor 10.1.1.2 activate
+ neighbor 10.1.1.2 remote-as 2
+ neighbor 10.1.1.2 default-originate route-map ROUTE_MAP
+!
+route-map ROUTE_MAP permit 10
+ set community 111:222 additive
+ set community 333:444 additive

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-bgp-default-originate/configs/ios-listener
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-bgp-default-originate/configs/ios-listener
@@ -1,0 +1,13 @@
+!
+hostname ios-listener
+!
+interface Loopback0
+ ip address 2.2.2.2 255.255.255.255
+!
+interface FastEthernet0/0
+  ip address 10.1.1.2 255.255.255.0
+!
+router bgp 2
+  bgp router-id 2.2.2.2
+  neighbor 10.1.1.1 remote-as 1
+!

--- a/tests/aws/nodes-example-aws.ref
+++ b/tests/aws/nodes-example-aws.ref
@@ -1312,8 +1312,55 @@
               }
             ]
           },
-          "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~" : {
-            "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~",
+          "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4:default:169.254.13.237~" : {
+            "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4:default:169.254.13.237~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "comment" : "match default route",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                        "prefixSpace" : [
+                          "0.0.0.0/0"
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "aggregate"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                    "originType" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                      "originType" : "igp"
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4:default:169.254.15.193~" : {
+            "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4:default:169.254.15.193~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -1474,7 +1521,7 @@
                 "comment" : "Export default route from peer with default-originate configured",
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                  "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~"
+                  "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4:default:169.254.13.237~"
                 },
                 "trueStatements" : [
                   {
@@ -1513,7 +1560,7 @@
                 "comment" : "Export default route from peer with default-originate configured",
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                  "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~"
+                  "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4:default:169.254.15.193~"
                 },
                 "trueStatements" : [
                   {

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -6688,8 +6688,8 @@
               }
             ]
           },
-          "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~" : {
-            "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~",
+          "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4:aVrfWithInnerStatements:10.0.1.2~" : {
+            "name" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4:aVrfWithInnerStatements:10.0.1.2~",
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -6743,7 +6743,7 @@
                 "comment" : "Export default route from peer with default-originate configured",
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                  "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4~"
+                  "calledPolicyName" : "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv4:aVrfWithInnerStatements:10.0.1.2~"
                 },
                 "trueStatements" : [
                   {


### PR DESCRIPTION
In the line:
`neighbor 10.1.1.2 default-originate route-map ROUTE_MAP`
Cisco uses `ROUTE_MAP` as a generation policy, but Arista instead applies it to the (unconditionally) exported default route (see [Arista's documentation](https://www.arista.com/en/um-eos/eos-section-32-4-bgp-commands#ww1116958) and [notes from GNS3](https://docs.google.com/document/d/1KFCT8ckUYOza4dVFMQ87XutsQWDKT_5UONngfA-eXJw) for details). Currently Batfish always converts the route-map to a generation policy. This PR makes it add the route-map to the default route export policy instead if on an Arista device.

The default route export policy can now vary per peer again, so we're back to creating one default route export policy per default-originating peer, except for NXOS, which still creates one default route export policy per config.