### PR TITLE
Set correct switchport mode for DOT1Q and ISL encapsulation

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2187,17 +2187,22 @@ public final class CiscoConfiguration extends VendorConfiguration {
     // switch settings
     newIface.setAccessVlan(iface.getAccessVlan());
 
-    if (iface.getSwitchportMode() == SwitchportMode.TRUNK) {
-      newIface.setNativeVlan(firstNonNull(iface.getNativeVlan(), 1));
-    }
-
     newIface.setSwitchportMode(iface.getSwitchportMode());
     SwitchportEncapsulationType encapsulation = iface.getSwitchportTrunkEncapsulation();
     if (encapsulation == null) { // no encapsulation set, so use default..
       // TODO: check if this is OK
       encapsulation = SwitchportEncapsulationType.DOT1Q;
+    } else if (newIface.getSwitchportMode() != SwitchportMode.TRUNK
+        && ImmutableSet.of(SwitchportEncapsulationType.DOT1Q, SwitchportEncapsulationType.ISL)
+            .contains(encapsulation)) { // if newIface is not already in TRUNK mode but has a trunk
+      // encapsulation type, set to trunk
+      newIface.setSwitchportMode(SwitchportMode.TRUNK);
     }
     newIface.setSwitchportTrunkEncapsulation(encapsulation);
+
+    if (newIface.getSwitchportMode() == SwitchportMode.TRUNK) {
+      newIface.setNativeVlan(firstNonNull(iface.getNativeVlan(), 1));
+    }
     if (iface.getSwitchportMode() == SwitchportMode.TRUNK) {
       /*
        * Compute allowed VLANs:

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -4942,6 +4942,8 @@ public class CiscoGrammarTest {
     Interface e1 = c.getAllInterfaces().get("Ethernet0/1");
     Interface e2 = c.getAllInterfaces().get("Ethernet0/2");
     Interface e3 = c.getAllInterfaces().get("Ethernet0/3");
+    Interface e4 = c.getAllInterfaces().get("Ethernet0/4");
+    Interface e5 = c.getAllInterfaces().get("Ethernet0/5");
 
     assertThat(e0, isSwitchport(false));
     assertThat(e0, hasSwitchPortMode(SwitchportMode.NONE));
@@ -4951,6 +4953,10 @@ public class CiscoGrammarTest {
     assertThat(e2, hasSwitchPortMode(SwitchportMode.ACCESS));
     assertThat(e3, isSwitchport(true));
     assertThat(e3, hasSwitchPortMode(SwitchportMode.TRUNK));
+    assertThat(e4, isSwitchport(true));
+    assertThat(e4, hasSwitchPortMode(SwitchportMode.TRUNK));
+    assertThat(e5, isSwitchport(true));
+    assertThat(e5, hasSwitchPortMode(SwitchportMode.TRUNK));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios_switchport_mode
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios_switchport_mode
@@ -18,4 +18,14 @@ interface Ethernet0/3
  switchport mode trunk
  no shutdown
 !
+interface Ethernet0/4
+ switchport
+ switchport trunk encapsulation dot1q
+ no shutdown
 !
+interface Ethernet0/5
+ switchport
+ switchport trunk encapsulation isl
+ no shutdown
+!
+


### PR DESCRIPTION
fixes https://github.com/batfish/batfish/issues/4018

DOT1Q and ISIL are VLAN trunk encapsulation mode with DOT1Q being the latest and more popular one.

https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst6500/ios/12-2SX/configuration/guide/book/layer2.html#42266