### PR TITLE
Fix & test nullsFirst in BGP best path comparator

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -228,8 +228,9 @@ public abstract class BgpRib<R extends BgpRoute> extends AbstractRib<R> {
     }
 
     // Continue with remaining tie breakers
+    return
     // Prefer lower originator router ID
-    return Comparator.comparing(R::getOriginatorIp, Comparator.reverseOrder())
+    Comparator.comparing(R::getOriginatorIp, Comparator.reverseOrder())
         // Prefer lower cluster list length. Only applicable to iBGP
         .thenComparing(r -> r.getClusterList().size(), Comparator.reverseOrder())
         // Prefer lower neighbor IP

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/BgpRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/BgpRibTest.java
@@ -1,0 +1,95 @@
+package org.batfish.dataplane.rib;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.batfish.datamodel.BgpTieBreaker;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RoutingProtocol;
+import org.junit.Test;
+
+/** Tests of {@link BgpRib} */
+public class BgpRibTest {
+
+  @Test
+  public void testBestPathComparatorArrivalOrder() {
+    BgpRib<Bgpv4Route> rib = new Bgpv4Rib(null, BgpTieBreaker.ARRIVAL_ORDER, 1, null, false);
+
+    // Create routes to compare
+    Bgpv4Route.Builder rb =
+        Bgpv4Route.builder()
+            .setNetwork(Prefix.ZERO)
+            .setNextHopIp(Ip.ZERO)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.BGP);
+    Bgpv4Route r1 = rb.setOriginatorIp(Ip.ZERO).build();
+    Bgpv4Route r2 = rb.setOriginatorIp(Ip.parse("3.3.3.3")).build();
+    Bgpv4Route r3 = rb.setOriginatorIp(Ip.parse("1.1.1.1")).build();
+    Bgpv4Route unaddedRoute = rb.setOriginatorIp(Ip.parse("2.2.2.2")).build();
+
+    rib.mergeRoute(r1);
+    rib.mergeRoute(r2);
+    rib.mergeRoute(r3);
+
+    // Tiebreaker is arrival order, so route attributes shouldn't affect best path.
+    List<Bgpv4Route> ordered = ImmutableList.of(unaddedRoute, r3, r2, r1);
+
+    for (int i = 0; i < ordered.size(); i++) {
+      for (int j = 0; j < ordered.size(); j++) {
+        assertThat(
+            Integer.signum(rib.bestPathComparator(ordered.get(i), (ordered.get(j)))),
+            equalTo(Integer.signum(i - j)));
+      }
+    }
+  }
+
+  @Test
+  public void testBestPathComparator() {
+    BgpRib<Bgpv4Route> rib = new Bgpv4Rib(null, BgpTieBreaker.ROUTER_ID, 1, null, false);
+    Bgpv4Route.Builder rb =
+        Bgpv4Route.builder()
+            .setNetwork(Prefix.ZERO)
+            .setNextHopIp(Ip.ZERO)
+            .setOriginType(OriginType.IGP)
+            .setProtocol(RoutingProtocol.IBGP);
+    /*
+    Create routes to compare. Arrival order shouldn't matter; preference should be:
+    1. Lowest originator IP
+    2. Shortest cluster list
+    3. Lowest receivedFromIp, nulls first (first two properties are nonnull)
+    */
+    List<Ip> decreasingIps = ImmutableList.of(Ip.parse("1.1.1.1"), Ip.ZERO);
+    List<Set<Long>> decreasingLengthClusterLists =
+        ImmutableList.of(ImmutableSet.of(1L), ImmutableSet.of());
+    List<Bgpv4Route> ordered = new ArrayList<>();
+    for (Ip originatorIp : decreasingIps) {
+      rb.setOriginatorIp(originatorIp);
+      for (Set<Long> clusterList : decreasingLengthClusterLists) {
+        rb.setClusterList(clusterList);
+        ordered.add(rb.setReceivedFromIp(null).build());
+        for (Ip receivedFromIp : decreasingIps) {
+          ordered.add(rb.setReceivedFromIp(receivedFromIp).build());
+        }
+      }
+    }
+
+    // Add one arbitrary route to the RIB to ascertain that arrival order doesn't matter
+    rib.mergeRoute(ordered.get(2));
+
+    for (int i = 0; i < ordered.size(); i++) {
+      for (int j = 0; j < ordered.size(); j++) {
+        assertThat(
+            Integer.signum(rib.bestPathComparator(ordered.get(i), (ordered.get(j)))),
+            equalTo(Integer.signum(i - j)));
+      }
+    }
+  }
+}


### PR DESCRIPTION
For `BgpRib.comparePreference(R lhs, R rhs)`, the parameters can't be null, but their `receivedFromIp` can.