### PR TITLE
Add parse status issues to initIssues question

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseStatus.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseStatus.java
@@ -34,7 +34,7 @@ public enum ParseStatus {
       case EMPTY:
         return "File is empty";
       case FAILED:
-        return "File contained at least one unrecognized line";
+        return "File failed to parse";
       case IGNORED:
         return "File explicitly ignored by user";
       case ORPHANED:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseStatus.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseStatus.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import org.batfish.common.BatfishException;
 
 public enum ParseStatus {
   EMPTY,
@@ -25,5 +26,30 @@ public enum ParseStatus {
    */
   public static ParseStatus resolve(ParseStatus... statuses) {
     return Arrays.stream(statuses).min(Comparator.comparingInt(ORDERED::indexOf)).orElse(UNKNOWN);
+  }
+
+  /** Get explanation for parse statuses. */
+  public static String explanation(ParseStatus status) {
+    switch (status) {
+      case EMPTY:
+        return "File is empty";
+      case FAILED:
+        return "File contained at least one unrecognized line";
+      case IGNORED:
+        return "File explicitly ignored by user";
+      case ORPHANED:
+        return "File is an orphaned overlay configuration";
+      case PARTIALLY_UNRECOGNIZED:
+        return "File contained at least one unrecognized line";
+      case PASSED:
+        return "File parsed successfully";
+      case UNKNOWN:
+        return "File format is unknown";
+      case UNSUPPORTED:
+        return "File format is known but unsupported";
+      default:
+        throw new BatfishException(
+            String.format("Unhandled parse status explanation for status: %s", status));
+    }
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/initialization/InitIssuesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/initialization/InitIssuesAnswerer.java
@@ -86,7 +86,7 @@ public class InitIssuesAnswerer extends Answerer {
                     .map(s -> new FileLines(s, ImmutableSortedSet.of()))
                     .collect(ImmutableList.toImmutableList()),
                 IssueType.ParseStatus,
-                String.format("File(s) not parsed successfully, with parse status: %s", status)));
+                String.format("File(s) not parsed successfully, parse status: %s", status)));
       }
     }
 

--- a/projects/question/src/main/java/org/batfish/question/initialization/InitIssuesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/initialization/InitIssuesAnswerer.java
@@ -5,10 +5,16 @@ import static org.batfish.question.initialization.IssueAggregation.aggregateDupl
 import static org.batfish.question.initialization.IssueAggregation.aggregateDuplicateParseWarnings;
 import static org.batfish.question.initialization.IssueAggregation.aggregateDuplicateWarnings;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.batfish.common.Answerer;
 import org.batfish.common.ErrorDetails;
@@ -16,6 +22,7 @@ import org.batfish.common.ErrorDetails.ParseExceptionContext;
 import org.batfish.common.Warnings;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
+import org.batfish.datamodel.answers.ParseStatus;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.collections.FileLines;
@@ -65,6 +72,24 @@ public class InitIssuesAnswerer extends Answerer {
                         triplet._text,
                         triplet._parserContext)));
 
