### PR TITLE
BGP: decouple export transformations

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -210,6 +210,10 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute> {
     q.addAll(routes);
   }
 
+  /**
+   * Message passing method between BGP processes. Take a stream of BGP {@link RouteAdvertisement}s
+   * and puts them onto a local queue corresponding to the session between given neighbors.
+   */
   void enqueueBgpMessages(
       @Nonnull EdgeId edgeId, @Nonnull Stream<RouteAdvertisement<Bgpv4Route>> routes) {
     Queue<RouteAdvertisement<Bgpv4Route>> q = _bgpv4IncomingRoutes.get(edgeId);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -26,6 +26,7 @@ import org.batfish.datamodel.BgpTieBreaker;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EvpnRoute;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.bgp.BgpTopology.EdgeId;
@@ -39,7 +40,7 @@ import org.batfish.dataplane.rib.RouteAdvertisement;
 @ParametersAreNonnullByDefault
 final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute> {
   /** Configuration for this process */
-  @Nonnull private final BgpProcess _process;
+  @Nonnull final BgpProcess _process;
   /** Parent node configuration */
   @Nonnull private final Configuration _c;
   /** Name of our VRF */
@@ -207,5 +208,17 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute> {
     Queue<RouteAdvertisement<Bgpv4Route>> q = _bgpv4IncomingRoutes.get(edgeId);
     assert q != null; // Invariant of the session being up
     q.addAll(routes);
+  }
+
+  void enqueueBgpMessages(
+      @Nonnull EdgeId edgeId, @Nonnull Stream<RouteAdvertisement<Bgpv4Route>> routes) {
+    Queue<RouteAdvertisement<Bgpv4Route>> q = _bgpv4IncomingRoutes.get(edgeId);
+    assert q != null; // Invariant of the session being up
+    routes.forEach(q::add);
+  }
+
+  @Nonnull
+  public Ip getRouterId() {
+    return _process.getRouterId();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -406,6 +406,16 @@ class IncrementalBdpEngine {
       NetworkConfigurations networkConfigurations) {
     try (ActiveSpan span =
         GlobalTracer.get()
+            .buildSpan(iterationLabel + ": Init for new BGP iteration")
+            .startActive()) {
+      assert span != null;
+      nodes
+          .values()
+          .parallelStream()
+          .forEach(n -> n.getVirtualRouters().values().forEach(vr -> vr.bgpIteration(allNodes)));
+    }
+    try (ActiveSpan span =
+        GlobalTracer.get()
             .buildSpan(iterationLabel + ": Init BGP generated/aggregate routes")
             .startActive()) {
       assert span != null; // avoid unused warning
@@ -426,7 +436,6 @@ class IncrementalBdpEngine {
           .flatMap(n -> n.getVirtualRouters().values().stream())
           .forEach(
               vr -> {
-                vr.bgpIteration(allNodes);
                 Map<Bgpv4Rib, RibDelta<Bgpv4Route>> deltas =
                     vr.processBgpMessages(bgpTopology, networkConfigurations, nodes);
                 vr.finalizeBgpRoutesAndQueueOutgoingMessages(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -43,7 +43,6 @@ import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AbstractRouteBuilder;
-import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.BgpActivePeerConfig;
@@ -1353,103 +1352,137 @@ public class VirtualRouter implements Serializable {
       BgpTopology bgpTopology,
       NetworkConfigurations networkConfigurations) {
     for (EdgeId edge : _bgpRoutingProcess._bgpv4IncomingRoutes.keySet()) {
-      final BgpSessionProperties session = getBgpSessionProperties(bgpTopology, edge);
+      queueOutgoingRoutesPerEdge(
+          edge,
+          ebgpBestPathDelta,
+          bgpDelta,
+          mainDelta,
+          allNodes,
+          bgpTopology,
+          networkConfigurations);
+    }
+  }
 
-      BgpPeerConfigId remoteConfigId = edge.tail();
-      BgpPeerConfigId ourConfigId = edge.head();
-      BgpPeerConfig ourConfig = networkConfigurations.getBgpPeerConfig(edge.head());
-      BgpPeerConfig remoteConfig = networkConfigurations.getBgpPeerConfig(edge.tail());
-      VirtualRouter remoteVirtualRouter = getRemoteBgpNeighborVR(remoteConfigId, allNodes);
-      if (remoteVirtualRouter == null) {
-        continue;
-      }
+  private void queueOutgoingRoutesPerEdge(
+      EdgeId edge,
+      RibDelta<Bgpv4Route> ebgpBestPathDelta,
+      RibDelta<Bgpv4Route> bgpDelta,
+      RibDelta<AnnotatedRoute<AbstractRoute>> mainDelta,
+      Map<String, Node> allNodes,
+      BgpTopology bgpTopology,
+      NetworkConfigurations networkConfigurations) {
+    final BgpSessionProperties session = getBgpSessionProperties(bgpTopology, edge);
 
-      // Needs to retain annotations since export policy will be run on routes from resulting delta.
-      Builder<AnnotatedRoute<AbstractRoute>> preExportPolicyDeltaBuilder = RibDelta.builder();
+    BgpPeerConfigId remoteConfigId = edge.tail();
+    BgpPeerConfigId ourConfigId = edge.head();
+    BgpPeerConfig ourConfig = networkConfigurations.getBgpPeerConfig(edge.head());
+    BgpPeerConfig remoteConfig = networkConfigurations.getBgpPeerConfig(edge.tail());
+    VirtualRouter remoteVirtualRouter = getRemoteBgpNeighborVR(remoteConfigId, allNodes);
+    if (remoteVirtualRouter == null) {
+      return;
+    }
 
-      // Queue mainRib updates that were not introduced by BGP process (i.e., IGP routes)
-      preExportPolicyDeltaBuilder.from(
-          mainDelta.getActions().filter(adv -> !(adv.getRoute().getRoute() instanceof BgpRoute)));
+    // Queue mainRib updates that were not introduced by BGP process (i.e., IGP routes)
+    // Also, do not double-export main RIB routes
+    Stream<RouteAdvertisement<Bgpv4Route>> mainRibExports =
+        mainDelta
+            .getActions()
+            .filter(adv -> !(adv.getRoute().getRoute() instanceof BgpRoute))
+            .map(
+                adv -> {
+                  Bgpv4Route bgpRoute =
+                      exportBgpRoute(
+                          adv.getRoute(),
+                          ourConfigId,
+                          remoteConfigId,
+                          ourConfig,
+                          allNodes,
+                          session);
+                  return bgpRoute == null
+                      ? null
+                      : RouteAdvertisement.<Bgpv4Route>builder()
+                          .setReason(adv.getReason())
+                          .setRoute(bgpRoute)
+                          .build();
+                })
+            .filter(Objects::nonNull);
 
-      /*
-       * By default only best-path routes from the BGP RIB that are **also installed in the main RIB**
-       * will be advertised to our neighbors.
-       *
-       * However, there are additional knobs that control re-advertisement behavior:
-       *
-       * 1. Advertise external: advertise best-path eBGP routes to iBGP peers regardless of whether
-       *    they are global BGP best-paths.
-       * 2. Advertise inactive: advertise best-path BGP routes to neighboring peers even if
-       *    they are not active in the main RIB.
-       */
-      if (session.getAdvertiseExternal()) {
-        importDeltaToBuilder(preExportPolicyDeltaBuilder, ebgpBestPathDelta, _name);
-      }
-      if (session.getAdvertiseInactive()) {
-        importDeltaToBuilder(preExportPolicyDeltaBuilder, bgpDelta, _name);
-      } else {
-        // Default behavior
-        preExportPolicyDeltaBuilder.from(
-            bgpDelta
-                .getActions()
-                .map(
-                    r ->
-                        RouteAdvertisement.<AnnotatedRoute<AbstractRoute>>builder()
-                            .setReason(r.getReason())
-                            .setRoute(annotateRoute(r.getRoute()))
-                            .build())
-                .filter(r -> _mainRib.containsRoute(r.getRoute())));
-      }
-
-      /*
-      * TODO: https://github.com/batfish/batfish/issues/704
-         Add path is broken for all intents and purposes.
-         Need support for additional-paths based on https://tools.ietf.org/html/rfc7911
-         AND the combination of vendor-specific knobs, none of which are currently supported.
-      */
-      if (session.getAdditionalPaths()) {
-        importDeltaToBuilder(preExportPolicyDeltaBuilder, bgpDelta, _name);
-      }
-
-      if (preExportPolicyDeltaBuilder.isEmpty()) {
-        // Nothing to advertise
-        continue;
-      }
-
-      RibDelta<AnnotatedRoute<AbstractRoute>> routesToExport = preExportPolicyDeltaBuilder.build();
-      // Compute a set of advertisements that can be queued on remote VR
-      Set<RouteAdvertisement<Bgpv4Route>> exportedAdvertisements =
-          routesToExport
+    // Needs to retain annotations since export policy will be run on routes from resulting delta.
+    Builder<AnnotatedRoute<Bgpv4Route>> bgpRibExports = RibDelta.builder();
+    /*
+     * By default only best-path routes from the BGP RIB that are **also installed in the main RIB**
+     * will be advertised to our neighbors.
+     *
+     * However, there are additional knobs that control re-advertisement behavior:
+     *
+     * 1. Advertise external: advertise best-path eBGP routes to iBGP peers regardless of whether
+     *    they are global BGP best-paths.
+     * 2. Advertise inactive: advertise best-path BGP routes to neighboring peers even if
+     *    they are not active in the main RIB.
+     */
+    if (session.getAdvertiseExternal()) {
+      importDeltaToBuilder(bgpRibExports, ebgpBestPathDelta, _name);
+    }
+    if (session.getAdvertiseInactive()) {
+      importDeltaToBuilder(bgpRibExports, bgpDelta, _name);
+    } else {
+      // Default behavior
+      bgpRibExports.from(
+          bgpDelta
               .getActions()
               .map(
-                  adv -> {
-                    Bgpv4Route transformedRoute =
-                        exportBgpRoute(
-                            adv.getRoute(),
-                            ourConfigId,
-                            remoteConfigId,
-                            ourConfig,
-                            remoteConfig,
-                            allNodes,
-                            session,
-                            Bgpv4Route.builder());
-                    return transformedRoute == null
-                        ? null
-                        // REPLACE does not make sense across routers, update with WITHDRAW
-                        : RouteAdvertisement.<Bgpv4Route>builder()
-                            .setReason(
-                                adv.getReason() == Reason.REPLACE
-                                    ? Reason.WITHDRAW
-                                    : adv.getReason())
-                            .setRoute(transformedRoute)
-                            .build();
-                  })
-              .filter(Objects::nonNull)
-              .collect(ImmutableSet.toImmutableSet());
-
-      // Call this on the REMOTE VR and REVERSE the edge!
-      remoteVirtualRouter.enqueueBgpMessages(edge.reverse(), exportedAdvertisements);
+                  r ->
+                      RouteAdvertisement.<AnnotatedRoute<Bgpv4Route>>builder()
+                          .setReason(r.getReason())
+                          .setRoute(annotateRoute(r.getRoute()))
+                          .build())
+              .filter(r -> _mainRib.containsRoute(r.getRoute())));
     }
+
+    /*
+    * TODO: https://github.com/batfish/batfish/issues/704
+       Add path is broken for all intents and purposes.
+       Need support for additional-paths based on https://tools.ietf.org/html/rfc7911
+       AND the combination of vendor-specific knobs, none of which are currently supported.
+    */
+    if (session.getAdditionalPaths()) {
+      importDeltaToBuilder(bgpRibExports, bgpDelta, _name);
+    }
+
+    RibDelta<AnnotatedRoute<Bgpv4Route>> bgpRoutesToExport = bgpRibExports.build();
+    // Compute a set of advertisements that can be queued on remote VR
+    Stream<RouteAdvertisement<Bgpv4Route>> exportedAdvertisements =
+        Stream.concat(
+            bgpRoutesToExport
+                .getActions()
+                .map(
+                    adv -> {
+                      Bgpv4Route transformedRoute =
+                          exportBgpRoute(
+                              adv.getRoute(),
+                              ourConfigId,
+                              remoteConfigId,
+                              ourConfig,
+                              remoteConfig,
+                              allNodes,
+                              session,
+                              Bgpv4Route.builder());
+                      return transformedRoute == null
+                          ? null
+                          // REPLACE does not make sense across routers, update with WITHDRAW
+                          : RouteAdvertisement.<Bgpv4Route>builder()
+                              .setReason(
+                                  adv.getReason() == Reason.REPLACE
+                                      ? Reason.WITHDRAW
+                                      : adv.getReason())
+                              .setRoute(transformedRoute)
+                              .build();
+                    })
+                .filter(Objects::nonNull),
+            mainRibExports);
+
+    // Call this on the REMOTE VR and REVERSE the edge!
+    remoteVirtualRouter.enqueueBgpMessages(edge.reverse(), exportedAdvertisements);
   }
 
   private static BgpSessionProperties getBgpSessionProperties(
@@ -1658,7 +1691,8 @@ public class VirtualRouter implements Serializable {
       return;
     }
     for (EdgeId edge : _bgpRoutingProcess._bgpv4IncomingRoutes.keySet()) {
-      newBgpSessionEstablishedHook(edge, getBgpSessionProperties(bgpTopology, edge), allNodes, nc);
+      newBgpSessionEstablishedHook(
+          edge, getBgpSessionProperties(bgpTopology, edge), allNodes, nc, bgpTopology);
     }
   }
 
@@ -1667,7 +1701,8 @@ public class VirtualRouter implements Serializable {
       @Nonnull EdgeId edge,
       @Nonnull BgpSessionProperties sessionProperties,
       @Nonnull Map<String, Node> allNodes,
-      NetworkConfigurations nc) {
+      NetworkConfigurations nc,
+      BgpTopology topology) {
 
     BgpPeerConfigId localConfigId = edge.head();
     BgpPeerConfigId remoteConfigId = edge.tail();
@@ -1679,32 +1714,27 @@ public class VirtualRouter implements Serializable {
       return;
     }
 
+    /*
+    TODO:
+      match up prefix tracer with proper prefixes. Low priority,
+      currently originated prefixes are not exposed to users
+     */
     // Note prefixes we tried to originate
     _mainRib.getTypedRoutes().forEach(r -> _prefixTracer.originated(r.getNetwork()));
 
     /*
-     * Export route advertisements by looking at main RIB
+     * Export routes by looking at main RIB and BGPv4 RIB
      */
-    Set<RouteAdvertisement<Bgpv4Route>> exportedRoutes =
-        _mainRib.getTypedRoutes().stream()
-            // This performs transformations and filtering using the export policy
-            .map(
-                r ->
-                    exportBgpRoute(
-                        r,
-                        localConfigId,
-                        remoteConfigId,
-                        localConfig,
-                        remoteConfig,
-                        allNodes,
-                        sessionProperties,
-                        Bgpv4Route.builder()))
-            .filter(Objects::nonNull)
-            .map(RouteAdvertisement::new)
-            .collect(ImmutableSet.toImmutableSet());
-
-    // Call this on the neighbor's VR!
-    remoteVr.enqueueBgpMessages(edge.reverse(), exportedRoutes);
+    queueOutgoingRoutesPerEdge(
+        edge,
+        RibDelta.<Bgpv4Route>builder()
+            .add(_bgpRoutingProcess._ebgpv4Rib.getBestPathRoutes())
+            .build(),
+        RibDelta.<Bgpv4Route>builder().add(_bgpRoutingProcess._bgpv4Rib.getTypedRoutes()).build(),
+        RibDelta.<AnnotatedRoute<AbstractRoute>>builder().add(_mainRib.getTypedRoutes()).build(),
+        allNodes,
+        topology,
+        nc);
 
     /*
      * Export neighbor-specific generated routes, these routes skip global export policy
@@ -1721,7 +1751,7 @@ public class VirtualRouter implements Serializable {
                   }
                   // Run pre-export transform, export policy, & post-export transform
                   return exportBgpRoute(
-                      bgpv4Route,
+                      new AnnotatedRoute<>(bgpv4Route, _name),
                       localConfigId,
                       remoteConfigId,
                       localConfig,
@@ -1833,6 +1863,73 @@ public class VirtualRouter implements Serializable {
     return _prefixTracer;
   }
 
+  @Nullable
+  private Bgpv4Route exportBgpRoute(
+      @Nonnull AnnotatedRoute<AbstractRoute> exportCandidate,
+      @Nonnull BgpPeerConfigId ourConfigId,
+      @Nonnull BgpPeerConfigId remoteConfigId,
+      @Nonnull BgpPeerConfig ourConfig,
+      @Nonnull Map<String, Node> allNodes,
+      @Nonnull BgpSessionProperties sessionProperties) {
+
+    RoutingPolicy exportPolicy = _c.getRoutingPolicies().get(ourConfig.getExportPolicy());
+    RoutingProtocol protocol =
+        sessionProperties.isEbgp() ? RoutingProtocol.BGP : RoutingProtocol.IBGP;
+    Bgpv4Route.Builder transformedOutgoingRouteBuilder =
+        exportCandidate.getRoute() instanceof GeneratedRoute
+            ? BgpProtocolHelper.convertGeneratedRouteToBgp(
+                    (GeneratedRoute) exportCandidate.getRoute(),
+                    _bgpRoutingProcess.getRouterId(),
+                    false)
+                .toBuilder()
+            : BgpProtocolHelper.convertNonBgpRouteToBgpRoute(
+                exportCandidate,
+                _bgpRoutingProcess.getRouterId(),
+                sessionProperties.getHeadIp(),
+                _bgpRoutingProcess._process.getAdminCost(protocol),
+                protocol);
+
+    // sessionProperties represents the incoming edge, so its tailIp is the remote peer's IP
+    Ip remoteIp = sessionProperties.getHeadIp();
+
+    // Process transformed outgoing route by the export policy
+    boolean shouldExport =
+        exportPolicy.process(
+            exportCandidate,
+            transformedOutgoingRouteBuilder,
+            remoteIp,
+            ourConfigId.getRemotePeerPrefix(),
+            ourConfigId.getVrfName(),
+            Direction.OUT);
+
+    VirtualRouter remoteVr = getRemoteBgpNeighborVR(remoteConfigId, allNodes);
+    if (!shouldExport) {
+      // This route could not be exported due to export policy
+      _prefixTracer.filtered(
+          exportCandidate.getNetwork(),
+          requireNonNull(remoteVr).getHostname(),
+          remoteIp,
+          remoteConfigId.getVrfName(),
+          ourConfig.getExportPolicy(),
+          Direction.OUT);
+      return null;
+    }
+
+    // Apply final post-policy transformations before sending advertisement to neighbor
+    BgpProtocolHelper.transformBgpRoutePostExport(
+        transformedOutgoingRouteBuilder, ourConfig, sessionProperties);
+
+    // Successfully exported route
+    Bgpv4Route transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();
+    _prefixTracer.sentTo(
+        transformedOutgoingRoute.getNetwork(),
+        requireNonNull(remoteVr).getHostname(),
+        remoteIp,
+        remoteConfigId.getVrfName(),
+        ourConfig.getExportPolicy());
+
+    return transformedOutgoingRoute;
+  }
   /**
    * Given an {@link AbstractRoute}, run it through the BGP outbound transformations and export
    * routing policy.
@@ -1843,13 +1940,12 @@ public class VirtualRouter implements Serializable {
    * @param allNodes all nodes in the network
    * @param sessionProperties {@link BgpSessionProperties} representing the <em>incoming</em> edge:
    *     i.e. the edge from {@code remoteConfig} to {@code ourConfig}
-   * @param builder a builder for the output route, of the desired route type
    * @return The transformed route as a {@link Bgpv4Route}, or {@code null} if the route should not
    *     be exported.
    */
   @Nullable
   private <R extends BgpRoute, B extends BgpRoute.Builder<B, R>> R exportBgpRoute(
-      @Nonnull AbstractRouteDecorator exportCandidate,
+      @Nonnull AnnotatedRoute<R> exportCandidate,
       @Nonnull BgpPeerConfigId ourConfigId,
       @Nonnull BgpPeerConfigId remoteConfigId,
       @Nonnull BgpPeerConfig ourConfig,
@@ -1866,7 +1962,7 @@ public class VirtualRouter implements Serializable {
             sessionProperties,
             _vrf.getBgpProcess(),
             requireNonNull(getRemoteBgpNeighborVR(remoteConfigId, allNodes))._vrf.getBgpProcess(),
-            exportCandidate.getAbstractRoute(),
+            exportCandidate.getRoute(),
             builder);
     if (transformedOutgoingRouteBuilder == null) {
       // This route could not be exported for core bgp protocol reasons
@@ -1993,7 +2089,7 @@ public class VirtualRouter implements Serializable {
     }
   }
 
-  private <R extends AbstractRoute> AnnotatedRoute<R> annotateRoute(R route) {
+  private <R extends AbstractRoute> AnnotatedRoute<R> annotateRoute(@Nonnull R route) {
     return new AnnotatedRoute<>(route, _name);
   }
 
@@ -2051,6 +2147,11 @@ public class VirtualRouter implements Serializable {
   /** Temporary wrapper for {@link BgpRoutingProcess#enqueueBgpMessages(EdgeId, Collection)} */
   private void enqueueBgpMessages(
       @Nonnull EdgeId edgeId, @Nonnull Collection<RouteAdvertisement<Bgpv4Route>> routes) {
+    _bgpRoutingProcess.enqueueBgpMessages(edgeId, routes);
+  }
+
+  private void enqueueBgpMessages(
+      @Nonnull EdgeId edgeId, @Nonnull Stream<RouteAdvertisement<Bgpv4Route>> routes) {
     _bgpRoutingProcess.enqueueBgpMessages(edgeId, routes);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1930,6 +1930,7 @@ public class VirtualRouter implements Serializable {
 
     return transformedOutgoingRoute;
   }
+
   /**
    * Given an {@link AbstractRoute}, run it through the BGP outbound transformations and export
    * routing policy.

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1392,12 +1392,7 @@ public class VirtualRouter implements Serializable {
                 adv -> {
                   Bgpv4Route bgpRoute =
                       exportNonBgpRouteToBgp(
-                          adv.getRoute(),
-                          ourConfigId,
-                          remoteConfigId,
-                          ourConfig,
-                          allNodes,
-                          session);
+                          adv.getRoute(), ourConfigId, remoteConfigId, ourConfig, session);
                   return bgpRoute == null
                       ? null
                       : RouteAdvertisement.<Bgpv4Route>builder()
@@ -1869,7 +1864,6 @@ public class VirtualRouter implements Serializable {
    *
    * @param exportCandidate a route to try and export
    * @param ourConfig {@link BgpPeerConfig} that sends the route
-   * @param allNodes all nodes in the network
    * @param sessionProperties {@link BgpSessionProperties} representing the <em>incoming</em> edge:
    *     i.e. the edge from {@code remoteConfig} to {@code ourConfig}
    * @return The transformed route as a {@link Bgpv4Route}, or {@code null} if the route should not
@@ -1881,7 +1875,6 @@ public class VirtualRouter implements Serializable {
       @Nonnull BgpPeerConfigId ourConfigId,
       @Nonnull BgpPeerConfigId remoteConfigId,
       @Nonnull BgpPeerConfig ourConfig,
-      @Nonnull Map<String, Node> allNodes,
       @Nonnull BgpSessionProperties sessionProperties) {
 
     RoutingPolicy exportPolicy = _c.getRoutingPolicies().get(ourConfig.getExportPolicy());

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1914,7 +1914,6 @@ public class VirtualRouter implements Serializable {
             ourConfigId.getVrfName(),
             Direction.OUT);
 
-    VirtualRouter remoteVr = getRemoteBgpNeighborVR(remoteConfigId, allNodes);
     if (!shouldExport) {
       // This route could not be exported due to export policy
       _prefixTracer.filtered(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1919,7 +1919,7 @@ public class VirtualRouter implements Serializable {
       // This route could not be exported due to export policy
       _prefixTracer.filtered(
           exportCandidate.getNetwork(),
-          requireNonNull(remoteVr).getHostname(),
+          remoteConfigId.getHostname(),
           remoteIp,
           remoteConfigId.getVrfName(),
           ourConfig.getExportPolicy(),
@@ -1935,7 +1935,7 @@ public class VirtualRouter implements Serializable {
     Bgpv4Route transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();
     _prefixTracer.sentTo(
         transformedOutgoingRoute.getNetwork(),
-        requireNonNull(remoteVr).getHostname(),
+        remoteConfigId.getHostname(),
         remoteIp,
         remoteConfigId.getVrfName(),
         ourConfig.getExportPolicy());

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -241,11 +241,11 @@ public class BgpProtocolHelper {
    * Convert a route that is neither a {@link BgpRoute} nor a {@link GeneratedRoute} to a {@link
    * Bgpv4Route.Builder}.
    *
-   * <p>Intended for converting main RIB routes into their BGP equivalents and merging into local
-   * BGP RIB.
+   * <p>Intended for converting main RIB routes into their BGP equivalents before passing {@code
+   * routeDecorator} to the export policy
    *
-   * <p>The route returned will be will be an eBGP route, with default local preference, incomplete
-   * origin type, and most other fields unset.
+   * <p>The builder returned will will have default local preference, incomplete origin type, and
+   * most other fields unset.
    */
   @Nonnull
   public static Bgpv4Route.Builder convertNonBgpRouteToBgpRoute(
@@ -267,8 +267,7 @@ public class BgpProtocolHelper {
         // TODO: support customization of route preference
         .setLocalPreference(BgpRoute.DEFAULT_LOCAL_PREFERENCE)
         .setReceivedFromIp(protocol == RoutingProtocol.BGP ? nextHopIp : Ip.ZERO)
-        .setNextHopIp(nextHopIp)
-        .setTag(route.getTag());
+        .setNextHopIp(nextHopIp);
     // Let everything else default to unset/empty/etc.
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -74,7 +74,6 @@ public class BgpProtocolHelper {
     builder.setReceivedFromRouteReflectorClient(
         !sessionProperties.isEbgp() && toNeighbor.getRouteReflectorClient());
 
-    // Extract original route's asPath and communities if it had them
     SortedSet<Community> communities = route.getCommunities();
     // Do not export route if it has NO_ADVERTISE community, or if its AS path contains the remote
     // peer's AS and local peer has not set getAllowRemoteOut
@@ -172,7 +171,7 @@ public class BgpProtocolHelper {
   /** Perform BGP import transformations on a given route after receiving an advertisement */
   @Nullable
   public static <R extends BgpRoute, B extends BgpRoute.Builder<B, R>> B transformBgpRouteOnImport(
-      @Nonnull BgpPeerConfigId toConfigId,
+      BgpPeerConfigId toConfigId,
       BgpPeerConfig toNeighbor,
       BgpSessionProperties sessionProperties,
       BgpRoute route,
@@ -280,9 +279,7 @@ public class BgpProtocolHelper {
    */
   public static <R extends BgpRoute, B extends BgpRoute.Builder<B, R>>
       void transformBgpRoutePostExport(
-          @Nonnull B routeBuilder,
-          @Nonnull BgpPeerConfig fromNeighbor,
-          @Nonnull BgpSessionProperties sessionProperties) {
+          B routeBuilder, BgpPeerConfig fromNeighbor, BgpSessionProperties sessionProperties) {
     if (sessionProperties.isEbgp()) {
       // if eBGP, prepend as-path sender's as-path number
       routeBuilder.setAsPath(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -3,17 +3,16 @@ package org.batfish.dataplane.protocols;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSortedSet;
 import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.WellKnownCommunity;
 import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.AsSet;
-import org.batfish.datamodel.BgpActivePeerConfig;
-import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
 import org.batfish.datamodel.BgpProcess;
@@ -30,6 +29,7 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 
+@ParametersAreNonnullByDefault
 public class BgpProtocolHelper {
 
   /**
@@ -48,160 +48,124 @@ public class BgpProtocolHelper {
       BgpSessionProperties sessionProperties,
       BgpProcess fromBgpProcess,
       BgpProcess toBgpProcess,
-      AbstractRoute route,
+      BgpRoute route,
       B builder) {
 
     // sessionProperties represents incoming edge, so fromNeighbor's IP is its headIp
     Ip fromNeighborIp = sessionProperties.getHeadIp();
+    RoutingProtocol routeProtocol = route.getProtocol();
 
-    // Set the tag
-    builder.setTag(route.getTag());
-
+    builder.setNetwork(route.getNetwork());
     builder.setReceivedFromIp(fromNeighborIp);
-    RoutingProtocol remoteRouteProtocol = route.getProtocol();
-
-    boolean remoteRouteIsBgp =
-        remoteRouteProtocol == RoutingProtocol.IBGP || remoteRouteProtocol == RoutingProtocol.BGP;
+    builder.setAsPath(route.getAsPath());
+    builder.setProtocol(sessionProperties.isEbgp() ? RoutingProtocol.BGP : RoutingProtocol.IBGP);
+    builder.setSrcProtocol(route.getProtocol());
+    builder.setOriginType(route.getOriginType());
 
     // Set originatorIP
-    Ip originatorIp;
-    if (!sessionProperties.isEbgp() && remoteRouteProtocol.equals(RoutingProtocol.IBGP)) {
-      Bgpv4Route bgpRemoteRoute = (Bgpv4Route) route;
-      originatorIp = bgpRemoteRoute.getOriginatorIp();
+    if (!sessionProperties.isEbgp() && routeProtocol.equals(RoutingProtocol.IBGP)) {
+      // iBGP session and iBGP route: preserve the originator
+      builder.setOriginatorIp(route.getOriginatorIp());
     } else {
-      originatorIp = fromBgpProcess.getRouterId();
+      builder.setOriginatorIp(fromBgpProcess.getRouterId());
     }
-    builder.setOriginatorIp(originatorIp);
 
     // note whether new route is received from route reflector client
     builder.setReceivedFromRouteReflectorClient(
         !sessionProperties.isEbgp() && toNeighbor.getRouteReflectorClient());
 
     // Extract original route's asPath and communities if it had them
-    AsPath originalAsPath = AsPath.empty();
-    SortedSet<Community> originalCommunities = ImmutableSortedSet.of();
-    if (route instanceof Bgpv4Route) {
-      // Includes all routes with protocols BGP and IBGP, plus some with protocol AGGREGATE
-      BgpRoute bgpRemoteRoute = (BgpRoute) route;
-      originalAsPath = bgpRemoteRoute.getAsPath();
-      originalCommunities = bgpRemoteRoute.getCommunities();
-    } else if (route instanceof GeneratedRoute) {
-      // Includes all other AGGREGATE routes
-      GeneratedRoute gr = (GeneratedRoute) route;
-      originalAsPath = gr.getAsPath();
-      originalCommunities = gr.getCommunities();
-    }
+    SortedSet<Community> communities = route.getCommunities();
     // Do not export route if it has NO_ADVERTISE community, or if its AS path contains the remote
     // peer's AS and local peer has not set getAllowRemoteOut
-    if (originalCommunities.contains(StandardCommunity.of(WellKnownCommunity.NO_ADVERTISE))
+    if (communities.contains(StandardCommunity.of(WellKnownCommunity.NO_ADVERTISE))
         || (sessionProperties.isEbgp()
-            && originalAsPath.containsAs(toNeighbor.getLocalAs())
+            && route.getAsPath().containsAs(toNeighbor.getLocalAs())
             && !fromNeighbor.getAllowRemoteAsOut())) {
       return null;
     }
-    // Set transformed route's AS path and communities
-    builder.setAsPath(originalAsPath);
+    // Set transformed route's communities
     if (fromNeighbor.getSendCommunity()) {
-      builder.addCommunities(originalCommunities);
+      builder.addCommunities(communities);
     }
 
-    // clusterList, receivedFromRouteReflectorClient, (originType for bgp remote route)
-    if (remoteRouteIsBgp) {
-      BgpRoute bgpRemoteRoute = (BgpRoute) route;
-
-      builder.setOriginType(bgpRemoteRoute.getOriginType());
+    /*
+     *  iBGP speaker should not send out routes to iBGP neighbor whose router-id is
+     *  same as originator id of advertisement
+     */
+    if (!sessionProperties.isEbgp() && toBgpProcess.getRouterId().equals(route.getOriginatorIp())) {
+      return null;
+    }
+    if (routeProtocol.equals(RoutingProtocol.IBGP) && !sessionProperties.isEbgp()) {
       /*
-       * route reflection: reflect everything received from
+       * The remote route is iBGP. The session is iBGP. We consider whether to reflect, and
+       * modify the outgoing route as appropriate.
+       *
+       * For route reflection: reflect everything received from
        * clients to clients and non-clients. reflect everything
        * received from non-clients to clients. Do not reflect to
        * originator
        */
-
-      Ip remoteOriginatorIp = bgpRemoteRoute.getOriginatorIp();
-      /*
-       *  iBGP speaker should not send out routes to iBGP neighbor whose router-id is
-       *  same as originator id of advertisement
-       */
-      if (!sessionProperties.isEbgp() && toBgpProcess.getRouterId().equals(remoteOriginatorIp)) {
+      boolean remoteRouteReceivedFromRouteReflectorClient =
+          route.getReceivedFromRouteReflectorClient();
+      boolean sendingToRouteReflectorClient = fromNeighbor.getRouteReflectorClient();
+      Ip remoteReceivedFromIp = route.getReceivedFromIp();
+      boolean remoteRouteOriginatedByRemoteNeighbor = Ip.ZERO.equals(remoteReceivedFromIp);
+      if (!remoteRouteReceivedFromRouteReflectorClient
+          && !sendingToRouteReflectorClient
+          && !remoteRouteOriginatedByRemoteNeighbor) {
+        /*
+         * Neither reflecting nor originating this iBGP route, so don't send
+         */
         return null;
       }
-      if (remoteRouteProtocol.equals(RoutingProtocol.IBGP) && !sessionProperties.isEbgp()) {
-        /*
-         *  The remote route is iBGP. The session is iBGP. We consider whether to reflect, and
-         *  modify the outgoing route as appropriate.
-         */
-        boolean remoteRouteReceivedFromRouteReflectorClient =
-            bgpRemoteRoute.getReceivedFromRouteReflectorClient();
-        boolean sendingToRouteReflectorClient = fromNeighbor.getRouteReflectorClient();
-        Ip remoteReceivedFromIp = bgpRemoteRoute.getReceivedFromIp();
-        boolean remoteRouteOriginatedByRemoteNeighbor = Ip.ZERO.equals(remoteReceivedFromIp);
-        if (!remoteRouteReceivedFromRouteReflectorClient
-            && !sendingToRouteReflectorClient
-            && !remoteRouteOriginatedByRemoteNeighbor) {
-          /*
-           * Neither reflecting nor originating this iBGP route, so don't send
-           */
-          return null;
-        }
-        builder.addClusterList(bgpRemoteRoute.getClusterList());
-        if (!remoteRouteOriginatedByRemoteNeighbor) {
-          // we are reflecting, so we need to get the clusterid associated with the
-          // remoteRoute
-          BgpPeerConfig remoteReceivedFromSession =
-              fromBgpProcess
-                  .getActiveNeighbors()
-                  .get(Prefix.create(remoteReceivedFromIp, Prefix.MAX_PREFIX_LENGTH));
-          long newClusterId = remoteReceivedFromSession.getClusterId();
+      builder.addClusterList(route.getClusterList());
+      if (!remoteRouteOriginatedByRemoteNeighbor) {
+        // we are reflecting, so we need to get the clusterid associated with the
+        // remoteRoute
+        BgpPeerConfig remoteReceivedFromSession =
+            fromBgpProcess
+                .getActiveNeighbors()
+                .get(Prefix.create(remoteReceivedFromIp, Prefix.MAX_PREFIX_LENGTH));
+        assert remoteReceivedFromSession != null;
+        Long newClusterId = remoteReceivedFromSession.getClusterId();
+        if (newClusterId != null) {
           builder.addToClusterList(newClusterId);
         }
-        Set<Long> localClusterIds = toBgpProcess.getClusterIds();
-        Set<Long> outgoingClusterList = builder.getClusterList();
-        if (localClusterIds.stream().anyMatch(outgoingClusterList::contains)) {
-          /*
-           *  receiver will reject new route if it contains any of its local cluster ids
-           */
-          return null;
-        }
+      }
+      Set<Long> localClusterIds = toBgpProcess.getClusterIds();
+      Set<Long> outgoingClusterList = builder.getClusterList();
+      if (localClusterIds.stream().anyMatch(outgoingClusterList::contains)) {
+        /*
+         *  receiver will reject new route if it contains any of its local cluster ids
+         */
+        return null;
       }
     }
 
-    // Outgoing protocol
-    builder.setProtocol(sessionProperties.isEbgp() ? RoutingProtocol.BGP : RoutingProtocol.IBGP);
-    builder.setNetwork(route.getNetwork());
-
     // Outgoing metric (MED) is preserved only if advertising to IBGP peer.
-    if (remoteRouteIsBgp & !sessionProperties.isEbgp()) {
+    if (!sessionProperties.isEbgp()) {
       builder.setMetric(route.getMetric());
     }
 
-    // Outgoing nextHopIp & localPreference
-    Ip nextHopIp;
-    long localPreference;
-    if (sessionProperties.isEbgp() || !remoteRouteIsBgp) {
-      nextHopIp = fromNeighborIp;
-      localPreference = BgpRoute.DEFAULT_LOCAL_PREFERENCE;
-    } else {
-      // iBGP session AND the route is a BGP route
-      nextHopIp = route.getNextHopIp();
-      BgpRoute remoteIbgpRoute = (BgpRoute) route;
-      localPreference = remoteIbgpRoute.getLocalPreference();
-    }
-    if (Route.UNSET_ROUTE_NEXT_HOP_IP.equals(nextHopIp)) {
-      // should only happen for ibgp or dynamic bgp
-      if (fromNeighbor instanceof BgpPassivePeerConfig) {
-        nextHopIp = ((BgpActivePeerConfig) toNeighbor).getPeerAddress();
-      } else {
-        // we somehow ended up with a BGP route that has no next-hop IP. This shouldn't happen,
-        // so make an assert. This will be a graceful ignore in prod.
-        assert !nextHopIp.equals(Route.UNSET_ROUTE_NEXT_HOP_IP);
-        return null;
-      }
-    }
-    builder.setNextHopIp(nextHopIp);
-    builder.setLocalPreference(localPreference);
+    // Local preference: only transitive for iBGP
+    builder.setLocalPreference(
+        sessionProperties.isEbgp()
+            ? BgpRoute.DEFAULT_LOCAL_PREFERENCE
+            : route.getLocalPreference());
 
-    // Outgoing srcProtocol
-    builder.setSrcProtocol(route.getProtocol());
+    // Outgoing nextHopIp
+    if (sessionProperties.isEbgp()) {
+      // If session is eBGP, always override next-hop
+      builder.setNextHopIp(fromNeighborIp);
+    } else {
+      // iBGP session: if route has next-hop ip, preserve it. If not, set our own.
+      // Note: implementation of next-hop-self in the general case is delegated to routing policy
+      builder.setNextHopIp(
+          route.getNextHopIp().equals(Route.UNSET_ROUTE_NEXT_HOP_IP)
+              ? fromNeighborIp
+              : route.getNextHopIp());
+    }
     return builder;
   }
 
@@ -272,6 +236,41 @@ public class BgpProtocolHelper {
         .setReceivedFromIp(Ip.ZERO)
         .setNonRouting(nonRouting)
         .build();
+  }
+
+  /**
+   * Convert a route that is neither a {@link BgpRoute} nor a {@link GeneratedRoute} to a {@link
+   * Bgpv4Route.Builder}.
+   *
+   * <p>Intended for converting main RIB routes into their BGP equivalents and merging into local
+   * BGP RIB.
+   *
+   * <p>The route returned will be will be an eBGP route, with default local preference, incomplete
+   * origin type, and most other fields unset.
+   */
+  @Nonnull
+  public static Bgpv4Route.Builder convertNonBgpRouteToBgpRoute(
+      AbstractRouteDecorator routeDecorator,
+      Ip routerId,
+      Ip nextHopIp,
+      int adminDistance,
+      RoutingProtocol protocol) {
+    assert protocol == RoutingProtocol.BGP || protocol == RoutingProtocol.IBGP;
+    assert !(routeDecorator.getAbstractRoute() instanceof BgpRoute);
+    AbstractRoute route = routeDecorator.getAbstractRoute();
+    return Bgpv4Route.builder()
+        .setNetwork(route.getNetwork())
+        .setAdmin(adminDistance)
+        .setOriginatorIp(routerId)
+        .setProtocol(protocol)
+        .setSrcProtocol(route.getProtocol())
+        .setOriginType(OriginType.INCOMPLETE)
+        // TODO: support customization of route preference
+        .setLocalPreference(BgpRoute.DEFAULT_LOCAL_PREFERENCE)
+        .setReceivedFromIp(protocol == RoutingProtocol.BGP ? nextHopIp : Ip.ZERO)
+        .setNextHopIp(nextHopIp)
+        .setTag(route.getTag());
+    // Let everything else default to unset/empty/etc.
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AnnotatedRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AnnotatedRib.java
@@ -30,4 +30,9 @@ public abstract class AnnotatedRib<R extends AbstractRoute> extends AbstractRib<
 
   @Override
   public abstract int comparePreference(AnnotatedRoute<R> lhs, AnnotatedRoute<R> rhs);
+
+  @SuppressWarnings("unchecked") // Since R is a supertype, this cast should be fine
+  public boolean containsRoute(AnnotatedRoute<? extends R> route) {
+    return super.containsRoute((AnnotatedRoute<R>) route);
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AnnotatedRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AnnotatedRibTest.java
@@ -1,0 +1,35 @@
+package org.batfish.dataplane.rib;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
+import org.junit.Test;
+
+public class AnnotatedRibTest {
+  @Test
+  public void testContainsRoute() {
+    Rib rib = new Rib();
+    StaticRoute sr =
+        StaticRoute.builder()
+            .setAdministrativeCost(1)
+            .setNetwork(Prefix.ZERO)
+            .setNextHopInterface("iface")
+            .build();
+    AnnotatedRoute<StaticRoute> ar = new AnnotatedRoute<>(sr, "vrf");
+    rib.mergeRoute(new AnnotatedRoute<>(sr, "vrf"));
+    assertTrue(rib.containsRoute(ar));
+    assertFalse(rib.containsRoute(new AnnotatedRoute<>(sr, "othervrf")));
+    assertFalse(
+        rib.containsRoute(
+            new AnnotatedRoute<>(
+                StaticRoute.builder()
+                    .setAdministrativeCost(1)
+                    .setNetwork(Prefix.ZERO)
+                    .setNextHopInterface("iface2")
+                    .build(),
+                "othervrf")));
+  }
+}


### PR DESCRIPTION
* No functional changes intended

* Differentiate AbstractRoute exports and BgpRoute exports
  This simplifies transformation logic; Sets up possibility of
  generifying BGP route exports

* Do not treat new BGP session establishment differently from message
  propagation -- call into the same functions (e.g.,
  queueOutgoingRoutes)