### PR TITLE
Palo Alto fix special vsys references

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -530,7 +530,6 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void enterPalo_alto_configuration(Palo_alto_configurationContext ctx) {
     _configuration = new PaloAltoConfiguration();
-    _configuration.getVirtualSystems().computeIfAbsent(SHARED_VSYS_NAME, Vsys::new);
     _defaultVsys = _configuration.getVirtualSystems().computeIfAbsent(DEFAULT_VSYS_NAME, Vsys::new);
     _currentVsys = _defaultVsys;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -454,17 +454,16 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
 
   /** Collects the rules from this Vsys and merges the common pre-/post-rulebases from Panorama. */
   private List<Map.Entry<Rule, Vsys>> getAllRules(Vsys vsys) {
-    @Nullable Vsys panorama = _virtualSystems.get(PANORAMA_VSYS_NAME);
     Stream<Map.Entry<Rule, Vsys>> pre =
-        panorama == null
+        _panorama == null
             ? Stream.of()
-            : panorama.getPreRules().values().stream()
-                .map(r -> new SimpleImmutableEntry<>(r, panorama));
+            : _panorama.getPreRules().values().stream()
+                .map(r -> new SimpleImmutableEntry<>(r, _panorama));
     Stream<Map.Entry<Rule, Vsys>> post =
-        panorama == null
+        _panorama == null
             ? Stream.of()
-            : panorama.getPostRules().values().stream()
-                .map(r -> new SimpleImmutableEntry<>(r, panorama));
+            : _panorama.getPostRules().values().stream()
+                .map(r -> new SimpleImmutableEntry<>(r, _panorama));
     Stream<Map.Entry<Rule, Vsys>> rules =
         vsys.getRules().values().stream().map(r -> new SimpleImmutableEntry<>(r, vsys));
 


### PR DESCRIPTION
- remove attempts to retrieve shared and panorama vsys namespace via `_virtualSystems`
- use `_shared` and `_panorama` instead