### PR TITLE
PAN: Support vsys importing

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -741,6 +741,11 @@ VIRTUAL_ROUTER
     'virtual-router'
 ;
 
+VISIBLE_VSYS
+:
+    'visible-vsys'
+;
+
 VLAN
 :
     'vlan'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_vsys.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_vsys.g4
@@ -13,5 +13,19 @@ s_vsys
         s_rulebase
         | s_zone
         | ss_common
+        | sv_import
     )
+;
+
+sv_import
+:
+    IMPORT
+    (
+        svi_visible_vsys
+    )?
+;
+
+svi_visible_vsys
+:
+    VISIBLE_VSYS variable_list
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -145,6 +145,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sservgrp_membersContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ssl_syslogContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ssls_serverContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sslss_serverContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Svi_visible_vsysContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Szn_layer3Context;
 import org.batfish.grammar.palo_alto.PaloAltoParser.VariableContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Variable_list_itemContext;
@@ -1289,6 +1290,14 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitS_vsys(S_vsysContext ctx) {
     _currentVsys = _defaultVsys;
+  }
+
+  @Override
+  public void exitSvi_visible_vsys(Svi_visible_vsysContext ctx) {
+    for (Variable_list_itemContext var : ctx.variable_list().variable_list_item()) {
+      String name = getText(var);
+      _currentVsys.getImportedVsyses().add(name);
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
@@ -27,6 +27,8 @@ public final class Vsys implements Serializable {
 
   private final Set<String> _importedInterfaces;
 
+  private final Set<String> _importedVsyses;
+
   private final String _name;
 
   // Note: these are all LinkedHashMaps to preserve insertion order.
@@ -50,6 +52,7 @@ public final class Vsys implements Serializable {
     _addressObjects = new TreeMap<>();
     _applications = new TreeMap<>();
     _importedInterfaces = new HashSet<>();
+    _importedVsyses = new HashSet<>();
     _rules = new LinkedHashMap<>();
     _preRules = new LinkedHashMap<>();
     _postRules = new LinkedHashMap<>();
@@ -82,6 +85,11 @@ public final class Vsys implements Serializable {
   /** Returns the interfaces imported for this vsys. */
   public Set<String> getImportedInterfaces() {
     return _importedInterfaces;
+  }
+
+  /** Returns the sibling vsyses imported for this vsys. */
+  public Set<String> getImportedVsyses() {
+    return _importedVsyses;
   }
 
   /** Returns the name of this vsys. */

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1188,6 +1188,15 @@ public class PaloAltoGrammarTest {
   }
 
   @Test
+  public void testVsysImport() {
+    PaloAltoConfiguration c = parsePaloAltoConfig("vsys-import");
+
+    // Confirm vsys imports are extracted correctly
+    assertThat(c.getVirtualSystems().get("vsys1").getImportedVsyses(), emptyIterable());
+    assertThat(c.getVirtualSystems().get("vsys2").getImportedVsyses(), contains("vsys1"));
+  }
+
+  @Test
   public void testVsysService() throws IOException {
     String hostname = "vsys-service";
     Configuration c = parseConfig(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/vsys-import
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/vsys-import
@@ -1,0 +1,4 @@
+set deviceconfig system hostname vsys-import
+
+set vsys vsys1
+set vsys vsys2 import visible-vsys vsys1


### PR DESCRIPTION
PAN: Support importing other `vsys`'s into a `vsys`.

Just extraction for now - no use in conversion and `vsys`'s are not yet tracked as defined structures.
