### PR TITLE
PaloAlto: improvements to non-routing interfaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -629,11 +629,6 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
     Zone zone = iface.getZone();
     if (zone != null) {
       newIface.setZoneName(zone.getName());
-    } else {
-      _w.redFlag(
-          String.format(
-              "Interface %s is not in a zone and will be treated as inactive", newIface.getName()));
-      newIface.setActive(false);
     }
 
     IpAccessList outgoing = computeOutgoingAcl(iface);

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -581,8 +581,8 @@ public class PaloAltoGrammarTest {
     // Confirm link status is extracted
     assertThat(c, hasInterface(interfaceName1, isActive()));
     assertThat(c, hasInterface(interfaceName2, not(isActive())));
-    assertThat(c, hasInterface(interfaceName3, not(isActive())));
-    assertThat(c, hasInterface(interfaceName311, not(isActive())));
+    assertThat(c, hasInterface(interfaceName3, isActive()));
+    assertThat(c, hasInterface(interfaceName311, isActive()));
 
     // Confirm tag extraction for units
     assertThat(c, hasInterface(interfaceName311, hasVlan(11)));

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -32,7 +32,7 @@ import static org.batfish.datamodel.matchers.VrfMatchers.hasInterfaces;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasName;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasStaticRoutes;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.DEFAULT_VSYS_NAME;
-import static org.batfish.representation.palo_alto.PaloAltoConfiguration.NULL_VRF_NAME;
+import static org.batfish.representation.palo_alto.PaloAltoConfiguration.NON_ROUTING_VRF_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.SHARED_VSYS_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeObjectName;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeServiceGroupMemberAclName;
@@ -581,7 +581,7 @@ public class PaloAltoGrammarTest {
     // Confirm link status is extracted
     assertThat(c, hasInterface(interfaceName1, isActive()));
     assertThat(c, hasInterface(interfaceName2, not(isActive())));
-    assertThat(c, hasInterface(interfaceName3, isActive()));
+    assertThat(c, hasInterface(interfaceName3, not(isActive())));
     assertThat(c, hasInterface(interfaceName311, not(isActive())));
 
     // Confirm tag extraction for units
@@ -659,7 +659,9 @@ public class PaloAltoGrammarTest {
 
     // Make sure the orphaned vrf is associated with the "null", constructed vrf
     assertThat(
-        c, hasInterface("ethernet1/4", InterfaceMatchers.hasVrf(hasName(equalTo(NULL_VRF_NAME)))));
+        c,
+        hasInterface(
+            "ethernet1/4", InterfaceMatchers.hasVrf(hasName(equalTo(NON_ROUTING_VRF_NAME)))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface
@@ -9,5 +9,10 @@ set network interface ethernet ethernet1/3 link-state up
 set network interface ethernet ethernet1/3 comment 'single quoted description'
 set network interface ethernet ethernet1/3 layer3 units ethernet1/3.11 comment 'unit description'
 set network interface ethernet ethernet1/3 layer3 units ethernet1/3.11 tag 11
-# Interfaces are not functionally active unless they are in a virtual-router
+
+# Interfaces have to be in a zone to be active.
+set vsys vsys1 import network interface ethernet1/1
+set vsys vsys1 zone zone1 network layer3 [ ethernet1/1 ethernet1/3.11]
+
+# Layer3 interfaces are not functionally active unless they are in a virtual-router
 set network virtual-router default interface [ ethernet1/1 ethernet1/2 ethernet1/3 ]

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -29762,7 +29762,7 @@
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
-            "vrf" : "~NULL_VRF~"
+            "vrf" : "~NON_ROUTING~"
           },
           "ethernet1/1.4" : {
             "name" : "ethernet1/1.4",
@@ -29788,7 +29788,7 @@
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "LOGICAL",
             "vlan" : 4,
-            "vrf" : "~NULL_VRF~"
+            "vrf" : "~NON_ROUTING~"
           },
           "ethernet1/1.5" : {
             "name" : "ethernet1/1.5",
@@ -29814,7 +29814,7 @@
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "LOGICAL",
             "vlan" : 5,
-            "vrf" : "~NULL_VRF~"
+            "vrf" : "~NON_ROUTING~"
           },
           "loopback" : {
             "name" : "loopback",
@@ -29839,7 +29839,7 @@
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "LOOPBACK",
-            "vrf" : "~NULL_VRF~"
+            "vrf" : "~NON_ROUTING~"
           },
           "loopback.1" : {
             "name" : "loopback.1",
@@ -29863,7 +29863,7 @@
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "LOOPBACK",
-            "vrf" : "~NULL_VRF~"
+            "vrf" : "~NON_ROUTING~"
           },
           "tunnel" : {
             "name" : "tunnel",
@@ -29887,7 +29887,7 @@
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "TUNNEL",
-            "vrf" : "~NULL_VRF~"
+            "vrf" : "~NON_ROUTING~"
           },
           "tunnel.3" : {
             "name" : "tunnel.3",
@@ -29912,7 +29912,7 @@
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "TUNNEL",
-            "vrf" : "~NULL_VRF~"
+            "vrf" : "~NON_ROUTING~"
           },
           "vlan" : {
             "name" : "vlan",
@@ -29937,7 +29937,7 @@
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "VLAN",
-            "vrf" : "~NULL_VRF~"
+            "vrf" : "~NON_ROUTING~"
           },
           "vlan.1" : {
             "name" : "vlan.1",
@@ -29961,13 +29961,13 @@
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "VLAN",
-            "vrf" : "~NULL_VRF~"
+            "vrf" : "~NON_ROUTING~"
           }
         },
         "vendorFamily" : { },
         "vrfs" : {
-          "~NULL_VRF~" : {
-            "name" : "~NULL_VRF~",
+          "~NON_ROUTING~" : {
+            "name" : "~NON_ROUTING~",
             "interfaces" : [
               "ethernet1/1",
               "ethernet1/1.4",
@@ -30011,7 +30011,7 @@
         "interfaces" : {
           "ethernet1/1" : {
             "name" : "ethernet1/1",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -30031,12 +30031,12 @@
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
-            "vrf" : "~NULL_VRF~",
+            "vrf" : "~NON_ROUTING~",
             "zone" : "zl2"
           },
           "ethernet1/2" : {
             "name" : "ethernet1/2",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -30056,12 +30056,12 @@
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
-            "vrf" : "~NULL_VRF~",
+            "vrf" : "~NON_ROUTING~",
             "zone" : "zl3"
           },
           "ethernet1/3" : {
             "name" : "ethernet1/3",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -30081,12 +30081,12 @@
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
-            "vrf" : "~NULL_VRF~",
+            "vrf" : "~NON_ROUTING~",
             "zone" : "ztap"
           },
           "ethernet1/4" : {
             "name" : "ethernet1/4",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -30106,7 +30106,7 @@
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
-            "vrf" : "~NULL_VRF~",
+            "vrf" : "~NON_ROUTING~",
             "zone" : "zvirtual-wire"
           }
         },
@@ -30201,8 +30201,8 @@
         },
         "vendorFamily" : { },
         "vrfs" : {
-          "~NULL_VRF~" : {
-            "name" : "~NULL_VRF~",
+          "~NON_ROUTING~" : {
+            "name" : "~NON_ROUTING~",
             "interfaces" : [
               "ethernet1/1",
               "ethernet1/2",

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -29742,7 +29742,7 @@
         "interfaces" : {
           "ethernet1/1" : {
             "name" : "ethernet1/1",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -29766,7 +29766,7 @@
           },
           "ethernet1/1.4" : {
             "name" : "ethernet1/1.4",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -29792,7 +29792,7 @@
           },
           "ethernet1/1.5" : {
             "name" : "ethernet1/1.5",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -29818,7 +29818,7 @@
           },
           "loopback" : {
             "name" : "loopback",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -29843,7 +29843,7 @@
           },
           "loopback.1" : {
             "name" : "loopback.1",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -29867,7 +29867,7 @@
           },
           "tunnel" : {
             "name" : "tunnel",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -29891,7 +29891,7 @@
           },
           "tunnel.3" : {
             "name" : "tunnel.3",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -29916,7 +29916,7 @@
           },
           "vlan" : {
             "name" : "vlan",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -76147,7 +76147,7 @@
         "paloalto_applications" : "PASSED",
         "paloalto_interfaces" : "WARNINGS",
         "paloalto_policy" : "PASSED",
-        "paloalto_zones" : "WARNINGS",
+        "paloalto_zones" : "PASSED",
         "peer_template" : "WARNINGS",
         "pim" : "PASSED",
         "pim_snooping" : "PASSED",
@@ -90809,59 +90809,39 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/1 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
+              "text" : "Interface ethernet1/1 is not in a zone and will be treated as inactive"
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/1.4 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
+              "text" : "Interface ethernet1/1.4 is not in a zone and will be treated as inactive"
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/1.5 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
+              "text" : "Interface ethernet1/1.5 is not in a zone and will be treated as inactive"
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface loopback is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
+              "text" : "Interface loopback is not in a zone and will be treated as inactive"
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface loopback.1 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
+              "text" : "Interface loopback.1 is not in a zone and will be treated as inactive"
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface tunnel is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
+              "text" : "Interface tunnel is not in a zone and will be treated as inactive"
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface tunnel.3 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
+              "text" : "Interface tunnel.3 is not in a zone and will be treated as inactive"
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface vlan is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
+              "text" : "Interface vlan is not in a zone and will be treated as inactive"
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface vlan.1 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            }
-          ]
-        },
-        "paloalto_zones" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/1 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/2 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/3 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/4 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
+              "text" : "Interface vlan.1 is not in a zone and will be treated as inactive"
             }
           ]
         },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -76145,7 +76145,7 @@
         "ospf-disable" : "PASSED",
         "palo_alto_virtual_routers" : "PASSED",
         "paloalto_applications" : "PASSED",
-        "paloalto_interfaces" : "WARNINGS",
+        "paloalto_interfaces" : "PASSED",
         "paloalto_policy" : "PASSED",
         "paloalto_zones" : "PASSED",
         "peer_template" : "WARNINGS",
@@ -90802,46 +90802,6 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Router-id is not manually configured for BGP process in VRF default. Unable to infer default router-id as no interfaces have IP addresses"
-            }
-          ]
-        },
-        "paloalto_interfaces" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/1 is not in a zone and will be treated as inactive"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/1.4 is not in a zone and will be treated as inactive"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/1.5 is not in a zone and will be treated as inactive"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface loopback is not in a zone and will be treated as inactive"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface loopback.1 is not in a zone and will be treated as inactive"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface tunnel is not in a zone and will be treated as inactive"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface tunnel.3 is not in a zone and will be treated as inactive"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface vlan is not in a zone and will be treated as inactive"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface vlan.1 is not in a zone and will be treated as inactive"
             }
           ]
         },


### PR DESCRIPTION
We should not deactivate all interfaces that are not in a router; instead, we should
only deactivate L3 interfaces that are not in a router.

Also rename NULL_VRF to NON_ROUTING, which is more accurate.

Also deactivate interfaces that are not in a zone, since that
is also more accurate.