### PR TITLE
Store BGP admin costs in BgpProcess

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
@@ -205,7 +205,7 @@ public final class IspModelingUtils {
         nf.bgpProcessBuilder()
             .setRouterId(INTERNET_OUT_ADDRESS)
             .setVrf(defaultVrf)
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
             .build();
     bgpProcess.setMultipathEbgp(true);
 
@@ -385,7 +385,7 @@ public final class IspModelingUtils {
                     .min(Ip::compareTo)
                     .orElse(null))
             .setVrf(ispConfiguration.getDefaultVrf())
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
             .build();
     bgpProcess.setMultipathEbgp(true);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
@@ -202,7 +202,11 @@ public final class IspModelingUtils {
                     .build()));
 
     BgpProcess bgpProcess =
-        nf.bgpProcessBuilder().setRouterId(INTERNET_OUT_ADDRESS).setVrf(defaultVrf).build();
+        nf.bgpProcessBuilder()
+            .setRouterId(INTERNET_OUT_ADDRESS)
+            .setVrf(defaultVrf)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
     bgpProcess.setMultipathEbgp(true);
 
     internetConfiguration.setRoutingPolicies(
@@ -381,6 +385,7 @@ public final class IspModelingUtils {
                     .min(Ip::compareTo)
                     .orElse(null))
             .setVrf(ispConfiguration.getDefaultVrf())
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
             .build();
     bgpProcess.setMultipathEbgp(true);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -6,6 +6,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
@@ -43,6 +44,10 @@ public class BgpProcess implements Serializable {
       return bgpProcess;
     }
 
+    /**
+     * Sets {@link #setEbgpAdminCost(int) ebgpAdminCost} and {@link #setIbgpAdminCost(int)
+     * ibgpAdminCost} to default BGP administrative costs for the given {@link ConfigurationFormat}.
+     */
     public Builder setAdminCostsToVendorDefaults(@Nonnull ConfigurationFormat format) {
       return setEbgpAdminCost(RoutingProtocol.BGP.getDefaultAdministrativeCost(format))
           .setIbgpAdminCost(RoutingProtocol.IBGP.getDefaultAdministrativeCost(format));
@@ -123,8 +128,10 @@ public class BgpProcess implements Serializable {
   private BgpTieBreaker _tieBreaker;
 
   /**
-   * Constructs a BgpProcess with the default admin costs for the given {@link ConfigurationFormat}
+   * Constructs a BgpProcess with the default admin costs for the given {@link ConfigurationFormat},
+   * for convenient creation of BGP processes in tests.
    */
+  @VisibleForTesting
   public BgpProcess(@Nonnull Ip routerId, @Nonnull ConfigurationFormat configurationFormat) {
     this(
         routerId,

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -960,7 +960,7 @@ public final class TopologyUtilTest {
     _ib.setOwner(cH2).setVrf(vH2).setName(i1Name).build(); // h2 => b2
 
     BgpProcess.Builder pb =
-        _nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+        _nf.bgpProcessBuilder().setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS);
 
     Configuration cB1 = _cb.setHostname(b1Name).build();
     Vrf vB1 = _vb.setOwner(cB1).build();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -920,7 +920,7 @@ public final class TopologyUtilTest {
   }
 
   @Test
-  public void testIncompleteLyaer1TopologyHandlingIsp() {
+  public void testIncompleteLayer1TopologyHandlingIsp() {
     /*
      * Connectivity between border routers and generated ISP nodes
      * Expected: h1 <=> b1 <=> INTERNET <=> b2 <=> h2
@@ -959,12 +959,14 @@ public final class TopologyUtilTest {
     Vrf vH2 = _vb.setOwner(cH2).build();
     _ib.setOwner(cH2).setVrf(vH2).setName(i1Name).build(); // h2 => b2
 
+    BgpProcess.Builder pb =
+        _nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+
     Configuration cB1 = _cb.setHostname(b1Name).build();
     Vrf vB1 = _vb.setOwner(cB1).build();
     _ib.setOwner(cB1).setVrf(vB1).setName(i1Name).build(); // b1 => h1
     _ib.setName(i2Name).setAddress(b1i2Address).build(); // b1 => INTERNET
-    BgpProcess b1Proc =
-        _nf.bgpProcessBuilder().setRouterId(b1i2Address.getIp()).setVrf(vB1).build();
+    BgpProcess b1Proc = pb.setRouterId(b1i2Address.getIp()).setVrf(vB1).build();
     _nf.bgpNeighborBuilder()
         .setBgpProcess(b1Proc)
         .setLocalAs(asB1)
@@ -977,8 +979,7 @@ public final class TopologyUtilTest {
     Vrf vB2 = _vb.setOwner(cB2).build();
     _ib.setOwner(cB2).setVrf(vB2).setName(i1Name).setAddress(null).build(); // b2 => h2
     _ib.setName(i2Name).setAddress(b2i2Address).build(); // B2 => INTERNET
-    BgpProcess b2Proc =
-        _nf.bgpProcessBuilder().setRouterId(b2i2Address.getIp()).setVrf(vB2).build();
+    BgpProcess b2Proc = pb.setRouterId(b2i2Address.getIp()).setVrf(vB2).build();
     _nf.bgpNeighborBuilder()
         .setBgpProcess(b2Proc)
         .setLocalAs(asB2)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
@@ -542,6 +542,8 @@ public class IspModelingUtilsTest {
   @Test
   public void testInterfaceNamesIsp() {
     NetworkFactory nf = new NetworkFactory();
+    BgpProcess.Builder pb =
+        nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
 
     Configuration.Builder cb = nf.configurationBuilder();
     Configuration configuration1 =
@@ -553,8 +555,7 @@ public class IspModelingUtilsTest {
         .setAddress(new InterfaceAddress(Ip.parse("1.1.1.1"), 24))
         .build();
     Vrf vrfConf1 = nf.vrfBuilder().setName(DEFAULT_VRF_NAME).setOwner(configuration1).build();
-    BgpProcess bgpProcess1 =
-        nf.bgpProcessBuilder().setRouterId(Ip.parse("1.1.1.1")).setVrf(vrfConf1).build();
+    BgpProcess bgpProcess1 = pb.setRouterId(Ip.parse("1.1.1.1")).setVrf(vrfConf1).build();
     BgpActivePeerConfig.builder()
         .setBgpProcess(bgpProcess1)
         .setPeerAddress(Ip.parse("1.1.1.2"))
@@ -572,8 +573,7 @@ public class IspModelingUtilsTest {
         .setAddress(new InterfaceAddress(Ip.parse("2.2.2.2"), 24))
         .build();
     Vrf vrfConf2 = nf.vrfBuilder().setName(DEFAULT_VRF_NAME).setOwner(configuration2).build();
-    BgpProcess bgpProcess2 =
-        nf.bgpProcessBuilder().setVrf(vrfConf2).setRouterId(Ip.parse("2.2.2.2")).build();
+    BgpProcess bgpProcess2 = pb.setVrf(vrfConf2).setRouterId(Ip.parse("2.2.2.2")).build();
     BgpActivePeerConfig.builder()
         .setBgpProcess(bgpProcess2)
         .setPeerAddress(Ip.parse("2.2.2.3"))
@@ -623,7 +623,11 @@ public class IspModelingUtilsTest {
         .build();
     Vrf vrfConf1 = nf.vrfBuilder().setName(DEFAULT_VRF_NAME).setOwner(configuration1).build();
     BgpProcess bgpProcess1 =
-        nf.bgpProcessBuilder().setRouterId(Ip.parse("1.1.1.1")).setVrf(vrfConf1).build();
+        nf.bgpProcessBuilder()
+            .setRouterId(Ip.parse("1.1.1.1"))
+            .setVrf(vrfConf1)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
     BgpActivePeerConfig.builder()
         .setBgpProcess(bgpProcess1)
         .setPeerAddress(Ip.parse("1.1.1.2"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
@@ -250,7 +250,7 @@ public class IspModelingUtilsTest {
             .setLocalIp(Ip.parse("2.2.2.2"))
             .setLocalAs(2L)
             .build();
-    BgpProcess bgpProcess = new BgpProcess(Ip.ZERO);
+    BgpProcess bgpProcess = new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS);
     bgpProcess.getActiveNeighbors().put(Prefix.parse("1.1.1.1/32"), peer);
     configuration.getDefaultVrf().setBgpProcess(bgpProcess);
 
@@ -300,7 +300,7 @@ public class IspModelingUtilsTest {
             .setLocalIp(Ip.parse("2.2.2.2"))
             .setLocalAs(2L)
             .build();
-    BgpProcess bgpProcess = new BgpProcess(Ip.ZERO);
+    BgpProcess bgpProcess = new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS);
     bgpProcess.getActiveNeighbors().put(Prefix.parse("1.1.1.1/32"), peer);
     ispConfiguration.getDefaultVrf().setBgpProcess(bgpProcess);
 
@@ -360,7 +360,7 @@ public class IspModelingUtilsTest {
             .setLocalIp(Ip.parse("2.2.2.2"))
             .setLocalAs(2L)
             .build();
-    BgpProcess bgpProcess = new BgpProcess(Ip.ZERO);
+    BgpProcess bgpProcess = new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS);
     bgpProcess.getActiveNeighbors().put(Prefix.parse("1.1.1.1/32"), peer);
     configuration.getDefaultVrf().setBgpProcess(bgpProcess);
 
@@ -399,7 +399,7 @@ public class IspModelingUtilsTest {
             .setLocalIp(Ip.parse("2.2.2.2"))
             .setLocalAs(2L)
             .build();
-    BgpProcess bgpProcess = new BgpProcess(Ip.ZERO);
+    BgpProcess bgpProcess = new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS);
     bgpProcess.getActiveNeighbors().put(Prefix.parse("1.1.1.1/32"), peer);
     configuration.getDefaultVrf().setBgpProcess(bgpProcess);
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
@@ -543,7 +543,7 @@ public class IspModelingUtilsTest {
   public void testInterfaceNamesIsp() {
     NetworkFactory nf = new NetworkFactory();
     BgpProcess.Builder pb =
-        nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+        nf.bgpProcessBuilder().setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS);
 
     Configuration.Builder cb = nf.configurationBuilder();
     Configuration configuration1 =
@@ -626,7 +626,7 @@ public class IspModelingUtilsTest {
         nf.bgpProcessBuilder()
             .setRouterId(Ip.parse("1.1.1.1"))
             .setVrf(vrfConf1)
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
             .build();
     BgpActivePeerConfig.builder()
         .setBgpProcess(bgpProcess1)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTest.java
@@ -37,7 +37,7 @@ public class ConfigurationTest {
     Vrf vrf = c.getVrfs().computeIfAbsent(Configuration.DEFAULT_VRF_NAME, Vrf::new);
 
     // BGP
-    BgpProcess bgpProcess = new BgpProcess(Ip.parse("1.1.1.1"));
+    BgpProcess bgpProcess = new BgpProcess(Ip.parse("1.1.1.1"), ConfigurationFormat.CISCO_IOS);
     vrf.setBgpProcess(bgpProcess);
     BgpPeerConfig neighbor =
         _factory

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/DeviceTypeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/DeviceTypeTest.java
@@ -62,7 +62,7 @@ public class DeviceTypeTest {
     _nf.bgpProcessBuilder()
         .setVrf(vrf)
         .setRouterId(Ip.ZERO)
-        .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+        .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
         .build();
     postProcessConfiguration(c);
     assertThat(c.getDeviceType(), is(DeviceType.ROUTER));
@@ -75,7 +75,7 @@ public class DeviceTypeTest {
     _nf.bgpProcessBuilder()
         .setVrf(vrf)
         .setRouterId(Ip.ZERO)
-        .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+        .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
         .build();
     postProcessConfiguration(c);
     assertThat(c.getDeviceType(), is(DeviceType.ROUTER));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/DeviceTypeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/DeviceTypeTest.java
@@ -48,7 +48,8 @@ public class DeviceTypeTest {
   public void hostWithBgpIsHost() {
     Configuration c = _cb.setConfigurationFormat(ConfigurationFormat.HOST).build();
     Vrf vrf = _vb.setOwner(c).build();
-    _nf.bgpProcessBuilder().setVrf(vrf).setRouterId(Ip.ZERO).build();
+    // Choose arbitrary BGP admin costs for HOST format
+    vrf.setBgpProcess(new BgpProcess(Ip.ZERO, 10, 100));
     postProcessConfiguration(c);
     assertThat(c.getDeviceType(), is(DeviceType.HOST));
   }
@@ -58,7 +59,11 @@ public class DeviceTypeTest {
     Configuration c = _cb.build();
     _vb.setOwner(c).build();
     Vrf vrf = _vb.setOwner(c).build();
-    _nf.bgpProcessBuilder().setVrf(vrf).setRouterId(Ip.ZERO).build();
+    _nf.bgpProcessBuilder()
+        .setVrf(vrf)
+        .setRouterId(Ip.ZERO)
+        .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+        .build();
     postProcessConfiguration(c);
     assertThat(c.getDeviceType(), is(DeviceType.ROUTER));
   }
@@ -67,7 +72,11 @@ public class DeviceTypeTest {
   public void configWithBgpIsRouter() {
     Configuration c = _cb.build();
     Vrf vrf = _vb.setOwner(c).build();
-    _nf.bgpProcessBuilder().setVrf(vrf).setRouterId(Ip.ZERO).build();
+    _nf.bgpProcessBuilder()
+        .setVrf(vrf)
+        .setRouterId(Ip.ZERO)
+        .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+        .build();
     postProcessConfiguration(c);
     assertThat(c.getDeviceType(), is(DeviceType.ROUTER));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfTest.java
@@ -25,7 +25,7 @@ public class VrfTest {
     vrf.setOspfProcesses(
         ImmutableSortedMap.of(
             "ospf", OspfProcess.builder().setProcessId("ospf").setReferenceBandwidth(1d).build()));
-    vrf.setBgpProcess(new BgpProcess(Ip.ZERO));
+    vrf.setBgpProcess(new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS));
     IsoAddress isoAddress = new IsoAddress("49.0001.0100.0500.5005.00");
     vrf.setIsisProcess(IsisProcess.builder().setNetAddress(isoAddress).build());
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
@@ -39,9 +39,12 @@ public class BgpTopologyUtilsTest {
   private static String NODE1 = "n1";
   private static String NODE2 = "n2";
   private static String NODE3 = "n3";
-  private static BgpProcess _node1BgpProcess = new BgpProcess(Ip.parse("0.0.0.1"));
-  private static BgpProcess _node2BgpProcess = new BgpProcess(Ip.parse("0.0.0.2"));
-  private static BgpProcess _node3BgpProcess = new BgpProcess(Ip.parse("0.0.0.3"));
+  private static BgpProcess _node1BgpProcess =
+      new BgpProcess(Ip.parse("0.0.0.1"), ConfigurationFormat.CISCO_IOS);
+  private static BgpProcess _node2BgpProcess =
+      new BgpProcess(Ip.parse("0.0.0.2"), ConfigurationFormat.CISCO_IOS);
+  private static BgpProcess _node3BgpProcess =
+      new BgpProcess(Ip.parse("0.0.0.3"), ConfigurationFormat.CISCO_IOS);
   private static Map<String, Configuration> _configs;
 
   /** Sets up three nodes with a BGP process on each. Tests can populate BGP processes. */

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpProcessPropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpProcessPropertySpecifierTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.junit.Test;
@@ -19,7 +20,7 @@ import org.junit.runners.JUnit4;
 public class BgpProcessPropertySpecifierTest {
   @Test
   public void testIsRouteReflector() {
-    BgpProcess emptyProcess = new BgpProcess(Ip.ZERO);
+    BgpProcess emptyProcess = new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS);
     assertFalse("no rr clients", isRouteReflector(emptyProcess));
 
     BgpActivePeerConfig activePeerWithRRC =
@@ -36,17 +37,17 @@ public class BgpProcessPropertySpecifierTest {
     Prefix p30b = Prefix.parse("1.2.3.8/30");
 
     // One active peer RRC
-    BgpProcess hasActiveNeighbor = new BgpProcess(Ip.ZERO);
+    BgpProcess hasActiveNeighbor = new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS);
     hasActiveNeighbor.setNeighbors(ImmutableSortedMap.of(p32a, activePeerWithRRC));
     assertTrue("has active rr client", isRouteReflector(hasActiveNeighbor));
 
     // One passive peer RRC
-    BgpProcess hasPassiveNeighbor = new BgpProcess(Ip.ZERO);
+    BgpProcess hasPassiveNeighbor = new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS);
     hasPassiveNeighbor.setPassiveNeighbors(ImmutableSortedMap.of(p30a, passivePeerWithRRC));
     assertTrue("has passive rr client", isRouteReflector(hasPassiveNeighbor));
 
     // Mix
-    BgpProcess hasNeighborMix = new BgpProcess(Ip.ZERO);
+    BgpProcess hasNeighborMix = new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS);
     hasNeighborMix.setNeighbors(
         ImmutableSortedMap.of(p32a, activePeerWithoutRRC, p32b, activePeerWithRRC));
     hasNeighborMix.setPassiveNeighbors(
@@ -54,7 +55,7 @@ public class BgpProcessPropertySpecifierTest {
     assertTrue("has mix of active and inactive rr client", isRouteReflector(hasNeighborMix));
 
     // Both inactive
-    BgpProcess hasAllInactive = new BgpProcess(Ip.ZERO);
+    BgpProcess hasAllInactive = new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS);
     hasAllInactive.setNeighbors(ImmutableSortedMap.of(p32a, activePeerWithoutRRC));
     hasAllInactive.setPassiveNeighbors(ImmutableSortedMap.of(p30a, passivePeerWithoutRRC));
     assertFalse("has multiple inactive rr clients", isRouteReflector(hasAllInactive));

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -306,6 +306,10 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
     ImmutableSortedMap.Builder<String, IpsecPeerConfig> ipsecPeerConfigMapBuilder =
         ImmutableSortedMap.naturalOrder();
 
+    // BGP administrative costs
+    int ebgpAdminCost = RoutingProtocol.BGP.getDefaultAdministrativeCost(ConfigurationFormat.AWS);
+    int ibgpAdminCost = RoutingProtocol.IBGP.getDefaultAdministrativeCost(ConfigurationFormat.AWS);
+
     for (int i = 0; i < _ipsecTunnels.size(); i++) {
       int idNum = i + 1;
       String vpnId = _vpnConnectionId + "-" + idNum;
@@ -360,7 +364,7 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
       if (ipsecTunnel.getVgwBgpAsn() != -1) {
         BgpProcess proc = vpnGatewayCfgNode.getDefaultVrf().getBgpProcess();
         if (proc == null) {
-          proc = new BgpProcess(ipsecTunnel.getVgwInsideAddress(), ConfigurationFormat.AWS);
+          proc = new BgpProcess(ipsecTunnel.getVgwInsideAddress(), ebgpAdminCost, ibgpAdminCost);
           proc.setMultipathEquivalentAsPathMatchMode(MultipathEquivalentAsPathMatchMode.EXACT_PATH);
           vpnGatewayCfgNode.getDefaultVrf().setBgpProcess(proc);
         }
@@ -407,7 +411,7 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
         // iBGP connection from VPC
         BgpActivePeerConfig.Builder vpcToVgwBgpPeerConfig = BgpActivePeerConfig.builder();
         vpcToVgwBgpPeerConfig.setPeerAddress(vgwToVpcIfaceAddress);
-        BgpProcess vpcProc = new BgpProcess(vpcIfaceAddress, ConfigurationFormat.AWS);
+        BgpProcess vpcProc = new BgpProcess(vpcIfaceAddress, ebgpAdminCost, ibgpAdminCost);
         vpcNode.getDefaultVrf().setBgpProcess(vpcProc);
         vpcProc.setMultipathEquivalentAsPathMatchMode(
             MultipathEquivalentAsPathMatchMode.EXACT_PATH);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -19,6 +19,7 @@ import org.batfish.common.Warnings;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DiffieHellmanGroup;
 import org.batfish.datamodel.EncryptionAlgorithm;
 import org.batfish.datamodel.IkeAuthenticationMethod;
@@ -359,7 +360,7 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
       if (ipsecTunnel.getVgwBgpAsn() != -1) {
         BgpProcess proc = vpnGatewayCfgNode.getDefaultVrf().getBgpProcess();
         if (proc == null) {
-          proc = new BgpProcess(ipsecTunnel.getVgwInsideAddress());
+          proc = new BgpProcess(ipsecTunnel.getVgwInsideAddress(), ConfigurationFormat.AWS);
           proc.setMultipathEquivalentAsPathMatchMode(MultipathEquivalentAsPathMatchMode.EXACT_PATH);
           vpnGatewayCfgNode.getDefaultVrf().setBgpProcess(proc);
         }
@@ -406,7 +407,7 @@ public class VpnConnection implements AwsVpcEntity, Serializable {
         // iBGP connection from VPC
         BgpActivePeerConfig.Builder vpcToVgwBgpPeerConfig = BgpActivePeerConfig.builder();
         vpcToVgwBgpPeerConfig.setPeerAddress(vgwToVpcIfaceAddress);
-        BgpProcess vpcProc = new BgpProcess(vpcIfaceAddress);
+        BgpProcess vpcProc = new BgpProcess(vpcIfaceAddress, ConfigurationFormat.AWS);
         vpcNode.getDefaultVrf().setBgpProcess(vpcProc);
         vpcProc.setMultipathEquivalentAsPathMatchMode(
             MultipathEquivalentAsPathMatchMode.EXACT_PATH);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1296,9 +1296,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
       CiscoNxBgpVrfConfiguration nxBgpVrf,
       String vrfName) {
     org.batfish.datamodel.Vrf v = c.getVrfs().get(vrfName);
+    int ebgpAdmin = RoutingProtocol.BGP.getDefaultAdministrativeCost(c.getConfigurationFormat());
+    int ibgpAdmin = RoutingProtocol.IBGP.getDefaultAdministrativeCost(c.getConfigurationFormat());
     org.batfish.datamodel.BgpProcess newBgpProcess =
         new org.batfish.datamodel.BgpProcess(
-            CiscoNxConversions.getNxBgpRouterId(nxBgpVrf, v, _w), c.getConfigurationFormat());
+            CiscoNxConversions.getNxBgpRouterId(nxBgpVrf, v, _w), ebgpAdmin, ibgpAdmin);
     if (nxBgpVrf.getBestpathCompareRouterId()) {
       newBgpProcess.setTieBreaker(BgpTieBreaker.ROUTER_ID);
     }
@@ -1552,8 +1554,10 @@ public final class CiscoConfiguration extends VendorConfiguration {
       final Configuration c, BgpProcess proc, String vrfName) {
     org.batfish.datamodel.Vrf v = c.getVrfs().get(vrfName);
     Ip bgpRouterId = getBgpRouterId(c, vrfName, proc);
+    int ebgpAdmin = RoutingProtocol.BGP.getDefaultAdministrativeCost(c.getConfigurationFormat());
+    int ibgpAdmin = RoutingProtocol.IBGP.getDefaultAdministrativeCost(c.getConfigurationFormat());
     org.batfish.datamodel.BgpProcess newBgpProcess =
-        new org.batfish.datamodel.BgpProcess(bgpRouterId, c.getConfigurationFormat());
+        new org.batfish.datamodel.BgpProcess(bgpRouterId, ebgpAdmin, ibgpAdmin);
     BgpTieBreaker tieBreaker = proc.getTieBreaker();
     if (tieBreaker != null) {
       newBgpProcess.setTieBreaker(tieBreaker);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1297,7 +1297,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
       String vrfName) {
     org.batfish.datamodel.Vrf v = c.getVrfs().get(vrfName);
     org.batfish.datamodel.BgpProcess newBgpProcess =
-        new org.batfish.datamodel.BgpProcess(CiscoNxConversions.getNxBgpRouterId(nxBgpVrf, v, _w));
+        new org.batfish.datamodel.BgpProcess(
+            CiscoNxConversions.getNxBgpRouterId(nxBgpVrf, v, _w), c.getConfigurationFormat());
     if (nxBgpVrf.getBestpathCompareRouterId()) {
       newBgpProcess.setTieBreaker(BgpTieBreaker.ROUTER_ID);
     }
@@ -1552,7 +1553,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     org.batfish.datamodel.Vrf v = c.getVrfs().get(vrfName);
     Ip bgpRouterId = getBgpRouterId(c, vrfName, proc);
     org.batfish.datamodel.BgpProcess newBgpProcess =
-        new org.batfish.datamodel.BgpProcess(bgpRouterId);
+        new org.batfish.datamodel.BgpProcess(bgpRouterId, c.getConfigurationFormat());
     BgpTieBreaker tieBreaker = proc.getTieBreaker();
     if (tieBreaker != null) {
       newBgpProcess.setTieBreaker(tieBreaker);

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -729,8 +729,10 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
         return null;
       }
     }
+    int ebgpAdmin = RoutingProtocol.BGP.getDefaultAdministrativeCost(_c.getConfigurationFormat());
+    int ibgpAdmin = RoutingProtocol.IBGP.getDefaultAdministrativeCost(_c.getConfigurationFormat());
     org.batfish.datamodel.BgpProcess newProc =
-        new org.batfish.datamodel.BgpProcess(routerId, _c.getConfigurationFormat());
+        new org.batfish.datamodel.BgpProcess(routerId, ebgpAdmin, ibgpAdmin);
     newProc.setMultipathEquivalentAsPathMatchMode(EXACT_PATH);
     newProc.setMultipathEbgp(false);
     newProc.setMultipathIbgp(false);

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -729,7 +729,8 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
         return null;
       }
     }
-    org.batfish.datamodel.BgpProcess newProc = new org.batfish.datamodel.BgpProcess(routerId);
+    org.batfish.datamodel.BgpProcess newProc =
+        new org.batfish.datamodel.BgpProcess(routerId, _c.getConfigurationFormat());
     newProc.setMultipathEquivalentAsPathMatchMode(EXACT_PATH);
     newProc.setMultipathEbgp(false);
     newProc.setMultipathIbgp(false);

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
@@ -1101,8 +1101,10 @@ public class F5BigipConfiguration extends VendorConfiguration {
   }
 
   private @Nonnull org.batfish.datamodel.BgpProcess toBgpProcess(BgpProcess proc) {
+    int ebgpAdmin = RoutingProtocol.BGP.getDefaultAdministrativeCost(_c.getConfigurationFormat());
+    int ibgpAdmin = RoutingProtocol.IBGP.getDefaultAdministrativeCost(_c.getConfigurationFormat());
     org.batfish.datamodel.BgpProcess newProc =
-        new org.batfish.datamodel.BgpProcess(getBgpRouterId(proc), _c.getConfigurationFormat());
+        new org.batfish.datamodel.BgpProcess(getBgpRouterId(proc), ebgpAdmin, ibgpAdmin);
 
     // TODO: verify correct method of determining whether two AS-paths are equivalent
     newProc.setMultipathEquivalentAsPathMatchMode(MultipathEquivalentAsPathMatchMode.EXACT_PATH);

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
@@ -1102,7 +1102,7 @@ public class F5BigipConfiguration extends VendorConfiguration {
 
   private @Nonnull org.batfish.datamodel.BgpProcess toBgpProcess(BgpProcess proc) {
     org.batfish.datamodel.BgpProcess newProc =
-        new org.batfish.datamodel.BgpProcess(getBgpRouterId(proc));
+        new org.batfish.datamodel.BgpProcess(getBgpRouterId(proc), _c.getConfigurationFormat());
 
     // TODO: verify correct method of determining whether two AS-paths are equivalent
     newProc.setMultipathEquivalentAsPathMatchMode(MultipathEquivalentAsPathMatchMode.EXACT_PATH);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -288,7 +288,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
         routerId = Ip.ZERO;
       }
     }
-    BgpProcess proc = new BgpProcess(routerId);
+    BgpProcess proc = new BgpProcess(routerId, _c.getConfigurationFormat());
     boolean multipathEbgp = false;
     boolean multipathIbgp = false;
     boolean multipathMultipleAs = false;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -288,7 +288,9 @@ public final class JuniperConfiguration extends VendorConfiguration {
         routerId = Ip.ZERO;
       }
     }
-    BgpProcess proc = new BgpProcess(routerId, _c.getConfigurationFormat());
+    int ebgpAdmin = RoutingProtocol.BGP.getDefaultAdministrativeCost(_c.getConfigurationFormat());
+    int ibgpAdmin = RoutingProtocol.IBGP.getDefaultAdministrativeCost(_c.getConfigurationFormat());
+    BgpProcess proc = new BgpProcess(routerId, ebgpAdmin, ibgpAdmin);
     boolean multipathEbgp = false;
     boolean multipathIbgp = false;
     boolean multipathMultipleAs = false;

--- a/projects/batfish/src/test/java/org/batfish/dataplane/BgpRibGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/BgpRibGroupsTest.java
@@ -144,7 +144,11 @@ public class BgpRibGroupsTest {
         .build();
 
     BgpProcess bgpProc1 =
-        nf.bgpProcessBuilder().setVrf(c1v1).setRouterId(Ip.parse("1.1.1.1")).build();
+        nf.bgpProcessBuilder()
+            .setVrf(c1v1)
+            .setRouterId(Ip.parse("1.1.1.1"))
+            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .build();
     RibGroup rg =
         new RibGroup(
             "RIB_GROUP",
@@ -186,7 +190,11 @@ public class BgpRibGroupsTest {
         .build();
 
     BgpProcess bgpProc2 =
-        nf.bgpProcessBuilder().setVrf(v2).setRouterId(Ip.parse("2.2.2.2")).build();
+        nf.bgpProcessBuilder()
+            .setVrf(v2)
+            .setRouterId(Ip.parse("2.2.2.2"))
+            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .build();
     nf.bgpNeighborBuilder()
         .setBgpProcess(bgpProc2)
         .setLocalAs(2L)
@@ -213,7 +221,11 @@ public class BgpRibGroupsTest {
         .build();
 
     BgpProcess bgpProc3 =
-        nf.bgpProcessBuilder().setVrf(v3).setRouterId(Ip.parse("3.3.3.3")).build();
+        nf.bgpProcessBuilder()
+            .setVrf(v3)
+            .setRouterId(Ip.parse("3.3.3.3"))
+            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .build();
     nf.bgpNeighborBuilder()
         .setBgpProcess(bgpProc3)
         .setLocalAs(3L)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/BgpRibGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/BgpRibGroupsTest.java
@@ -147,7 +147,7 @@ public class BgpRibGroupsTest {
         nf.bgpProcessBuilder()
             .setVrf(c1v1)
             .setRouterId(Ip.parse("1.1.1.1"))
-            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.JUNIPER)
             .build();
     RibGroup rg =
         new RibGroup(
@@ -193,7 +193,7 @@ public class BgpRibGroupsTest {
         nf.bgpProcessBuilder()
             .setVrf(v2)
             .setRouterId(Ip.parse("2.2.2.2"))
-            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.JUNIPER)
             .build();
     nf.bgpNeighborBuilder()
         .setBgpProcess(bgpProc2)
@@ -224,7 +224,7 @@ public class BgpRibGroupsTest {
         nf.bgpProcessBuilder()
             .setVrf(v3)
             .setRouterId(Ip.parse("3.3.3.3"))
-            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.JUNIPER)
             .build();
     nf.bgpNeighborBuilder()
         .setBgpProcess(bgpProc3)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -17,7 +17,7 @@ public class BgpRoutingProcessTest {
     NetworkFactory nf = new NetworkFactory();
     BgpRoutingProcess process =
         new BgpRoutingProcess(
-            new BgpProcess(Ip.ZERO),
+            new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS),
             nf.configurationBuilder()
                 .setHostname("c")
                 .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -149,7 +149,7 @@ public class IncrementalDataPlanePluginTest {
     BgpProcess coreProc =
         _pb.setRouterId(coreId)
             .setVrf(corevrf)
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
             .build();
     _nb.setBgpProcess(coreProc)
         .setRemoteAs(1L)
@@ -167,7 +167,7 @@ public class IncrementalDataPlanePluginTest {
     BgpProcess n1Proc =
         _pb.setRouterId(neighborId1)
             .setVrf(n1Vrf)
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
             .build();
     _nb.setBgpProcess(n1Proc)
         .setRemoteAs(1L)
@@ -184,7 +184,7 @@ public class IncrementalDataPlanePluginTest {
     BgpProcess n2Proc =
         _pb.setRouterId(neighborId2)
             .setVrf(n2Vrf)
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
             .build();
     _nb.setBgpProcess(n2Proc)
         .setRemoteAs(1L)
@@ -797,7 +797,7 @@ public class IncrementalDataPlanePluginTest {
     BgpProcess bgpp1 =
         _pb.setVrf(vrf1)
             .setRouterId(Ip.parse("1.1.1.2"))
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
             .build();
     _nb.setPeerAddress(lo2Ip)
         .setLocalAs(1L)
@@ -836,7 +836,7 @@ public class IncrementalDataPlanePluginTest {
     BgpProcess bgpp2 =
         _pb.setVrf(vrf2)
             .setRouterId(Ip.parse("1.1.1.3"))
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
             .build();
     // Bgp neighbor:
     _nb.setPeerAddress(lo1Ip)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -146,7 +146,11 @@ public class IncrementalDataPlanePluginTest {
     Vrf corevrf = _vb.setOwner(core).build();
     _ib.setOwner(core).setVrf(corevrf);
     _ib.setAddress(new InterfaceAddress(coreId, interfcePrefixBits)).build();
-    BgpProcess coreProc = _pb.setRouterId(coreId).setVrf(corevrf).build();
+    BgpProcess coreProc =
+        _pb.setRouterId(coreId)
+            .setVrf(corevrf)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
     _nb.setBgpProcess(coreProc)
         .setRemoteAs(1L)
         .setLocalAs(1L)
@@ -160,7 +164,11 @@ public class IncrementalDataPlanePluginTest {
     Vrf n1Vrf = _vb.setOwner(n1).build();
     _ib.setOwner(n1).setVrf(n1Vrf);
     _ib.setAddress(new InterfaceAddress(neighborId1, interfcePrefixBits)).build();
-    BgpProcess n1Proc = _pb.setRouterId(neighborId1).setVrf(n1Vrf).build();
+    BgpProcess n1Proc =
+        _pb.setRouterId(neighborId1)
+            .setVrf(n1Vrf)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
     _nb.setBgpProcess(n1Proc)
         .setRemoteAs(1L)
         .setLocalAs(1L)
@@ -173,7 +181,11 @@ public class IncrementalDataPlanePluginTest {
     Vrf n2Vrf = _vb.setOwner(n2).build();
     _ib.setOwner(n2).setVrf(n2Vrf);
     _ib.setAddress(new InterfaceAddress(neighborId2, interfcePrefixBits)).build();
-    BgpProcess n2Proc = _pb.setRouterId(neighborId2).setVrf(n2Vrf).build();
+    BgpProcess n2Proc =
+        _pb.setRouterId(neighborId2)
+            .setVrf(n2Vrf)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
     _nb.setBgpProcess(n2Proc)
         .setRemoteAs(1L)
         .setLocalAs(1L)
@@ -782,7 +794,11 @@ public class IncrementalDataPlanePluginTest {
         .setVrf(vrf1)
         .build();
     // Bgp process and neighbor:
-    BgpProcess bgpp1 = _pb.setVrf(vrf1).setRouterId(Ip.parse("1.1.1.2")).build();
+    BgpProcess bgpp1 =
+        _pb.setVrf(vrf1)
+            .setRouterId(Ip.parse("1.1.1.2"))
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
     _nb.setPeerAddress(lo2Ip)
         .setLocalAs(1L)
         .setLocalIp(lo1Ip)
@@ -817,7 +833,11 @@ public class IncrementalDataPlanePluginTest {
         .setLevel2(IsisLevelSettings.builder().build())
         .setVrf(vrf2)
         .build();
-    BgpProcess bgpp2 = _pb.setVrf(vrf2).setRouterId(Ip.parse("1.1.1.3")).build();
+    BgpProcess bgpp2 =
+        _pb.setVrf(vrf2)
+            .setRouterId(Ip.parse("1.1.1.3"))
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
     // Bgp neighbor:
     _nb.setPeerAddress(lo1Ip)
         .setLocalAs(1L)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/PrefixTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/PrefixTracerTest.java
@@ -106,7 +106,12 @@ public class PrefixTracerTest {
                 .setNetwork(_staticRoutePrefix)
                 .setAdministrativeCost(1)
                 .build()));
-    BgpProcess bp = nf.bgpProcessBuilder().setVrf(vrf1).setRouterId(neighbor1Ip).build();
+    BgpProcess bp =
+        nf.bgpProcessBuilder()
+            .setVrf(vrf1)
+            .setRouterId(neighbor1Ip)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
     nf.bgpNeighborBuilder()
         .setBgpProcess(bp)
         .setLocalIp(neighbor1Ip)
@@ -124,7 +129,12 @@ public class PrefixTracerTest {
         .setOwner(c2)
         .setVrf(vrf2)
         .build();
-    bp = nf.bgpProcessBuilder().setVrf(vrf2).setRouterId(neighbor2Ip).build();
+    bp =
+        nf.bgpProcessBuilder()
+            .setVrf(vrf2)
+            .setRouterId(neighbor2Ip)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
     nf.bgpNeighborBuilder()
         .setBgpProcess(bp)
         .setLocalIp(neighbor2Ip)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/PrefixTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/PrefixTracerTest.java
@@ -110,7 +110,7 @@ public class PrefixTracerTest {
         nf.bgpProcessBuilder()
             .setVrf(vrf1)
             .setRouterId(neighbor1Ip)
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
             .build();
     nf.bgpNeighborBuilder()
         .setBgpProcess(bp)
@@ -133,7 +133,7 @@ public class PrefixTracerTest {
         nf.bgpProcessBuilder()
             .setVrf(vrf2)
             .setRouterId(neighbor2Ip)
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
             .build();
     nf.bgpNeighborBuilder()
         .setBgpProcess(bp)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
@@ -374,7 +374,7 @@ public class RouteReflectionTest {
     _cb = _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     _ib = _nf.interfaceBuilder();
     _nb = _nf.bgpNeighborBuilder().setLocalAs(2L);
-    _pb = _nf.bgpProcessBuilder();
+    _pb = _nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     _vb = _nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
     If acceptIffBgp = new If();
     Disjunction guard = new Disjunction();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
@@ -374,7 +374,7 @@ public class RouteReflectionTest {
     _cb = _nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     _ib = _nf.interfaceBuilder();
     _nb = _nf.bgpNeighborBuilder().setLocalAs(2L);
-    _pb = _nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    _pb = _nf.bgpProcessBuilder().setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS);
     _vb = _nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
     If acceptIffBgp = new If();
     Disjunction guard = new Disjunction();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -283,7 +283,7 @@ public class VirtualRouterTest {
         nf.bgpProcessBuilder()
             .setVrf(vr._vrf)
             .setRouterId(routerId)
-            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
             .build();
     bgpProcess.getActiveNeighbors().put(Prefix.parse("2.2.2.2/32"), evpnPeer);
     vr._vrf
@@ -607,7 +607,7 @@ public class VirtualRouterTest {
     Vrf vrf2 = nf.vrfBuilder().setName(DEFAULT_VRF_NAME).setOwner(c2).build();
     // Set bgp processes and neighbors
     BgpProcess.Builder pb =
-        nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+        nf.bgpProcessBuilder().setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS);
     BgpProcess proc1 = pb.setVrf(vrf1).setRouterId(Ip.parse("1.1.1.1")).build();
     BgpProcess proc2 = pb.setVrf(vrf2).setRouterId(Ip.parse("1.1.1.2")).build();
     nf.bgpNeighborBuilder()

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -279,7 +279,12 @@ public class VirtualRouterTest {
                             ExtendedCommunity.target(65500, 10001),
                             false))))
             .build();
-    BgpProcess bgpProcess = nf.bgpProcessBuilder().setVrf(vr._vrf).setRouterId(routerId).build();
+    BgpProcess bgpProcess =
+        nf.bgpProcessBuilder()
+            .setVrf(vr._vrf)
+            .setRouterId(routerId)
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
     bgpProcess.getActiveNeighbors().put(Prefix.parse("2.2.2.2/32"), evpnPeer);
     vr._vrf
         .getVniSettings()
@@ -601,8 +606,10 @@ public class VirtualRouterTest {
     Vrf vrf1 = nf.vrfBuilder().setName(DEFAULT_VRF_NAME).setOwner(c1).build();
     Vrf vrf2 = nf.vrfBuilder().setName(DEFAULT_VRF_NAME).setOwner(c2).build();
     // Set bgp processes and neighbors
-    BgpProcess proc1 = nf.bgpProcessBuilder().setVrf(vrf1).setRouterId(Ip.parse("1.1.1.1")).build();
-    BgpProcess proc2 = nf.bgpProcessBuilder().setVrf(vrf2).setRouterId(Ip.parse("1.1.1.2")).build();
+    BgpProcess.Builder pb =
+        nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    BgpProcess proc1 = pb.setVrf(vrf1).setRouterId(Ip.parse("1.1.1.1")).build();
+    BgpProcess proc2 = pb.setVrf(vrf2).setRouterId(Ip.parse("1.1.1.2")).build();
     nf.bgpNeighborBuilder()
         .setPeerAddress(Ip.parse("1.1.1.2"))
         .setLocalIp(Ip.parse("1.1.1.1"))

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
@@ -66,7 +66,7 @@ public class NodeColoredScheduleTest {
     Vrf.Builder vb = nf.vrfBuilder();
     Interface.Builder ib = nf.interfaceBuilder().setOspfEnabled(true).setOspfProcess("1");
     BgpProcess.Builder pb =
-        nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+        nf.bgpProcessBuilder().setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS);
     BgpActivePeerConfig.Builder nb = nf.bgpNeighborBuilder();
     OspfProcess.Builder ob = nf.ospfProcessBuilder().setProcessId("1").setReferenceBandwidth(1e8);
     OspfArea.Builder ospfArea = nf.ospfAreaBuilder().setNumber(0);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
@@ -65,7 +65,8 @@ public class NodeColoredScheduleTest {
         nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     Vrf.Builder vb = nf.vrfBuilder();
     Interface.Builder ib = nf.interfaceBuilder().setOspfEnabled(true).setOspfProcess("1");
-    BgpProcess.Builder pb = nf.bgpProcessBuilder();
+    BgpProcess.Builder pb =
+        nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     BgpActivePeerConfig.Builder nb = nf.bgpNeighborBuilder();
     OspfProcess.Builder ob = nf.ospfProcessBuilder().setProcessId("1").setReferenceBandwidth(1e8);
     OspfArea.Builder ospfArea = nf.ospfAreaBuilder().setNumber(0);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
@@ -98,7 +98,7 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
             .build();
     _sessionProperties = BgpSessionProperties.from(_fromNeighbor, _toNeighbor, false);
     BgpProcess.Builder pb =
-        _nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+        _nf.bgpProcessBuilder().setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS);
     Vrf fromVrf = _nf.vrfBuilder().setOwner(c1).build();
     _fromBgpProcess = pb.setVrf(fromVrf).setRouterId(SOURCE_IP).build();
     Vrf toVrf = _nf.vrfBuilder().setOwner(c2).build();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
@@ -97,10 +97,12 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
             .setLocalIp(DEST_IP)
             .build();
     _sessionProperties = BgpSessionProperties.from(_fromNeighbor, _toNeighbor, false);
+    BgpProcess.Builder pb =
+        _nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     Vrf fromVrf = _nf.vrfBuilder().setOwner(c1).build();
-    _fromBgpProcess = _nf.bgpProcessBuilder().setVrf(fromVrf).setRouterId(SOURCE_IP).build();
+    _fromBgpProcess = pb.setVrf(fromVrf).setRouterId(SOURCE_IP).build();
     Vrf toVrf = _nf.vrfBuilder().setOwner(c2).build();
-    _toBgpProcess = _nf.bgpProcessBuilder().setVrf(toVrf).setRouterId(DEST_IP).build();
+    _toBgpProcess = pb.setVrf(toVrf).setRouterId(DEST_IP).build();
   }
 
   /**

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/abstraction/AbstractionBuilder.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/abstraction/AbstractionBuilder.java
@@ -555,7 +555,7 @@ class AbstractionBuilder {
 
       BgpProcess bgp = vrf.getBgpProcess();
       if (bgp != null) {
-        BgpProcess abstractBgp = new BgpProcess(bgp.getRouterId());
+        BgpProcess abstractBgp = new BgpProcess(bgp.getRouterId(), conf.getConfigurationFormat());
         abstractBgp.setMultipathEbgp(bgp.getMultipathEbgp());
         abstractBgp.setMultipathIbgp(bgp.getMultipathIbgp());
         abstractBgp.setOriginationSpace(bgp.getOriginationSpace());

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/abstraction/AbstractionBuilder.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/abstraction/AbstractionBuilder.java
@@ -24,6 +24,7 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpLink;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.ospf.OspfNeighbor;
 import org.batfish.datamodel.ospf.OspfProcess;
@@ -555,7 +556,11 @@ class AbstractionBuilder {
 
       BgpProcess bgp = vrf.getBgpProcess();
       if (bgp != null) {
-        BgpProcess abstractBgp = new BgpProcess(bgp.getRouterId(), conf.getConfigurationFormat());
+        int ebgpAdmin =
+            RoutingProtocol.BGP.getDefaultAdministrativeCost(conf.getConfigurationFormat());
+        int ibgpAdmin =
+            RoutingProtocol.IBGP.getDefaultAdministrativeCost(conf.getConfigurationFormat());
+        BgpProcess abstractBgp = new BgpProcess(bgp.getRouterId(), ebgpAdmin, ibgpAdmin);
         abstractBgp.setMultipathEbgp(bgp.getMultipathEbgp());
         abstractBgp.setMultipathIbgp(bgp.getMultipathIbgp());
         abstractBgp.setOriginationSpace(bgp.getOriginationSpace());

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/GraphTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/GraphTest.java
@@ -51,7 +51,8 @@ public class GraphTest {
     // Non-default vrfs are not handled yet
     Vrf.Builder vb = _nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
     Interface.Builder ib = _nf.interfaceBuilder();
-    BgpProcess.Builder bpb = _nf.bgpProcessBuilder();
+    BgpProcess.Builder bpb =
+        _nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     BgpActivePeerConfig.Builder bnb = _nf.bgpNeighborBuilder().setLocalAs(1L).setRemoteAs(1L);
 
     Configuration c1 = cb.setHostname("r1").build();

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/GraphTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/GraphTest.java
@@ -52,7 +52,7 @@ public class GraphTest {
     Vrf.Builder vb = _nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
     Interface.Builder ib = _nf.interfaceBuilder();
     BgpProcess.Builder bpb =
-        _nf.bgpProcessBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+        _nf.bgpProcessBuilder().setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS);
     BgpActivePeerConfig.Builder bnb = _nf.bgpNeighborBuilder().setLocalAs(1L).setRemoteAs(1L);
 
     Configuration c1 = cb.setHostname("r1").build();

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPeerConfigurationAnswererTest.java
@@ -93,7 +93,7 @@ public final class BgpPeerConfigurationAnswererTest {
             .setSendCommunity(false)
             .build();
 
-    BgpProcess process = new BgpProcess(Ip.ZERO);
+    BgpProcess process = new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS);
     process.setNeighbors(ImmutableSortedMap.of(Prefix.create(Ip.parse("1.1.1.0"), 24), activePeer));
     process.setPassiveNeighbors(
         ImmutableSortedMap.of(Prefix.create(Ip.parse("1.1.1.0"), 24), passivePeer));

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpProcessConfigurationAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpProcessConfigurationAnswererTest.java
@@ -32,7 +32,7 @@ public class BgpProcessConfigurationAnswererTest {
   @Test
   public void testWithNeighbors() {
     // Create process with active, passive, and unnumbered peers
-    BgpProcess proc = new BgpProcess(Ip.ZERO);
+    BgpProcess proc = new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS);
     BgpActivePeerConfig.builder()
         .setBgpProcess(proc)
         .setLocalAs(100L)
@@ -94,7 +94,7 @@ public class BgpProcessConfigurationAnswererTest {
   @Test
   public void getProperties() {
 
-    BgpProcess bgp1 = new BgpProcess(Ip.parse("1.1.1.1"));
+    BgpProcess bgp1 = new BgpProcess(Ip.parse("1.1.1.1"), ConfigurationFormat.CISCO_IOS);
     bgp1.setMultipathEbgp(true);
     bgp1.setTieBreaker(BgpTieBreaker.ARRIVAL_ORDER);
 

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswererTest.java
@@ -513,7 +513,7 @@ public class BgpSessionCompatibilityAnswererTest {
           nf.bgpProcessBuilder()
               .setVrf(vrf)
               .setRouterId(Ip.ZERO)
-              .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+              .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
               .build();
       configs.put(c.getHostname(), c);
 

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswererTest.java
@@ -509,7 +509,12 @@ public class BgpSessionCompatibilityAnswererTest {
               .setHostname(id.getHostname())
               .build();
       Vrf vrf = nf.vrfBuilder().setOwner(c).setName(id.getVrfName()).build();
-      BgpProcess bgpProc = nf.bgpProcessBuilder().setVrf(vrf).setRouterId(Ip.ZERO).build();
+      BgpProcess bgpProc =
+          nf.bgpProcessBuilder()
+              .setVrf(vrf)
+              .setRouterId(Ip.ZERO)
+              .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+              .build();
       configs.put(c.getHostname(), c);
 
       // Add interface to make IpOwners accurate

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -278,8 +278,8 @@ public class EdgesAnswererTest {
 
   @Test
   public void testGetBgpEdges() {
-    BgpProcess bgp1 = new BgpProcess(Ip.parse("1.1.1.1"));
-    BgpProcess bgp2 = new BgpProcess(Ip.parse("2.2.2.2"));
+    BgpProcess bgp1 = new BgpProcess(Ip.parse("1.1.1.1"), ConfigurationFormat.CISCO_IOS);
+    BgpProcess bgp2 = new BgpProcess(Ip.parse("2.2.2.2"), ConfigurationFormat.CISCO_IOS);
 
     // Edge between active peers
     Ip ip1 = Ip.parse("1.1.1.1");

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -2380,6 +2380,8 @@
               }
             },
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "10.10.255.8",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -4815,6 +4817,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "169.254.15.193",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -4970,6 +4974,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "240.0.0.7",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -2401,6 +2401,8 @@
             }
           },
           "bgpProcess" : {
+            "ebgpAdminCost" : 20,
+            "ibgpAdminCost" : 200,
             "routerId" : "1.1.1.1",
             "multipathEbgp" : true,
             "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -4475,6 +4475,8 @@
               }
             },
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "1.1.1.1",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -5786,6 +5788,8 @@
               }
             },
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "1.2.2.2",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -6274,6 +6278,8 @@
               }
             },
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "1.10.1.1",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -7569,6 +7575,8 @@
               }
             ],
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "2.1.1.1",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -8838,6 +8846,8 @@
               }
             ],
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "2.1.1.2",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -9510,6 +9520,8 @@
               }
             },
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "2.1.2.1",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -10146,6 +10158,8 @@
               }
             },
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "2.1.2.2",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -11158,6 +11172,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "2.1.4.1",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -11959,6 +11975,8 @@
               }
             },
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "2.1.3.1",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -12775,6 +12793,8 @@
               }
             },
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "2.1.3.2",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -13970,6 +13990,8 @@
               }
             },
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "3.1.1.1",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -15093,6 +15115,8 @@
               }
             },
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "3.2.2.2",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -15758,6 +15782,8 @@
               }
             },
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "3.10.1.1",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -525,6 +525,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -901,6 +903,8 @@
               }
             ],
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "198.188.136.21",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -1112,6 +1116,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 200,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -3276,6 +3282,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 170,
+              "ibgpAdminCost" : 170,
               "routerId" : "1.1.1.1",
               "dynamicNeighbors" : {
                 "10.1.1.0/24" : {
@@ -3587,6 +3595,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 170,
+              "ibgpAdminCost" : 170,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "FIRST_AS",
@@ -3865,6 +3875,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "1.1.1.1",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -3971,6 +3983,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -4101,6 +4115,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -4161,6 +4177,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -4297,6 +4315,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -4659,6 +4679,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 20,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -6452,6 +6474,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -7152,6 +7176,8 @@
               }
             ],
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -7200,6 +7226,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -7260,6 +7288,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -9126,6 +9156,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "207.46.160.15",
               "dynamicNeighbors" : {
                 "10.10.20.0/24" : {
@@ -10979,6 +11011,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -13093,6 +13127,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -14392,6 +14428,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "192.0.2.2",
               "interfaceNeighbors" : {
                 "swp1" : {
@@ -14483,6 +14521,8 @@
           "vrf1" : {
             "name" : "vrf1",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "192.0.2.3",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -14586,6 +14626,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "192.0.2.2",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -14681,6 +14723,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "192.0.2.8",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -15584,6 +15628,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -16065,6 +16111,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "192.0.2.1",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -16489,6 +16537,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "192.0.2.100",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -16722,6 +16772,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -18421,6 +18473,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -18812,6 +18866,8 @@
               }
             ],
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -18944,6 +19000,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -20918,6 +20976,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 170,
+              "ibgpAdminCost" : 170,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "FIRST_AS",
@@ -21301,6 +21361,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 170,
+              "ibgpAdminCost" : 170,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "FIRST_AS",
@@ -21499,6 +21561,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 170,
+              "ibgpAdminCost" : 170,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "FIRST_AS",
@@ -23932,6 +23996,8 @@
           "ROUTING_INSTANCE_NAME" : {
             "name" : "ROUTING_INSTANCE_NAME",
             "bgpProcess" : {
+              "ebgpAdminCost" : 170,
+              "ibgpAdminCost" : 170,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "FIRST_AS",
@@ -23976,6 +24042,8 @@
               }
             },
             "bgpProcess" : {
+              "ebgpAdminCost" : 170,
+              "ibgpAdminCost" : 170,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "FIRST_AS",
@@ -24240,6 +24308,8 @@
           "ROUTING_INSTANCE_NAME" : {
             "name" : "ROUTING_INSTANCE_NAME",
             "bgpProcess" : {
+              "ebgpAdminCost" : 170,
+              "ibgpAdminCost" : 170,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "FIRST_AS",
@@ -24250,6 +24320,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 170,
+              "ibgpAdminCost" : 170,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "FIRST_AS",
@@ -26335,6 +26407,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -26850,6 +26924,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "10.10.10.10",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -26978,6 +27054,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -27050,6 +27128,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -27340,6 +27420,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -27665,6 +27747,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -27805,6 +27889,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "PATH_LENGTH",
@@ -29857,6 +29943,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "dynamicNeighbors" : {
                 "10.98.25.0/25" : {
@@ -30307,6 +30395,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -34184,6 +34274,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
               "routerId" : "0.0.0.0",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
@@ -35653,6 +35745,8 @@
           "default" : {
             "name" : "default",
             "bgpProcess" : {
+              "ebgpAdminCost" : 170,
+              "ibgpAdminCost" : 170,
               "routerId" : "192.168.1.2",
               "multipathEbgp" : true,
               "multipathEquivalentAsPathMatchMode" : "FIRST_AS",


### PR DESCRIPTION
Adds `ebgpAdminCost` and `ibgpAdminCost` fields to BgpProcess in order to reduce dependencies on ConfigurationFormat in dataplane.