### PR TITLE
Make TopologyContext non-transient in dataplane

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Topology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Topology.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
@@ -105,5 +106,24 @@ public final class Topology implements Serializable {
   @JsonValue
   public SortedSet<Edge> sortedEdges() {
     return _edges;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Topology)) {
+      return false;
+    }
+    Topology topology = (Topology) o;
+    return Objects.equals(_edges, topology._edges)
+        && Objects.equals(_interfaceNeighbors, topology._interfaceNeighbors)
+        && Objects.equals(_nodeEdges, topology._nodeEdges);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_edges, _interfaceNeighbors, _nodeEdges);
   }
 }

--- a/projects/batfish/BUILD
+++ b/projects/batfish/BUILD
@@ -110,6 +110,7 @@ junit_tests(
         "//projects/bdd",
         "//projects/lib/z3",
         "@antlr4_runtime//:compile",
+        "@commons_lang3//:compile",
         "@guava//:compile",
         "@guava_testlib//:compile",
         "@hamcrest//:compile",

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -111,7 +111,7 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
 
   private final Map<String, Node> _nodes;
 
-  private final transient TopologyContext _topologyContext;
+  private final TopologyContext _topologyContext;
 
   private transient SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
       _ribs;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/TopologyContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/TopologyContext.java
@@ -1,6 +1,7 @@
 package org.batfish.dataplane.ibdp;
 
 import com.google.common.collect.ImmutableSortedSet;
+import java.io.Serializable;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -15,7 +16,9 @@ import org.batfish.datamodel.vxlan.VxlanTopology;
 
 /** Container for various topologies used during data plane computation. */
 @ParametersAreNonnullByDefault
-public final class TopologyContext {
+public final class TopologyContext implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   public static final class Builder {
 


### PR DESCRIPTION
Fixes an NPE when DP is loaded from disk and then we asked for an L3 topology.