### PR TITLE
Update BgpPeerConfiguration to show unnumbered peers

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
@@ -28,7 +28,7 @@ import org.batfish.datamodel.answers.Schema;
  *
  * <ul>
  *   <li>multipath-ebgp —&gt; gets the process's corresponding value
- *   <li>multipath-.* --&gt; gets all properties that start with 'max-metric-'
+ *   <li>max-metric-.* -&gt; gets all properties that start with 'max-metric-'
  * </ul>
  */
 public class BgpPeerPropertySpecifier extends PropertySpecifier {
@@ -47,7 +47,7 @@ public class BgpPeerPropertySpecifier extends PropertySpecifier {
   public static final Map<String, PropertyDescriptor<BgpPeerConfig>> JAVA_MAP =
       new ImmutableMap.Builder<String, PropertyDescriptor<BgpPeerConfig>>()
           .put(LOCAL_AS, new PropertyDescriptor<>(BgpPeerConfig::getLocalAs, Schema.LONG))
-          .put(LOCAL_IP, new PropertyDescriptor<>(BgpPeerConfig::getLocalIp, Schema.IP))
+          .put(LOCAL_IP, new PropertyDescriptor<>(BgpPeerPropertySpecifier::getLocalIp, Schema.IP))
           .put(IS_PASSIVE, new PropertyDescriptor<>((peer) -> getIsPassive(peer), Schema.BOOLEAN))
           .put(REMOTE_AS, new PropertyDescriptor<>(BgpPeerConfig::getRemoteAsns, Schema.STRING))
           .put(
@@ -101,6 +101,11 @@ public class BgpPeerPropertySpecifier extends PropertySpecifier {
     return JAVA_MAP.keySet().stream()
         .filter(prop -> _pattern.matcher(prop.toLowerCase()).matches())
         .collect(ImmutableList.toImmutableList());
+  }
+
+  private static Ip getLocalIp(@Nonnull BgpPeerConfig peer) {
+    // Do not expose local IP of unnumbered peers
+    return peer instanceof BgpUnnumberedPeerConfig ? null : peer.getLocalIp();
   }
 
   @VisibleForTesting

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswerer.java
@@ -188,7 +188,8 @@ public class BgpPeerConfigurationAnswerer extends Answerer {
       BgpPeerPropertySpecifier propertySpecifier) {
     RowBuilder rowBuilder = Row.builder(columnMetadata).put(COL_NODE, node).put(COL_VRF, vrfName);
 
-    // Row should have local interface for unnumbered peers, local & remote IP for other peers
+    // Row should have local interface for unnumbered peers, local & remote IP for other peers.
+    // Local IP will be taken care of in BgpPeerPropertySpecifier (see its getLocalIp() method).
     if (peer instanceof BgpUnnumberedPeerConfig) {
       rowBuilder.put(COL_LOCAL_INTERFACE, ((BgpUnnumberedPeerConfig) peer).getPeerInterface());
     } else {

--- a/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswerer.java
@@ -29,6 +29,7 @@ import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.answers.Schema;
@@ -51,6 +52,7 @@ public class BgpPeerConfigurationAnswerer extends Answerer {
 
   public static final String COL_NODE = "Node";
   public static final String COL_VRF = "VRF";
+  public static final String COL_LOCAL_INTERFACE = "Local_Interface";
   public static final String COL_REMOTE_IP = "Remote_IP";
 
   private static final List<String> COLUMN_ORDER =
@@ -59,6 +61,7 @@ public class BgpPeerConfigurationAnswerer extends Answerer {
           COL_VRF,
           LOCAL_AS,
           LOCAL_IP,
+          COL_LOCAL_INTERFACE,
           REMOTE_AS,
           COL_REMOTE_IP,
           ROUTE_REFLECTOR_CLIENT,
@@ -94,6 +97,9 @@ public class BgpPeerConfigurationAnswerer extends Answerer {
                             true)));
     columnMetadatas.put(COL_NODE, new ColumnMetadata(COL_NODE, Schema.NODE, "Node", true, false));
     columnMetadatas.put(COL_VRF, new ColumnMetadata(COL_VRF, Schema.STRING, "VRF", true, false));
+    columnMetadatas.put(
+        COL_LOCAL_INTERFACE,
+        new ColumnMetadata(COL_LOCAL_INTERFACE, Schema.STRING, "Local Interface", true, false));
     columnMetadatas.put(
         COL_REMOTE_IP,
         new ColumnMetadata(COL_REMOTE_IP, Schema.SELF_DESCRIBING, "Remote IP", true, false));
@@ -166,6 +172,9 @@ public class BgpPeerConfigurationAnswerer extends Answerer {
         for (BgpPassivePeerConfig peer : bgpProcess.getPassiveNeighbors().values()) {
           rows.add(getRow(node, vrf.getName(), peer, columnMetadata, propertySpecifier));
         }
+        for (BgpUnnumberedPeerConfig peer : bgpProcess.getInterfaceNeighbors().values()) {
+          rows.add(getRow(node, vrf.getName(), peer, columnMetadata, propertySpecifier));
+        }
       }
     }
     return rows;
@@ -177,11 +186,15 @@ public class BgpPeerConfigurationAnswerer extends Answerer {
       BgpPeerConfig peer,
       Map<String, ColumnMetadata> columnMetadata,
       BgpPeerPropertySpecifier propertySpecifier) {
-    RowBuilder rowBuilder =
-        Row.builder(columnMetadata)
-            .put(COL_NODE, node)
-            .put(COL_VRF, vrfName)
-            .put(COL_REMOTE_IP, getRemoteIp(peer));
+    RowBuilder rowBuilder = Row.builder(columnMetadata).put(COL_NODE, node).put(COL_VRF, vrfName);
+
+    // Row should have local interface for unnumbered peers, local & remote IP for other peers
+    if (peer instanceof BgpUnnumberedPeerConfig) {
+      rowBuilder.put(COL_LOCAL_INTERFACE, ((BgpUnnumberedPeerConfig) peer).getPeerInterface());
+    } else {
+      rowBuilder.put(COL_REMOTE_IP, getRemoteIp(peer));
+    }
+
     for (String property : propertySpecifier.getMatchingProperties()) {
       PropertyDescriptor<BgpPeerConfig> propertyDescriptor =
           BgpPeerPropertySpecifier.JAVA_MAP.get(property);


### PR DESCRIPTION
Adds a local interface column. Unnumbered peers have local interface, but null local and remote IP; other peers have null local interface.