### PR TITLE
Specialize a BgpRoute matcher

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchers.java
@@ -7,12 +7,13 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.HasCommunities;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.HasOriginType;
 import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.HasWeight;
-import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.IsBgpRouteThat;
+import org.batfish.datamodel.matchers.BgpRouteMatchersImpl.IsBgpv4RouteThat;
 import org.hamcrest.Matcher;
 
 @ParametersAreNonnullByDefault
@@ -44,12 +45,12 @@ public final class BgpRouteMatchers {
   }
 
   /**
-   * Provides a matcher that matches when the {@link AbstractRoute} is a {@link BgpRoute} matched by
-   * the provided {@code subMatcher}.
+   * Provides a matcher that matches when the {@link AbstractRoute} is a {@link Bgpv4Route} matched
+   * by the provided {@code subMatcher}.
    */
-  public static @Nonnull Matcher<AbstractRoute> isBgpRouteThat(
-      Matcher<? super BgpRoute> subMatcher) {
-    return new IsBgpRouteThat(subMatcher);
+  public static @Nonnull Matcher<AbstractRoute> isBgpv4RouteThat(
+      Matcher<? super Bgpv4Route> subMatcher) {
+    return new IsBgpv4RouteThat(subMatcher);
   }
 
   private BgpRouteMatchers() {}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchersImpl.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.BgpRoute;
+import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.bgp.community.Community;
 import org.hamcrest.FeatureMatcher;
@@ -45,9 +46,9 @@ final class BgpRouteMatchersImpl {
     }
   }
 
-  static final class IsBgpRouteThat extends IsInstanceThat<AbstractRoute, BgpRoute> {
-    IsBgpRouteThat(Matcher<? super BgpRoute> subMatcher) {
-      super(BgpRoute.class, subMatcher);
+  static final class IsBgpv4RouteThat extends IsInstanceThat<AbstractRoute, Bgpv4Route> {
+    IsBgpv4RouteThat(Matcher<? super Bgpv4Route> subMatcher) {
+      super(Bgpv4Route.class, subMatcher);
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -36,7 +36,7 @@ import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasMultipathEbgp
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasMultipathEquivalentAsPathMatchMode;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasNeighbors;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasWeight;
-import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpRouteThat;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpv4RouteThat;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasConfigurationFormat;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIkePhase1Policy;
@@ -1485,8 +1485,8 @@ public class CiscoGrammarTest {
     IncrementalDataPlane dp = (IncrementalDataPlane) batfish.loadDataPlane();
     Set<AbstractRoute> r1Routes = dp.getRibs().get("r1").get(DEFAULT_VRF_NAME).getRoutes();
     Set<AbstractRoute> r2Routes = dp.getRibs().get("r2").get(DEFAULT_VRF_NAME).getRoutes();
-    assertThat(r1Routes, hasItem(isBgpRouteThat(hasPrefix(Prefix.parse("8.8.8.8/32")))));
-    assertThat(r2Routes, hasItem(isBgpRouteThat(hasPrefix(Prefix.parse("7.7.7.7/32")))));
+    assertThat(r1Routes, hasItem(isBgpv4RouteThat(hasPrefix(Prefix.parse("8.8.8.8/32")))));
+    assertThat(r2Routes, hasItem(isBgpv4RouteThat(hasPrefix(Prefix.parse("7.7.7.7/32")))));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -8,7 +8,6 @@ import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasRemoteAs;
 import static org.batfish.datamodel.matchers.BgpNeighborMatchers.hasSendCommunity;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasInterfaceNeighbors;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasRouterId;
-import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpRouteThat;
 import static org.batfish.datamodel.matchers.BgpUnnumberedPeerConfigMatchers.hasPeerInterface;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasHostname;
@@ -295,8 +294,8 @@ public final class CumulusNcluGrammarTest {
             .setOriginatorIp(Ip.parse("192.0.2.1"))
             .build();
 
-    assertThat(n1Routes, hasItem(isBgpRouteThat(equalTo(expectedRoute1))));
-    assertThat(n2Routes, hasItem(isBgpRouteThat(equalTo(expectedRoute2))));
+    assertThat(n1Routes, hasItem(equalTo(expectedRoute1)));
+    assertThat(n2Routes, hasItem(equalTo(expectedRoute2)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishGrammarTest.java
@@ -16,7 +16,7 @@ import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasNeighbors;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasRouterId;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasCommunities;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasOriginType;
-import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpRouteThat;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpv4RouteThat;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpAccessLists;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasNumReferrers;
@@ -337,8 +337,8 @@ public final class F5BigipImishGrammarTest {
     assertThat(routes2, hasItem(isKernelRouteThat(hasPrefix(Prefix.strict("10.0.0.2/32")))));
 
     // kernel routes should be redistributed
-    assertThat(routes1, hasItem(isBgpRouteThat(hasPrefix(Prefix.strict("10.0.0.2/32")))));
-    assertThat(routes2, hasItem(isBgpRouteThat(hasPrefix(Prefix.strict("10.0.0.1/32")))));
+    assertThat(routes1, hasItem(isBgpv4RouteThat(hasPrefix(Prefix.strict("10.0.0.2/32")))));
+    assertThat(routes2, hasItem(isBgpv4RouteThat(hasPrefix(Prefix.strict("10.0.0.1/32")))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredGrammarTest.java
@@ -15,7 +15,7 @@ import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasActiveNeighbo
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasMultipathEquivalentAsPathMatchMode;
 import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasRouterId;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasCommunities;
-import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpRouteThat;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpv4RouteThat;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterfaces;
@@ -333,8 +333,8 @@ public final class F5BigipStructuredGrammarTest {
     assertThat(routes2, hasItem(isKernelRouteThat(hasPrefix(Prefix.strict("10.0.0.2/32")))));
 
     // kernel routes should be redistributed
-    assertThat(routes1, hasItem(isBgpRouteThat(hasPrefix(Prefix.strict("10.0.0.2/32")))));
-    assertThat(routes2, hasItem(isBgpRouteThat(hasPrefix(Prefix.strict("10.0.0.1/32")))));
+    assertThat(routes1, hasItem(isBgpv4RouteThat(hasPrefix(Prefix.strict("10.0.0.2/32")))));
+    assertThat(routes2, hasItem(isBgpv4RouteThat(hasPrefix(Prefix.strict("10.0.0.1/32")))));
   }
 
   @Test


### PR DESCRIPTION
We use `IsBgpRouteThat` only when we really mean `Bgpv4RouteThat`.
Rename to reflect that.
This also eases making `BgpRoute` generic.