### PR TITLE
use annotations to generate property descriptors

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -312,6 +312,7 @@ public final class Configuration implements Serializable {
 
   /** Dictionary of all AS-path access-lists for this node. */
   @JsonProperty(PROP_AS_PATH_ACCESS_LISTS)
+  @PropertySpec(name = "property", description = "My property description", schema = "String")
   public NavigableMap<String, AsPathAccessList> getAsPathAccessLists() {
     return _asPathAccessLists;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PropertySpec.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PropertySpec.java
@@ -1,0 +1,16 @@
+package org.batfish.datamodel;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PropertySpec {
+  String name();
+
+  String description();
+
+  String schema();
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/Schema.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/Schema.java
@@ -105,7 +105,11 @@ public class Schema {
   @Nonnull private final Type _type;
 
   @JsonCreator
-  Schema(String schema) {
+  private static Schema create(String schema) {
+    return new Schema(schema);
+  }
+
+  public Schema(String schema) {
 
     // base case
     Schema innerSchema = null;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
@@ -3,14 +3,12 @@ package org.batfish.datamodel.questions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.answers.Schema;
 
 /**
  * Enables specification a set of node properties.
@@ -65,115 +63,129 @@ public class NodePropertySpecifier extends PropertySpecifier {
   public static final String ZONES = "Zones";
 
   public static Map<String, PropertyDescriptor<Configuration>> JAVA_MAP =
-      new ImmutableMap.Builder<String, PropertyDescriptor<Configuration>>()
-          .put(
-              AS_PATH_ACCESS_LISTS,
-              new PropertyDescriptor<>(
-                  Configuration::getAsPathAccessLists, Schema.set(Schema.STRING)))
-          .put(
-              AUTHENTICATION_KEY_CHAINS,
-              new PropertyDescriptor<>(
-                  Configuration::getAuthenticationKeyChains, Schema.set(Schema.STRING)))
-          .put(CANONICAL_IP, new PropertyDescriptor<>(Configuration::getCanonicalIp, Schema.IP))
-          .put(
-              COMMUNITY_LISTS,
-              new PropertyDescriptor<>(Configuration::getCommunityLists, Schema.set(Schema.STRING)))
-          .put(
-              CONFIGURATION_FORMAT,
-              new PropertyDescriptor<>(Configuration::getConfigurationFormat, Schema.STRING))
-          .put(
-              DEFAULT_CROSS_ZONE_ACTION,
-              new PropertyDescriptor<>(Configuration::getDefaultCrossZoneAction, Schema.STRING))
-          .put(
-              DEFAULT_INBOUND_ACTION,
-              new PropertyDescriptor<>(Configuration::getDefaultInboundAction, Schema.STRING))
-          .put(DEVICE_TYPE, new PropertyDescriptor<>(Configuration::getDeviceType, Schema.STRING))
-          .put(
-              DNS_SERVERS,
-              new PropertyDescriptor<>(Configuration::getDnsServers, Schema.set(Schema.STRING)))
-          .put(
-              DNS_SOURCE_INTERFACE,
-              new PropertyDescriptor<>(Configuration::getDnsSourceInterface, Schema.STRING))
-          .put(DOMAIN_NAME, new PropertyDescriptor<>(Configuration::getDomainName, Schema.STRING))
-          .put(HOSTNAME, new PropertyDescriptor<>(Configuration::getHostname, Schema.STRING))
-          .put(
-              IKE_PHASE1_KEYS,
-              new PropertyDescriptor<>(Configuration::getIkePhase1Keys, Schema.set(Schema.STRING)))
-          .put(
-              IKE_PHASE1_POLICIES,
-              new PropertyDescriptor<>(
-                  Configuration::getIkePhase1Policies, Schema.set(Schema.STRING)))
-          .put(
-              IKE_PHASE1_PROPOSALS,
-              new PropertyDescriptor<>(
-                  Configuration::getIkePhase1Proposals, Schema.set(Schema.STRING)))
-          .put(
-              INTERFACES,
-              new PropertyDescriptor<>(Configuration::getAllInterfaces, Schema.set(Schema.STRING)))
-          .put(
-              IP_ACCESS_LISTS,
-              new PropertyDescriptor<>(Configuration::getIpAccessLists, Schema.set(Schema.STRING)))
-          .put(
-              IP_SPACES,
-              new PropertyDescriptor<>(Configuration::getIpSpaces, Schema.set(Schema.STRING)))
-          .put(
-              IP_6_ACCESS_LISTS,
-              new PropertyDescriptor<>(Configuration::getIp6AccessLists, Schema.set(Schema.STRING)))
-          .put(
-              IPSEC_PEER_CONFIGS,
-              new PropertyDescriptor<>(
-                  Configuration::getIpsecPeerConfigs, Schema.set(Schema.STRING)))
-          .put(
-              IPSEC_PHASE2_POLICIES,
-              new PropertyDescriptor<>(
-                  Configuration::getIpsecPhase2Policies, Schema.set(Schema.STRING)))
-          .put(
-              IPSEC_PHASE2_PROPOSALS,
-              new PropertyDescriptor<>(
-                  Configuration::getIpsecPhase2Proposals, Schema.set(Schema.STRING)))
-          .put(
-              LOGGING_SERVERS,
-              new PropertyDescriptor<>(Configuration::getLoggingServers, Schema.set(Schema.STRING)))
-          .put(
-              LOGGING_SOURCE_INTERFACE,
-              new PropertyDescriptor<>(Configuration::getLoggingSourceInterface, Schema.STRING))
-          .put(
-              NTP_SERVERS,
-              new PropertyDescriptor<>(Configuration::getNtpServers, Schema.set(Schema.STRING)))
-          .put(
-              NTP_SOURCE_INTERFACE,
-              new PropertyDescriptor<>(Configuration::getNtpSourceInterface, Schema.STRING))
-          .put(
-              ROUTE_FILTER_LISTS,
-              new PropertyDescriptor<>(
-                  Configuration::getRouteFilterLists, Schema.set(Schema.STRING)))
-          .put(
-              ROUTE_6_FILTER_LISTS,
-              new PropertyDescriptor<>(
-                  Configuration::getRoute6FilterLists, Schema.set(Schema.STRING)))
-          .put(
-              ROUTING_POLICIES,
-              new PropertyDescriptor<>(
-                  Configuration::getRoutingPolicies, Schema.set(Schema.STRING)))
-          .put(
-              SNMP_SOURCE_INTERFACE,
-              new PropertyDescriptor<>(Configuration::getSnmpSourceInterface, Schema.STRING))
-          .put(
-              SNMP_TRAP_SERVERS,
-              new PropertyDescriptor<>(
-                  Configuration::getSnmpTrapServers, Schema.set(Schema.STRING)))
-          .put(
-              TACACS_SERVERS,
-              new PropertyDescriptor<>(Configuration::getTacacsServers, Schema.set(Schema.STRING)))
-          .put(
-              TACACS_SOURCE_INTERFACE,
-              new PropertyDescriptor<>(Configuration::getTacacsSourceInterface, Schema.STRING))
-          .put(
-              VENDOR_FAMILY,
-              new PropertyDescriptor<>(Configuration::getVendorFamily, Schema.STRING))
-          .put(VRFS, new PropertyDescriptor<>(Configuration::getVrfs, Schema.set(Schema.STRING)))
-          .put(ZONES, new PropertyDescriptor<>(Configuration::getZones, Schema.set(Schema.STRING)))
-          .build();
+      initPropertyMap(Configuration.class);
+
+  //  public static Map<String, PropertyDescriptor<Configuration>> JAVA_MAP =
+  //      new ImmutableMap.Builder<String, PropertyDescriptor<Configuration>>()
+  //          .put(
+  //              AS_PATH_ACCESS_LISTS,
+  //              new PropertyDescriptor<>(
+  //                  Configuration::getAsPathAccessLists, Schema.set(Schema.STRING)))
+  //          .put(
+  //              AUTHENTICATION_KEY_CHAINS,
+  //              new PropertyDescriptor<>(
+  //                  Configuration::getAuthenticationKeyChains, Schema.set(Schema.STRING)))
+  //          .put(CANONICAL_IP, new PropertyDescriptor<>(Configuration::getCanonicalIp, Schema.IP))
+  //          .put(
+  //              COMMUNITY_LISTS,
+  //              new PropertyDescriptor<>(Configuration::getCommunityLists,
+  // Schema.set(Schema.STRING)))
+  //          .put(
+  //              CONFIGURATION_FORMAT,
+  //              new PropertyDescriptor<>(Configuration::getConfigurationFormat, Schema.STRING))
+  //          .put(
+  //              DEFAULT_CROSS_ZONE_ACTION,
+  //              new PropertyDescriptor<>(Configuration::getDefaultCrossZoneAction, Schema.STRING))
+  //          .put(
+  //              DEFAULT_INBOUND_ACTION,
+  //              new PropertyDescriptor<>(Configuration::getDefaultInboundAction, Schema.STRING))
+  //          .put(DEVICE_TYPE, new PropertyDescriptor<>(Configuration::getDeviceType,
+  // Schema.STRING))
+  //          .put(
+  //              DNS_SERVERS,
+  //              new PropertyDescriptor<>(Configuration::getDnsServers, Schema.set(Schema.STRING)))
+  //          .put(
+  //              DNS_SOURCE_INTERFACE,
+  //              new PropertyDescriptor<>(Configuration::getDnsSourceInterface, Schema.STRING))
+  //          .put(DOMAIN_NAME, new PropertyDescriptor<>(Configuration::getDomainName,
+  // Schema.STRING))
+  //          .put(HOSTNAME, new PropertyDescriptor<>(Configuration::getHostname, Schema.STRING))
+  //          .put(
+  //              IKE_PHASE1_KEYS,
+  //              new PropertyDescriptor<>(Configuration::getIkePhase1Keys,
+  // Schema.set(Schema.STRING)))
+  //          .put(
+  //              IKE_PHASE1_POLICIES,
+  //              new PropertyDescriptor<>(
+  //                  Configuration::getIkePhase1Policies, Schema.set(Schema.STRING)))
+  //          .put(
+  //              IKE_PHASE1_PROPOSALS,
+  //              new PropertyDescriptor<>(
+  //                  Configuration::getIkePhase1Proposals, Schema.set(Schema.STRING)))
+  //          .put(
+  //              INTERFACES,
+  //              new PropertyDescriptor<>(Configuration::getAllInterfaces,
+  // Schema.set(Schema.STRING)))
+  //          .put(
+  //              IP_ACCESS_LISTS,
+  //              new PropertyDescriptor<>(Configuration::getIpAccessLists,
+  // Schema.set(Schema.STRING)))
+  //          .put(
+  //              IP_SPACES,
+  //              new PropertyDescriptor<>(Configuration::getIpSpaces, Schema.set(Schema.STRING)))
+  //          .put(
+  //              IP_6_ACCESS_LISTS,
+  //              new PropertyDescriptor<>(Configuration::getIp6AccessLists,
+  // Schema.set(Schema.STRING)))
+  //          .put(
+  //              IPSEC_PEER_CONFIGS,
+  //              new PropertyDescriptor<>(
+  //                  Configuration::getIpsecPeerConfigs, Schema.set(Schema.STRING)))
+  //          .put(
+  //              IPSEC_PHASE2_POLICIES,
+  //              new PropertyDescriptor<>(
+  //                  Configuration::getIpsecPhase2Policies, Schema.set(Schema.STRING)))
+  //          .put(
+  //              IPSEC_PHASE2_PROPOSALS,
+  //              new PropertyDescriptor<>(
+  //                  Configuration::getIpsecPhase2Proposals, Schema.set(Schema.STRING)))
+  //          .put(
+  //              LOGGING_SERVERS,
+  //              new PropertyDescriptor<>(Configuration::getLoggingServers,
+  // Schema.set(Schema.STRING)))
+  //          .put(
+  //              LOGGING_SOURCE_INTERFACE,
+  //              new PropertyDescriptor<>(Configuration::getLoggingSourceInterface, Schema.STRING))
+  //          .put(
+  //              NTP_SERVERS,
+  //              new PropertyDescriptor<>(Configuration::getNtpServers, Schema.set(Schema.STRING)))
+  //          .put(
+  //              NTP_SOURCE_INTERFACE,
+  //              new PropertyDescriptor<>(Configuration::getNtpSourceInterface, Schema.STRING))
+  //          .put(
+  //              ROUTE_FILTER_LISTS,
+  //              new PropertyDescriptor<>(
+  //                  Configuration::getRouteFilterLists, Schema.set(Schema.STRING)))
+  //          .put(
+  //              ROUTE_6_FILTER_LISTS,
+  //              new PropertyDescriptor<>(
+  //                  Configuration::getRoute6FilterLists, Schema.set(Schema.STRING)))
+  //          .put(
+  //              ROUTING_POLICIES,
+  //              new PropertyDescriptor<>(
+  //                  Configuration::getRoutingPolicies, Schema.set(Schema.STRING)))
+  //          .put(
+  //              SNMP_SOURCE_INTERFACE,
+  //              new PropertyDescriptor<>(Configuration::getSnmpSourceInterface, Schema.STRING))
+  //          .put(
+  //              SNMP_TRAP_SERVERS,
+  //              new PropertyDescriptor<>(
+  //                  Configuration::getSnmpTrapServers, Schema.set(Schema.STRING)))
+  //          .put(
+  //              TACACS_SERVERS,
+  //              new PropertyDescriptor<>(Configuration::getTacacsServers,
+  // Schema.set(Schema.STRING)))
+  //          .put(
+  //              TACACS_SOURCE_INTERFACE,
+  //              new PropertyDescriptor<>(Configuration::getTacacsSourceInterface, Schema.STRING))
+  //          .put(
+  //              VENDOR_FAMILY,
+  //              new PropertyDescriptor<>(Configuration::getVendorFamily, Schema.STRING))
+  //          .put(VRFS, new PropertyDescriptor<>(Configuration::getVrfs,
+  // Schema.set(Schema.STRING)))
+  //          .put(ZONES, new PropertyDescriptor<>(Configuration::getZones,
+  // Schema.set(Schema.STRING)))
+  //          .build();
 
   public static final NodePropertySpecifier ALL = new NodePropertySpecifier(".*");
 

--- a/projects/question/src/main/java/org/batfish/question/nodeproperties/NodePropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/nodeproperties/NodePropertiesAnswerer.java
@@ -1,5 +1,7 @@
 package org.batfish.question.nodeproperties;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multiset;
@@ -48,7 +50,9 @@ public class NodePropertiesAnswerer extends Answerer {
                         new ColumnMetadata(
                             getColumnName(prop),
                             NodePropertySpecifier.JAVA_MAP.get(prop).getSchema(),
-                            "Property " + prop,
+                            firstNonNull(
+                                NodePropertySpecifier.JAVA_MAP.get(prop).getDescription(),
+                                "Property " + prop),
                             false,
                             true))
                 .collect(Collectors.toList()))


### PR DESCRIPTION
It is not a complete PR but I am curious if you have any thoughts/objections on this way of doing things: 
1/ Generate the property descriptor map using annotations on methods instead of separate listings
2/ Extend the PropertyDescriptor to include a description, which can then be embedded into the column metadata. 

The main motivation is to be able to attach useful descriptions, and I wanted to avoid doing so in the out of band map as we were doing thus far. 
