### PR TITLE
Add ACL checks in config finalizer

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -104,27 +104,30 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
     for (Interface iface : c.getAllInterfaces().values()) {
       String ifaceName = iface.getName();
       String outName = iface.getOutgoingFilterName();
-      String inName = iface.getIncomingFilterName();
-      String postTransformName = iface.getPostTransformationIncomingFilterName();
-      String preTransformName = iface.getPreTransformationOutgoingFilterName();
       if (outName != null && !c.getIpAccessLists().containsKey(outName)) {
         throw new BatfishException(
             String.format(
                 "IpAccessList map is missing filter %s: outgoing filter for interface %s",
                 outName, ifaceName));
       }
+
+      String inName = iface.getIncomingFilterName();
       if (inName != null && !c.getIpAccessLists().containsKey(inName)) {
         throw new BatfishException(
             String.format(
                 "IpAccessList map is missing filter %s: incoming filter for interface %s",
                 inName, ifaceName));
       }
+
+      String postTransformName = iface.getPostTransformationIncomingFilterName();
       if (postTransformName != null && !c.getIpAccessLists().containsKey(postTransformName)) {
         throw new BatfishException(
             String.format(
                 "IpAccessList map is missing filter %s: post transformation incoming filter for interface %s",
                 postTransformName, ifaceName));
       }
+
+      String preTransformName = iface.getPreTransformationOutgoingFilterName();
       if (preTransformName != null && !c.getIpAccessLists().containsKey(preTransformName)) {
         throw new BatfishException(
             String.format(

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -96,43 +96,47 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
         verifyAndToImmutableMap(c.getRouteFilterLists(), RouteFilterList::getName, w));
     c.setRoute6FilterLists(
         verifyAndToImmutableMap(c.getRoute6FilterLists(), Route6FilterList::getName, w));
-    validateAssignedAcls(c);
+    removeInvalidAcls(c, w);
   }
 
   /** Confirm assigned ACLs (e.g. interface's outgoing ACL) exist in config's IpAccessList map */
-  private static void validateAssignedAcls(Configuration c) {
+  private static void removeInvalidAcls(Configuration c, Warnings w) {
     for (Interface iface : c.getAllInterfaces().values()) {
       String ifaceName = iface.getName();
       String outName = iface.getOutgoingFilterName();
       if (outName != null && !c.getIpAccessLists().containsKey(outName)) {
-        throw new BatfishException(
+        w.redFlag(
             String.format(
                 "IpAccessList map is missing filter %s: outgoing filter for interface %s",
                 outName, ifaceName));
+        iface.setOutgoingFilter((IpAccessList) null);
       }
 
       String inName = iface.getIncomingFilterName();
       if (inName != null && !c.getIpAccessLists().containsKey(inName)) {
-        throw new BatfishException(
+        w.redFlag(
             String.format(
                 "IpAccessList map is missing filter %s: incoming filter for interface %s",
                 inName, ifaceName));
+        iface.setIncomingFilter(null);
       }
 
       String postTransformName = iface.getPostTransformationIncomingFilterName();
       if (postTransformName != null && !c.getIpAccessLists().containsKey(postTransformName)) {
-        throw new BatfishException(
+        w.redFlag(
             String.format(
                 "IpAccessList map is missing filter %s: post transformation incoming filter for interface %s",
                 postTransformName, ifaceName));
+        iface.setPostTransformationIncomingFilter((IpAccessList) null);
       }
 
       String preTransformName = iface.getPreTransformationOutgoingFilterName();
       if (preTransformName != null && !c.getIpAccessLists().containsKey(preTransformName)) {
-        throw new BatfishException(
+        w.redFlag(
             String.format(
                 "IpAccessList map is missing filter %s: pre transformation outgoing filter for interface %s",
                 preTransformName, ifaceName));
+        iface.setPreTransformationOutgoingFilter((IpAccessList) null);
       }
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -103,19 +103,34 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
   private static void validateAssignedAcls(Configuration c) {
     for (Interface iface : c.getAllInterfaces().values()) {
       String ifaceName = iface.getName();
-      assertAssignedAclInMap(c, iface.getOutgoingFilterName(), ifaceName);
-      assertAssignedAclInMap(c, iface.getIncomingFilterName(), ifaceName);
-      assertAssignedAclInMap(c, iface.getPostTransformationIncomingFilterName(), ifaceName);
-      assertAssignedAclInMap(c, iface.getPreTransformationOutgoingFilterName(), ifaceName);
-    }
-  }
-
-  private static void assertAssignedAclInMap(Configuration c, String name, String interfaceName) {
-    if (!c.getIpAccessLists().containsKey(name)) {
-      throw new BatfishException(
-          String.format(
-              "IpAccessList map is missing filter %s, which is assigned to interface %s",
-              name, interfaceName));
+      String outName = iface.getOutgoingFilterName();
+      String inName = iface.getIncomingFilterName();
+      String postTransformName = iface.getPostTransformationIncomingFilterName();
+      String preTransformName = iface.getPreTransformationOutgoingFilterName();
+      if (outName != null && !c.getIpAccessLists().containsKey(outName)) {
+        throw new BatfishException(
+            String.format(
+                "IpAccessList map is missing filter %s: outgoing filter for interface %s",
+                outName, ifaceName));
+      }
+      if (inName != null && !c.getIpAccessLists().containsKey(inName)) {
+        throw new BatfishException(
+            String.format(
+                "IpAccessList map is missing filter %s: incoming filter for interface %s",
+                inName, ifaceName));
+      }
+      if (postTransformName != null && !c.getIpAccessLists().containsKey(postTransformName)) {
+        throw new BatfishException(
+            String.format(
+                "IpAccessList map is missing filter %s: post transformation incoming filter for interface %s",
+                postTransformName, ifaceName));
+      }
+      if (preTransformName != null && !c.getIpAccessLists().containsKey(preTransformName)) {
+        throw new BatfishException(
+            String.format(
+                "IpAccessList map is missing filter %s: pre transformation outgoing filter for interface %s",
+                preTransformName, ifaceName));
+      }
     }
   }
 


### PR DESCRIPTION
Add check to make sure all attached ACLs (e.g. interface's outgoing filter) exist in the config's `IpAccessList` map.
