### PR TITLE
IpWildcard: intern and cleanup

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/minesweeper/smt/SmtReachabilityTwoLinkPerDstIpTest.java
+++ b/projects/allinone/src/test/java/org/batfish/minesweeper/smt/SmtReachabilityTwoLinkPerDstIpTest.java
@@ -88,7 +88,7 @@ public class SmtReachabilityTwoLinkPerDstIpTest {
     final ReachabilityQuestion question = new ReachabilityQuestion();
     question.setIngressNodeRegex(_srcNode.getHostname());
     question.setFinalNodeRegex(_dstNode.getHostname());
-    question.setDstIps(ImmutableSet.of(new IpWildcard(_dstIp)));
+    question.setDstIps(ImmutableSet.of(IpWildcard.create(_dstIp)));
     final AnswerElement answer = Answerer.create(question, _batfish).answer();
     assertThat(answer, instanceOf(SmtReachabilityAnswerElement.class));
 
@@ -112,7 +112,7 @@ public class SmtReachabilityTwoLinkPerDstIpTest {
     // verify unreachability, which is false (we'll get a counterexample).
     question.setNegate(true);
 
-    question.setDstIps(ImmutableSet.of(new IpWildcard(_dstIp)));
+    question.setDstIps(ImmutableSet.of(IpWildcard.create(_dstIp)));
     final AnswerElement answer = Answerer.create(question, _batfish).answer();
     assertThat(answer, instanceOf(SmtReachabilityAnswerElement.class));
 
@@ -139,7 +139,7 @@ public class SmtReachabilityTwoLinkPerDstIpTest {
     final ReachabilityQuestion question = new ReachabilityQuestion();
     question.setIngressNodeRegex(_srcNode.getHostname());
     question.setFinalNodeRegex(_dstNode.getHostname());
-    question.setDstIps(ImmutableSet.of(new IpWildcard(_dstIp)));
+    question.setDstIps(ImmutableSet.of(IpWildcard.create(_dstIp)));
     question.setFailures(1); // at most 1 failure
 
     final AnswerElement answer = Answerer.create(question, _batfish).answer();
@@ -163,7 +163,7 @@ public class SmtReachabilityTwoLinkPerDstIpTest {
     final ReachabilityQuestion question = new ReachabilityQuestion();
     question.setIngressNodeRegex(_srcNode.getHostname());
     question.setFinalNodeRegex(_dstNode.getHostname());
-    question.setDstIps(ImmutableSet.of(new IpWildcard(_dstIp)));
+    question.setDstIps(ImmutableSet.of(IpWildcard.create(_dstIp)));
     question.setFailures(1);
     question.setNegate(true);
 
@@ -181,7 +181,7 @@ public class SmtReachabilityTwoLinkPerDstIpTest {
     final ReachabilityQuestion question = new ReachabilityQuestion();
     question.setIngressNodeRegex(_srcNode.getHostname());
     question.setFinalNodeRegex(_dstNode.getHostname());
-    question.setNotDstIps(ImmutableSet.of(new IpWildcard(_dstIp)));
+    question.setNotDstIps(ImmutableSet.of(IpWildcard.create(_dstIp)));
     question.setFailures(1);
 
     final AnswerElement answer = Answerer.create(question, _batfish).answer();

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -522,7 +522,7 @@ public class Client extends AbstractClient implements IClient {
           throw new BatfishException(
               String.format("A Batfish %s must be a JSON string", expectedType.getName()));
         }
-        new IpWildcard(value.textValue());
+        IpWildcard.parse(value.textValue());
         break;
       case IPSEC_SESSION_STATUS:
         if (!value.isTextual()) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpSpaceToBDD.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpSpaceToBDD.java
@@ -118,7 +118,7 @@ public class IpSpaceToBDD implements GenericIpSpaceVisitor<BDD> {
 
   public BDD toBDD(IpWildcard ipWildcard) {
     long ip = ipWildcard.getIp().asLong();
-    long wildcard = ipWildcard.getWildcard().asLong();
+    long wildcard = ipWildcard.getWildcardMask();
     BDD acc = _one;
     BDD[] bitBDDs = _bddInteger.getBitvec();
     for (int i = Prefix.MAX_PREFIX_LENGTH - 1; i >= 0; i--) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IpsecUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IpsecUtil.java
@@ -471,11 +471,11 @@ public class IpsecUtil {
               .collect(ImmutableSet.toImmutableSet());
       Set<IpWildcard> blacklist =
           nonNattedInterfaceAddresses.stream()
-              .map(address -> new IpWildcard(address.getIp(), Ip.ZERO))
+              .map(address -> IpWildcard.create(address.getIp()))
               .collect(ImmutableSet.toImmutableSet());
       Set<IpWildcard> whitelist =
           nonNattedInterfaceAddresses.stream()
-              .map(address -> new IpWildcard(address.getPrefix()))
+              .map(address -> IpWildcard.create(address.getPrefix()))
               .collect(ImmutableSet.toImmutableSet());
       IpWildcardSetIpSpace ipSpace =
           IpWildcardSetIpSpace.builder().including(whitelist).excluding(blacklist).build();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -329,7 +329,7 @@ public final class FibImpl implements Fib {
               return subTriePrefixes;
             }
 
-            IpWildcard wc = new IpWildcard(prefix);
+            IpWildcard wc = IpWildcard.create(prefix);
 
             if (subTriePrefixes.isEmpty()) {
               builder.put(prefix, prefix.toIpSpace());

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -449,7 +449,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis {
       return EmptyIpSpace.INSTANCE;
     }
     IpWildcardSetIpSpace.Builder ipsAssignedToThisInterfaceBuilder = IpWildcardSetIpSpace.builder();
-    ips.forEach(ip -> ipsAssignedToThisInterfaceBuilder.including(new IpWildcard(ip)));
+    ips.forEach(ip -> ipsAssignedToThisInterfaceBuilder.including(IpWildcard.create(ip)));
     return ipsAssignedToThisInterfaceBuilder.build();
   }
 
@@ -635,7 +635,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis {
                           vrfEntry.getValue().allEntries().stream()
                               .map(
                                   fibEntry ->
-                                      new IpWildcard(fibEntry.getTopLevelRoute().getNetwork()))
+                                      IpWildcard.create(fibEntry.getTopLevelRoute().getNetwork()))
                               .collect(ImmutableSortedSet.toImmutableSortedSet(natural())))));
     }
   }
@@ -1398,7 +1398,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis {
               interfaceOwnedIps.values().stream()
                   .flatMap(ifaceMap -> ifaceMap.values().stream())
                   .flatMap(Collection::stream)
-                  .map(IpWildcard::new)
+                  .map(IpWildcard::create)
                   .collect(Collectors.toList()))
           .build();
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkePhase1Key.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkePhase1Key.java
@@ -29,7 +29,7 @@ public class IkePhase1Key implements Serializable {
 
   @JsonCreator
   public IkePhase1Key() {
-    _remoteIdentity = new IpWildcard("0.0.0.0:0.0.0.0").toIpSpace();
+    _remoteIdentity = IpWildcard.parse("0.0.0.0:0.0.0.0").toIpSpace();
     _localInterface = UNSET_LOCAL_INTERFACE;
   }
 
@@ -91,7 +91,7 @@ public class IkePhase1Key implements Serializable {
 
   @JsonProperty(PROP_REMOTE_IDENTITY)
   public void setRemoteIdentity(@Nullable IpSpace remoteIdentity) {
-    _remoteIdentity = firstNonNull(remoteIdentity, new IpWildcard("0.0.0.0:0.0.0.0").toIpSpace());
+    _remoteIdentity = firstNonNull(remoteIdentity, IpWildcard.parse("0.0.0.0:0.0.0.0").toIpSpace());
   }
 
   @JsonProperty(PROP_LOCAL_INTERFACE)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcard.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcard.java
@@ -5,6 +5,9 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import java.io.Serializable;
 import java.util.Comparator;
 import javax.annotation.Nonnull;
@@ -14,11 +17,18 @@ import javax.annotation.ParametersAreNonnullByDefault;
 /** An IP wildcard consisting of a IP address and a wildcard (also expressed as an IP address) */
 @ParametersAreNonnullByDefault
 public final class IpWildcard implements Serializable, Comparable<IpWildcard> {
+  // Soft values: let it be garbage collected in times of pressure.
+  // Maximum size 2^20: Just some upper bound on cache size, well less than GiB.
+  //   (16 bytes seems smallest possible entry (long), would be 16 MiB total).
+  private static final LoadingCache<IpWildcard, IpWildcard> CACHE =
+      CacheBuilder.newBuilder().softValues().maximumSize(1 << 20).build(CacheLoader.from(x -> x));
 
   @Nonnull private final Ip _ip;
-  @Nonnull private final Ip _mask;
+  // Set bits are "don't care" bits
+  private final long _wildcardMask;
 
-  public static final IpWildcard ANY = new IpWildcard(Ip.ZERO, Ip.MAX);
+  private static final long ALL_BITS_MASKED = 0xFFFFFFFFL;
+  public static final IpWildcard ANY = new IpWildcard(Ip.ZERO, ALL_BITS_MASKED);
 
   private static final long serialVersionUID = 1L;
 
@@ -51,33 +61,57 @@ public final class IpWildcard implements Serializable, Comparable<IpWildcard> {
     }
   }
 
-  public IpWildcard(Ip ip) {
-    this(Prefix.create(ip, Prefix.MAX_PREFIX_LENGTH));
+  /**
+   * Return an {@link IpWildcard} from the given {@link Ip IP address} and {@code wildcardMask}.
+   *
+   * <p>Bits that are set in the {@code wildcardMask} are "don't care" bits.
+   */
+  public static IpWildcard ipWithWildcardMask(Ip address, long wildcardMask) {
+    IpWildcard wildcard = new IpWildcard(address, wildcardMask);
+    return CACHE.getUnchecked(wildcard);
   }
 
-  public IpWildcard(Ip address, Ip wildcardMask) {
-    // Canonicalize the address before passing it to parent, so that #equals works.
-    _ip = Ip.create(address.asLong() & ~wildcardMask.asLong());
-    _mask = wildcardMask;
-    checkArgument(wildcardMask.valid(), "Invalid wildcard: %s", wildcardMask);
+  /**
+   * Return an {@link IpWildcard} from the given {@link Ip IP address} and {@link Ip wildcardMask}.
+   *
+   * <p>Bits that are set in the {@code wildcardMask} are "don't care" bits.
+   *
+   * @see #ipWithWildcardMask(Ip, long) for a version that directly accesses the mask.
+   */
+  public static IpWildcard ipWithWildcardMask(Ip address, Ip wildcardMask) {
+    return ipWithWildcardMask(address, wildcardMask.asLong());
   }
 
-  public IpWildcard(Prefix prefix) {
-    this(prefix.getStartIp(), prefix.getPrefixWildcard());
+  public static IpWildcard create(Prefix prefix) {
+    int wildcardBits = Prefix.MAX_PREFIX_LENGTH - prefix.getPrefixLength();
+    long wildcardMask = (1L << wildcardBits) - 1L;
+    return new IpWildcard(prefix.getStartIp(), wildcardMask);
+  }
+
+  public static IpWildcard create(Ip ip) {
+    return ipWithWildcardMask(ip, 0L);
   }
 
   @JsonCreator
-  public IpWildcard(String str) {
-    this(parseAddress(str), parseMask(str));
+  public static IpWildcard parse(String str) {
+    return ipWithWildcardMask(parseAddress(str), parseMask(str).asLong());
   }
 
   public boolean containsIp(Ip ip) {
-    long wildcardIpAsLong = getIp().asLong();
-    long wildcardMask = getWildcard().asLong();
-    long ipAsLong = ip.asLong();
-    long maskedIpAsLong = ipAsLong | wildcardMask;
-    long maskedWildcard = wildcardIpAsLong | wildcardMask;
-    return maskedIpAsLong == maskedWildcard;
+    checkArgument(ip.valid(), "Invalid IP address %s", ip);
+    long thisMasked = _ip.asLong() | _wildcardMask;
+    long ipMasked = ip.asLong() | _wildcardMask;
+    return thisMasked == ipMasked;
+  }
+
+  @Override
+  public int compareTo(IpWildcard o) {
+    if (this == o) {
+      return 0;
+    }
+    return Comparator.comparing(IpWildcard::getIp)
+        .thenComparing(IpWildcard::getWildcardMask)
+        .compare(this, o);
   }
 
   @Override
@@ -88,19 +122,12 @@ public final class IpWildcard implements Serializable, Comparable<IpWildcard> {
       return false;
     }
     IpWildcard other = (IpWildcard) o;
-    return this._ip.equals(other._ip) && this._mask.equals(other._mask);
+    return this._ip.equals(other._ip) && this._wildcardMask == other._wildcardMask;
   }
 
   @Override
   public int hashCode() {
-    return 31 * _ip.hashCode() + _mask.hashCode();
-  }
-
-  @Override
-  public int compareTo(IpWildcard o) {
-    return Comparator.comparing(IpWildcard::getIp)
-        .thenComparing(IpWildcard::getWildcard)
-        .compare(this, o);
+    return 31 * _ip.hashCode() + Long.hashCode(_wildcardMask);
   }
 
   @Nonnull
@@ -109,8 +136,16 @@ public final class IpWildcard implements Serializable, Comparable<IpWildcard> {
   }
 
   @Nonnull
-  public Ip getWildcard() {
-    return _mask;
+  public Ip getWildcardMaskAsIp() {
+    return Ip.create(_wildcardMask);
+  }
+
+  public long getWildcardMask() {
+    return _wildcardMask;
+  }
+
+  public long getMask() {
+    return ALL_BITS_MASKED ^ _wildcardMask;
   }
 
   /**
@@ -118,8 +153,8 @@ public final class IpWildcard implements Serializable, Comparable<IpWildcard> {
    * @return whether the set of IPs matched by this intersects the set of those matched by other.
    */
   public boolean intersects(IpWildcard other) {
-    long differentIpBits = getIp().asLong() ^ other.getIp().asLong();
-    long canDiffer = getWildcard().asLong() | other.getWildcard().asLong();
+    long differentIpBits = _ip.asLong() ^ other._ip.asLong();
+    long canDiffer = _wildcardMask | other._wildcardMask;
 
     /*
      * All IP bits that different must be wild in either this or other.
@@ -128,11 +163,7 @@ public final class IpWildcard implements Serializable, Comparable<IpWildcard> {
   }
 
   public boolean isPrefix() {
-    long w = _mask.asLong();
-    long wp = w + 1L;
-    int numTrailingZeros = Long.numberOfTrailingZeros(wp);
-    long check = 1L << numTrailingZeros;
-    return wp == check;
+    return (_wildcardMask & (_wildcardMask + 1L)) == 0L;
   }
 
   /**
@@ -148,9 +179,9 @@ public final class IpWildcard implements Serializable, Comparable<IpWildcard> {
    * @return whether the set of IPs matched by this is a superset of those matched by other.
    */
   public boolean supersetOf(IpWildcard other) {
-    long wildToThis = getWildcard().asLong();
-    long wildToOther = other.getWildcard().asLong();
-    long differentIpBits = getIp().asLong() ^ other.getIp().asLong();
+    long wildToThis = _wildcardMask;
+    long wildToOther = other._wildcardMask;
+    long differentIpBits = _ip.asLong() ^ other._ip.asLong();
 
     /*
      * 1. Any bits wild in other must be wild in this (i.e. other's wild bits must be a subset
@@ -167,19 +198,43 @@ public final class IpWildcard implements Serializable, Comparable<IpWildcard> {
   }
 
   public Prefix toPrefix() {
-    checkState(isPrefix(), "Invalid wildcard format for conversion to prefix: %s", _mask);
-    return Prefix.create(_ip, _mask.inverted());
+    checkState(isPrefix(), "Invalid wildcard format for conversion to prefix: %s", _wildcardMask);
+    return Prefix.create(_ip, Integer.numberOfLeadingZeros((int) _wildcardMask));
   }
 
   @JsonValue
   @Override
   public String toString() {
-    if (_mask.equals(Ip.ZERO)) {
+    if (_wildcardMask == 0L) {
       return _ip.toString();
     } else if (isPrefix()) {
       return toPrefix().toString();
     } else {
-      return _ip + ":" + _mask;
+      return _ip + ":" + getWildcardMaskAsIp();
     }
+  }
+
+  private IpWildcard(Ip address, long wildcardMask) {
+    checkArgument(address.valid(), "Invalid IP address %s", address);
+    checkArgument(
+        (wildcardMask & ALL_BITS_MASKED) == wildcardMask, "Invalid mask %s", wildcardMask);
+
+    long inputIp = address.asLong();
+    long canonicalIp = inputIp & (ALL_BITS_MASKED ^ wildcardMask);
+    _ip = (canonicalIp == inputIp) ? address : Ip.create(canonicalIp);
+    _wildcardMask = wildcardMask;
+  }
+
+  // Old constructor, visible for transitioning off it.
+  public IpWildcard(Prefix prefix) {
+    int wildcardBits = Prefix.MAX_PREFIX_LENGTH - prefix.getPrefixLength();
+    _wildcardMask = (1L << wildcardBits) - 1L;
+    _ip = prefix.getStartIp();
+  }
+
+  // Old constructor, visible for transitioning off it.
+  public IpWildcard(String str) {
+    _ip = parseAddress(str);
+    _wildcardMask = parseMask(str).asLong();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
@@ -87,7 +87,7 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
   private Prefix(Ip ip, int prefixLength) {
     checkArgument(
         prefixLength >= 0 && prefixLength <= MAX_PREFIX_LENGTH,
-        "Invalid prefix length %d",
+        "Invalid prefix length %s",
         prefixLength);
     if (ip.valid()) {
       // TODO: stop using Ip as a holder for invalid values.

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RouteFilterLine.java
@@ -47,12 +47,12 @@ public final class RouteFilterLine implements Serializable {
 
   public RouteFilterLine(LineAction action, Prefix prefix, SubRange lengthRange) {
     _action = action;
-    _ipWildcard = new IpWildcard(prefix);
+    _ipWildcard = IpWildcard.create(prefix);
     _lengthRange = lengthRange;
   }
 
   public RouteFilterLine(LineAction action, PrefixRange prefixRange) {
-    this(action, new IpWildcard(prefixRange.getPrefix()), prefixRange.getLengthRange());
+    this(action, IpWildcard.create(prefixRange.getPrefix()), prefixRange.getLengthRange());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceMayIntersectWildcard.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceMayIntersectWildcard.java
@@ -92,7 +92,7 @@ public class IpSpaceMayIntersectWildcard implements GenericIpSpaceVisitor<Boolea
 
   @Override
   public Boolean visitPrefixIpSpace(PrefixIpSpace prefixIpSpace) {
-    return new IpWildcard(prefixIpSpace.getPrefix()).intersects(_ipWildcard);
+    return IpWildcard.create(prefixIpSpace.getPrefix()).intersects(_ipWildcard);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceMayNotContainWildcard.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/IpSpaceMayNotContainWildcard.java
@@ -80,7 +80,7 @@ public class IpSpaceMayNotContainWildcard implements GenericIpSpaceVisitor<Boole
 
   @Override
   public Boolean visitIpIpSpace(IpIpSpace ipIpSpace) {
-    return !new IpWildcard(ipIpSpace.getIp()).equals(_ipWildcard);
+    return !IpWildcard.create(ipIpSpace.getIp()).equals(_ipWildcard);
   }
 
   @Override
@@ -104,7 +104,7 @@ public class IpSpaceMayNotContainWildcard implements GenericIpSpaceVisitor<Boole
 
   @Override
   public Boolean visitPrefixIpSpace(PrefixIpSpace prefixIpSpace) {
-    return !new IpWildcard(prefixIpSpace.getPrefix()).supersetOf(_ipWildcard);
+    return !IpWildcard.create(prefixIpSpace.getPrefix()).supersetOf(_ipWildcard);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/AddressGroup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/AddressGroup.java
@@ -55,7 +55,7 @@ public class AddressGroup implements Comparable<AddressGroup>, Serializable {
     _childGroupNames = firstNonNull(childGroupNames, new TreeSet<>());
 
     // check if all the input address strings can be mapped to an IpWildCard
-    _addresses.forEach(IpWildcard::new);
+    _addresses.forEach(IpWildcard::parse);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/ReferenceBook.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/ReferenceBook.java
@@ -295,7 +295,7 @@ public class ReferenceBook implements Comparable<ReferenceBook>, Serializable {
     return allGroupNames.stream()
         // get() is safe because we got names from the book itself
         .flatMap(groupName -> getAddressGroup(groupName).get().getAddresses().stream())
-        .map(IpWildcard::new)
+        .map(IpWildcard::parse)
         .collect(ImmutableSet.toImmutableSet());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleIpSpaceSpecifierFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/FlexibleIpSpaceSpecifierFactory.java
@@ -82,7 +82,7 @@ public final class FlexibleIpSpaceSpecifierFactory implements IpSpaceSpecifierFa
     String[] wildcardStrs = wildcardsStr.split(",");
     return Arrays.stream(wildcardStrs)
         .map(String::trim)
-        .map(IpWildcard::new)
+        .map(IpWildcard::parse)
         .collect(ImmutableList.toImmutableList());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceWithConnectedIpsSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceWithConnectedIpsSpecifier.java
@@ -85,7 +85,7 @@ public final class InterfaceWithConnectedIpsSpecifier implements InterfaceSpecif
           "%s requires an IP address, prefix, or wildcard provided as a string input, not %s",
           NAME,
           input);
-      return new InterfaceWithConnectedIpsSpecifier(new IpWildcard((String) input).toIpSpace());
+      return new InterfaceWithConnectedIpsSpecifier(IpWildcard.parse((String) input).toIpSpace());
     }
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/IpWildcardAstNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/IpWildcardAstNode.java
@@ -13,13 +13,13 @@ final class IpWildcardAstNode implements IpSpaceAstNode {
   }
 
   IpWildcardAstNode(String ipWildcard) {
-    _ipWildcard = new IpWildcard(ipWildcard);
+    _ipWildcard = IpWildcard.parse(ipWildcard);
   }
 
   IpWildcardAstNode(AstNode addressNode, AstNode maskNode) {
     Ip address = ((IpAstNode) addressNode).getIp();
     Ip mask = ((IpAstNode) maskNode).getIp();
-    _ipWildcard = new IpWildcard(address, mask);
+    _ipWildcard = IpWildcard.ipWithWildcardMask(address, mask);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/IpSpaceToBDDTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/IpSpaceToBDDTest.java
@@ -111,7 +111,8 @@ public class IpSpaceToBDDTest {
 
   @Test
   public void testIpWildcard() {
-    IpSpace ipSpace = new IpWildcard(Ip.parse("255.0.255.0"), Ip.parse("0.255.0.255")).toIpSpace();
+    IpSpace ipSpace =
+        IpWildcard.ipWithWildcardMask(Ip.parse("255.0.255.0"), Ip.parse("0.255.0.255")).toIpSpace();
     BDD bdd = ipSpace.accept(_ipSpaceToBdd);
     assertThat(
         bdd,
@@ -126,7 +127,7 @@ public class IpSpaceToBDDTest {
   @Test
   public void testIpWildcard_prefix() {
     IpSpace ipWildcardIpSpace =
-        new IpWildcard(Ip.parse("123.0.0.0"), Ip.parse("0.255.255.255")).toIpSpace();
+        IpWildcard.ipWithWildcardMask(Ip.parse("123.0.0.0"), Ip.parse("0.255.255.255")).toIpSpace();
     IpSpace prefixIpSpace = Prefix.parse("123.0.0.0/8").toIpSpace();
     BDD bdd1 = ipWildcardIpSpace.accept(_ipSpaceToBdd);
     BDD bdd2 = prefixIpSpace.accept(_ipSpaceToBdd);
@@ -201,13 +202,13 @@ public class IpSpaceToBDDTest {
     Prefix exclude4 = Prefix.parse("1.1.3.3/32");
     IpWildcardSetIpSpace ipSpace =
         IpWildcardSetIpSpace.builder()
-            .including(new IpWildcard(include1))
-            .including(new IpWildcard(include2))
-            .including(new IpWildcard(include3))
-            .excluding(new IpWildcard(exclude1))
-            .excluding(new IpWildcard(exclude2))
-            .excluding(new IpWildcard(exclude3))
-            .excluding(new IpWildcard(exclude4))
+            .including(IpWildcard.create(include1))
+            .including(IpWildcard.create(include2))
+            .including(IpWildcard.create(include3))
+            .excluding(IpWildcard.create(exclude1))
+            .excluding(IpWildcard.create(exclude2))
+            .excluding(IpWildcard.create(exclude3))
+            .excluding(IpWildcard.create(exclude4))
             .build();
 
     BDD include1Bdd = _ipSpaceToBdd.toBDD(include1);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/ipspace/IpSpaceSimplifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/ipspace/IpSpaceSimplifierTest.java
@@ -115,7 +115,8 @@ public class IpSpaceSimplifierTest {
   public void testVisitIpWildcard() {
     assertThat(SIMPLIFIER.simplify(IpWildcard.ANY.toIpSpace()), equalTo(UniverseIpSpace.INSTANCE));
 
-    IpWildcard ipWildcard = new IpWildcard(Ip.parse("1.2.0.5"), Ip.create(0xFFFF00FFL));
+    IpWildcard ipWildcard =
+        IpWildcard.ipWithWildcardMask(Ip.parse("1.2.0.5"), Ip.create(0xFFFF00FFL));
     assertThat(SIMPLIFIER.simplify(ipWildcard.toIpSpace()), equalTo(ipWildcard.toIpSpace()));
   }
 
@@ -126,7 +127,7 @@ public class IpSpaceSimplifierTest {
         equalTo(EmptyIpSpace.INSTANCE));
     assertThat(
         SIMPLIFIER.simplify(
-            IpWildcardSetIpSpace.builder().excluding(new IpWildcard("1.2.3.0/24")).build()),
+            IpWildcardSetIpSpace.builder().excluding(IpWildcard.parse("1.2.3.0/24")).build()),
         equalTo(EmptyIpSpace.INSTANCE));
 
     assertThat(
@@ -143,24 +144,24 @@ public class IpSpaceSimplifierTest {
     // whitelisted wildcards that are covered by a blacklisted wildcard are removed
     IpWildcardSetIpSpace ipSpace =
         IpWildcardSetIpSpace.builder()
-            .including(new IpWildcard("1.2.1.0/24"), new IpWildcard("2.2.2.2"))
-            .excluding(new IpWildcard("1.2.0.0/16"))
+            .including(IpWildcard.parse("1.2.1.0/24"), IpWildcard.parse("2.2.2.2"))
+            .excluding(IpWildcard.parse("1.2.0.0/16"))
             .build();
-    IpSpace simplifiedIpSpace = new IpWildcard("2.2.2.2").toIpSpace();
+    IpSpace simplifiedIpSpace = IpWildcard.parse("2.2.2.2").toIpSpace();
     assertThat(SIMPLIFIER.simplify(ipSpace), equalTo(simplifiedIpSpace));
 
     // blacklisted wildcards that don't overlap whitelisted wildcards are removed
     ipSpace =
         IpWildcardSetIpSpace.builder()
-            .including(new IpWildcard("2.2.2.2"))
-            .excluding(new IpWildcard("1.0.0.0/8"))
+            .including(IpWildcard.parse("2.2.2.2"))
+            .excluding(IpWildcard.parse("1.0.0.0/8"))
             .build();
     assertThat(SIMPLIFIER.simplify(ipSpace), equalTo(simplifiedIpSpace));
   }
 
   @Test
   public void testVisitIpWildcardSetIpSpace_whitelistOne() {
-    IpWildcard ipWildcard = new IpWildcard("1.2.3.4");
+    IpWildcard ipWildcard = IpWildcard.parse("1.2.3.4");
     assertThat(
         SIMPLIFIER.simplify(IpWildcardSetIpSpace.builder().including(ipWildcard).build()),
         equalTo(ipWildcard.toIpSpace()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -107,8 +107,11 @@ public class ForwardingAnalysisImplTest {
     i1.setAdditionalArpIps(additionalIp.toIpSpace());
     i2.setAdditionalArpIps(additionalIp.toIpSpace());
     IpSpace ipsRoutedOutI1 =
-        IpWildcardSetIpSpace.builder().including(new IpWildcard(P1), new IpWildcard(P3)).build();
-    IpSpace ipsRoutedOutI2 = IpWildcardSetIpSpace.builder().including(new IpWildcard(P2)).build();
+        IpWildcardSetIpSpace.builder()
+            .including(IpWildcard.create(P1), IpWildcard.create(P3))
+            .build();
+    IpSpace ipsRoutedOutI2 =
+        IpWildcardSetIpSpace.builder().including(IpWildcard.create(P2)).build();
     Map<String, Configuration> configurations =
         ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2);
     Map<String, Map<String, IpSpace>> routableIps =
@@ -199,8 +202,11 @@ public class ForwardingAnalysisImplTest {
             .build();
     Interface i3 = _ib.setAddress(null).setProxyArp(true).build();
     IpSpace ipsRoutedOutI1 =
-        IpWildcardSetIpSpace.builder().including(new IpWildcard(P1), new IpWildcard(P3)).build();
-    IpSpace ipsRoutedOutI2 = IpWildcardSetIpSpace.builder().including(new IpWildcard(P2)).build();
+        IpWildcardSetIpSpace.builder()
+            .including(IpWildcard.create(P1), IpWildcard.create(P3))
+            .build();
+    IpSpace ipsRoutedOutI2 =
+        IpWildcardSetIpSpace.builder().including(IpWildcard.create(P2)).build();
     IpSpace ipsRoutedOutI3 = EmptyIpSpace.INSTANCE;
     Map<String, Interface> interfaces =
         ImmutableMap.of(i1.getName(), i1, i2.getName(), i2, i3.getName(), i3);
@@ -277,7 +283,7 @@ public class ForwardingAnalysisImplTest {
     Map<String, Map<String, Set<Ip>>> interfaceOwnedIps =
         TopologyUtil.computeInterfaceOwnedIps(configs, false);
 
-    IpSpace p1IpSpace = new IpWildcard(P1).toIpSpace();
+    IpSpace p1IpSpace = IpWildcard.create(P1).toIpSpace();
     IpSpace i1ArpReplies =
         computeInterfaceArpReplies(i1, UniverseIpSpace.INSTANCE, p1IpSpace, interfaceOwnedIps);
     IpSpace i2ArpReplies =
@@ -478,7 +484,9 @@ public class ForwardingAnalysisImplTest {
     Interface iProxyArp = _ib.setProxyArp(true).build();
     IpSpace routableIpsForThisVrf = UniverseIpSpace.INSTANCE;
     IpSpace ipsRoutedThroughInterface =
-        IpWildcardSetIpSpace.builder().including(new IpWildcard(P1), new IpWildcard(P2)).build();
+        IpWildcardSetIpSpace.builder()
+            .including(IpWildcard.create(P1), IpWildcard.create(P2))
+            .build();
     Map<String, Map<String, Set<Ip>>> interfaceOwnedIps =
         TopologyUtil.computeInterfaceOwnedIps(ImmutableMap.of(config.getHostname(), config), false);
     IpSpace noProxyArpResult =
@@ -851,7 +859,7 @@ public class ForwardingAnalysisImplTest {
                 c1,
                 ImmutableMap.of(
                     v1,
-                    IpWildcardSetIpSpace.builder().including(new IpWildcard(prefix)).build()))));
+                    IpWildcardSetIpSpace.builder().including(IpWildcard.create(prefix)).build()))));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpSpaceTest.java
@@ -16,17 +16,17 @@ public class IpSpaceTest {
   public void testIpSpace() {
     IpWildcardSetIpSpace any = IpWildcardSetIpSpace.builder().including(IpWildcard.ANY).build();
     IpWildcardSetIpSpace justMax =
-        IpWildcardSetIpSpace.builder().including(new IpWildcard(Ip.MAX)).build();
+        IpWildcardSetIpSpace.builder().including(IpWildcard.create(Ip.MAX)).build();
     IpWildcardSetIpSpace anyExceptMax =
         IpWildcardSetIpSpace.builder()
             .including(IpWildcard.ANY)
-            .excluding(new IpWildcard(Ip.MAX))
+            .excluding(IpWildcard.create(Ip.MAX))
             .build();
     IpWildcardSetIpSpace none1 = IpWildcardSetIpSpace.builder().build();
     IpWildcardSetIpSpace none2 =
         IpWildcardSetIpSpace.builder().including(IpWildcard.ANY).excluding(IpWildcard.ANY).build();
     IpWildcardSetIpSpace someButNotMax =
-        IpWildcardSetIpSpace.builder().including(new IpWildcard("1.2.3.4")).build();
+        IpWildcardSetIpSpace.builder().including(IpWildcard.parse("1.2.3.4")).build();
 
     /*
      * Contains every IP, so should contain Ip.MAX
@@ -65,11 +65,11 @@ public class IpSpaceTest {
     IpIpSpace ipIpSpace = ip.toIpSpace();
     Prefix p = Prefix.create(ip, 24);
     IpSpace prefixIpSpace = p.toIpSpace();
-    IpWildcard ipWildcard1 = new IpWildcard(p);
+    IpWildcard ipWildcard1 = IpWildcard.create(p);
     IpWildcardIpSpace ipWildcard1IpSpace = ipWildcard1.toIpSpace();
-    IpWildcard ipWildcard2 = new IpWildcard(ip);
+    IpWildcard ipWildcard2 = IpWildcard.create(ip);
     IpWildcardIpSpace ipWildcard2IpSpace = ipWildcard2.toIpSpace();
-    IpWildcard ipWildcard3 = new IpWildcard(ip, Ip.parse("0.255.0.255"));
+    IpWildcard ipWildcard3 = IpWildcard.ipWithWildcardMask(ip, Ip.parse("0.255.0.255"));
     IpWildcardIpSpace ipWildcard3IpSpace = ipWildcard3.toIpSpace();
     IpSpace ipWildcardSetIpSpace =
         IpWildcardSetIpSpace.builder().including(ipWildcard1, ipWildcard2, ipWildcard3).build();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpWildcardSetIpSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpWildcardSetIpSpaceTest.java
@@ -9,10 +9,8 @@ import org.junit.Test;
 public class IpWildcardSetIpSpaceTest {
   private static final IpSpace ipSpace =
       IpWildcardSetIpSpace.builder()
-          .including(
-              new IpWildcard(Prefix.parse("1.1.1.0/24")),
-              new IpWildcard(Prefix.parse("1.1.2.0/24")))
-          .excluding(new IpWildcard(Prefix.parse("1.1.1.1/32")))
+          .including(IpWildcard.parse("1.1.1.0/24"), IpWildcard.parse("1.1.2.0/24"))
+          .excluding(IpWildcard.parse("1.1.1.1/32"))
           .build();
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpWildcardTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpWildcardTest.java
@@ -3,26 +3,46 @@ package org.batfish.datamodel;
 import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 
+/** Tests of {@link IpWildcard}. */
 public class IpWildcardTest {
   @Test
-  public void testConstructors() {
-    assertThat(
-        new IpWildcard(Ip.parse("1.2.3.4")),
-        equalTo(new IpWildcard(Ip.create(0x01020304L), Ip.ZERO)));
-
-    assertThat(new IpWildcard("1.2.3.4"), equalTo(new IpWildcard(Ip.create(0x01020304L), Ip.ZERO)));
-
-    assertThat(new IpWildcard("1.2.3.4/8"), equalTo(new IpWildcard("1.0.0.0/8")));
+  public void testConstructionAndEquality() {
+    new EqualsTester()
+        .addEqualityGroup(
+            IpWildcard.parse("1.2.3.4"),
+            IpWildcard.create(Ip.parse("1.2.3.4")),
+            IpWildcard.create(Prefix.parse("1.2.3.4/32")),
+            IpWildcard.ipWithWildcardMask(Ip.parse("1.2.3.4"), 0L),
+            IpWildcard.parse("1.2.3.4:0.0.0.0"))
+        .addEqualityGroup(
+            IpWildcard.parse("1.2.3.4/8"),
+            IpWildcard.create(Prefix.parse("1.2.3.4/8")),
+            IpWildcard.ipWithWildcardMask(Ip.parse("1.2.3.4"), 0x00FFFFFFL),
+            IpWildcard.parse("1.2.3.4:0.255.255.255"))
+        .addEqualityGroup(
+            IpWildcard.create(Prefix.ZERO),
+            IpWildcard.parse("0.0.0.0:255.255.255.255"),
+            IpWildcard.parse("1.2.3.4:255.255.255.255"))
+        .addEqualityGroup(
+            IpWildcard.ipWithWildcardMask(Ip.parse("1.2.3.4"), 0xF0F0F0F0L),
+            IpWildcard.ipWithWildcardMask(Ip.parse("65.66.67.68"), 0xF0F0F0F0L),
+            IpWildcard.ipWithWildcardMask(Ip.parse("97.98.99.100"), 0xF0F0F0F0L),
+            IpWildcard.ipWithWildcardMask(Ip.parse("129.130.131.132"), 0xF0F0F0F0L),
+            IpWildcard.ipWithWildcardMask(Ip.parse("1.66.99.132"), 0xF0F0F0F0L))
+        .testEquals();
   }
 
   @Test
   public void testContains() {
-    IpSpace ipWildcard = new IpWildcard(Ip.create(0x01010001L), Ip.create(0x0000FF00L)).toIpSpace();
+    IpSpace ipWildcard =
+        IpWildcard.ipWithWildcardMask(Ip.create(0x01010001L), Ip.create(0x0000FF00L)).toIpSpace();
     assertThat(ipWildcard, containsIp(Ip.parse("1.1.1.1")));
     assertThat(ipWildcard, containsIp(Ip.parse("1.1.255.1")));
     assertThat(ipWildcard, not(containsIp(Ip.parse("1.1.0.0"))));
@@ -31,7 +51,9 @@ public class IpWildcardTest {
   @Test
   public void testComplement() {
     IpSpace ipSpace =
-        new IpWildcard(Ip.create(0x01010001L), Ip.create(0x0000FF00L)).toIpSpace().complement();
+        IpWildcard.ipWithWildcardMask(Ip.create(0x01010001L), Ip.create(0x0000FF00L))
+            .toIpSpace()
+            .complement();
     assertThat(ipSpace, not(containsIp(Ip.parse("1.1.1.1"))));
     assertThat(ipSpace, not(containsIp(Ip.parse("1.1.255.1"))));
     assertThat(ipSpace, containsIp(Ip.parse("1.1.0.0")));
@@ -44,8 +66,10 @@ public class IpWildcardTest {
      * are significant (i.e. not wild). In this example, since the significant bits of
      * wc1 and wc2 don't overlap, they should intersect (i.e. their bitwise OR is included in each).
      */
-    IpWildcard wc1 = new IpWildcard(Ip.create(0x00b0000aL), Ip.create(0x00FF00FFL).inverted());
-    IpWildcard wc2 = new IpWildcard(Ip.create(0x000cd000L), Ip.create(0x0000FF00L).inverted());
+    IpWildcard wc1 =
+        IpWildcard.ipWithWildcardMask(Ip.create(0x00b0000aL), Ip.create(0x00FF00FFL).inverted());
+    IpWildcard wc2 =
+        IpWildcard.ipWithWildcardMask(Ip.create(0x000cd000L), Ip.create(0x0000FF00L).inverted());
     assertTrue("wildcards should overlap", wc1.intersects(wc2));
   }
 
@@ -55,29 +79,41 @@ public class IpWildcardTest {
      * Since the significant regions of wc1 and wc2 overlap and are not equal, there is no
      * intersection between them.
      */
-    IpWildcard wc1 = new IpWildcard(Ip.create(0x00000F00L), Ip.create(0x0000FF00L).inverted());
-    IpWildcard wc2 = new IpWildcard(Ip.create(0x0000F000L), Ip.create(0x0000FF00L).inverted());
-    assertTrue("wildcards should not overlap", !wc1.intersects(wc2));
+    IpWildcard wc1 =
+        IpWildcard.ipWithWildcardMask(Ip.create(0x00000F00L), Ip.create(0x0000FF00L).inverted());
+    IpWildcard wc2 =
+        IpWildcard.ipWithWildcardMask(Ip.create(0x0000F000L), Ip.create(0x0000FF00L).inverted());
+    assertFalse(wc1.intersects(wc2));
   }
 
   @Test
   public void testSupersetOf() {
-    IpWildcard wc1 = new IpWildcard("1.2.0.0/16");
-    IpWildcard wc2 = new IpWildcard("1.2.3.0/24");
+    IpWildcard wc1 = IpWildcard.parse("1.2.0.0/16");
+    IpWildcard wc2 = IpWildcard.parse("1.2.3.0/24");
 
     assertTrue("IpWildcard.supersetOf should not be strict", wc1.supersetOf(wc1));
 
     assertTrue("wc1 should be a superset of wc2", wc1.supersetOf(wc2));
-    assertTrue("wc2 should not be a superset of wc1", !wc2.supersetOf(wc1));
+    assertFalse("wc2 should not be a superset of wc1", wc2.supersetOf(wc1));
 
-    wc1 = new IpWildcard(Ip.create(0x12005600L), Ip.create(0xFF00FF00L).inverted());
-    wc2 = new IpWildcard(Ip.create(0x12345600L), Ip.create(0xFFFFFF00L).inverted());
+    wc1 = IpWildcard.ipWithWildcardMask(Ip.create(0x12005600L), Ip.create(0xFF00FF00L).inverted());
+    wc2 = IpWildcard.ipWithWildcardMask(Ip.create(0x12345600L), Ip.create(0xFFFFFF00L).inverted());
     assertTrue("wc1 should be a superset of wc2", wc1.supersetOf(wc2));
-    assertTrue("wc2 should not be a superset of wc1", !wc2.supersetOf(wc1));
+    assertFalse("wc2 should not be a superset of wc1", wc2.supersetOf(wc1));
   }
 
   @Test
   public void testSuperset_ANY() {
     assertTrue("ANY should be a superset of itself", IpWildcard.ANY.supersetOf(IpWildcard.ANY));
+  }
+
+  @Test
+  public void testToString() {
+    assertThat(IpWildcard.parse("1.2.3.4").toString(), equalTo("1.2.3.4"));
+    assertThat(IpWildcard.parse("1.2.3.4/0").toString(), equalTo("0.0.0.0/0"));
+    assertThat(IpWildcard.parse("1.2.3.4/8").toString(), equalTo("1.0.0.0/8"));
+    assertThat(IpWildcard.parse("1.2.3.4/31").toString(), equalTo("1.2.3.4/31"));
+    assertThat(IpWildcard.parse("1.2.3.4/32").toString(), equalTo("1.2.3.4"));
+    assertThat(IpWildcard.parse("1.2.3.4:255.0.255.0").toString(), equalTo("0.2.0.4:255.0.255.0"));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RouteFilterLineTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RouteFilterLineTest.java
@@ -17,23 +17,21 @@ public class RouteFilterLineTest {
   @Test
   public void testEquals() {
     RouteFilterLine rfl =
-        new RouteFilterLine(
-            LineAction.PERMIT, new IpWildcard(Ip.parse("1.1.1.1")), new SubRange(30, 32));
+        new RouteFilterLine(LineAction.PERMIT, IpWildcard.parse("1.1.1.1"), new SubRange(30, 32));
     new EqualsTester()
         .addEqualityGroup(
             rfl,
             rfl,
             new RouteFilterLine(
-                LineAction.PERMIT, new IpWildcard(Ip.parse("1.1.1.1")), new SubRange(30, 32)))
+                LineAction.PERMIT, IpWildcard.parse("1.1.1.1"), new SubRange(30, 32)))
+        .addEqualityGroup(
+            new RouteFilterLine(LineAction.DENY, IpWildcard.parse("1.1.1.1"), new SubRange(30, 32)))
         .addEqualityGroup(
             new RouteFilterLine(
-                LineAction.DENY, new IpWildcard(Ip.parse("1.1.1.1")), new SubRange(30, 32)))
+                LineAction.PERMIT, IpWildcard.parse("2.2.2.2"), new SubRange(30, 32)))
         .addEqualityGroup(
             new RouteFilterLine(
-                LineAction.PERMIT, new IpWildcard(Ip.parse("2.2.2.2")), new SubRange(30, 32)))
-        .addEqualityGroup(
-            new RouteFilterLine(
-                LineAction.PERMIT, new IpWildcard(Ip.parse("2.2.2.2")), new SubRange(29, 32)))
+                LineAction.PERMIT, IpWildcard.parse("2.2.2.2"), new SubRange(29, 32)))
         .addEqualityGroup(new Object())
         .testEquals();
   }
@@ -41,16 +39,14 @@ public class RouteFilterLineTest {
   @Test
   public void testJavaSerialization() {
     RouteFilterLine rfl =
-        new RouteFilterLine(
-            LineAction.PERMIT, new IpWildcard(Ip.parse("1.1.1.1")), new SubRange(30, 32));
+        new RouteFilterLine(LineAction.PERMIT, IpWildcard.parse("1.1.1.1"), new SubRange(30, 32));
     assertThat(SerializationUtils.clone(rfl), equalTo(rfl));
   }
 
   @Test
   public void testJsonSerialization() throws IOException {
     RouteFilterLine rfl =
-        new RouteFilterLine(
-            LineAction.PERMIT, new IpWildcard(Ip.parse("1.1.1.1")), new SubRange(30, 32));
+        new RouteFilterLine(LineAction.PERMIT, IpWildcard.parse("1.1.1.1"), new SubRange(30, 32));
     assertThat(BatfishObjectMapper.clone(rfl, RouteFilterLine.class), equalTo(rfl));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RouteFilterListTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RouteFilterListTest.java
@@ -23,7 +23,7 @@ public class RouteFilterListTest {
             ImmutableList.of(
                 new RouteFilterLine(
                     LineAction.PERMIT,
-                    new IpWildcard("1.2.3.4:0.255.0.255"),
+                    IpWildcard.parse("1.2.3.4:0.255.0.255"),
                     new SubRange(24, 24))));
     _rfPrefixMoreSpecific =
         new RouteFilterList(
@@ -31,7 +31,7 @@ public class RouteFilterListTest {
             ImmutableList.of(
                 new RouteFilterLine(
                     LineAction.PERMIT,
-                    new IpWildcard("1.2.3.4:0.0.255.255"),
+                    IpWildcard.parse("1.2.3.4:0.0.255.255"),
                     new SubRange(26, 32))));
     _rfPrefixExact =
         new RouteFilterList(
@@ -39,7 +39,7 @@ public class RouteFilterListTest {
             ImmutableList.of(
                 new RouteFilterLine(
                     LineAction.PERMIT,
-                    new IpWildcard("1.2.3.4:0.0.255.255"),
+                    IpWildcard.parse("1.2.3.4:0.0.255.255"),
                     new SubRange(26, 26))));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclLineMatchExprNormalizerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclLineMatchExprNormalizerTest.java
@@ -27,15 +27,15 @@ public class AclLineMatchExprNormalizerTest {
   private static final String IFACE = "IFACE";
 
   private static final AclLineMatchExpr A =
-      matchDst(new IpWildcard(Ip.create(0x00000000L), Ip.create(0xFFFFFFF0L)));
+      matchDst(IpWildcard.ipWithWildcardMask(Ip.create(0x00000000L), Ip.create(0xFFFFFFF0L)));
   private static final AclLineMatchExpr B =
-      matchDst(new IpWildcard(Ip.create(0x00000000L), Ip.create(0xFFFFFF0FL)));
+      matchDst(IpWildcard.ipWithWildcardMask(Ip.create(0x00000000L), Ip.create(0xFFFFFF0FL)));
   private static final AclLineMatchExpr C =
-      matchDst(new IpWildcard(Ip.create(0x00000000L), Ip.create(0xFFFFF0FFL)));
+      matchDst(IpWildcard.ipWithWildcardMask(Ip.create(0x00000000L), Ip.create(0xFFFFF0FFL)));
   private static final AclLineMatchExpr D =
-      matchDst(new IpWildcard(Ip.create(0x00000000L), Ip.create(0xFFFF0FFFL)));
+      matchDst(IpWildcard.ipWithWildcardMask(Ip.create(0x00000000L), Ip.create(0xFFFF0FFFL)));
   private static final AclLineMatchExpr E =
-      matchDst(new IpWildcard(Ip.create(0x00000000L), Ip.create(0xFFF0FFFFL)));
+      matchDst(IpWildcard.ipWithWildcardMask(Ip.create(0x00000000L), Ip.create(0xFFF0FFFFL)));
 
   private IpAccessListToBdd _toBDD;
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/PermittedByAclTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/PermittedByAclTest.java
@@ -40,7 +40,7 @@ public class PermittedByAclTest {
             .setMatchCondition(
                 new MatchHeaderSpace(
                     HeaderSpace.builder()
-                        .setSrcIps(ImmutableSet.of(new IpWildcard(srcIpWildcard)))
+                        .setSrcIps(ImmutableSet.of(IpWildcard.parse(srcIpWildcard)))
                         .build()))
             .setAction(lineAction)
             .build();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceDescriberTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceDescriberTest.java
@@ -154,7 +154,7 @@ public final class IpSpaceDescriberTest {
 
   @Test
   public void testVisitIpWildcardIpSpace() {
-    IpSpace ipSpace = new IpWildcard("1.0.1.4:4.3.2.1").toIpSpace();
+    IpSpace ipSpace = IpWildcard.parse("1.0.1.4:4.3.2.1").toIpSpace();
     IpSpaceDescriber describerWithMetadata =
         new IpSpaceDescriber(
             new AclTracer(
@@ -172,8 +172,8 @@ public final class IpSpaceDescriberTest {
   public void testVisitIpWildcardSetIpSpace() {
     IpSpace ipSpace =
         IpWildcardSetIpSpace.builder()
-            .including(new IpWildcard("1.0.0.0:1.0.1.0"))
-            .excluding(new IpWildcard("2.0.0.0:0.1.0.1"))
+            .including(IpWildcard.parse("1.0.0.0:1.0.1.0"))
+            .excluding(IpWildcard.parse("2.0.0.0:0.1.0.1"))
             .build();
     IpSpaceDescriber describerWithMetadata =
         new IpSpaceDescriber(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceRenamerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceRenamerTest.java
@@ -29,11 +29,11 @@ public class IpSpaceRenamerTest {
   private static final IpSpaceRenamer RENAMER = new IpSpaceRenamer(ImmutableMap.of(FOO, BAR)::get);
   private static final IpSpace PREFIX_IP_SPACE = Prefix.parse("1.0.0.0/8").toIpSpace();
   private static final IpWildcardIpSpace IP_WILDCARD_IP_SPACE =
-      new IpWildcard("1.2.0.0/16").toIpSpace();
+      IpWildcard.parse("1.2.0.0/16").toIpSpace();
   private static final IpWildcardSetIpSpace IP_WILDCARD_SET_IP_SPACE =
       IpWildcardSetIpSpace.builder()
-          .including(new IpWildcard("1.2.3.4"))
-          .excluding(new IpWildcard("5.6.7.8"))
+          .including(IpWildcard.parse("1.2.3.4"))
+          .excluding(IpWildcard.parse("5.6.7.8"))
           .build();
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceRepresentativeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/visitors/IpSpaceRepresentativeTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 public class IpSpaceRepresentativeTest {
   private static final IpWildcard EVEN_IPS =
-      new IpWildcard(Ip.parse("0.0.0.0"), Ip.parse("255.255.255.254"));
+      IpWildcard.ipWithWildcardMask(Ip.parse("0.0.0.0"), Ip.parse("255.255.255.254"));
 
   private IpSpaceRepresentative _ipSpaceRepresentative;
 
@@ -86,7 +86,7 @@ public class IpSpaceRepresentativeTest {
   public void testIpWildcardIpSpace() {
     Ip ip = Ip.parse("1.0.2.0");
     Ip mask = Ip.parse("0.255.0.255");
-    IpWildcard wc = new IpWildcard(ip, mask);
+    IpWildcard wc = IpWildcard.ipWithWildcardMask(ip, mask);
     assertThat(_ipSpaceRepresentative.getRepresentative(wc.toIpSpace()), equalTo(Optional.of(ip)));
   }
 
@@ -94,7 +94,7 @@ public class IpSpaceRepresentativeTest {
   public void testIpWildcardSetIpSpace() {
     IpSpace ipSpace =
         IpWildcardSetIpSpace.builder()
-            .including(new IpWildcard("1.2.3.0/24"))
+            .including(IpWildcard.parse("1.2.3.0/24"))
             .excluding(EVEN_IPS)
             .build();
     assertThat(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/referencelibrary/ReferenceBookTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/referencelibrary/ReferenceBookTest.java
@@ -166,7 +166,7 @@ public class ReferenceBookTest {
     // should include addresses from a and b; no addresses in c shouldn't matter
     assertThat(
         book.getAddressesRecursive("a"),
-        equalTo(ImmutableSet.of(new IpWildcard("1.1.1.1"), new IpWildcard("2.2.2.2"))));
+        equalTo(ImmutableSet.of(IpWildcard.parse("1.1.1.1"), IpWildcard.parse("2.2.2.2"))));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/FlexibleInterfaceSpecifierFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/FlexibleInterfaceSpecifierFactoryTest.java
@@ -18,7 +18,7 @@ public class FlexibleInterfaceSpecifierFactoryTest {
   public void testConnectedTo() {
     assertThat(
         new FlexibleInterfaceSpecifierFactory().buildInterfaceSpecifier("connectedTo(1.2.3.4)"),
-        equalTo(new InterfaceWithConnectedIpsSpecifier(new IpWildcard("1.2.3.4").toIpSpace())));
+        equalTo(new InterfaceWithConnectedIpsSpecifier(IpWildcard.parse("1.2.3.4").toIpSpace())));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/FlexibleIpSpaceSpecifierFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/FlexibleIpSpaceSpecifierFactoryTest.java
@@ -26,7 +26,7 @@ public class FlexibleIpSpaceSpecifierFactoryTest {
         parse("1.2.3.4"),
         equalTo(
             new ConstantIpSpaceSpecifier(
-                IpWildcardSetIpSpace.builder().including(new IpWildcard("1.2.3.4")).build())));
+                IpWildcardSetIpSpace.builder().including(IpWildcard.parse("1.2.3.4")).build())));
     assertThat(
         parse("ref.addressgroup(foo,bar)"),
         equalTo(new ReferenceAddressGroupIpSpaceSpecifier("foo", "bar")));
@@ -47,7 +47,8 @@ public class FlexibleIpSpaceSpecifierFactoryTest {
         parseIpSpace("1.0.0.0,2.0.0.0/8"),
         equalTo(
             IpWildcardSetIpSpace.builder()
-                .including(ImmutableList.of(new IpWildcard("1.0.0.0"), new IpWildcard("2.0.0.0/8")))
+                .including(
+                    ImmutableList.of(IpWildcard.parse("1.0.0.0"), IpWildcard.parse("2.0.0.0/8")))
                 .build()));
   }
 
@@ -57,9 +58,10 @@ public class FlexibleIpSpaceSpecifierFactoryTest {
         parseIpSpace("1.0.0.0,2.0.0.0/8 - 3.0.0.0,4.0.0.0/32"),
         equalTo(
             IpWildcardSetIpSpace.builder()
-                .including(ImmutableList.of(new IpWildcard("1.0.0.0"), new IpWildcard("2.0.0.0/8")))
+                .including(
+                    ImmutableList.of(IpWildcard.parse("1.0.0.0"), IpWildcard.parse("2.0.0.0/8")))
                 .excluding(
-                    ImmutableList.of(new IpWildcard("3.0.0.0"), new IpWildcard("4.0.0.0/32")))
+                    ImmutableList.of(IpWildcard.parse("3.0.0.0"), IpWildcard.parse("4.0.0.0/32")))
                 .build()));
   }
 
@@ -69,9 +71,10 @@ public class FlexibleIpSpaceSpecifierFactoryTest {
         parseIpSpace("1.0.0.0,2.0.0.0/8 \\ 3.0.0.0,4.0.0.0/32"),
         equalTo(
             IpWildcardSetIpSpace.builder()
-                .including(ImmutableList.of(new IpWildcard("1.0.0.0"), new IpWildcard("2.0.0.0/8")))
+                .including(
+                    ImmutableList.of(IpWildcard.parse("1.0.0.0"), IpWildcard.parse("2.0.0.0/8")))
                 .excluding(
-                    ImmutableList.of(new IpWildcard("3.0.0.0"), new IpWildcard("4.0.0.0/32")))
+                    ImmutableList.of(IpWildcard.parse("3.0.0.0"), IpWildcard.parse("4.0.0.0/32")))
                 .build()));
   }
 
@@ -89,13 +92,14 @@ public class FlexibleIpSpaceSpecifierFactoryTest {
 
   @Test
   public void testParseWildcards_one() {
-    assertThat(parseWildcards("1.0.0.0/8"), equalTo(ImmutableList.of(new IpWildcard("1.0.0.0/8"))));
+    assertThat(
+        parseWildcards("1.0.0.0/8"), equalTo(ImmutableList.of(IpWildcard.parse("1.0.0.0/8"))));
   }
 
   @Test
   public void testParseWildcards_two() {
     assertThat(
         parseWildcards("1.0.0.0/8, 2.0.0.0/8"),
-        equalTo(ImmutableList.of(new IpWildcard("1.0.0.0/8"), new IpWildcard("2.0.0.0/8"))));
+        equalTo(ImmutableList.of(IpWildcard.parse("1.0.0.0/8"), IpWildcard.parse("2.0.0.0/8"))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/ReferenceAddressGroupIpSpaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/ReferenceAddressGroupIpSpaceSpecifierTest.java
@@ -39,7 +39,7 @@ public class ReferenceAddressGroupIpSpaceSpecifierTest {
         resolvedSpace,
         equalTo(
             AclIpSpace.union(
-                new IpWildcard("1.1.1.1").toIpSpace(),
-                new IpWildcard("2.2.2.2:0.0.0.8").toIpSpace())));
+                IpWildcard.parse("1.1.1.1").toIpSpace(),
+                IpWildcard.parse("2.2.2.2:0.0.0.8").toIpSpace())));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledIpSpaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledIpSpaceSpecifierTest.java
@@ -46,7 +46,7 @@ public class ParboiledIpSpaceSpecifierTest {
             new AddressGroupIpSpaceAstNode(
                 new StringAstNode(book), new StringAstNode(addressGroup)),
             ctxt),
-        equalTo(new IpWildcard(ip).toIpSpace()));
+        equalTo(IpWildcard.parse(ip).toIpSpace()));
 
     // reverse also works
     assertThat(
@@ -54,7 +54,7 @@ public class ParboiledIpSpaceSpecifierTest {
             new AddressGroupIpSpaceAstNode(
                 new StringAstNode(addressGroup), new StringAstNode(book)),
             ctxt),
-        equalTo(new IpWildcard(ip).toIpSpace()));
+        equalTo(IpWildcard.parse(ip).toIpSpace()));
   }
 
   @Test
@@ -103,7 +103,7 @@ public class ParboiledIpSpaceSpecifierTest {
 
   @Test
   public void testComputeIpSpaceIpWildcard() {
-    IpWildcard wildcard = new IpWildcard("1.1.1.1:255.255.255.255");
+    IpWildcard wildcard = IpWildcard.parse("1.1.1.1:255.255.255.255");
     assertThat(
         computeIpSpace(new IpWildcardAstNode(wildcard), _emptyCtxt), equalTo(wildcard.toIpSpace()));
   }

--- a/projects/batfish/src/main/java/org/batfish/datamodel/visitors/IpSpaceContainedInWildcard.java
+++ b/projects/batfish/src/main/java/org/batfish/datamodel/visitors/IpSpaceContainedInWildcard.java
@@ -64,7 +64,7 @@ public class IpSpaceContainedInWildcard implements GenericIpSpaceVisitor<Boolean
 
   @Override
   public Boolean visitPrefixIpSpace(PrefixIpSpace prefixIpSpace) {
-    return _ipWildcard.supersetOf(new IpWildcard(prefixIpSpace.getPrefix()));
+    return _ipWildcard.supersetOf(IpWildcard.create(prefixIpSpace.getPrefix()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -3084,11 +3084,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       AddressBookEntry addressEntry = new AddressAddressBookEntry(name, ipWildcard);
       _currentAddressBook.getEntries().put(name, addressEntry);
     } else if (ctx.address != null) {
-      IpWildcard ipWildcard = new IpWildcard(Ip.parse(ctx.address.getText()));
+      IpWildcard ipWildcard = IpWildcard.create(Ip.parse(ctx.address.getText()));
       AddressBookEntry addressEntry = new AddressAddressBookEntry(name, ipWildcard);
       _currentAddressBook.getEntries().put(name, addressEntry);
     } else if (ctx.prefix != null) {
-      IpWildcard ipWildcard = new IpWildcard(Prefix.parse(ctx.prefix.getText()));
+      IpWildcard ipWildcard = IpWildcard.create(Prefix.parse(ctx.prefix.getText()));
       AddressBookEntry addressEntry = new AddressAddressBookEntry(name, ipWildcard);
       _currentAddressBook.getEntries().put(name, addressEntry);
     } else if (ctx.DESCRIPTION() != null) {
@@ -5667,7 +5667,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     Ip address = Ip.parse(ctx.ip_address.getText());
     Ip mask = Ip.parse(ctx.wildcard_mask.getText());
     // Mask needs to be inverted since 0's are don't-cares in this context
-    return new IpWildcard(address, mask.inverted());
+    return IpWildcard.ipWithWildcardMask(address, mask.inverted());
   }
 
   @Override
@@ -5677,9 +5677,9 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     if (ctx.wildcard_address() != null) {
       ipWildcard = toIpWildcard(ctx.wildcard_address());
     } else if (ctx.address != null) {
-      ipWildcard = new IpWildcard(Ip.parse(ctx.address.getText()));
+      ipWildcard = IpWildcard.create(Ip.parse(ctx.address.getText()));
     } else if (ctx.prefix != null) {
-      ipWildcard = new IpWildcard(Prefix.parse(ctx.prefix.getText()));
+      ipWildcard = IpWildcard.create(Prefix.parse(ctx.prefix.getText()));
     } else {
       throw convError(IpWildcard.class, ctx);
     }
@@ -5896,13 +5896,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     } else if (ctx.ip_address != null && ctx.wildcard_mask != null) {
       Ip ipAddress = Ip.parse(ctx.ip_address.getText());
       Ip mask = Ip.parse(ctx.wildcard_mask.getText());
-      ipWildcard = new IpWildcard(ipAddress, mask.inverted());
+      ipWildcard = IpWildcard.ipWithWildcardMask(ipAddress, mask.inverted());
     } else if (ctx.ip_address != null) {
       ipWildcard =
-          new IpWildcard(
+          IpWildcard.create(
               Prefix.create(Ip.parse(ctx.ip_address.getText()), Prefix.MAX_PREFIX_LENGTH));
     } else if (ctx.IP_PREFIX() != null) {
-      ipWildcard = new IpWildcard(Prefix.parse(ctx.IP_PREFIX().getText()));
+      ipWildcard = IpWildcard.create(Prefix.parse(ctx.IP_PREFIX().getText()));
     }
     return ipWildcard;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -87,7 +87,7 @@ public class IpPermissions implements Serializable {
     ImmutableSortedSet.Builder<IpWildcard> ipWildcardBuilder =
         new ImmutableSortedSet.Builder<>(Comparator.naturalOrder());
 
-    _ipRanges.stream().map(IpWildcard::new).forEach(ipWildcardBuilder::add);
+    _ipRanges.stream().map(IpWildcard::create).forEach(ipWildcardBuilder::add);
 
     _securityGroups.stream()
         .map(sgID -> region.getSecurityGroups().get(sgID))

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/NetworkAcl.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/NetworkAcl.java
@@ -56,9 +56,9 @@ public class NetworkAcl implements AwsVpcEntity, Serializable {
         HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
         if (!prefix.equals(Prefix.ZERO)) {
           if (isEgress) {
-            headerSpaceBuilder.setDstIps(ImmutableSortedSet.of(new IpWildcard(prefix)));
+            headerSpaceBuilder.setDstIps(ImmutableSortedSet.of(IpWildcard.create(prefix)));
           } else {
-            headerSpaceBuilder.setSrcIps(ImmutableSortedSet.of(new IpWildcard(prefix)));
+            headerSpaceBuilder.setSrcIps(ImmutableSortedSet.of(IpWildcard.create(prefix)));
           }
         }
         IpProtocol protocol = IpPermissions.toIpProtocol(entry.getProtocol());

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -157,7 +157,7 @@ public class SecurityGroup implements AwsVpcEntity, Serializable {
     configuration.getAllInterfaces().values().stream()
         .flatMap(iface -> iface.getAllAddresses().stream())
         .map(InterfaceAddress::getIp)
-        .map(IpWildcard::new)
+        .map(IpWildcard::create)
         .forEach(ipWildcard -> getUsersIpSpace().add(ipWildcard));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2617,14 +2617,14 @@ public final class CiscoConfiguration extends VendorConfiguration {
         summaryFilter.addLine(
             new RouteFilterLine(
                 LineAction.DENY,
-                new IpWildcard(prefix),
+                IpWildcard.create(prefix),
                 new SubRange(filterMinPrefixLength, Prefix.MAX_PREFIX_LENGTH)));
       }
       area.addSummaries(ImmutableSortedMap.copyOf(summaries));
       summaryFilter.addLine(
           new RouteFilterLine(
               LineAction.PERMIT,
-              new IpWildcard(Prefix.ZERO),
+              IpWildcard.create(Prefix.ZERO),
               new SubRange(0, Prefix.MAX_PREFIX_LENGTH)));
     }
     newProcess.setAreas(toImmutableSortedMap(areas, Entry::getKey, e -> e.getValue().build()));

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -1230,7 +1230,7 @@ class CiscoConversions {
             .map(
                 l ->
                     new RouteFilterLine(
-                        l.getAction(), new IpWildcard(l.getPrefix()), l.getLengthRange()))
+                        l.getAction(), IpWildcard.create(l.getPrefix()), l.getLengthRange()))
             .collect(ImmutableList.toImmutableList());
     newRouteFilterList.setLines(newLines);
     return newRouteFilterList;
@@ -1437,14 +1437,14 @@ class CiscoConversions {
     IpWildcard dstIpWildcard =
         ((WildcardAddressSpecifier) fromLine.getDestinationAddressSpecifier()).getIpWildcard();
     long minSubnet = dstIpWildcard.getIp().asLong();
-    long maxSubnet = minSubnet | dstIpWildcard.getWildcard().asLong();
+    long maxSubnet = minSubnet | dstIpWildcard.getWildcardMask();
     int minPrefixLength = dstIpWildcard.getIp().numSubnetBits();
     int maxPrefixLength = Ip.create(maxSubnet).numSubnetBits();
-    int statedPrefixLength = srcIpWildcard.getWildcard().inverted().numSubnetBits();
+    int statedPrefixLength = srcIpWildcard.getWildcardMaskAsIp().inverted().numSubnetBits();
     int prefixLength = Math.min(statedPrefixLength, minPrefixLength);
     Prefix prefix = Prefix.create(ip, prefixLength);
     return new RouteFilterLine(
-        action, new IpWildcard(prefix), new SubRange(minPrefixLength, maxPrefixLength));
+        action, IpWildcard.create(prefix), new SubRange(minPrefixLength, maxPrefixLength));
   }
 
   /** Convert a standard access list line to a route filter list line */
@@ -1460,7 +1460,7 @@ class CiscoConversions {
 
     return new RouteFilterLine(
         action,
-        new IpWildcard(prefix),
+        IpWildcard.create(prefix),
         new SubRange(prefix.getPrefixLength(), Prefix.MAX_PREFIX_LENGTH));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/EigrpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/EigrpProcess.java
@@ -55,7 +55,7 @@ public class EigrpProcess implements Serializable {
       for (IpWildcard wn : _wildcardNetworks) {
         // Check if the interface IP address matches the eigrp network
         // when the wildcard is ORed to both
-        long wildcardLong = wn.getWildcard().asLong();
+        long wildcardLong = wn.getWildcardMask();
         long eigrpNetworkLong = wn.getIp().asLong();
         long intIpLong = address.getIp().asLong();
         long wildcardedNetworkLong = eigrpNetworkLong | wildcardLong;

--- a/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesMatch.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/iptables/IptablesMatch.java
@@ -70,9 +70,9 @@ public class IptablesMatch implements Serializable {
 
     if (_matchData instanceof Ip) {
       Prefix pfx = Prefix.create((Ip) _matchData, Prefix.MAX_PREFIX_LENGTH);
-      return new IpWildcard(pfx);
+      return IpWildcard.create(pfx);
     } else if (_matchData instanceof Prefix) {
-      return new IpWildcard((Prefix) _matchData);
+      return IpWildcard.create((Prefix) _matchData);
     } else {
       throw new BatfishException("Unknown matchdata type: " + _matchData);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/HostProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/HostProtocol.java
@@ -180,7 +180,7 @@ public enum HostProtocol {
               .setIpProtocols(ImmutableSet.of(IpProtocol.UDP))
               .setDstPorts(
                   ImmutableSet.of(new SubRange(NamedPort.SAP.number(), NamedPort.SAP.number())))
-              .setDstIps(ImmutableSet.of(new IpWildcard(Prefix.parse("224.2.127.254/32"))));
+              .setDstIps(ImmutableSet.of(IpWildcard.create(Prefix.parse("224.2.127.254/32"))));
           break;
         }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -883,13 +883,13 @@ public final class JuniperConfiguration extends VendorConfiguration {
       summaryFilter.addLine(
           new org.batfish.datamodel.RouteFilterLine(
               LineAction.DENY,
-              new IpWildcard(prefix),
+              IpWildcard.create(prefix),
               new SubRange(filterMinPrefixLength, Prefix.MAX_PREFIX_LENGTH)));
     }
     summaryFilter.addLine(
         new org.batfish.datamodel.RouteFilterLine(
             LineAction.PERMIT,
-            new IpWildcard(Prefix.ZERO),
+            IpWildcard.create(Prefix.ZERO),
             new SubRange(0, Prefix.MAX_PREFIX_LENGTH)));
     newAreaBuilder.setSummaryFilter(summaryFilter.getName());
     return newAreaBuilder;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineAddressMask.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Route4FilterLineAddressMask.java
@@ -26,7 +26,7 @@ public final class Route4FilterLineAddressMask extends Route4FilterLine {
     org.batfish.datamodel.RouteFilterLine line =
         new org.batfish.datamodel.RouteFilterLine(
             LineAction.PERMIT,
-            new IpWildcard(
+            IpWildcard.ipWithWildcardMask(
                 Prefix.create(_prefix.getStartIp(), prefixLength).getStartIp(), _addressMask),
             new SubRange(prefixLength, prefixLength));
     rfl.addLine(line);

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseFlowTransformationFactoryImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseFlowTransformationFactoryImplTest.java
@@ -213,7 +213,7 @@ public class BDDReverseFlowTransformationFactoryImplTest {
     BDD shiftPrefixBdd = srcBdd(shiftPrefix);
 
     IpWildcard preshiftMatchWildcard =
-        new IpWildcard(Ip.create(0x00000001L), Ip.create(0xFFFFFF00L));
+        IpWildcard.ipWithWildcardMask(Ip.create(0x00000001L), Ip.create(0xFFFFFF00L));
     BDD preshiftMatchBdd = srcBdd(preshiftMatchWildcard);
 
     Transition transition = factory.reverseFlowIncomingTransformation(HOSTNAME, i.getName());

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformationToTransitionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransformationToTransitionTest.java
@@ -81,7 +81,8 @@ public class TransformationToTransitionTest {
 
     // backward -- constrained
     expectedIn =
-        _dstIpSpaceToBdd.toBDD(new IpWildcard(Ip.parse("0.0.3.0"), Ip.parse("255.255.0.255")));
+        _dstIpSpaceToBdd.toBDD(
+            IpWildcard.ipWithWildcardMask(Ip.parse("0.0.3.0"), Ip.parse("255.255.0.255")));
     actualIn = transition.transitBackward(expectedOut);
     assertThat(actualIn, equalTo(expectedIn));
   }
@@ -116,7 +117,7 @@ public class TransformationToTransitionTest {
     Ip address = Ip.parse("0.0.0.12");
     // all bits wild except 28,29,30
     Ip mask = Ip.parse("255.255.255.227");
-    expectedIn = _dstIpSpaceToBdd.toBDD(new IpWildcard(address, mask));
+    expectedIn = _dstIpSpaceToBdd.toBDD(IpWildcard.ipWithWildcardMask(address, mask));
     actualIn = transition.transitBackward(expectedOut);
     assertThat(actualIn, equalTo(expectedIn));
   }
@@ -189,7 +190,8 @@ public class TransformationToTransitionTest {
     BDD out = _dstIpSpaceToBdd.toBDD(Prefix.parse("5.5.3.0/24"));
     expectedIn =
         out.or(
-            _dstIpSpaceToBdd.toBDD(new IpWildcard(Ip.parse("1.0.3.0"), Ip.parse("0.255.0.255"))));
+            _dstIpSpaceToBdd.toBDD(
+                IpWildcard.ipWithWildcardMask(Ip.parse("1.0.3.0"), Ip.parse("0.255.0.255"))));
     actualIn = transition.transitBackward(out);
     assertThat(actualIn, equalTo(expectedIn));
   }
@@ -230,7 +232,7 @@ public class TransformationToTransitionTest {
     // backward -- matched and transformed or not matched
     BDD out = _dstIpSpaceToBdd.toBDD(Prefix.parse("5.5.3.0/24"));
     IpWildcard preTransformationDestIps =
-        new IpWildcard(Ip.parse("0.0.3.0"), Ip.parse("255.255.0.255"));
+        IpWildcard.ipWithWildcardMask(Ip.parse("0.0.3.0"), Ip.parse("255.255.0.255"));
     expectedIn = guardBdd.ite(_dstIpSpaceToBdd.toBDD(preTransformationDestIps), out);
     actualIn = transition.transitBackward(out);
     assertThat(actualIn, equalTo(expectedIn));
@@ -414,7 +416,9 @@ public class TransformationToTransitionTest {
       assertThat(transition.transitForward(dstToBdd.toBDD(shiftPrefix).not()), equalTo(_zero));
       assertThat(
           transition.transitForward(dstToBdd.toBDD(Ip.parse("6.6.6.6"))),
-          equalTo(dstToBdd.toBDD(new IpWildcard(Ip.parse("0.0.6.6"), Ip.parse("255.255.0.0")))));
+          equalTo(
+              dstToBdd.toBDD(
+                  IpWildcard.ipWithWildcardMask(Ip.parse("0.0.6.6"), Ip.parse("255.255.0.0")))));
 
       assertEquals(
           transition.transitBackward(dstToBdd.toBDD(Ip.parse("5.5.6.6"))),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -895,7 +895,7 @@ public class CiscoGrammarTest {
 
     // ASN is 1
     EigrpProcess eigrpProcess = config.getDefaultVrf().getEigrpProcesses().get(1L);
-    assertThat(eigrpProcess.getWildcardNetworks(), contains(new IpWildcard("10.0.0.0/24")));
+    assertThat(eigrpProcess.getWildcardNetworks(), contains(IpWildcard.parse("10.0.0.0/24")));
   }
 
   @Test
@@ -3711,16 +3711,16 @@ public class CiscoGrammarTest {
                 .setMatchCondition(
                     new MatchHeaderSpace(
                         HeaderSpace.builder()
-                            .setSrcIps(new IpWildcard("1.1.1.1").toIpSpace())
-                            .setDstIps(new IpWildcard("2.2.2.2").toIpSpace())
+                            .setSrcIps(IpWildcard.parse("1.1.1.1").toIpSpace())
+                            .setDstIps(IpWildcard.parse("2.2.2.2").toIpSpace())
                             .build()))
                 .build(),
             IpAccessListLine.accepting()
                 .setMatchCondition(
                     new MatchHeaderSpace(
                         HeaderSpace.builder()
-                            .setSrcIps(new IpWildcard("2.2.2.2").toIpSpace())
-                            .setDstIps(new IpWildcard("1.1.1.1").toIpSpace())
+                            .setSrcIps(IpWildcard.parse("2.2.2.2").toIpSpace())
+                            .setDstIps(IpWildcard.parse("1.1.1.1").toIpSpace())
                             .build()))
                 .build());
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2396,11 +2396,11 @@ public final class FlatJuniperGrammarTest {
                                     HeaderSpace.builder()
                                         .setSrcIps(
                                             AclIpSpace.union(
-                                                new IpWildcard(
+                                                IpWildcard.ipWithWildcardMask(
                                                         Ip.parse("1.0.3.0"),
                                                         Ip.parse("0.255.0.255"))
                                                     .toIpSpace(),
-                                                new IpWildcard("2.3.4.5/24").toIpSpace()))
+                                                IpWildcard.parse("2.3.4.5/24").toIpSpace()))
                                         .build()))
                             .setName("TERM")
                             .build())))));
@@ -2680,11 +2680,11 @@ public final class FlatJuniperGrammarTest {
                                     HeaderSpace.builder()
                                         .setDstIps(
                                             AclIpSpace.union(
-                                                new IpWildcard(
+                                                IpWildcard.ipWithWildcardMask(
                                                         Ip.parse("1.0.3.0"),
                                                         Ip.parse("0.255.0.255"))
                                                     .toIpSpace(),
-                                                new IpWildcard("2.3.4.5/24").toIpSpace()))
+                                                IpWildcard.parse("2.3.4.5/24").toIpSpace()))
                                         .build()))
                             .setName("TERM")
                             .build())))));
@@ -4028,7 +4028,7 @@ public final class FlatJuniperGrammarTest {
                     LineAction.PERMIT, Prefix.parse("1.7.0.0/17"), new SubRange(17, 17)),
                 new RouteFilterLine(
                     LineAction.PERMIT,
-                    new IpWildcard("1.0.0.0:0.255.0.255"),
+                    IpWildcard.parse("1.0.0.0:0.255.0.255"),
                     new SubRange(16, 16)))));
   }
 
@@ -4392,7 +4392,7 @@ public final class FlatJuniperGrammarTest {
                             LineAction.PERMIT,
                             AclLineMatchExprs.match(
                                 HeaderSpace.builder()
-                                    .setSrcIps(new IpWildcard(Ip.parse("1.2.3.6")).toIpSpace())
+                                    .setSrcIps(IpWildcard.parse("1.2.3.6").toIpSpace())
                                     .build()),
                             "TERM")))
                 .build()));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -178,14 +178,14 @@ public class ElasticsearchDomainTest {
                               .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                               .setDstIps(
                                   Sets.newHashSet(
-                                      new IpWildcard("1.2.3.4/32"),
-                                      new IpWildcard("10.193.16.105/32")))
+                                      IpWildcard.parse("1.2.3.4/32"),
+                                      IpWildcard.parse("10.193.16.105/32")))
                               .setSrcPorts(Sets.newHashSet(new SubRange(45, 50)))
                               .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                               .build()),
                       IpAccessListLine.acceptingHeaderSpace(
                           HeaderSpace.builder()
-                              .setDstIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
+                              .setDstIps(Sets.newHashSet(IpWildcard.parse("0.0.0.0/0")))
                               .build())))));
       assertThat(
           iface.getIncomingFilter(),
@@ -194,7 +194,7 @@ public class ElasticsearchDomainTest {
                   ImmutableList.of(
                       IpAccessListLine.acceptingHeaderSpace(
                           HeaderSpace.builder()
-                              .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
+                              .setSrcIps(Sets.newHashSet(IpWildcard.parse("0.0.0.0/0")))
                               .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                               .build()),
                       IpAccessListLine.acceptingHeaderSpace(
@@ -202,8 +202,8 @@ public class ElasticsearchDomainTest {
                               .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                               .setSrcIps(
                                   Sets.newHashSet(
-                                      new IpWildcard("1.2.3.4/32"),
-                                      new IpWildcard("10.193.16.105/32")))
+                                      IpWildcard.parse("1.2.3.4/32"),
+                                      IpWildcard.parse("10.193.16.105/32")))
                               .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
                               .build())))));
     }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -158,14 +158,14 @@ public class RdsInstanceTest {
                               .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                               .setDstIps(
                                   Sets.newHashSet(
-                                      new IpWildcard("1.2.3.4/32"),
-                                      new IpWildcard("10.193.16.105/32")))
+                                      IpWildcard.parse("1.2.3.4/32"),
+                                      IpWildcard.parse("10.193.16.105/32")))
                               .setSrcPorts(Sets.newHashSet(new SubRange(45, 50)))
                               .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                               .build()),
                       IpAccessListLine.acceptingHeaderSpace(
                           HeaderSpace.builder()
-                              .setDstIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
+                              .setDstIps(Sets.newHashSet(IpWildcard.parse("0.0.0.0/0")))
                               .build())))));
       assertThat(
           iface.getIncomingFilter(),
@@ -174,7 +174,7 @@ public class RdsInstanceTest {
                   ImmutableList.of(
                       IpAccessListLine.acceptingHeaderSpace(
                           HeaderSpace.builder()
-                              .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
+                              .setSrcIps(Sets.newHashSet(IpWildcard.parse("0.0.0.0/0")))
                               .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                               .build()),
                       IpAccessListLine.acceptingHeaderSpace(
@@ -182,8 +182,8 @@ public class RdsInstanceTest {
                               .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
                               .setSrcIps(
                                   Sets.newHashSet(
-                                      new IpWildcard("1.2.3.4/32"),
-                                      new IpWildcard("10.193.16.105/32")))
+                                      IpWildcard.parse("1.2.3.4/32"),
+                                      IpWildcard.parse("10.193.16.105/32")))
                               .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
                               .build())))));
     }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -47,7 +47,7 @@ public class SecurityGroupsTest {
     _allowAllReverseOutboundRule =
         IpAccessListLine.acceptingHeaderSpace(
             HeaderSpace.builder()
-                .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
+                .setSrcIps(Sets.newHashSet(IpWildcard.parse("0.0.0.0/0")))
                 .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                 .build());
     _region = new Region("test");
@@ -72,7 +72,7 @@ public class SecurityGroupsTest {
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(22, 22)))
                         .build()))));
   }
