### PR TITLE
StateExpr: refactor into hierarchy

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysis.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysis.java
@@ -344,7 +344,7 @@ public class BDDReachabilityAnalysis {
     } else {
       OriginateInterfaceLink originateInterfaceLink = (OriginateInterfaceLink) stateExpr;
       return IngressLocation.interfaceLink(
-          originateInterfaceLink.getHostname(), originateInterfaceLink.getIface());
+          originateInterfaceLink.getHostname(), originateInterfaceLink.getInterface());
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -538,7 +538,7 @@ public final class BDDReachabilityAnalysisFactory {
               OriginateInterfaceLink originateInterfaceLink =
                   (OriginateInterfaceLink) entry.getKey();
               String hostname = originateInterfaceLink.getHostname();
-              String iface = originateInterfaceLink.getIface();
+              String iface = originateInterfaceLink.getInterface();
               PreInInterface preInInterface = new PreInInterface(hostname, iface);
 
               BDD rootBdd = entry.getValue();

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateToTerminationState.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateToTerminationState.java
@@ -139,7 +139,7 @@ public class OriginationStateToTerminationState implements StateExprVisitor<List
   @Override
   public List<StateExpr> visitOriginateInterfaceLink(OriginateInterfaceLink state) {
     String hostname = state.getHostname();
-    String iface = state.getIface();
+    String iface = state.getInterface();
     return ImmutableList.of(
         new NodeInterfaceDeliveredToSubnet(hostname, iface),
         new NodeInterfaceExitsNetwork(hostname, iface),

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/ReversePassOriginationState.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/ReversePassOriginationState.java
@@ -122,12 +122,12 @@ public class ReversePassOriginationState implements StateExprVisitor<StateExpr> 
 
   @Override
   public StateExpr visitNodeInterfaceDeliveredToSubnet(NodeInterfaceDeliveredToSubnet state) {
-    return new OriginateInterfaceLink(state.getHostname(), state.getIface());
+    return new OriginateInterfaceLink(state.getHostname(), state.getInterface());
   }
 
   @Override
   public StateExpr visitNodeInterfaceExitsNetwork(NodeInterfaceExitsNetwork state) {
-    return new OriginateInterfaceLink(state.getHostname(), state.getIface());
+    return new OriginateInterfaceLink(state.getHostname(), state.getInterface());
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/SessionCreationNodeVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/SessionCreationNodeVisitor.java
@@ -114,12 +114,12 @@ final class SessionCreationNodeVisitor implements StateExprVisitor<NodeInterface
   @Override
   public NodeInterfacePair visitNodeInterfaceDeliveredToSubnet(
       NodeInterfaceDeliveredToSubnet expr) {
-    return new NodeInterfacePair(expr.getHostname(), expr.getIface());
+    return new NodeInterfacePair(expr.getHostname(), expr.getInterface());
   }
 
   @Override
   public NodeInterfacePair visitNodeInterfaceExitsNetwork(NodeInterfaceExitsNetwork expr) {
-    return new NodeInterfacePair(expr.getHostname(), expr.getIface());
+    return new NodeInterfacePair(expr.getHostname(), expr.getInterface());
   }
 
   @Override

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/EdgeStateExpr.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/EdgeStateExpr.java
@@ -1,0 +1,70 @@
+package org.batfish.symbolic.state;
+
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+/**
+ * A base class for a {@link StateExpr} for which the only properties are those of an edge: a source
+ * and destination pair of {@link String} {@code hostname} and a {@link String} {@code interface}
+ * name.
+ *
+ * <p>This class provides default implementations for {@link #equals(Object)} and {@link
+ * #hashCode()}, where {@link #hashCode()} is different for different types.
+ */
+public abstract class EdgeStateExpr implements StateExpr {
+  @Nonnull private final String _srcHostname;
+  @Nonnull private final String _srcInterface;
+  @Nonnull private final String _dstHostname;
+  @Nonnull private final String _dstInterface;
+
+  public EdgeStateExpr(
+      @Nonnull String srcNode,
+      @Nonnull String srcIface,
+      @Nonnull String dstNode,
+      @Nonnull String dstIface) {
+    _srcHostname = srcNode;
+    _srcInterface = srcIface;
+    _dstHostname = dstNode;
+    _dstInterface = dstIface;
+  }
+
+  @Nonnull
+  public final String getDstIface() {
+    return _dstInterface;
+  }
+
+  @Nonnull
+  public final String getDstNode() {
+    return _dstHostname;
+  }
+
+  @Nonnull
+  public final String getSrcIface() {
+    return _srcInterface;
+  }
+
+  @Nonnull
+  public final String getSrcNode() {
+    return _srcHostname;
+  }
+
+  @Override
+  public final boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (!(other instanceof EdgeStateExpr)) {
+      return false;
+    } else if (!(other.getClass() == getClass())) {
+      return false;
+    }
+    return _srcHostname.equals(((EdgeStateExpr) other)._srcHostname)
+        && _srcInterface.equals(((EdgeStateExpr) other)._srcInterface)
+        && _dstHostname.equals(((EdgeStateExpr) other)._dstHostname)
+        && _dstInterface.equals(((EdgeStateExpr) other)._dstInterface);
+  }
+
+  @Override
+  public final int hashCode() {
+    return Objects.hash(getClass(), _srcHostname, _srcInterface, _dstHostname, _dstInterface);
+  }
+}

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/EdgeStateExpr.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/EdgeStateExpr.java
@@ -8,8 +8,8 @@ import javax.annotation.Nonnull;
  * and destination pair of {@link String} {@code hostname} and a {@link String} {@code interface}
  * name.
  *
- * <p>This class provides default implementations for {@link #equals(Object)} and {@link
- * #hashCode()}, where {@link #hashCode()} is different for different types.
+ * <p>This class provides the implementations for {@link #equals(Object)} and {@link #hashCode()},
+ * where {@link #hashCode()} is different for different types.
  */
 public abstract class EdgeStateExpr implements StateExpr {
   @Nonnull private final String _srcHostname;

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/InterfaceStateExpr.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/InterfaceStateExpr.java
@@ -6,8 +6,8 @@ import javax.annotation.Nonnull;
  * A base class for a {@link StateExpr} for which the only properties are a {@link String} {@code
  * hostname} and a {@link String} {@code interface} name.
  *
- * <p>This class provides default implementations for {@link #equals(Object)} and {@link
- * #hashCode()}, where {@link #hashCode()} is different for different types.
+ * <p>This class provides the implementations for {@link #equals(Object)} and {@link #hashCode()},
+ * where {@link #hashCode()} is different for different types.
  */
 public abstract class InterfaceStateExpr implements StateExpr {
   @Nonnull private final String _hostname;

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/InterfaceStateExpr.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/InterfaceStateExpr.java
@@ -28,11 +28,6 @@ public abstract class InterfaceStateExpr implements StateExpr {
     return _interface;
   }
 
-  @Nonnull
-  public final String getIface() {
-    return _interface;
-  }
-
   @Override
   public final boolean equals(Object other) {
     if (this == other) {

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/InterfaceStateExpr.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/InterfaceStateExpr.java
@@ -1,0 +1,53 @@
+package org.batfish.symbolic.state;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A base class for a {@link StateExpr} for which the only properties are a {@link String} {@code
+ * hostname} and a {@link String} {@code interface} name.
+ *
+ * <p>This class provides default implementations for {@link #equals(Object)} and {@link
+ * #hashCode()}, where {@link #hashCode()} is different for different types.
+ */
+public abstract class InterfaceStateExpr implements StateExpr {
+  @Nonnull private final String _hostname;
+  @Nonnull private final String _interface;
+
+  public InterfaceStateExpr(@Nonnull String hostname, @Nonnull String iface) {
+    _hostname = hostname;
+    _interface = iface;
+  }
+
+  @Nonnull
+  public final String getHostname() {
+    return _hostname;
+  }
+
+  @Nonnull
+  public final String getInterface() {
+    return _interface;
+  }
+
+  @Nonnull
+  public final String getIface() {
+    return _interface;
+  }
+
+  @Override
+  public final boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (!(other instanceof InterfaceStateExpr)) {
+      return false;
+    } else if (!(other.getClass() == getClass())) {
+      return false;
+    }
+    return _hostname.equals(((InterfaceStateExpr) other)._hostname)
+        && _interface.equals(((InterfaceStateExpr) other)._interface);
+  }
+
+  @Override
+  public final int hashCode() {
+    return 31 * 31 * getClass().hashCode() + 31 * _hostname.hashCode() + _interface.hashCode();
+  }
+}

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeAccept.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeAccept.java
@@ -3,37 +3,14 @@ package org.batfish.symbolic.state;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class NodeAccept implements StateExpr {
-
-  private final String _hostname;
+public final class NodeAccept extends NodeStateExpr {
 
   public NodeAccept(String hostname) {
-    _hostname = hostname;
+    super(hostname);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitNodeAccept(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof NodeAccept)) {
-      return false;
-    }
-    NodeAccept that = (NodeAccept) o;
-    return _hostname.equals(that._hostname);
-  }
-
-  @Override
-  public int hashCode() {
-    return _hostname.hashCode();
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeDropAclIn.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeDropAclIn.java
@@ -3,37 +3,14 @@ package org.batfish.symbolic.state;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class NodeDropAclIn implements StateExpr {
-
-  private final String _hostname;
+public final class NodeDropAclIn extends NodeStateExpr {
 
   public NodeDropAclIn(String hostname) {
-    _hostname = hostname;
+    super(hostname);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitNodeDropAclIn(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof NodeDropAclIn)) {
-      return false;
-    }
-    NodeDropAclIn that = (NodeDropAclIn) o;
-    return _hostname.equals(that._hostname);
-  }
-
-  @Override
-  public int hashCode() {
-    return _hostname.hashCode();
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeDropAclOut.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeDropAclOut.java
@@ -3,37 +3,14 @@ package org.batfish.symbolic.state;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class NodeDropAclOut implements StateExpr {
-
-  private final String _hostname;
+public final class NodeDropAclOut extends NodeStateExpr {
 
   public NodeDropAclOut(String hostname) {
-    _hostname = hostname;
+    super(hostname);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitNodeDropAclOut(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof NodeDropAclOut)) {
-      return false;
-    }
-    NodeDropAclOut that = (NodeDropAclOut) o;
-    return _hostname.equals(that._hostname);
-  }
-
-  @Override
-  public int hashCode() {
-    return _hostname.hashCode();
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeDropNoRoute.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeDropNoRoute.java
@@ -3,37 +3,13 @@ package org.batfish.symbolic.state;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class NodeDropNoRoute implements StateExpr {
-
-  private final String _hostname;
-
+public final class NodeDropNoRoute extends NodeStateExpr {
   public NodeDropNoRoute(String hostname) {
-    _hostname = hostname;
+    super(hostname);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitNodeDropNoRoute(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof NodeDropNoRoute)) {
-      return false;
-    }
-    NodeDropNoRoute that = (NodeDropNoRoute) o;
-    return _hostname.equals(that._hostname);
-  }
-
-  @Override
-  public int hashCode() {
-    return _hostname.hashCode();
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeDropNullRoute.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeDropNullRoute.java
@@ -3,37 +3,13 @@ package org.batfish.symbolic.state;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class NodeDropNullRoute implements StateExpr {
-
-  private final String _hostname;
-
+public final class NodeDropNullRoute extends NodeStateExpr {
   public NodeDropNullRoute(String hostname) {
-    _hostname = hostname;
+    super(hostname);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitNodeDropNullRoute(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof NodeDropNullRoute)) {
-      return false;
-    }
-    NodeDropNullRoute that = (NodeDropNullRoute) o;
-    return _hostname.equals(that._hostname);
-  }
-
-  @Override
-  public int hashCode() {
-    return _hostname.hashCode();
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeInterfaceDeliveredToSubnet.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeInterfaceDeliveredToSubnet.java
@@ -1,47 +1,15 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class NodeInterfaceDeliveredToSubnet implements StateExpr {
-
-  private final String _hostname;
-
-  private final String _iface;
-
+public final class NodeInterfaceDeliveredToSubnet extends InterfaceStateExpr {
   public NodeInterfaceDeliveredToSubnet(String hostname, String iface) {
-    _hostname = hostname;
-    _iface = iface;
+    super(hostname, iface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitNodeInterfaceDeliveredToSubnet(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getIface() {
-    return _iface;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof NodeInterfaceDeliveredToSubnet)) {
-      return false;
-    }
-    NodeInterfaceDeliveredToSubnet that = (NodeInterfaceDeliveredToSubnet) o;
-    return _hostname.equals(that._hostname) && _iface.equals(that._iface);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _iface);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeInterfaceExitsNetwork.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeInterfaceExitsNetwork.java
@@ -1,47 +1,15 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class NodeInterfaceExitsNetwork implements StateExpr {
-
-  private final String _hostname;
-
-  private final String _iface;
-
+public final class NodeInterfaceExitsNetwork extends InterfaceStateExpr {
   public NodeInterfaceExitsNetwork(String hostname, String iface) {
-    _hostname = hostname;
-    _iface = iface;
+    super(hostname, iface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitNodeInterfaceExitsNetwork(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getIface() {
-    return _iface;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof NodeInterfaceExitsNetwork)) {
-      return false;
-    }
-    NodeInterfaceExitsNetwork that = (NodeInterfaceExitsNetwork) o;
-    return _hostname.equals(that._hostname) && _iface.equals(that._iface);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _iface);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeInterfaceInsufficientInfo.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeInterfaceInsufficientInfo.java
@@ -1,47 +1,16 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class NodeInterfaceInsufficientInfo implements StateExpr {
-
-  private final String _hostname;
-
-  private final String _iface;
+public final class NodeInterfaceInsufficientInfo extends InterfaceStateExpr {
 
   public NodeInterfaceInsufficientInfo(String hostname, String iface) {
-    _hostname = hostname;
-    _iface = iface;
+    super(hostname, iface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitNodeInterfaceInsufficientInfo(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getIface() {
-    return _iface;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof NodeInterfaceInsufficientInfo)) {
-      return false;
-    }
-    NodeInterfaceInsufficientInfo that = (NodeInterfaceInsufficientInfo) o;
-    return _hostname.equals(that._hostname) && _iface.equals(that._iface);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _iface);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeInterfaceNeighborUnreachable.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeInterfaceNeighborUnreachable.java
@@ -1,47 +1,15 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class NodeInterfaceNeighborUnreachable implements StateExpr {
-
-  private final String _hostname;
-
-  private final String _iface;
-
+public final class NodeInterfaceNeighborUnreachable extends InterfaceStateExpr {
   public NodeInterfaceNeighborUnreachable(String hostname, String iface) {
-    _hostname = hostname;
-    _iface = iface;
+    super(hostname, iface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitNodeInterfaceNeighborUnreachable(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getIface() {
-    return _iface;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof NodeInterfaceNeighborUnreachable)) {
-      return false;
-    }
-    NodeInterfaceNeighborUnreachable that = (NodeInterfaceNeighborUnreachable) o;
-    return _hostname.equals(that._hostname) && _iface.equals(that._iface);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _iface);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeStateExpr.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeStateExpr.java
@@ -6,8 +6,8 @@ import javax.annotation.Nonnull;
  * A base class for a {@link StateExpr} for which the only property is a {@link String} {@code
  * hostname}.
  *
- * <p>This class provides default implementations for {@link #equals(Object)} and {@link
- * #hashCode()}, where {@link #hashCode()} is different for different types.
+ * <p>This class provides the implementations for {@link #equals(Object)} and {@link #hashCode()},
+ * where {@link #hashCode()} is different for different types.
  */
 public abstract class NodeStateExpr implements StateExpr {
   @Nonnull private final String _hostname;

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeStateExpr.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/NodeStateExpr.java
@@ -1,0 +1,40 @@
+package org.batfish.symbolic.state;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A base class for a {@link StateExpr} for which the only property is a {@link String} {@code
+ * hostname}.
+ *
+ * <p>This class provides default implementations for {@link #equals(Object)} and {@link
+ * #hashCode()}, where {@link #hashCode()} is different for different types.
+ */
+public abstract class NodeStateExpr implements StateExpr {
+  @Nonnull private final String _hostname;
+
+  public NodeStateExpr(@Nonnull String hostname) {
+    _hostname = hostname;
+  }
+
+  @Nonnull
+  public final String getHostname() {
+    return _hostname;
+  }
+
+  @Override
+  public final boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (!(other instanceof NodeStateExpr)) {
+      return false;
+    } else if (!(other.getClass() == getClass())) {
+      return false;
+    }
+    return _hostname.equals(((NodeStateExpr) other)._hostname);
+  }
+
+  @Override
+  public final int hashCode() {
+    return 31 * getClass().hashCode() + _hostname.hashCode();
+  }
+}

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/OriginateInterfaceLink.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/OriginateInterfaceLink.java
@@ -1,50 +1,16 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /** A {@link StateExpr Nod program state} for traffic originating from the link of an interface. */
-public final class OriginateInterfaceLink implements StateExpr {
-
-  private final @Nonnull String _hostname;
-
-  private final @Nonnull String _iface;
+public final class OriginateInterfaceLink extends InterfaceStateExpr {
 
   public OriginateInterfaceLink(@Nonnull String hostname, @Nonnull String iface) {
-    _hostname = hostname;
-    _iface = iface;
+    super(hostname, iface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitOriginateInterfaceLink(this);
-  }
-
-  @Nonnull
-  public String getHostname() {
-    return _hostname;
-  }
-
-  @Nonnull
-  public String getIface() {
-    return _iface;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof OriginateInterfaceLink)) {
-      return false;
-    }
-
-    OriginateInterfaceLink that = (OriginateInterfaceLink) o;
-    return _hostname.equals(that._hostname) && _iface.equals(that._iface);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _iface);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/OriginateVrf.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/OriginateVrf.java
@@ -1,47 +1,15 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class OriginateVrf implements StateExpr {
-
-  private final String _hostname;
-
-  private final String _vrf;
-
+public final class OriginateVrf extends VrfStateExpr {
   public OriginateVrf(String hostname, String vrf) {
-    _hostname = hostname;
-    _vrf = vrf;
+    super(hostname, vrf);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitOriginateVrf(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getVrf() {
-    return _vrf;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof OriginateVrf)) {
-      return false;
-    }
-    OriginateVrf that = (OriginateVrf) o;
-    return _hostname.equals(that._hostname) && _vrf.equals(that._vrf);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _vrf);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/PostInInterface.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/PostInInterface.java
@@ -1,47 +1,15 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class PostInInterface implements StateExpr {
-
-  private final String _hostname;
-
-  private final String _iface;
-
+public final class PostInInterface extends InterfaceStateExpr {
   public PostInInterface(String hostname, String iface) {
-    _hostname = hostname;
-    _iface = iface;
+    super(hostname, iface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitPostInInterface(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getIface() {
-    return _iface;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof PostInInterface)) {
-      return false;
-    }
-    PostInInterface that = (PostInInterface) o;
-    return _hostname.equals(that._hostname) && _iface.equals(that._iface);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _iface);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/PostInInterfacePostNat.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/PostInInterfacePostNat.java
@@ -1,47 +1,15 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class PostInInterfacePostNat implements StateExpr {
-
-  private final String _hostname;
-
-  private final String _iface;
-
+public final class PostInInterfacePostNat extends InterfaceStateExpr {
   public PostInInterfacePostNat(String hostname, String iface) {
-    _hostname = hostname;
-    _iface = iface;
+    super(hostname, iface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitPostInInterfacePostNat(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getIface() {
-    return _iface;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof PostInInterfacePostNat)) {
-      return false;
-    }
-    PostInInterfacePostNat that = (PostInInterfacePostNat) o;
-    return _hostname.equals(that._hostname) && _iface.equals(that._iface);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _iface);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/PostInVrf.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/PostInVrf.java
@@ -1,47 +1,15 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class PostInVrf implements StateExpr {
-
-  private final String _hostname;
-
-  private final String _vrf;
-
+public final class PostInVrf extends VrfStateExpr {
   public PostInVrf(String hostname, String vrf) {
-    _hostname = hostname;
-    _vrf = vrf;
+    super(hostname, vrf);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitPostInVrf(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getVrf() {
-    return _vrf;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof PostInVrf)) {
-      return false;
-    }
-    PostInVrf postInVrf = (PostInVrf) o;
-    return _hostname.equals(postInVrf._hostname) && _vrf.equals(postInVrf._vrf);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _vrf);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreInInterface.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreInInterface.java
@@ -1,47 +1,15 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class PreInInterface implements StateExpr {
-
-  private final String _hostname;
-
-  private final String _iface;
-
+public final class PreInInterface extends InterfaceStateExpr {
   public PreInInterface(String hostname, String iface) {
-    _hostname = hostname;
-    _iface = iface;
+    super(hostname, iface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitPreInInterface(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getIface() {
-    return _iface;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof PreInInterface)) {
-      return false;
-    }
-    PreInInterface that = (PreInInterface) o;
-    return _hostname.equals(that._hostname) && _iface.equals(that._iface);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _iface);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutEdge.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutEdge.java
@@ -1,64 +1,15 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class PreOutEdge implements StateExpr {
-
-  private final String _dstIface;
-
-  private final String _dstNode;
-
-  private final String _srcIface;
-
-  private final String _srcNode;
-
+public final class PreOutEdge extends EdgeStateExpr {
   public PreOutEdge(String srcNode, String srcIface, String dstNode, String dstIface) {
-    _srcNode = srcNode;
-    _srcIface = srcIface;
-    _dstNode = dstNode;
-    _dstIface = dstIface;
+    super(srcNode, srcIface, dstNode, dstIface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitPreOutEdge(this);
-  }
-
-  public String getDstIface() {
-    return _dstIface;
-  }
-
-  public String getDstNode() {
-    return _dstNode;
-  }
-
-  public String getSrcIface() {
-    return _srcIface;
-  }
-
-  public String getSrcNode() {
-    return _srcNode;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof PreOutEdge)) {
-      return false;
-    }
-    PreOutEdge that = (PreOutEdge) o;
-    return _dstIface.equals(that._dstIface)
-        && _dstNode.equals(that._dstNode)
-        && _srcIface.equals(that._srcIface)
-        && _srcNode.equals(that._srcNode);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_dstIface, _dstNode, _srcIface, _srcNode);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutEdgePostNat.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutEdgePostNat.java
@@ -1,64 +1,15 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class PreOutEdgePostNat implements StateExpr {
-
-  private final String _dstIface;
-
-  private final String _dstNode;
-
-  private final String _srcIface;
-
-  private final String _srcNode;
-
+public final class PreOutEdgePostNat extends EdgeStateExpr {
   public PreOutEdgePostNat(String srcNode, String srcIface, String dstNode, String dstIface) {
-    _srcNode = srcNode;
-    _srcIface = srcIface;
-    _dstNode = dstNode;
-    _dstIface = dstIface;
+    super(srcNode, srcIface, dstNode, dstIface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitPreOutEdgePostNat(this);
-  }
-
-  public String getDstNode() {
-    return _dstNode;
-  }
-
-  public String getDstIface() {
-    return _dstIface;
-  }
-
-  public String getSrcIface() {
-    return _srcIface;
-  }
-
-  public String getSrcNode() {
-    return _srcNode;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof PreOutEdgePostNat)) {
-      return false;
-    }
-    PreOutEdgePostNat that = (PreOutEdgePostNat) o;
-    return _dstIface.equals(that._dstIface)
-        && _dstNode.equals(that._dstNode)
-        && _srcIface.equals(that._srcIface)
-        && _srcNode.equals(that._srcNode);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_dstIface, _dstNode, _srcIface, _srcNode);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutInterfaceDeliveredToSubnet.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutInterfaceDeliveredToSubnet.java
@@ -1,48 +1,17 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
-
 /**
  * A {@link StateExpr} for flows being forwarded out an interface with the {@link
  * org.batfish.datamodel.FlowDisposition#DELIVERED_TO_SUBNET} disposition, before the outgoing
  * ACL(s) or transformation are applied.
  */
-public final class PreOutInterfaceDeliveredToSubnet implements StateExpr {
-  private final String _hostname;
-  private final String _interface;
-
+public final class PreOutInterfaceDeliveredToSubnet extends InterfaceStateExpr {
   public PreOutInterfaceDeliveredToSubnet(String hostname, String iface) {
-    _hostname = hostname;
-    _interface = iface;
+    super(hostname, iface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitPreOutInterfaceDeliveredToSubnet(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getInterface() {
-    return _interface;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof PreOutInterfaceDeliveredToSubnet)) {
-      return false;
-    }
-    PreOutInterfaceDeliveredToSubnet that = (PreOutInterfaceDeliveredToSubnet) o;
-    return _hostname.equals(that._hostname) && _interface.equals(that._interface);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _interface);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutInterfaceExitsNetwork.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutInterfaceExitsNetwork.java
@@ -1,48 +1,17 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
-
 /**
  * A {@link StateExpr} for flows being forwarded out an interface with the {@link
  * org.batfish.datamodel.FlowDisposition#EXITS_NETWORK} disposition, before the outgoing ACL(s) or
  * transformation are applied.
  */
-public final class PreOutInterfaceExitsNetwork implements StateExpr {
-  private final String _hostname;
-  private final String _interface;
-
+public final class PreOutInterfaceExitsNetwork extends InterfaceStateExpr {
   public PreOutInterfaceExitsNetwork(String hostname, String iface) {
-    _hostname = hostname;
-    _interface = iface;
+    super(hostname, iface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitPreOutInterfaceExitsNetwork(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getInterface() {
-    return _interface;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof PreOutInterfaceExitsNetwork)) {
-      return false;
-    }
-    PreOutInterfaceExitsNetwork that = (PreOutInterfaceExitsNetwork) o;
-    return _hostname.equals(that._hostname) && _interface.equals(that._interface);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _interface);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutInterfaceInsufficientInfo.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutInterfaceInsufficientInfo.java
@@ -1,48 +1,17 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
-
 /**
  * A {@link StateExpr} for flows being forwarded out an interface with the {@link
  * org.batfish.datamodel.FlowDisposition#INSUFFICIENT_INFO} disposition, before the outgoing ACL(s)
  * or transformation are applied.
  */
-public final class PreOutInterfaceInsufficientInfo implements StateExpr {
-  private final String _hostname;
-  private final String _interface;
-
+public final class PreOutInterfaceInsufficientInfo extends InterfaceStateExpr {
   public PreOutInterfaceInsufficientInfo(String hostname, String iface) {
-    _hostname = hostname;
-    _interface = iface;
+    super(hostname, iface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitPreOutInterfaceInsufficientInfo(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getInterface() {
-    return _interface;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof PreOutInterfaceInsufficientInfo)) {
-      return false;
-    }
-    PreOutInterfaceInsufficientInfo that = (PreOutInterfaceInsufficientInfo) o;
-    return _hostname.equals(that._hostname) && _interface.equals(that._interface);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _interface);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutInterfaceNeighborUnreachable.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutInterfaceNeighborUnreachable.java
@@ -1,48 +1,17 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
-
 /**
  * A {@link StateExpr} for flows being forwarded out an interface with the {@link
  * org.batfish.datamodel.FlowDisposition#NEIGHBOR_UNREACHABLE} disposition, before the outgoing
  * ACL(s) or transformation are applied.
  */
-public final class PreOutInterfaceNeighborUnreachable implements StateExpr {
-  private final String _hostname;
-  private final String _interface;
-
+public final class PreOutInterfaceNeighborUnreachable extends InterfaceStateExpr {
   public PreOutInterfaceNeighborUnreachable(String hostname, String iface) {
-    _hostname = hostname;
-    _interface = iface;
+    super(hostname, iface);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitPreOutInterfaceNeighborUnreachable(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getInterface() {
-    return _interface;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof PreOutInterfaceNeighborUnreachable)) {
-      return false;
-    }
-    PreOutInterfaceNeighborUnreachable that = (PreOutInterfaceNeighborUnreachable) o;
-    return _hostname.equals(that._hostname) && _interface.equals(that._interface);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _interface);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutVrf.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/PreOutVrf.java
@@ -1,47 +1,15 @@
 package org.batfish.symbolic.state;
 
-import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public final class PreOutVrf implements StateExpr {
-
-  private final String _hostname;
-
-  private final String _vrf;
-
+public final class PreOutVrf extends VrfStateExpr {
   public PreOutVrf(String hostname, String vrf) {
-    _hostname = hostname;
-    _vrf = vrf;
+    super(hostname, vrf);
   }
 
   @Override
   public <R> R accept(StateExprVisitor<R> visitor) {
     return visitor.visitPreOutVrf(this);
-  }
-
-  public String getHostname() {
-    return _hostname;
-  }
-
-  public String getVrf() {
-    return _vrf;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof PreOutVrf)) {
-      return false;
-    }
-    PreOutVrf preOutVrf = (PreOutVrf) o;
-    return _hostname.equals(preOutVrf._hostname) && _vrf.equals(preOutVrf._vrf);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_hostname, _vrf);
   }
 }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/VrfStateExpr.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/VrfStateExpr.java
@@ -1,0 +1,48 @@
+package org.batfish.symbolic.state;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A base class for a {@link StateExpr} for which the only properties are a {@link String} {@code
+ * hostname} and a {@link String} {@code vrf} name.
+ *
+ * <p>This class provides default implementations for {@link #equals(Object)} and {@link
+ * #hashCode()}, where {@link #hashCode()} is different for different types.
+ */
+public abstract class VrfStateExpr implements StateExpr {
+  @Nonnull private final String _hostname;
+  @Nonnull private final String _vrf;
+
+  public VrfStateExpr(@Nonnull String hostname, @Nonnull String vrf) {
+    _hostname = hostname;
+    _vrf = vrf;
+  }
+
+  @Nonnull
+  public final String getHostname() {
+    return _hostname;
+  }
+
+  @Nonnull
+  public final String getVrf() {
+    return _vrf;
+  }
+
+  @Override
+  public final boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (!(other instanceof VrfStateExpr)) {
+      return false;
+    } else if (!(other.getClass() == getClass())) {
+      return false;
+    }
+    return _hostname.equals(((VrfStateExpr) other)._hostname)
+        && _vrf.equals(((VrfStateExpr) other)._vrf);
+  }
+
+  @Override
+  public final int hashCode() {
+    return 31 * 31 * getClass().hashCode() + 31 * _hostname.hashCode() + _vrf.hashCode();
+  }
+}

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/VrfStateExpr.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/VrfStateExpr.java
@@ -6,8 +6,8 @@ import javax.annotation.Nonnull;
  * A base class for a {@link StateExpr} for which the only properties are a {@link String} {@code
  * hostname} and a {@link String} {@code vrf} name.
  *
- * <p>This class provides default implementations for {@link #equals(Object)} and {@link
- * #hashCode()}, where {@link #hashCode()} is different for different types.
+ * <p>This class provides the implementations for {@link #equals(Object)} and {@link #hashCode()},
+ * where {@link #hashCode()} is different for different types.
  */
 public abstract class VrfStateExpr implements StateExpr {
   @Nonnull private final String _hostname;


### PR DESCRIPTION
1. Add NodeStateExpr, InterfaceStateExpr, and VrfStateExpr as abstract classes
   that allow code reuse for getters, equals, and hashCode.
2. Make hashCode different for different concrete classes with the same fields.

Number 2 provides a significant performance boost in building and using hash-based
collections of StateExpr.