### PR TITLE
Parsing rsa-encr authentication method in IKE

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkeAuthenticationMethod.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IkeAuthenticationMethod.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel;
 public enum IkeAuthenticationMethod {
   DSA_SIGNATURES,
   PRE_SHARED_KEYS,
+  RSA_ENCRYPTED_NONCES,
   RSA_SIGNATURES,
   X509
 }

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -11013,7 +11013,7 @@ RSA
 
 RSA_ENCR
 :
- 'rsa-encr'
+   'rsa-encr'
 ;
 
 RSA_SIG

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -11011,6 +11011,11 @@ RSA
    'rsa'
 ;
 
+RSA_ENCR
+:
+ 'rsa-encr'
+;
+
 RSA_SIG
 :
    'rsa-sig'
@@ -15350,6 +15355,11 @@ M_Authentication_PPP
 M_Authentication_PRE_SHARE
 :
    'pre-share' -> type ( PRE_SHARE ) , popMode
+;
+
+M_Authentication_RSA_ENCR
+:
+   'rsa-encr' -> type ( RSA_ENCR ) , popMode
 ;
 
 M_Authentication_RSA_SIG

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_crypto.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_crypto.g4
@@ -411,6 +411,7 @@ cispol_authentication
    AUTHENTICATION
    (
       PRE_SHARE
+      | RSA_ENCR
       | RSA_SIG
    ) NEWLINE
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -2048,6 +2048,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   public void exitCispol_authentication(Cispol_authenticationContext ctx) {
     if (ctx.PRE_SHARE() != null) {
       _currentIsakmpPolicy.setAuthenticationMethod(IkeAuthenticationMethod.PRE_SHARED_KEYS);
+    } else if (ctx.RSA_ENCR() != null) {
+      _currentIsakmpPolicy.setAuthenticationMethod(IkeAuthenticationMethod.RSA_ENCRYPTED_NONCES);
     } else if (ctx.RSA_SIG() != null) {
       _currentIsakmpPolicy.setAuthenticationMethod(IkeAuthenticationMethod.RSA_SIGNATURES);
     } else {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -3834,6 +3834,12 @@ public class CiscoGrammarTest {
                 IkePhase1ProposalMatchers.hasHashingAlgorithm(IkeHashingAlgorithm.SHA1),
                 IkePhase1ProposalMatchers.hasDiffieHellmanGroup(DiffieHellmanGroup.GROUP2),
                 IkePhase1ProposalMatchers.hasLifeTimeSeconds(86400))));
+    assertThat(
+        c,
+        hasIkePhase1Proposal(
+            "30",
+            IkePhase1ProposalMatchers.hasAuthenticationMethod(
+                IkeAuthenticationMethod.RSA_ENCRYPTED_NONCES)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -3857,9 +3857,8 @@ public class CiscoGrammarTest {
                 hasRemoteIdentity(containsIp(Ip.parse("1.2.3.4"))),
                 hasSelfIdentity(equalTo(Ip.parse("2.3.4.6"))),
                 hasLocalInterface(equalTo("TenGigabitEthernet0/0")),
-                // TODO: filter proposals during conversion so that they match IKE Phase 1
-                // proposal's
-                // authentication method
+                // TODO: filter proposals during conversion so that they match IKE Phase 1 policy's
+                // key type
                 hasIkePhase1Proposals(equalTo(ImmutableList.of("10", "20", "30"))))));
 
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -3857,7 +3857,10 @@ public class CiscoGrammarTest {
                 hasRemoteIdentity(containsIp(Ip.parse("1.2.3.4"))),
                 hasSelfIdentity(equalTo(Ip.parse("2.3.4.6"))),
                 hasLocalInterface(equalTo("TenGigabitEthernet0/0")),
-                hasIkePhase1Proposals(equalTo(ImmutableList.of("10", "20"))))));
+                // TODO: filter proposals during conversion so that they match IKE Phase 1
+                // proposal's
+                // authentication method
+                hasIkePhase1Proposals(equalTo(ImmutableList.of("10", "20", "30"))))));
 
     assertThat(
         c,
@@ -3870,7 +3873,7 @@ public class CiscoGrammarTest {
                 hasRemoteIdentity(containsIp(Ip.parse("1.2.3.4"))),
                 hasSelfIdentity(equalTo(Ip.parse("2.3.4.6"))),
                 hasLocalInterface(equalTo("TenGigabitEthernet0/0")),
-                hasIkePhase1Proposals(equalTo(ImmutableList.of("10", "20"))))));
+                hasIkePhase1Proposals(equalTo(ImmutableList.of("10", "20", "30"))))));
   }
 
   private static CommunitySetExpr communityListToMatchCondition(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-crypto
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-crypto
@@ -10,6 +10,9 @@ crypto isakmp policy 10
   authentication rsa-sig
   lifetime 14400
 !
+crypto isakmp policy 30
+  authentication rsa-encr
+!
 crypto keyring ISAKMP-KEYRING-ADDRESS
   pre-shared-key address 1.2.3.4 key psk1
   local-address 2.3.4.6


### PR DESCRIPTION
parsing RSA encryption authentication method in Cisco IOS's ISAKMP policy
ISAKMP policy is stored in VI model's `IkePhase1Proposal`