### PR TITLE
Portchannel subinterface dependency on parent

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3414,6 +3414,18 @@ public final class CiscoConfiguration extends VendorConfiguration {
               viIface.addDependency(new Dependency(ifaceName, DependencyType.AGGREGATE));
             }
           }
+          // Portchannel subinterfaces
+          Matcher m = INTERFACE_WITH_SUBINTERFACE.matcher(iface.getName());
+          if (m.matches()) {
+            String parentInterfaceName = m.group(1);
+            Interface parentInterface = _interfaces.get(parentInterfaceName);
+            if (parentInterface != null) {
+              org.batfish.datamodel.Interface viIface = c.getAllInterfaces().get(ifaceName);
+              if (viIface != null) {
+                viIface.addDependency(new Dependency(parentInterfaceName, DependencyType.BIND));
+              }
+            }
+          }
           // Tunnels
           Tunnel tunnel = iface.getTunnel();
           if (tunnel != null && isRealInterfaceName(tunnel.getSourceInterfaceName())) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -5759,11 +5759,17 @@ public class CiscoGrammarTest {
   @Test
   public void testPortchannelSubinterfaceIsUp() throws IOException {
     Configuration config = parseConfig("ios-portchannel-subinterface");
+    double eth1Bandwidth = 1E7;
+    assertThat(config, hasInterface("Ethernet1", hasBandwidth(eth1Bandwidth)));
+    assertThat(config, hasInterface("Port-Channel1", hasBandwidth(eth1Bandwidth)));
     assertThat(
         config,
         hasInterface(
             "Port-Channel1.1",
-            allOf(hasInterfaceType(InterfaceType.AGGREGATE_CHILD), isActive(true))));
+            allOf(
+                hasInterfaceType(InterfaceType.AGGREGATE_CHILD),
+                isActive(true),
+                hasBandwidth(eth1Bandwidth))));
   }
 
   @Test


### PR DESCRIPTION
Gives portchannel subinterfaces a `BIND` dependency on their parent portchannels, so that they will inherit bandwidth from their parents.

In the process, fixed a couple bugs in bandwidth calculation for aggregate interfaces and their children:
- There was only one loop through interfaces to calculate their bandwidths. Split into two loops to calculate first aggregate interface bandwidths, then aggregate child interface bandwidths (since an aggregate child interface's bandwidth depends on its parent's bandwidth).
- Aggregate interface bandwidths were calculated from channel group members, then recalculated from dependencies if they had dependencies. This would be okay except that aggregate child interface bandwidths were calculated in between those two calculations, so if a parent interface's bandwidth was overwritten in the second calculation, its child would still have the initial channel-group-member-based bandwidth. Fixed by calculating aggregate interface bandwidths in one go, before calculating child bandwidths.