### PR TITLE
AbstractRoute: create the comparator once

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
@@ -45,7 +45,7 @@ public abstract class AbstractRoute implements AbstractRouteDecorator, Serializa
   private final boolean _nonRouting;
   private final boolean _nonForwarding;
 
-  /** The composite scomparator for this class. */
+  /** The composite comparator for this class. */
   private static final Comparator<AbstractRoute> COMPARATOR =
       Comparator.comparing(AbstractRoute::getNetwork)
           .thenComparingInt(AbstractRoute::getAdministrativeCost)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
@@ -45,6 +45,18 @@ public abstract class AbstractRoute implements AbstractRouteDecorator, Serializa
   private final boolean _nonRouting;
   private final boolean _nonForwarding;
 
+  /** The composite scomparator for this class. */
+  private static final Comparator<AbstractRoute> COMPARATOR =
+      Comparator.comparing(AbstractRoute::getNetwork)
+          .thenComparingInt(AbstractRoute::getAdministrativeCost)
+          .thenComparing(AbstractRoute::getMetric)
+          .thenComparing(AbstractRoute::routeCompare)
+          .thenComparing(AbstractRoute::getNextHopIp)
+          .thenComparing(AbstractRoute::getNextHopInterface)
+          .thenComparingInt(AbstractRoute::getTag)
+          .thenComparing(AbstractRoute::getNonRouting)
+          .thenComparing(AbstractRoute::getNonForwarding);
+
   @JsonCreator
   protected AbstractRoute(
       @Nullable Prefix network, int admin, boolean nonRouting, boolean nonForwarding) {
@@ -63,17 +75,7 @@ public abstract class AbstractRoute implements AbstractRouteDecorator, Serializa
 
   @Override
   public final int compareTo(AbstractRouteDecorator rhs) {
-    int routeComparison =
-        Comparator.comparing(AbstractRoute::getNetwork)
-            .thenComparingInt(AbstractRoute::getAdministrativeCost)
-            .thenComparing(AbstractRoute::getMetric)
-            .thenComparing(AbstractRoute::routeCompare)
-            .thenComparing(AbstractRoute::getNextHopIp)
-            .thenComparing(AbstractRoute::getNextHopInterface)
-            .thenComparingInt(AbstractRoute::getTag)
-            .thenComparing(AbstractRoute::getNonRouting)
-            .thenComparing(AbstractRoute::getNonForwarding)
-            .compare(this, rhs.getAbstractRoute());
+    int routeComparison = COMPARATOR.compare(this, rhs.getAbstractRoute());
     if (routeComparison != 0) {
       return routeComparison;
     }


### PR DESCRIPTION
It's a fairly complex object, no need to create it per-comparison.