### PR TITLE
RIB: fix backup routes logic

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Streams;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -136,8 +135,8 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
 
     _intraAreaRib = new OspfIntraAreaRib();
     _interAreaRib = new OspfInterAreaRib();
-    _type1Rib = new OspfExternalType1Rib(_c.getHostname(), new HashMap<>(0));
-    _type2Rib = new OspfExternalType2Rib(_c.getHostname(), new HashMap<>(0));
+    _type1Rib = new OspfExternalType1Rib(_c.getHostname());
+    _type2Rib = new OspfExternalType2Rib(_c.getHostname());
     _ospfRib = new OspfRib();
 
     updateQueues(topology);
@@ -418,10 +417,8 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   private static <R extends AbstractRoute, T extends R> RibDelta<R> processRouteAdvertisement(
       RouteAdvertisement<T> ra, AbstractRib<R> rib) {
     if (ra.isWithdrawn()) {
-      rib.removeBackupRoute(ra.getRoute());
       return rib.removeRouteGetDelta(ra.getRoute(), ra.getReason());
     } else {
-      rib.addBackupRoute(ra.getRoute());
       return rib.mergeRouteGetDelta(ra.getRoute());
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualEigrpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualEigrpProcess.java
@@ -270,10 +270,8 @@ class VirtualEigrpProcess {
 
             if (routeAdvert.isWithdrawn()) {
               deltaBuilder.remove(newRoute, Reason.WITHDRAW);
-              _externalRib.removeBackupRoute(newRoute);
             } else {
               deltaBuilder.from(_externalStagingRib.mergeRouteGetDelta(newRoute));
-              _externalRib.addBackupRoute(newRoute);
             }
           }
         });

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1021,10 +1021,10 @@ public class VirtualRouter implements Serializable {
 
     // ISIS
     _isisRib = new IsisRib(isL1Only());
-    _isisL1Rib = new IsisLevelRib();
-    _isisL2Rib = new IsisLevelRib();
-    _isisL1StagingRib = new IsisLevelRib();
-    _isisL2StagingRib = new IsisLevelRib();
+    _isisL1Rib = new IsisLevelRib(true);
+    _isisL2Rib = new IsisLevelRib(true);
+    _isisL1StagingRib = new IsisLevelRib(false);
+    _isisL2StagingRib = new IsisLevelRib(false);
 
     // RIP
     _ripInternalRib = new RipInternalRib();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1243,7 +1243,6 @@ public class VirtualRouter implements Serializable {
                 routeLevel == IsisLevel.LEVEL_1 ? RoutingProtocol.ISIS_L1 : RoutingProtocol.ISIS_L2;
             RibDelta.Builder<IsisRoute> deltaBuilder =
                 routeLevel == IsisLevel.LEVEL_1 ? l1DeltaBuilder : l2DeltaBuilder;
-            IsisLevelRib levelRib = routeLevel == IsisLevel.LEVEL_1 ? _isisL1Rib : _isisL2Rib;
             long incrementalMetric =
                 firstNonNull(isisLevelSettings.getCost(), IsisRoute.DEFAULT_METRIC);
             IsisRoute newRoute =

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -995,36 +995,36 @@ public class VirtualRouter implements Serializable {
     BgpTieBreaker tieBreaker = getBestPathTieBreaker();
     _ebgpRib =
         new Bgpv4Rib(
-            null,
             _mainRib,
             tieBreaker,
             proc == null || proc.getMultipathEbgp() ? null : 1,
-            mpTieBreaker);
+            mpTieBreaker,
+            false);
     _ibgpRib =
         new Bgpv4Rib(
-            null,
             _mainRib,
             tieBreaker,
             proc == null || proc.getMultipathIbgp() ? null : 1,
-            mpTieBreaker);
+            mpTieBreaker,
+            false);
     _bgpRib =
         new Bgpv4Rib(
-            null,
             _mainRib,
             tieBreaker,
             proc == null || proc.getMultipathEbgp() || proc.getMultipathIbgp() ? null : 1,
-            mpTieBreaker);
+            mpTieBreaker,
+            false);
     _bgpDeltaBuilder = RibDelta.builder();
 
-    _ebgpStagingRib = new Bgpv4Rib(null, _mainRib, tieBreaker, null, mpTieBreaker);
-    _ibgpStagingRib = new Bgpv4Rib(null, _mainRib, tieBreaker, null, mpTieBreaker);
+    _ebgpStagingRib = new Bgpv4Rib(_mainRib, tieBreaker, null, mpTieBreaker, false);
+    _ibgpStagingRib = new Bgpv4Rib(_mainRib, tieBreaker, null, mpTieBreaker, false);
 
     // ISIS
     _isisRib = new IsisRib(isL1Only());