+    for (Entry<ParseStatus, Set<String>> entry :
+        aggregateParseStatuses(pvcae.getParseStatus()).entrySet()) {
+      // We're already adding issues for FAILED and PARTIALLY_UNRECOGNIZED, so skip those
+      ParseStatus status = entry.getKey();
+      if (status != ParseStatus.FAILED
+          && status != ParseStatus.PARTIALLY_UNRECOGNIZED
+          && status != ParseStatus.PASSED) {
+        rows.add(
+            getRow(
+                null,
+                entry.getValue().stream()
+                    .map(s -> new FileLines(s, ImmutableSortedSet.of()))
+                    .collect(ImmutableList.toImmutableList()),
+                IssueType.ParseStatus,
+                String.format("File(s) not parsed successfully, with parse status: %s", status)));
+      }
+    }
+
     aggregateDuplicateErrors(ccae.getErrorDetails())
         .forEach(
             (errorDetails, nodeNames) ->
@@ -102,6 +127,18 @@ public class InitIssuesAnswerer extends Answerer {
 
   InitIssuesAnswerer(InitIssuesQuestion question, IBatfish batfish) {
     super(question, batfish);
+  }
+
+  @VisibleForTesting
+  static SortedMap<ParseStatus, Set<String>> aggregateParseStatuses(
+      SortedMap<String, ParseStatus> fileStatuses) {
+    SortedMap<ParseStatus, Set<String>> aggregatedStatuses = new TreeMap<>();
+    for (Entry<String, ParseStatus> entry : fileStatuses.entrySet()) {
+      Set<String> files =
+          aggregatedStatuses.computeIfAbsent(entry.getValue(), s -> new HashSet<>());
+      files.add(entry.getKey());
+    }
+    return aggregatedStatuses;
   }
 
   private static Row getRow(

--- a/projects/question/src/main/java/org/batfish/question/initialization/IssueType.java
+++ b/projects/question/src/main/java/org/batfish/question/initialization/IssueType.java
@@ -11,6 +11,7 @@ public enum IssueType {
   ConvertWarningRedFlag("Convert warning (redflag)"),
   ConvertWarningUnimplemented("Convert warning (unimplemented)"),
   ParseError("Parse error"),
+  ParseStatus("Parse status"),
   ParseWarning("Parse warning");
 
   private static final Map<String, IssueType> _map = buildMap();

--- a/projects/question/src/test/java/org/batfish/question/initialization/InitIssuesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/initialization/InitIssuesAnswererTest.java
@@ -235,7 +235,7 @@ public class InitIssuesAnswererTest {
                 COL_TYPE,
                 IssueType.ParseStatus.toString(),
                 COL_DETAILS,
-                String.format("File(s) not parsed successfully, with parse status: %s", statusStr),
+                String.format("File(s) not parsed successfully, parse status: %s", statusStr),
                 COL_LINE_TEXT,
                 null,
                 COL_PARSER_CONTEXT,

--- a/projects/question/src/test/java/org/batfish/question/initialization/InitIssuesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/initialization/InitIssuesAnswererTest.java
@@ -6,12 +6,18 @@ import static org.batfish.question.initialization.InitIssuesAnswerer.COL_LINE_TE
 import static org.batfish.question.initialization.InitIssuesAnswerer.COL_NODES;
 import static org.batfish.question.initialization.InitIssuesAnswerer.COL_PARSER_CONTEXT;
 import static org.batfish.question.initialization.InitIssuesAnswerer.COL_TYPE;
+import static org.batfish.question.initialization.InitIssuesAnswerer.aggregateParseStatuses;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import java.util.Set;
+import java.util.SortedMap;
 import javax.annotation.Nullable;
 import org.batfish.common.ErrorDetails;
 import org.batfish.common.ErrorDetails.ParseExceptionContext;
@@ -19,11 +25,13 @@ import org.batfish.common.Warnings;
 import org.batfish.common.Warnings.ParseWarning;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
+import org.batfish.datamodel.answers.ParseStatus;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.collections.FileLines;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.Rows;
 import org.batfish.datamodel.table.TableAnswerElement;
+import org.hamcrest.collection.IsMapContaining;
 import org.junit.Test;
 
 /** Tests for {@link InitIssuesAnswerer}. */
@@ -201,6 +209,44 @@ public class InitIssuesAnswererTest {
   }
 
   @Test
+  public void testAnswererParseStatus() {
+    ParseVendorConfigurationAnswerElement pvcae = new ParseVendorConfigurationAnswerElement();
+    for (ParseStatus status : ParseStatus.values()) {
+      pvcae.getParseStatus().put(status.toString(), status);
+    }
+
+    // Answerer using TestBatfish that should produce issues for non-passed and non-failed files
+    InitIssuesAnswerer answerer =
+        new InitIssuesAnswerer(new InitIssuesQuestion(), new TestBatfishBase(pvcae, null));
+    TableAnswerElement answer = answerer.answer();
+
+    ImmutableMultiset.Builder<Row> expectedRows = ImmutableMultiset.builder();
+    for (ParseStatus status : ParseStatus.values()) {
+      if (status != ParseStatus.FAILED
+          && status != ParseStatus.PARTIALLY_UNRECOGNIZED
+          && status != ParseStatus.PASSED) {
+        String statusStr = status.toString();
+        expectedRows.add(
+            Row.of(
+                COL_NODES,
+                null,
+                COL_FILELINES,
+                ImmutableList.of(new FileLines(statusStr, ImmutableSortedSet.of())),
+                COL_TYPE,
+                IssueType.ParseStatus.toString(),
+                COL_DETAILS,
+                String.format("File(s) not parsed successfully, with parse status: %s", statusStr),
+                COL_LINE_TEXT,
+                null,
+                COL_PARSER_CONTEXT,
+                null));
+      }
+    }
+    // Make sure we only see issues for non-passed, non-partly-recognized, non-failed files
+    assertThat(answer.getRows().getData(), equalTo(expectedRows.build()));
+  }
+
+  @Test
   public void testAnswererParseWarn() {
     String node = "nodeWarn";
     String text = "line text";
@@ -236,6 +282,29 @@ public class InitIssuesAnswererTest {
                         text,
                         COL_PARSER_CONTEXT,
                         context))));
+  }
+
+  @Test
+  public void testAggregateParseStatuses() {
+    SortedMap<ParseStatus, Set<String>> aggregatedStatuses =
+        aggregateParseStatuses(
+            ImmutableSortedMap.of(
+                "empty1",
+                ParseStatus.EMPTY,
+                "empty2",
+                ParseStatus.EMPTY,
+                "unknown",
+                ParseStatus.UNKNOWN));
+
+    // Confirm common parse statuses (EMPTY) are aggregated as expected and unique status (UNKNOWN)
+    // is left alone
+    assertThat(aggregatedStatuses, aMapWithSize(2));
+    assertThat(
+        aggregatedStatuses,
+        IsMapContaining.hasEntry(equalTo(ParseStatus.EMPTY), contains("empty1", "empty2")));
+    assertThat(
+        aggregatedStatuses,
+        IsMapContaining.hasEntry(equalTo(ParseStatus.UNKNOWN), contains("unknown")));
   }
 
   private static class TestBatfishBase extends IBatfishTestAdapter {

--- a/projects/question/src/test/java/org/batfish/question/initialization/InitIssuesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/initialization/InitIssuesAnswererTest.java
@@ -223,6 +223,7 @@ public class InitIssuesAnswererTest {
     ImmutableMultiset.Builder<Row> expectedRows = ImmutableMultiset.builder();
     for (ParseStatus status : ParseStatus.values()) {
       if (status != ParseStatus.FAILED
+          && status != ParseStatus.IGNORED
           && status != ParseStatus.PARTIALLY_UNRECOGNIZED
           && status != ParseStatus.PASSED) {
         String statusStr = status.toString();
@@ -235,7 +236,7 @@ public class InitIssuesAnswererTest {
                 COL_TYPE,
                 IssueType.ParseStatus.toString(),
                 COL_DETAILS,
-                String.format("File(s) not parsed successfully, parse status: %s", statusStr),
+                ParseStatus.explanation(status),
                 COL_LINE_TEXT,
                 null,
                 COL_PARSER_CONTEXT,


### PR DESCRIPTION
Add issues to `initIssues` question for files with non-passing parse statuses that don't explicitly generate warnings or exceptions (e.g. `UNKNOWN`).

For example:
<img width="706" alt="Screen Shot 2019-04-25 at 12 16 56 PM" src="https://user-images.githubusercontent.com/33436396/56762163-0fb5d780-6754-11e9-925a-8a4a72941c12.png">

Fixes #3561