### PR TITLE
Move nullsFirst comparator to right place

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Pair.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Pair.java
@@ -25,8 +25,8 @@ public class Pair<T1 extends Comparable<? super T1>, T2 extends Comparable<? sup
 
   @Override
   public int compareTo(Pair<T1, T2> rhs) {
-    return Comparator.nullsFirst(
-            Comparator.comparing(Pair<T1, T2>::getFirst).thenComparing(Pair::getSecond))
+    return Comparator.comparing(Pair<T1, T2>::getFirst)
+        .thenComparing(Pair::getSecond, Comparator.nullsFirst(T2::compareTo))
         .compare(this, rhs);
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/PairTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/PairTest.java
@@ -1,0 +1,34 @@
+package org.batfish.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+
+/** Tests of {@link Pair} */
+public class PairTest {
+
+  private static class PairImpl extends Pair<Integer, Integer> {
+    private static final long serialVersionUID = 1L;
+
+    PairImpl(Integer i1, Integer i2) {
+      super(i1, i2);
+    }
+  }
+
+  @Test
+  public void testCompareToWithNullSecond() {
+    List<PairImpl> ordered =
+        ImmutableList.of(
+            new PairImpl(1, null), new PairImpl(1, 2), new PairImpl(2, null), new PairImpl(2, 2));
+    for (int i = 0; i < ordered.size(); i++) {
+      for (int j = 0; j < ordered.size(); j++) {
+        assertThat(
+            Integer.signum(ordered.get(i).compareTo(ordered.get(j))),
+            equalTo(Integer.signum(i - j)));
+      }
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/PairTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/PairTest.java
@@ -9,20 +9,11 @@ import org.junit.Test;
 
 /** Tests of {@link Pair} */
 public class PairTest {
-
-  private static class PairImpl extends Pair<Integer, Integer> {
-    private static final long serialVersionUID = 1L;
-
-    PairImpl(Integer i1, Integer i2) {
-      super(i1, i2);
-    }
-  }
-
   @Test
   public void testCompareToWithNullSecond() {
-    List<PairImpl> ordered =
+    List<Pair<Integer, Integer>> ordered =
         ImmutableList.of(
-            new PairImpl(1, null), new PairImpl(1, 2), new PairImpl(2, null), new PairImpl(2, 2));
+            new Pair<>(1, null), new Pair<>(1, 2), new Pair<>(2, null), new Pair<>(2, 2));
     for (int i = 0; i < ordered.size(); i++) {
       for (int j = 0; j < ordered.size(); j++) {
         assertThat(


### PR DESCRIPTION
The thing that can be null is `Pair::getSecond`, not `rhs`.