### PR TITLE
BgpSessionProperties: fix arg permutation bug

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
@@ -196,8 +196,8 @@ public final class BgpSessionProperties {
             && listener.getAdditionalPathsReceive()
             && initiator.getAdditionalPathsSend()
             && initiator.getAdditionalPathsSelectAll(),
-        SessionType.isEbgp(sessionType) && initiator.getAdvertiseInactive(),
         !SessionType.isEbgp(sessionType) && initiator.getAdvertiseExternal(),
+        SessionType.isEbgp(sessionType) && initiator.getAdvertiseInactive(),
         reverseDirection ? listenerIp : initiatorIp,
         reverseDirection ? initiatorIp : listenerIp,
         sessionType);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
@@ -1,0 +1,34 @@
+package org.batfish.datamodel;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/** Tests of {@link BgpSessionProperties} */
+public class BgpSessionPropertiesTest {
+  @Test
+  public void testSessionCreation() {
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("2.2.2.2");
+    BgpActivePeerConfig p1 =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(ip1)
+            .setLocalAs(1L)
+            .setRemoteAs(2L)
+            .setPeerAddress(ip2)
+            .setAdvertiseInactive(true)
+            .build();
+    BgpActivePeerConfig p2 =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(ip2)
+            .setLocalAs(1L)
+            .setRemoteAs(2L)
+            .setPeerAddress(ip1)
+            .setAdvertiseInactive(false)
+            .build();
+    BgpSessionProperties session = BgpSessionProperties.from(p1, p2, false);
+    assertTrue(session.getAdvertiseInactive());
+    assertFalse(session.getAdvertiseExternal());
+  }
+}


### PR DESCRIPTION
There seem to be other bugs here, which I'm not fixing in this PR.