### PR TITLE
Infer BGP router ID from loopback if present

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -581,10 +581,14 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
     org.batfish.datamodel.BgpProcess newProc = new org.batfish.datamodel.BgpProcess();
     Ip routerId = bgpVrf.getRouterId();
     if (routerId == null) {
-      _w.redFlag(
-          String.format(
-              "Cannot configure BGP session for vrf '%s' because router-id is missing", vrfName));
-      return null;
+      if (_loopback.getConfigured() && !_loopback.getAddresses().isEmpty()) {
+        routerId = _loopback.getAddresses().get(0).getIp();
+      } else {
+        _w.redFlag(
+            String.format(
+                "Cannot configure BGP session for vrf '%s' because router-id is missing", vrfName));
+        return null;
+      }
     }
     newProc.setRouterId(routerId);
     newProc.setMultipathEquivalentAsPathMatchMode(EXACT_PATH);

--- a/tests/parsing-tests/networks/unit-tests/configs/cumulus_nclu_bgp_no_router_id
+++ b/tests/parsing-tests/networks/unit-tests/configs/cumulus_nclu_bgp_no_router_id
@@ -1,0 +1,7 @@
+net del all
+#
+net add hostname cumulus_nclu_bgp_no_router_id
+#
+net add bgp autonomous-system 65500
+net add loopback lo ip address 192.0.2.8/32
+net commit

--- a/tests/parsing-tests/networks/unit-tests/configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip
+++ b/tests/parsing-tests/networks/unit-tests/configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip
@@ -1,0 +1,7 @@
+net del all
+#
+net add hostname cumulus_nclu_bgp_no_router_id_or_loopback_ip
+#
+net add bgp autonomous-system 65500
+net add loopback lo
+net commit

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -14171,6 +14171,150 @@
           }
         }
       },
