### PR TITLE
Configuration: remove NavigableMap from several key structures

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -145,11 +145,11 @@ public final class Configuration implements Serializable {
 
   private static final int VLAN_NORMAL_MIN_DEFAULT = 1;
 
-  private NavigableMap<String, AsPathAccessList> _asPathAccessLists;
+  private Map<String, AsPathAccessList> _asPathAccessLists;
 
   private NavigableMap<String, AuthenticationKeyChain> _authenticationKeyChains;
 
-  private NavigableMap<String, CommunityList> _communityLists;
+  private Map<String, CommunityList> _communityLists;
 
   private final ConfigurationFormat _configurationFormat;
 
@@ -173,11 +173,11 @@ public final class Configuration implements Serializable {
 
   private NavigableMap<String, IkePhase1Policy> _ikePhase1Policies;
 
-  private NavigableMap<String, Interface> _interfaces;
+  private Map<String, Interface> _interfaces;
 
-  private NavigableMap<String, Ip6AccessList> _ip6AccessLists;
+  private Map<String, Ip6AccessList> _ip6AccessLists;
 
-  private NavigableMap<String, IpAccessList> _ipAccessLists;
+  private Map<String, IpAccessList> _ipAccessLists;
 
   private NavigableMap<String, IpSpace> _ipSpaces;
 
@@ -206,11 +206,11 @@ public final class Configuration implements Serializable {
 
   private NavigableMap<String, PacketPolicy> _packetPolicies;
 
-  private NavigableMap<String, Route6FilterList> _route6FilterLists;
+  private Map<String, Route6FilterList> _route6FilterLists;
 
-  private NavigableMap<String, RouteFilterList> _routeFilterLists;
+  private Map<String, RouteFilterList> _routeFilterLists;
 
-  private NavigableMap<String, RoutingPolicy> _routingPolicies;
+  private Map<String, RoutingPolicy> _routingPolicies;
 
   private String _snmpSourceInterface;
 
@@ -312,7 +312,7 @@ public final class Configuration implements Serializable {
 
   /** Dictionary of all AS-path access-lists for this node. */
   @JsonProperty(PROP_AS_PATH_ACCESS_LISTS)
-  public NavigableMap<String, AsPathAccessList> getAsPathAccessLists() {
+  public Map<String, AsPathAccessList> getAsPathAccessLists() {
     return _asPathAccessLists;
   }
 
@@ -331,7 +331,7 @@ public final class Configuration implements Serializable {
 
   /** Dictionary of all community-lists for this node. */
   @JsonProperty(PROP_COMMUNITY_LISTS)
-  public NavigableMap<String, CommunityList> getCommunityLists() {
+  public Map<String, CommunityList> getCommunityLists() {
     return _communityLists;
   }
 
@@ -413,7 +413,7 @@ public final class Configuration implements Serializable {
 
   /** Dictionary of all interfaces across all VRFs for this node. */
   @JsonProperty(PROP_INTERFACES)
-  public NavigableMap<String, Interface> getAllInterfaces() {
+  public Map<String, Interface> getAllInterfaces() {
     return _interfaces;
   }
 
@@ -424,21 +424,15 @@ public final class Configuration implements Serializable {
         .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
   }
 
-  @JsonIgnore
-  @Deprecated // to enable users to migrate to new API.
-  public NavigableMap<String, Interface> getInterfaces() {
-    return getAllInterfaces();
-  }
-
   /** Dictionary of all IPV6 access-lists for this node. */
   @JsonProperty(PROP_IP6_ACCESS_LISTS)
-  public NavigableMap<String, Ip6AccessList> getIp6AccessLists() {
+  public Map<String, Ip6AccessList> getIp6AccessLists() {
     return _ip6AccessLists;
   }
 
   /** Dictionary of all IPV4 access-lists for this node. */
   @JsonProperty(PROP_IP_ACCESS_LISTS)
-  public NavigableMap<String, IpAccessList> getIpAccessLists() {
+  public Map<String, IpAccessList> getIpAccessLists() {
     return _ipAccessLists;
   }
 
@@ -509,19 +503,19 @@ public final class Configuration implements Serializable {
 
   /** Dictionary of all IPV6 route filter lists for this node. */
   @JsonProperty(PROP_ROUTE6_FILTER_LISTS)
-  public NavigableMap<String, Route6FilterList> getRoute6FilterLists() {
+  public Map<String, Route6FilterList> getRoute6FilterLists() {
     return _route6FilterLists;
   }
 
   /** Dictionary of all IPV4 route filter lists for this node. */
   @JsonProperty(PROP_ROUTE_FILTER_LISTS)
-  public NavigableMap<String, RouteFilterList> getRouteFilterLists() {
+  public Map<String, RouteFilterList> getRouteFilterLists() {
     return _routeFilterLists;
   }
 
   /** Dictionary of all routing policies for this node. */
   @JsonProperty(PROP_ROUTING_POLICIES)
-  public NavigableMap<String, RoutingPolicy> getRoutingPolicies() {
+  public Map<String, RoutingPolicy> getRoutingPolicies() {
     return _routingPolicies;
   }
 
@@ -583,7 +577,7 @@ public final class Configuration implements Serializable {
   }
 
   @JsonProperty(PROP_AS_PATH_ACCESS_LISTS)
-  public void setAsPathAccessLists(NavigableMap<String, AsPathAccessList> asPathAccessLists) {
+  public void setAsPathAccessLists(Map<String, AsPathAccessList> asPathAccessLists) {
     _asPathAccessLists = asPathAccessLists;
   }
 
@@ -594,7 +588,7 @@ public final class Configuration implements Serializable {
   }
 
   @JsonProperty(PROP_COMMUNITY_LISTS)
-  public void setCommunityLists(NavigableMap<String, CommunityList> communityLists) {
+  public void setCommunityLists(Map<String, CommunityList> communityLists) {
     _communityLists = communityLists;
   }
 
@@ -642,17 +636,17 @@ public final class Configuration implements Serializable {
   }
 
   @JsonProperty(PROP_INTERFACES)
-  public void setInterfaces(NavigableMap<String, Interface> interfaces) {
+  public void setInterfaces(Map<String, Interface> interfaces) {
     _interfaces = interfaces;
   }
 
   @JsonProperty(PROP_IP6_ACCESS_LISTS)
-  public void setIp6AccessLists(NavigableMap<String, Ip6AccessList> ip6AccessLists) {
+  public void setIp6AccessLists(Map<String, Ip6AccessList> ip6AccessLists) {
     _ip6AccessLists = ip6AccessLists;
   }
 
   @JsonProperty(PROP_IP_ACCESS_LISTS)
-  public void setIpAccessLists(NavigableMap<String, IpAccessList> ipAccessLists) {
+  public void setIpAccessLists(Map<String, IpAccessList> ipAccessLists) {
     _ipAccessLists = ipAccessLists;
   }
 
@@ -719,17 +713,17 @@ public final class Configuration implements Serializable {
   }
 
   @JsonProperty(PROP_ROUTE6_FILTER_LISTS)
-  public void setRoute6FilterLists(NavigableMap<String, Route6FilterList> route6FilterLists) {
+  public void setRoute6FilterLists(Map<String, Route6FilterList> route6FilterLists) {
     _route6FilterLists = route6FilterLists;
   }
 
   @JsonProperty(PROP_ROUTE_FILTER_LISTS)
-  public void setRouteFilterLists(NavigableMap<String, RouteFilterList> routeFilterLists) {
+  public void setRouteFilterLists(Map<String, RouteFilterList> routeFilterLists) {
     _routeFilterLists = routeFilterLists;
   }
 
   @JsonProperty(PROP_ROUTING_POLICIES)
-  public void setRoutingPolicies(NavigableMap<String, RoutingPolicy> routingPolicies) {
+  public void setRoutingPolicies(Map<String, RoutingPolicy> routingPolicies) {
     _routingPolicies = routingPolicies;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConfigurationMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConfigurationMatchersImpl.java
@@ -269,14 +269,13 @@ final class ConfigurationMatchersImpl {
   }
 
   static final class HasRoute6FilterLists
-      extends FeatureMatcher<Configuration, NavigableMap<String, Route6FilterList>> {
-    HasRoute6FilterLists(
-        @Nonnull Matcher<? super NavigableMap<String, Route6FilterList>> subMatcher) {
+      extends FeatureMatcher<Configuration, Map<String, Route6FilterList>> {
+    HasRoute6FilterLists(@Nonnull Matcher<? super Map<String, Route6FilterList>> subMatcher) {
       super(subMatcher, "A Configuration with route6FilterLists:", "route6FilterLists");
     }
 
     @Override
-    protected NavigableMap<String, Route6FilterList> featureValueOf(Configuration actual) {
+    protected Map<String, Route6FilterList> featureValueOf(Configuration actual) {
       return actual.getRoute6FilterLists();
     }
   }
@@ -299,14 +298,13 @@ final class ConfigurationMatchersImpl {
   }
 
   static final class HasRouteFilterLists
-      extends FeatureMatcher<Configuration, NavigableMap<String, RouteFilterList>> {
-    HasRouteFilterLists(
-        @Nonnull Matcher<? super NavigableMap<String, RouteFilterList>> subMatcher) {
+      extends FeatureMatcher<Configuration, Map<String, RouteFilterList>> {
+    HasRouteFilterLists(@Nonnull Matcher<? super Map<String, RouteFilterList>> subMatcher) {
       super(subMatcher, "A Configuration with routeFilterLists:", "routeFilterLists");
     }
 
     @Override
-    protected NavigableMap<String, RouteFilterList> featureValueOf(Configuration actual) {
+    protected Map<String, RouteFilterList> featureValueOf(Configuration actual) {
       return actual.getRouteFilterLists();
     }
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableMap;
 import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
@@ -168,7 +167,7 @@ public final class DataModelMatchers {
    * routeFilterLists.
    */
   public static Matcher<Configuration> hasRouteFilterLists(
-      @Nonnull Matcher<? super NavigableMap<String, RouteFilterList>> subMatcher) {
+      @Nonnull Matcher<? super Map<String, RouteFilterList>> subMatcher) {
     return new HasRouteFilterLists(subMatcher);
   }
 
@@ -203,7 +202,7 @@ public final class DataModelMatchers {
    * route6FilterLists.
    */
   public static Matcher<Configuration> hasRoute6FilterLists(
-      @Nonnull Matcher<? super NavigableMap<String, Route6FilterList>> subMatcher) {
+      @Nonnull Matcher<? super Map<String, Route6FilterList>> subMatcher) {
     return new HasRoute6FilterLists(subMatcher);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -60,7 +60,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -1910,7 +1909,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
         .values()
         .forEach(
             config -> {
-              NavigableMap<String, Interface> allInterfaces = config.getAllInterfaces();
+              Map<String, Interface> allInterfaces = config.getAllInterfaces();
               Graph<String, Dependency> graph = new SimpleDirectedGraph<>(Dependency.class);
               allInterfaces.keySet().forEach(graph::addVertex);
               allInterfaces

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/LastHopOutgoingInterfaceManagerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/LastHopOutgoingInterfaceManagerTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
@@ -87,7 +88,10 @@ public final class LastHopOutgoingInterfaceManagerTest {
     assertThat(mgr.getFiniteDomains().values(), empty());
     assertThat(
         mgr.getLastHopOutgoingInterfaceBdd(
-            NODE1, IFACE1, c.getHostname(), c.getAllInterfaces().firstKey()),
+            NODE1,
+            IFACE1,
+            c.getHostname(),
+            Iterables.getFirst(c.getAllInterfaces().keySet(), null)),
         equalTo(_trueBdd));
   }
 
@@ -95,7 +99,7 @@ public final class LastHopOutgoingInterfaceManagerTest {
   public void testOneEdge() {
     Configuration c = configurationWithSession();
     String node = c.getHostname();
-    String iface = c.getAllInterfaces().firstKey();
+    String iface = Iterables.getFirst(c.getAllInterfaces().keySet(), null);
     Set<Edge> edges = ImmutableSortedSet.of(Edge.of(NODE1, IFACE1, node, iface));
     LastHopOutgoingInterfaceManager mgr =
         new LastHopOutgoingInterfaceManager(_pkt, configs(c), edges);
@@ -115,7 +119,7 @@ public final class LastHopOutgoingInterfaceManagerTest {
   public void testTwoEdges() {
     Configuration c = configurationWithSession();
     String node = c.getHostname();
-    String iface = c.getAllInterfaces().firstKey();
+    String iface = Iterables.getFirst(c.getAllInterfaces().keySet(), null);
     Set<Edge> edges =
         ImmutableSet.of(Edge.of(NODE1, IFACE1, node, iface), Edge.of(NODE2, IFACE2, node, iface));
     LastHopOutgoingInterfaceManager mgr =

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -3573,14 +3573,13 @@ public class CiscoGrammarTest {
     Map<String, Configuration> configurations = batfish.loadConfigurations();
 
     Configuration iosCommunityListConfig = configurations.get(iosName);
-    SortedMap<String, CommunityList> iosCommunityLists = iosCommunityListConfig.getCommunityLists();
+    Map<String, CommunityList> iosCommunityLists = iosCommunityListConfig.getCommunityLists();
 
     Configuration eosCommunityListConfig = configurations.get(eosName);
-    SortedMap<String, CommunityList> eosCommunityLists = eosCommunityListConfig.getCommunityLists();
+    Map<String, CommunityList> eosCommunityLists = eosCommunityListConfig.getCommunityLists();
 
     Configuration nxosCommunityListConfig = configurations.get(nxosName);
-    SortedMap<String, CommunityList> nxosCommunityLists =
-        nxosCommunityListConfig.getCommunityLists();
+    Map<String, CommunityList> nxosCommunityLists = nxosCommunityListConfig.getCommunityLists();
 
     Community iosImpliedStd = communityListToCommunity(iosCommunityLists, "40");
     String iosRegexImpliedExp = communityListToRegex(iosCommunityLists, "400");
@@ -3930,12 +3929,12 @@ public class CiscoGrammarTest {
   }
 
   private static CommunitySetExpr communityListToMatchCondition(
-      SortedMap<String, CommunityList> communityLists, String communityName) {
+      Map<String, CommunityList> communityLists, String communityName) {
     return communityLists.get(communityName).getLines().get(0).getMatchCondition();
   }
 
   private static Community communityListToCommunity(
-      SortedMap<String, CommunityList> communityLists, String communityName) {
+      Map<String, CommunityList> communityLists, String communityName) {
     return communityLists
         .get(communityName)
         .getLines()
@@ -3946,7 +3945,7 @@ public class CiscoGrammarTest {
   }
 
   private static @Nonnull String communityListToRegex(
-      SortedMap<String, CommunityList> communityLists, String communityName) {
+      Map<String, CommunityList> communityLists, String communityName) {
     return ((RegexCommunitySet)
             communityLists.get(communityName).getLines().get(0).getMatchCondition())
         .getRegex();

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -164,7 +164,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NavigableMap;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -3491,7 +3490,7 @@ public final class FlatJuniperGrammarTest {
   public void testNatDest() throws IOException {
     Configuration config = parseConfig("nat-dest");
 
-    NavigableMap<String, Interface> interfaces = config.getAllInterfaces();
+    Map<String, Interface> interfaces = config.getAllInterfaces();
     assertThat(interfaces.keySet(), containsInAnyOrder("ge-0/0/0", "ge-0/0/0.0"));
 
     assertThat(interfaces.get("ge-0/0/0").getIncomingTransformation(), nullValue());

--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
@@ -212,7 +212,7 @@ public class FilterLineReachabilityAnswerer extends Answerer {
   private static void createAclNode(
       IpAccessList acl,
       Map<String, AclNode> aclNodeMap,
-      SortedMap<String, IpAccessList> acls,
+      Map<String, IpAccessList> acls,
       HeaderSpaceSanitizer headerSpaceSanitizer,
       Set<String> nodeInterfaces) {
 


### PR DESCRIPTION
Instead, ensure at conversion time that these structures are ordered by key.

This leads to much faster lookups by key.