### PR TITLE
Use BgpSessionProperties IPs instead peers' local IPs

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
@@ -5,12 +5,14 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.service.AutoService;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Network;
+import com.google.common.graph.ValueGraph;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
@@ -29,6 +31,7 @@ import org.batfish.common.topology.Layer3Edge;
 import org.batfish.common.topology.TopologyUtil;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
+import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Interface;
@@ -54,7 +57,8 @@ import org.batfish.datamodel.questions.Question;
 @AutoService(Plugin.class)
 public class VIModelQuestionPlugin extends QuestionPlugin {
 
-  private static final Comparator<VerboseBgpEdge> VERBOSE_BGP_EDGE_COMPARATOR =
+  @VisibleForTesting
+  static final Comparator<VerboseBgpEdge> VERBOSE_BGP_EDGE_COMPARATOR =
       Comparator.nullsFirst(
           Comparator.comparing(VerboseBgpEdge::getEdgeSummary)
               .thenComparing(VerboseBgpEdge::getSession1Id)
@@ -212,19 +216,27 @@ public class VIModelQuestionPlugin extends QuestionPlugin {
         Layer2Topology layer2Topology) {
       BgpTopology bgpTopology =
           BgpTopologyUtils.initBgpTopology(configs, ipOwners, false, false, null, layer2Topology);
+      return getBgpEdges(bgpTopology.getGraph(), NetworkConfigurations.of(configs));
+    }
+
+    @VisibleForTesting
+    static SortedSet<VerboseBgpEdge> getBgpEdges(
+        ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology, NetworkConfigurations nc) {
       SortedSet<VerboseBgpEdge> bgpEdges = new TreeSet<>(VERBOSE_BGP_EDGE_COMPARATOR);
-      for (EndpointPair<BgpPeerConfigId> session : bgpTopology.getGraph().edges()) {
+      for (EndpointPair<BgpPeerConfigId> session : bgpTopology.edges()) {
         BgpPeerConfigId bgpPeerConfigId = session.source();
         BgpPeerConfigId remoteBgpPeerConfigId = session.target();
-        NetworkConfigurations nc = NetworkConfigurations.of(configs);
+        BgpSessionProperties sessionProperties =
+            bgpTopology.edgeValue(bgpPeerConfigId, remoteBgpPeerConfigId).orElse(null);
+        assert sessionProperties != null; // condition of the edge existing
         String hostname = bgpPeerConfigId.getHostname();
         String remoteHostname = remoteBgpPeerConfigId.getHostname();
         BgpPeerConfig bgpPeerConfig = nc.getBgpPeerConfig(bgpPeerConfigId);
         BgpPeerConfig remoteBgpPeerConfig = nc.getBgpPeerConfig(remoteBgpPeerConfigId);
 
         if (bgpPeerConfig != null && remoteBgpPeerConfig != null) {
-          Ip localIp = bgpPeerConfig.getLocalIp();
-          Ip remoteIp = remoteBgpPeerConfig.getLocalIp();
+          Ip localIp = sessionProperties.getTailIp();
+          Ip remoteIp = sessionProperties.getHeadIp();
           IpEdge ipEdge = new IpEdge(hostname, localIp, remoteHostname, remoteIp);
           bgpEdges.add(
               new VerboseBgpEdge(

--- a/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
@@ -57,8 +57,7 @@ import org.batfish.datamodel.questions.Question;
 @AutoService(Plugin.class)
 public class VIModelQuestionPlugin extends QuestionPlugin {
 
-  @VisibleForTesting
-  static final Comparator<VerboseBgpEdge> VERBOSE_BGP_EDGE_COMPARATOR =
+  private static final Comparator<VerboseBgpEdge> VERBOSE_BGP_EDGE_COMPARATOR =
       Comparator.nullsFirst(
           Comparator.comparing(VerboseBgpEdge::getEdgeSummary)
               .thenComparing(VerboseBgpEdge::getSession1Id)

--- a/projects/question/src/test/java/org/batfish/question/VIModelAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/VIModelAnswererTest.java
@@ -63,7 +63,8 @@ public class VIModelAnswererTest {
     NetworkFactory nf = new NetworkFactory();
     Configuration.Builder cb =
         nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
-    BgpProcess.Builder pb = nf.bgpProcessBuilder();
+    BgpProcess.Builder pb =
+        nf.bgpProcessBuilder().setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS);
     Configuration c1 = cb.setHostname("c1").build();
     Configuration c2 = cb.setHostname("c2").build();
     Vrf vrf1 = nf.vrfBuilder().setOwner(c1).setName("vrf1").build();

--- a/projects/question/src/test/java/org/batfish/question/VIModelAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/VIModelAnswererTest.java
@@ -63,8 +63,7 @@ public class VIModelAnswererTest {
     NetworkFactory nf = new NetworkFactory();
     Configuration.Builder cb =
         nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
-    BgpProcess.Builder pb =
-        nf.bgpProcessBuilder().setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS);
+    BgpProcess.Builder pb = nf.bgpProcessBuilder();
     Configuration c1 = cb.setHostname("c1").build();
     Configuration c2 = cb.setHostname("c2").build();
     Vrf vrf1 = nf.vrfBuilder().setOwner(c1).setName("vrf1").build();

--- a/projects/question/src/test/java/org/batfish/question/VIModelAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/VIModelAnswererTest.java
@@ -1,6 +1,5 @@
 package org.batfish.question;
 
-import static org.batfish.question.VIModelQuestionPlugin.VERBOSE_BGP_EDGE_COMPARATOR;
 import static org.batfish.question.VIModelQuestionPlugin.VIModelAnswerer.getBgpEdges;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -78,13 +77,26 @@ public class VIModelAnswererTest {
     SortedSet<VerboseBgpEdge> edges =
         getBgpEdges(topology, NetworkConfigurations.of(ImmutableSortedMap.of("c1", c1, "c2", c2)));
     assertThat(edges, hasSize(2));
+    Iterator<VerboseBgpEdge> edgeIterator = edges.iterator();
 
+    // Compare edge from 1 to 2
+    VerboseBgpEdge edge1To2 = edgeIterator.next();
     VerboseBgpEdge expected1To2 =
         new VerboseBgpEdge(peer1, peer2, id1, id2, new IpEdge("c1", ip1, "c2", ip2));
+    assertEdgesEqual(edge1To2, expected1To2);
+
+    // Compare edge from 2 to 1
+    VerboseBgpEdge edge2To1 = edgeIterator.next();
     VerboseBgpEdge expected2To1 =
         new VerboseBgpEdge(peer2, peer1, id2, id1, new IpEdge("c2", ip2, "c1", ip1));
-    Iterator<VerboseBgpEdge> edgeIterator = edges.iterator();
-    assertThat(VERBOSE_BGP_EDGE_COMPARATOR.compare(edgeIterator.next(), expected1To2), equalTo(0));
-    assertThat(VERBOSE_BGP_EDGE_COMPARATOR.compare(edgeIterator.next(), expected2To1), equalTo(0));
+    assertEdgesEqual(edge2To1, expected2To1);
+  }
+
+  private static void assertEdgesEqual(VerboseBgpEdge e1, VerboseBgpEdge e2) {
+    assertThat(e1.getEdgeSummary(), equalTo(e2.getEdgeSummary()));
+    assertThat(e1.getSession1Id(), equalTo(e2.getSession1Id()));
+    assertThat(e1.getSession2Id(), equalTo(e2.getSession2Id()));
+    assertThat(e1.getNode1Session(), equalTo(e2.getNode1Session()));
+    assertThat(e1.getNode2Session(), equalTo(e2.getNode2Session()));
   }
 }

--- a/projects/question/src/test/java/org/batfish/question/VIModelAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/VIModelAnswererTest.java
@@ -1,0 +1,90 @@
+package org.batfish.question;
+
+import static org.batfish.question.VIModelQuestionPlugin.VERBOSE_BGP_EDGE_COMPARATOR;
+import static org.batfish.question.VIModelQuestionPlugin.VIModelAnswerer.getBgpEdges;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.graph.MutableValueGraph;
+import com.google.common.graph.ValueGraphBuilder;
+import java.util.Iterator;
+import java.util.SortedSet;
+import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.BgpPeerConfigId;
+import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.BgpSessionProperties;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NetworkConfigurations;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.collections.IpEdge;
+import org.batfish.datamodel.collections.VerboseBgpEdge;
+import org.junit.Test;
+
+public class VIModelAnswererTest {
+
+  @Test
+  public void testGetBgpEdgesWithNullLocalIp() {
+    /*
+    Can have edges in BGP topology where one of the peers is missing its local IP; this should not
+    cause problems for creating or sorting the VerboseBgpEdge.
+     */
+
+    // Set up two correctly configured active peers, except second is missing local IP
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("2.2.2.2");
+    Prefix prefix1 = Prefix.create(ip1, Prefix.MAX_PREFIX_LENGTH);
+    Prefix prefix2 = Prefix.create(ip2, Prefix.MAX_PREFIX_LENGTH);
+
+    BgpPeerConfigId id1 = new BgpPeerConfigId("c1", "vrf1", prefix2, false);
+    BgpActivePeerConfig peer1 =
+        BgpActivePeerConfig.builder()
+            .setLocalIp(ip1)
+            .setPeerAddress(ip2)
+            .setLocalAs(1L)
+            .setRemoteAs(2L)
+            .build();
+    BgpPeerConfigId id2 = new BgpPeerConfigId("c2", "vrf2", prefix1, false);
+    BgpActivePeerConfig peer2 =
+        BgpActivePeerConfig.builder().setPeerAddress(ip1).setLocalAs(2L).setRemoteAs(1L).build();
+
+    // Create topology with edges between the peers
+    MutableValueGraph<BgpPeerConfigId, BgpSessionProperties> topology =
+        ValueGraphBuilder.directed().allowsSelfLoops(false).build();
+    topology.putEdgeValue(id1, id2, BgpSessionProperties.from(peer1, peer2, false));
+    topology.putEdgeValue(id2, id1, BgpSessionProperties.from(peer1, peer2, true));
+
+    // Create configurations
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    BgpProcess.Builder pb =
+        nf.bgpProcessBuilder().setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS);
+    Configuration c1 = cb.setHostname("c1").build();
+    Configuration c2 = cb.setHostname("c2").build();
+    Vrf vrf1 = nf.vrfBuilder().setOwner(c1).setName("vrf1").build();
+    Vrf vrf2 = nf.vrfBuilder().setOwner(c2).setName("vrf2").build();
+    BgpProcess proc1 = pb.setVrf(vrf1).setRouterId(Ip.ZERO).build();
+    BgpProcess proc2 = pb.setVrf(vrf2).setRouterId(Ip.ZERO).build();
+    proc1.setNeighbors(ImmutableSortedMap.of(prefix2, peer1));
+    proc2.setNeighbors(ImmutableSortedMap.of(prefix1, peer2));
+
+    // Get BGP edges
+    SortedSet<VerboseBgpEdge> edges =
+        getBgpEdges(topology, NetworkConfigurations.of(ImmutableSortedMap.of("c1", c1, "c2", c2)));
+    assertThat(edges, hasSize(2));
+
+    VerboseBgpEdge expected1To2 =
+        new VerboseBgpEdge(peer1, peer2, id1, id2, new IpEdge("c1", ip1, "c2", ip2));
+    VerboseBgpEdge expected2To1 =
+        new VerboseBgpEdge(peer2, peer1, id2, id1, new IpEdge("c2", ip2, "c1", ip1));
+    Iterator<VerboseBgpEdge> edgeIterator = edges.iterator();
+    assertThat(VERBOSE_BGP_EDGE_COMPARATOR.compare(edgeIterator.next(), expected1To2), equalTo(0));
+    assertThat(VERBOSE_BGP_EDGE_COMPARATOR.compare(edgeIterator.next(), expected2To1), equalTo(0));
+  }
+}


### PR DESCRIPTION
The head and tail IPs in `BgpSessionProperties` are guaranteed to be nonnull, whereas BGP peer config IDs can have null local IPs even if they have edges in the BGP topology.

Separation of `getBgpEdges()` methods is solely for easier testing and should not affect functionality.