### PR TITLE
Cleanup blacklists

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import javax.annotation.Nonnull;
@@ -18,7 +17,6 @@ import org.batfish.common.topology.TopologyProvider;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Topology;
@@ -31,7 +29,6 @@ import org.batfish.datamodel.answers.ParseEnvironmentBgpTablesAnswerElement;
 import org.batfish.datamodel.answers.ParseEnvironmentRoutingTablesAnswerElement;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.collections.BgpAdvertisementsByVrf;
-import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.collections.RoutesByVrf;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.pojo.Environment;
@@ -189,18 +186,6 @@ public interface IBatfish extends IPluginConsumer {
 
   @Nullable
   String loadQuestionSettings(@Nonnull Question question);
-
-  /** Returns edge blacklist for given snapshot or empty set if absent. */
-  @Nonnull
-  SortedSet<Edge> getEdgeBlacklist(@Nonnull NetworkSnapshot networkSnapshot);
-
-  /** Returns interface blacklist for given snapshot or empty set if absent. */
-  @Nonnull
-  SortedSet<NodeInterfacePair> getInterfaceBlacklist(@Nonnull NetworkSnapshot networkSnapshot);
-
-  /** Returns node blacklist for given snapshot or empty set if absent. */
-  @Nonnull
-  SortedSet<String> getNodeBlacklist(@Nonnull NetworkSnapshot networkSnapshot);
 
   /** Performs bidirectional reachability analysis. */
   @Nonnull

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -47,7 +47,6 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.VniSettings;
-import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.vxlan.VxlanNode;
 import org.batfish.datamodel.vxlan.VxlanTopology;
 
@@ -430,20 +429,14 @@ public final class TopologyUtil {
    * and blacklists.
    */
   public static @Nonnull Topology computeLayer3Topology(
-      Topology rawLayer3Topology,
-      Set<Edge> edgeBlacklist,
-      Set<String> nodeBlacklist,
-      Set<NodeInterfacePair> interfaceBlacklist,
-      Map<String, Configuration> configurations) {
+      Topology rawLayer3Topology, Map<String, Configuration> configurations) {
     return rawLayer3Topology.prune(
-        Sets.union(
-            IpsecUtil.computeFailedIpsecSessionEdges(
-                rawLayer3Topology.getEdges(),
-                IpsecUtil.initIpsecTopology(configurations),
-                configurations),
-            edgeBlacklist),
-        nodeBlacklist,
-        interfaceBlacklist);
+        IpsecUtil.computeFailedIpsecSessionEdges(
+            rawLayer3Topology.getEdges(),
+            IpsecUtil.initIpsecTopology(configurations),
+            configurations),
+        ImmutableSet.of(),
+        ImmutableSet.of());
   }
 
   private static @Nullable Configuration getConfiguration(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -426,7 +426,7 @@ public final class TopologyUtil {
 
   /**
    * Compute the pruned layer-3 topology from the raw layer-3 topology, configuration information,
-   * and blacklists.
+   * and failed edges.
    */
   public static @Nonnull Topology computeLayer3Topology(
       Topology rawLayer3Topology, Map<String, Configuration> configurations) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -59,7 +59,6 @@ import org.batfish.common.util.CommonUtil;
 import org.batfish.common.util.ZipUtility;
 import org.batfish.datamodel.AnalysisMetadata;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.SnapshotMetadata;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.AnswerMetadata;
@@ -187,26 +186,6 @@ public final class FileBasedStorage implements StorageProvider {
       _logger.errorf(
           "Failed to deserialize ConvertConfigurationAnswerElement: %s",
           Throwables.getStackTraceAsString(e));
-      return null;
-    }
-  }
-
-  @Override
-  public @Nullable SortedSet<Edge> loadEdgeBlacklist(NetworkId network, SnapshotId snapshot) {
-    Path path =
-        _d.getSnapshotDir(network, snapshot)
-            .resolve(Paths.get(BfConsts.RELPATH_INPUT, BfConsts.RELPATH_EDGE_BLACKLIST_FILE));
-    if (!Files.exists(path)) {
-      return null;
-    }
-    String fileText = CommonUtil.readFile(path);
-    try {
-      return BatfishObjectMapper.mapper()
-          .readValue(fileText, new TypeReference<SortedSet<Edge>>() {});
-    } catch (IOException e) {
-      _logger.warnf(
-          "Unexpected exception caught while loading edge blacklist for snapshot %s: %s",
-          snapshot, Throwables.getStackTraceAsString(e));
       return null;
     }
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -18,7 +18,6 @@ import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.topology.Layer2Topology;
 import org.batfish.datamodel.AnalysisMetadata;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.SnapshotMetadata;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.AnswerMetadata;
@@ -61,15 +60,6 @@ public interface StorageProvider {
   @Nullable
   ConvertConfigurationAnswerElement loadConvertConfigurationAnswerElement(
       NetworkId network, SnapshotId snapshot);
-
-  /**
-   * Returns the edge blacklist for the specified snapshot.
-   *
-   * @param network The name of the network
-   * @param snapshot The name of the snapshot
-   */
-  @Nullable
-  SortedSet<Edge> loadEdgeBlacklist(NetworkId network, SnapshotId snapshot);
 
   /**
    * Returns the interface blacklist for the specified snapshot.

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
@@ -24,7 +23,6 @@ import org.batfish.common.topology.TopologyUtil;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Topology;
@@ -38,7 +36,6 @@ import org.batfish.datamodel.answers.ParseEnvironmentRoutingTablesAnswerElement;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.collections.BgpAdvertisementsByVrf;
-import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.collections.RoutesByVrf;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.ospf.OspfTopology;
@@ -415,21 +412,6 @@ public class IBatfishTestAdapter implements IBatfish {
   public NetworkSnapshot getNetworkSnapshot() {
     return new NetworkSnapshot(
         new NetworkId(UUID.randomUUID().toString()), new SnapshotId(UUID.randomUUID().toString()));
-  }
-
-  @Override
-  public SortedSet<Edge> getEdgeBlacklist(NetworkSnapshot networkSnapshot) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public SortedSet<NodeInterfacePair> getInterfaceBlacklist(NetworkSnapshot networkSnapshot) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public SortedSet<String> getNodeBlacklist(NetworkSnapshot networkSnapshot) {
-    throw new UnsupportedOperationException();
   }
 
   @Nonnull

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
@@ -16,7 +16,6 @@ import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.topology.Layer2Topology;
 import org.batfish.datamodel.AnalysisMetadata;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.SnapshotMetadata;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.answers.AnswerMetadata;
@@ -49,12 +48,6 @@ public class TestStorageProvider implements StorageProvider {
   @Override
   public ConvertConfigurationAnswerElement loadConvertConfigurationAnswerElement(
       NetworkId network, SnapshotId snapshot) {
-    throw new UnsupportedOperationException("no implementation for generated method");
-  }
-
-  @Nullable
-  @Override
-  public SortedSet<Edge> loadEdgeBlacklist(NetworkId network, SnapshotId snapshot) {
     throw new UnsupportedOperationException("no implementation for generated method");
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -148,9 +148,6 @@ class IncrementalBdpEngine {
                       initialTopologyContext.getRawLayer1PhysicalTopology(),
                       newLayer2Topology,
                       configurations),
-                  initialTopologyContext.getEdgeBlacklist(),
-                  initialTopologyContext.getNodeBlacklist(),
-                  initialTopologyContext.getInterfaceBlacklist(),
                   configurations);
 
           // Initialize BGP topology

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/TopologyContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/TopologyContext.java
@@ -1,19 +1,15 @@
 package org.batfish.dataplane.ibdp;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.topology.Layer2Topology;
 import org.batfish.common.topology.TopologyContainer;
-import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.bgp.BgpTopology;
-import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.eigrp.EigrpTopology;
 import org.batfish.datamodel.isis.IsisTopology;
 import org.batfish.datamodel.ospf.OspfTopology;
@@ -26,14 +22,11 @@ public final class TopologyContext implements TopologyContainer {
   public static final class Builder {
 
     private @Nonnull BgpTopology _bgpTopology;
-    private @Nonnull Set<Edge> _edgeBlacklist;
     private @Nonnull EigrpTopology _eigrpTopology;
-    private @Nonnull Set<NodeInterfacePair> _interfaceBlacklist;
     private @Nonnull IsisTopology _isisTopology;
     private @Nonnull Optional<Layer1Topology> _layer1LogicalTopology;
     private @Nonnull Optional<Layer2Topology> _layer2Topology;
     private @Nonnull Topology _layer3Topology;
-    private @Nonnull Set<String> _nodeBlacklist;
     private @Nonnull OspfTopology _ospfTopology;
     private @Nonnull Optional<Layer1Topology> _rawLayer1PhysicalTopology;
     private @Nonnull VxlanTopology _vxlanTopology;
@@ -41,14 +34,11 @@ public final class TopologyContext implements TopologyContainer {
     public @Nonnull TopologyContext build() {
       return new TopologyContext(
           _bgpTopology,
-          _edgeBlacklist,
           _eigrpTopology,
-          _interfaceBlacklist,
           _isisTopology,
           _layer1LogicalTopology,
           _layer2Topology,
           _layer3Topology,
-          _nodeBlacklist,
           _ospfTopology,
           _rawLayer1PhysicalTopology,
           _vxlanTopology);
@@ -56,14 +46,11 @@ public final class TopologyContext implements TopologyContainer {
 
     private Builder() {
       _bgpTopology = BgpTopology.EMPTY;
-      _edgeBlacklist = ImmutableSet.of();
       _eigrpTopology = EigrpTopology.EMPTY;
-      _interfaceBlacklist = ImmutableSet.of();
       _isisTopology = IsisTopology.EMPTY;
       _layer1LogicalTopology = Optional.empty();
       _layer2Topology = Optional.empty();
       _layer3Topology = Topology.EMPTY;
-      _nodeBlacklist = ImmutableSet.of();
       _ospfTopology = OspfTopology.EMPTY;
       _rawLayer1PhysicalTopology = Optional.empty();
       _vxlanTopology = VxlanTopology.EMPTY;
@@ -74,18 +61,8 @@ public final class TopologyContext implements TopologyContainer {
       return this;
     }
 
-    public @Nonnull Builder setEdgeBlacklist(Set<Edge> edgeBlacklist) {
-      _edgeBlacklist = edgeBlacklist;
-      return this;
-    }
-
     public @Nonnull Builder setEigrpTopology(EigrpTopology eigrpTopology) {
       _eigrpTopology = eigrpTopology;
-      return this;
-    }
-
-    public @Nonnull Builder setInterfaceBlacklist(Set<NodeInterfacePair> interfaceBlacklist) {
-      _interfaceBlacklist = interfaceBlacklist;
       return this;
     }
 
@@ -107,11 +84,6 @@ public final class TopologyContext implements TopologyContainer {
 
     public @Nonnull Builder setLayer3Topology(Topology layer3Topology) {
       _layer3Topology = layer3Topology;
-      return this;
-    }
-
-    public @Nonnull Builder setNodeBlacklist(Set<String> nodeBlacklist) {
-      _nodeBlacklist = nodeBlacklist;
       return this;
     }
 
@@ -137,40 +109,31 @@ public final class TopologyContext implements TopologyContainer {
   }
 
   private final @Nonnull BgpTopology _bgpTopology;
-  private final @Nonnull Set<Edge> _edgeBlacklist;
   private final @Nonnull EigrpTopology _eigrpTopology;
-  private final @Nonnull Set<NodeInterfacePair> _interfaceBlacklist;
   private final @Nonnull IsisTopology _isisTopology;
   private final @Nonnull Optional<Layer1Topology> _layer1LogicalTopology;
   private final @Nonnull Optional<Layer2Topology> _layer2Topology;
   private final @Nonnull Topology _layer3Topology;
-  private final @Nonnull Set<String> _nodeBlacklist;
   private final @Nonnull OspfTopology _ospfTopology;
   private final @Nonnull Optional<Layer1Topology> _rawLayer1PhysicalTopology;
   private final @Nonnull VxlanTopology _vxlanTopology;
 
   private TopologyContext(
       BgpTopology bgpTopology,
-      Set<Edge> edgeBlacklist,
       EigrpTopology eigrpTopology,
-      Set<NodeInterfacePair> interfaceBlacklist,
       IsisTopology isisTopology,
       Optional<Layer1Topology> layer1LogicalTopology,
       Optional<Layer2Topology> layer2Topology,
       Topology layer3Topology,
-      Set<String> nodeBlacklist,
       OspfTopology ospfTopology,
       Optional<Layer1Topology> rawLayer1PhysicalTopology,
       VxlanTopology vxlanTopology) {
     _bgpTopology = bgpTopology;
-    _edgeBlacklist = edgeBlacklist;
     _eigrpTopology = eigrpTopology;
-    _interfaceBlacklist = interfaceBlacklist;
     _isisTopology = isisTopology;
     _layer1LogicalTopology = layer1LogicalTopology;
     _layer2Topology = layer2Topology;
     _layer3Topology = layer3Topology;
-    _nodeBlacklist = nodeBlacklist;
     _ospfTopology = ospfTopology;
     _rawLayer1PhysicalTopology = rawLayer1PhysicalTopology;
     _vxlanTopology = vxlanTopology;
@@ -181,17 +144,9 @@ public final class TopologyContext implements TopologyContainer {
     return _bgpTopology;
   }
 
-  public @Nonnull Set<Edge> getEdgeBlacklist() {
-    return _edgeBlacklist;
-  }
-
   @Override
   public @Nonnull EigrpTopology getEigrpTopology() {
     return _eigrpTopology;
-  }
-
-  public @Nonnull Set<NodeInterfacePair> getInterfaceBlacklist() {
-    return _interfaceBlacklist;
   }
 
   @Override
@@ -211,10 +166,6 @@ public final class TopologyContext implements TopologyContainer {
   @Override
   public @Nonnull Topology getLayer3Topology() {
     return _layer3Topology;
-  }
-
-  public @Nonnull Set<String> getNodeBlacklist() {
-    return _nodeBlacklist;
   }
 
   @Override
@@ -241,14 +192,11 @@ public final class TopologyContext implements TopologyContainer {
     }
     TopologyContext rhs = (TopologyContext) obj;
     return _bgpTopology.equals(rhs._bgpTopology)
-        && _edgeBlacklist.equals(rhs._edgeBlacklist)
         && _eigrpTopology.equals(rhs._eigrpTopology)
-        && _interfaceBlacklist.equals(rhs._interfaceBlacklist)
         && _isisTopology.equals(rhs._isisTopology)
         && _layer1LogicalTopology.equals(rhs._layer1LogicalTopology)
         && _layer2Topology.equals(rhs._layer2Topology)
         && _layer3Topology.equals(rhs._layer3Topology)
-        && _nodeBlacklist.equals(rhs._nodeBlacklist)
         && _ospfTopology.equals(rhs._ospfTopology)
         && _rawLayer1PhysicalTopology.equals(rhs._rawLayer1PhysicalTopology)
         && _vxlanTopology.equals(rhs._vxlanTopology);
@@ -258,14 +206,11 @@ public final class TopologyContext implements TopologyContainer {
   public int hashCode() {
     return Objects.hash(
         _bgpTopology,
-        _edgeBlacklist,
         _eigrpTopology,
-        _interfaceBlacklist,
         _isisTopology,
         _layer1LogicalTopology,
         _layer2Topology,
         _layer3Topology,
-        _nodeBlacklist,
         _ospfTopology,
         _rawLayer1PhysicalTopology,
         _vxlanTopology);
@@ -274,14 +219,11 @@ public final class TopologyContext implements TopologyContainer {
   public @Nonnull Builder toBuilder() {
     return builder()
         .setBgpTopology(_bgpTopology)
-        .setEdgeBlacklist(_edgeBlacklist)
         .setEigrpTopology(_eigrpTopology)
-        .setInterfaceBlacklist(_interfaceBlacklist)
         .setIsisTopology(_isisTopology)
         .setLayer1LogicalTopology(_layer1LogicalTopology)
         .setLayer2Topology(_layer2Topology)
         .setLayer3Topology(_layer3Topology)
-        .setNodeBlacklist(_nodeBlacklist)
         .setOspfTopology(_ospfTopology)
         .setRawLayer1PhysicalTopology(_rawLayer1PhysicalTopology)
         .setVxlanTopology(_vxlanTopology);

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1,5 +1,6 @@
 package org.batfish.main;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -1047,15 +1048,12 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   @Override
   public Environment getEnvironment() {
-    SortedSet<Edge> edgeBlackList = getEdgeBlacklist();
-    SortedSet<NodeInterfacePair> interfaceBlackList = getInterfaceBlacklist();
-    SortedSet<String> nodeBlackList = getNodeBlacklist();
-    // TODO: add bgp tables and external announcements as well
+    // TODO: delete entirely
     return new Environment(
         _settings.getSnapshotName(),
-        edgeBlackList,
-        interfaceBlackList,
-        nodeBlackList,
+        ImmutableSortedSet.of(),
+        ImmutableSortedSet.of(),
+        ImmutableSortedSet.of(),
         null,
         null,
         null);
@@ -1100,51 +1098,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
     }
   }
 
-  @Override
-  @Nonnull
-  public SortedSet<Edge> getEdgeBlacklist(@Nonnull NetworkSnapshot networkSnapshot) {
-    SortedSet<Edge> blacklistEdges =
-        _storage.loadEdgeBlacklist(networkSnapshot.getNetwork(), networkSnapshot.getSnapshot());
-    if (blacklistEdges == null) {
-      return Collections.emptySortedSet();
-    }
-    return blacklistEdges;
-  }
-
-  @Override
-  @Nonnull
-  public SortedSet<NodeInterfacePair> getInterfaceBlacklist(
-      @Nonnull NetworkSnapshot networkSnapshot) {
-    SortedSet<NodeInterfacePair> blacklistInterfaces =
-        _storage.loadInterfaceBlacklist(
-            networkSnapshot.getNetwork(), networkSnapshot.getSnapshot());
-    if (blacklistInterfaces == null) {
-      return Collections.emptySortedSet();
-    }
-    return blacklistInterfaces;
-  }
-
-  @Override
-  @Nonnull
-  public SortedSet<String> getNodeBlacklist(@Nonnull NetworkSnapshot networkSnapshot) {
-    SortedSet<String> blacklistNodes =
-        _storage.loadNodeBlacklist(networkSnapshot.getNetwork(), networkSnapshot.getSnapshot());
-    if (blacklistNodes == null) {
-      return Collections.emptySortedSet();
-    }
-    return blacklistNodes;
-  }
-
-  @Nonnull
-  private SortedSet<Edge> getEdgeBlacklist() {
-    return getEdgeBlacklist(getNetworkSnapshot());
-  }
-
-  @Nonnull
-  private SortedSet<NodeInterfacePair> getInterfaceBlacklist() {
-    return getInterfaceBlacklist(getNetworkSnapshot());
-  }
-
   @Nonnull
   private Map<String, Configuration> getIspConfigurations(
       Map<String, Configuration> configurations, Map<String, Warnings> warningsByHost) {
@@ -1159,11 +1112,6 @@ public class Batfish extends PluginConsumer implements IBatfish {
             IspModelingUtils.INTERNET_HOST_NAME, k -> buildWarnings(_settings));
     return IspModelingUtils.getInternetAndIspNodes(
         configurations, ispConfiguration, _logger, warnings);
-  }
-
-  @Nonnull
-  private SortedSet<String> getNodeBlacklist() {
-    return getNodeBlacklist(getNetworkSnapshot());
   }
 
   @Override
@@ -2326,8 +2274,19 @@ public class Batfish extends PluginConsumer implements IBatfish {
    */
   private void updateBlacklistedAndInactiveConfigs(Map<String, Configuration> configurations) {
     NetworkConfigurations nc = NetworkConfigurations.of(configurations);
-    processInterfaceBlacklist(nodeToInterfaceBlacklist(getNodeBlacklist(), nc), nc);
-    processInterfaceBlacklist(getInterfaceBlacklist(), nc);
+    NetworkSnapshot networkSnapshot = getNetworkSnapshot();
+    NetworkId networkId = networkSnapshot.getNetwork();
+    SnapshotId snapshotId = networkSnapshot.getSnapshot();
+
+    processInterfaceBlacklist(
+        nodeToInterfaceBlacklist(
+            firstNonNull(
+                _storage.loadNodeBlacklist(networkId, snapshotId), ImmutableSortedSet.of()),
+            nc),
+        nc);
+    processInterfaceBlacklist(
+        firstNonNull(_storage.loadInterfaceBlacklist(networkId, snapshotId), ImmutableSet.of()),
+        nc);
     if (_settings.ignoreManagementInterfaces()) {
       processManagementInterfaces(configurations);
     }

--- a/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
@@ -1,11 +1,9 @@
 package org.batfish.topology;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.datamodel.ospf.OspfTopologyUtils.computeOspfTopology;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.ImmutableSet;
 import io.opentracing.ActiveSpan;
 import io.opentracing.util.GlobalTracer;
 import java.io.IOException;
@@ -29,8 +27,6 @@ import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.ospf.OspfTopology;
 import org.batfish.datamodel.vxlan.VxlanTopology;
 import org.batfish.datamodel.vxlan.VxlanTopologyUtils;
-import org.batfish.identifiers.NetworkId;
-import org.batfish.identifiers.SnapshotId;
 import org.batfish.storage.StorageProvider;
 
 @ParametersAreNonnullByDefault
@@ -122,16 +118,10 @@ public final class TopologyProviderImpl implements TopologyProvider {
   private Topology computeLayer3Topology(NetworkSnapshot networkSnapshot) {
     try (ActiveSpan span =
         GlobalTracer.get().buildSpan("TopologyProviderImpl::computeLayer3Topology").startActive()) {
-      NetworkId network = networkSnapshot.getNetwork();
-      SnapshotId snapshot = networkSnapshot.getSnapshot();
       assert span != null; // avoid unused warning
       Map<String, Configuration> configurations = _batfish.loadConfigurations(networkSnapshot);
       return TopologyUtil.computeLayer3Topology(
-          getInitialRawLayer3Topology(networkSnapshot),
-          firstNonNull(_storage.loadEdgeBlacklist(network, snapshot), ImmutableSet.of()),
-          firstNonNull(_storage.loadNodeBlacklist(network, snapshot), ImmutableSet.of()),
-          firstNonNull(_storage.loadInterfaceBlacklist(network, snapshot), ImmutableSet.of()),
-          configurations);
+          getInitialRawLayer3Topology(networkSnapshot), configurations);
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/FixedPointTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/FixedPointTopologyTest.java
@@ -150,11 +150,7 @@ public final class FixedPointTopologyTest {
         .setLayer2Topology(Optional.of(l2))
         .setLayer3Topology(
             computeLayer3Topology(
-                computeRawLayer3Topology(Optional.of(l1), Optional.of(l2), configs),
-                ImmutableSet.of(),
-                ImmutableSet.of(),
-                ImmutableSet.of(),
-                configs))
+                computeRawLayer3Topology(Optional.of(l1), Optional.of(l2), configs), configs))
         .setOspfTopology(OspfTopology.EMPTY)
         .setRawLayer1PhysicalTopology(Optional.of(l1))
         .build();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TopologyContextTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TopologyContextTest.java
@@ -23,7 +23,6 @@ import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.bgp.BgpTopology;
-import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.eigrp.EigrpEdge;
 import org.batfish.datamodel.eigrp.EigrpInterface;
 import org.batfish.datamodel.eigrp.EigrpTopology;
@@ -62,11 +61,7 @@ public final class TopologyContextTest {
         .addEqualityGroup(new Object())
         .addEqualityGroup(base, base, builder.build())
         .addEqualityGroup(builder.setBgpTopology(new BgpTopology(bgpTopology)).build())
-        .addEqualityGroup(
-            builder.setEdgeBlacklist(ImmutableSet.of(Edge.of("a", "b", "c", "d"))).build())
         .addEqualityGroup(builder.setEigrpTopology(new EigrpTopology(eigrpTopology)).build())
-        .addEqualityGroup(
-            builder.setInterfaceBlacklist(ImmutableSet.of(new NodeInterfacePair("a", "b"))).build())
         .addEqualityGroup(builder.setIsisTopology(new IsisTopology(isisTopology)).build())
         .addEqualityGroup(
             builder
@@ -85,7 +80,6 @@ public final class TopologyContextTest {
             builder
                 .setLayer3Topology(new Topology(ImmutableSortedSet.of(Edge.of("a", "b", "c", "d"))))
                 .build())
-        .addEqualityGroup(builder.setNodeBlacklist(ImmutableSet.of("a")).build())
         .addEqualityGroup(builder.setOspfTopology(new OspfTopology(ospfTopology)).build())
         .addEqualityGroup(
             builder
@@ -115,9 +109,7 @@ public final class TopologyContextTest {
     vxlanTopology.addNode(new VxlanNode("a", 5));
     builder
         .setBgpTopology(new BgpTopology(bgpTopology))
-        .setEdgeBlacklist(ImmutableSet.of(Edge.of("a", "b", "c", "d")))
         .setEigrpTopology(new EigrpTopology(eigrpTopology))
-        .setInterfaceBlacklist(ImmutableSet.of(new NodeInterfacePair("a", "b")))
         .setIsisTopology(new IsisTopology(isisTopology))
         .setLayer1LogicalTopology(
             Optional.of(new Layer1Topology(ImmutableList.of(new Layer1Edge("a", "b", "c", "d")))))
@@ -126,7 +118,6 @@ public final class TopologyContextTest {
                 Layer2Topology.fromDomains(
                     ImmutableList.of(ImmutableSet.of(new Layer2Node("a", "b", 5))))))
         .setLayer3Topology(new Topology(ImmutableSortedSet.of(Edge.of("a", "b", "c", "d"))))
-        .setNodeBlacklist(ImmutableSet.of("a"))
         .setOspfTopology(new OspfTopology(ospfTopology))
         .setRawLayer1PhysicalTopology(
             Optional.of(new Layer1Topology(ImmutableList.of(new Layer1Edge("a", "b", "c", "d")))))

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -720,8 +720,6 @@ public final class WorkMgrTest {
         _storage.loadInterfaceBlacklist(networkId, snapshotId1),
         containsInAnyOrder(interfaces.toArray()));
     assertThat(
-        _storage.loadEdgeBlacklist(networkId, snapshotId1), containsInAnyOrder(links.toArray()));
-    assertThat(
         _storage.loadNodeBlacklist(networkId, snapshotId1), containsInAnyOrder(nodes.toArray()));
 
     // Remove blacklisted items from a fork of the first fork
@@ -735,7 +733,6 @@ public final class WorkMgrTest {
     assertThat(_manager.getLatestSnapshot(networkName), equalTo(Optional.of(snapshotNewName2)));
     // Confirm the blacklists are empty
     assertThat(_storage.loadInterfaceBlacklist(networkId, snapshotId2), iterableWithSize(0));
-    assertThat(_storage.loadEdgeBlacklist(networkId, snapshotId2), iterableWithSize(0));
     assertThat(_storage.loadNodeBlacklist(networkId, snapshotId2), iterableWithSize(0));
   }
 


### PR DESCRIPTION
- remove edge blacklist
- only use node and interface blacklists to disable interfaces upon
  configuration deserialization