@@ -94,7 +94,7 @@ public class SecurityGroupsTest {
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(0, 22)))
                         .build()))));
   }
@@ -116,7 +116,7 @@ public class SecurityGroupsTest {
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(65530, 65535)))
                         .build()))));
   }
@@ -138,7 +138,7 @@ public class SecurityGroupsTest {
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
                         .build()))));
   }
 
@@ -158,7 +158,7 @@ public class SecurityGroupsTest {
                 _allowAllReverseOutboundRule,
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("0.0.0.0/0")))
+                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("0.0.0.0/0")))
                         .setDstPorts(Sets.newHashSet())
                         .build()))));
   }
@@ -180,7 +180,7 @@ public class SecurityGroupsTest {
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
                         .build()))));
   }
@@ -202,7 +202,7 @@ public class SecurityGroupsTest {
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(0, 50)))
                         .build()))));
   }
@@ -224,7 +224,7 @@ public class SecurityGroupsTest {
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(30, 65535)))
                         .build()))));
   }
@@ -246,14 +246,14 @@ public class SecurityGroupsTest {
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("5.6.7.8/32")))
+                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("5.6.7.8/32")))
                         .setSrcPorts(Sets.newHashSet(new SubRange(80, 80)))
                         .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                         .build()),
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(22, 22)))
                         .build()))));
     assertThat(
@@ -264,14 +264,14 @@ public class SecurityGroupsTest {
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setDstIps(Sets.newHashSet(new IpWildcard("1.2.3.4/32")))
+                        .setDstIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
                         .setSrcPorts(Sets.newHashSet(new SubRange(22, 22)))
                         .setTcpFlags(ImmutableSet.of(TcpFlagsMatchConditions.ACK_TCP_FLAG))
                         .build()),
                 IpAccessListLine.acceptingHeaderSpace(
                     HeaderSpace.builder()
                         .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setDstIps(Sets.newHashSet(new IpWildcard("5.6.7.8/32")))
+                        .setDstIps(Sets.newHashSet(IpWildcard.parse("5.6.7.8/32")))
                         .setDstPorts(Sets.newHashSet(new SubRange(80, 80)))
                         .build()))));
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
@@ -58,9 +58,9 @@ public class CiscoConversionsTest {
                         .setMatchCondition(
                             new MatchHeaderSpace(
                                 HeaderSpace.builder()
-                                    .setSrcIps(new IpWildcard("1.1.1.1").toIpSpace())
-                                    .setDstIps(new IpWildcard("2.2.2.2").toIpSpace())
-                                    .setNotSrcIps(new IpWildcard("3.3.3.3").toIpSpace())
+                                    .setSrcIps(IpWildcard.parse("1.1.1.1").toIpSpace())
+                                    .setDstIps(IpWildcard.parse("2.2.2.2").toIpSpace())
+                                    .setNotSrcIps(IpWildcard.parse("3.3.3.3").toIpSpace())
                                     .setIpProtocols(ImmutableSet.of(IpProtocol.IP))
                                     .build()))
                         .build()))
