### PR TITLE
Bazel: sickbay javadoc for real

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -87,7 +87,7 @@ EOF
 ###### Ensure the code still compiles with Bazel
 cat <<EOF
   - label: ":bazel: Bazel"
-    command: "bazel build -- //... -projects:javadoc"
+    command: "bazel build -- //..."
     plugins:
       - docker#${BATFISH_DOCKER_PLUGIN_VERSION}:
           image: ${BATFISH_DOCKER_CI_BASE_IMAGE}

--- a/projects/BUILD
+++ b/projects/BUILD
@@ -15,4 +15,5 @@ java_doc(
     pkgs = [
         "org.batfish",
     ],
+    tags = ["manual"],
 )


### PR DESCRIPTION
Use the `manual` tag to make this target only build if you invoke it directly. Gets around the
issue until Bazel has better java11 support.