### PR TITLE
 Don't assume Cumulus BGP IPv4 address family is nonnull

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -120,6 +120,15 @@ public class BgpProcess implements Serializable {
   }
 
   /**
+   * Expand the origination space for this prefix
+   *
+   * @param prefix {@link Prefix} to add
+   */
+  public void addToOriginationSpace(Prefix prefix) {
+    _originationSpace.addPrefix(prefix);
+  }
+
+  /**
    * Returns set of all cluster IDs for all neighbors. The result is memoized, so this should only
    * be called after the neighbors are finalized.
    */

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -631,7 +631,8 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
     exportConditions.add(new MatchProtocol(RoutingProtocol.BGP));
     exportConditions.add(new MatchProtocol(RoutingProtocol.IBGP));
 
-    // If no IPv4 address family is defined, nothing else should be exported
+    // If no IPv4 address family is not defined, there is no capability to explicitly advertise v4
+    // networks or redistribute protocols, so no non-BGP routes can be exported.
     if (bgpVrf.getIpv4Unicast() == null) {
       return exportConditions;
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Streams;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,6 +43,7 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.Mlag;
 import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.PrefixRange;
 import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.SwitchportMode;
@@ -590,27 +592,51 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
     newProc.setMultipathIbgp(false);
 
     /*
-     * Create common BGP export policy. This policy encompasses:
-     * - network statements
-     * - redistribution from other protocols
+     * Create common BGP export policy. This policy permits:
+     * - BGP and iBGP routes
+     * - routes whose network matches a configured network statement
+     * - routes whose protocol matches a configured protocol redistribution policy
+     * and denies all other routes.
      */
-    RoutingPolicy.Builder bgpCommonExportPolicy =
-        RoutingPolicy.builder().setOwner(_c).setName(computeBgpCommonExportPolicyName(vrfName));
+    RoutingPolicy.builder()
+        .setOwner(_c)
+        .setName(computeBgpCommonExportPolicyName(vrfName))
+        .setStatements(
+            ImmutableList.of(
+                new If(
+                    new Disjunction(getBgpExportConditions(bgpVrf)),
+                    ImmutableList.of(Statements.ReturnTrue.toStaticStatement()),
+                    ImmutableList.of(Statements.ReturnFalse.toStaticStatement()))))
+        .build();
 
-    // The body of the export policy is a huge disjunction over many reasons routes may be exported.
-    Disjunction routesShouldBeExported = new Disjunction();
-    bgpCommonExportPolicy.addStatement(
-        new If(
-            routesShouldBeExported,
-            ImmutableList.of(Statements.ReturnTrue.toStaticStatement()),
-            ImmutableList.of()));
-    // This list of reasons to export a route will be built up over the remainder of this function.
-    List<BooleanExpr> exportConditions = routesShouldBeExported.getDisjuncts();
+    // Add networks from network statements to new process's origination space
+    if (bgpVrf.getIpv4Unicast() != null) {
+      bgpVrf.getIpv4Unicast().getNetworks().keySet().forEach(newProc::addToOriginationSpace);
+    }
 
-    // Finally, the export policy ends with returning false: do not export unmatched routes.
-    bgpCommonExportPolicy.addStatement(Statements.ReturnFalse.toStaticStatement()).build();
+    Long localAs = bgpVrf.getAutonomousSystem();
+    bgpVrf
+        .getInterfaceNeighbors()
+        .forEach(
+            (peerInterface, neighbor) ->
+                addInterfaceNeighbor(peerInterface, neighbor, localAs, bgpVrf, newProc));
 
-    // Export routes that should be redistributed.
+    return newProc;
+  }
+
+  private List<BooleanExpr> getBgpExportConditions(BgpVrf bgpVrf) {
+    List<BooleanExpr> exportConditions = new ArrayList<>();
+
+    // Always export BGP and iBGP routes
+    exportConditions.add(new MatchProtocol(RoutingProtocol.BGP));
+    exportConditions.add(new MatchProtocol(RoutingProtocol.IBGP));
+
+    // If no IPv4 address family is defined, nothing else should be exported
+    if (bgpVrf.getIpv4Unicast() == null) {
+      return exportConditions;
+    }
+
+    // Add conditions to redistribute other protocols
     for (BgpRedistributionPolicy redistributeProtocolPolicy :
         bgpVrf.getIpv4Unicast().getRedistributionPolicies().values()) {
 
@@ -646,39 +672,23 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
               BooleanExpr weExpr = BooleanExprs.TRUE;
               BooleanExpr we = bgpRedistributeWithEnvironmentExpr(weExpr, OriginType.IGP);
               Conjunction exportNetworkConditions = new Conjunction();
-              PrefixSpace space = new PrefixSpace();
-              space.addPrefix(prefix);
-              newProc.addToOriginationSpace(space);
               exportNetworkConditions
                   .getConjuncts()
                   .add(
                       new MatchPrefixSet(
-                          DestinationNetwork.instance(), new ExplicitPrefixSet(space)));
-              exportNetworkConditions
-                  .getConjuncts()
-                  .add(new Not(new MatchProtocol(RoutingProtocol.BGP)));
-              exportNetworkConditions
-                  .getConjuncts()
-                  .add(new Not(new MatchProtocol(RoutingProtocol.IBGP)));
+                          DestinationNetwork.instance(),
+                          new ExplicitPrefixSet(new PrefixSpace(PrefixRange.fromPrefix(prefix)))));
+              /*
+              Don't need to explicitly exclude BGP and iBGP routes here because those routes will
+              already be matched earlier in exportConditions (which are disjuncts).
+               */
               exportNetworkConditions
                   .getConjuncts()
                   .add(new Not(new MatchProtocol(RoutingProtocol.AGGREGATE)));
               exportNetworkConditions.getConjuncts().add(we);
               exportConditions.add(exportNetworkConditions);
             });
