### PR TITLE
AsSet: switch to array internally

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
@@ -1,19 +1,19 @@
 package org.batfish.datamodel;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.cache.Cache;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.Comparators;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
+import com.google.common.primitives.Longs;
 import java.io.Serializable;
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.SortedSet;
-import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang3.StringUtils;
@@ -24,55 +24,55 @@ public class AsSet implements Serializable, Comparable<AsSet> {
   // Soft values: let it be garbage collected in times of pressure.
   // Maximum size 2^16: Just some upper bound on cache size, well less than GiB.
   //   (8 bytes seems smallest possible entry (set(long)), would be 1 MiB total).
-  private static final Cache<ImmutableSortedSet<Long>, AsSet> CACHE =
-      CacheBuilder.newBuilder().softValues().maximumSize(1 << 16).build();
+  private static final LoadingCache<AsSet, AsSet> CACHE =
+      CacheBuilder.newBuilder().softValues().maximumSize(1 << 16).build(CacheLoader.from(x -> x));
 
   private static final long serialVersionUID = 1L;
 
-  private final ImmutableSortedSet<Long> _value;
+  private final long[] _value;
 
-  private AsSet(ImmutableSortedSet<Long> value) {
+  private AsSet(long[] value) {
+    Arrays.sort(value);
     _value = value;
   }
 
   /** Create a new empty {@link AsSet}. */
   public static AsSet empty() {
-    return of(ImmutableSortedSet.of());
+    return of();
   }
 
-  /** Create a new {@link AsSet} containing only the given ASN. */
-  public static AsSet of(Long value) {
-    return of(ImmutableSortedSet.of(value));
+  /** Create a new {@link AsSet} that is for a single ASN. */
+  public static AsSet of(long value) {
+    return of(new long[] {value});
   }
 
-  /** Create a new {@link AsSet} containing only the given ASN. */
-  public static AsSet of(Long... value) {
-    return of(ImmutableSortedSet.copyOf(value));
-  }
-
-  /** Create a new {@link AsSet} that is an immutable copy of {@code value}. */
-  public static AsSet of(Collection<Long> value) {
-    ImmutableSortedSet<Long> immutableValues = ImmutableSortedSet.copyOf(value);
-    try {
-      return CACHE.get(immutableValues, () -> new AsSet(immutableValues));
-    } catch (ExecutionException e) {
-      // This shouldn't happen, but handle anyway.
-      return new AsSet(immutableValues);
-    }
+  /**
+   * Create a new {@link AsSet} that is an immutable copy of {@code value}.
+   *
+   * <p>Note: this {@link AsSet} will take ownership of the given {@code long[]}.
+   */
+  public static AsSet of(long... value) {
+    AsSet set = new AsSet(value);
+    return CACHE.getUnchecked(set);
   }
 
   @JsonCreator
-  private static AsSet jsonCreator(@Nullable ImmutableSortedSet<Long> value) {
-    return AsSet.of(firstNonNull(value, ImmutableSortedSet.of()));
+  private static AsSet jsonCreator(@Nullable long[] value) {
+    return AsSet.of(firstNonNull(value, new long[] {}));
   }
 
   @Override
   public int compareTo(AsSet o) {
-    return Comparators.lexicographical(Ordering.<Long>natural()).compare(_value, o._value);
+    return Longs.lexicographicalComparator().compare(_value, o._value);
   }
 
-  public boolean containsAs(Long asn) {
-    return _value.contains(asn);
+  public boolean containsAs(long asn) {
+    for (long l : _value) {
+      if (l == asn) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override
@@ -82,37 +82,40 @@ public class AsSet implements Serializable, Comparable<AsSet> {
     } else if (!(o instanceof AsSet)) {
       return false;
     }
-    return _value.equals(((AsSet) o)._value);
+    return Arrays.equals(_value, ((AsSet) o)._value);
   }
 
+  /** Expensive. */
+  @VisibleForTesting
   @JsonValue
   public SortedSet<Long> getAsns() {
-    return _value;
+    return Arrays.stream(_value)
+        .boxed()
+        .collect(ImmutableSortedSet.toImmutableSortedSet(Ordering.natural()));
   }
 
   @Override
   public int hashCode() {
-    return _value.hashCode();
+    return Arrays.hashCode(_value);
   }
 
   public boolean isEmpty() {
-    return _value.isEmpty();
+    return _value.length == 0;
   }
 
   /** Returns a new {@link AsSet} that consists of this set with any private ASNs removed. */
   public AsSet removePrivateAs() {
-    return AsSet.of(
-        _value.stream().filter(asn -> !AsPath.isPrivateAs(asn)).collect(toImmutableList()));
+    return AsSet.of(Arrays.stream(_value).filter(asn -> !AsPath.isPrivateAs(asn)).toArray());
   }
 
   public int size() {
-    return _value.size();
+    return _value.length;
   }
 
   @Override
   public String toString() {
-    if (_value.size() == 1) {
-      return _value.first().toString();
+    if (_value.length == 1) {
+      return Long.toString(_value[0]);
     }
     return "{" + StringUtils.join(_value, ",") + "}";
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -89,7 +89,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Ordering;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -6121,10 +6120,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     if (ctx.bgp_asn() != null) {
       return AsSet.of(toAsNum(ctx.bgp_asn()));
     } else {
-      return AsSet.of(
-          ctx.as_set().items.stream()
-              .map(this::toAsNum)
-              .collect(ImmutableSortedSet.toImmutableSortedSet(Ordering.natural())));
+      return AsSet.of(ctx.as_set().items.stream().mapToLong(this::toAsNum).toArray());
     }
   }
 


### PR DESCRIPTION
- Using an internal array will result in less boxing globally
- Switch to a LoadingCache for simpler code.