### PR TITLE
PAN: extract more service builtins

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -2,7 +2,6 @@ package org.batfish.grammar.palo_alto;
 
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.CATCHALL_APPLICATION_NAME;
-import static org.batfish.representation.palo_alto.PaloAltoConfiguration.CATCHALL_SERVICE_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.CATCHALL_ZONE_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.DEFAULT_VSYS_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.PANORAMA_VSYS_NAME;
@@ -41,6 +40,7 @@ import static org.batfish.representation.palo_alto.Zone.Type.LAYER3;
 import static org.batfish.representation.palo_alto.Zone.Type.TAP;
 import static org.batfish.representation.palo_alto.Zone.Type.VIRTUAL_WIRE;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -314,9 +314,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     // Use constructed object name so same-named refs across vsys are unique
     String uniqueName = computeObjectName(_currentVsys.getName(), serviceName);
 
-    if (serviceName.equals(ServiceBuiltIn.SERVICE_HTTP.getName())
-        || serviceName.equals(ServiceBuiltIn.SERVICE_HTTPS.getName())
-        || serviceName.equals(CATCHALL_SERVICE_NAME)) {
+    if (Arrays.stream(ServiceBuiltIn.values()).anyMatch(n -> serviceName.equals(n.getName()))) {
       // Built-in services can be overridden, so add optional object reference
       _configuration.referenceStructure(
           SERVICE_OR_SERVICE_GROUP_OR_NONE, uniqueName, usage, getLine(var.start));

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -70,9 +70,6 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
   /** This is the name of an endpoint that matches all traffic */
   public static final String CATCHALL_ENDPOINT_NAME = "any";
 
-  /** This is the name of a service that matches all traffic */
-  public static final String CATCHALL_SERVICE_NAME = "any";
-
   /** This is the name of the zone that matches traffic in all zones (but not unzoned traffic) */
   public static final String CATCHALL_ZONE_NAME = "any";
 
@@ -447,7 +444,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
         if (vsysName != null) {
           serviceDisjuncts.add(
               new PermittedByAcl(computeServiceGroupMemberAclName(vsysName, serviceName)));
-        } else if (serviceName.equals(CATCHALL_SERVICE_NAME)) {
+        } else if (serviceName.equals(ServiceBuiltIn.ANY.getName())) {
           serviceDisjuncts.clear();
           serviceDisjuncts.add(TrueExpr.INSTANCE);
           break;

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceBuiltIn.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceBuiltIn.java
@@ -9,6 +9,8 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.SubRange;
 
 public enum ServiceBuiltIn {
+  ANY,
+  APPLICATION_DEFAULT,
   SERVICE_HTTP,
   SERVICE_HTTPS;
 
@@ -30,6 +32,9 @@ public enum ServiceBuiltIn {
             .setIpProtocols(ImmutableList.of(IpProtocol.TCP))
             .setDstPorts(ImmutableSortedSet.of(new SubRange(443, 443)))
             .build();
+        // any and application-default don't match a specific port
+      case ANY:
+      case APPLICATION_DEFAULT:
       default:
         return null;
     }
@@ -41,6 +46,10 @@ public enum ServiceBuiltIn {
 
   public String getName() {
     switch (this) {
+      case ANY:
+        return "any";
+      case APPLICATION_DEFAULT:
+        return "application-default";
       case SERVICE_HTTP:
         return "service-http";
       case SERVICE_HTTPS:

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceGroup.java
@@ -1,6 +1,5 @@
 package org.batfish.representation.palo_alto;
 
-import static org.batfish.representation.palo_alto.PaloAltoConfiguration.CATCHALL_SERVICE_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeServiceGroupMemberAclName;
 
 import java.util.List;
@@ -52,7 +51,7 @@ public final class ServiceGroup implements ServiceGroupMember {
                 new PermittedByAcl(
                     computeServiceGroupMemberAclName(vsysName, memberReference.getName())),
                 memberReference.getName()));
-      } else if (serviceName.equals(CATCHALL_SERVICE_NAME)) {
+      } else if (serviceName.equals(ServiceBuiltIn.ANY.getName())) {
         lines.clear();
         lines.add(new IpAccessListLine(action, TrueExpr.INSTANCE, _name));
         break;

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -29,7 +29,6 @@ import static org.batfish.datamodel.matchers.IpAccessListMatchers.rejects;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasInterfaces;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasName;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasStaticRoutes;
-import static org.batfish.representation.palo_alto.PaloAltoConfiguration.CATCHALL_SERVICE_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.DEFAULT_VSYS_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.NULL_VRF_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.SHARED_VSYS_NAME;
@@ -1045,7 +1044,7 @@ public class PaloAltoGrammarTest {
         computeObjectName(DEFAULT_VSYS_NAME, ServiceBuiltIn.SERVICE_HTTP.getName());
     String serviceHttps =
         computeObjectName(DEFAULT_VSYS_NAME, ServiceBuiltIn.SERVICE_HTTPS.getName());
-    String serviceAny = computeObjectName(DEFAULT_VSYS_NAME, CATCHALL_SERVICE_NAME);
+    String serviceAny = computeObjectName(DEFAULT_VSYS_NAME, ServiceBuiltIn.ANY.getName());
 
     String serviceGroupHttpName = computeObjectName(DEFAULT_VSYS_NAME, "SG-HTTP");
     String serviceGroupHttpsName = computeObjectName(DEFAULT_VSYS_NAME, "SG-HTTPS");
@@ -1064,7 +1063,9 @@ public class PaloAltoGrammarTest {
     // Confirm there are no undefined references for the built-ins
     assertThat(
         ccae,
-        not(hasUndefinedReference(filename, SERVICE_OR_SERVICE_GROUP, CATCHALL_SERVICE_NAME)));
+        not(
+            hasUndefinedReference(
+                filename, SERVICE_OR_SERVICE_GROUP, ServiceBuiltIn.ANY.getName())));
     assertThat(
         ccae,
         not(
@@ -1124,7 +1125,7 @@ public class PaloAltoGrammarTest {
     ConvertConfigurationAnswerElement ccae =
         batfish.loadConvertConfigurationAnswerElementOrReparse();
 
-    String serviceAnyName = computeObjectName(DEFAULT_VSYS_NAME, CATCHALL_SERVICE_NAME);
+    String serviceAnyName = computeObjectName(DEFAULT_VSYS_NAME, ServiceBuiltIn.ANY.getName());
     String serviceHttpName =
         computeObjectName(DEFAULT_VSYS_NAME, ServiceBuiltIn.SERVICE_HTTP.getName());
     String serviceHttpsName =

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -851,6 +851,18 @@ public class PaloAltoGrammarTest {
             PaloAltoStructureType.ZONE,
             zoneUndefName,
             PaloAltoStructureUsage.RULE_FROM_ZONE));
+
+    // Confirm builtins do not show up as undefined references
+    assertThat(
+        ccae,
+        not(
+            hasUndefinedReference(
+                filename, SERVICE_OR_SERVICE_GROUP, ServiceBuiltIn.ANY.getName())));
+    assertThat(
+        ccae,
+        not(
+            hasUndefinedReference(
+                filename, SERVICE_OR_SERVICE_GROUP, ServiceBuiltIn.APPLICATION_DEFAULT.getName())));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase
@@ -14,7 +14,7 @@ set rulebase security rules "disabled rule" from [ any ZONE_UNDEF ]
 set rulebase security rules "disabled rule" to any
 set rulebase security rules "disabled rule" source any
 set rulebase security rules "disabled rule" destination any
-set rulebase security rules "disabled rule" service [ any SERVICE_UNDEF ]
+set rulebase security rules "disabled rule" service [ any application-default SERVICE_UNDEF ]
 set rulebase security rules "disabled rule" application any
 set rulebase security rules "disabled rule" action drop
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-service
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-service
@@ -16,5 +16,5 @@ set rulebase security rules RULE1 action allow
 # Override built-in service
 set service service-http protocol tcp port 1
 
-# Reference another built-in service
-set service-group SG-BUILT-IN members [ service-https ]
+# Reference more built-in services
+set service-group SG-BUILT-IN members [ application-default service-https ]

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-service
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-service
@@ -16,5 +16,5 @@ set rulebase security rules RULE1 action allow
 # Override built-in service
 set service service-http protocol tcp port 1
 
-# Reference more built-in services
-set service-group SG-BUILT-IN members [ application-default service-https ]
+# Reference another built-in service
+set service-group SG-BUILT-IN members [ service-https ]


### PR DESCRIPTION
Extract `application-default` service builtin and treat `any` as a service builtin instead of catchall service for PAN

`application-default` has no effect until applications are added (https://github.com/batfish/batfish/issues/2097)
