### PR TITLE
junit: use newer bazel syntax

### DIFF
--- a/skylark/junit.bzl
+++ b/skylark/junit.bzl
@@ -55,7 +55,7 @@ def _impl(ctx):
     classes = ",".join(
         [_AsClassName(x) for x in ctx.attr.srcs],
     )
-    ctx.file_action(output = ctx.outputs.out, content = _OUTPUT % (
+    ctx.actions.write(output = ctx.outputs.out, content = _OUTPUT % (
         classes,
         ctx.attr.outname,
     ))


### PR DESCRIPTION
Required after bazel 0.26.0