### PR TITLE
Remove TODO after confirming behavior

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -419,7 +419,6 @@ class CiscoConversions {
                 null));
     List<Statement> defaultRouteExportStatements;
     if (defaultOriginateExportMapName == null
-        // TODO Test behavior if route-map is undefined
         || !c.getRoutingPolicies().keySet().contains(defaultOriginateExportMapName)) {
       defaultRouteExportStatements =
           ImmutableList.of(setOrigin, Statements.ReturnTrue.toStaticStatement());

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-bgp-default-originate/configs/arista-originator-undefined-rm
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-bgp-default-originate/configs/arista-originator-undefined-rm
@@ -1,0 +1,15 @@
+boot system flash this-is-an-arista-device.swi
+!
+hostname arista-originator-undefined-rm
+!
+interface Loopback0
+ ip address 1.1.1.1/32
+!
+interface Eth0
+ ip address 10.1.1.1/24
+!
+router bgp 1
+ router-id 1.1.1.1
+ neighbor 10.1.1.2 activate
+ neighbor 10.1.1.2 remote-as 2
+ neighbor 10.1.1.2 default-originate route-map ROUTE_MAP


### PR DESCRIPTION
[Confirmed](https://docs.google.com/document/d/1KFCT8ckUYOza4dVFMQ87XutsQWDKT_5UONngfA-eXJw/edit#heading=h.eqvs8hr9omtl) that if the route-map is undefined here, the default route is exported as if no route-map were configured.