### PR TITLE
Cumulus: bgp send community is true by default

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchers.java
@@ -17,6 +17,7 @@ import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasExportPolicy;
 import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasLocalAs;
 import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasLocalIp;
 import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasRemoteAs;
+import org.batfish.datamodel.matchers.BgpNeighborMatchersImpl.HasSendCommunity;
 import org.hamcrest.Matcher;
 
 /** Matchers for {@link BgpPeerConfig} */
@@ -129,5 +130,13 @@ public class BgpNeighborMatchers {
    */
   public static Matcher<BgpPeerConfig> hasRemoteAs(Matcher<? super LongSpace> subMatcher) {
     return new HasRemoteAs(subMatcher);
+  }
+
+  /**
+   * Provides a matcher that matches if the {@link BgpPeerConfig}'s sendCommunity is equal to the
+   * given value.
+   */
+  public static Matcher<BgpPeerConfig> hasSendCommunity(boolean value) {
+    return new HasSendCommunity(equalTo(value));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpNeighborMatchersImpl.java
@@ -106,4 +106,15 @@ final class BgpNeighborMatchersImpl {
       return actual.getRemoteAsns();
     }
   }
+
+  static final class HasSendCommunity extends FeatureMatcher<BgpPeerConfig, Boolean> {
+    HasSendCommunity(@Nonnull Matcher<? super Boolean> subMatcher) {
+      super(subMatcher, "A BgpPeerConfig with sendCommunity:", "sendCommunity");
+    }
+
+    @Override
+    protected Boolean featureValueOf(BgpPeerConfig actual) {
+      return actual.getSendCommunity();
+    }
+  }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -183,7 +183,8 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
             .setLocalAs(localAs)
             .setLocalIp(BgpProcess.BGP_UNNUMBERED_IP)
             .setPeerInterface(peerInterface)
-            .setRemoteAsns(computeRemoteAsns(neighbor, localAs));
+            .setRemoteAsns(computeRemoteAsns(neighbor, localAs))
+            .setSendCommunity(true);
     builder.setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.instance());
 
     BgpL2vpnEvpnAddressFamily evpnConfig = bgpVrf.getL2VpnEvpn();

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasExportPolicy;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasLocalAs;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasRemoteAs;
+import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasSendCommunity;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasInterfaceNeighbors;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasRouterId;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpRouteThat;
@@ -241,6 +242,7 @@ public final class CumulusNcluGrammarTest {
         BgpUnnumberedPeerConfig.builder()
             .setLocalIp(BGP_UNNUMBERED_IP)
             .setPeerInterface("swp1")
+            .setSendCommunity(true)
             .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.instance())
             .setExportPolicy(computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, "swp1"));
     Map<String, BgpUnnumberedPeerConfig> expectedPeers1 =
@@ -315,6 +317,7 @@ public final class CumulusNcluGrammarTest {
     assertThat(pc, hasLocalAs(65500L));
     assertThat(pc, hasRemoteAs(equalTo(ALL_AS_NUMBERS.difference(LongSpace.of(65500L)))));
     assertThat(pc, hasExportPolicy(peerExportPolicyName));
+    assertThat(pc, hasSendCommunity(true));
 
     // ARP response for link-local address for BGP unnumbered interface
     assertThat(c, hasInterface(peerInterface, hasAdditionalArpIps(containsIp(BGP_UNNUMBERED_IP))));

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -14477,7 +14477,7 @@
                   "peerInterface" : "swp1",
                   "remoteAsns" : "1-65499,65501-4294967295",
                   "routeReflectorClient" : false,
-                  "sendCommunity" : false
+                  "sendCommunity" : true
                 }
               },
               "multipathEbgp" : false,


### PR DESCRIPTION
Our tests and also docs, indirectly (https://docs.cumulusnetworks.com/display/DOCS/Border+Gateway+Protocol+-+BGP#BorderGatewayProtocol-BGP-BGPCommunityLists) indicate that this is the case