### PR TITLE
 L3 VNI config: differentiate between import and export route targets

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/Layer3VniConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/Layer3VniConfig.java
@@ -28,28 +28,28 @@ public final class Layer3VniConfig implements Serializable, Comparable<Layer3Vni
   private static final String PROP_ROUTE_DISTINGUISHER = "routeDistinguisher";
   private static final String PROP_ROUTE_TARGET = "routeTarget";
   private static final String PROP_IMPORT_ROUTE_TARGET = "importRouteTarget";
-  private static final String PROP_ADVERTISE_V4_UNICAST = "advertiseV4UnicastRoutes";
+  private static final String PROP_ADVERTISE_V4_UNICAST = "advertiseV4Unicast";
 
   private final int _vni;
   @Nonnull private final String _vrf;
   @Nonnull private final RouteDistinguisher _rd;
   @Nonnull private final ExtendedCommunity _routeTarget;
   @Nonnull private final String _importRouteTarget;
-  private final boolean _advertisev4Unicast;
+  private final boolean _advertiseV4Unicast;
 
-  public Layer3VniConfig(
+  private Layer3VniConfig(
       int vni,
       String vrf,
       RouteDistinguisher rd,
       ExtendedCommunity routeTarget,
       String importRouteTarget,
-      boolean advertisev4Unicast) {
+      boolean advertiseV4Unicast) {
     _vni = vni;
     _vrf = vrf;
     _rd = rd;
     _routeTarget = routeTarget;
     _importRouteTarget = importRouteTarget;
-    _advertisev4Unicast = advertisev4Unicast;
+    _advertiseV4Unicast = advertiseV4Unicast;
   }
 
   @JsonCreator
@@ -59,7 +59,7 @@ public final class Layer3VniConfig implements Serializable, Comparable<Layer3Vni
       @Nullable @JsonProperty(PROP_ROUTE_DISTINGUISHER) RouteDistinguisher rd,
       @Nullable @JsonProperty(PROP_ROUTE_TARGET) ExtendedCommunity routeTarget,
       @Nullable @JsonProperty(PROP_IMPORT_ROUTE_TARGET) String importRouteTarget,
-      @Nullable @JsonProperty(PROP_ADVERTISE_V4_UNICAST) Boolean advertisev4Unicast) {
+      @Nullable @JsonProperty(PROP_ADVERTISE_V4_UNICAST) Boolean advertiseV4Unicast) {
     checkArgument(vni != null, "Missing %s", PROP_VNI);
     checkArgument(vrf != null, "Missing %s", PROP_VRF);
     checkArgument(rd != null, "Missing %s", PROP_ROUTE_DISTINGUISHER);
@@ -71,7 +71,7 @@ public final class Layer3VniConfig implements Serializable, Comparable<Layer3Vni
         .setRouteDistinguisher(rd)
         .setRouteTarget(routeTarget)
         .setImportRouteTarget(importRouteTarget)
-        .setAdvertisev4Unicast(firstNonNull(advertisev4Unicast, Boolean.FALSE))
+        .setAdvertiseV4Unicast(firstNonNull(advertiseV4Unicast, Boolean.FALSE))
         .build();
   }
 
@@ -112,8 +112,8 @@ public final class Layer3VniConfig implements Serializable, Comparable<Layer3Vni
    * #getRouteDistinguisher()}
    */
   @JsonProperty(PROP_ADVERTISE_V4_UNICAST)
-  public boolean getAdvertisev4Unicast() {
-    return _advertisev4Unicast;
+  public boolean getAdvertiseV4Unicast() {
+    return _advertiseV4Unicast;
   }
 
   @Override
@@ -129,7 +129,8 @@ public final class Layer3VniConfig implements Serializable, Comparable<Layer3Vni
         && Objects.equals(_vrf, vniConfig._vrf)
         && Objects.equals(_rd, vniConfig._rd)
         && Objects.equals(_routeTarget, vniConfig._routeTarget)
-        && _advertisev4Unicast == vniConfig._advertisev4Unicast;
+        && Objects.equals(_importRouteTarget, vniConfig._importRouteTarget)
+        && _advertiseV4Unicast == vniConfig._advertiseV4Unicast;
   }
 
   @Override
