### PR TITLE
Track potential match path

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParserUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParserUtils.java
@@ -6,7 +6,6 @@ import static org.batfish.specifier.parboiled.Anchor.Type.STRING_LITERAL;
 import static org.batfish.specifier.parboiled.Anchor.Type.WHITESPACE;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -16,8 +15,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.parboiled.errors.InvalidInputError;
 import org.parboiled.support.MatcherPath;
@@ -26,52 +23,6 @@ import org.parboiled.support.ParsingResult;
 /** A helper class to interpret parser errors */
 @ParametersAreNonnullByDefault
 final class ParserUtils {
-
-  /** Captures elements of paths that failed to match. */
-  @ParametersAreNonnullByDefault
-  static class PathElement {
-
-    @Nullable private final Anchor.Type _anchorType;
-    private final String _label;
-    private int _level;
-
-    PathElement(String label, int level, @Nullable Anchor.Type anchorType) {
-      _label = label;
-      _level = level;
-      if (anchorType != null) {
-        _anchorType = anchorType;
-      } else if (isStringLiteralLabel(label)) {
-        _anchorType = Anchor.Type.STRING_LITERAL;
-      } else if (isCharLiteralLabel(label)) {
-        _anchorType = CHAR_LITERAL;
-      } else {
-        _anchorType = null;
-      }
-    }
-
-    @Nullable
-    Anchor.Type getAnchorType() {
-      return _anchorType;
-    }
-
-    @Nonnull
-    String getLabel() {
-      return _label;
-    }
-
-    int getLevel() {
-      return _level;
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(getClass())
-          .add("label", _label)
-          .add("level", _level)
-          .add("anchorType", _anchorType)
-          .toString();
-    }
-  }
 
   static AstNode getAst(ParsingResult<AstNode> result) {
     if (!result.parseErrors.isEmpty()) {
@@ -150,14 +101,10 @@ final class ParserUtils {
     ImmutableSet.Builder<PotentialMatch> potentialMatches = ImmutableSet.builder();
 
     for (MatcherPath path : error.getFailedMatchers()) {
+      // convert the parboiled path to a list of PathElement
       List<PathElement> pathElements =
           IntStream.range(0, path.length())
-              .mapToObj(
-                  i ->
-                      new PathElement(
-                          path.getElementAtLevel(i).matcher.getLabel(),
-                          i,
-                          anchorTypes.get(path.getElementAtLevel(i).matcher.getLabel())))
+              .mapToObj(i -> PathElement.create(path.getElementAtLevel(i), anchorTypes))
               .collect(ImmutableList.toImmutableList());
 
       // at least one anchor should exist along every path
@@ -174,36 +121,11 @@ final class ParserUtils {
         continue;
       }
 
-      // Build PotentialMatch objects from path anchor
       PathElement pathAnchor = pathAnchorOpt.get();
       String matchPrefix =
-          error
-              .getInputBuffer()
-              .extract(
-                  path.getElementAtLevel(pathAnchor.getLevel()).startIndex,
-                  path.element.startIndex);
+          error.getInputBuffer().extract(pathAnchor.getStartIndex(), path.element.startIndex);
 
-      if (pathAnchor.getAnchorType() == STRING_LITERAL
-          || pathAnchor.getAnchorType() == CHAR_LITERAL) {
-        // Remove quotes inserted by parboiled for completion suggestions
-        String fullToken = path.getElementAtLevel(pathAnchor.getLevel()).matcher.getLabel();
-        if (fullToken.length() >= 2) { // remove surrounding quotes
-          fullToken = fullToken.substring(1, fullToken.length() - 1);
-        }
-        potentialMatches.add(
-            new PotentialMatch(
-                pathAnchor.getAnchorType(),
-                matchPrefix,
-                fullToken,
-                path.getElementAtLevel(pathAnchor.getLevel()).startIndex));
-      } else {
-        potentialMatches.add(
-            new PotentialMatch(
-                pathAnchor.getAnchorType(),
-                matchPrefix,
-                null,
-                path.getElementAtLevel(pathAnchor.getLevel()).startIndex));
-      }
+      potentialMatches.add(new PotentialMatch(pathAnchor, matchPrefix, pathElements));
     }
 
     return potentialMatches.build();
@@ -263,11 +185,13 @@ final class ParserUtils {
         .findFirst();
   }
 
-  private static boolean isCharLiteralLabel(String label) {
+  @VisibleForTesting
+  static boolean isCharLiteralLabel(String label) {
     return label.startsWith("\'") && label.endsWith("\'");
   }
 
-  private static boolean isStringLiteralLabel(String label) {
+  @VisibleForTesting
+  static boolean isStringLiteralLabel(String label) {
     return label.startsWith("\"") && label.endsWith("\"");
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PathElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PathElement.java
@@ -16,7 +16,7 @@ import org.parboiled.support.MatcherPath.Element;
 
 /** Captures elements of that matched the input or failed to match for invalid input */
 @ParametersAreNonnullByDefault
-class PathElement {
+final class PathElement {
 
   /** The anchor type of this element */
   @Nullable private final Anchor.Type _anchorType;
@@ -54,7 +54,7 @@ class PathElement {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof PathElement)) {
       return false;
     }
     PathElement that = (PathElement) o;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PathElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PathElement.java
@@ -1,0 +1,99 @@
+package org.batfish.specifier.parboiled;
+
+import static org.batfish.specifier.parboiled.Anchor.Type.CHAR_LITERAL;
+import static org.batfish.specifier.parboiled.Anchor.Type.STRING_LITERAL;
+import static org.batfish.specifier.parboiled.ParserUtils.isCharLiteralLabel;
+import static org.batfish.specifier.parboiled.ParserUtils.isStringLiteralLabel;
+
+import com.google.common.base.MoreObjects;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.specifier.parboiled.Anchor.Type;
+import org.parboiled.support.MatcherPath.Element;
+
+/** Captures elements of that matched the input or failed to match for invalid input */
+@ParametersAreNonnullByDefault
+class PathElement {
+
+  /** The anchor type of this element */
+  @Nullable private final Anchor.Type _anchorType;
+
+  /** The parboiled label for this element */
+  private String _label;
+
+  /** How deep this element is from the start */
+  private int _level;
+
+  /** Where in the input buffer (query) this element starts */
+  private int _startIndex;
+
+  static PathElement create(Element element, Map<String, Type> anchorTypes) {
+    String label = element.matcher.getLabel();
+    Anchor.Type anchorType =
+        anchorTypes.containsKey(label)
+            ? anchorTypes.get(label)
+            : isStringLiteralLabel(label)
+                ? STRING_LITERAL
+                : isCharLiteralLabel(label) ? CHAR_LITERAL : null;
+
+    return new PathElement(anchorType, label, element.level, element.startIndex);
+  }
+
+  PathElement(@Nullable Anchor.Type anchorType, String label, int level, int startIndex) {
+    _anchorType = anchorType;
+    _label = label;
+    _level = level;
+    _startIndex = startIndex;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PathElement that = (PathElement) o;
+    return _anchorType == that._anchorType
+        && Objects.equals(_label, that._label)
+        && _level == that._level
+        && _startIndex == that._startIndex;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_anchorType, _label, _level, _startIndex);
+  }
+
+  @Nullable
+  Anchor.Type getAnchorType() {
+    return _anchorType;
+  }
+
+  @Nonnull
+  String getLabel() {
+    return _label;
+  }
+
+  int getLevel() {
+    return _level;
+  }
+
+  int getStartIndex() {
+    return _startIndex;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(getClass())
+        .add("anchorType", _anchorType)
+        .add("label", _label)
+        .add("level", _level)
+        .add("startIndex", _startIndex)
+        .toString();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PotentialMatch.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/PotentialMatch.java
@@ -1,28 +1,32 @@
 package org.batfish.specifier.parboiled;
 
+import static org.batfish.specifier.parboiled.Anchor.Type.CHAR_LITERAL;
+import static org.batfish.specifier.parboiled.Anchor.Type.STRING_LITERAL;
+
 import com.google.common.base.MoreObjects;
+import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** Represents one (of possibly multiple) potential matches when the parser input does not match */
+@ParametersAreNonnullByDefault
 class PotentialMatch {
 
-  /** The type of completion this match indicates */
-  private final Anchor.Type _anchorType;
+  /** The anchor where this match hinges on and we use for auto completion */
+  @Nonnull private final PathElement _anchor;
 
-  /** The current rule would have matched if the input was this */
-  private final String _match;
+  /** What the user entered for this match */
+  @Nullable private final String _matchPrefix;
 
-  /** What the user entered */
-  private final String _matchPrefix;
+  /** The list of elements along the path we are analyzing */
+  @Nonnull private final List<PathElement> _path;
 
-  /** Where in the input this match started */
-  private final int _matchStartIndex;
-
-  PotentialMatch(Anchor.Type anchorType, String matchPrefix, String match, int matchStartIndex) {
-    _anchorType = anchorType;
+  PotentialMatch(PathElement anchor, @Nullable String matchPrefix, List<PathElement> path) {
+    _anchor = anchor;
     _matchPrefix = matchPrefix;
-    _match = match;
-    _matchStartIndex = matchStartIndex;
+    _path = path;
   }
 
   @Override
@@ -30,40 +34,56 @@ class PotentialMatch {
     if (!(o instanceof PotentialMatch)) {
       return false;
     }
-    return Objects.equals(_anchorType, ((PotentialMatch) o)._anchorType)
-        && Objects.equals(_match, ((PotentialMatch) o)._match)
+    return Objects.equals(_anchor, ((PotentialMatch) o)._anchor)
         && Objects.equals(_matchPrefix, ((PotentialMatch) o)._matchPrefix)
-        && Objects.equals(_matchStartIndex, ((PotentialMatch) o)._matchStartIndex);
+        && Objects.equals(_path, ((PotentialMatch) o)._path);
+  }
+
+  PathElement getAnchor() {
+    return _anchor;
   }
 
   Anchor.Type getAnchorType() {
-    return _anchorType;
+    return _anchor.getAnchorType();
   }
 
+  /**
+   * Computes what input would have matched the current rule. This is knowable (and thus non-null)
+   * only for rules that correspond to string and char literals.
+   */
+  @Nullable
   String getMatch() {
-    return _match;
+    if (getAnchorType() == STRING_LITERAL || getAnchorType() == CHAR_LITERAL) {
+      // Remove quotes inserted by parboiled for completion suggestions
+      String fullToken = _anchor.getLabel();
+      if (fullToken.length() >= 2) { // remove surrounding quotes
+        fullToken = fullToken.substring(1, fullToken.length() - 1);
+      }
+      return fullToken;
+    }
+    return null;
   }
 
+  @Nullable
   String getMatchPrefix() {
     return _matchPrefix;
   }
 
   int getMatchStartIndex() {
-    return _matchStartIndex;
+    return _anchor.getStartIndex();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_anchorType, _match, _matchPrefix, _matchStartIndex);
+    return Objects.hash(_anchor, _matchPrefix, _path);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this.getClass())
-        .add("anchorType", _anchorType)
+        .add("anchor", _anchor)
         .add("matchingPrefix", _matchPrefix)
-        .add("matchingCompletion", _match)
-        .add("matchStartIndex", _matchStartIndex)
+        .add("path", _path)
         .toString();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteTest.java
@@ -270,7 +270,9 @@ public class ParboiledAutoCompleteTest {
 
   @Test
   public void testAutoCompletePotentialMatchStringLiteral() {
-    PotentialMatch pm = new PotentialMatch(Type.STRING_LITERAL, "pfx", "pfxcomp", 0);
+    PotentialMatch pm =
+        new PotentialMatch(
+            new PathElement(Type.STRING_LITERAL, "\"pfxcomp\"", 0, 0), "pfx", ImmutableList.of());
     assertThat(
         getTestPAC(null).autoCompletePotentialMatch(pm),
         equalTo(ImmutableList.of(new AutocompleteSuggestion("pfxcomp", true, null, -1, 0))));
@@ -279,7 +281,9 @@ public class ParboiledAutoCompleteTest {
   /** The suggestion should have the case in the grammar token independent of user input */
   @Test
   public void testAutoCompletePotentialMatchStringLiteralCasePreserve() {
-    PotentialMatch pm = new PotentialMatch(Type.STRING_LITERAL, "PfX", "pfxcomp", 0);
+    PotentialMatch pm =
+        new PotentialMatch(
+            new PathElement(Type.STRING_LITERAL, "\"pfxcomp\"", 0, 0), "PfX", ImmutableList.of());
     assertThat(
         getTestPAC(null).autoCompletePotentialMatch(pm),
         equalTo(ImmutableList.of(new AutocompleteSuggestion("pfxcomp", true, null, -1, 0))));
@@ -287,7 +291,9 @@ public class ParboiledAutoCompleteTest {
 
   @Test
   public void testAutoCompletePotentialMatchSkipLabel() {
-    PotentialMatch pm = new PotentialMatch(Type.IP_ADDRESS_MASK, "pfx", "comp", 0);
+    PotentialMatch pm =
+        new PotentialMatch(
+            new PathElement(Type.IP_ADDRESS_MASK, "label", 0, 0), "pfx", ImmutableList.of());
     assertThat(getTestPAC(null).autoCompletePotentialMatch(pm), equalTo(ImmutableList.of()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
@@ -38,44 +38,6 @@ public class ParserUtilsTest {
     return new ReportingParseRunner<>(TestParser.instance().getInputRule());
   }
 
-  private static PotentialMatch createSimplePotentialMatch(
-      Anchor.Type anchorType, String label, int startIndex) {
-    return createSimplePotentialMatch(anchorType, label, startIndex, "");
-  }
-
-  private static PotentialMatch createSimplePotentialMatch(
-      Anchor.Type anchorType, String label, int startIndex, String matchPrefix) {
-    return new PotentialMatch(
-        new PathElement(anchorType, label, 0, startIndex), matchPrefix, ImmutableList.of());
-  }
-
-  private static Set<PotentialMatch> simplifyPotentialMatches(
-      Set<PotentialMatch> potentialMatches) {
-    return potentialMatches.stream()
-        .map(ParserUtilsTest::simplifyPotentialMatch)
-        .collect(ImmutableSet.toImmutableSet());
-  }
-
-  private static PotentialMatch simplifyPotentialMatch(PotentialMatch pm) {
-    return createSimplePotentialMatch(
-        pm.getAnchorType(),
-        pm.getAnchor().getLabel(),
-        pm.getAnchor().getStartIndex(),
-        pm.getMatchPrefix());
-  }
-
-  /** These represent all the ways valid input can start */
-  private static Set<PotentialMatch> getValidStarts(int matchStartIndex) {
-    return ImmutableSet.of(
-        createSimplePotentialMatch(STRING_LITERAL, "\"@specifier\"", matchStartIndex),
-        createSimplePotentialMatch(CHAR_LITERAL, "'!'", matchStartIndex),
-        createSimplePotentialMatch(IP_ADDRESS, "TestIpAddress", matchStartIndex),
-        createSimplePotentialMatch(NODE_NAME, "TestName", matchStartIndex),
-        createSimplePotentialMatch(CHAR_LITERAL, "'\"'", matchStartIndex),
-        createSimplePotentialMatch(CHAR_LITERAL, "'/'", matchStartIndex),
-        createSimplePotentialMatch(CHAR_LITERAL, "'('", matchStartIndex));
-  }
-
   @Test
   public void testIsStringLiteralLabel() {
     // double quoted strings map to STRING_LITERAL
@@ -178,6 +140,50 @@ public class ParserUtilsTest {
             Parser.ANCHORS);
 
     assertThat(errorString, containsString(Grammar.IP_SPACE_SPECIFIER.getFullUrl()));
+  }
+
+  // The tests below for getPotentialMatches compare a simplified form of PotentialMatch from which
+  // the path and the related level information has been removed. This is done for test simplicity,
+  // as comparing full paths will become unwieldy. The simplification does not reduce coverage
+  // meaningfully because the path information is a direct translation of parboiled path and that
+  // translation is tested elsewhere.
+
+  private static PotentialMatch createSimplePotentialMatch(
+      Anchor.Type anchorType, String label, int startIndex) {
+    return createSimplePotentialMatch(anchorType, label, startIndex, "");
+  }
+
+  private static PotentialMatch createSimplePotentialMatch(
+      Anchor.Type anchorType, String label, int startIndex, String matchPrefix) {
+    return new PotentialMatch(
+        new PathElement(anchorType, label, 0, startIndex), matchPrefix, ImmutableList.of());
+  }
+
+  private static Set<PotentialMatch> simplifyPotentialMatches(
+      Set<PotentialMatch> potentialMatches) {
+    return potentialMatches.stream()
+        .map(ParserUtilsTest::simplifyPotentialMatch)
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  private static PotentialMatch simplifyPotentialMatch(PotentialMatch pm) {
+    return createSimplePotentialMatch(
+        pm.getAnchorType(),
+        pm.getAnchor().getLabel(),
+        pm.getAnchor().getStartIndex(),
+        pm.getMatchPrefix());
+  }
+
+  /** These represent all the ways valid input can start */
+  private static Set<PotentialMatch> getValidStarts(int matchStartIndex) {
+    return ImmutableSet.of(
+        createSimplePotentialMatch(STRING_LITERAL, "\"@specifier\"", matchStartIndex),
+        createSimplePotentialMatch(CHAR_LITERAL, "'!'", matchStartIndex),
+        createSimplePotentialMatch(IP_ADDRESS, "TestIpAddress", matchStartIndex),
+        createSimplePotentialMatch(NODE_NAME, "TestName", matchStartIndex),
+        createSimplePotentialMatch(CHAR_LITERAL, "'\"'", matchStartIndex),
+        createSimplePotentialMatch(CHAR_LITERAL, "'/'", matchStartIndex),
+        createSimplePotentialMatch(CHAR_LITERAL, "'('", matchStartIndex));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserUtilsTest.java
@@ -10,16 +10,18 @@ import static org.batfish.specifier.parboiled.Anchor.Type.STRING_LITERAL;
 import static org.batfish.specifier.parboiled.ParserUtils.findPathAnchorFromBottom;
 import static org.batfish.specifier.parboiled.ParserUtils.getErrorString;
 import static org.batfish.specifier.parboiled.ParserUtils.getPotentialMatches;
+import static org.batfish.specifier.parboiled.ParserUtils.isCharLiteralLabel;
+import static org.batfish.specifier.parboiled.ParserUtils.isStringLiteralLabel;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
 import java.util.Set;
-import org.batfish.specifier.parboiled.ParserUtils.PathElement;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.parboiled.errors.InvalidInputError;
@@ -27,6 +29,7 @@ import org.parboiled.parserunners.AbstractParseRunner;
 import org.parboiled.parserunners.ReportingParseRunner;
 import org.parboiled.support.ParsingResult;
 
+/** Tests for {@link ParserUtils} */
 public class ParserUtilsTest {
 
   @org.junit.Rule public ExpectedException _thrown = ExpectedException.none();
@@ -35,49 +38,75 @@ public class ParserUtilsTest {
     return new ReportingParseRunner<>(TestParser.instance().getInputRule());
   }
 
+  private static PotentialMatch createSimplePotentialMatch(
+      Anchor.Type anchorType, String label, int startIndex) {
+    return createSimplePotentialMatch(anchorType, label, startIndex, "");
+  }
+
+  private static PotentialMatch createSimplePotentialMatch(
+      Anchor.Type anchorType, String label, int startIndex, String matchPrefix) {
+    return new PotentialMatch(
+        new PathElement(anchorType, label, 0, startIndex), matchPrefix, ImmutableList.of());
+  }
+
+  private static Set<PotentialMatch> simplifyPotentialMatches(
+      Set<PotentialMatch> potentialMatches) {
+    return potentialMatches.stream()
+        .map(ParserUtilsTest::simplifyPotentialMatch)
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  private static PotentialMatch simplifyPotentialMatch(PotentialMatch pm) {
+    return createSimplePotentialMatch(
+        pm.getAnchorType(),
+        pm.getAnchor().getLabel(),
+        pm.getAnchor().getStartIndex(),
+        pm.getMatchPrefix());
+  }
+
   /** These represent all the ways valid input can start */
   private static Set<PotentialMatch> getValidStarts(int matchStartIndex) {
     return ImmutableSet.of(
-        new PotentialMatch(STRING_LITERAL, "", "@specifier", matchStartIndex),
-        new PotentialMatch(CHAR_LITERAL, "", "!", matchStartIndex),
-        new PotentialMatch(IP_ADDRESS, "", null, matchStartIndex),
-        new PotentialMatch(NODE_NAME, "", null, matchStartIndex),
-        new PotentialMatch(CHAR_LITERAL, "", "\"", matchStartIndex),
-        new PotentialMatch(CHAR_LITERAL, "", "/", matchStartIndex),
-        new PotentialMatch(CHAR_LITERAL, "", "(", matchStartIndex));
+        createSimplePotentialMatch(STRING_LITERAL, "\"@specifier\"", matchStartIndex),
+        createSimplePotentialMatch(CHAR_LITERAL, "'!'", matchStartIndex),
+        createSimplePotentialMatch(IP_ADDRESS, "TestIpAddress", matchStartIndex),
+        createSimplePotentialMatch(NODE_NAME, "TestName", matchStartIndex),
+        createSimplePotentialMatch(CHAR_LITERAL, "'\"'", matchStartIndex),
+        createSimplePotentialMatch(CHAR_LITERAL, "'/'", matchStartIndex),
+        createSimplePotentialMatch(CHAR_LITERAL, "'('", matchStartIndex));
   }
 
   @Test
-  public void testConstructorPathElement() {
+  public void testIsStringLiteralLabel() {
     // double quoted strings map to STRING_LITERAL
-    assertThat(new PathElement("\"@specifier\"", 0, null).getAnchorType(), equalTo(STRING_LITERAL));
+    assertTrue(isStringLiteralLabel("\"@specifier\""));
 
     // unquoted strings do not
-    assertThat(new PathElement("@specifier", 0, null).getAnchorType(), equalTo(null));
+    assertFalse(isStringLiteralLabel("@specifier"));
+  }
 
+  @Test
+  public void testIsCharLiteralLabel() {
     // single-quoted characters map to CHAR_LITERAL
-    assertThat(new PathElement("'a'", 0, null).getAnchorType(), equalTo(CHAR_LITERAL));
+    assertTrue(isCharLiteralLabel("'a'"));
 
     // unquoted characters do not
-    assertThat(new PathElement("a", 0, null).getAnchorType(), equalTo(null));
-
-    // anchor type is preserved if provided
-    assertThat(new PathElement("\"@specifier\"", 0, NODE_NAME).getAnchorType(), equalTo(NODE_NAME));
+    assertFalse(isCharLiteralLabel("a"));
   }
 
   @Test
   public void testFindPathAnchorFromBottomNoAnchor() {
     assertFalse(findPathAnchorFromBottom(ImmutableList.of(), -1).isPresent());
     assertFalse(
-        findPathAnchorFromBottom(ImmutableList.of(new PathElement("TestSomething", 0, null)), -1)
+        findPathAnchorFromBottom(ImmutableList.of(new PathElement(null, "label", 0, 0)), -1)
             .isPresent());
   }
 
   @Test
   public void testFindPathAnchorFromBottomCharAnchor() {
-    PathElement stringElement = new PathElement("aloha", 0, STRING_LITERAL);
-    PathElement charElement = new PathElement("a", 1, CHAR_LITERAL);
-    PathElement otherElement = new PathElement("TestName", 0, NODE_NAME);
+    PathElement stringElement = new PathElement(STRING_LITERAL, "label", 0, 0);
+    PathElement charElement = new PathElement(CHAR_LITERAL, "label", 1, 0);
+    PathElement otherElement = new PathElement(NODE_NAME, "label", 0, 0);
 
     // if parent is string, that should be returned
     assertThat(
@@ -92,7 +121,7 @@ public class ParserUtilsTest {
 
   @Test
   public void testFindPathAnchorFromBottomIgnoreIsIgnored() {
-    PathElement ignoreElement = new PathElement("aloha", 0, IGNORE);
+    PathElement ignoreElement = new PathElement(IGNORE, "label", 0, 0);
 
     assertThat(
         findPathAnchorFromBottom(ImmutableList.of(ignoreElement), 0), equalTo(Optional.empty()));
@@ -100,11 +129,11 @@ public class ParserUtilsTest {
 
   @Test
   public void testFindPathAnchorFromBottomIgnoreIsSkipped() {
-    PathElement element0 = new PathElement("aloha", 0, NODE_NAME);
-    PathElement element1 = new PathElement("aloha", 1, IGNORE);
-    PathElement element2 = new PathElement("aloha", 2, null);
-    PathElement element3 = new PathElement("aloha", 3, IGNORE);
-    PathElement element4 = new PathElement("aloha", 4, null);
+    PathElement element0 = new PathElement(NODE_NAME, "label", 0, 0);
+    PathElement element1 = new PathElement(IGNORE, "label", 1, 0);
+    PathElement element2 = new PathElement(null, "label", 2, 0);
+    PathElement element3 = new PathElement(IGNORE, "label", 3, 0);
+    PathElement element4 = new PathElement(IGNORE, "label", 4, 0);
 
     assertThat(
         findPathAnchorFromBottom(
@@ -114,16 +143,22 @@ public class ParserUtilsTest {
 
   @Test
   public void testFindPathAnchorFromBottomStringAnchor() {
-    PathElement element = new PathElement("\"@specifier\"", 0, null);
+    PathElement element = new PathElement(STRING_LITERAL, "label", 0, 0);
     assertThat(
         findPathAnchorFromBottom(ImmutableList.of(element), 0), equalTo(Optional.of(element)));
   }
 
   @Test
   public void testGetErrorString() {
-    assertThat(getErrorString(new PotentialMatch(STRING_LITERAL, "a", "b", 0)), equalTo("'b'"));
     assertThat(
-        getErrorString(new PotentialMatch(IP_ADDRESS, "", "b", 0)), equalTo(IP_ADDRESS.toString()));
+        getErrorString(
+            new PotentialMatch(
+                new PathElement(STRING_LITERAL, "\"b\"", 0, 0), "a", ImmutableList.of())),
+        equalTo("'b'"));
+    assertThat(
+        getErrorString(
+            new PotentialMatch(new PathElement(IP_ADDRESS, "label", 0, 0), "", ImmutableList.of())),
+        equalTo(IP_ADDRESS.toString()));
   }
 
   @Test
@@ -146,143 +181,168 @@ public class ParserUtilsTest {
   }
 
   @Test
-  public void testGetPartialMatchesEmpty() {
+  public void testGetPotentialMatchesEmpty() {
     ParsingResult<?> resultEmpty = getRunner().run("");
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false)),
         equalTo(getValidStarts(0)));
   }
 
   @Test
-  public void testGetPartialMatchesBadStart() {
+  public void testGetPotentialMatchesBadStart() {
     ParsingResult<?> resultEmpty =
         getRunner().run(new String(Character.toChars(ParboiledAutoComplete.ILLEGAL_CHAR)));
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false)),
         equalTo(getValidStarts(0)));
   }
 
   @Test
-  public void testGetPartialMatchesIncompleteBase() {
+  public void testGetPotentialMatchesIncompleteBase() {
     ParsingResult<?> result = getRunner().run("(1.1.1.");
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(IP_ADDRESS, "1.1.1.", null, 1))));
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false)),
+        equalTo(
+            ImmutableSet.of(
+                new PotentialMatch(
+                    new PathElement(IP_ADDRESS, "TestIpAddress", 0, 1),
+                    "1.1.1.",
+                    ImmutableList.of()))));
   }
 
   @Test
-  public void testGetPartialMatchesIncompleteList() {
+  public void testGetPotentialMatchesIncompleteList() {
     ParsingResult<?> resultEmpty = getRunner().run("a,");
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false)),
         equalTo(getValidStarts(2)));
   }
 
   @Test
-  public void testGetPartialMatchesOpenParens() {
+  public void testGetPotentialMatchesOpenParens() {
     ParsingResult<?> resultEmpty = getRunner().run("(");
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false)),
         equalTo(getValidStarts(1)));
   }
 
   @Test
-  public void testGetPartialMatchesOperator() {
+  public void testGetPotentialMatchesOperator() {
     ParsingResult<?> resultEmpty = getRunner().run("!");
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false),
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) resultEmpty.parseErrors.get(0), TestParser.ANCHORS, false)),
         equalTo(getValidStarts(1)));
   }
 
   @Test
-  public void testGetPartialMatchesMissingCloseParens() {
+  public void testGetPotentialMatchesMissingCloseParens() {
     ParsingResult<?> result = getRunner().run("(1.1.1.1");
+
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false)),
         equalTo(
             ImmutableSet.of(
-                new PotentialMatch(CHAR_LITERAL, "", ")", 8),
-                new PotentialMatch(CHAR_LITERAL, "", ",", 8),
-                new PotentialMatch(IP_ADDRESS, "1.1.1.1", null, 1),
-                new PotentialMatch(CHAR_LITERAL, "", "-", 8))));
+                createSimplePotentialMatch(CHAR_LITERAL, "')'", 8),
+                createSimplePotentialMatch(CHAR_LITERAL, "','", 8),
+                createSimplePotentialMatch(IP_ADDRESS, "TestIpAddress", 1, "1.1.1.1"),
+                createSimplePotentialMatch(CHAR_LITERAL, "'-'", 8))));
   }
 
   @Test
-  public void testGetPartialMatchesQuoteOpenName() {
+  public void testGetPotentialMatchesQuoteOpenName() {
     ParsingResult<?> result = getRunner().run("\"a");
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false)),
         equalTo(
             ImmutableSet.of(
-                new PotentialMatch(CHAR_LITERAL, "", "\"", 2),
-                new PotentialMatch(NODE_NAME, "\"a", null, 0))));
+                createSimplePotentialMatch(CHAR_LITERAL, "'\"'", 2),
+                createSimplePotentialMatch(NODE_NAME, "TestName", 0, "\"a"))));
   }
 
   @Test
-  public void testGetPartialMatchesSpecifierComplete() {
+  public void testGetPotentialMatchesSpecifierComplete() {
     ParsingResult<?> result = getRunner().run("@specifier");
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(CHAR_LITERAL, "", "(", 10))));
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false)),
+        equalTo(ImmutableSet.of(createSimplePotentialMatch(CHAR_LITERAL, "'('", 10))));
   }
 
   @Test
