### PR TITLE
handle autocomplete parse errors

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
@@ -175,368 +175,374 @@ public final class AutoCompleteUtils {
       @Nullable ReferenceLibrary referenceLibrary) {
     List<AutocompleteSuggestion> suggestions;
 
-    switch (completionType) {
-      case ADDRESS_GROUP_AND_BOOK:
-        // deprecated -- left for now for backward compatibility
-        suggestions = ImmutableList.of();
-        break;
-      case ADDRESS_GROUP_NAME:
-        {
-          checkReferenceLibrary(referenceLibrary, network);
-          ImmutableSet<String> groups =
-              referenceLibrary.getReferenceBooks().stream()
-                  .map(
-                      b ->
-                          b.getAddressGroups().stream()
-                              .map(ag -> ag.getName())
-                              .collect(ImmutableSet.toImmutableSet()))
-                  .flatMap(Collection::stream)
-                  .collect(ImmutableSet.toImmutableSet());
-          suggestions = stringAutoComplete(query, groups);
+    try {
+      switch (completionType) {
+        case ADDRESS_GROUP_AND_BOOK:
+          // deprecated -- left for now for backward compatibility
+          suggestions = ImmutableList.of();
           break;
-        }
-      case APPLICATION_SPEC:
-        {
-          suggestions =
-              ParboiledAutoComplete.autoComplete(
-                  Grammar.APPLICATION_SPECIFIER,
-                  network,
-                  snapshot,
-                  query,
-                  maxSuggestions,
-                  completionMetadata,
-                  nodeRolesData,
-                  referenceLibrary);
-          break;
-        }
-      case BGP_PEER_PROPERTY_SPEC:
-        {
-          suggestions = baseAutoComplete(query, BgpPeerPropertySpecifier.JAVA_MAP.keySet());
-          break;
-        }
-      case BGP_PROCESS_PROPERTY_SPEC:
-        {
-          suggestions = baseAutoComplete(query, BgpProcessPropertySpecifier.JAVA_MAP.keySet());
-          break;
-        }
-      case BGP_SESSION_STATUS:
-        {
-          suggestions =
-              baseAutoComplete(
-                  query,
-                  Stream.of(ConfiguredSessionStatus.values())
-                      .map(ConfiguredSessionStatus::name)
-                      .collect(Collectors.toSet()));
-          break;
-        }
-      case BGP_SESSION_TYPE:
-        {
-          suggestions =
-              baseAutoComplete(
-                  query,
-                  Stream.of(SessionType.values())
-                      .map(SessionType::name)
-                      .collect(Collectors.toSet()));
+        case ADDRESS_GROUP_NAME:
+          {
+            checkReferenceLibrary(referenceLibrary, network);
+            ImmutableSet<String> groups =
+                referenceLibrary.getReferenceBooks().stream()
+                    .map(
+                        b ->
+                            b.getAddressGroups().stream()
+                                .map(ag -> ag.getName())
+                                .collect(ImmutableSet.toImmutableSet()))
+                    .flatMap(Collection::stream)
+                    .collect(ImmutableSet.toImmutableSet());
+            suggestions = stringAutoComplete(query, groups);
+            break;
+          }
+        case APPLICATION_SPEC:
+          {
+            suggestions =
+                ParboiledAutoComplete.autoComplete(
+                    Grammar.APPLICATION_SPECIFIER,
+                    network,
+                    snapshot,
+                    query,
+                    maxSuggestions,
+                    completionMetadata,
+                    nodeRolesData,
+                    referenceLibrary);
+            break;
+          }
+        case BGP_PEER_PROPERTY_SPEC:
+          {
+            suggestions = baseAutoComplete(query, BgpPeerPropertySpecifier.JAVA_MAP.keySet());
+            break;
+          }
+        case BGP_PROCESS_PROPERTY_SPEC:
+          {
+            suggestions = baseAutoComplete(query, BgpProcessPropertySpecifier.JAVA_MAP.keySet());
+            break;
+          }
+        case BGP_SESSION_STATUS:
+          {
+            suggestions =
+                baseAutoComplete(
+                    query,
+                    Stream.of(ConfiguredSessionStatus.values())
+                        .map(ConfiguredSessionStatus::name)
+                        .collect(Collectors.toSet()));
+            break;
+          }
+        case BGP_SESSION_TYPE:
+          {
+            suggestions =
+                baseAutoComplete(
+                    query,
+                    Stream.of(SessionType.values())
+                        .map(SessionType::name)
+                        .collect(Collectors.toSet()));
 
+            break;
+          }
+        case DISPOSITION_SPEC:
+          {
+            suggestions = DispositionSpecifier.autoComplete(query);
+            break;
+          }
+        case FILTER_NAME:
+          {
+            checkCompletionMetadata(completionMetadata, network, snapshot);
+            suggestions = stringAutoComplete(query, completionMetadata.getFilterNames());
+            break;
+          }
+        case FILTER:
+          {
+            checkCompletionMetadata(completionMetadata, network, snapshot);
+            suggestions = baseAutoComplete(query, completionMetadata.getFilterNames());
+            break;
+          }
+        case FILTER_SPEC:
+          {
+            suggestions =
+                ParboiledAutoComplete.autoComplete(
+                    Grammar.FILTER_SPECIFIER,
+                    network,
+                    snapshot,
+                    query,
+                    maxSuggestions,
+                    completionMetadata,
+                    nodeRolesData,
+                    referenceLibrary);
+            break;
+          }
+        case FLOW_STATE:
+          {
+            suggestions =
+                baseAutoComplete(
+                    query,
+                    Stream.of(FlowState.values()).map(FlowState::name).collect(Collectors.toSet()));
+            break;
+          }
+        case INTERFACE:
+          {
+            checkCompletionMetadata(completionMetadata, network, snapshot);
+            suggestions =
+                baseAutoComplete(
+                    query,
+                    completionMetadata.getInterfaces().stream()
+                        .map(NodeInterfacePair::toString)
+                        .collect(ImmutableSet.toImmutableSet()));
+            break;
+          }
+        case INTERFACE_GROUP_AND_BOOK:
+          // deprecated -- left for now for backward compatibility
+          suggestions = ImmutableList.of();
           break;
-        }
-      case DISPOSITION_SPEC:
-        {
-          suggestions = DispositionSpecifier.autoComplete(query);
+        case INTERFACE_GROUP_NAME:
+          {
+            checkReferenceLibrary(referenceLibrary, network);
+            ImmutableSet<String> groups =
+                referenceLibrary.getReferenceBooks().stream()
+                    .flatMap(b -> b.getInterfaceGroups().stream().map(g -> g.getName()))
+                    .collect(ImmutableSet.toImmutableSet());
+            suggestions = stringAutoComplete(query, groups);
+            break;
+          }
+        case INTERFACE_NAME:
+          {
+            checkCompletionMetadata(completionMetadata, network, snapshot);
+            suggestions =
+                stringAutoComplete(
+                    query,
+                    completionMetadata.getInterfaces().stream()
+                        .map(NodeInterfacePair::getInterface)
+                        .collect(Collectors.toSet()));
+            break;
+          }
+        case INTERFACE_TYPE:
+          {
+            suggestions =
+                stringAutoComplete(
+                    query,
+                    Arrays.stream(InterfaceType.values())
+                        .map(type -> type.toString())
+                        .collect(ImmutableSet.toImmutableSet()));
+            break;
+          }
+        case INTERFACES_SPEC:
+          {
+            suggestions =
+                ParboiledAutoComplete.autoComplete(
+                    Grammar.INTERFACE_SPECIFIER,
+                    network,
+                    snapshot,
+                    query,
+                    maxSuggestions,
+                    completionMetadata,
+                    nodeRolesData,
+                    referenceLibrary);
+            break;
+          }
+        case INTERFACE_PROPERTY_SPEC:
+          {
+            suggestions = baseAutoComplete(query, InterfacePropertySpecifier.JAVA_MAP.keySet());
+            break;
+          }
+        case IP:
+          {
+            checkCompletionMetadata(completionMetadata, network, snapshot);
+            suggestions = stringAutoComplete(query, completionMetadata.getIps());
+            break;
+          }
+        case IP_PROTOCOL_SPEC:
+          {
+            suggestions =
+                ParboiledAutoComplete.autoComplete(
+                    Grammar.IP_PROTOCOL_SPECIFIER,
+                    network,
+                    snapshot,
+                    query,
+                    maxSuggestions,
+                    completionMetadata,
+                    nodeRolesData,
+                    referenceLibrary);
+            break;
+          }
+        case IP_SPACE_SPEC:
+          {
+            suggestions =
+                ParboiledAutoComplete.autoComplete(
+                    Grammar.IP_SPACE_SPECIFIER,
+                    network,
+                    snapshot,
+                    query,
+                    maxSuggestions,
+                    completionMetadata,
+                    nodeRolesData,
+                    referenceLibrary);
+            break;
+          }
+        case IPSEC_SESSION_STATUS:
+          {
+            suggestions =
+                baseAutoComplete(
+                    query,
+                    Stream.of(IpsecSessionStatus.values())
+                        .map(IpsecSessionStatus::name)
+                        .collect(Collectors.toSet()));
+            break;
+          }
+        case LOCATION_SPEC:
+          {
+            suggestions =
+                ParboiledAutoComplete.autoComplete(
+                    Grammar.LOCATION_SPECIFIER,
+                    network,
+                    snapshot,
+                    query,
+                    maxSuggestions,
+                    completionMetadata,
+                    nodeRolesData,
+                    referenceLibrary);
+            break;
+          }
+        case NAMED_STRUCTURE_SPEC:
+          {
+            suggestions = baseAutoComplete(query, NamedStructureSpecifier.JAVA_MAP.keySet());
+            break;
+          }
+        case NODE_NAME:
+          {
+            checkCompletionMetadata(completionMetadata, network, snapshot);
+            suggestions = stringAutoComplete(query, completionMetadata.getNodes());
+            break;
+          }
+        case NODE_PROPERTY_SPEC:
+          {
+            suggestions = baseAutoComplete(query, NodePropertySpecifier.JAVA_MAP.keySet());
+            break;
+          }
+        case NODE_ROLE_AND_DIMENSION:
+          // deprecated -- left for now for backward compatibility
+          suggestions = ImmutableList.of();
           break;
-        }
-      case FILTER_NAME:
-        {
-          checkCompletionMetadata(completionMetadata, network, snapshot);
-          suggestions = stringAutoComplete(query, completionMetadata.getFilterNames());
+        case NODE_ROLE_DIMENSION:
+          // deprecated -- left for now for backward compatibility
+          suggestions = ImmutableList.of();
           break;
-        }
-      case FILTER:
-        {
-          checkCompletionMetadata(completionMetadata, network, snapshot);
-          suggestions = baseAutoComplete(query, completionMetadata.getFilterNames());
-          break;
-        }
-      case FILTER_SPEC:
-        {
-          suggestions =
-              ParboiledAutoComplete.autoComplete(
-                  Grammar.FILTER_SPECIFIER,
-                  network,
-                  snapshot,
-                  query,
-                  maxSuggestions,
-                  completionMetadata,
-                  nodeRolesData,
-                  referenceLibrary);
-          break;
-        }
-      case FLOW_STATE:
-        {
-          suggestions =
-              baseAutoComplete(
-                  query,
-                  Stream.of(FlowState.values()).map(FlowState::name).collect(Collectors.toSet()));
-          break;
-        }
-      case INTERFACE:
-        {
-          checkCompletionMetadata(completionMetadata, network, snapshot);
-          suggestions =
-              baseAutoComplete(
-                  query,
-                  completionMetadata.getInterfaces().stream()
-                      .map(NodeInterfacePair::toString)
-                      .collect(ImmutableSet.toImmutableSet()));
-          break;
-        }
-      case INTERFACE_GROUP_AND_BOOK:
-        // deprecated -- left for now for backward compatibility
-        suggestions = ImmutableList.of();
-        break;
-      case INTERFACE_GROUP_NAME:
-        {
-          checkReferenceLibrary(referenceLibrary, network);
-          ImmutableSet<String> groups =
-              referenceLibrary.getReferenceBooks().stream()
-                  .flatMap(b -> b.getInterfaceGroups().stream().map(g -> g.getName()))
-                  .collect(ImmutableSet.toImmutableSet());
-          suggestions = stringAutoComplete(query, groups);
-          break;
-        }
-      case INTERFACE_NAME:
-        {
-          checkCompletionMetadata(completionMetadata, network, snapshot);
-          suggestions =
-              stringAutoComplete(
-                  query,
-                  completionMetadata.getInterfaces().stream()
-                      .map(NodeInterfacePair::getInterface)
-                      .collect(Collectors.toSet()));
-          break;
-        }
-      case INTERFACE_TYPE:
-        {
-          suggestions =
-              stringAutoComplete(
-                  query,
-                  Arrays.stream(InterfaceType.values())
-                      .map(type -> type.toString())
-                      .collect(ImmutableSet.toImmutableSet()));
-          break;
-        }
-      case INTERFACES_SPEC:
-        {
-          suggestions =
-              ParboiledAutoComplete.autoComplete(
-                  Grammar.INTERFACE_SPECIFIER,
-                  network,
-                  snapshot,
-                  query,
-                  maxSuggestions,
-                  completionMetadata,
-                  nodeRolesData,
-                  referenceLibrary);
-          break;
-        }
-      case INTERFACE_PROPERTY_SPEC:
-        {
-          suggestions = baseAutoComplete(query, InterfacePropertySpecifier.JAVA_MAP.keySet());
-          break;
-        }
-      case IP:
-        {
-          checkCompletionMetadata(completionMetadata, network, snapshot);
-          suggestions = stringAutoComplete(query, completionMetadata.getIps());
-          break;
-        }
-      case IP_PROTOCOL_SPEC:
-        {
-          suggestions =
-              ParboiledAutoComplete.autoComplete(
-                  Grammar.IP_PROTOCOL_SPECIFIER,
-                  network,
-                  snapshot,
-                  query,
-                  maxSuggestions,
-                  completionMetadata,
-                  nodeRolesData,
-                  referenceLibrary);
-          break;
-        }
-      case IP_SPACE_SPEC:
-        {
-          suggestions =
-              ParboiledAutoComplete.autoComplete(
-                  Grammar.IP_SPACE_SPECIFIER,
-                  network,
-                  snapshot,
-                  query,
-                  maxSuggestions,
-                  completionMetadata,
-                  nodeRolesData,
-                  referenceLibrary);
-          break;
-        }
-      case IPSEC_SESSION_STATUS:
-        {
-          suggestions =
-              baseAutoComplete(
-                  query,
-                  Stream.of(IpsecSessionStatus.values())
-                      .map(IpsecSessionStatus::name)
-                      .collect(Collectors.toSet()));
-          break;
-        }
-      case LOCATION_SPEC:
-        {
-          suggestions =
-              ParboiledAutoComplete.autoComplete(
-                  Grammar.LOCATION_SPECIFIER,
-                  network,
-                  snapshot,
-                  query,
-                  maxSuggestions,
-                  completionMetadata,
-                  nodeRolesData,
-                  referenceLibrary);
-          break;
-        }
-      case NAMED_STRUCTURE_SPEC:
-        {
-          suggestions = baseAutoComplete(query, NamedStructureSpecifier.JAVA_MAP.keySet());
-          break;
-        }
-      case NODE_NAME:
-        {
-          checkCompletionMetadata(completionMetadata, network, snapshot);
-          suggestions = stringAutoComplete(query, completionMetadata.getNodes());
-          break;
-        }
-      case NODE_PROPERTY_SPEC:
-        {
-          suggestions = baseAutoComplete(query, NodePropertySpecifier.JAVA_MAP.keySet());
-          break;
-        }
-      case NODE_ROLE_AND_DIMENSION:
-        // deprecated -- left for now for backward compatibility
-        suggestions = ImmutableList.of();
-        break;
-      case NODE_ROLE_DIMENSION:
-        // deprecated -- left for now for backward compatibility
-        suggestions = ImmutableList.of();
-        break;
-      case NODE_ROLE_DIMENSION_NAME:
-        {
-          checkNodeRolesData(nodeRolesData, network);
-          suggestions =
-              stringAutoComplete(
-                  query,
-                  nodeRolesData.getNodeRoleDimensions().stream()
-                      .map(NodeRoleDimension::getName)
-                      .collect(Collectors.toSet()));
-          break;
-        }
-      case NODE_ROLE_NAME:
-        {
-          checkNodeRolesData(nodeRolesData, network);
-          ImmutableSet<String> roles =
-              nodeRolesData.getNodeRoleDimensions().stream()
-                  .flatMap(d -> d.getRoles().stream().map(r -> r.getName()))
-                  .collect(ImmutableSet.toImmutableSet());
-          suggestions = stringAutoComplete(query, roles);
-          break;
-        }
-      case NODE_SPEC:
-        {
-          suggestions =
-              ParboiledAutoComplete.autoComplete(
-                  Grammar.NODE_SPECIFIER,
-                  network,
-                  snapshot,
-                  query,
-                  maxSuggestions,
-                  completionMetadata,
-                  nodeRolesData,
-                  referenceLibrary);
-          break;
-        }
-      case OSPF_PROPERTY_SPEC:
-        {
-          suggestions = baseAutoComplete(query, OspfPropertySpecifier.JAVA_MAP.keySet());
-          break;
-        }
-      case PREFIX:
-        {
-          checkCompletionMetadata(completionMetadata, network, snapshot);
-          suggestions = stringAutoComplete(query, completionMetadata.getPrefixes());
-          break;
-        }
-      case PROTOCOL:
-        {
-          suggestions =
-              baseAutoComplete(
-                  query,
-                  Stream.of(Protocol.values()).map(Protocol::name).collect(Collectors.toSet()));
-          break;
-        }
-      case REFERENCE_BOOK_NAME:
-        {
-          checkReferenceLibrary(referenceLibrary, network);
-          suggestions =
-              stringAutoComplete(
-                  query,
-                  referenceLibrary.getReferenceBooks().stream()
-                      .map(ReferenceBook::getName)
-                      .collect(Collectors.toSet()));
-          break;
-        }
-      case ROUTING_POLICY_NAME:
-        {
-          checkCompletionMetadata(completionMetadata, network, snapshot);
-          suggestions = stringAutoComplete(query, completionMetadata.getRoutingPolicyNames());
-          break;
-        }
-      case ROUTING_POLICY_SPEC:
-        {
-          suggestions =
-              ParboiledAutoComplete.autoComplete(
-                  Grammar.ROUTING_POLICY_SPECIFIER,
-                  network,
-                  snapshot,
-                  query,
-                  maxSuggestions,
-                  completionMetadata,
-                  nodeRolesData,
-                  referenceLibrary);
-          break;
-        }
-      case ROUTING_PROTOCOL_SPEC:
-        {
-          suggestions = RoutingProtocolSpecifier.autoComplete(query);
-          break;
-        }
-      case STRUCTURE_NAME:
-        {
-          checkCompletionMetadata(completionMetadata, network, snapshot);
-          suggestions = baseAutoComplete(query, completionMetadata.getStructureNames());
-          break;
-        }
-      case VRF:
-        {
-          checkCompletionMetadata(completionMetadata, network, snapshot);
-          suggestions = baseAutoComplete(query, completionMetadata.getVrfs());
-          break;
-        }
-      case ZONE:
-        {
-          checkCompletionMetadata(completionMetadata, network, snapshot);
-          suggestions = baseAutoComplete(query, completionMetadata.getZones());
-          break;
-        }
-      default:
-        throw new IllegalArgumentException("Unsupported completion type: " + completionType);
+        case NODE_ROLE_DIMENSION_NAME:
+          {
+            checkNodeRolesData(nodeRolesData, network);
+            suggestions =
+                stringAutoComplete(
+                    query,
+                    nodeRolesData.getNodeRoleDimensions().stream()
+                        .map(NodeRoleDimension::getName)
+                        .collect(Collectors.toSet()));
+            break;
+          }
+        case NODE_ROLE_NAME:
+          {
+            checkNodeRolesData(nodeRolesData, network);
+            ImmutableSet<String> roles =
+                nodeRolesData.getNodeRoleDimensions().stream()
+                    .flatMap(d -> d.getRoles().stream().map(r -> r.getName()))
+                    .collect(ImmutableSet.toImmutableSet());
+            suggestions = stringAutoComplete(query, roles);
+            break;
+          }
+        case NODE_SPEC:
+          {
+            suggestions =
+                ParboiledAutoComplete.autoComplete(
+                    Grammar.NODE_SPECIFIER,
+                    network,
+                    snapshot,
+                    query,
+                    maxSuggestions,
+                    completionMetadata,
+                    nodeRolesData,
+                    referenceLibrary);
+            break;
+          }
+        case OSPF_PROPERTY_SPEC:
+          {
+            suggestions = baseAutoComplete(query, OspfPropertySpecifier.JAVA_MAP.keySet());
+            break;
+          }
+        case PREFIX:
+          {
+            checkCompletionMetadata(completionMetadata, network, snapshot);
+            suggestions = stringAutoComplete(query, completionMetadata.getPrefixes());
+            break;
+          }
+        case PROTOCOL:
+          {
+            suggestions =
+                baseAutoComplete(
+                    query,
+                    Stream.of(Protocol.values()).map(Protocol::name).collect(Collectors.toSet()));
+            break;
+          }
+        case REFERENCE_BOOK_NAME:
+          {
+            checkReferenceLibrary(referenceLibrary, network);
+            suggestions =
+                stringAutoComplete(
+                    query,
+                    referenceLibrary.getReferenceBooks().stream()
+                        .map(ReferenceBook::getName)
+                        .collect(Collectors.toSet()));
+            break;
+          }
+        case ROUTING_POLICY_NAME:
+          {
+            checkCompletionMetadata(completionMetadata, network, snapshot);
+            suggestions = stringAutoComplete(query, completionMetadata.getRoutingPolicyNames());
+            break;
+          }
+        case ROUTING_POLICY_SPEC:
+          {
+            suggestions =
+                ParboiledAutoComplete.autoComplete(
+                    Grammar.ROUTING_POLICY_SPECIFIER,
+                    network,
+                    snapshot,
+                    query,
+                    maxSuggestions,
+                    completionMetadata,
+                    nodeRolesData,
+                    referenceLibrary);
+            break;
+          }
+        case ROUTING_PROTOCOL_SPEC:
+          {
+            suggestions = RoutingProtocolSpecifier.autoComplete(query);
+            break;
+          }
+        case STRUCTURE_NAME:
+          {
+            checkCompletionMetadata(completionMetadata, network, snapshot);
+            suggestions = baseAutoComplete(query, completionMetadata.getStructureNames());
+            break;
+          }
+        case VRF:
+          {
+            checkCompletionMetadata(completionMetadata, network, snapshot);
+            suggestions = baseAutoComplete(query, completionMetadata.getVrfs());
+            break;
+          }
+        case ZONE:
+          {
+            checkCompletionMetadata(completionMetadata, network, snapshot);
+            suggestions = baseAutoComplete(query, completionMetadata.getZones());
+            break;
+          }
+        default:
+          throw new IllegalArgumentException("Unsupported completion type: " + completionType);
+      }
+    } catch (Exception e) {
+      // if any error occurs, just return an empty list
+      return ImmutableList.of();
     }
+
     return suggestions.subList(0, Integer.min(suggestions.size(), maxSuggestions));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AutoCompleteUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AutoCompleteUtilsTest.java
@@ -1300,10 +1300,9 @@ public class AutoCompleteUtilsTest {
   public void testAutocompleteUnsupportedType() throws IOException {
     Type type = Type.ANSWER_ELEMENT;
 
-    _thrown.expect(IllegalArgumentException.class);
-    _thrown.expectMessage("Unsupported completion type: " + type);
-
-    AutoCompleteUtils.autoComplete("network", "snapshot", type, "blah", 5, null, null, null);
+    assertThat(
+        AutoCompleteUtils.autoComplete("network", "snapshot", type, "blah", 5, null, null, null),
+        equalTo(ImmutableList.of()));
   }
 
   @Test
@@ -1346,5 +1345,26 @@ public class AutoCompleteUtilsTest {
         orderSuggestions(query, ImmutableList.of(s1, s2)), equalTo(ImmutableList.of(s1, s2)));
     assertThat(
         orderSuggestions(query, ImmutableList.of(s2, s1)), equalTo(ImmutableList.of(s1, s2)));
+  }
+
+  @Test
+  public void testParseErrorsHandled() {
+    String query = "1.1.1.345";
+
+    // an invalid IP will cause a parse error, which should be handled
+    assertThat(
+        AutoCompleteUtils.autoComplete(
+                "network",
+                "snapshot",
+                Type.IP_SPACE_SPEC,
+                query,
+                5,
+                CompletionMetadata.builder().build(),
+                null,
+                null)
+            .stream()
+            .map(AutocompleteSuggestion::getText)
+            .collect(Collectors.toSet()),
+        equalTo(ImmutableSet.of(":", "-", "&", ",", "\\")));
   }
 }


### PR DESCRIPTION
If an error occurs during autocomplete, `WorkMgrService.autoComplete` would catch it and return a `failureResponse` and would fail to capture the validation info (to a user this will look like a valid input). That error is now being handled deeper in the stack so that validation info will still be captured and sent to the user