@@ -142,7 +143,7 @@ public final class Layer3VniConfig implements Serializable, Comparable<Layer3Vni
     return Comparator.comparing(Layer3VniConfig::getVrf)
         .thenComparing(Layer3VniConfig::getRouteDistinguisher)
         .thenComparing(Layer3VniConfig::getRouteTarget)
-        .thenComparing(Layer3VniConfig::getAdvertisev4Unicast)
+        .thenComparing(Layer3VniConfig::getAdvertiseV4Unicast)
         .compare(this, o);
   }
 
@@ -153,7 +154,7 @@ public final class Layer3VniConfig implements Serializable, Comparable<Layer3Vni
         .add(PROP_VRF, _vrf)
         .add(PROP_ROUTE_DISTINGUISHER, _rd)
         .add(PROP_ROUTE_TARGET, _routeTarget)
-        .add(PROP_ADVERTISE_V4_UNICAST, _advertisev4Unicast)
+        .add(PROP_ADVERTISE_V4_UNICAST, _advertiseV4Unicast)
         .toString();
   }
 
@@ -164,6 +165,10 @@ public final class Layer3VniConfig implements Serializable, Comparable<Layer3Vni
     return String.format("^\\d+:%d$", vni);
   }
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   public static final class Builder {
 
     @Nullable private Integer _vni;
@@ -171,7 +176,9 @@ public final class Layer3VniConfig implements Serializable, Comparable<Layer3Vni
     @Nullable private RouteDistinguisher _rd;
     @Nullable private ExtendedCommunity _routeTarget;
     @Nullable private String _importRouteTarget;
-    private boolean _advertisev4Unicast;
+    private boolean _advertiseV4Unicast;
+
+    private Builder() {}
 
     public Builder setVni(int vni) {
       _vni = vni;
@@ -198,8 +205,8 @@ public final class Layer3VniConfig implements Serializable, Comparable<Layer3Vni
       return this;
     }
 
-    public Builder setAdvertisev4Unicast(boolean advertisev4Unicast) {
-      _advertisev4Unicast = advertisev4Unicast;
+    public Builder setAdvertiseV4Unicast(boolean advertisev4Unicast) {
+      _advertiseV4Unicast = advertisev4Unicast;
       return this;
     }
 
@@ -216,7 +223,7 @@ public final class Layer3VniConfig implements Serializable, Comparable<Layer3Vni
         throw new IllegalArgumentException(
             String.format("Invalid patthern %s for %s", importRt, PROP_IMPORT_ROUTE_TARGET));
       }
-      return new Layer3VniConfig(_vni, _vrf, _rd, _routeTarget, importRt, _advertisev4Unicast);
+      return new Layer3VniConfig(_vni, _vrf, _rd, _routeTarget, importRt, _advertiseV4Unicast);
     }
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/EvpnAddressFamilyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/EvpnAddressFamilyTest.java
@@ -8,6 +8,7 @@ import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.bgp.Layer3VniConfig.Builder;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.junit.Test;
 
@@ -28,12 +29,14 @@ public class EvpnAddressFamilyTest {
             new EvpnAddressFamily(
                 ImmutableSet.of(),
                 ImmutableSet.of(
-                    new Layer3VniConfig(
-                        1,
-                        "v",
-                        RouteDistinguisher.from(1L, 1),
-                        ExtendedCommunity.of(0, 1, 1),
-                        false))))
+                    new Builder()
+                        .setVni(1)
+                        .setVrf("v")
+                        .setRouteDistinguisher(RouteDistinguisher.from(1L, 1))
+                        .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+                        .setImportRouteTarget(Layer3VniConfig.importRtPatternForAnyAs(1))
+                        .setAdvertisev4Unicast(false)
+                        .build())))
         .addEqualityGroup(new Object())
         .testEquals();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/EvpnAddressFamilyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/EvpnAddressFamilyTest.java
@@ -8,7 +8,6 @@ import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
-import org.batfish.datamodel.bgp.Layer3VniConfig.Builder;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.junit.Test;
 