-  public void testGetPartialMatchesSpecifierOpenParens() {
+  public void testGetPotentialMatchesSpecifierOpenParens() {
     ParsingResult<?> result = getRunner().run("@specifier(");
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false)),
         equalTo(
             ImmutableSet.of(
-                new PotentialMatch(CHAR_LITERAL, "", "\"", 11),
-                new PotentialMatch(ADDRESS_GROUP_NAME, "", null, 11))));
+                createSimplePotentialMatch(CHAR_LITERAL, "'\"'", 11),
+                createSimplePotentialMatch(ADDRESS_GROUP_NAME, "TestAddressGroupName", 11))));
   }
 
   @Test
-  public void testGetPartialMatchesSpecifierOneOfPair() {
+  public void testGetPotentialMatchesSpecifierOneOfPair() {
     ParsingResult<?> result = getRunner().run("@specifier(a,");
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false)),
         equalTo(
             ImmutableSet.of(
-                new PotentialMatch(CHAR_LITERAL, "", "\"", 13),
-                new PotentialMatch(REFERENCE_BOOK_NAME, "", null, 13))));
+                createSimplePotentialMatch(CHAR_LITERAL, "'\"'", 13),
+                createSimplePotentialMatch(REFERENCE_BOOK_NAME, "TestReferenceBookName", 13))));
   }
 
   @Test
