### PR TITLE
 Property specifier descriptions: tweaks and todos

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
@@ -54,51 +54,55 @@ public class BgpPeerPropertySpecifier extends PropertySpecifier {
               new PropertyDescriptor<>(
                   BgpPeerPropertySpecifier::getLocalIp,
                   Schema.IP,
-                  "Local IPv4 address (null for BGP unnumbered peerings)"))
+                  "Local IPv4 address (null for BGP unnumbered peers)"))
           .put(
               IS_PASSIVE,
               new PropertyDescriptor<>(
-                  (peer) -> getIsPassive(peer), Schema.BOOLEAN, "Whether the peering is passive"))
+                  BgpPeerPropertySpecifier::getIsPassive,
+                  Schema.BOOLEAN,
+                  "Whether this peer is passive"))
           .put(
               REMOTE_AS,
               new PropertyDescriptor<>(
                   BgpPeerConfig::getRemoteAsns,
                   Schema.STRING,
-                  "Valid remote AS numbers for session establishment"))
+                  "Remote AS numbers with which this peer may establish a session"))
           .put(
               ROUTE_REFLECTOR_CLIENT,
               new PropertyDescriptor<>(
                   BgpPeerConfig::getRouteReflectorClient,
                   Schema.BOOLEAN,
-                  "Whether the peering points to a route reflector client"))
+                  "Whether this peer is a route reflector client"))
           .put(
               CLUSTER_ID,
               new PropertyDescriptor<>(
-                  (peer) -> getClusterId(peer), Schema.IP, "TODO: description"))
+                  BgpPeerPropertySpecifier::getClusterId,
+                  Schema.IP,
+                  "Cluster ID of this peer (null for peers that are not route reflector clients)"))
           .put(
               PEER_GROUP,
               new PropertyDescriptor<>(
                   BgpPeerConfig::getGroup,
                   Schema.STRING,
-                  "Name of the group to which this peering belongs"))
+                  "Name of the BGP peer group to which this peer belongs"))
           .put(
               IMPORT_POLICY,
               new PropertyDescriptor<>(
                   BgpPeerConfig::getImportPolicySources,
                   Schema.set(Schema.STRING),
-                  "Names of import policies to be applied"))
+                  "Names of import policies to be applied to routes received by this peer"))
           .put(
               EXPORT_POLICY,
               new PropertyDescriptor<>(
                   BgpPeerConfig::getExportPolicySources,
                   Schema.set(Schema.STRING),
-                  "Names of export policies to be applied"))
+                  "Names of export policies to be applied to routes exported by this peer"))
           .put(
               SEND_COMMUNITY,
               new PropertyDescriptor<>(
                   BgpPeerConfig::getSendCommunity,
                   Schema.BOOLEAN,
-                  "Whether to propagate communities along this peering"))
+                  "Whether this peer propagates communities"))
           .build();
 
   /** A {@link BgpPeerPropertySpecifier} that matches all BGP properties. */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpProcessPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpProcessPropertySpecifier.java
@@ -48,7 +48,7 @@ public class BgpProcessPropertySpecifier extends PropertySpecifier {
               new PropertyDescriptor<>(
                   BgpProcessPropertySpecifier::isRouteReflector,
                   Schema.BOOLEAN,
-                  "Whether any BGP peer is configured as a route reflector client"))
+                  "Whether any BGP peer in this process is configured as a route reflector client"))
           .put(
               MULTIPATH_EQUIVALENT_AS_PATH_MATCH_MODE,
               new PropertyDescriptor<>(
@@ -80,7 +80,7 @@ public class BgpProcessPropertySpecifier extends PropertySpecifier {
                           process.getPassiveNeighbors().keySet(),
                           process.getInterfaceNeighbors().keySet()),
                   Schema.set(Schema.STRING),
-                  "TODO: description ... what is reported for each type of neighbor"))
+                  "All peers configured on this process, identified by peer address (for active and dynamic peers) or peer interface (for BGP unnumbered peers)"))
           // skip router-id; included as part of process identity
           .put(
               TIE_BREAKER,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
@@ -81,7 +81,7 @@ public class NodePropertySpecifier extends PropertySpecifier {
               new PropertyDescriptor<>(
                   Configuration::getAuthenticationKeyChains,
                   Schema.set(Schema.STRING),
-                  "Names of authentication key chains"))
+                  "Names of authentication keychains"))
           .put(
               COMMUNITY_LISTS,
               new PropertyDescriptor<>(
@@ -135,7 +135,7 @@ public class NodePropertySpecifier extends PropertySpecifier {
               new PropertyDescriptor<>(
                   Configuration::getDnsSourceInterface,
                   Schema.STRING,
-                  "Source interface to use for communicating with the DNS servers"))
+                  "Source interface to use for communicating with DNS servers"))
           .put(
               DOMAIN_NAME,
               new PropertyDescriptor<>(
@@ -191,7 +191,7 @@ public class NodePropertySpecifier extends PropertySpecifier {
               new PropertyDescriptor<>(
                   Configuration::getIpsecPhase2Policies,
                   Schema.set(Schema.STRING),
-                  "Names of IKE Phase 2 policies"))
+                  "Names of IPSec Phase 2 policies"))
           .put(
               IPSEC_PHASE2_PROPOSALS,
               new PropertyDescriptor<>(
@@ -209,7 +209,7 @@ public class NodePropertySpecifier extends PropertySpecifier {
               new PropertyDescriptor<>(
                   Configuration::getLoggingSourceInterface,
                   Schema.STRING,
-                  "Source interface for communicating with the logging servers"))
+                  "Source interface for communicating with logging servers"))
           .put(
               NTP_SERVERS,
               new PropertyDescriptor<>(
@@ -221,7 +221,7 @@ public class NodePropertySpecifier extends PropertySpecifier {
               new PropertyDescriptor<>(
                   Configuration::getNtpSourceInterface,
                   Schema.STRING,
-                  "Source interface for communication with the NTP servers"))
+                  "Source interface for communicating with NTP servers"))
           .put(
               ROUTE_FILTER_LISTS,
               new PropertyDescriptor<>(
@@ -245,7 +245,7 @@ public class NodePropertySpecifier extends PropertySpecifier {
               new PropertyDescriptor<>(
                   Configuration::getSnmpSourceInterface,
                   Schema.STRING,
-                  "Source interface to use for communicating with the SNMP servers"))
+                  "Source interface to use for communicating with SNMP servers"))
           .put(
               SNMP_TRAP_SERVERS,
               new PropertyDescriptor<>(


### PR DESCRIPTION
Tweaks are mainly:
- increasing self-consistency
- using "peer" in lieu of "peering"; to me "peering" implies two peers, but the properties in `BgpPeerPropertySpecifier` only apply to one peer
- other tweaks to move focus onto the peer and away from the session(s) it might establish.