### PR TITLE
Fix allowed VLANs in Interfaces

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -1387,8 +1387,14 @@ if_switchport_trunk_allowed
 :
    SWITCHPORT TRUNK ALLOWED VLAN
    (
-      ADD? r = range
-      | NONE
+      NONE
+      |
+      (
+         ADD?
+         (
+            r = range
+         )
+      )
    ) NEWLINE
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -1385,7 +1385,11 @@ if_switchport_private_vlan_mapping
 
 if_switchport_trunk_allowed
 :
-   SWITCHPORT TRUNK ALLOWED VLAN ADD? r = range NEWLINE
+   SWITCHPORT TRUNK ALLOWED VLAN
+   (
+      ADD? r = range
+      | NONE
+   ) NEWLINE
 ;
 
 if_switchport_trunk_encapsulation

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -1390,10 +1390,7 @@ if_switchport_trunk_allowed
       NONE
       |
       (
-         ADD?
-         (
-            r = range
-         )
+         ADD? r = range
       )
    ) NEWLINE
 ;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2206,16 +2206,17 @@ public final class CiscoConfiguration extends VendorConfiguration {
        *
        * https://www.arista.com/en/um-eos/eos-section-19-3-vlan-configuration-procedures#ww1152330
        */
-      if (!Interface.ALL_VLANS.equals(iface.getAllowedVlans())
-          || iface.getVlanTrunkGroups().isEmpty()) {
+      if (iface.getAllowedVlans() != null) {
         newIface.setAllowedVlans(iface.getAllowedVlans());
-      } else {
+      } else if (!iface.getVlanTrunkGroups().isEmpty()) {
         newIface.setAllowedVlans(
             iface.getVlanTrunkGroups().stream()
                 .map(_eosVlanTrunkGroups::get)
                 .map(VlanTrunkGroup::getVlans)
                 .reduce(IntegerSpace::union)
                 .get());
+      } else {
+        newIface.setAllowedVlans(Interface.ALL_VLANS);
       }
     }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -511,6 +511,25 @@ public class CiscoGrammarTest {
   }
 
   @Test
+  public void testAllowedVlans() throws IOException {
+    Configuration c = parseConfig("eos-allowed-vlans");
+
+    assertThat(
+        c.getAllInterfaces().get("Port-Channel1").getAllowedVlans(),
+        equalTo(IntegerSpace.of(Range.closed(1, 2))));
+    assertThat(
+        c.getAllInterfaces().get("Port-Channel2").getAllowedVlans(),
+        equalTo(IntegerSpace.of(Range.closed(2, 3))));
+    assertThat(
+        c.getAllInterfaces().get("Port-Channel3").getAllowedVlans(), equalTo(IntegerSpace.EMPTY));
+    assertThat(
+        c.getAllInterfaces().get("Port-Channel4").getAllowedVlans(), equalTo(IntegerSpace.EMPTY));
+    assertThat(
+        c.getAllInterfaces().get("Port-Channel5").getAllowedVlans(),
+        equalTo(IntegerSpace.of(Range.closed(1, 4094))));
+  }
+
+  @Test
   public void testAaaAuthenticationLogin() throws IOException {
     // test ASA config
     Configuration aaaAuthAsaConfiguration = parseConfig("aaaAuthenticationAsa");

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -527,6 +527,9 @@ public class CiscoGrammarTest {
     assertThat(
         c.getAllInterfaces().get("Port-Channel5").getAllowedVlans(),
         equalTo(IntegerSpace.of(Range.closed(1, 4094))));
+    assertThat(
+        c.getAllInterfaces().get("Port-Channel6").getAllowedVlans(),
+        equalTo(IntegerSpace.of(Range.closed(1, 4))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/eos-allowed-vlans
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/eos-allowed-vlans
@@ -1,0 +1,23 @@
+! boot system flash:/EOS-4.19.1F.swi
+!
+hostname eos-allowed-vlans
+!
+interface Port-Channel1
+   switchport trunk allowed vlan 1,2
+   switchport mode trunk
+!
+interface Port-Channel2
+   switchport mode trunk
+   switchport trunk allowed vlan 2,3
+!
+interface Port-Channel3
+   switchport mode trunk
+   switchport trunk allowed vlan none
+!
+interface Port-Channel4
+   switchport trunk allowed vlan none
+   switchport mode trunk
+!
+interface Port-Channel5
+   switchport mode trunk
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/eos-allowed-vlans
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/eos-allowed-vlans
@@ -21,3 +21,8 @@ interface Port-Channel4
 interface Port-Channel5
    switchport mode trunk
 !
+interface Port-Channel6
+   switchport trunk allowed vlan 1,2
+   switchport trunk allowed vlan add 3,4
+   switchport mode trunk
+!


### PR DESCRIPTION
We were incorrectly setting allowed vlans for a configuration like below:
```
interface Port-Channel1
   switchport trunk allowed vlan 1,2
   switchport mode trunk
!
```
the first line would set the allowed vlans to `[1,2]` but the second line would reset it to `[1, 4094]`, which would cause the layer 2 topology self edges computation to blow up (because we were not able to honor allowed vlans even when the configuration said `allowed vlan none`). This was happening because we assumed that we will always see `switchport mode trunk` before `switchport trunk allowed vlan <none|x,y>`.
This PR addresses the above and also adds handling of:
`switchport trunk allowed vlan none` 