-    _isisL1Rib = new IsisLevelRib(new TreeMap<>());
-    _isisL2Rib = new IsisLevelRib(new TreeMap<>());
-    _isisL1StagingRib = new IsisLevelRib(null);
-    _isisL2StagingRib = new IsisLevelRib(null);
+    _isisL1Rib = new IsisLevelRib();
+    _isisL2Rib = new IsisLevelRib();
+    _isisL1StagingRib = new IsisLevelRib();
+    _isisL2StagingRib = new IsisLevelRib();
 
     // RIP
     _ripInternalRib = new RipInternalRib();
@@ -1177,12 +1177,10 @@ public class VirtualRouter implements Serializable {
           // Note this route was removed
           ribDeltas.get(targetRib).remove(transformedIncomingRoute, Reason.WITHDRAW);
           perNeighborDeltaForRibGroups.remove(annotatedTransformedRoute, Reason.WITHDRAW);
-          _bgpRib.removeBackupRoute(transformedIncomingRoute);
         } else {
           // Merge into staging rib, note delta
           ribDeltas.get(targetRib).from(targetRib.mergeRouteGetDelta(transformedIncomingRoute));
           perNeighborDeltaForRibGroups.add(annotatedTransformedRoute);
-          _bgpRib.addBackupRoute(transformedIncomingRoute);
           _prefixTracer.installed(
               transformedIncomingRoute.getNetwork(),
               remoteConfigId.getHostname(),
@@ -1259,12 +1257,10 @@ public class VirtualRouter implements Serializable {
                     .build();
             if (withdraw) {
               deltaBuilder.remove(newRoute, Reason.WITHDRAW);
-              levelRib.removeBackupRoute(newRoute);
             } else {
               IsisLevelRib levelStagingRib =
                   routeLevel == IsisLevel.LEVEL_1 ? _isisL1StagingRib : _isisL2StagingRib;
               deltaBuilder.from(levelStagingRib.mergeRouteGetDelta(newRoute));
-              levelRib.addBackupRoute(newRoute);
             }
           }
         });
