### PR TITLE
Configuration: move finalization from VS to CCJ

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Ordering;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
@@ -21,7 +22,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
@@ -832,9 +832,10 @@ public final class Configuration implements Serializable {
 
   public void simplifyRoutingPolicies() {
     NavigableMap<String, RoutingPolicy> simpleRoutingPolicies =
-        new TreeMap<>(
-            _routingPolicies.entrySet().stream()
-                .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().simplify())));
+        _routingPolicies.entrySet().stream()
+            .collect(
+                ImmutableSortedMap.toImmutableSortedMap(
+                    Ordering.natural(), Entry::getKey, e -> e.getValue().simplify()));
     _routingPolicies = simpleRoutingPolicies;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3961,10 +3961,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
         CiscoStructureType.BGP_UNDECLARED_PEER_GROUP,
         CiscoStructureUsage.BGP_PEER_GROUP_REFERENCED_BEFORE_DEFINED);
 
-    c.simplifyRoutingPolicies();
-
-    c.computeRoutingPolicySources(_w);
-
     return ImmutableList.of(c);
   }
 

--- a/tests/parsing-tests/unit-tests-nodes.ref
+++ b/tests/parsing-tests/unit-tests-nodes.ref
@@ -13652,21 +13652,16 @@
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                      "prefix" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                      },
-                      "prefixSet" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                        "prefixSpace" : [
-                          "192.0.2.8/32"
-                        ]
-                      }
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "192.0.2.8/32"
+                    ]
+                  }
                 },
                 "trueStatements" : [
                   {
@@ -13708,13 +13703,8 @@
                       "comment" : "Redistribute CONNECTED routes into BGP",
                       "conjuncts" : [
                         {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                              "protocol" : "connected"
-                            }
-                          ]
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                          "protocol" : "connected"
                         },
                         {
                           "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
@@ -13844,13 +13834,8 @@
                       "comment" : "Redistribute CONNECTED routes into BGP",
                       "conjuncts" : [
                         {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                              "protocol" : "connected"
-                            }
-                          ]
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                          "protocol" : "connected"
                         },
                         {
                           "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
@@ -13891,13 +13876,8 @@
                       "comment" : "Redistribute STATIC routes into BGP",
                       "conjuncts" : [
                         {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                          "disjuncts" : [
-                            {
-                              "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                              "protocol" : "static"
-                            }
-                          ]
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                          "protocol" : "static"
                         },
                         {
                           "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
@@ -13957,18 +13937,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                          "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
                 },
                 "trueStatements" : [
                   {
@@ -15147,18 +15117,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                          "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:1~"
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:1~"
                 },
                 "trueStatements" : [
                   {
@@ -15638,18 +15598,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                          "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:/Common/my_bgp~"
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:/Common/my_bgp~"
                 },
                 "trueStatements" : [
                   {
@@ -15776,71 +15726,8 @@
             "name" : "/Common/MY_ROUTE_MAP",
             "statements" : [
               {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
-                      "type" : "False"
-                    }
-                  ]
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetCommunity",
-                    "expr" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
-                      "communities" : [
-                        65538,
-                        2162732
-                      ]
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnFalse"
-                  }
-                ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
-                      "type" : "False"
-                    }
-                  ]
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetCommunity",
-                    "expr" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet",
-                      "communities" : [
-                        3604546
-                      ]
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnTrue"
-                  }
-                ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction"
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnFalse"
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
@@ -16033,16 +15920,8 @@
                 ]
               },
               {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction"
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnFalse"
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
@@ -16143,18 +16022,8 @@
                   }
                 ],
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
-                      "disjuncts" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                          "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:65500~"
-                        }
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:65500~"
                 },
                 "trueStatements" : [
                   {
@@ -16191,6 +16060,9 @@
                   "ebgpMultihop" : false,
                   "enforceFirstAs" : false,
                   "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:65500:10.0.0.1~",
+                  "exportPolicySources" : [
+                    "rm1"
+                  ],
                   "ipv4UnicastAddressFamily" : { },
                   "localAs" : 65500,
                   "peerAddress" : "10.0.0.1",
@@ -17943,22 +17815,8 @@
                 "metricType" : "E2"
               },
               {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "falseStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitReject"
-                  }
-                ],
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction"
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitAccept"
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ExitReject"
               }
             ]
           }
@@ -19835,22 +19693,8 @@
                 "metricType" : "E2"
               },
               {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "falseStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitReject"
-                  }
-                ],
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction"
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitAccept"
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ExitReject"
               }
             ]
           },
@@ -22941,22 +22785,8 @@
                 "metricType" : "E2"
               },
               {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "falseStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitReject"
-                  }
-                ],
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction"
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitAccept"
-                  }
-                ]
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ExitReject"
               }
             ]
           }
@@ -23108,123 +22938,6 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "comment" : "TERM",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
-                  "type" : "False"
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetAdministrativeCost",
-                    "admin" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
-                      "value" : 100
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
-                    "originType" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
-                      "originType" : "igp"
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetNextHop",
-                    "destinationVrf" : false,
-                    "expr" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.SelfNextHop"
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
-                    "metric" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.IncrementMetric",
-                      "addend" : 20
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetMetric",
-                    "metric" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralLong",
-                      "value" : 10
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOspfMetricType",
-                    "metricType" : "E1"
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.PrependAsPath",
-                    "expr" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralAsList",
-                      "list" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitAs",
-                          "as" : 456
-                        },
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitAs",
-                          "as" : 8060929
-                        },
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitAs",
-                          "as" : 789
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.PrependAsPath",
-                    "expr" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralAsList",
-                      "list" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitAs",
-                          "as" : 456
-                        },
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitAs",
-                          "as" : 789
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.PrependAsPath",
-                    "expr" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralAsList",
-                      "list" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitAs",
-                          "as" : 8061384
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.PrependAsPath",
-                    "expr" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralAsList",
-                      "list" : [
-                        {
-                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitAs",
-                          "as" : 123
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetDefaultActionAccept"
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetDefaultActionReject"
-                  }
-                ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "comment" : "AS_PATH",
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchAsPath",
@@ -23259,14 +22972,6 @@
                     ]
                   }
                 ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "comment" : "__POLICY-NAME__DEFAULT_TERM__",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                  "protocol" : "evpn"
-                }
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
@@ -24221,20 +23926,6 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "comment" : "t1",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                  "prefix" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                  },
-                  "prefixSet" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                    "name" : "route-filter-test-v4:t1"
-                  }
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "falseStatements" : [
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
@@ -24251,20 +23942,6 @@
           "route-filter-test-v6" : {
             "name" : "route-filter-test-v6",
             "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "comment" : "t1",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefix6Set",
-                  "prefix" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork6"
-                  },
-                  "prefixSet" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefix6Set",
-                    "name" : "route-filter-test-v6:t1"
-                  }
-                }
-              },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "falseStatements" : [
@@ -24867,35 +24544,6 @@
                       }
                     }
                   ]
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                    "falseStatements" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                        "type" : "ExitAccept"
-                      }
-                    ],
-                    "guard" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
-                      "type" : "CallExprContext"
-                    },
-                    "trueStatements" : [
-                      {
-                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                        "type" : "ReturnTrue"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "comment" : "TERM2",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
-                  "type" : "False"
                 },
                 "trueStatements" : [
                   {


### PR DESCRIPTION
Extract the simplification/finalization logic from Cisco and move it to ConvertConfigurationJob
so that it applies to all vendors.