### PR TITLE
optimize BDDSourceManager

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
@@ -243,7 +243,7 @@ public final class BDDSourceManager {
     ImmutableSet.Builder<String> builder = ImmutableSet.builder();
     builder.addAll(activeAndReferenced);
 
-    // add one source as the representative of "everything else"
+    // use the min active but unreferenced source to represent any/all of them
     if (!activeButUnreferenced.isEmpty()) {
       builder.add(activeButUnreferenced.stream().min(Comparator.naturalOrder()).get());
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
@@ -46,8 +46,9 @@ public final class BDDSourceManager {
    * the finite domain doesn't track each active but unreferenced source. Instead, it tracks a
    * single representative value that represents all of them.
    *
-   * <p>{@code null} when (1) there are no referenced sources, or (2) there are no active but
-   * unreferenced sources.
+   * <p>{@code null} when we don't need BDDs to distinguish between active and referenced sources vs
+   * active but unreferenced sources. This is true when either (1) there are no active and
+   * referenced sources, or (2) there are no active but unreferenced sources.
    */
   private final @Nullable String _activeButUnreferencedRepresentative;
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
@@ -101,6 +101,8 @@ public class BDDSourceManagerTest {
     IpAccessList acl = config.getIpAccessLists().values().iterator().next();
 
     BDDSourceManager mgr = BDDSourceManager.forIpAccessList(_pkt, config, acl);
+    assertFalse(mgr.isTrivial());
+    assertFalse(mgr.allSourcesTracked());
 
     BDD iface1BDD = mgr.getSourceInterfaceBDD(IFACE1);
     BDD iface2BDD = mgr.getSourceInterfaceBDD(IFACE2);
@@ -118,7 +120,7 @@ public class BDDSourceManagerTest {
   @Test
   public void testForNetwork() {
     /*
-     * Create a network with two configs. Both have two interfaces and
+     * Create a network with two configs. Both have the same interfaces and ACLs
      */
     NetworkFactory nf = new NetworkFactory();
     Configuration config1 = configWithOneAcl(nf);
@@ -140,19 +142,23 @@ public class BDDSourceManagerTest {
   @Test
   public void testAllSourcesTracked() {
     BDDSourceManager mgr = BDDSourceManager.forSources(_pkt, ALL_IFACES, ALL_IFACES);
+    assertFalse(mgr.isTrivial());
     assertTrue(mgr.allSourcesTracked());
 
     mgr = BDDSourceManager.forSources(_pkt, ALL_IFACES, ImmutableSet.of(IFACE1));
+    assertFalse(mgr.isTrivial());
     assertFalse(mgr.allSourcesTracked());
   }
 
   @Test
   public void testSourceBDDs() {
     BDDSourceManager mgr = BDDSourceManager.forSources(_pkt, ALL_IFACES, ALL_IFACES);
+    assertFalse(mgr.isTrivial());
     Map<String, BDD> srcBdds = mgr.getSourceBDDs();
     assertEquals(srcBdds.values().stream().distinct().count(), ALL_IFACES.size());
 
     mgr = BDDSourceManager.forSources(_pkt, ALL_IFACES, ImmutableSet.of(IFACE1));
+    assertFalse(mgr.isTrivial());
     srcBdds = mgr.getSourceBDDs();
     BDD iface1 = srcBdds.get(IFACE1);
     BDD others = srcBdds.get(IFACE2); // some other source
@@ -181,6 +187,7 @@ public class BDDSourceManagerTest {
     String hostname = config.getHostname();
     Map<String, Configuration> configs = ImmutableMap.of(hostname, config);
     BDDSourceManager mgr = BDDSourceManager.forNetwork(_pkt, configs, true).get(hostname);
+    assertFalse(mgr.isTrivial());
     assertTrue(mgr.allSourcesTracked());
     assertEquals(
         mgr.getSourceBDDs().keySet(),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
@@ -67,6 +67,7 @@ public class BDDSourceManagerTest {
   @Test
   public void testNoReferencedSources() {
     BDDSourceManager mgr = BDDSourceManager.forSources(_pkt, IFACES_1_2, ImmutableSet.of());
+    assertTrue(mgr.isTrivial());
     assertTrue(mgr.getSourceInterfaceBDD(IFACE1).isOne());
     assertTrue(mgr.getSourceInterfaceBDD(IFACE2).isOne());
   }
@@ -200,7 +201,8 @@ public class BDDSourceManagerTest {
     String hostname = config.getHostname();
     Map<String, Configuration> configs = ImmutableMap.of(hostname, config);
     BDDSourceManager mgr = BDDSourceManager.forNetwork(_pkt, configs, true).get(hostname);
-    assertTrue(!mgr.allSourcesTracked());
+    assertTrue(mgr.isTrivial());
+    assertFalse(mgr.allSourcesTracked());
     assertEquals(
         mgr.getSourceBDDs().keySet(),
         ImmutableSet.of(IFACE1, IFACE2, IFACE3, SOURCE_ORIGINATING_FROM_DEVICE));


### PR DESCRIPTION
When no sources are referenced, we don't need a representative of the
active but unreferenced sources. Not having one makes the manager
trivial, which makes source tracking more efficient.