### PR TITLE
Layer1Topology: Ignore self-loops and parallel edges

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Topology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer1Topology.java
@@ -10,6 +10,7 @@ import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /** Represents connections between physical or logical interfaces. */
@@ -20,7 +21,7 @@ public final class Layer1Topology {
 
   @JsonCreator
   private static @Nonnull Layer1Topology create(
-      @JsonProperty(PROP_EDGES) Iterable<Layer1Edge> edges) {
+      @Nullable @JsonProperty(PROP_EDGES) Iterable<Layer1Edge> edges) {
     return new Layer1Topology(edges != null ? edges : ImmutableSortedSet.of());
   }
 
@@ -31,8 +32,10 @@ public final class Layer1Topology {
         NetworkBuilder.directed().allowsParallelEdges(false).allowsSelfLoops(false).build();
     edges.forEach(
         edge -> {
-          graph.addNode(edge.getNode1());
-          graph.addNode(edge.getNode2());
+          if (edge.getNode1().equals(edge.getNode2()) || graph.edges().contains(edge)) {
+            // Ignore self-loops and parallel edges
+            return;
+          }
           graph.addEdge(edge.getNode1(), edge.getNode2(), edge);
         });
     _graph = ImmutableNetwork.copyOf(graph);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer1TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer1TopologyTest.java
@@ -1,0 +1,34 @@
+package org.batfish.common.topology;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+/** Tests of {@link Layer1Topology} */
+public class Layer1TopologyTest {
+
+  @Test
+  public void testConstructorIgnoresParallelEdge() {
+    // Two equivalent edges. Resulting topology should contain only one copy of the edge.
+    Layer1Edge e1 = new Layer1Edge("c1", "i1", "c2", "i2");
+    Layer1Edge e2 = new Layer1Edge("c1", "i1", "c2", "i2");
+    assertThat(new Layer1Topology(ImmutableList.of(e1, e2)).getGraph().edges(), contains(e1));
+  }
+
+  @Test
+  public void testConstructorIgnoresSelfLoop() {
+    // Edge with equivalent endpoints should be ignored, resulting in an empty topology.
+    Layer1Edge selfEdge = new Layer1Edge("c1", "i1", "c1", "i1");
+    assertThat(new Layer1Topology(ImmutableList.of(selfEdge)), equalTo(Layer1Topology.EMPTY));
+  }
+
+  @Test
+  public void testConstructorDoesNotIgnoreEdgeBetweenInterfacesOnSameNode() {
+    // Edge between two different interfaces on the same node should not be ignored.
+    Layer1Edge e = new Layer1Edge("c1", "i1", "c1", "i2");
+    assertThat(new Layer1Topology(ImmutableList.of(e)).getGraph().edges(), contains(e));
+  }
+}


### PR DESCRIPTION
Since we don't allow self-loops or parallel (duplicate) edges in the graph representing `Layer1Topology`, we currently ignore any provided L1 topology file that contains such edges. In the interest of flexibility, this PR modifies the behavior to accept those topology files. Self-loops are now ignored and parallel edges are included in the `Layer1Topology` only once; other edges are added to the topology as usual.