### PR TITLE
BGP: simplify transformations 1

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -28,7 +28,7 @@ public class BgpProcess implements Serializable {
     private Ip _routerId;
     private Vrf _vrf;
 
-    Builder(NetworkFactory networkFactory) {
+    private Builder(@Nullable NetworkFactory networkFactory) {
       super(networkFactory, BgpProcess.class);
     }
 
@@ -167,6 +167,14 @@ public class BgpProcess implements Serializable {
         firstNonNull(
             ibgpAdminCost,
             RoutingProtocol.IBGP.getDefaultAdministrativeCost(ConfigurationFormat.CISCO_IOS)));
+  }
+
+  public static Builder builder() {
+    return new Builder(null);
+  }
+
+  static Builder builder(@Nullable NetworkFactory nf) {
+    return new Builder(nf);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -85,6 +85,11 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
     }
 
     @Nullable
+    public String getNextHopInterface() {
+      return _nextHopInterface;
+    }
+
+    @Nullable
     public Ip getOriginatorIp() {
       return _originatorIp;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkFactory.java
@@ -68,7 +68,7 @@ public class NetworkFactory {
   }
 
   public BgpProcess.Builder bgpProcessBuilder() {
-    return new BgpProcess.Builder(this);
+    return BgpProcess.builder(this);
   }
 
   public Configuration.Builder configurationBuilder() {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -54,6 +54,10 @@ public class BgpProtocolHelperTest {
             _process,
             null),
         nullValue());
+  }
+
+  @Test
+  public void testTransformOnImportAllowAsIn() {
     assertThat(
         "AS path loop allowed",
         transformBgpRouteOnImport(
@@ -64,6 +68,10 @@ public class BgpProtocolHelperTest {
             _process,
             null),
         notNullValue());
+  }
+
+  @Test
+  public void testTransformOnImportEbgp() {
     assertThat(
         "No AS path loop, eBGP",
         transformBgpRouteOnImport(
@@ -75,17 +83,19 @@ public class BgpProtocolHelperTest {
                 null)
             .getProtocol(),
         equalTo(RoutingProtocol.BGP));
+  }
+
+  @Test
+  public void testTransformOnImportIbgp() {
     assertThat(
         "No AS path loop, iBGP",
-        transformBgpRouteOnImport(
-                _baseBgpRouteBuilder.setAsPath(AsPath.empty()).build(),
-                1L,
-                false,
-                false,
-                _process,
-                null)
+        transformBgpRouteOnImport(_baseBgpRouteBuilder.build(), 1L, false, false, _process, null)
             .getProtocol(),
         equalTo(RoutingProtocol.IBGP));
+  }
+
+  @Test
+  public void testTransformOnImportClearAdminSetInterface() {
     final Builder builder =
         transformBgpRouteOnImport(
             _baseBgpRouteBuilder.setAdmin(Integer.MAX_VALUE).build(),

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -1,0 +1,103 @@
+package org.batfish.dataplane.protocols;
+
+import static org.batfish.dataplane.protocols.BgpProtocolHelper.transformBgpRouteOnImport;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.batfish.datamodel.AsPath;
+import org.batfish.datamodel.BgpProcess;
+import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.Bgpv4Route.Builder;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RoutingProtocol;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BgpProtocolHelperTest {
+  private static final Ip DEST_IP = Ip.parse("3.3.3.3");
+  private static final Prefix DEST_NETWORK = Prefix.parse("4.4.4.0/24");
+  private static final Ip ORIGINATOR_IP = Ip.parse("1.1.1.1");
+  private final BgpProcess _process =
+      BgpProcess.builder()
+          .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
+          .setRouterId(ORIGINATOR_IP)
+          .build();
+  private Builder _baseBgpRouteBuilder;
+
+  /** Reset route builder */
+  @Before
+  public void resetDefaultRouteBuilders() {
+    _baseBgpRouteBuilder =
+        new Bgpv4Route.Builder()
+            .setOriginatorIp(ORIGINATOR_IP)
+            .setOriginType(OriginType.IGP)
+            .setNetwork(DEST_NETWORK)
+            .setNextHopIp(DEST_IP)
+            .setProtocol(RoutingProtocol.IBGP)
+            .setReceivedFromIp(Ip.ZERO);
+  }
+
+  @Test
+  public void testTransformOnImportNoAllowAsIn() {
+    assertThat(
+        "AS path loop, return null",
+        transformBgpRouteOnImport(
+            _baseBgpRouteBuilder.setAsPath(AsPath.ofSingletonAsSets(1L)).build(),
+            1L,
+            false,
+            true,
+            _process,
+            null),
+        nullValue());
+    assertThat(
+        "AS path loop allowed",
+        transformBgpRouteOnImport(
+            _baseBgpRouteBuilder.setAsPath(AsPath.ofSingletonAsSets(1L)).build(),
+            1L,
+            true,
+            true,
+            _process,
+            null),
+        notNullValue());
+    assertThat(
+        "No AS path loop, eBGP",
+        transformBgpRouteOnImport(
+                _baseBgpRouteBuilder.setAsPath(AsPath.ofSingletonAsSets(1L)).build(),
+                2L,
+                false,
+                true,
+                _process,
+                null)
+            .getProtocol(),
+        equalTo(RoutingProtocol.BGP));
+    assertThat(
+        "No AS path loop, iBGP",
+        transformBgpRouteOnImport(
+                _baseBgpRouteBuilder.setAsPath(AsPath.empty()).build(),
+                1L,
+                false,
+                false,
+                _process,
+                null)
+            .getProtocol(),
+        equalTo(RoutingProtocol.IBGP));
+    final Builder builder =
+        transformBgpRouteOnImport(
+            _baseBgpRouteBuilder.setAdmin(Integer.MAX_VALUE).build(),
+            2L,
+            false,
+            true,
+            _process,
+            "eth0");
+    assertThat("PeerInterface is set", builder.getNextHopInterface(), equalTo("eth0"));
+    assertThat(
+        "AdminDistance is set",
+        builder.getAdmin(),
+        equalTo(RoutingProtocol.BGP.getDefaultAdministrativeCost(ConfigurationFormat.CISCO_IOS)));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
@@ -119,8 +119,7 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
           _sessionProperties,
           _fromBgpProcess,
           _toBgpProcess,
-          convertGeneratedRouteToBgp((GeneratedRoute) route, _fromBgpProcess.getRouterId(), false),
-          Bgpv4Route.builder());
+          convertGeneratedRouteToBgp((GeneratedRoute) route, _fromBgpProcess.getRouterId(), false));
     } else if (route instanceof Bgpv4Route) {
       return BgpProtocolHelper.transformBgpRoutePreExport(
           _fromNeighbor,
@@ -128,8 +127,7 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
           _sessionProperties,
           _fromBgpProcess,
           _toBgpProcess,
-          (Bgpv4Route) route,
-          Bgpv4Route.builder());
+          (Bgpv4Route) route);
     } else {
       RoutingProtocol protocol =
           _sessionProperties.isEbgp() ? RoutingProtocol.BGP : RoutingProtocol.IBGP;
@@ -145,8 +143,7 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
                   _sessionProperties.getTailIp(),
                   protocol.getDefaultAdministrativeCost(ConfigurationFormat.CISCO_IOS),
                   protocol)
-              .build(),
-          Bgpv4Route.builder());
+              .build());
     }
   }
 


### PR DESCRIPTION
Remove builder as parameter from transformation functions, simplify import
of BGP routes, add tests for import.

Side effect: cleanup the builder pattern for BgpProcess a little.