@@ -29,13 +28,13 @@ public class EvpnAddressFamilyTest {
             new EvpnAddressFamily(
                 ImmutableSet.of(),
                 ImmutableSet.of(
-                    new Builder()
+                    Layer3VniConfig.builder()
                         .setVni(1)
                         .setVrf("v")
                         .setRouteDistinguisher(RouteDistinguisher.from(1L, 1))
                         .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
                         .setImportRouteTarget(Layer3VniConfig.importRtPatternForAnyAs(1))
-                        .setAdvertisev4Unicast(false)
+                        .setAdvertiseV4Unicast(false)
                         .build())))
         .addEqualityGroup(new Object())
         .testEquals();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Layer3VniConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Layer3VniConfigTest.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.bgp;
 
+import static org.batfish.datamodel.bgp.Layer3VniConfig.importRtPatternForAnyAs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -7,53 +8,136 @@ import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.bgp.Layer3VniConfig.Builder;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /** Tests of {@link Layer3VniConfig} */
 public class Layer3VniConfigTest {
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+
   @Test
   public void testEquals() {
     Layer3VniConfig vni =
-        new Layer3VniConfig(
-            1, "v", RouteDistinguisher.from(65555L, 1), ExtendedCommunity.of(0, 1, 1), false);
+        new Builder()
+            .setVni(1)
+            .setVrf("v")
+            .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
+            .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+            .setImportRouteTarget(importRtPatternForAnyAs(1))
+            .setAdvertisev4Unicast(false)
+            .build();
     new EqualsTester()
         .addEqualityGroup(
             vni,
             vni,
-            new Layer3VniConfig(
-                1, "v", RouteDistinguisher.from(65555L, 1), ExtendedCommunity.of(0, 1, 1), false))
+            new Builder()
+                .setVni(1)
+                .setVrf("v")
+                .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
+                .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+                .setImportRouteTarget(importRtPatternForAnyAs(1))
+                .setAdvertisev4Unicast(false)
+                .build())
         .addEqualityGroup(
-            new Layer3VniConfig(
-                2, "v", RouteDistinguisher.from(65555L, 1), ExtendedCommunity.of(0, 1, 1), false))
+            new Builder()
+                .setVni(2)
+                .setVrf("v")
+                .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
+                .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+                .setImportRouteTarget(importRtPatternForAnyAs(1))
+                .setAdvertisev4Unicast(false)
+                .build())
         .addEqualityGroup(
-            new Layer3VniConfig(
-                1, "v2", RouteDistinguisher.from(65555L, 1), ExtendedCommunity.of(0, 1, 1), false))
+            new Builder()
+                .setVni(1)
+                .setVrf("v2")
+                .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
+                .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+                .setImportRouteTarget(importRtPatternForAnyAs(1))
+                .setAdvertisev4Unicast(false)
+                .build())
         .addEqualityGroup(
-            new Layer3VniConfig(
-                1, "v", RouteDistinguisher.from(65555L, 2), ExtendedCommunity.of(0, 1, 1), false))
+            new Builder()
+                .setVni(1)
+                .setVrf("v")
+                .setRouteDistinguisher(RouteDistinguisher.from(65555L, 2))
+                .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+                .setImportRouteTarget(importRtPatternForAnyAs(1))
+                .setAdvertisev4Unicast(false)
+                .build())
         .addEqualityGroup(
-            new Layer3VniConfig(
-                1, "v", RouteDistinguisher.from(65555L, 0), ExtendedCommunity.of(0, 2, 1), false))
+            new Builder()
+                .setVni(1)
+                .setVrf("v")
+                .setRouteDistinguisher(RouteDistinguisher.from(65555L, 0))
+                .setRouteTarget(ExtendedCommunity.of(0, 2, 1))
+                .setImportRouteTarget("^2:1$")
+                .setAdvertisev4Unicast(false)
+                .build())
         .addEqualityGroup(
-            new Layer3VniConfig(
-                1, "v", RouteDistinguisher.from(65555L, 0), ExtendedCommunity.of(0, 1, 1), true))
+            new Builder()
+                .setVni(1)
+                .setVrf("v")
+                .setRouteDistinguisher(RouteDistinguisher.from(65555L, 0))
+                .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+                .setImportRouteTarget(importRtPatternForAnyAs(1))
+                .setAdvertisev4Unicast(true)
+                .build())
         .testEquals();
   }
 
   @Test
   public void testJavaSerialization() {
     Layer3VniConfig vni =
-        new Layer3VniConfig(
-            1, "v", RouteDistinguisher.from(65555L, 1), ExtendedCommunity.of(0, 1, 1), false);
+        new Builder()
+            .setVni(1)
+            .setVrf("v")
+            .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
+            .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+            .setImportRouteTarget(importRtPatternForAnyAs(1))
+            .setAdvertisev4Unicast(false)
+            .build();
     assertThat(SerializationUtils.clone(vni), equalTo(vni));
   }
 
   @Test
   public void testJsonSerialization() throws IOException {
     Layer3VniConfig vni =
-        new Layer3VniConfig(
-            1, "v", RouteDistinguisher.from(65555L, 1), ExtendedCommunity.of(0, 1, 1), false);
+        new Builder()
+            .setVni(1)
+            .setVrf("v")
+            .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
+            .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+            .setImportRouteTarget(importRtPatternForAnyAs(1))
+            .setAdvertisev4Unicast(false)
+            .build();
     assertThat(BatfishObjectMapper.clone(vni, Layer3VniConfig.class), equalTo(vni));
+  }
+
+  @Test
+  public void testImportRtPatternForAnyAs() {
+    assertThat(importRtPatternForAnyAs(1), equalTo("^\\d+:1$"));
+    assertThat(importRtPatternForAnyAs(2), equalTo("^\\d+:2$"));
+  }
+
+  @Test
+  public void testImportRtPatternForAnyAsTooLow() {
+    _thrown.expect(IllegalArgumentException.class);
+    importRtPatternForAnyAs(-1);
+  }
+
+  @Test
+  public void testImportRtPatternForAnyAsTooHigh() {
+    _thrown.expect(IllegalArgumentException.class);
+    importRtPatternForAnyAs(16777216);
+  }
+
+  @Test
+  public void testInvalidPattern() {
+    _thrown.expect(IllegalArgumentException.class);
+    importRtPatternForAnyAs(16777216);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Layer3VniConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Layer3VniConfigTest.java
@@ -8,7 +8,6 @@ import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
-import org.batfish.datamodel.bgp.Layer3VniConfig.Builder;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,85 +19,36 @@ public class Layer3VniConfigTest {
 
   @Test
   public void testEquals() {
-    Layer3VniConfig vni =
-        new Builder()
+    Layer3VniConfig.Builder builder =
+        Layer3VniConfig.builder()
             .setVni(1)
             .setVrf("v")
             .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
             .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
             .setImportRouteTarget(importRtPatternForAnyAs(1))
-            .setAdvertisev4Unicast(false)
-            .build();
+            .setAdvertiseV4Unicast(false);
+    Layer3VniConfig vni = builder.build();
     new EqualsTester()
-        .addEqualityGroup(
-            vni,
-            vni,
-            new Builder()
-                .setVni(1)
-                .setVrf("v")
-                .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
-                .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
-                .setImportRouteTarget(importRtPatternForAnyAs(1))
-                .setAdvertisev4Unicast(false)
-                .build())
-        .addEqualityGroup(
-            new Builder()
-                .setVni(2)
-                .setVrf("v")
-                .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
-                .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
-                .setImportRouteTarget(importRtPatternForAnyAs(1))
-                .setAdvertisev4Unicast(false)
-                .build())
-        .addEqualityGroup(
-            new Builder()
-                .setVni(1)
-                .setVrf("v2")
-                .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
-                .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
-                .setImportRouteTarget(importRtPatternForAnyAs(1))
-                .setAdvertisev4Unicast(false)
-                .build())
-        .addEqualityGroup(
-            new Builder()
-                .setVni(1)
-                .setVrf("v")
-                .setRouteDistinguisher(RouteDistinguisher.from(65555L, 2))
-                .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
-                .setImportRouteTarget(importRtPatternForAnyAs(1))
-                .setAdvertisev4Unicast(false)
-                .build())
-        .addEqualityGroup(
-            new Builder()
-                .setVni(1)
-                .setVrf("v")
-                .setRouteDistinguisher(RouteDistinguisher.from(65555L, 0))
-                .setRouteTarget(ExtendedCommunity.of(0, 2, 1))
-                .setImportRouteTarget("^2:1$")
-                .setAdvertisev4Unicast(false)
-                .build())
-        .addEqualityGroup(
-            new Builder()
-                .setVni(1)
-                .setVrf("v")
-                .setRouteDistinguisher(RouteDistinguisher.from(65555L, 0))
-                .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
-                .setImportRouteTarget(importRtPatternForAnyAs(1))
-                .setAdvertisev4Unicast(true)
-                .build())
+        .addEqualityGroup(vni, vni, builder.build())
+        .addEqualityGroup(builder.setVni(2).build())
+        .addEqualityGroup(builder.setVrf("v2").build())
+        .addEqualityGroup(builder.setRouteDistinguisher(RouteDistinguisher.from(65555L, 2)).build())
+        .addEqualityGroup(builder.setRouteTarget(ExtendedCommunity.of(0, 2, 1)).build())
+        .addEqualityGroup(builder.setImportRouteTarget(importRtPatternForAnyAs(2)).build())
+        .addEqualityGroup(builder.setAdvertiseV4Unicast(true).build())
         .testEquals();
   }
 
   @Test
   public void testJavaSerialization() {
     Layer3VniConfig vni =
-        new Builder()
+        Layer3VniConfig.builder()
             .setVni(1)
             .setVrf("v")
             .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
             .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
             .setImportRouteTarget(importRtPatternForAnyAs(1))
-            .setAdvertisev4Unicast(false)
+            .setAdvertiseV4Unicast(false)
             .build();
     assertThat(SerializationUtils.clone(vni), equalTo(vni));
   }
@@ -106,13 +56,13 @@ public class Layer3VniConfigTest {
   @Test
   public void testJsonSerialization() throws IOException {
     Layer3VniConfig vni =
-        new Builder()
+        Layer3VniConfig.builder()
             .setVni(1)
             .setVrf("v")
             .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
             .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
             .setImportRouteTarget(importRtPatternForAnyAs(1))
-            .setAdvertisev4Unicast(false)
+            .setAdvertiseV4Unicast(false)
             .build();
     assertThat(BatfishObjectMapper.clone(vni, Layer3VniConfig.class), equalTo(vni));
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -58,7 +58,6 @@ import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.Layer2VniConfig;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
-import org.batfish.datamodel.bgp.Layer3VniConfig.Builder;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
@@ -217,13 +216,13 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
           if (evpnConfig.getAdvertiseDefaultGw()) {
             // Advertise VTEP gateway IP address for the L2 VNI as type 3 route
             l3Vnis.add(
-                new Builder()
+                Layer3VniConfig.builder()
                     .setVni(vxlan.getVni())
                     .setVrf(bgpVrf.getVrfName())
                     .setRouteDistinguisher(rd)
                     .setRouteTarget(rt)
                     .setImportRouteTarget(importRtPatternForAnyAs(vxlan.getVni()))
-                    .setAdvertisev4Unicast(false)
+                    .setAdvertiseV4Unicast(false)
                     .build());
           }
         }
@@ -242,13 +241,13 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
                           vniToIndex.get(l3Vni));
                   ExtendedCommunity rt = ExtendedCommunity.target(localAs, l3Vni);
                   l3Vnis.add(
-                      new Builder()
+                      Layer3VniConfig.builder()
                           .setVni(l3Vni)
                           .setVrf(aBgpVrf.getVrfName())
                           .setRouteDistinguisher(rd)
                           .setRouteTarget(rt)
                           .setImportRouteTarget(importRtPatternForAnyAs(l3Vni))
-                          .setAdvertisev4Unicast(evpnConfig.getAdvertiseIpv4Unicast() != null)
+                          .setAdvertiseV4Unicast(evpnConfig.getAdvertiseIpv4Unicast() != null)
                           .build());
                 }
               });

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -67,7 +67,6 @@ import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
-import org.batfish.datamodel.bgp.Layer3VniConfig.Builder;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.eigrp.EigrpMetric;
@@ -273,13 +272,13 @@ public class VirtualRouterTest {
                 new EvpnAddressFamily(
                     ImmutableSet.of(),
                     ImmutableSet.of(
-                        new Builder()
+                        Layer3VniConfig.builder()
                             .setVni(1)
                             .setVrf(DEFAULT_VRF_NAME)
                             .setRouteDistinguisher(RouteDistinguisher.from(routerId, 2))
                             .setRouteTarget(ExtendedCommunity.target(65500, 10001))
                             .setImportRouteTarget(Layer3VniConfig.importRtPatternForAnyAs(1))
-                            .setAdvertisev4Unicast(false)
+                            .setAdvertiseV4Unicast(false)
                             .build())))
             .build();
     BgpProcess bgpProcess =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -67,6 +67,7 @@ import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
