### PR TITLE
Unnumbered peers in BgpProcessConfiguration answer

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpProcessPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpProcessPropertySpecifier.java
@@ -60,7 +60,8 @@ public class BgpProcessPropertySpecifier extends PropertySpecifier {
                   (process) ->
                       Iterables.concat(
                           process.getActiveNeighbors().keySet(),
-                          process.getPassiveNeighbors().keySet()),
+                          process.getPassiveNeighbors().keySet(),
+                          process.getInterfaceNeighbors().keySet()),
                   Schema.set(Schema.STRING)))
           // skip router-id; included as part of process identity
           .put(TIE_BREAKER, new PropertyDescriptor<>(BgpProcess::getTieBreaker, Schema.STRING))

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpProcessConfigurationAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpProcessConfigurationAnswererTest.java
@@ -5,12 +5,18 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
+import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpTieBreaker;
+import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.LongSpace;
+import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.questions.BgpProcessPropertySpecifier;
@@ -22,6 +28,68 @@ import org.batfish.specifier.NameNodeSpecifier;
 import org.junit.Test;
 
 public class BgpProcessConfigurationAnswererTest {
+
+  @Test
+  public void testWithNeighbors() {
+    // Create process with active, passive, and unnumbered peers
+    BgpProcess proc = new BgpProcess();
+    BgpActivePeerConfig.builder()
+        .setBgpProcess(proc)
+        .setLocalAs(100L)
+        .setRemoteAsns(LongSpace.of(200L))
+        .setLocalIp(Ip.parse("1.1.1.1"))
+        .setPeerAddress(Ip.parse("2.2.2.2"))
+        .build();
+    BgpPassivePeerConfig.builder()
+        .setBgpProcess(proc)
+        .setLocalAs(100L)
+        .setRemoteAsns(LongSpace.of(300L))
+        .setLocalIp(Ip.parse("1.1.1.2"))
+        .setPeerPrefix(Prefix.create(Ip.parse("3.3.3.0"), 24))
+        .build();
+    BgpUnnumberedPeerConfig.builder()
+        .setBgpProcess(proc)
+        .setLocalAs(100L)
+        .setRemoteAsns(LongSpace.of(400L))
+        .setLocalIp(Ip.parse("169.254.0.1"))
+        .setPeerInterface("iface")
+        .build();
+
+    Vrf vrf = new Vrf("vrf");
+    vrf.setBgpProcess(proc);
+    Configuration conf = new Configuration("c", ConfigurationFormat.CISCO_IOS);
+    conf.setVrfs(ImmutableMap.of("vrf", vrf));
+
+    // Generate process configuration answer
+    BgpProcessConfigurationQuestion question =
+        new BgpProcessConfigurationQuestion(
+            AllNodesNodeSpecifier.INSTANCE, BgpProcessPropertySpecifier.ALL);
+    MockSpecifierContext ctxt =
+        MockSpecifierContext.builder().setConfigs(ImmutableMap.of("c", conf)).build();
+    Multiset<Row> rows =
+        BgpProcessConfigurationAnswerer.getProperties(
+            BgpProcessPropertySpecifier.ALL,
+            ctxt,
+            new NameNodeSpecifier("c"),
+            BgpProcessConfigurationAnswerer.createTableMetadata(question).toColumnMap());
+
+    // Create expected answer and compare
+    Row expectedRow =
+        Row.builder()
+            .put(BgpProcessConfigurationAnswerer.COL_NODE, new Node("c"))
+            .put(BgpProcessConfigurationAnswerer.COL_VRF, "vrf")
+            .put(BgpProcessConfigurationAnswerer.COL_ROUTER_ID, null)
+            .put(BgpProcessPropertySpecifier.MULTIPATH_EQUIVALENT_AS_PATH_MATCH_MODE, null)
+            .put(BgpProcessPropertySpecifier.MULTIPATH_EBGP, false)
+            .put(BgpProcessPropertySpecifier.MULTIPATH_IBGP, false)
+            .put(
+                BgpProcessPropertySpecifier.NEIGHBORS,
+                ImmutableSet.of("2.2.2.2/32", "3.3.3.0/24", "iface"))
+            .put(BgpProcessPropertySpecifier.ROUTE_REFLECTOR, false)
+            .put(BgpProcessPropertySpecifier.TIE_BREAKER, BgpTieBreaker.ARRIVAL_ORDER.toString())
+            .build();
+    assertThat(rows, equalTo(ImmutableMultiset.of(expectedRow)));
+  }
 
   @Test
   public void getProperties() {


### PR DESCRIPTION
The `Neighbors` column schema is just a set of strings, so it was straightforward to add the interface names for unnumbered peers.