### PR TITLE
Fix specifier Javadocs to have correct examples

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/BgpPeerPropertySpecifier.java
@@ -22,13 +22,13 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.answers.Schema;
 
 /**
- * Enables specification a set of BGP peer properties.
+ * Enables specification of a set of BGP peer properties.
  *
  * <p>Example specifiers:
  *
  * <ul>
- *   <li>multipath-ebgp —&gt; gets the process's corresponding value
- *   <li>max-metric-.* -&gt; gets all properties that start with 'max-metric-'
+ *   <li>local_as —&gt; gets the peer's local AS
+ *   <li>.*policy -&gt; gets all properties that end with 'policy'
  * </ul>
  */
 public class BgpPeerPropertySpecifier extends PropertySpecifier {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
@@ -21,7 +21,7 @@ import org.batfish.datamodel.answers.Schema;
  * <p>Currently supported example specifiers:
  *
  * <ul>
- *   <li>channel-group -&gt; gets the interface's channel groups using a configured Java function
+ *   <li>channel_group -&gt; gets the interface's channel groups using a configured Java function
  *   <li>channel.* gets all properties that start with 'channel'
  * </ul>
  *

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/NodePropertySpecifier.java
@@ -22,7 +22,7 @@ import org.batfish.datamodel.vendor_family.VendorFamily;
  * <p>Currently supported example specifier:
  *
  * <ul>
- *   <li>ntp-servers -&gt; gets NTP servers using a configured Java function
+ *   <li>ntp_servers -&gt; gets NTP servers using a configured Java function
  *   <li>ntp.* gets all properties that start with 'ntp'
  * </ul>
  *

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/OspfPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/OspfPropertySpecifier.java
@@ -18,8 +18,8 @@ import org.batfish.datamodel.ospf.OspfProcess;
  * <p>Example specifiers:
  *
  * <ul>
- *   <li>max-metric-summary-links -&gt; gets the process's corresponding value
- *   <li>max-metric-.* -&gt; gets all properties that start with 'max-metric-'
+ *   <li>reference_bandwidth -&gt; gets the process's reference bandwidth
+ *   <li>area.* -&gt; gets all properties that start with 'area'
  * </ul>
  */
 public class OspfPropertySpecifier extends PropertySpecifier {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/VxlanVniPropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/VxlanVniPropertySpecifier.java
@@ -23,6 +23,7 @@ import org.batfish.datamodel.answers.Schema;
  *
  * <ul>
  *   <li>vlan gets the VLAN ID property
+ *   <li>.*vtep.* gets all properties that include 'VTEP'
  * </ul>
  */
 @ParametersAreNonnullByDefault


### PR DESCRIPTION
These examples will actually work if used for the `properties` parameter in questions that use these specifiers.