-
-    // Export BGP and IBGP routes.
-    exportConditions.add(new MatchProtocol(RoutingProtocol.BGP));
-    exportConditions.add(new MatchProtocol(RoutingProtocol.IBGP));
-
-    Long localAs = bgpVrf.getAutonomousSystem();
-    bgpVrf
-        .getInterfaceNeighbors()
-        .forEach(
-            (peerInterface, neighbor) ->
-                addInterfaceNeighbor(peerInterface, neighbor, localAs, bgpVrf, newProc));
-
-    return newProc;
+    return exportConditions;
   }
 
   private @Nonnull BooleanExpr toGuard(RouteMapEntry entry) {

--- a/tests/parsing-tests/networks/unit-tests/configs/cumulus_nclu_bgp_no_address_family
+++ b/tests/parsing-tests/networks/unit-tests/configs/cumulus_nclu_bgp_no_address_family
@@ -1,0 +1,7 @@
+net del all
+#
+net add hostname cumulus_nclu_bgp_no_address_family
+#
+net add bgp autonomous-system 65500
+net add bgp router-id 192.0.2.2
+net commit

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -13677,9 +13677,23 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ],
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
                   "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    },
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
                       "comment" : "Redistribute CONNECTED routes into BGP",
@@ -13746,20 +13760,6 @@
                           "class" : "org.batfish.datamodel.routing_policy.expr.Not",
                           "expr" : {
                             "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                            "protocol" : "bgp"
-                          }
-                        },
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
-                          "expr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                            "protocol" : "ibgp"
-                          }
-                        },
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Not",
-                          "expr" : {
-                            "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
                             "protocol" : "aggregate"
                           }
                         },
@@ -13796,14 +13796,6 @@
                           ]
                         }
                       ]
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                      "protocol" : "bgp"
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                      "protocol" : "ibgp"
                     }
                   ]
                 },
@@ -13813,10 +13805,6 @@
                     "type" : "ReturnTrue"
                   }
                 ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "ReturnFalse"
               }
             ]
           },
@@ -13825,9 +13813,23 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ],
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
                   "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    },
                     {
                       "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
                       "comment" : "Redistribute CONNECTED routes into BGP",
@@ -13921,14 +13923,6 @@
                           ]
                         }
                       ]
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                      "protocol" : "bgp"
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                      "protocol" : "ibgp"
                     }
                   ]
                 },
@@ -13938,10 +13932,6 @@
                     "type" : "ReturnTrue"
                   }
                 ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "ReturnFalse"
               }
             ]
           },

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -14080,6 +14080,97 @@
           }
         }
       },
