### PR TITLE
BDDInteger: add range helper and use it

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
@@ -90,11 +90,7 @@ public final class BDDFlowConstraintGenerator {
   BDD computeUDPConstraint() {
     BDDInteger dstPort = _bddPacket.getDstPort();
     BDDInteger srcPort = _bddPacket.getSrcPort();
-    BDD bdd1 =
-        dstPort
-            .geq(33434)
-            .and(dstPort.leq(33534))
-            .and(srcPort.geq(NamedPort.EPHEMERAL_LOWEST.number()));
+    BDD bdd1 = dstPort.range(33434, 33534).and(srcPort.geq(NamedPort.EPHEMERAL_LOWEST.number()));
     BDD bdd2 = _bddPacket.swapSourceAndDestinationFields(bdd1);
     return _bddPacket.getIpProtocol().value(IpProtocol.UDP).and(bdd1.or(bdd2));
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
@@ -147,21 +147,47 @@ public class BDDInteger {
     return bdd;
   }
 
+  // Helper function to compute leq on the last N bits of the input value.
+  private BDD leqN(long val, int n) {
+    assert n <= _bitvec.length;
+    long currentVal = val;
+    BDD acc = _factory.one(); // whether the suffix of BDD is leq suffix of val.
+    for (int i = 0; i < n; ++i) {
+      BDD bit = _bitvec[_bitvec.length - i - 1];
+      if ((currentVal & 1) != 0) {
+        // since this bit of val is 1: 0 implies lt OR 1 and suffix leq. ('1 and' is redundant).
+        acc = bit.imp(acc); // "not i or acc" rewritten "i implies acc".
+      } else {
+        // since this bit of val is 0: must be 0 and have leq suffix.
+        acc = bit.less(acc); // "not i and acc" rewritten "i less acc"
+      }
+      currentVal >>= 1;
+    }
+    return acc;
+  }
+
   /*
    * Less than or equal to on integers
    */
   public BDD leq(long val) {
     checkArgument(val >= 0, "value is negative");
     checkArgument(val < (1L << _bitvec.length), "value %s is out of range", val);
+    return leqN(val, _bitvec.length);
+  }
+
+  // Helper function to compute geq on the last N bits of the input value.
+  private BDD geqN(long val, int n) {
+    assert n <= _bitvec.length;
     long currentVal = val;
-    BDD acc = _factory.one(); // whether the suffix of BDD is leq suffix of val.
-    for (int i = _bitvec.length - 1; i >= 0; i--) {
+    BDD acc = _factory.one(); // whether the suffix of BDD is geq suffix of val.
+    for (int i = 0; i < n; ++i) {
+      BDD bit = _bitvec[_bitvec.length - i - 1];
       if ((currentVal & 1) != 0) {
-        // since this bit of val is 1: 0 implies lt OR 1 and suffix leq. ('1 and' is redundant).
-        acc = _bitvec[i].imp(acc); // "not i or acc" rewritten "i implies acc".
+        // since this bit of val is 1: must be 1 and have geq suffix.
+        acc = bit.and(acc);
       } else {
-        // since this bit of val is 0: must be 0 and have leq suffix.
-        acc = _bitvec[i].less(acc); // "not i and acc" rewritten "i less acc"
+        // since this bit of val is 0: 1 implies gt OR 0 and suffix geq. ('0 and' is redundant.)
+        acc = bit.or(acc);
       }
       currentVal >>= 1;
     }
@@ -174,19 +200,41 @@ public class BDDInteger {
   public BDD geq(long val) {
     checkArgument(val >= 0, "value is negative");
     checkArgument(val < (1L << _bitvec.length), "value %s is out of range", val);
-    long currentVal = val;
-    BDD acc = _factory.one(); // whether the suffix of BDD is geq suffix of val.
-    for (int i = _bitvec.length - 1; i >= 0; i--) {
+    return geqN(val, _bitvec.length);
+  }
+
+  /*
+   * Integers in the given range, inclusive, where {@code a} is less than or equal to {@code b}.
+   */
+  // This is basically this.geq(a).and(this.leq(b)). Two differences:
+  //   1. Short-circuit a == b
+  //   2. Save work in the case where a and b have a common prefix.
+  public BDD range(long a, long b) {
+    checkArgument(a <= b, "range is not ordered correctly");
+    checkArgument(a >= 0, "value is negative");
+    checkArgument(b < (1L << _bitvec.length), "value %s is out of range", b);
+
+    if (a == b) {
+      return value(a);
+    }
+
+    long bitOfFirstDifference = Long.highestOneBit(a ^ b);
+    int sizeOfDifferentSuffix = Long.numberOfTrailingZeros(bitOfFirstDifference) + 1;
+    BDD geqA = geqN(a, sizeOfDifferentSuffix);
+    BDD leqB = leqN(b, sizeOfDifferentSuffix);
+
+    BDD between = geqA.and(leqB);
+    long currentVal = a >> sizeOfDifferentSuffix;
+    for (int i = sizeOfDifferentSuffix; i < _bitvec.length; ++i) {
+      BDD bit = _bitvec[_bitvec.length - i - 1];
       if ((currentVal & 1) != 0) {
-        // since this bit of val is 1: must be 1 and have geq suffix.
-        acc = _bitvec[i].and(acc);
+        between = bit.and(between);
       } else {
-        // since this bit of val is 0: 1 implies gt OR 0 and suffix geq. ('0 and' is redundant.)
-        acc = _bitvec[i].or(acc);
+        between = bit.less(between); // "not i and x" rewritten "i less x"
       }
       currentVal >>= 1;
     }
-    return acc;
+    return between;
   }
 
   /*

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPrefix.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPrefix.java
@@ -106,10 +106,7 @@ public final class BDDPrefix {
     SubRange r = prefixRange.getLengthRange();
     int lower = r.getStart();
     int upper = r.getEnd();
-    BDD lenMatch =
-        lower == upper
-            ? _prefixLength.value(lower)
-            : _prefixLength.geq(lower).and(_prefixLength.leq(upper));
+    BDD lenMatch = _prefixLength.range(lower, upper);
 
     return lenMatch.and(prefixMatch);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/HeaderSpaceToBDD.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/HeaderSpaceToBDD.java
@@ -111,9 +111,7 @@ public final class HeaderSpaceToBDD {
   }
 
   private static BDD toBDD(SubRange range, BDDInteger var) {
-    long start = range.getStart();
-    long end = range.getEnd();
-    return start == end ? var.value(start) : var.geq(start).and(var.leq(end));
+    return var.range((long) range.getStart(), (long) range.getEnd());
   }
 
   private BDD toBDD(List<TcpFlagsMatchConditions> tcpFlags) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
@@ -119,4 +119,17 @@ public class BDDIntegerTest {
     // y == 31 ==> x == 30
     assertThat(x.getValuesSatisfying(yEqXPlus1.and(y.value(31)), 5), contains(30L));
   }
+
+  @Test
+  public void testRange() {
+    BDDFactory factory = BDDUtils.bddFactory(10);
+    BDDInteger x = BDDInteger.makeFromIndex(factory, 5, 0, false);
+    for (int a = 0; a < 32; ++a) {
+      for (int b = a; b < 32; ++b) {
+        BDD range = x.range(a, b);
+        BDD rangeEquiv = x.geq(a).and(x.leq(b));
+        assertThat(range, equalTo(rangeEquiv));
+      }
+    }
+  }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/HeaderSpaceToBDDTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/HeaderSpaceToBDDTest.java
@@ -89,9 +89,9 @@ public class HeaderSpaceToBDDTest {
     BDD bdd = _toBDD.toBDD(headerSpace);
 
     BDDInteger dstPort = _pkt.getDstPort();
-    BDD dstPortBDD = dstPort.leq(20).and(dstPort.geq(10));
+    BDD dstPortBDD = dstPort.range(10, 20);
     BDDInteger srcPort = _pkt.getSrcPort();
-    BDD srcPortBDD = srcPort.leq(20).and(srcPort.geq(10));
+    BDD srcPortBDD = srcPort.range(10, 20);
     assertThat(bdd, equalTo(dstPortBDD.or(srcPortBDD)));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -1472,8 +1472,7 @@ public final class BDDReachabilityAnalysisFactory {
           assignIpAddressFromPool.getIpRanges().asRanges().stream()
               .map(
                   range ->
-                      var.geq(range.lowerEndpoint().asLong())
-                          .and(var.leq(range.upperEndpoint().asLong())))
+                      var.range(range.lowerEndpoint().asLong(), range.upperEndpoint().asLong()))
               .reduce(var.getFactory().zero(), BDD::or);
       _ipRanges.merge(ipField, bdd, BDD::or);
       return null;
@@ -1496,8 +1495,7 @@ public final class BDDReachabilityAnalysisFactory {
     public Void visitAssignPortFromPool(AssignPortFromPool assignPortFromPool) {
       PortField portField = assignPortFromPool.getPortField();
       BDDInteger var = getPortVar(portField);
-      BDD bdd =
-          var.geq(assignPortFromPool.getPoolStart()).and(var.leq(assignPortFromPool.getPoolEnd()));
+      BDD bdd = var.range(assignPortFromPool.getPoolStart(), assignPortFromPool.getPoolEnd());
       _portRanges.merge(portField, bdd, BDD::or);
       return null;
     }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/TransformationToTransition.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/TransformationToTransition.java
@@ -50,20 +50,14 @@ public class TransformationToTransition {
     BDD erase = Arrays.stream(var.getBitvec()).reduce(var.getFactory().one(), BDD::and);
     BDD setValue =
         ranges.asRanges().stream()
-            .map(
-                range ->
-                    range.lowerEndpoint().equals(range.upperEndpoint())
-                        ? var.value(range.lowerEndpoint().asLong())
-                        : var.geq(range.lowerEndpoint().asLong())
-                            .and(var.leq(range.upperEndpoint().asLong())))
+            .map(range -> var.range(range.lowerEndpoint().asLong(), range.upperEndpoint().asLong()))
             .reduce(var.getFactory().zero(), BDD::or);
     return new EraseAndSet(erase, setValue);
   }
 
   private static EraseAndSet assignPortFromPool(BDDInteger var, int poolStart, int poolEnd) {
     BDD erase = Arrays.stream(var.getBitvec()).reduce(var.getFactory().one(), BDD::and);
-    BDD setValue =
-        poolStart == poolEnd ? var.value(poolStart) : var.geq(poolStart).and(var.leq(poolEnd));
+    BDD setValue = var.range(poolStart, poolEnd);
     return new EraseAndSet(erase, setValue);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/symbolic/bdd/TransferBDD.java
+++ b/projects/batfish/src/main/java/org/batfish/symbolic/bdd/TransferBDD.java
@@ -704,10 +704,7 @@ class TransferBDD {
     SubRange r = range.getLengthRange();
     int lower = r.getStart();
     int upper = r.getEnd();
-    BDD lenMatch =
-        lower == upper
-            ? prefixLength.value(lower)
-            : prefixLength.geq(lower).and(prefixLength.leq(upper));
+    BDD lenMatch = prefixLength.range(lower, upper);
 
     return lenMatch.and(prefixMatch);
   }


### PR DESCRIPTION
Adds `bddint.range(a, b)` which is equivalent to `bddint.geq(a).and(bddint.leq(b))`.

Internally, there are two differences:
    1. Short-circuit `a == b`
    2. Save work in the case where `a` and `b` have a common prefix.