@@ -161,13 +161,13 @@ public class CiscoConversionsTest {
     // Empty interfaceName value represents incorrect local-address value
     isakmpProfile.setLocalInterfaceName("local_interface");
     isakmpProfile.setKeyring("IKE_Phase1_Key");
-    isakmpProfile.setMatchIdentity(new IpWildcard("1.2.3.4:0.0.0.0"));
+    isakmpProfile.setMatchIdentity(IpWildcard.parse("1.2.3.4:0.0.0.0"));
 
     IkePhase1Key ikePhase1Key = new IkePhase1Key();
     ikePhase1Key.setKeyHash("test_key");
     ikePhase1Key.setKeyType(IkeKeyType.PRE_SHARED_KEY);
     ikePhase1Key.setLocalInterface("local_interface");
-    ikePhase1Key.setRemoteIdentity(new IpWildcard("1.2.3.4:0.0.0.0").toIpSpace());
+    ikePhase1Key.setRemoteIdentity(IpWildcard.parse("1.2.3.4:0.0.0.0").toIpSpace());
 
     IkePhase1Key matchingKey =
         getMatchingPsk(isakmpProfile, _warnings, ImmutableMap.of(IKE_PHASE1_KEY, ikePhase1Key));
@@ -181,13 +181,13 @@ public class CiscoConversionsTest {
     // Empty interfaceName value represents incorrect local-address value
     isakmpProfile.setLocalInterfaceName("local_interface");
     isakmpProfile.setKeyring("IKE_Phase1_Key");
-    isakmpProfile.setMatchIdentity(new IpWildcard("2.4.3.4:255.255.0.0"));
+    isakmpProfile.setMatchIdentity(IpWildcard.parse("2.4.3.4:255.255.0.0"));
 
     IkePhase1Key ikePhase1Key = new IkePhase1Key();
     ikePhase1Key.setKeyHash("test_key");
     ikePhase1Key.setKeyType(IkeKeyType.PRE_SHARED_KEY);
     ikePhase1Key.setLocalInterface("local_interface");
-    ikePhase1Key.setRemoteIdentity(new IpWildcard("1.2.3.5:0.0.0.0").toIpSpace());
+    ikePhase1Key.setRemoteIdentity(IpWildcard.parse("1.2.3.5:0.0.0.0").toIpSpace());
 
     IkePhase1Key matchingKey =
         getMatchingPsk(isakmpProfile, _warnings, ImmutableMap.of(IKE_PHASE1_KEY, ikePhase1Key));

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListExceptTest.java
@@ -49,7 +49,7 @@ public class FwFromDestinationPrefixListExceptTest {
   @Test
   public void testApplyTo() {
     IpSpace additionalIpSpace = Ip.parse("2.2.2.2").toIpSpace();
-    IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
+    IpSpace baseIpSpace = IpWildcard.parse(BASE_IP_PREFIX).toIpSpace();
 
     HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
     HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationPrefixListTest.java
@@ -49,7 +49,7 @@ public class FwFromDestinationPrefixListTest {
   @Test
   public void testApplyTo() {
     IpSpace additionalIpSpace = Ip.parse("2.2.2.2").toIpSpace();
-    IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
+    IpSpace baseIpSpace = IpWildcard.parse(BASE_IP_PREFIX).toIpSpace();
 
     HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
     HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromPrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromPrefixListTest.java
@@ -49,7 +49,7 @@ public class FwFromPrefixListTest {
   @Test
   public void testApplyTo() {
     IpSpace additionalIpSpace = Ip.parse("2.2.2.2").toIpSpace();
-    IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
+    IpSpace baseIpSpace = IpWildcard.parse(BASE_IP_PREFIX).toIpSpace();
 
     HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
     HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListExceptTest.java
@@ -49,7 +49,7 @@ public class FwFromSourcePrefixListExceptTest {
   @Test
   public void testApplyTo() {
     IpSpace additionalIpSpace = Ip.parse("2.2.2.2").toIpSpace();
-    IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
+    IpSpace baseIpSpace = IpWildcard.parse(BASE_IP_PREFIX).toIpSpace();
 
     HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
     HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourcePrefixListTest.java
@@ -49,7 +49,7 @@ public class FwFromSourcePrefixListTest {
   @Test
   public void testApplyTo() {
     IpSpace additionalIpSpace = Ip.parse("2.2.2.2").toIpSpace();
-    IpSpace baseIpSpace = new IpWildcard(BASE_IP_PREFIX).toIpSpace();
+    IpSpace baseIpSpace = IpWildcard.parse(BASE_IP_PREFIX).toIpSpace();
 
     HeaderSpace.Builder headerSpaceBuilder = HeaderSpace.builder();
     HeaderSpace.Builder headerSpaceBuilderWithIpSpaceFilter =

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -43,7 +43,6 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AndMatchExpr;
@@ -70,7 +69,7 @@ public class JuniperConfigurationTest {
 
     FwTerm term = new FwTerm("term");
     String ipAddrPrefix = "1.2.3.0/24";
-    term.getFroms().add(new FwFromSourceAddress(new IpWildcard(Prefix.parse(ipAddrPrefix))));
+    term.getFroms().add(new FwFromSourceAddress(IpWildcard.parse(ipAddrPrefix)));
     term.getThens().add(FwThenAccept.INSTANCE);
     filter.getTerms().put("term", term);
     IpAccessList headerSpaceAcl = config.toIpAccessList(filter);
@@ -113,7 +112,7 @@ public class JuniperConfigurationTest {
                         new MatchSrcInterface(ImmutableList.of(interface1Name, interface2Name)),
                         new MatchHeaderSpace(
                             HeaderSpace.builder()
-                                .setSrcIps(new IpWildcard(Prefix.parse(ipAddrPrefix)).toIpSpace())
+                                .setSrcIps(IpWildcard.parse(ipAddrPrefix).toIpSpace())
                                 .build()))))));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleTest.java
@@ -90,7 +90,7 @@ public class NatRuleTest {
 
     rule.setThen(new NatRuleThenPrefixName("prefix", DESTINATION));
     Map<String, AddressBookEntry> entryMap =
-        ImmutableMap.of("prefix", new AddressAddressBookEntry("prefix", new IpWildcard(prefix)));
+        ImmutableMap.of("prefix", new AddressAddressBookEntry("prefix", IpWildcard.create(prefix)));
 
     assertThat(
         rule.toTransformationBuilder(staticNat, entryMap, interfaceIp, null).map(Builder::build),

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleThenPrefixNameTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/NatRuleThenPrefixNameTest.java
@@ -40,7 +40,7 @@ public class NatRuleThenPrefixNameTest {
     String prefixName = "entry";
     Prefix prefix = Prefix.parse("1.1.1.1/24");
     Map<String, AddressBookEntry> entryMap =
-        ImmutableMap.of("entry", new AddressAddressBookEntry("entry", new IpWildcard(prefix)));
+        ImmutableMap.of("entry", new AddressAddressBookEntry("entry", IpWildcard.create(prefix)));
 
     NatRuleThenPrefixName then = new NatRuleThenPrefixName(prefixName, DESTINATION);
     List<TransformationStep> steps =

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/abstraction/DestinationClasses.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/abstraction/DestinationClasses.java
@@ -102,7 +102,7 @@ public class DestinationClasses {
     catchAll.setNotDstIps(
         Stream.concat(
                 notDstIps.stream(), destinationMap.values().stream().flatMap(Collection::stream))
-            .map(IpWildcard::new)
+            .map(IpWildcard::create)
             .collect(Collectors.toSet()));
 
     if (_headerspace != null) {
@@ -245,7 +245,7 @@ public class DestinationClasses {
    */
   private HeaderSpace createHeaderSpace(List<Prefix> prefixes) {
     HeaderSpace h = new HeaderSpace();
-    h.setDstIps(prefixes.stream().map(IpWildcard::new).collect(Collectors.toSet()));
+    h.setDstIps(prefixes.stream().map(IpWildcard::create).collect(Collectors.toSet()));
     return h;
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/smt/Encoder.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/smt/Encoder.java
@@ -254,7 +254,7 @@ public class Encoder {
 
           // Make sure messages are sent to this destination IP
           SortedSet<IpWildcard> ips = new TreeSet<>();
-          ips.add(new IpWildcard(n.getLocalIp()));
+          ips.add(IpWildcard.create(n.getLocalIp()));
           hs.setDstIps(ips);
 
           // Make sure messages use TCP port 179

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/smt/EncoderSlice.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/smt/EncoderSlice.java
@@ -407,7 +407,7 @@ class EncoderSlice {
     if (_headerSpace.getDstIps() == null) {
       return true;
     }
-    return new IpSpaceMayIntersectWildcard(new IpWildcard(p), ImmutableMap.of())
+    return new IpSpaceMayIntersectWildcard(IpWildcard.create(p), ImmutableMap.of())
         .visit(_headerSpace.getDstIps());
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/smt/IpSpaceToBoolExpr.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/smt/IpSpaceToBoolExpr.java
@@ -61,7 +61,7 @@ public class IpSpaceToBoolExpr implements GenericIpSpaceVisitor<BoolExpr> {
 
   private BoolExpr toBoolExpr(IpWildcard ipWildcard) {
     BitVecExpr ip = _context.mkBV(ipWildcard.getIp().asLong(), 32);
-    BitVecExpr mask = _context.mkBV(~ipWildcard.getWildcard().asLong(), 32);
+    BitVecExpr mask = _context.mkBV(~ipWildcard.getWildcardMask(), 32);
     return _context.mkEq(_context.mkBVAND(_var, mask), _context.mkBVAND(ip, mask));
   }
 
@@ -84,7 +84,7 @@ public class IpSpaceToBoolExpr implements GenericIpSpaceVisitor<BoolExpr> {
 
   @Override
   public BoolExpr visitPrefixIpSpace(PrefixIpSpace prefixIpSpace) {
-    return toBoolExpr(new IpWildcard(prefixIpSpace.getPrefix()));
+    return toBoolExpr(IpWildcard.create(prefixIpSpace.getPrefix()));
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/smt/PropertyChecker.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/smt/PropertyChecker.java
@@ -106,21 +106,21 @@ public class PropertyChecker {
       // If we don't know what is on the other end
       if (ge.getPeer() == null) {
         Prefix pfx = ge.getStart().getAddress().getPrefix();
-        IpWildcard dst = new IpWildcard(pfx);
+        IpWildcard dst = IpWildcard.create(pfx);
         headerSpace.setDstIps(AclIpSpace.union(headerSpace.getDstIps(), dst.toIpSpace()));
       } else {
         // If host, add the subnet but not the neighbor's address
         if (g.isHost(ge.getRouter())) {
           Prefix pfx = ge.getStart().getAddress().getPrefix();
-          IpWildcard dst = new IpWildcard(pfx);
+          IpWildcard dst = IpWildcard.create(pfx);
           headerSpace.setDstIps(AclIpSpace.union(headerSpace.getDstIps(), dst.toIpSpace()));
           Ip ip = ge.getEnd().getAddress().getIp();
-          IpWildcard dst2 = new IpWildcard(ip);
+          IpWildcard dst2 = IpWildcard.create(ip);
           headerSpace.setNotDstIps(AclIpSpace.union(headerSpace.getNotDstIps(), dst2.toIpSpace()));
         } else {
           // Otherwise, we add the exact address
           Ip ip = ge.getStart().getAddress().getIp();
-          IpWildcard dst = new IpWildcard(ip);
+          IpWildcard dst = IpWildcard.create(ip);
           headerSpace.setDstIps(AclIpSpace.union(headerSpace.getDstIps(), dst.toIpSpace()));
         }
       }
@@ -849,7 +849,7 @@ public class PropertyChecker {
 
     SortedSet<IpWildcard> pfxs = new TreeSet<>();
     for (Prefix prefix : prefixes) {
-      pfxs.add(new IpWildcard(prefix));
+      pfxs.add(IpWildcard.create(prefix));
     }
     q.getHeaderSpace().setDstIps(pfxs);
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/abstraction/BatfishCompressionTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/abstraction/BatfishCompressionTest.java
@@ -313,9 +313,7 @@ public class BatfishCompressionTest {
   @Test
   public void testCompressionFibs_diamondNetwork() throws IOException {
     HeaderSpace line =
-        HeaderSpace.builder()
-            .setDstIps(ImmutableList.of(new IpWildcard(Prefix.parse("4.4.4.4/32"))))
-            .build();
+        HeaderSpace.builder().setDstIps(ImmutableList.of(IpWildcard.parse("4.4.4.4/32"))).build();
     SortedMap<String, Configuration> origConfigs = diamondNetwork();
     Batfish batfish = getBatfish(origConfigs);
     DataPlane origDataPlane = batfish.loadDataPlane();

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/smt/IpSpaceToBoolExprTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/smt/IpSpaceToBoolExprTest.java
@@ -78,7 +78,7 @@ public class IpSpaceToBoolExprTest {
   public void testIpWildcardIpSpace() {
     Ip ip = Ip.create(0x01000200);
     Ip mask = Ip.create(0x00FF00FF);
-    IpWildcard ipWildcard = new IpWildcard(ip, mask);
+    IpWildcard ipWildcard = IpWildcard.ipWithWildcardMask(ip, mask);
     BitVecExpr ipBV = CONTEXT.mkBV(ip.asLong(), 32);
     BitVecExpr maskBV = CONTEXT.mkBV(mask.inverted().asLong(), 32);
     assertThat(

--- a/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityTest.java
+++ b/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityTest.java
@@ -123,15 +123,18 @@ public class FilterLineReachabilityTest {
         ImmutableList.of(
             IpAccessListLine.acceptingHeaderSpace(
                 HeaderSpace.builder()
-                    .setSrcIps(new IpWildcard(Prefix.create(Ip.parse("1.2.3.4"), 30)).toIpSpace())
+                    .setSrcIps(
+                        IpWildcard.create(Prefix.create(Ip.parse("1.2.3.4"), 30)).toIpSpace())
                     .build()),
             IpAccessListLine.acceptingHeaderSpace(
                 HeaderSpace.builder()
-                    .setSrcIps(new IpWildcard(Prefix.create(Ip.parse("1.2.3.4"), 32)).toIpSpace())
+                    .setSrcIps(
+                        IpWildcard.create(Prefix.create(Ip.parse("1.2.3.4"), 32)).toIpSpace())
                     .build()),
             IpAccessListLine.acceptingHeaderSpace(
                 HeaderSpace.builder()
-                    .setSrcIps(new IpWildcard(Prefix.create(Ip.parse("1.2.3.4"), 28)).toIpSpace())
+                    .setSrcIps(
+                        IpWildcard.create(Prefix.create(Ip.parse("1.2.3.4"), 28)).toIpSpace())
                     .build()));
     _aclb.setLines(lines).setName("acl").build();
     List<String> lineNames = lines.stream().map(Object::toString).collect(Collectors.toList());
@@ -320,15 +323,15 @@ public class FilterLineReachabilityTest {
         ImmutableList.of(
             acceptingHeaderSpace(
                 HeaderSpace.builder()
-                    .setSrcIps(new IpWildcard("1.0.0.0:0.0.0.0").toIpSpace())
+                    .setSrcIps(IpWildcard.parse("1.0.0.0:0.0.0.0").toIpSpace())
                     .build()),
             acceptingHeaderSpace(
                 HeaderSpace.builder()
-                    .setSrcIps(new IpWildcard("1.0.0.1:0.0.0.0").toIpSpace())
+                    .setSrcIps(IpWildcard.parse("1.0.0.1:0.0.0.0").toIpSpace())
                     .build()),
             acceptingHeaderSpace(
                 HeaderSpace.builder()
-                    .setSrcIps(new IpWildcard("1.0.0.0:0.0.0.1").toIpSpace())
+                    .setSrcIps(IpWildcard.parse("1.0.0.0:0.0.0.1").toIpSpace())
                     .build()));
     IpAccessList acl = _aclb.setLines(aclLines).setName("acl").build();
     List<String> lineNames = aclLines.stream().map(Object::toString).collect(Collectors.toList());

--- a/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersAnswererTest.java
@@ -151,7 +151,7 @@ public class SpecifiersAnswererTest {
                     COL_IP_SPACE,
                     SpecifierFactories.ACTIVE_VERSION == Version.V1
                         ? IpWildcardSetIpSpace.builder()
-                            .including(new IpWildcard(prefix))
+                            .including(IpWildcard.parse(prefix))
                             .build()
                             .toString()
                         : Prefix.parse(prefix).toIpSpace().toString()))));

--- a/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersReachabilityQuestionTest.java
@@ -84,7 +84,7 @@ public class SpecifiersReachabilityQuestionTest {
                     locations,
                     SpecifierFactories.ACTIVE_VERSION == Version.V1
                         ? IpWildcardSetIpSpace.builder()
-                            .including(new IpWildcard("1.2.3.0/24"), new IpWildcard("1.2.3.4"))
+                            .including(IpWildcard.parse("1.2.3.0/24"), IpWildcard.parse("1.2.3.4"))
                             .build()
                         : AclIpSpace.union(
                             Prefix.parse("1.2.3.0/24").toIpSpace(),
@@ -141,8 +141,8 @@ public class SpecifiersReachabilityQuestionTest {
                     locations,
                     SpecifierFactories.ACTIVE_VERSION == Version.V1
                         ? IpWildcardSetIpSpace.builder()
-                            .including(new IpWildcard("1.2.3.3"))
-                            .excluding(new IpWildcard("1.2.3.4"))
+                            .including(IpWildcard.parse("1.2.3.3"))
+                            .excluding(IpWildcard.parse("1.2.3.4"))
                             .build()
                         : IpRange.range(Ip.parse("1.2.3.3"), Ip.parse("1.2.3.4")))
                 .build()));


### PR DESCRIPTION
1. Intern IpWildcard by removing all public constructors in favor of static creators and a LoadingCache
2. Store wildcardMask as a primitive internally, rather than an Ip.
3. Short-circuit compareTo, which is important now that we are interning.
4. Cleanup some internal functions, mainly for better bit operations.
5. Update callers.
6. Add better tests of equality and toString.

Add old constructors back, for transitioning to new code.