### PR TITLE
Remove comparable from AbstractRoute

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
@@ -15,9 +15,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * A base class for all types of routes supported in the dataplane computation, making this the most
  * general route type available. "Main" non-protocol-specific RIBs store and reason about this type
  * of route.
- *
- * <p><i>Note:</i> This class implements {@link Comparable} because we put AbstractRoute in ordered
- * collections all throughout the codebase.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 @ParametersAreNonnullByDefault

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteDecorator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteDecorator.java
@@ -4,14 +4,10 @@ package org.batfish.datamodel;
  * Interface for classes that contain an instance of an {@link AbstractRoute}.
  *
  * <p><i>Note:</i> This class implements {@link Comparable} because we put AbstractRouteDecorator in
- * ordered collections all throughout the codebase. {@link #compareTo(AbstractRouteDecorator)} has
- * <b>NO</b> impact on route preference.
+ * ordered collections all throughout the codebase.
  */
-public interface AbstractRouteDecorator extends Comparable<AbstractRouteDecorator> {
+public interface AbstractRouteDecorator {
   AbstractRoute getAbstractRoute();
 
   Prefix getNetwork();
-
-  @Override
-  int compareTo(AbstractRouteDecorator o);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteDecorator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteDecorator.java
@@ -1,11 +1,6 @@
 package org.batfish.datamodel;
 
-/**
- * Interface for classes that contain an instance of an {@link AbstractRoute}.
- *
- * <p><i>Note:</i> This class implements {@link Comparable} because we put AbstractRouteDecorator in
- * ordered collections all throughout the codebase.
- */
+/** Interface for classes that contain an instance of an {@link AbstractRoute}. */
 public interface AbstractRouteDecorator {
   AbstractRoute getAbstractRoute();
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AnnotatedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AnnotatedRoute.java
@@ -24,20 +24,6 @@ public final class AnnotatedRoute<R extends AbstractRoute>
   }
 
   @Override
-  public final int compareTo(AbstractRouteDecorator o) {
-    int routeComparison = _route.compareTo(o.getAbstractRoute());
-    if (routeComparison != 0) {
-      return routeComparison;
-    }
-    if (!(o instanceof AnnotatedRoute)) {
-      // Routes are equal; AbstractRoutes arbitrarily come before AnnotatedRoutes
-      return 1;
-    }
-    AnnotatedRoute<?> other = (AnnotatedRoute<?>) o;
-    return _sourceVrf.compareTo(other._sourceVrf);
-  }
-
-  @Override
   public AbstractRoute getAbstractRoute() {
     return _route;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Bgpv4Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Bgpv4Route.java
@@ -205,14 +205,6 @@ public final class Bgpv4Route extends BgpRoute {
           .thenComparing(Bgpv4Route::getWeight);
 
   @Override
-  public int routeCompare(@Nonnull AbstractRoute rhs) {
-    if (getClass() != rhs.getClass()) {
-      return 0;
-    }
-    return COMPARATOR.compare(this, (Bgpv4Route) rhs);
-  }
-
-  @Override
   public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Bgpv4Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Bgpv4Route.java
@@ -5,9 +5,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.Comparators;
-import com.google.common.collect.Ordering;
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
@@ -187,22 +184,6 @@ public final class Bgpv4Route extends BgpRoute {
         .setSrcProtocol(_srcProtocol)
         .setWeight(_weight);
   }
-
-  private static final Comparator<Bgpv4Route> COMPARATOR =
-      Comparator.comparing(Bgpv4Route::getAsPath)
-          .thenComparing(
-              Bgpv4Route::getClusterList, Comparators.lexicographical(Ordering.natural()))
-          .thenComparing(
-              Bgpv4Route::getCommunities, Comparators.lexicographical(Ordering.natural()))
-          .thenComparing(Bgpv4Route::getDiscard)
-          .thenComparing(Bgpv4Route::getLocalPreference)
-          .thenComparing(Bgpv4Route::getNextHopInterface)
-          .thenComparing(Bgpv4Route::getOriginType)
-          .thenComparing(Bgpv4Route::getOriginatorIp)
-          .thenComparing(Bgpv4Route::getReceivedFromIp)
-          .thenComparing(Bgpv4Route::getReceivedFromRouteReflectorClient)
-          .thenComparing(Bgpv4Route::getSrcProtocol)
-          .thenComparing(Bgpv4Route::getWeight);
 
   @Override
   public boolean equals(@Nullable Object o) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRoute.java
@@ -92,11 +92,6 @@ public final class ConnectedRoute extends AbstractRoute {
   }
 
   @Override
-  public int routeCompare(@Nonnull AbstractRoute rhs) {
-    return 0;
-  }
-
-  @Override
   public Builder toBuilder() {
     return builder()
         .setNetwork(getNetwork())

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpRoute.java
@@ -84,9 +84,4 @@ public abstract class EigrpRoute extends AbstractRoute {
     // https://github.com/batfish/batfish/issues/1945
     return NO_TAG;
   }
-
-  @Override
-  public int routeCompare(@Nonnull AbstractRoute rhs) {
-    return 0;
-  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType2Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType2Route.java
@@ -5,10 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.Comparators;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Ordering;
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
@@ -100,25 +97,6 @@ public final class EvpnType2Route extends EvpnRoute {
 
   private static final String PROP_IP = "ip";
   private static final String PROP_MAC_ADDRESS = "macAddress";
-
-  private static final Comparator<EvpnType2Route> COMPARATOR =
-      Comparator.comparing(EvpnType2Route::getAsPath)
-          .thenComparing(
-              EvpnType2Route::getClusterList, Comparators.lexicographical(Ordering.natural()))
-          .thenComparing(
-              EvpnType2Route::getCommunities, Comparators.lexicographical(Ordering.natural()))
-          .thenComparing(EvpnType2Route::getDiscard)
-          .thenComparing(EvpnType2Route::getIp)
-          .thenComparing(EvpnType2Route::getLocalPreference)
-          .thenComparing(EvpnType2Route::getMacAddress)
-          .thenComparing(EvpnType2Route::getNextHopInterface)
-          .thenComparing(EvpnType2Route::getOriginType)
-          .thenComparing(EvpnType2Route::getOriginatorIp)
-          .thenComparing(EvpnType2Route::getReceivedFromIp)
-          .thenComparing(EvpnType2Route::getReceivedFromRouteReflectorClient)
-          .thenComparing(EvpnType2Route::getRouteDistinguisher)
-          .thenComparing(EvpnType2Route::getSrcProtocol)
-          .thenComparing(EvpnType2Route::getWeight);
 
   @Nonnull private final Ip _ip;
   @Nullable private final MacAddress _macAddress;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType2Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType2Route.java
@@ -329,12 +329,4 @@ public final class EvpnType2Route extends EvpnRoute {
     }
     return h;
   }
-
-  @Override
-  public int routeCompare(@Nonnull AbstractRoute rhs) {
-    if (getClass() != rhs.getClass()) {
-      return 0;
-    }
-    return COMPARATOR.compare(this, (EvpnType2Route) rhs);
-  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType3Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType3Route.java
@@ -302,12 +302,4 @@ public final class EvpnType3Route extends EvpnRoute {
     }
     return h;
   }
-
-  @Override
-  public int routeCompare(@Nonnull AbstractRoute rhs) {
-    if (getClass() != rhs.getClass()) {
-      return 0;
-    }
-    return COMPARATOR.compare(this, (EvpnType3Route) rhs);
-  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType3Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType3Route.java
@@ -5,10 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.Comparators;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Ordering;
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
@@ -86,24 +83,6 @@ public final class EvpnType3Route extends EvpnRoute {
   }
 
   private static final String PROP_VNI_IP = "vniIp";
-
-  private static final Comparator<EvpnType3Route> COMPARATOR =
-      Comparator.comparing(EvpnType3Route::getAsPath)
-          .thenComparing(
-              EvpnType3Route::getClusterList, Comparators.lexicographical(Ordering.natural()))
-          .thenComparing(
-              EvpnType3Route::getCommunities, Comparators.lexicographical(Ordering.natural()))
-          .thenComparing(EvpnType3Route::getDiscard)
-          .thenComparing(EvpnType3Route::getLocalPreference)
-          .thenComparing(EvpnType3Route::getNextHopInterface)
-          .thenComparing(EvpnType3Route::getOriginType)
-          .thenComparing(EvpnType3Route::getOriginatorIp)
-          .thenComparing(EvpnType3Route::getReceivedFromIp)
-          .thenComparing(EvpnType3Route::getReceivedFromRouteReflectorClient)
-          .thenComparing(EvpnType3Route::getRouteDistinguisher)
-          .thenComparing(EvpnType3Route::getSrcProtocol)
-          .thenComparing(EvpnType3Route::getVniIp)
-          .thenComparing(EvpnType3Route::getWeight);
 
   @Nonnull private final Ip _vniIp;
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType5Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType5Route.java
@@ -273,12 +273,4 @@ public final class EvpnType5Route extends EvpnRoute {
     }
     return h;
   }
-
-  @Override
-  public int routeCompare(@Nonnull AbstractRoute rhs) {
-    if (getClass() != rhs.getClass()) {
-      return 0;
-    }
-    return COMPARATOR.compare(this, (EvpnType5Route) rhs);
-  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType5Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType5Route.java
@@ -5,10 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.Comparators;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Ordering;
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
@@ -72,23 +69,6 @@ public final class EvpnType5Route extends EvpnRoute {
       return this;
     }
   }
-
-  private static final Comparator<EvpnType5Route> COMPARATOR =
-      Comparator.comparing(EvpnType5Route::getAsPath)
-          .thenComparing(
-              EvpnType5Route::getClusterList, Comparators.lexicographical(Ordering.natural()))
-          .thenComparing(
-              EvpnType5Route::getCommunities, Comparators.lexicographical(Ordering.natural()))
-          .thenComparing(EvpnType5Route::getDiscard)
-          .thenComparing(EvpnType5Route::getLocalPreference)
-          .thenComparing(EvpnType5Route::getNextHopInterface)
-          .thenComparing(EvpnType5Route::getOriginType)
-          .thenComparing(EvpnType5Route::getOriginatorIp)
-          .thenComparing(EvpnType5Route::getReceivedFromIp)
-          .thenComparing(EvpnType5Route::getReceivedFromRouteReflectorClient)
-          .thenComparing(EvpnType5Route::getRouteDistinguisher)
-          .thenComparing(EvpnType5Route::getSrcProtocol)
-          .thenComparing(EvpnType5Route::getWeight);
 
   /* Cache the hashcode */
   private transient int _hashCode = 0;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
@@ -21,7 +21,26 @@ import org.batfish.datamodel.bgp.community.Community;
 
 /** A generated/aggregate IPV4 route. */
 @ParametersAreNonnullByDefault
-public final class GeneratedRoute extends AbstractRoute {
+public final class GeneratedRoute extends AbstractRoute implements Comparable<GeneratedRoute> {
+
+  // The comparator has no impact on route preference in RIBs and should not be used as such
+  private static final Comparator<GeneratedRoute> COMPARATOR =
+      Comparator.comparing(GeneratedRoute::getNetwork)
+          .thenComparing(GeneratedRoute::getNextHopIp)
+          .thenComparing(GeneratedRoute::getNextHopInterface)
+          .thenComparing(GeneratedRoute::getMetric)
+          .thenComparing(GeneratedRoute::getAdministrativeCost)
+          .thenComparing(GeneratedRoute::getTag)
+          .thenComparing(GeneratedRoute::getNonRouting)
+          .thenComparing(GeneratedRoute::getNonForwarding)
+          .thenComparing(GeneratedRoute::getAsPath)
+          .thenComparing(
+              GeneratedRoute::getAttributePolicy, Comparator.nullsLast(String::compareTo))
+          .thenComparing(
+              GeneratedRoute::getCommunities, Comparators.lexicographical(Ordering.natural()))
+          .thenComparing(GeneratedRoute::getDiscard)
+          .thenComparing(
+              GeneratedRoute::getGenerationPolicy, Comparator.nullsLast(String::compareTo));
 
   /** A {@link GeneratedRoute} builder */
   public static class Builder extends AbstractRouteBuilder<Builder, GeneratedRoute> {
@@ -295,18 +314,9 @@ public final class GeneratedRoute extends AbstractRoute {
   }
 
   @Override
-  public int routeCompare(@Nonnull AbstractRoute rhs) {
-    if (getClass() != rhs.getClass()) {
-      return 0;
-    }
-    GeneratedRoute castRhs = (GeneratedRoute) rhs;
-    return Comparator.comparing(GeneratedRoute::getAsPath)
-        .thenComparing(GeneratedRoute::getAttributePolicy, Comparator.nullsLast(String::compareTo))
-        .thenComparing(
-            GeneratedRoute::getCommunities, Comparators.lexicographical(Ordering.natural()))
-        .thenComparing(GeneratedRoute::getDiscard)
-        .thenComparing(GeneratedRoute::getGenerationPolicy, Comparator.nullsLast(String::compareTo))
-        .compare(this, castRhs);
+  public int compareTo(GeneratedRoute rhs) {
+    // The comparator has no impact on route preference in RIBs and should not be used as such
+    return COMPARATOR.compare(this, rhs);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
@@ -22,8 +22,8 @@ import org.batfish.datamodel.bgp.community.Community;
 /**
  * A generated/aggregate IPV4 route.
  *
- * <p>Implements {@link Comparable}, but {@link #compareTo(GeneratedRoute)} <emph>should not</emph>
- * be used for determining route preference in RIBs.
+ * <p>Implements {@link Comparable}, but {@link #compareTo(GeneratedRoute)} <em>should not</em> be
+ * used for determining route preference in RIBs.
  */
 @ParametersAreNonnullByDefault
 public final class GeneratedRoute extends AbstractRoute implements Comparable<GeneratedRoute> {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
@@ -19,7 +19,12 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.bgp.community.Community;
 
-/** A generated/aggregate IPV4 route. */
+/**
+ * A generated/aggregate IPV4 route.
+ *
+ * <p>Implements {@link Comparable}, but {@link #compareTo(GeneratedRoute)} <emph>should not</emph>
+ * be used for determining route preference in RIBs.
+ */
 @ParametersAreNonnullByDefault
 public final class GeneratedRoute extends AbstractRoute implements Comparable<GeneratedRoute> {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Comparator;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.isis.IsisLevel;
@@ -296,20 +295,5 @@ public class IsisRoute extends AbstractRoute {
   @Override
   public int getTag() {
     return NO_TAG;
-  }
-
-  @Override
-  public int routeCompare(@Nonnull AbstractRoute rhs) {
-    if (getClass() != rhs.getClass()) {
-      return 0;
-    }
-    IsisRoute castRhs = (IsisRoute) rhs;
-    return Comparator.comparing(IsisRoute::getArea)
-        .thenComparing(IsisRoute::getAttach)
-        .thenComparing(IsisRoute::getDown)
-        .thenComparing(IsisRoute::getLevel)
-        .thenComparing(IsisRoute::getOverload)
-        .thenComparing(IsisRoute::getSystemId)
-        .compare(this, castRhs);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/KernelRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/KernelRoute.java
@@ -9,7 +9,12 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-/** Non-routing virtual route used for advertisement */
+/**
+ * Non-routing virtual route used for advertisement.
+ *
+ * <p>Implements {@link Comparable}, but {@link #compareTo(KernelRoute)} <emph>should not</emph> be
+ * used for determining route preference in RIBs.
+ */
 @ParametersAreNonnullByDefault
 public final class KernelRoute extends AbstractRoute implements Comparable<KernelRoute> {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/KernelRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/KernelRoute.java
@@ -12,8 +12,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 /**
  * Non-routing virtual route used for advertisement.
  *
- * <p>Implements {@link Comparable}, but {@link #compareTo(KernelRoute)} <emph>should not</emph> be
- * used for determining route preference in RIBs.
+ * <p>Implements {@link Comparable}, but {@link #compareTo(KernelRoute)} <em>should not</em> be used
+ * for determining route preference in RIBs.
  */
 @ParametersAreNonnullByDefault
 public final class KernelRoute extends AbstractRoute implements Comparable<KernelRoute> {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/KernelRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/KernelRoute.java
@@ -4,13 +4,25 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Comparator;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /** Non-routing virtual route used for advertisement */
 @ParametersAreNonnullByDefault
-public final class KernelRoute extends AbstractRoute {
+public final class KernelRoute extends AbstractRoute implements Comparable<KernelRoute> {
+
+  // The comparator has no impact on route preference in RIBs and should not be used as such
+  private static final Comparator<KernelRoute> COMPARATOR =
+      Comparator.comparing(KernelRoute::getNetwork)
+          .thenComparing(KernelRoute::getNextHopIp)
+          .thenComparing(KernelRoute::getNextHopInterface)
+          .thenComparing(KernelRoute::getMetric)
+          .thenComparing(KernelRoute::getAdministrativeCost)
+          .thenComparing(KernelRoute::getTag)
+          .thenComparing(KernelRoute::getNonRouting)
+          .thenComparing(KernelRoute::getNonForwarding);
 
   /** Builder for {@link KernelRoute} */
   public static final class Builder extends AbstractRouteBuilder<Builder, KernelRoute> {
@@ -63,12 +75,18 @@ public final class KernelRoute extends AbstractRoute {
   }
 
   @Override
+  public int compareTo(KernelRoute o) {
+    // The comparator has no impact on route preference in RIBs and should not be used as such
+    return COMPARATOR.compare(this, o);
+  }
+
+  @Override
   public Long getMetric() {
     return 0L;
   }
 
   @JsonProperty(PROP_NEXT_HOP_INTERFACE)
-  @Nullable
+  @Nonnull
   @Override
   public String getNextHopInterface() {
     return Route.UNSET_NEXT_HOP_INTERFACE;
@@ -88,11 +106,6 @@ public final class KernelRoute extends AbstractRoute {
   @Override
   public int getTag() {
     return NO_TAG;
-  }
-
-  @Override
-  public int routeCompare(@Nonnull AbstractRoute rhs) {
-    return 0;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/LocalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/LocalRoute.java
@@ -116,14 +116,6 @@ public final class LocalRoute extends AbstractRoute {
   }
 
   @Override
-  public int routeCompare(@Nonnull AbstractRoute rhs) {
-    if (getClass() != rhs.getClass()) {
-      return 0;
-    }
-    return Integer.compare(_sourcePrefixLength, ((LocalRoute) rhs)._sourcePrefixLength);
-  }
-
-  @Override
   public AbstractRouteBuilder<Builder, LocalRoute> toBuilder() {
     return builder()
         .setNetwork(getNetwork())

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType1Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType1Route.java
@@ -81,11 +81,6 @@ public class OspfExternalType1Route extends OspfExternalRoute {
   }
 
   @Override
-  public int routeCompare(@Nonnull AbstractRoute rhs) {
-    return 0;
-  }
-
-  @Override
   public OspfExternalRoute.Builder toBuilder() {
     return OspfExternalRoute.builder()
         // AbstractRoute properties

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType2Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalType2Route.java
@@ -81,15 +81,6 @@ public class OspfExternalType2Route extends OspfExternalRoute {
   }
 
   @Override
-  public int routeCompare(AbstractRoute rhs) {
-    if (getClass() != rhs.getClass()) {
-      return 0;
-    }
-    OspfExternalType2Route castRhs = (OspfExternalType2Route) rhs;
-    return Long.compare(getCostToAdvertiser(), castRhs.getCostToAdvertiser());
-  }
-
-  @Override
   public OspfExternalRoute.Builder toBuilder() {
     return OspfExternalRoute.builder()
         // AbstractRoute properties

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfInterAreaRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfInterAreaRoute.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
-import java.util.Comparator;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -71,15 +70,6 @@ public final class OspfInterAreaRoute extends OspfInternalRoute {
   @Override
   public int hashCode() {
     return Objects.hash(_network, _admin, _area, _metric, _nextHopIp);
-  }
-
-  @Override
-  public int routeCompare(AbstractRoute rhs) {
-    if (getClass() != rhs.getClass()) {
-      return 0;
-    }
-    OspfInterAreaRoute castRhs = (OspfInterAreaRoute) rhs;
-    return Comparator.comparing(OspfInterAreaRoute::getArea).compare(this, castRhs);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfIntraAreaRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfIntraAreaRoute.java
@@ -83,15 +83,6 @@ public class OspfIntraAreaRoute extends OspfInternalRoute {
   }
 
   @Override
-  public int routeCompare(AbstractRoute rhs) {
-    if (getClass() != rhs.getClass()) {
-      return 0;
-    }
-    OspfIntraAreaRoute castRhs = (OspfIntraAreaRoute) rhs;
-    return Long.compare(_area, castRhs._area);
-  }
-
-  @Override
   public Builder toBuilder() {
     return builder()
         // AbstractRoute properties

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RipInternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RipInternalRoute.java
@@ -2,7 +2,6 @@ package org.batfish.datamodel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Comparator;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -56,17 +55,6 @@ public class RipInternalRoute extends RipRoute {
   @Override
   public int getTag() {
     return NO_TAG;
-  }
-
-  @Override
-  public int routeCompare(@Nonnull AbstractRoute rhs) {
-    if (rhs instanceof RipInternalRoute) {
-      RipInternalRoute other = (RipInternalRoute) rhs;
-      return Comparator.comparing(RipInternalRoute::getNextHopIp)
-          .thenComparing(RipRoute::getMetric)
-          .compare(this, other);
-    }
-    return 0;
   }
 
   public static Builder builder() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -13,7 +13,12 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-/** A static route */
+/**
+ * A static route.
+ *
+ * <p>Implements {@link Comparable}, but {@link #compareTo(StaticRoute)} <emph>should not</emph> be
+ * used for determining route preference in RIBs.
+ */
 @ParametersAreNonnullByDefault
 public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute> {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -16,8 +16,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 /**
  * A static route.
  *
- * <p>Implements {@link Comparable}, but {@link #compareTo(StaticRoute)} <emph>should not</emph> be
- * used for determining route preference in RIBs.
+ * <p>Implements {@link Comparable}, but {@link #compareTo(StaticRoute)} <em>should not</em> be used
+ * for determining route preference in RIBs.
  */
 @ParametersAreNonnullByDefault
 public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute> {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -7,6 +7,7 @@ import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Comparator;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -14,7 +15,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 /** A static route */
 @ParametersAreNonnullByDefault
-public class StaticRoute extends AbstractRoute {
+public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute> {
 
   static final long DEFAULT_STATIC_ROUTE_METRIC = 0L;
   private static final long serialVersionUID = 1L;
@@ -24,6 +25,16 @@ public class StaticRoute extends AbstractRoute {
   @Nonnull private final String _nextHopInterface;
   @Nonnull private final Ip _nextHopIp;
   private final int _tag;
+  // The comparator has no impact on route preference in RIBs and should not be used as such
+  private static final Comparator<StaticRoute> COMPARATOR =
+      Comparator.comparing(StaticRoute::getNetwork)
+          .thenComparing(StaticRoute::getNextHopIp)
+          .thenComparing(StaticRoute::getNextHopInterface)
+          .thenComparing(StaticRoute::getMetric)
+          .thenComparing(StaticRoute::getAdministrativeCost)
+          .thenComparing(StaticRoute::getTag)
+          .thenComparing(StaticRoute::getNonRouting)
+          .thenComparing(StaticRoute::getNonForwarding);
 
   private transient int _hashCode;
 
@@ -139,8 +150,9 @@ public class StaticRoute extends AbstractRoute {
   }
 
   @Override
-  public int routeCompare(AbstractRoute rhs) {
-    return 0;
+  public int compareTo(StaticRoute o) {
+    // The comparator has no impact on route preference in RIBs and should not be used as such
+    return COMPARATOR.compare(this, o);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
@@ -18,7 +18,7 @@ public class MockRib implements GenericRib<AbstractRoute> {
     private Builder() {
       _longestPrefixMatchResults = ImmutableMap.of();
       _mergeRouteTrues = ImmutableSet.of();
-      _routePreferenceComparator = Comparator.naturalOrder();
+      _routePreferenceComparator = (a, b) -> 0;
       _routes = ImmutableSet.of();
     }
 

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -9223,24 +9223,6 @@
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 100,
-                "metric" : 0,
-                "network" : "0.0.0.0/0",
-                "nextHopInterface" : "Loopback66",
-                "nextHopIp" : "AUTO/NONE(-1l)",
-                "tag" : -1
-              },
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 150,
-                "metric" : 0,
-                "network" : "0.0.0.0/0",
-                "nextHopInterface" : "Loopback99",
-                "nextHopIp" : "AUTO/NONE(-1l)",
-                "tag" : -1
-              },
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
                 "administrativeCost" : 250,
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
@@ -9254,6 +9236,24 @@
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
                 "nextHopInterface" : "Dialer2",
+                "nextHopIp" : "AUTO/NONE(-1l)",
+                "tag" : -1
+              },
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 100,
+                "metric" : 0,
+                "network" : "0.0.0.0/0",
+                "nextHopInterface" : "Loopback66",
+                "nextHopIp" : "AUTO/NONE(-1l)",
+                "tag" : -1
+              },
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 150,
+                "metric" : 0,
+                "network" : "0.0.0.0/0",
+                "nextHopInterface" : "Loopback99",
                 "nextHopIp" : "AUTO/NONE(-1l)",
                 "tag" : -1
               },


### PR DESCRIPTION
* Routes across protocols have no meaningful ordering
* Removes confusion as to whether comparator can be used for route preference in RIBs (it cannot).
* Reduce potential bugs where I our comparators where potentially not consistent with equals
* Keep comparators that *are* consistent with equals for route types that we put into the datamodel/refs (static, kernel, generated).

Note: the existing ref change is just an order swap.