### PR TITLE
Identifying IPsec sessions between cloud type configurations

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IpsecUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IpsecUtil.java
@@ -165,9 +165,7 @@ public class IpsecUtil {
     IpsecSession.Builder ipsecSessionBuilder = IpsecSession.builder();
 
     ipsecSessionBuilder.setCloud(
-        IpsecSession.CLOUD_CONFIGURATION_FORMATS.contains(initiatorOwner.getConfigurationFormat())
-            || IpsecSession.CLOUD_CONFIGURATION_FORMATS.contains(
-                peerOwner.getConfigurationFormat()));
+        IpsecSession.isCloudConfig(initiatorOwner) || IpsecSession.isCloudConfig(peerOwner));
 
     negotiateIkeP1(initiatorOwner, peerOwner, initiator, candidatePeer, ipsecSessionBuilder);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IpsecUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IpsecUtil.java
@@ -3,6 +3,7 @@ package org.batfish.common.util;
 import static org.batfish.datamodel.transformation.TransformationUtil.hasSourceNat;
 import static org.batfish.datamodel.transformation.TransformationUtil.sourceNatPoolIps;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -154,13 +155,19 @@ public class IpsecUtil {
    * respective fields for IKE P1 proposals, IKE P1 keys and IPSec P2 proposals populated depending
    * on the negotiation.
    */
+  @VisibleForTesting
   @Nonnull
-  private static IpsecSession getIpsecSession(
+  static IpsecSession getIpsecSession(
       Configuration initiatorOwner,
       Configuration peerOwner,
       IpsecStaticPeerConfig initiator,
       IpsecPeerConfig candidatePeer) {
     IpsecSession.Builder ipsecSessionBuilder = IpsecSession.builder();
+
+    ipsecSessionBuilder.setCloud(
+        IpsecSession.CLOUD_CONFIGURATION_FORMATS.contains(initiatorOwner.getConfigurationFormat())
+            || IpsecSession.CLOUD_CONFIGURATION_FORMATS.contains(
+                peerOwner.getConfigurationFormat()));
 
     negotiateIkeP1(initiatorOwner, peerOwner, initiator, candidatePeer, ipsecSessionBuilder);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecSession.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecSession.java
@@ -1,11 +1,15 @@
 package org.batfish.datamodel;
 
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNullableByDefault;
 
 /** Represents the attributes of the session established between two {@link IpsecPeerConfig}s */
 @ParametersAreNullableByDefault
 public class IpsecSession {
+  public static final Set<ConfigurationFormat> CLOUD_CONFIGURATION_FORMATS =
+      ImmutableSet.of(ConfigurationFormat.AWS);
 
   @Nullable private final IkePhase1Policy _initiatorIkeP1Policy;
 
@@ -21,7 +25,14 @@ public class IpsecSession {
 
   @Nullable private final IpsecPhase2Policy _responderIpsecP2Policy;
 
+  /**
+   * Is true when at least one of the peers for this IPsec session is a cloud type configuration
+   * (like AWS)
+   */
+  private final boolean _cloud;
+
   private IpsecSession(
+      boolean cloud,
       IkePhase1Policy initiatorIkeP1Policy,
       IpsecPhase2Policy initiatorIpsecP2Policy,
       IkePhase1Proposal negotiatedIkeP1Proposal,
@@ -29,6 +40,7 @@ public class IpsecSession {
       IpsecPhase2Proposal negotiatedIpsecP2Proposal,
       IkePhase1Policy responderIkeP1Policy,
       IpsecPhase2Policy responderIpsecP2Policy) {
+    _cloud = cloud;
     _initiatorIkeP1Policy = initiatorIkeP1Policy;
     _initiatorIpsecP2Policy = initiatorIpsecP2Policy;
     _negotiatedIkeP1Proposal = negotiatedIkeP1Proposal;
@@ -36,6 +48,10 @@ public class IpsecSession {
     _negotiatedIpsecP2Proposal = negotiatedIpsecP2Proposal;
     _responderIkeP1Policy = responderIkeP1Policy;
     _responderIpsecP2Policy = responderIpsecP2Policy;
+  }
+
+  public boolean getCloud() {
+    return _cloud;
   }
 
   @Nullable
@@ -78,6 +94,8 @@ public class IpsecSession {
   }
 
   public static class Builder {
+    private boolean _cloud;
+
     private IkePhase1Policy _initiatorIkeP1Policy;
 
     private IpsecPhase2Policy _initiatorIpsecP2Policy;
@@ -94,6 +112,7 @@ public class IpsecSession {
 
     public IpsecSession build() {
       return new IpsecSession(
+          _cloud,
           _initiatorIkeP1Policy,
           _initiatorIpsecP2Policy,
           _negotiatedIkeP1Proposal,
@@ -101,6 +120,10 @@ public class IpsecSession {
           _negotiatedIpsecP2Proposal,
           _responderIkeP1Policy,
           _responderIpsecP2Policy);
+    }
+
+    public boolean getCloud() {
+      return _cloud;
     }
 
     @Nullable
@@ -136,6 +159,11 @@ public class IpsecSession {
     @Nullable
     public IpsecPhase2Proposal getNegotiatedIpsecP2Proposal() {
       return _negotiatedIpsecP2Proposal;
+    }
+
+    public Builder setCloud(boolean cloud) {
+      _cloud = cloud;
+      return this;
     }
 
     public Builder setInitiatorIkeP1Policy(IkePhase1Policy initiatorIkeP1Policy) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecSession.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecSession.java
@@ -50,7 +50,13 @@ public class IpsecSession {
     _responderIpsecP2Policy = responderIpsecP2Policy;
   }
 
-  public boolean getCloud() {
+  /**
+   * Is true when at least one of the peers for this IPsec session is a cloud type configuration
+   * (like AWS)
+   *
+   * @return true for a cloud type {@link IpsecSession}
+   */
+  public boolean isCloud() {
     return _cloud;
   }
 
@@ -122,7 +128,7 @@ public class IpsecSession {
           _responderIpsecP2Policy);
     }
 
-    public boolean getCloud() {
+    public boolean isCloud() {
       return _cloud;
     }
 
@@ -205,5 +211,15 @@ public class IpsecSession {
   public enum IpsecSessionType {
     STATIC,
     DYNAMIC
+  }
+
+  /**
+   * Returns true if the given {@link Configuration} has a cloud type {@link ConfigurationFormat}
+   *
+   * @param configuration {@link Configuration}
+   * @return true if {@link Configuration} is a cloud type node
+   */
+  public static boolean isCloudConfig(Configuration configuration) {
+    return CLOUD_CONFIGURATION_FORMATS.contains(configuration.getConfigurationFormat());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IpsecUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IpsecUtilTest.java
@@ -1,9 +1,14 @@
 package org.batfish.common.util;
 
+import static org.batfish.common.util.IpsecUtil.getIpsecSession;
 import static org.batfish.common.util.IpsecUtil.retainCompatibleTunnelEdges;
 import static org.batfish.common.util.IpsecUtil.toEdgeSet;
+import static org.batfish.datamodel.ConfigurationFormat.AWS;
+import static org.batfish.datamodel.ConfigurationFormat.CISCO_IOS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.graph.MutableValueGraph;
@@ -19,6 +24,7 @@ import org.batfish.datamodel.IpsecPeerConfigId;
 import org.batfish.datamodel.IpsecPhase2Proposal;
 import org.batfish.datamodel.IpsecSession;
 import org.batfish.datamodel.IpsecStaticPeerConfig;
+import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.ipsec.IpsecTopology;
 import org.junit.Before;
@@ -171,5 +177,36 @@ public class IpsecUtilTest {
             new Edge(
                 new NodeInterfacePair("host2", "Tunnel2"),
                 new NodeInterfacePair("host1", "Tunnel1"))));
+  }
+
+  @Test
+  public void testGetIpsecSesssionCloud() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb = nf.configurationBuilder();
+    IpsecStaticPeerConfig.Builder ipsecPeerConfigBuilder = IpsecStaticPeerConfig.builder();
+
+    assertTrue(
+        getIpsecSession(
+                cb.setConfigurationFormat(AWS).build(),
+                cb.setConfigurationFormat(AWS).build(),
+                ipsecPeerConfigBuilder.build(),
+                ipsecPeerConfigBuilder.build())
+            .getCloud());
+
+    assertTrue(
+        getIpsecSession(
+                cb.setConfigurationFormat(CISCO_IOS).build(),
+                cb.setConfigurationFormat(AWS).build(),
+                ipsecPeerConfigBuilder.build(),
+                ipsecPeerConfigBuilder.build())
+            .getCloud());
+
+    assertFalse(
+        getIpsecSession(
+                cb.setConfigurationFormat(CISCO_IOS).build(),
+                cb.setConfigurationFormat(CISCO_IOS).build(),
+                ipsecPeerConfigBuilder.build(),
+                ipsecPeerConfigBuilder.build())
+            .getCloud());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IpsecUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IpsecUtilTest.java
@@ -191,7 +191,7 @@ public class IpsecUtilTest {
                 cb.setConfigurationFormat(AWS).build(),
                 ipsecPeerConfigBuilder.build(),
                 ipsecPeerConfigBuilder.build())
-            .getCloud());
+            .isCloud());
 
     assertTrue(
         getIpsecSession(
@@ -199,7 +199,7 @@ public class IpsecUtilTest {
                 cb.setConfigurationFormat(AWS).build(),
                 ipsecPeerConfigBuilder.build(),
                 ipsecPeerConfigBuilder.build())
-            .getCloud());
+            .isCloud());
 
     assertFalse(
         getIpsecSession(
@@ -207,6 +207,6 @@ public class IpsecUtilTest {
                 cb.setConfigurationFormat(CISCO_IOS).build(),
                 ipsecPeerConfigBuilder.build(),
                 ipsecPeerConfigBuilder.build())
-            .getCloud());
+            .isCloud());
   }
 }


### PR DESCRIPTION
We need to be able to identify if any of the peers for an IPsec session was a cloud configuration (like AWS). This will be later used to decide if we can verify reachability for that IPsec session: we will not verify reachability for IPsec sessions with the flag `cloud` set to true.