### PR TITLE
Arista parsing for BGP redistribution into OSPF

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/matchers/ParseWarningMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/matchers/ParseWarningMatchers.java
@@ -1,0 +1,31 @@
+package org.batfish.common.matchers;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Warnings.ParseWarning;
+import org.batfish.common.matchers.ParseWarningMatchersImpl.HasComment;
+import org.batfish.common.matchers.ParseWarningMatchersImpl.HasText;
+import org.hamcrest.Matcher;
+
+/** {@link Matcher Matchers} for {@link ParseWarning}. */
+@ParametersAreNonnullByDefault
+public class ParseWarningMatchers {
+
+  /**
+   * Provides a matcher that matches if the parse warning's comment exactly matches {@code comment}.
+   */
+  public static Matcher<ParseWarning> hasComment(String comment) {
+    return new HasComment(equalTo(comment));
+  }
+
+  /**
+   * Provides a matcher that matches if the parse warning's text is matched by the provided {@code
+   * subMatcher}.
+   */
+  public static Matcher<ParseWarning> hasText(Matcher<? super String> subMatcher) {
+    return new HasText(subMatcher);
+  }
+
+  private ParseWarningMatchers() {}
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/matchers/ParseWarningMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/matchers/ParseWarningMatchersImpl.java
@@ -1,0 +1,33 @@
+package org.batfish.common.matchers;
+
+import javax.annotation.Nonnull;
+import org.batfish.common.Warnings.ParseWarning;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+final class ParseWarningMatchersImpl {
+
+  static final class HasComment extends FeatureMatcher<ParseWarning, String> {
+    HasComment(@Nonnull Matcher<? super String> subMatcher) {
+      super(subMatcher, "A parse warning with comment:", "comment");
+    }
+
+    @Override
+    protected String featureValueOf(ParseWarning actual) {
+      return actual.getComment();
+    }
+  }
+
+  static final class HasText extends FeatureMatcher<ParseWarning, String> {
+    HasText(@Nonnull Matcher<? super String> subMatcher) {
+      super(subMatcher, "A parse warning with text:", "text:");
+    }
+
+    @Override
+    protected String featureValueOf(ParseWarning actual) {
+      return actual.getText();
+    }
+  }
+
+  private ParseWarningMatchersImpl() {}
+}

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ospf.g4
@@ -323,9 +323,15 @@ ro_passive_interface
    NO? PASSIVE_INTERFACE i = interface_name NEWLINE
 ;
 
+ro_redistribute_bgp_arista
+:
+   REDISTRIBUTE BGP
+   (
+      ROUTE_MAP map = VARIABLE
+   )? NEWLINE
+;
 
-
-ro_redistribute_bgp
+ro_redistribute_bgp_cisco
 :
    REDISTRIBUTE BGP bgp_asn
    (
@@ -672,7 +678,8 @@ s_router_ospf
       | ro_network
       | ro_passive_interface_default
       | ro_passive_interface
-      | ro_redistribute_bgp
+      | ro_redistribute_bgp_arista
+      | ro_redistribute_bgp_cisco
       | ro_redistribute_connected
       | ro_redistribute_eigrp
       | ro_redistribute_ospf_null

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ospf.g4
@@ -678,8 +678,8 @@ s_router_ospf
       | ro_network
       | ro_passive_interface_default
       | ro_passive_interface
-      | ro_redistribute_bgp_arista
-      | ro_redistribute_bgp_cisco
+      | { _eos }? ro_redistribute_bgp_arista
+      | { !_eos }? ro_redistribute_bgp_cisco
       | ro_redistribute_connected
       | ro_redistribute_eigrp
       | ro_redistribute_ospf_null

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -8802,10 +8802,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitRo_redistribute_bgp_arista(Ro_redistribute_bgp_aristaContext ctx) {
-    if (_format != ARISTA) {
-      _w.addWarning(ctx, getFullText(ctx), _parser, "This syntax is unrecognized");
-      return;
-    }
     OspfProcess proc = _currentOspfProcess;
     RoutingProtocol sourceProtocol = RoutingProtocol.BGP;
     OspfRedistributionPolicy r = new OspfRedistributionPolicy(sourceProtocol);
@@ -8823,10 +8819,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitRo_redistribute_bgp_cisco(Ro_redistribute_bgp_ciscoContext ctx) {
-    if (_format == ARISTA) {
-      _w.addWarning(ctx, getFullText(ctx), _parser, "This syntax is unrecognized");
-      return;
-    }
     OspfProcess proc = _currentOspfProcess;
     RoutingProtocol sourceProtocol = RoutingProtocol.BGP;
     OspfRedistributionPolicy r = new OspfRedistributionPolicy(sourceProtocol);

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -962,7 +962,8 @@ import org.batfish.grammar.cisco.CiscoParser.Ro_maximum_pathsContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_networkContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_passive_interfaceContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_passive_interface_defaultContext;
-import org.batfish.grammar.cisco.CiscoParser.Ro_redistribute_bgpContext;
+import org.batfish.grammar.cisco.CiscoParser.Ro_redistribute_bgp_aristaContext;
+import org.batfish.grammar.cisco.CiscoParser.Ro_redistribute_bgp_ciscoContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_redistribute_connectedContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_redistribute_eigrpContext;
 import org.batfish.grammar.cisco.CiscoParser.Ro_redistribute_ripContext;
@@ -8800,7 +8801,32 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   }
 
   @Override
-  public void exitRo_redistribute_bgp(Ro_redistribute_bgpContext ctx) {
+  public void exitRo_redistribute_bgp_arista(Ro_redistribute_bgp_aristaContext ctx) {
+    if (_format != ARISTA) {
+      _w.addWarning(ctx, getFullText(ctx), _parser, "This syntax is unrecognized");
+      return;
+    }
+    OspfProcess proc = _currentOspfProcess;
+    RoutingProtocol sourceProtocol = RoutingProtocol.BGP;
+    OspfRedistributionPolicy r = new OspfRedistributionPolicy(sourceProtocol);
+    proc.getRedistributionPolicies().put(sourceProtocol, r);
+    if (ctx.map != null) {
+      String map = ctx.map.getText();
+      int mapLine = ctx.map.getLine();
+      r.setRouteMap(map);
+      r.setRouteMapLine(mapLine);
+      _configuration.referenceStructure(ROUTE_MAP, map, OSPF_REDISTRIBUTE_BGP_MAP, mapLine);
+    }
+    r.setOspfMetricType(OspfRedistributionPolicy.DEFAULT_METRIC_TYPE);
+    r.setOnlyClassfulRoutes(false);
+  }
+
+  @Override
+  public void exitRo_redistribute_bgp_cisco(Ro_redistribute_bgp_ciscoContext ctx) {
+    if (_format == ARISTA) {
+      _w.addWarning(ctx, getFullText(ctx), _parser, "This syntax is unrecognized");
+      return;
+    }
     OspfProcess proc = _currentOspfProcess;
     RoutingProtocol sourceProtocol = RoutingProtocol.BGP;
     OspfRedistributionPolicy r = new OspfRedistributionPolicy(sourceProtocol);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-vs-ios-warnings/configs/arista-ospf-redistribute-bgp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-vs-ios-warnings/configs/arista-ospf-redistribute-bgp
@@ -1,0 +1,10 @@
+boot system flash this-is-an-arista-device.swi
+!
+hostname arista-ospf-redistribute-bgp
+!
+router ospf 1
+ redistribute bgp
+ redistribute bgp route-map MAP
+ redistribute bgp 65100
+ redistribute bgp 65100 route-map MAP
+ redistribute bgp 65100 metric 10

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-vs-ios-warnings/configs/ios-ospf-redistribute-bgp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-vs-ios-warnings/configs/ios-ospf-redistribute-bgp
@@ -1,0 +1,9 @@
+!
+hostname ios-ospf-redistribute-bgp
+!
+router ospf 1
+ redistribute bgp
+ redistribute bgp route-map MAP
+ redistribute bgp 65100
+ redistribute bgp 65100 route-map MAP
+ redistribute bgp 65100 metric 10


### PR DESCRIPTION
Creates a separate parse rule for Arista BGP redistribution into OSPF.

Arista syntax for redistributing BGP into OSPF is:
`redistribute bgp`
whereas Cisco vendors require an ASN:
`redistribute bgp 65100`

Both vendors allow configuring an optional route-map for BGP redistribution, but Cisco vendors also allow other options such as setting metric, metric-type, subnets, or tag.