+      "cumulus_nclu_bgp_no_address_family" : {
+        "configurationFormat" : "CUMULUS_NCLU",
+        "name" : "cumulus_nclu_bgp_no_address_family",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "interfaces" : {
+          "lo" : {
+            "name" : "lo",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "mtu" : 1500,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "routingPolicies" : {
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cumulus" : {
+            "bridge" : {
+              "pvid" : 1,
+              "vids" : ""
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : false,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : false,
+              "routerId" : "192.0.2.2",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "lo"
+            ]
+          }
+        }
+      },
       "cumulus_nclu_invalid_bonds" : {
         "configurationFormat" : "CUMULUS_NCLU",
         "name" : "cumulus_nclu_invalid_bonds",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -81863,6 +81863,9 @@
         "configs/cumulus_nclu" : [
           "cumulus_nclu"
         ],
+        "configs/cumulus_nclu_bgp_no_address_family" : [
+          "cumulus_nclu_bgp_no_address_family"
+        ],
         "configs/cumulus_nclu_invalid_bonds" : [
           "cumulus_nclu_invalid_bonds"
         ],

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -459,6 +459,9 @@
         "cumulus_nclu" : [
           "configs/cumulus_nclu"
         ],
+        "cumulus_nclu_bgp_no_address_family" : [
+          "configs/cumulus_nclu_bgp_no_address_family"
+        ],
         "cumulus_nclu_invalid_bonds" : [
           "configs/cumulus_nclu_invalid_bonds"
         ],
@@ -1028,6 +1031,7 @@
         "configs/community_name_numbers_dos" : "PASSED",
         "configs/community_set" : "PASSED",
         "configs/cumulus_nclu" : "PASSED",
+        "configs/cumulus_nclu_bgp_no_address_family" : "PASSED",
         "configs/cumulus_nclu_invalid_bonds" : "PASSED",
         "configs/cumulus_nclu_invalid_interfaces" : "PASSED",
         "configs/cumulus_nclu_invalid_vrfs" : "PASSED",
@@ -41438,6 +41442,58 @@
             "  EOF:<EOF>)"
           ]
         },
+        "configs/cumulus_nclu_bgp_no_address_family" : {
+          "sentences" : [
+            "(cumulus_nclu_configuration",
+            "  (statement",
+            "    (s_null",
+            "      NET:'net'",
+            "      (null_rest_of_line",
+            "        DEL:'del'",
+            "        WORD:'all'",
+            "        NEWLINE:'\\n')))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_hostname",
+            "        HOSTNAME:'hostname'",
+            "        hostname = (word",
+            "          WORD:'cumulus_nclu_bgp_no_address_family')",
+            "        NEWLINE:'\\n')))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_bgp",
+            "        BGP:'bgp'",
+            "        (b_common",
+            "          (b_autonomous_system",
+            "            AUTONOMOUS_SYSTEM:'autonomous-system'",
+            "            as = (uint32",
+            "              d = DEC:'65500')",
+            "            NEWLINE:'\\n')))))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_bgp",
+            "        BGP:'bgp'",
+            "        (b_common",
+            "          (b_router_id",
+            "            ROUTER_ID:'router-id'",
+            "            id = (ip_address",
+            "              IP_ADDRESS:'192.0.2.2')",
+            "            NEWLINE:'\\n')))))",
+            "  (statement",
+            "    (s_null",
+            "      NET:'net'",
+            "      (null_rest_of_line",
+            "        COMMIT:'commit'",
+            "        NEWLINE:'\\n\\n')))",
+            "  EOF:<EOF>)"
+          ]
+        },
         "configs/cumulus_nclu_invalid_bonds" : {
           "sentences" : [
             "(cumulus_nclu_configuration",
@@ -74848,6 +74904,7 @@
         "community_list_named" : "PASSED",
         "community_set" : "PASSED",
         "cumulus_nclu" : "WARNINGS",
+        "cumulus_nclu_bgp_no_address_family" : "PASSED",
         "cumulus_nclu_invalid_bonds" : "PASSED",
         "cumulus_nclu_invalid_interfaces" : "PASSED",
         "cumulus_nclu_invalid_vrfs" : "PASSED",
@@ -77620,6 +77677,7 @@
             }
           }
         },
+        "configs/cumulus_nclu_bgp_no_address_family" : { },
         "configs/cumulus_nclu_invalid_bonds" : {
           "interface" : {
             "swp1" : {
@@ -88543,6 +88601,7 @@
         "configs/community_name_numbers_dos" : "PASSED",
         "configs/community_set" : "PASSED",
         "configs/cumulus_nclu" : "PASSED",
+        "configs/cumulus_nclu_bgp_no_address_family" : "PASSED",
         "configs/cumulus_nclu_invalid_bonds" : "PASSED",
         "configs/cumulus_nclu_invalid_interfaces" : "PASSED",
         "configs/cumulus_nclu_invalid_vrfs" : "PASSED",


### PR DESCRIPTION
Adds a ref test where `bgpVrf.getIpv4Unicast()` is null, which results in a parse failure due to a null pointer exception on master. Fixes `toBgpProcess()` to avoid the NPE.