### PR TITLE
Cumulus: use VI repr of VXLAN for EVPN conversions

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -192,30 +192,31 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
       ImmutableSet.Builder<Layer2VniConfig> l2Vnis = ImmutableSet.builder();
       ImmutableSet.Builder<Layer3VniConfig> l3Vnis = ImmutableSet.builder();
       ImmutableMap.Builder<Integer, Integer> vniToIndexBuilder = ImmutableMap.builder();
-      if (evpnConfig.getAdvertiseAllVni()) {
-        CommonUtil.forEachWithIndex(
-            // Keep indices in deterministic order
-            ImmutableList.sortedCopyOf(
-                Comparator.nullsLast(Comparator.comparing(Vxlan::getId)), _vxlans.values()),
-            (index, vxlan) -> {
-              if (vxlan.getId() == null) {
-                return;
-              }
-              vniToIndexBuilder.put(vxlan.getId(), index);
-              RouteDistinguisher rd = RouteDistinguisher.from(newProc.getRouterId(), index);
-              ExtendedCommunity rt = ExtendedCommunity.target(localAs, vxlan.getId());
-              if (vxlan.getLocalTunnelip() != null) {
-                // Advertise L2 VNIs
-                l2Vnis.add(new Layer2VniConfig(vxlan.getId(), bgpVrf.getVrfName(), rd, rt));
-                if (evpnConfig.getAdvertiseDefaultGw()) {
-                  // Advertise VTEP gateway IP address for the L2 VNI as type 3 route
-                  l3Vnis.add(
-                      new Layer3VniConfig(vxlan.getId(), bgpVrf.getVrfName(), rd, rt, false));
-                }
-              }
-            });
-      }
+      CommonUtil.forEachWithIndex(
+          // Keep indices in deterministic order
+          ImmutableList.sortedCopyOf(
+              Comparator.nullsLast(Comparator.comparing(Vxlan::getId)), _vxlans.values()),
+          (index, vxlan) -> {
+            if (vxlan.getId() == null) {
+              return;
+            }
+            vniToIndexBuilder.put(vxlan.getId(), index);
+          });
       Map<Integer, Integer> vniToIndex = vniToIndexBuilder.build();
+
+      if (evpnConfig.getAdvertiseAllVni()) {
+        for (VniSettings vxlan : _c.getVrfs().get(bgpVrf.getVrfName()).getVniSettings().values()) {
+          RouteDistinguisher rd =
+              RouteDistinguisher.from(newProc.getRouterId(), vniToIndex.get(vxlan.getVni()));
+          ExtendedCommunity rt = ExtendedCommunity.target(localAs, vxlan.getVni());
+          // Advertise L2 VNIs
+          l2Vnis.add(new Layer2VniConfig(vxlan.getVni(), bgpVrf.getVrfName(), rd, rt));
+          if (evpnConfig.getAdvertiseDefaultGw()) {
+            // Advertise VTEP gateway IP address for the L2 VNI as type 3 route
+            l3Vnis.add(new Layer3VniConfig(vxlan.getVni(), bgpVrf.getVrfName(), rd, rt, false));
+          }
+        }
+      }
       // Advertise the L3 VNI per vrf if one is configured
       assert _bgpProcess != null; // Since we are in neighbor conversion, this must be true
       Iterables.concat(ImmutableSet.of(_bgpProcess.getDefaultVrf()), _bgpProcess.getVrfs().values())

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -1428,12 +1428,7 @@ public final class CumulusNcluGrammarTest {
                 10002,
                 DEFAULT_VRF_NAME,
                 RouteDistinguisher.from(routerId, 1),
-                ExtendedCommunity.target(65500, 10002)),
-            new Layer2VniConfig(
-                10004,
-                DEFAULT_VRF_NAME,
-                RouteDistinguisher.from(routerId, 2),
-                ExtendedCommunity.target(65500, 10004)));
+                ExtendedCommunity.target(65500, 10002)));
 
     ImmutableSortedSet<Layer3VniConfig> expectedL3Vnis =
         ImmutableSortedSet.of(
@@ -1449,12 +1444,6 @@ public final class CumulusNcluGrammarTest {
                 DEFAULT_VRF_NAME,
                 RouteDistinguisher.from(routerId, 1),
                 ExtendedCommunity.target(65500, 10002),
-                false),
-            new Layer3VniConfig(
-                10004,
-                DEFAULT_VRF_NAME,
-                RouteDistinguisher.from(routerId, 2),
-                ExtendedCommunity.target(65500, 10004),
                 false),
             // VRF1's explicitly defined l3-VNI with advertise-ipv4-unicast
             new Layer3VniConfig(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testconfigs/cumulus_nclu_evpn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testconfigs/cumulus_nclu_evpn
@@ -12,16 +12,19 @@ net add bgp l2vpn evpn advertise-default-gw
 net add bgp neighbor swp1 interface remote-as external
 net add bgp l2vpn evpn neighbor swp1 activate
 # VNIs for default VRF
-net add vxlan vni10001 bridge access 5
 net add vxlan vni10001 vxlan id 10001
 net add vxlan vni10001 vxlan local-tunnelip 192.0.2.11
-net add vxlan vni10005 vxlan id 10002
-net add vxlan vni10005 vxlan local-tunnelip 192.0.2.12
+net add vxlan vni10001 bridge access 1
+
+net add vxlan vni10002 vxlan id 10002
+net add vxlan vni10002 vxlan local-tunnelip 192.0.2.12
+net add vxlan vni10002 bridge access 2
 # VNIs for vrf1
 net add vrf vrf1 vni 10004
 net add bgp vrf vrf1 router-id 192.0.1.1
 net add vxlan vni10004 vxlan id 10004
 net add vxlan vni10004 vxlan local-tunnelip 192.0.2.14
+net add vxlan vni10004 bridge access 4
 net commit
 # Unrelated to EVPN vrf
 net add vrf vrf2

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -14445,22 +14445,7 @@
                   "ebgpMultihop" : false,
                   "enforceFirstAs" : false,
                   "evpnAddressFamily" : {
-                    "l2Vnis" : [
-                      {
-                        "routeDistinguisher" : "192.0.2.2:1",
-                        "routeTarget" : "2:65500:10004",
-                        "vni" : 10004,
-                        "vrf" : "default"
-                      }
-                    ],
                     "l3Vnis" : [
-                      {
-                        "advertiseV4UnicastRoutes" : false,
-                        "routeDistinguisher" : "192.0.2.2:1",
-                        "routeTarget" : "2:65500:10004",
-                        "vni" : 10004,
-                        "vrf" : "default"
-                      },
                       {
                         "advertiseV4UnicastRoutes" : true,
                         "routeDistinguisher" : "192.0.2.3:0",


### PR DESCRIPTION
1. Simpler logic: no need to check that a VXLAN config is valid, conversion takes care of that.
2. This uncovered:

    1.  `cumulus_nclu_evpn` test file had missing data 
    2.  I had unintentionally been creating duplicate L3-VNI to VRF mappings, which is incorrect. Fixed now.

Any one reviewer will do.