@@ -1648,8 +1644,8 @@ public class VirtualRouter implements Serializable {
      */
     BgpTieBreaker tieBreaker = getBestPathTieBreaker();
     MultipathEquivalentAsPathMatchMode mpTieBreaker = getBgpMpTieBreaker();
-    _ebgpStagingRib = new Bgpv4Rib(null, _mainRib, tieBreaker, null, mpTieBreaker);
-    _ibgpStagingRib = new Bgpv4Rib(null, _mainRib, tieBreaker, null, mpTieBreaker);
+    _ebgpStagingRib = new Bgpv4Rib(_mainRib, tieBreaker, null, mpTieBreaker, false);
+    _ibgpStagingRib = new Bgpv4Rib(_mainRib, tieBreaker, null, mpTieBreaker, false);
 
     /*
      * Add routes that cannot change (does not affect below computation)

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -118,7 +118,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
    */
   private void addBackupRoute(R route) {
     if (_backupRoutes != null) {
-      _backupRoutes.computeIfAbsent(route.getNetwork(), k -> new HashSet<>(0)).add(route);
+      _backupRoutes.computeIfAbsent(route.getNetwork(), k -> new HashSet<>(1)).add(route);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AnnotatedRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AnnotatedRib.java
@@ -1,13 +1,9 @@
 package org.batfish.dataplane.rib;
 
 import java.io.Serializable;
-import java.util.Map;
-import java.util.SortedSet;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AnnotatedRoute;
-import org.batfish.datamodel.Prefix;
 
 /**
  * An {@link AbstractRib} in which all routes are of type {@link AnnotatedRoute} to preserve
@@ -21,8 +17,8 @@ public abstract class AnnotatedRib<R extends AbstractRoute> extends AbstractRib<
 
   private static final long serialVersionUID = 1L;
 
-  AnnotatedRib(@Nullable Map<Prefix, SortedSet<AnnotatedRoute<R>>> backupRoutes) {
-    super(backupRoutes);
+  AnnotatedRib() {
+    super();
   }
 
   /*

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -56,12 +55,12 @@ public abstract class BgpRib<R extends BgpRoute> extends AbstractRib<R> {
   protected Map<R, Long> _logicalArrivalTime;
 
   protected BgpRib(
-      @Nullable Map<Prefix, SortedSet<R>> backupRoutes,
       @Nullable Rib mainRib,
       BgpTieBreaker tieBreaker,
       @Nullable Integer maxPaths,
-      @Nullable MultipathEquivalentAsPathMatchMode multipathEquivalentAsPathMatchMode) {
-    super(backupRoutes);
+      @Nullable MultipathEquivalentAsPathMatchMode multipathEquivalentAsPathMatchMode,
+      boolean withBackups) {
+    super(withBackups);
     _mainRib = mainRib;
     _tieBreaker = tieBreaker;
     checkArgument(maxPaths == null || maxPaths > 0, "Invalid max-paths value %s", maxPaths);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
@@ -1,6 +1,5 @@
 package org.batfish.dataplane.rib;
 
-import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.BgpTieBreaker;
@@ -20,15 +19,5 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
       @Nullable MultipathEquivalentAsPathMatchMode multipathEquivalentAsPathMatchMode,
       boolean withBackups) {
     super(mainRib, tieBreaker, maxPaths, multipathEquivalentAsPathMatchMode, withBackups);
-  }
-
-  /** Shortcut constructor for testing only */
-  @VisibleForTesting
-  Bgpv4Rib(
-      @Nullable Rib mainRib,
-      BgpTieBreaker tieBreaker,
-      @Nullable Integer maxPaths,
-      @Nullable MultipathEquivalentAsPathMatchMode multipathEquivalentAsPathMatchMode) {
-    super(mainRib, tieBreaker, maxPaths, multipathEquivalentAsPathMatchMode, false);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
@@ -1,13 +1,11 @@
 package org.batfish.dataplane.rib;
 
-import java.util.Map;
-import java.util.SortedSet;
+import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.BgpTieBreaker;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
-import org.batfish.datamodel.Prefix;
 
 /** BGPv4-specific RIB implementation */
 @ParametersAreNonnullByDefault
@@ -16,11 +14,21 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
   private static final long serialVersionUID = 1L;
 
   public Bgpv4Rib(
-      @Nullable Map<Prefix, SortedSet<Bgpv4Route>> backupRoutes,
+      @Nullable Rib mainRib,
+      BgpTieBreaker tieBreaker,
+      @Nullable Integer maxPaths,
+      @Nullable MultipathEquivalentAsPathMatchMode multipathEquivalentAsPathMatchMode,
+      boolean withBackups) {
+    super(mainRib, tieBreaker, maxPaths, multipathEquivalentAsPathMatchMode, withBackups);
+  }
+
+  /** Shortcut constructor for testing only */
+  @VisibleForTesting
+  Bgpv4Rib(
       @Nullable Rib mainRib,
       BgpTieBreaker tieBreaker,
       @Nullable Integer maxPaths,
       @Nullable MultipathEquivalentAsPathMatchMode multipathEquivalentAsPathMatchMode) {
-    super(backupRoutes, mainRib, tieBreaker, maxPaths, multipathEquivalentAsPathMatchMode);
+    super(mainRib, tieBreaker, maxPaths, multipathEquivalentAsPathMatchMode, false);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/ConnectedRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/ConnectedRib.java
@@ -11,7 +11,7 @@ public class ConnectedRib extends AnnotatedRib<ConnectedRoute> {
   private static final long serialVersionUID = 1L;
 
   public ConnectedRib() {
-    super(null);
+    super();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/EigrpExternalRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/EigrpExternalRib.java
@@ -1,7 +1,6 @@
 package org.batfish.dataplane.rib;
 
 import java.util.Comparator;
-import java.util.TreeMap;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.EigrpExternalRoute;
 
@@ -12,7 +11,7 @@ public class EigrpExternalRib extends AbstractRib<EigrpExternalRoute> {
   private static final long serialVersionUID = 1L;
 
   public EigrpExternalRib() {
-    super(new TreeMap<>());
+    super();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/EigrpExternalRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/EigrpExternalRib.java
@@ -11,7 +11,7 @@ public class EigrpExternalRib extends AbstractRib<EigrpExternalRoute> {
   private static final long serialVersionUID = 1L;
 
   public EigrpExternalRib() {
-    super();
+    super(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/EigrpInternalRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/EigrpInternalRib.java
@@ -11,7 +11,7 @@ public class EigrpInternalRib extends AbstractRib<EigrpInternalRoute> {
   private static final long serialVersionUID = 1L;
 
   public EigrpInternalRib() {
-    super(null);
+    super();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/EigrpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/EigrpRib.java
@@ -12,7 +12,7 @@ public class EigrpRib extends AbstractRib<EigrpRoute> {
   private static final long serialVersionUID = 1L;
 
   public EigrpRib() {
-    super(null);
+    super();
   }
 
   private static int getTypeCost(EigrpRoute route) {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/EvpnRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/EvpnRib.java
@@ -1,13 +1,10 @@
 package org.batfish.dataplane.rib;
 
-import java.util.Map;
-import java.util.SortedSet;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.BgpTieBreaker;
 import org.batfish.datamodel.EvpnRoute;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
-import org.batfish.datamodel.Prefix;
 
 /** RIB implementation for all types of EVPN routes */
 @ParametersAreNonnullByDefault
@@ -16,11 +13,10 @@ public final class EvpnRib<R extends EvpnRoute> extends BgpRib<R> {
   private static final long serialVersionUID = 1L;
 
   public EvpnRib(
-      @Nullable Map<Prefix, SortedSet<R>> backupRoutes,
       @Nullable Rib mainRib,
       BgpTieBreaker tieBreaker,
       @Nullable Integer maxPaths,
       @Nullable MultipathEquivalentAsPathMatchMode multipathEquivalentAsPathMatchMode) {
-    super(backupRoutes, mainRib, tieBreaker, maxPaths, multipathEquivalentAsPathMatchMode);
+    super(mainRib, tieBreaker, maxPaths, multipathEquivalentAsPathMatchMode, true);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/IsisLevelRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/IsisLevelRib.java
@@ -1,11 +1,7 @@
 package org.batfish.dataplane.rib;
 
-import java.util.Map;
-import java.util.SortedSet;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.IsisRoute;
-import org.batfish.datamodel.Prefix;
 
 /** Rib for storing {@link IsisRoute}s */
 @ParametersAreNonnullByDefault
@@ -13,8 +9,8 @@ public class IsisLevelRib extends AbstractRib<IsisRoute> {
 
   private static final long serialVersionUID = 1L;
 
-  public IsisLevelRib(@Nullable Map<Prefix, SortedSet<IsisRoute>> backupRoutes) {
-    super(backupRoutes);
+  public IsisLevelRib() {
+    super();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/IsisLevelRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/IsisLevelRib.java
@@ -9,8 +9,8 @@ public class IsisLevelRib extends AbstractRib<IsisRoute> {
 
   private static final long serialVersionUID = 1L;
 
-  public IsisLevelRib() {
-    super();
+  public IsisLevelRib(boolean withBackups) {
+    super(withBackups);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/IsisRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/IsisRib.java
@@ -34,7 +34,7 @@ public class IsisRib extends AbstractRib<IsisRoute> {
   private final boolean _l1Only;
 
   public IsisRib(boolean l1Only) {
-    super(null);
+    super();
     _l1Only = l1Only;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/KernelRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/KernelRib.java
@@ -11,7 +11,7 @@ public class KernelRib extends AnnotatedRib<KernelRoute> {
   private static final long serialVersionUID = 1L;
 
   public KernelRib() {
-    super(null);
+    super();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/LocalRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/LocalRib.java
@@ -10,7 +10,7 @@ public class LocalRib extends AnnotatedRib<LocalRoute> {
   private static final long serialVersionUID = 1L;
 
   public LocalRib() {
-    super(null);
+    super();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/OspfExternalType1Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/OspfExternalType1Rib.java
@@ -1,12 +1,8 @@
 package org.batfish.dataplane.rib;
 
-import java.util.Map;
-import java.util.SortedSet;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.OspfExternalType1Route;
-import org.batfish.datamodel.Prefix;
 
 @ParametersAreNonnullByDefault
 public class OspfExternalType1Rib extends AbstractRib<OspfExternalType1Route> {
@@ -15,9 +11,8 @@ public class OspfExternalType1Rib extends AbstractRib<OspfExternalType1Route> {
 
   private final String _hostname;
 
-  public OspfExternalType1Rib(
-      String hostname, @Nullable Map<Prefix, SortedSet<OspfExternalType1Route>> backupRoutes) {
-    super(backupRoutes);
+  public OspfExternalType1Rib(String hostname) {
+    super(true);
     _hostname = hostname;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/OspfExternalType2Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/OspfExternalType2Rib.java
@@ -1,12 +1,8 @@
 package org.batfish.dataplane.rib;
 
-import java.util.Map;
-import java.util.SortedSet;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.OspfExternalType2Route;
-import org.batfish.datamodel.Prefix;
 
 @ParametersAreNonnullByDefault
 public class OspfExternalType2Rib extends AbstractRib<OspfExternalType2Route> {
@@ -15,9 +11,8 @@ public class OspfExternalType2Rib extends AbstractRib<OspfExternalType2Route> {
 
   private final String _hostname;
 
-  public OspfExternalType2Rib(
-      String hostname, @Nullable Map<Prefix, SortedSet<OspfExternalType2Route>> backupRoutes) {
-    super(backupRoutes);
+  public OspfExternalType2Rib(String hostname) {
+    super(true);
     _hostname = hostname;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/OspfInterAreaRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/OspfInterAreaRib.java
@@ -9,7 +9,7 @@ public class OspfInterAreaRib extends AbstractRib<OspfInterAreaRoute> {
   private static final long serialVersionUID = 1L;
 
   public OspfInterAreaRib() {
-    super(null);
+    super();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/OspfIntraAreaRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/OspfIntraAreaRib.java
@@ -9,7 +9,7 @@ public class OspfIntraAreaRib extends AbstractRib<OspfIntraAreaRoute> {
   private static final long serialVersionUID = 1L;
 
   public OspfIntraAreaRib() {
-    super(null);
+    super();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/OspfRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/OspfRib.java
@@ -11,7 +11,7 @@ public class OspfRib extends AbstractRib<OspfRoute> {
   private static final long serialVersionUID = 1L;
 
   public OspfRib() {
-    super(null);
+    super();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Rib.java
@@ -18,7 +18,7 @@ public class Rib extends AnnotatedRib<AbstractRoute> implements Serializable {
 
   /** Create a new empty RIB. */
   public Rib() {
-    super(null);
+    super();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibTree.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibTree.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
 import java.util.Set;
-import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -53,13 +52,13 @@ final class RibTree<R extends AbstractRouteDecorator> implements Serializable {
     Builder<R> b = RibDelta.builder();
     b.remove(route, reason);
     if (_root.get(route.getNetwork()).isEmpty() && _owner._backupRoutes != null) {
-      SortedSet<? extends R> backups =
+      Set<? extends R> backups =
           _owner._backupRoutes.getOrDefault(route.getNetwork(), ImmutableSortedSet.of());
       if (backups.isEmpty()) {
         return b.build();
       }
-      _root.put(route.getNetwork(), backups.first());
-      b.add(backups.first());
+      // re-merge any backups we have
+      backups.forEach(r -> b.from(mergeRoute(r)));
     }
     // Return new delta
     return b.build();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RipInternalRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RipInternalRib.java
@@ -10,7 +10,7 @@ public class RipInternalRib extends AbstractRib<RipInternalRoute> {
   private static final long serialVersionUID = 1L;
 
   public RipInternalRib() {
-    super(null);
+    super();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RipRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RipRib.java
@@ -16,7 +16,7 @@ public class RipRib extends AbstractRib<RipRoute> {
   private static final long serialVersionUID = 1L;
 
   public RipRib() {
-    super(null);
+    super();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/StaticRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/StaticRib.java
@@ -7,7 +7,7 @@ public class StaticRib extends AbstractRib<StaticRoute> {
   private static final long serialVersionUID = 1L;
 
   public StaticRib() {
-    super(null);
+    super();
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -486,6 +486,7 @@ public class AbstractRibTest {
     Bgpv4Route.Builder routeBuilder =
         new Bgpv4Route.Builder()
             .setNetwork(Prefix.ZERO)
+            .setLocalPreference(100)
             .setOriginType(OriginType.INCOMPLETE)
             .setOriginatorIp(originator1)
             .setProtocol(RoutingProtocol.IBGP)
@@ -498,13 +499,15 @@ public class AbstractRibTest {
             .setOriginatorIp(originator2)
             .setReceivedFromIp(originator2)
             .build();
+    Bgpv4Route route3 = routeBuilder.setLocalPreference(1).build();
 
     bestPathRib.mergeRoute(route1);
     bestPathRib.mergeRoute(route2);
+    bestPathRib.mergeRoute(route3);
     // Route 2 is preferred so it replaces route 1
     assertThat(bestPathRib.getTypedRoutes(), contains(route2));
     RibDelta<Bgpv4Route> delta = bestPathRib.removeRouteGetDelta(route2);
-    // Route 2 is removed but route 1 fills the gap as the next-available route
+    // Route 2 is removed but route 1 fills the gap as the next-best route
     assertThat(bestPathRib.getTypedRoutes(), contains(route1));
     assertThat(
         delta.getActions().collect(Collectors.toList()),

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
@@ -63,42 +63,54 @@ public class Bgpv4RibTest {
 
     _multiPathRib =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
-    _bestPathRib = new Bgpv4Rib(null, BgpTieBreaker.ROUTER_ID, 1, null);
+            null,
+            BgpTieBreaker.ROUTER_ID,
+            null,
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH,
+            false);
+    _bestPathRib = new Bgpv4Rib(null, BgpTieBreaker.ROUTER_ID, 1, null, false);
   }
 
   @Test
   public void testParameterValidationMaxPaths() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid max-paths value");
-    new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 0, null);
+    new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 0, null, false);
   }
 
   @Test
   public void testParameterValidationMatchMode() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Multipath AS-Path-Match-mode must be specified");
-    new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 2, null);
+    new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 2, null, false);
   }
 
   @Test
   public void testParameterValidationMatchModeNullMaxPaths() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Multipath AS-Path-Match-mode must be specified");
-    new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, null, null);
+    new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, null, null, false);
   }
 
   @Test
   public void testIsMultipath() {
-    Bgpv4Rib rib = new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 1, null);
+    Bgpv4Rib rib = new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 1, null, false);
     assertTrue("MaxPaths=1, not multipath", !rib.isMultipath());
     rib =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ARRIVAL_ORDER, 2, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null,
+            BgpTieBreaker.ARRIVAL_ORDER,
+            2,
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH,
+            false);
     assertTrue("Maxpaths=2 -> multipath", rib.isMultipath());
     rib =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ARRIVAL_ORDER, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null,
+            BgpTieBreaker.ARRIVAL_ORDER,
+            null,
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH,
+            false);
     assertTrue("Maxpaths=null -> multipath", rib.isMultipath());
   }
 
@@ -202,7 +214,11 @@ public class Bgpv4RibTest {
 
     Bgpv4Rib rib =
         new Bgpv4Rib(
-            mainRib, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            mainRib,
+            BgpTieBreaker.ROUTER_ID,
+            null,
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH,
+            false);
 
     Bgpv4Route worse = _rb.setNextHopIp(Ip.parse("5.5.5.6")).build();
     // Lower IGP cost to next hop is better
@@ -218,7 +234,11 @@ public class Bgpv4RibTest {
   public void testMultipathAsPathModeExactPath() {
     Bgpv4Rib rib =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null,
+            BgpTieBreaker.ROUTER_ID,
+            null,
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH,
+            false);
 
     Bgpv4Route base = _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 2L)).build();
     Bgpv4Route candidate1 =
@@ -237,7 +257,11 @@ public class Bgpv4RibTest {
   public void testMultipathAsPathModeFirstAs() {
     Bgpv4Rib rib =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.FIRST_AS);
+            null,
+            BgpTieBreaker.ROUTER_ID,
+            null,
+            MultipathEquivalentAsPathMatchMode.FIRST_AS,
+            false);
 
     Bgpv4Route base = _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 2L)).build();
     Bgpv4Route candidate1 =
@@ -266,7 +290,11 @@ public class Bgpv4RibTest {
   public void testMultipathArrivalOrder() {
     _multiPathRib =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ARRIVAL_ORDER, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null,
+            BgpTieBreaker.ARRIVAL_ORDER,
+            null,
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH,
+            false);
     Bgpv4Route best = _rb.build();
     Bgpv4Route earliest = _rb.setOriginatorIp(Ip.parse("2.2.2.2")).build();
     _multiPathRib.mergeRoute(earliest);
@@ -328,7 +356,7 @@ public class Bgpv4RibTest {
 
   @Test
   public void testBestPathsEqualRoutesForBestPathRib() {
-    Bgpv4Rib bestPathRib = new Bgpv4Rib(null, BgpTieBreaker.ROUTER_ID, 1, null);
+    Bgpv4Rib bestPathRib = new Bgpv4Rib(null, BgpTieBreaker.ROUTER_ID, 1, null, false);
     Bgpv4Route bestPath = _rb.build();
     bestPathRib.mergeRoute(_rb.setReceivedFromIp(Ip.parse("2.2.2.2")).build());
     bestPathRib.mergeRoute(_rb.setReceivedFromIp(Ip.parse("2.2.2.3")).build());
@@ -386,7 +414,7 @@ public class Bgpv4RibTest {
 
   @Test
   public void testBestPathSelectionTieBreakingArrivalOrder() {
-    _bestPathRib = new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 1, null);
+    _bestPathRib = new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 1, null, false);
     Bgpv4Route bestPath = _rb.build();
     _bestPathRib.mergeRoute(bestPath);
     // Oldest route should win despite newer having lower in Originator IP
@@ -480,7 +508,8 @@ public class Bgpv4RibTest {
             .build();
 
     Bgpv4Rib bmr =
-        new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, null, multipathEquivalentAsPathMatchMode);
+        new Bgpv4Rib(
+            null, BgpTieBreaker.ARRIVAL_ORDER, null, multipathEquivalentAsPathMatchMode, false);
 
     /*
      * Add routes to multipath RIB.
@@ -541,10 +570,14 @@ public class Bgpv4RibTest {
   public void testBgpCompareOriginType() {
     Bgpv4Rib bbr =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH, false);
     Bgpv4Rib bmr =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null,
+            BgpTieBreaker.ROUTER_ID,
+            null,
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH,
+            false);
 
     Prefix p = Prefix.ZERO;
     Bgpv4Route.Builder b = new Bgpv4Route.Builder().setNetwork(p).setProtocol(RoutingProtocol.IBGP);
@@ -590,10 +623,14 @@ public class Bgpv4RibTest {
 
     Bgpv4Rib bbr =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH, false);
     Bgpv4Rib bmr =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null,
+            BgpTieBreaker.ROUTER_ID,
+            null,
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH,
+            false);
     Ip ip1 = Ip.parse("1.0.0.0");
     Ip ip2 = Ip.parse("2.2.0.0");
     Bgpv4Route.Builder b1 =
@@ -659,11 +696,15 @@ public class Bgpv4RibTest {
     // good for both ebgp and ibgp
     Bgpv4Rib bmr =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null,
+            BgpTieBreaker.ROUTER_ID,
+            null,
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH,
+            false);
     // ebgp
     Bgpv4Rib ebgpBpr =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH, false);
     Bgpv4Route.Builder ebgpBuilder =
         new Bgpv4Route.Builder()
             .setNetwork(Prefix.ZERO)
@@ -679,7 +720,7 @@ public class Bgpv4RibTest {
     // ibgp
     Bgpv4Rib ibgpBpr =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH, false);
     Bgpv4Route.Builder ibgpBuilder =
         new Bgpv4Route.Builder()
             .setNetwork(Prefix.ZERO)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/Bgpv4RibTest.java
@@ -63,54 +63,42 @@ public class Bgpv4RibTest {
 
     _multiPathRib =
         new Bgpv4Rib(
-            null,
-            null,
-            BgpTieBreaker.ROUTER_ID,
-            null,
-            MultipathEquivalentAsPathMatchMode.EXACT_PATH);
-    _bestPathRib = new Bgpv4Rib(null, null, BgpTieBreaker.ROUTER_ID, 1, null);
+            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+    _bestPathRib = new Bgpv4Rib(null, BgpTieBreaker.ROUTER_ID, 1, null);
   }
 
   @Test
   public void testParameterValidationMaxPaths() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid max-paths value");
-    new Bgpv4Rib(null, null, BgpTieBreaker.ARRIVAL_ORDER, 0, null);
+    new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 0, null);
   }
 
   @Test
   public void testParameterValidationMatchMode() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Multipath AS-Path-Match-mode must be specified");
-    new Bgpv4Rib(null, null, BgpTieBreaker.ARRIVAL_ORDER, 2, null);
+    new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 2, null);
   }
 
   @Test
   public void testParameterValidationMatchModeNullMaxPaths() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Multipath AS-Path-Match-mode must be specified");
-    new Bgpv4Rib(null, null, BgpTieBreaker.ARRIVAL_ORDER, null, null);
+    new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, null, null);
   }
 
   @Test
   public void testIsMultipath() {
-    Bgpv4Rib rib = new Bgpv4Rib(null, null, BgpTieBreaker.ARRIVAL_ORDER, 1, null);
+    Bgpv4Rib rib = new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 1, null);
     assertTrue("MaxPaths=1, not multipath", !rib.isMultipath());
     rib =
         new Bgpv4Rib(
-            null,
-            null,
-            BgpTieBreaker.ARRIVAL_ORDER,
-            2,
-            MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ARRIVAL_ORDER, 2, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
     assertTrue("Maxpaths=2 -> multipath", rib.isMultipath());
     rib =
         new Bgpv4Rib(
-            null,
-            null,
-            BgpTieBreaker.ARRIVAL_ORDER,
-            null,
-            MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ARRIVAL_ORDER, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
     assertTrue("Maxpaths=null -> multipath", rib.isMultipath());
   }
 
@@ -214,11 +202,7 @@ public class Bgpv4RibTest {
 
     Bgpv4Rib rib =
         new Bgpv4Rib(
-            null,
-            mainRib,
-            BgpTieBreaker.ROUTER_ID,
-            null,
-            MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            mainRib, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
 
     Bgpv4Route worse = _rb.setNextHopIp(Ip.parse("5.5.5.6")).build();
     // Lower IGP cost to next hop is better
@@ -234,11 +218,7 @@ public class Bgpv4RibTest {
   public void testMultipathAsPathModeExactPath() {
     Bgpv4Rib rib =
         new Bgpv4Rib(
-            null,
-            null,
-            BgpTieBreaker.ROUTER_ID,
-            null,
-            MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
 
     Bgpv4Route base = _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 2L)).build();
     Bgpv4Route candidate1 =
@@ -257,7 +237,7 @@ public class Bgpv4RibTest {
   public void testMultipathAsPathModeFirstAs() {
     Bgpv4Rib rib =
         new Bgpv4Rib(
-            null, null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.FIRST_AS);
+            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.FIRST_AS);
 
     Bgpv4Route base = _rb.setAsPath(AsPath.ofSingletonAsSets(1L, 2L)).build();
     Bgpv4Route candidate1 =
@@ -286,11 +266,7 @@ public class Bgpv4RibTest {
   public void testMultipathArrivalOrder() {
     _multiPathRib =
         new Bgpv4Rib(
-            null,
-            null,
-            BgpTieBreaker.ARRIVAL_ORDER,
-            null,
-            MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ARRIVAL_ORDER, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
     Bgpv4Route best = _rb.build();
     Bgpv4Route earliest = _rb.setOriginatorIp(Ip.parse("2.2.2.2")).build();
     _multiPathRib.mergeRoute(earliest);
@@ -352,7 +328,7 @@ public class Bgpv4RibTest {
 
   @Test
   public void testBestPathsEqualRoutesForBestPathRib() {
-    Bgpv4Rib bestPathRib = new Bgpv4Rib(null, null, BgpTieBreaker.ROUTER_ID, 1, null);
+    Bgpv4Rib bestPathRib = new Bgpv4Rib(null, BgpTieBreaker.ROUTER_ID, 1, null);
     Bgpv4Route bestPath = _rb.build();
     bestPathRib.mergeRoute(_rb.setReceivedFromIp(Ip.parse("2.2.2.2")).build());
     bestPathRib.mergeRoute(_rb.setReceivedFromIp(Ip.parse("2.2.2.3")).build());
@@ -410,7 +386,7 @@ public class Bgpv4RibTest {
 
   @Test
   public void testBestPathSelectionTieBreakingArrivalOrder() {
-    _bestPathRib = new Bgpv4Rib(null, null, BgpTieBreaker.ARRIVAL_ORDER, 1, null);
+    _bestPathRib = new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 1, null);
     Bgpv4Route bestPath = _rb.build();
     _bestPathRib.mergeRoute(bestPath);
     // Oldest route should win despite newer having lower in Originator IP
@@ -504,8 +480,7 @@ public class Bgpv4RibTest {
             .build();
 
     Bgpv4Rib bmr =
-        new Bgpv4Rib(
-            null, null, BgpTieBreaker.ARRIVAL_ORDER, null, multipathEquivalentAsPathMatchMode);
+        new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, null, multipathEquivalentAsPathMatchMode);
 
     /*
      * Add routes to multipath RIB.
@@ -566,14 +541,10 @@ public class Bgpv4RibTest {
   public void testBgpCompareOriginType() {
     Bgpv4Rib bbr =
         new Bgpv4Rib(
-            null, null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
     Bgpv4Rib bmr =
         new Bgpv4Rib(
-            null,
-            null,
-            BgpTieBreaker.ROUTER_ID,
-            null,
-            MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
 
     Prefix p = Prefix.ZERO;
     Bgpv4Route.Builder b = new Bgpv4Route.Builder().setNetwork(p).setProtocol(RoutingProtocol.IBGP);
@@ -619,14 +590,10 @@ public class Bgpv4RibTest {
 
     Bgpv4Rib bbr =
         new Bgpv4Rib(
-            null, null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
     Bgpv4Rib bmr =
         new Bgpv4Rib(
-            null,
-            null,
-            BgpTieBreaker.ROUTER_ID,
-            null,
-            MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
     Ip ip1 = Ip.parse("1.0.0.0");
     Ip ip2 = Ip.parse("2.2.0.0");
     Bgpv4Route.Builder b1 =
@@ -692,15 +659,11 @@ public class Bgpv4RibTest {
     // good for both ebgp and ibgp
     Bgpv4Rib bmr =
         new Bgpv4Rib(
-            null,
-            null,
-            BgpTieBreaker.ROUTER_ID,
-            null,
-            MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
     // ebgp
     Bgpv4Rib ebgpBpr =
         new Bgpv4Rib(
-            null, null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
     Bgpv4Route.Builder ebgpBuilder =
         new Bgpv4Route.Builder()
             .setNetwork(Prefix.ZERO)
@@ -716,7 +679,7 @@ public class Bgpv4RibTest {
     // ibgp
     Bgpv4Rib ibgpBpr =
         new Bgpv4Rib(
-            null, null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, 1, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
     Bgpv4Route.Builder ibgpBuilder =
         new Bgpv4Route.Builder()
             .setNetwork(Prefix.ZERO)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
@@ -160,7 +160,8 @@ public class RibDeltaTest {
             null,
             BgpTieBreaker.CLUSTER_LIST_LENGTH,
             null,
-            MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH,
+            false);
     Bgpv4Route.Builder routeBuilder = new Bgpv4Route.Builder();
     routeBuilder
         .setNetwork(Prefix.create(Ip.parse("1.1.1.1"), Prefix.MAX_PREFIX_LENGTH))
@@ -193,7 +194,11 @@ public class RibDeltaTest {
   public void testImportRibExactRemoval() {
     Bgpv4Rib rib =
         new Bgpv4Rib(
-            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null,
+            BgpTieBreaker.ROUTER_ID,
+            null,
+            MultipathEquivalentAsPathMatchMode.EXACT_PATH,
+            false);
     Bgpv4Route r1 =
         new Bgpv4Route.Builder()
             .setNetwork(Prefix.create(Ip.parse("1.1.1.1"), Prefix.MAX_PREFIX_LENGTH))

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibDeltaTest.java
@@ -158,7 +158,6 @@ public class RibDeltaTest {
     Bgpv4Rib rib =
         new Bgpv4Rib(
             null,
-            null,
             BgpTieBreaker.CLUSTER_LIST_LENGTH,
             null,
             MultipathEquivalentAsPathMatchMode.EXACT_PATH);
@@ -194,11 +193,7 @@ public class RibDeltaTest {
   public void testImportRibExactRemoval() {
     Bgpv4Rib rib =
         new Bgpv4Rib(
-            null,
-            null,
-            BgpTieBreaker.ROUTER_ID,
-            null,
-            MultipathEquivalentAsPathMatchMode.EXACT_PATH);
+            null, BgpTieBreaker.ROUTER_ID, null, MultipathEquivalentAsPathMatchMode.EXACT_PATH);
     Bgpv4Route r1 =
         new Bgpv4Route.Builder()
             .setNetwork(Prefix.create(Ip.parse("1.1.1.1"), Prefix.MAX_PREFIX_LENGTH))


### PR DESCRIPTION
1. Make backup routes manipulation private to the RIB and automatic on merge/remove
2. Do not rely on SortedSet in any way.

Note: This does not attempt to fix any incorrectly-initialized RIBs inside DP. Tested to ensure this has no behavior changes on a large complex network.