### PR TITLE
Fix shared-gateway traffic semantics

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Ordering;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
@@ -105,8 +106,12 @@ public final class AclLineMatchExprs {
         HeaderSpace.builder().setSrcPorts(ImmutableList.of(new SubRange(port, port))).build());
   }
 
-  public static MatchSrcInterface matchSrcInterface(String... iface) {
-    return new MatchSrcInterface(ImmutableList.copyOf(iface));
+  public static @Nonnull MatchSrcInterface matchSrcInterface(Iterable<String> ifaces) {
+    return new MatchSrcInterface(ImmutableList.copyOf(ifaces));
+  }
+
+  public static @Nonnull MatchSrcInterface matchSrcInterface(String... ifaces) {
+    return matchSrcInterface(ImmutableList.copyOf(ifaces));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoBidirectionalBehaviorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoBidirectionalBehaviorTest.java
@@ -292,6 +292,26 @@ public final class PaloAltoBidirectionalBehaviorTest {
   }
 
   @Test
+  public void testAllowInterSg() throws IOException {
+    String hostname = "allow-inter-sg";
+    TracerouteEngine tracerouteEngine = bidirTracerouteEngine(hostname);
+
+    // Bidirectional traffic from interface in shared-gateway to interface in another shared-gateway
+    // is allowed.
+    assertBidirAccepted(tracerouteEngine, bidirForwardOutsideFlow(hostname));
+  }
+
+  @Test
+  public void testAllowIntraSg() throws IOException {
+    String hostname = "allow-intra-sg";
+    TracerouteEngine tracerouteEngine = bidirTracerouteEngine(hostname);
+
+    // Bidirectional traffic from interface in shared-gateway to interface in same shared-gateway is
+    // allowed.
+    assertBidirAccepted(tracerouteEngine, bidirForwardOutsideFlow(hostname));
+  }
+
+  @Test
   public void testAllowSgToVsys() throws IOException {
     String hostname = "allow-sg-to-vsys";
     TracerouteEngine tracerouteEngine = bidirTracerouteEngine(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/allow-inter-sg
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/allow-inter-sg
@@ -1,0 +1,7 @@
+set deviceconfig system hostname allow-inter-sg
+set network interface ethernet ethernet1/1 layer3 ip 10.0.1.1/24
+set network interface ethernet ethernet1/2 layer3 ip 10.0.2.1/24
+set network virtual-router vr1 interface ethernet1/1
+set network virtual-router vr1 interface ethernet1/2
+set network shared-gateway sg1 import network interface ethernet1/1
+set network shared-gateway sg2 import network interface ethernet1/2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/allow-intra-sg
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/allow-intra-sg
@@ -1,0 +1,7 @@
+set deviceconfig system hostname allow-intra-sg
+set network interface ethernet ethernet1/1 layer3 ip 10.0.1.1/24
+set network interface ethernet ethernet1/2 layer3 ip 10.0.2.1/24
+set network virtual-router vr1 interface ethernet1/1
+set network virtual-router vr1 interface ethernet1/2
+set network shared-gateway sg1 import network interface ethernet1/1
+set network shared-gateway sg1 import network interface ethernet1/2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/allow-sg-to-vsys
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/allow-sg-to-vsys
@@ -7,7 +7,6 @@ set vsys vsys1 import network interface ethernet1/1
 set vsys vsys1 zone zin network layer3 ethernet1/1
 set vsys vsys1 zone vsys1-sg1 network external sg1
 set network shared-gateway sg1 import network interface ethernet1/2
-set network shared-gateway sg1 zone sg1z network layer3 ethernet1/2
 set vsys vsys1 rulebase security rules rule1 from vsys1-sg1
 set vsys vsys1 rulebase security rules rule1 to zin
 set vsys vsys1 rulebase security rules rule1 action allow

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/allow-vsys-to-sg
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/allow-vsys-to-sg
@@ -7,7 +7,6 @@ set vsys vsys1 import network interface ethernet1/1
 set vsys vsys1 zone zin network layer3 ethernet1/1
 set vsys vsys1 zone vsys1-sg1 network external sg1
 set network shared-gateway sg1 import network interface ethernet1/2
-set network shared-gateway sg1 zone sg1z network layer3 ethernet1/2
 set vsys vsys1 rulebase security rules rule1 from zin
 set vsys vsys1 rulebase security rules rule1 to vsys1-sg1
 set vsys vsys1 rulebase security rules rule1 action allow

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/allow-vsys-to-sg-next-vr
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/allow-vsys-to-sg-next-vr
@@ -11,7 +11,6 @@ set vsys vsys1 import network interface ethernet1/1
 set vsys vsys1 zone zin network layer3 ethernet1/1
 set vsys vsys1 zone vsys1-sg1 network external sg1
 set network shared-gateway sg1 import network interface ethernet1/2
-set network shared-gateway sg1 zone sg1z network layer3 ethernet1/2
 set vsys vsys1 rulebase security rules rule1 from zin
 set vsys vsys1 rulebase security rules rule1 to vsys1-sg1
 set vsys vsys1 rulebase security rules rule1 action allow

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/drop-vsys-to-sg-misconfigured-external
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/drop-vsys-to-sg-misconfigured-external
@@ -7,7 +7,6 @@ set vsys vsys1 import network interface ethernet1/1
 set vsys vsys1 zone zin network layer3 ethernet1/1
 set vsys vsys1 zone vsys1-sg1 network external
 set network shared-gateway sg1 import network interface ethernet1/2
-set network shared-gateway sg1 zone sg1z network layer3 ethernet1/2
 set vsys vsys1 rulebase security rules rule1 from any
 set vsys vsys1 rulebase security rules rule1 to any
 set vsys vsys1 rulebase security rules rule1 action allow

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/drop-vsys-to-sg-missing-external
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/drop-vsys-to-sg-missing-external
@@ -6,7 +6,6 @@ set network virtual-router vr1 interface ethernet1/2
 set vsys vsys1 import network interface ethernet1/1
 set vsys vsys1 zone zin network layer3 ethernet1/1
 set network shared-gateway sg1 import network interface ethernet1/2
-set network shared-gateway sg1 zone sg1z network layer3 ethernet1/2
 set vsys vsys1 rulebase security rules rule1 from any
 set vsys vsys1 rulebase security rules rule1 to any
 set vsys vsys1 rulebase security rules rule1 action allow


### PR DESCRIPTION
- unconditionally allow inter- and intra-shared-gateway traffic
- don't generate rules guarded by empty set of source interfaces
- ignore zones entirely for shared-gateways
- Add sg-sg tests
- Remove unnecessary sg zones