### PR TITLE
Update dataplane VniSettings based on type3 routes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -16,6 +16,7 @@ public interface DataPlane extends Serializable {
 
   Map<String, Configuration> getConfigurations();
 
+  /** Return a {@link Fib} for each node/VRF */
   Map<String, Map<String, Fib>> getFibs();
 
   ForwardingAnalysis getForwardingAnalysis();
@@ -35,4 +36,11 @@ public interface DataPlane extends Serializable {
    */
   SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
       getPrefixTracingInfoSummary();
+
+  /**
+   * Return {@link VniSettings} for each node/VRF. Returned settings are based on the vni settings
+   * in a {@link Vrf}, but may include additional information obtained during dataplane computation,
+   * such as updated flood lists due to EVPN route exchange.
+   */
+  Table<String, String, Set<VniSettings>> getVniSettings();
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
@@ -7,34 +7,41 @@ import com.google.common.collect.Table;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class MockDataPlane implements DataPlane {
 
   public static class Builder {
-    private Map<String, Configuration> _configurations;
+    @Nonnull private Table<String, String, Set<Bgpv4Route>> _bgpRoutes;
+    @Nonnull private Map<String, Configuration> _configurations;
+    @Nonnull private Table<String, String, Set<EvpnRoute<?, ?>>> _evpnRoutes;
+    @Nonnull private Map<String, Map<String, Fib>> _fibs;
+    @Nullable private ForwardingAnalysis _forwardingAnalysis;
 
-    private Map<String, Map<String, Fib>> _fibs;
-
-    private ForwardingAnalysis _forwardingAnalysis;
-
+    @Nonnull
     private SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> _ribs;
 
-    @Nullable private Topology _topology;
-
-    Map<Ip, Set<String>> _ipOwners;
-
-    Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
+    @Nonnull private Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
+    @Nonnull private Table<String, String, Set<VniSettings>> _vniSettings;
 
     private Builder() {
+      _bgpRoutes = HashBasedTable.create();
       _configurations = ImmutableMap.of();
+      _evpnRoutes = HashBasedTable.create();
       _fibs = ImmutableMap.of();
       _ribs = ImmutableSortedMap.of();
-      _ipOwners = ImmutableMap.of();
+      _ipVrfOwners = ImmutableMap.of();
+      _vniSettings = HashBasedTable.create();
     }
 
     public MockDataPlane build() {
       return new MockDataPlane(this);
+    }
+
+    public Builder setBgpRoutes(@Nonnull Table<String, String, Set<Bgpv4Route>> bgpRoutes) {
+      _bgpRoutes = bgpRoutes;
+      return this;
     }
 
     public Builder setConfigs(Map<String, Configuration> configs) {
@@ -42,8 +49,13 @@ public class MockDataPlane implements DataPlane {
       return this;
     }
 
-    public Builder setIpOwners(Map<Ip, Set<String>> owners) {
-      _ipOwners = owners;
+    public Builder setEvpnRoutes(@Nonnull Table<String, String, Set<EvpnRoute<?, ?>>> evpnRoutes) {
+      _evpnRoutes = evpnRoutes;
+      return this;
+    }
+
+    public Builder setFibs(@Nonnull Map<String, Map<String, Fib>> fibs) {
+      _fibs = fibs;
       return this;
     }
 
@@ -52,14 +64,19 @@ public class MockDataPlane implements DataPlane {
       return this;
     }
 
-    public Builder setRibs(
-        SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs) {
-      _ribs = ribs;
+    public Builder setIpVrfOwners(@Nonnull Map<Ip, Map<String, Set<String>>> ipVrfOwners) {
+      _ipVrfOwners = ipVrfOwners;
       return this;
     }
 
-    public Builder setTopology(Topology topology) {
-      _topology = topology;
+    public Builder setVniSettings(@Nonnull Table<String, String, Set<VniSettings>> vniSettings) {
+      _vniSettings = vniSettings;
+      return this;
+    }
+
+    public Builder setRibs(
+        SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs) {
+      _ribs = ribs;
       return this;
     }
   }
@@ -70,65 +87,82 @@ public class MockDataPlane implements DataPlane {
     return new Builder();
   }
 
-  private Table<String, String, Set<Bgpv4Route>> _bgpRoutes;
+  @Nonnull private Table<String, String, Set<Bgpv4Route>> _bgpRoutes;
+  @Nonnull private final Map<String, Configuration> _configurations;
+  @Nonnull private Table<String, String, Set<EvpnRoute<?, ?>>> _evpnRoutes;
+  @Nonnull private final Map<String, Map<String, Fib>> _fibs;
+  @Nullable private final ForwardingAnalysis _forwardingAnalysis;
+  @Nonnull private final Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
 
-  private final Map<String, Configuration> _configurations;
-
-  private final Map<String, Map<String, Fib>> _fibs;
-
-  private final ForwardingAnalysis _forwardingAnalysis;
-
-  private final Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
-
+  @Nonnull
   private final SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
       _ribs;
 
+  @Nonnull private Table<String, String, Set<VniSettings>> _vniSettings;
+
   private MockDataPlane(Builder builder) {
+    _bgpRoutes = builder._bgpRoutes;
     _configurations = builder._configurations;
+    _evpnRoutes = builder._evpnRoutes;
     _fibs = builder._fibs;
     _forwardingAnalysis = builder._forwardingAnalysis;
     _ipVrfOwners = builder._ipVrfOwners;
     _ribs = ImmutableSortedMap.copyOf(builder._ribs);
+    _vniSettings = builder._vniSettings;
   }
 
+  @Nonnull
   @Override
   public Table<String, String, Set<Bgpv4Route>> getBgpRoutes() {
     return _bgpRoutes;
   }
 
+  @Nonnull
   @Override
   public Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnRoutes() {
-    return HashBasedTable.create();
+    return _evpnRoutes;
   }
 
+  @Nonnull
   @Override
   public Map<String, Map<String, Fib>> getFibs() {
     return _fibs;
   }
 
+  @Nullable
   @Override
   public ForwardingAnalysis getForwardingAnalysis() {
     return _forwardingAnalysis;
   }
 
+  @Nonnull
   @Override
   public Map<Ip, Map<String, Set<String>>> getIpVrfOwners() {
     return _ipVrfOwners;
   }
 
+  @Nonnull
   @Override
   public SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> getRibs() {
     return _ribs;
   }
 
+  @Nonnull
   @Override
   public Map<String, Configuration> getConfigurations() {
     return _configurations;
   }
 
   @Override
+  @Nonnull
   public SortedMap<String, SortedMap<String, Map<Prefix, Map<String, Set<String>>>>>
       getPrefixTracingInfoSummary() {
     return ImmutableSortedMap.of();
+  }
+
+  @Nonnull
+  @Override
+  public Table<String, String, Set<VniSettings>> getVniSettings() {
+    return _vniSettings;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -335,8 +335,10 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     DeltaPair<EvpnType3Route> type3Delta = processEvpnType3Messages(nc, allNodes);
     sendOutEvpnRoutes(type3Delta._toAdvertise, nc, allNodes);
     // Merge EVPN routes into EVPN RIB and prepare for merging into main RIB
-    _changeSet.from(importRibDelta(_evpnRib, type3Delta._toMerge._ebgpDelta));
-    _changeSet.from(importRibDelta(_evpnRib, type3Delta._toMerge._ibgpDelta));
+    _changeSet.from(
+        importRibDelta(_evpnRib, importRibDelta(_evpnType3Rib, type3Delta._toMerge._ebgpDelta)));
+    _changeSet.from(
+        importRibDelta(_evpnRib, importRibDelta(_evpnType3Rib, type3Delta._toMerge._ibgpDelta)));
 
     // TODO: migrate v4 route propagation here
   }
@@ -703,6 +705,11 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   @Nonnull
   public Ip getRouterId() {
     return _process.getRouterId();
+  }
+
+  /** Return all type 3 EVPN routes */
+  public Set<EvpnType3Route> getEvpnType3Routes() {
+    return _evpnType3Rib.getTypedRoutes();
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -53,11 +53,13 @@ import org.batfish.datamodel.BgpPeerConfigId;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.EvpnRoute;
+import org.batfish.datamodel.EvpnType3Route;
 import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.FibImpl;
 import org.batfish.datamodel.GeneratedRoute;
@@ -74,6 +76,7 @@ import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.VniSettings;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.bgp.BgpTopology.EdgeId;
@@ -179,6 +182,12 @@ public class VirtualRouter implements Serializable {
   /** List of all EIGRP processes in this VRF */
   @VisibleForTesting transient ImmutableMap<Long, VirtualEigrpProcess> _virtualEigrpProcesses;
 
+  /**
+   * VNI settings that are updated dynamically as the dataplane is being computed (e.g., based on
+   * EVPN route advertisements).
+   */
+  private Set<VniSettings> _vniSettings;
+
   /** A {@link Vrf} that this virtual router represents */
   final Vrf _vrf;
 
@@ -197,6 +206,7 @@ public class VirtualRouter implements Serializable {
     _prefixTracer = new PrefixTracer();
     _virtualEigrpProcesses = ImmutableMap.of();
     _ospfProcesses = ImmutableMap.of();
+    _vniSettings = ImmutableSet.copyOf(_vrf.getVniSettings().values());
     if (_vrf.getBgpProcess() != null) {
       _bgpRoutingProcess =
           new BgpRoutingProcess(_vrf.getBgpProcess(), _c, _name, _mainRib, BgpTopology.EMPTY);
@@ -2046,6 +2056,10 @@ public class VirtualRouter implements Serializable {
     return _ospfProcesses;
   }
 
+  public Set<VniSettings> getVniSettings() {
+    return _vniSettings;
+  }
+
   /** Check whether this virtual router has any remaining computation to do */
   boolean isDirty() {
     return
@@ -2067,7 +2081,32 @@ public class VirtualRouter implements Serializable {
   void bgpIteration(Map<String, Node> allNodes) {
     if (_bgpRoutingProcess != null) {
       _bgpRoutingProcess.executeIteration(allNodes);
+      updateFloodLists();
     }
+  }
+
+  /**
+   * Process EVPN type 3 routes in our RIB and update flood lists for any {@link VniSettings} if
+   * necessary.
+   */
+  private void updateFloodLists() {
+    for (EvpnType3Route route : _bgpRoutingProcess.getEvpnType3Routes()) {
+      _vniSettings =
+          _vniSettings.stream()
+              .map(vs -> updateVniFloodList(vs, route))
+              .collect(ImmutableSet.toImmutableSet());
+    }
+  }
+
+  @VisibleForTesting
+  static VniSettings updateVniFloodList(VniSettings vs, EvpnType3Route route) {
+    if (vs.getBumTransportMethod() != BumTransportMethod.UNICAST_FLOOD_GROUP
+        || route.getVniIp().equals(vs.getSourceAddress())) {
+      // Only update settings if transport method is unicast.
+      // Do not add our own source to the flood list.
+      return vs;
+    }
+    return vs.addToFloodList(route.getVniIp());
   }
 
   void redistribute() {


### PR DESCRIPTION
Includes following fixes/cleanups:
1. We were skipping type3 RIB when merging some routes
2. Cleaned up and annotated `MockDataPlane`

After #4061 