+import org.batfish.datamodel.bgp.Layer3VniConfig.Builder;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.eigrp.EigrpMetric;
@@ -272,12 +273,14 @@ public class VirtualRouterTest {
                 new EvpnAddressFamily(
                     ImmutableSet.of(),
                     ImmutableSet.of(
-                        new Layer3VniConfig(
-                            1,
-                            DEFAULT_VRF_NAME,
-                            RouteDistinguisher.from(routerId, 2),
-                            ExtendedCommunity.target(65500, 10001),
-                            false))))
+                        new Builder()
+                            .setVni(1)
+                            .setVrf(DEFAULT_VRF_NAME)
+                            .setRouteDistinguisher(RouteDistinguisher.from(routerId, 2))
+                            .setRouteTarget(ExtendedCommunity.target(65500, 10001))
+                            .setImportRouteTarget(Layer3VniConfig.importRtPatternForAnyAs(1))
+                            .setAdvertisev4Unicast(false)
+                            .build())))
             .build();
     BgpProcess bgpProcess =
         nf.bgpProcessBuilder()

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -102,7 +102,6 @@ import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.Layer2VniConfig;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
-import org.batfish.datamodel.bgp.Layer3VniConfig.Builder;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.matchers.VniSettingsMatchers;
@@ -1437,30 +1436,30 @@ public final class CumulusNcluGrammarTest {
     ImmutableSortedSet<Layer3VniConfig> expectedL3Vnis =
         ImmutableSortedSet.of(
             // All defined VXLAN VNIs as l3 because of advertise-default-gw
-            new Builder()
+            Layer3VniConfig.builder()
                 .setVni(10001)
                 .setVrf(DEFAULT_VRF_NAME)
                 .setRouteDistinguisher(RouteDistinguisher.from(routerId, 0))
                 .setRouteTarget(ExtendedCommunity.target(65500, 10001))
                 .setImportRouteTarget(Layer3VniConfig.importRtPatternForAnyAs(10001))
-                .setAdvertisev4Unicast(false)
+                .setAdvertiseV4Unicast(false)
                 .build(),
-            new Builder()
+            Layer3VniConfig.builder()
                 .setVni(10002)
                 .setVrf(DEFAULT_VRF_NAME)
                 .setRouteDistinguisher(RouteDistinguisher.from(routerId, 1))
                 .setRouteTarget(ExtendedCommunity.target(65500, 10002))
                 .setImportRouteTarget(Layer3VniConfig.importRtPatternForAnyAs(10002))
-                .setAdvertisev4Unicast(false)
+                .setAdvertiseV4Unicast(false)
                 .build(),
             // VRF1's explicitly defined l3-VNI with advertise-ipv4-unicast
-            new Builder()
+            Layer3VniConfig.builder()
                 .setVni(10004)
                 .setVrf("vrf1")
                 .setRouteDistinguisher(RouteDistinguisher.from(Ip.parse("192.0.1.1"), 2))
                 .setRouteTarget(ExtendedCommunity.target(65500, 10004))
                 .setImportRouteTarget(Layer3VniConfig.importRtPatternForAnyAs(10004))
-                .setAdvertisev4Unicast(true)
+                .setAdvertiseV4Unicast(true)
                 .build());
 
     assertThat(bgpPeer.getEvpnAddressFamily().getL2VNIs(), equalTo(expectedL2Vnis));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -102,6 +102,7 @@ import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.Layer2VniConfig;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
+import org.batfish.datamodel.bgp.Layer3VniConfig.Builder;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.matchers.VniSettingsMatchers;
@@ -1436,25 +1437,31 @@ public final class CumulusNcluGrammarTest {
     ImmutableSortedSet<Layer3VniConfig> expectedL3Vnis =
         ImmutableSortedSet.of(
             // All defined VXLAN VNIs as l3 because of advertise-default-gw
-            new Layer3VniConfig(
-                10001,
-                DEFAULT_VRF_NAME,
-                RouteDistinguisher.from(routerId, 0),
-                ExtendedCommunity.target(65500, 10001),
-                false),
-            new Layer3VniConfig(
-                10002,
-                DEFAULT_VRF_NAME,
-                RouteDistinguisher.from(routerId, 1),
-                ExtendedCommunity.target(65500, 10002),
-                false),
+            new Builder()
+                .setVni(10001)
+                .setVrf(DEFAULT_VRF_NAME)
+                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 0))
+                .setRouteTarget(ExtendedCommunity.target(65500, 10001))
+                .setImportRouteTarget(Layer3VniConfig.importRtPatternForAnyAs(10001))
+                .setAdvertisev4Unicast(false)
+                .build(),
+            new Builder()
+                .setVni(10002)
+                .setVrf(DEFAULT_VRF_NAME)
+                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 1))
+                .setRouteTarget(ExtendedCommunity.target(65500, 10002))
+                .setImportRouteTarget(Layer3VniConfig.importRtPatternForAnyAs(10002))
+                .setAdvertisev4Unicast(false)
+                .build(),
             // VRF1's explicitly defined l3-VNI with advertise-ipv4-unicast