-  public void testGetPartialMatchesSpecifierSubstring() {
+  public void testGetPotentialMatchesSpecifierSubstring() {
     ParsingResult<?> result = getRunner().run("@specifi");
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(STRING_LITERAL, "@specifi", "@specifier", 0))));
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false)),
+        equalTo(
+            ImmutableSet.of(
+                createSimplePotentialMatch(STRING_LITERAL, "\"@specifier\"", 0, "@specifi"))));
   }
 
   @Test
-  public void testGetPartialMatchesSpecifierIncorrect() {
+  public void testGetPotentialMatchesSpecifierIncorrect() {
     ParsingResult<?> result = getRunner().run("@wrong");
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(STRING_LITERAL, "@", "@specifier", 0))));
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false)),
+        equalTo(
+            ImmutableSet.of(createSimplePotentialMatch(STRING_LITERAL, "\"@specifier\"", 0, "@"))));
   }
 
   @Test
-  public void testGetPartialMatchesStringLiteralCasePreserve() {
+  public void testGetPotentialMatchesStringLiteralCasePreserve() {
     ParsingResult<?> result = getRunner().run("@SPeciFi");
     assertThat(
-        getPotentialMatches(
-            (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false),
-        equalTo(ImmutableSet.of(new PotentialMatch(STRING_LITERAL, "@SPeciFi", "@specifier", 0))));
+        simplifyPotentialMatches(
+            getPotentialMatches(
+                (InvalidInputError) result.parseErrors.get(0), TestParser.ANCHORS, false)),
+        equalTo(
+            ImmutableSet.of(
+                createSimplePotentialMatch(STRING_LITERAL, "\"@specifier\"", 0, "@SPeciFi"))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/PathElementTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/PathElementTest.java
@@ -1,0 +1,68 @@
+package org.batfish.specifier.parboiled;
+
+import static org.batfish.specifier.parboiled.Anchor.Type.ADDRESS_GROUP_NAME;
+import static org.batfish.specifier.parboiled.Anchor.Type.CHAR_LITERAL;
+import static org.batfish.specifier.parboiled.Anchor.Type.STRING_LITERAL;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.parboiled.MatcherContext;
+import org.parboiled.matchers.AbstractMatcher;
+import org.parboiled.matchervisitors.MatcherVisitor;
+import org.parboiled.support.MatcherPath.Element;
+
+public class PathElementTest {
+
+  class MockMatcher extends AbstractMatcher {
+
+    MockMatcher(String label) {
+      super(label);
+    }
+
+    @Override
+    public <V> boolean match(MatcherContext<V> matcherContext) {
+      return false;
+    }
+
+    @Override
+    public <R> R accept(MatcherVisitor<R> matcherVisitor) {
+      return null;
+    }
+  }
+
+  @Test
+  public void testCreateCharAnchor() {
+    Element element = new Element(new MockMatcher("\'label\'"), 1, 2); // startindex, level
+    assertThat(
+        PathElement.create(element, ImmutableMap.of()),
+        equalTo(new PathElement(CHAR_LITERAL, "\'label\'", 2, 1)));
+  }
+
+  /** Anchor is not defined for the label and label is not a string or char literal */
+  @Test
+  public void testCreateNullAnchor() {
+    Element element = new Element(new MockMatcher("label"), 1, 2); // startindex, level
+    assertThat(
+        PathElement.create(element, ImmutableMap.of()),
+        equalTo(new PathElement(null, "label", 2, 1)));
+  }
+
+  @Test
+  public void testCreateStringAnchor() {
+    Element element = new Element(new MockMatcher("\"label\""), 1, 2); // startindex, level
+    assertThat(
+        PathElement.create(element, ImmutableMap.of()),
+        equalTo(new PathElement(STRING_LITERAL, "\"label\"", 2, 1)));
+  }
+
+  /** Label is a known anchor */
+  @Test
+  public void testCreateKnownAnchor() {
+    Element element = new Element(new MockMatcher("label"), 1, 2); // startindex, level
+    assertThat(
+        PathElement.create(element, ImmutableMap.of("label", ADDRESS_GROUP_NAME)),
+        equalTo(new PathElement(ADDRESS_GROUP_NAME, "label", 2, 1)));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/PotentialMatchTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/PotentialMatchTest.java
@@ -1,0 +1,28 @@
+package org.batfish.specifier.parboiled;
+
+import static org.batfish.specifier.parboiled.Anchor.Type.ADDRESS_GROUP_NAME;
+import static org.batfish.specifier.parboiled.Anchor.Type.STRING_LITERAL;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+public class PotentialMatchTest {
+
+  @Test
+  public void testGetMatchNonStringLiteral() {
+    PotentialMatch pm =
+        new PotentialMatch(
+            new PathElement(ADDRESS_GROUP_NAME, "\"label\"", 0, 0), "pfx", ImmutableList.of());
+    assertThat(pm.getMatch(), equalTo(null));
+  }
+
+  @Test
+  public void testGetMatchStringLiteral() {
+    PotentialMatch pm =
+        new PotentialMatch(
+            new PathElement(STRING_LITERAL, "\"label\"", 0, 0), "pfx", ImmutableList.of());
+    assertThat(pm.getMatch(), equalTo("label"));
+  }
+}


### PR DESCRIPTION
Adding the entire path to the PotentialMatch class, which would (later -- not this PR) enable us to do context-sensitive autocompletion. 

This PR covers the first modification in this doc:
https://docs.google.com/document/d/1h1dGp7fN_4nIfXVxUzCIdB-hvRHeH9oW1poyIc3x-fU/edit#