+      "cumulus_nclu_bgp_no_router_id" : {
+        "configurationFormat" : "CUMULUS_NCLU",
+        "name" : "cumulus_nclu_bgp_no_router_id",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "interfaces" : {
+          "lo" : {
+            "name" : "lo",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allPrefixes" : [
+              "192.0.2.8/32"
+            ],
+            "allowedVlans" : "",
+            "autostate" : true,
+            "mtu" : 1500,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "prefix" : "192.0.2.8/32",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "routingPolicies" : {
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "bgp"
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocol" : "ibgp"
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cumulus" : {
+            "bridge" : {
+              "pvid" : 1,
+              "vids" : ""
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "multipathEbgp" : false,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : false,
+              "routerId" : "192.0.2.8",
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "lo"
+            ]
+          }
+        }
+      },
+      "cumulus_nclu_bgp_no_router_id_or_loopback_ip" : {
+        "configurationFormat" : "CUMULUS_NCLU",
+        "name" : "cumulus_nclu_bgp_no_router_id_or_loopback_ip",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "SWITCH",
+        "interfaces" : {
+          "lo" : {
+            "name" : "lo",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "mtu" : 1500,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "vendorFamily" : {
+          "cumulus" : {
+            "bridge" : {
+              "pvid" : 1,
+              "vids" : ""
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "interfaces" : [
+              "lo"
+            ]
+          }
+        }
+      },
       "cumulus_nclu_invalid_bonds" : {
         "configurationFormat" : "CUMULUS_NCLU",
         "name" : "cumulus_nclu_invalid_bonds",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -462,6 +462,12 @@
         "cumulus_nclu_bgp_no_address_family" : [
           "configs/cumulus_nclu_bgp_no_address_family"
         ],
+        "cumulus_nclu_bgp_no_router_id" : [
+          "configs/cumulus_nclu_bgp_no_router_id"
+        ],
+        "cumulus_nclu_bgp_no_router_id_or_loopback_ip" : [
+          "configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip"
+        ],
         "cumulus_nclu_invalid_bonds" : [
           "configs/cumulus_nclu_invalid_bonds"
         ],
@@ -1032,6 +1038,8 @@
         "configs/community_set" : "PASSED",
         "configs/cumulus_nclu" : "PASSED",
         "configs/cumulus_nclu_bgp_no_address_family" : "PASSED",
+        "configs/cumulus_nclu_bgp_no_router_id" : "PASSED",
+        "configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip" : "PASSED",
         "configs/cumulus_nclu_invalid_bonds" : "PASSED",
         "configs/cumulus_nclu_invalid_interfaces" : "PASSED",
         "configs/cumulus_nclu_invalid_vrfs" : "PASSED",
@@ -41494,6 +41502,107 @@
             "  EOF:<EOF>)"
           ]
         },
+        "configs/cumulus_nclu_bgp_no_router_id" : {
+          "sentences" : [
+            "(cumulus_nclu_configuration",
+            "  (statement",
+            "    (s_null",
+            "      NET:'net'",
+            "      (null_rest_of_line",
+            "        DEL:'del'",
+            "        WORD:'all'",
+            "        NEWLINE:'\\n')))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_hostname",
+            "        HOSTNAME:'hostname'",
+            "        hostname = (word",
+            "          WORD:'cumulus_nclu_bgp_no_router_id')",
+            "        NEWLINE:'\\n')))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_bgp",
+            "        BGP:'bgp'",
+            "        (b_common",
+            "          (b_autonomous_system",
+            "            AUTONOMOUS_SYSTEM:'autonomous-system'",
+            "            as = (uint32",
+            "              d = DEC:'65500')",
+            "            NEWLINE:'\\n')))))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_loopback",
+            "        LOOPBACK:'loopback'",
+            "        LO:'lo'",
+            "        (l_ip_address",
+            "          IP:'ip'",
+            "          ADDRESS:'address'",
+            "          address = (interface_address",
+            "            IP_PREFIX:'192.0.2.8/32')",
+            "          NEWLINE:'\\n'))))",
+            "  (statement",
+            "    (s_null",
+            "      NET:'net'",
+            "      (null_rest_of_line",
+            "        COMMIT:'commit'",
+            "        NEWLINE:'\\n\\n')))",
+            "  EOF:<EOF>)"
+          ]
+        },
+        "configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip" : {
+          "sentences" : [
+            "(cumulus_nclu_configuration",
+            "  (statement",
+            "    (s_null",
+            "      NET:'net'",
+            "      (null_rest_of_line",
+            "        DEL:'del'",
+            "        WORD:'all'",
+            "        NEWLINE:'\\n')))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_hostname",
+            "        HOSTNAME:'hostname'",
+            "        hostname = (word",
+            "          WORD:'cumulus_nclu_bgp_no_router_id_or_loopback_ip')",
+            "        NEWLINE:'\\n')))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_bgp",
+            "        BGP:'bgp'",
+            "        (b_common",
+            "          (b_autonomous_system",
+            "            AUTONOMOUS_SYSTEM:'autonomous-system'",
+            "            as = (uint32",
+            "              d = DEC:'65500')",
+            "            NEWLINE:'\\n')))))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_loopback",
+            "        LOOPBACK:'loopback'",
+            "        LO:'lo'",
+            "        NEWLINE:'\\n')))",
+            "  (statement",
+            "    (s_null",
+            "      NET:'net'",
+            "      (null_rest_of_line",
+            "        COMMIT:'commit'",
+            "        NEWLINE:'\\n\\n')))",
+            "  EOF:<EOF>)"
+          ]
+        },
         "configs/cumulus_nclu_invalid_bonds" : {
           "sentences" : [
             "(cumulus_nclu_configuration",
@@ -74905,6 +75014,8 @@
         "community_set" : "PASSED",
         "cumulus_nclu" : "WARNINGS",
         "cumulus_nclu_bgp_no_address_family" : "PASSED",
+        "cumulus_nclu_bgp_no_router_id" : "PASSED",
+        "cumulus_nclu_bgp_no_router_id_or_loopback_ip" : "WARNINGS",
         "cumulus_nclu_invalid_bonds" : "PASSED",
         "cumulus_nclu_invalid_interfaces" : "PASSED",
         "cumulus_nclu_invalid_vrfs" : "PASSED",
@@ -77678,6 +77789,26 @@
           }
         },
         "configs/cumulus_nclu_bgp_no_address_family" : { },
+        "configs/cumulus_nclu_bgp_no_router_id" : {
+          "loopback" : {
+            "lo" : {
+              "definitionLines" : [
+                6
+              ],
+              "numReferrers" : 1
+            }
+          }
+        },
+        "configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip" : {
+          "loopback" : {
+            "lo" : {
+              "definitionLines" : [
+                6
+              ],
+              "numReferrers" : 1
+            }
+          }
+        },
         "configs/cumulus_nclu_invalid_bonds" : {
           "interface" : {
             "swp1" : {
@@ -81866,6 +81997,12 @@
         "configs/cumulus_nclu_bgp_no_address_family" : [
           "cumulus_nclu_bgp_no_address_family"
         ],
+        "configs/cumulus_nclu_bgp_no_router_id" : [
+          "cumulus_nclu_bgp_no_router_id"
+        ],
+        "configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip" : [
+          "cumulus_nclu_bgp_no_router_id_or_loopback_ip"
+        ],
         "configs/cumulus_nclu_invalid_bonds" : [
           "cumulus_nclu_invalid_bonds"
         ],
@@ -84453,6 +84590,24 @@
             "vni10001" : {
               "vxlan self-reference" : [
                 75
+              ]
+            }
+          }
+        },
+        "configs/cumulus_nclu_bgp_no_router_id" : {
+          "loopback" : {
+            "lo" : {
+              "loopback self-reference" : [
+                6
+              ]
+            }
+          }
+        },
+        "configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip" : {
+          "loopback" : {
+            "lo" : {
+              "loopback self-reference" : [
+                6
               ]
             }
           }
@@ -88993,6 +89148,14 @@
             }
           ]
         },
+        "cumulus_nclu_bgp_no_router_id_or_loopback_ip" : {
+          "Red flags" : [
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Cannot configure BGP session for vrf 'default' because router-id is missing"
+            }
+          ]
+        },
         "f5_bigip_imish_malformed" : {
           "Red flags" : [
             {
@@ -89472,6 +89635,8 @@
         "configs/community_set" : "PASSED",
         "configs/cumulus_nclu" : "PASSED",
         "configs/cumulus_nclu_bgp_no_address_family" : "PASSED",
+        "configs/cumulus_nclu_bgp_no_router_id" : "PASSED",
+        "configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip" : "PASSED",
         "configs/cumulus_nclu_invalid_bonds" : "PASSED",
         "configs/cumulus_nclu_invalid_interfaces" : "PASSED",
         "configs/cumulus_nclu_invalid_vrfs" : "PASSED",


### PR DESCRIPTION
If no router ID is explicitly configured for a BGP process, use the address of the loopback interface as the router ID. This only works if the loopback interface has a configured network:
`net add loopback lo ip address 1.2.3.4/32`

It is also possible to configure the loopback without an explicit network, and this PR does not infer a BGP router ID for that case:
`net add loopback lo`