-            new Layer3VniConfig(
-                10004,
-                "vrf1",
-                RouteDistinguisher.from(Ip.parse("192.0.1.1"), 2),
-                ExtendedCommunity.target(65500, 10004),
-                true));
+            new Builder()
+                .setVni(10004)
+                .setVrf("vrf1")
+                .setRouteDistinguisher(RouteDistinguisher.from(Ip.parse("192.0.1.1"), 2))
+                .setRouteTarget(ExtendedCommunity.target(65500, 10004))
+                .setImportRouteTarget(Layer3VniConfig.importRtPatternForAnyAs(10004))
+                .setAdvertisev4Unicast(true)
+                .build());
 
     assertThat(bgpPeer.getEvpnAddressFamily().getL2VNIs(), equalTo(expectedL2Vnis));
     assertThat(bgpPeer.getEvpnAddressFamily().getL3VNIs(), equalTo(expectedL3Vnis));

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -14447,7 +14447,7 @@
                   "evpnAddressFamily" : {
                     "l3Vnis" : [
                       {
-                        "advertiseV4UnicastRoutes" : true,
+                        "advertiseV4Unicast" : true,
                         "importRouteTarget" : "^\\d+:10001$",
                         "routeDistinguisher" : "192.0.2.3:0",
                         "routeTarget" : "2:65500:10001",

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -14532,7 +14532,8 @@
                   "evpnAddressFamily" : {
                     "l3Vnis" : [
                       {
-                        "advertiseV4UnicastRoutes" : true,
+                        "advertiseV4Unicast" : true,
+                        "importRouteTarget" : "^\\d+:10001$",
                         "routeDistinguisher" : "192.0.2.3:0",
                         "routeTarget" : "2:65500:10001",
                         "vni" : 10001,
@@ -14564,7 +14565,8 @@
                   "evpnAddressFamily" : {
                     "l3Vnis" : [
                       {
-                        "advertiseV4UnicastRoutes" : true,
+                        "advertiseV4Unicast" : true,
+                        "importRouteTarget" : "^\\d+:10001$",
                         "routeDistinguisher" : "192.0.2.3:0",
                         "routeTarget" : "2:65500:10001",
                         "vni" : 10001,

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -14448,6 +14448,7 @@
                     "l3Vnis" : [
                       {
                         "advertiseV4UnicastRoutes" : true,
+                        "importRouteTarget" : "^\\d+:10001$",
                         "routeDistinguisher" : "192.0.2.3:0",
                         "routeTarget" : "2:65500:10001",
                         "vni" : 10001,


### PR DESCRIPTION
For eBGP, import RT must differ from export RT because remote as is not
known ahead of time.

Also, switch to builder pattern.

Any one reviewer will do.