### PR TITLE
PaloAlto: fix parser for link-state

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -351,9 +351,9 @@ LIFETIME
     'lifetime'
 ;
 
-LINK_STATUS
+LINK_STATE
 :
-    'link-status'
+    'link-state'
 ;
 
 LLDP

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
@@ -20,7 +20,7 @@ sni_ethernet
     (
         snie_comment
         | snie_layer3
-        | snie_link_status
+        | snie_link_state
     )
 ;
 
@@ -38,9 +38,9 @@ snie_layer3
     )
 ;
 
-snie_link_status
+snie_link_state
 :
-    LINK_STATUS
+    LINK_STATE
     (
         AUTO
         | DOWN

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -85,7 +85,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Snicp_global_protectContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snicp_ike_crypto_profilesContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snicp_ipsec_crypto_profilesContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snie_commentContext;
-import org.batfish.grammar.palo_alto.PaloAltoParser.Snie_link_statusContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Snie_link_stateContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sniel3_ipContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sniel3_mtuContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sniel3_unitsContext;
@@ -703,7 +703,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   }
 
   @Override
-  public void exitSnie_link_status(Snie_link_statusContext ctx) {
+  public void exitSnie_link_state(Snie_link_stateContext ctx) {
     _currentInterface.setActive((ctx.DOWN() == null));
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface
@@ -2,10 +2,10 @@ set deviceconfig system hostname interface
 set network interface ethernet ethernet1/1 layer3 mtu 9001
 set network interface ethernet ethernet1/1 layer3 ip 1.1.1.1/24
 set network interface ethernet ethernet1/1 comment description
-set network interface ethernet ethernet1/2 link-status down
+set network interface ethernet ethernet1/2 link-state down
 set network interface ethernet ethernet1/2 comment "interface's long description"
-set network interface ethernet ethernet1/3 link-status down
-set network interface ethernet ethernet1/3 link-status up
+set network interface ethernet ethernet1/3 link-state down
+set network interface ethernet ethernet1/3 link-state up
 set network interface ethernet ethernet1/3 comment 'single quoted description'
 # Interfaces are not functionally active unless they are in a virtual-router
 set network virtual-router default interface [ ethernet1/1 ethernet1/2 ethernet1/3 ]


### PR DESCRIPTION
The command is link-state, not link-status.

E.g., see: https://knowledgebase.paloaltonetworks.com/KCSArticleDetail?id=kA10g000000ClZQCA0

searching for "palo alto" "link-status down" only found things about `show`, not `set`.