### PR TITLE
Cisco: delete spammy eigrp warning

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2141,12 +2141,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
         _w.redFlag("Interface: '" + iface.getName() + "' failed to set EIGRP settings");
       }
     }
-    if (eigrpProcess == null && iface.getDelay() != null) {
-      _w.redFlag(
-          "Interface: '"
-              + iface.getName()
-              + "' contains EIGRP settings but is not part of an EIGRP process");
-    }
 
     boolean level1 = false;
     boolean level2 = false;

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -90441,10 +90441,6 @@
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface: 'Ethernet0' contains EIGRP settings but is not part of an EIGRP process"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
               "text" : "Interface: 'inside' contains OSPF settings, but there is no OSPF process"
             }
           ]


### PR DESCRIPTION
Interfaces have a delay configured by default; but many devices do not use EIGRP.

Drop this spammy warning.