### PR TITLE
Small tweaks to routing process initialization

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -127,7 +127,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   }
 
   @Override
-  public void initialize() {}
+  public void initialize(Node n) {}
 
   /**
    * Initialize incoming BGP message queues.

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -167,7 +167,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   }
 
   @Override
-  public void initialize() {
+  public void initialize(Node n) {
     initializeIntraAreaRoutes();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/RoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/RoutingProcess.java
@@ -19,7 +19,7 @@ public interface RoutingProcess<T, R extends AbstractRouteDecorator> {
   /**
    * Initialization of the routing process. Called exactly once per computation of the dataplane.
    */
-  void initialize();
+  void initialize(Node n);
 
   /**
    * Topology update. Called every time the dataplane engine determines that a change to the

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -284,7 +284,7 @@ public class VirtualRouter implements Serializable {
                     e ->
                         new OspfRoutingProcess(
                             e.getValue(), _name, _c, topologyContext.getOspfTopology())));
-    _ospfProcesses.values().forEach(OspfRoutingProcess::initialize);
+    _ospfProcesses.values().forEach(p -> p.initialize(_node));
 
     initEigrp();
     initBaseRipRoutes();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -276,7 +276,7 @@ public class OspfRoutingProcessTest {
 
   @Test
   public void testDirtyPostInitialization() {
-    _routingProcess.initialize();
+    _routingProcess.initialize(new Node(_c));
     assertTrue(_routingProcess.isDirty());
   }
 
@@ -286,7 +286,7 @@ public class OspfRoutingProcessTest {
    */
   @Test
   public void testNotDirtyAfterOneIteration() {
-    _routingProcess.initialize();
+    _routingProcess.initialize(new Node(_c));
     // Empty map in this particular case just means no valid neighbors.
     _routingProcess.executeIteration(ImmutableMap.of());
     assertTrue("Still have updates to main RIB", _routingProcess.isDirty());


### PR DESCRIPTION
Take in `Node` so we have access to other VRFs during initialization.