### PR TITLE
Fix tunnel Interface types 

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -2,7 +2,6 @@ package org.batfish.common.topology;
 
 import static org.batfish.common.util.IpsecUtil.initIpsecTopology;
 import static org.batfish.common.util.IpsecUtil.retainCompatibleTunnelEdges;
-import static org.batfish.datamodel.Interface.TUNNEL_INTERFACE_TYPES;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashBasedTable;
@@ -803,9 +802,9 @@ public final class TopologyUtil {
           if (haveIpInCommon(iface1, iface2)) {
             continue;
           }
-          // don't connect if any of the two endpoint interfaces have Tunnel or VPN interfaceTypes
-          if (TUNNEL_INTERFACE_TYPES.contains(iface1.getInterfaceType())
-              || TUNNEL_INTERFACE_TYPES.contains(iface2.getInterfaceType())) {
+          // don't connect if any of the two endpoint interfaces are IPsec tunnel interfaces
+          if (iface1.getInterfaceType() == InterfaceType.IPSEC_TUNNEL
+              || iface2.getInterfaceType() == InterfaceType.IPSEC_TUNNEL) {
             continue;
           }
           edges.add(new Edge(iface1, iface2));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -630,6 +630,8 @@ public final class Interface extends ComparableStructure<String> {
       return InterfaceType.AGGREGATED;
     } else if (name.startsWith("cmp-mgmt")) {
       return InterfaceType.PHYSICAL;
+    } else if (name.startsWith("Crypto-Engine")) {
+      return InterfaceType.IPSEC_TUNNEL; // IPSec VPN
     } else if (name.startsWith("Dialer")) {
       return InterfaceType.PHYSICAL;
     } else if (name.startsWith("Dot11Radio")) {
@@ -758,8 +760,6 @@ public final class Interface extends ComparableStructure<String> {
     if (name.startsWith("st")) {
       return InterfaceType.IPSEC_TUNNEL;
     } else if (name.startsWith("gr")) {
-      return InterfaceType.TUNNEL;
-    } else if (name.startsWith("ip")) {
       return InterfaceType.TUNNEL;
     } else if (name.startsWith("reth")) {
       return InterfaceType.REDUNDANT;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -532,7 +532,7 @@ public final class Interface extends ComparableStructure<String> {
   public static final String NULL_INTERFACE_NAME = "null_interface";
 
   public static final Set<InterfaceType> TUNNEL_INTERFACE_TYPES =
-      ImmutableSet.of(InterfaceType.TUNNEL, InterfaceType.VPN);
+      ImmutableSet.of(InterfaceType.IPSEC_TUNNEL);
 
   public static final String UNSET_LOCAL_INTERFACE = "unset_local_interface";
 
@@ -615,7 +615,7 @@ public final class Interface extends ComparableStructure<String> {
 
   private static InterfaceType computeAwsInterfaceType(String name) {
     if (name.startsWith("vpn")) {
-      return InterfaceType.VPN;
+      return InterfaceType.IPSEC_TUNNEL;
     } else {
       return InterfaceType.PHYSICAL;
     }
@@ -630,8 +630,6 @@ public final class Interface extends ComparableStructure<String> {
       return InterfaceType.AGGREGATED;
     } else if (name.startsWith("cmp-mgmt")) {
       return InterfaceType.PHYSICAL;
-    } else if (name.startsWith("Crypto-Engine")) {
-      return InterfaceType.VPN; // IPSec VPN
     } else if (name.startsWith("Dialer")) {
       return InterfaceType.PHYSICAL;
     } else if (name.startsWith("Dot11Radio")) {
@@ -677,16 +675,12 @@ public final class Interface extends ComparableStructure<String> {
       return InterfaceType.PHYSICAL;
     } else if (name.startsWith("TenGigabitEthernet")) {
       return InterfaceType.PHYSICAL;
-    } else if (name.startsWith("Tunnel")) {
-      return InterfaceType.TUNNEL;
     } else if (name.startsWith("tunnel-ip")) {
       return InterfaceType.TUNNEL;
     } else if (name.startsWith("tunnel-te")) {
       return InterfaceType.TUNNEL;
     } else if (name.startsWith("Vlan")) {
       return InterfaceType.VLAN;
-    } else if (name.startsWith("Vxlan")) {
-      return InterfaceType.TUNNEL;
     } else {
       return InterfaceType.UNKNOWN;
     }
@@ -762,7 +756,11 @@ public final class Interface extends ComparableStructure<String> {
 
   private static InterfaceType computeJuniperInterfaceType(String name) {
     if (name.startsWith("st")) {
-      return InterfaceType.VPN;
+      return InterfaceType.IPSEC_TUNNEL;
+    } else if (name.startsWith("gr")) {
+      return InterfaceType.TUNNEL;
+    } else if (name.startsWith("ip")) {
+      return InterfaceType.TUNNEL;
     } else if (name.startsWith("reth")) {
       return InterfaceType.REDUNDANT;
     } else if (name.startsWith("ae") && name.contains(".")) {
@@ -782,7 +780,7 @@ public final class Interface extends ComparableStructure<String> {
 
   private static InterfaceType computeVyosInterfaceType(String name) {
     if (name.startsWith("vti")) {
-      return InterfaceType.VPN;
+      return InterfaceType.IPSEC_TUNNEL;
     } else if (name.startsWith("lo")) {
       return InterfaceType.LOOPBACK;
     } else {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -531,9 +531,6 @@ public final class Interface extends ComparableStructure<String> {
 
   public static final String NULL_INTERFACE_NAME = "null_interface";
 
-  public static final Set<InterfaceType> TUNNEL_INTERFACE_TYPES =
-      ImmutableSet.of(InterfaceType.IPSEC_TUNNEL);
-
   public static final String UNSET_LOCAL_INTERFACE = "unset_local_interface";
 
   public static final String INVALID_LOCAL_INTERFACE = "invalid_local_interface";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/InterfaceType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/InterfaceType.java
@@ -6,7 +6,7 @@ public enum InterfaceType {
   AGGREGATED,
   /** Child of a aggregate interface: logical, sub-interface of an AGGREGATED interface */
   AGGREGATE_CHILD,
-  /** Tunnel configured to use IPsec protocol */
+  /** Tunnel interface configured to use IPsec protocol */
   IPSEC_TUNNEL,
   /** Generic Logical interface, (e.g., units on Juniper devices) */
   LOGICAL,
@@ -24,6 +24,4 @@ public enum InterfaceType {
   UNKNOWN, // for use as sentinel value
   /** Logical VLAN/irb interface */
   VLAN,
-  /** Logical VPN interface, (i.e., IPSec tunnel) */
-  VPN,
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/InterfaceType.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/InterfaceType.java
@@ -6,6 +6,8 @@ public enum InterfaceType {
   AGGREGATED,
   /** Child of a aggregate interface: logical, sub-interface of an AGGREGATED interface */
   AGGREGATE_CHILD,
+  /** Tunnel configured to use IPsec protocol */
+  IPSEC_TUNNEL,
   /** Generic Logical interface, (e.g., units on Juniper devices) */
   LOGICAL,
   /** Logical loopback interface */
@@ -16,9 +18,9 @@ public enum InterfaceType {
   PHYSICAL,
   /** Logical redundant ethernet interface (in Juniper parlance) */
   REDUNDANT,
-  /** A logical tunnel interface (e.g., GRE, IP-in-IP encapsulation) */
+  /** Tunnel interface running anything else than IPsec, for e.g., GRE, IPIP, MPLS, etc. */
   TUNNEL,
-  /** Uknknown interface type */
+  /** Unknown interface type */
   UNKNOWN, // for use as sentinel value
   /** Logical VLAN/irb interface */
   VLAN,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Link.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Link.java
@@ -83,10 +83,10 @@ public class Link extends BfObject {
 
       case AGGREGATED:
       case AGGREGATE_CHILD:
+      case IPSEC_TUNNEL:
       case REDUNDANT:
       case TUNNEL:
       case VLAN:
-      case VPN:
         return LinkType.VIRTUAL;
 
         // loopback and null shouldn't really happen; lets call it unknown

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TypesInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TypesInterfaceSpecifierTest.java
@@ -29,7 +29,6 @@ public class TypesInterfaceSpecifierTest {
   private static final Interface TUNNEL;
   private static final Interface UNKNOWN;
   private static final Interface VLAN;
-  private static final Interface VPN;
 
   private static final String HOSTNAME = "hostname";
   private static final MockSpecifierContext CTXT;
@@ -68,9 +67,6 @@ public class TypesInterfaceSpecifierTest {
     VLAN = ib.build();
     VLAN.setInterfaceType(InterfaceType.VLAN);
 
-    VPN = ib.build();
-    VPN.setInterfaceType(InterfaceType.VPN);
-
     CTXT =
         MockSpecifierContext.builder()
             .setConfigs(ImmutableMap.of(config.getHostname(), config))
@@ -103,7 +99,7 @@ public class TypesInterfaceSpecifierTest {
     assertThat(
         specifiedInterfaces("u.*"), equalTo(ImmutableSet.of(new NodeInterfacePair(UNKNOWN))));
     assertThat(specifiedInterfaces("vlan"), equalTo(ImmutableSet.of(new NodeInterfacePair(VLAN))));
-    assertThat(specifiedInterfaces("vpn"), equalTo(ImmutableSet.of(new NodeInterfacePair(VPN))));
+
     assertThat(
         specifiedInterfaces(".*"),
         equalTo(
@@ -115,7 +111,6 @@ public class TypesInterfaceSpecifierTest {
                 new NodeInterfacePair(REDUNDANT),
                 new NodeInterfacePair(TUNNEL),
                 new NodeInterfacePair(UNKNOWN),
-                new NodeInterfacePair(VLAN),
-                new NodeInterfacePair(VPN))));
+                new NodeInterfacePair(VLAN))));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TypesInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TypesInterfaceSpecifierTest.java
@@ -22,6 +22,7 @@ public class TypesInterfaceSpecifierTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   private static final Interface AGGREGATED;
+  private static final Interface IPSEC_TUNNEL;
   private static final Interface LOOPBACK;
   private static final Interface NULL;
   private static final Interface PHYSICAL;
@@ -45,6 +46,9 @@ public class TypesInterfaceSpecifierTest {
 
     AGGREGATED = ib.build();
     AGGREGATED.setInterfaceType(InterfaceType.AGGREGATED);
+
+    IPSEC_TUNNEL = ib.build();
+    IPSEC_TUNNEL.setInterfaceType(InterfaceType.IPSEC_TUNNEL);
 
     LOOPBACK = ib.build();
     LOOPBACK.setInterfaceType(InterfaceType.LOOPBACK);
@@ -89,6 +93,9 @@ public class TypesInterfaceSpecifierTest {
     assertThat(
         specifiedInterfaces("a.*"), equalTo(ImmutableSet.of(new NodeInterfacePair(AGGREGATED))));
     assertThat(
+        specifiedInterfaces("ipsec.*"),
+        equalTo(ImmutableSet.of(new NodeInterfacePair(IPSEC_TUNNEL))));
+    assertThat(
         specifiedInterfaces("l.*"), equalTo(ImmutableSet.of(new NodeInterfacePair(LOOPBACK))));
     assertThat(specifiedInterfaces("n.*"), equalTo(ImmutableSet.of(new NodeInterfacePair(NULL))));
     assertThat(
@@ -105,6 +112,7 @@ public class TypesInterfaceSpecifierTest {
         equalTo(
             ImmutableSet.of(
                 new NodeInterfacePair(AGGREGATED),
+                new NodeInterfacePair(IPSEC_TUNNEL),
                 new NodeInterfacePair(LOOPBACK),
                 new NodeInterfacePair(NULL),
                 new NodeInterfacePair(PHYSICAL),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifierTest.java
@@ -153,10 +153,11 @@ public class ParboiledInterfaceSpecifierTest {
   @Test
   public void testResolveType() {
     _iface11B.setType(InterfaceType.VLAN);
-    _iface12B.setType(InterfaceType.VPN);
+    _iface12B.setType(InterfaceType.IPSEC_TUNNEL);
     build();
     assertThat(
-        new ParboiledInterfaceSpecifier(new TypeInterfaceAstNode("vpn")).resolve(_nodes, _ctxt),
+        new ParboiledInterfaceSpecifier(new TypeInterfaceAstNode("ipsec_tunnel"))
+            .resolve(_nodes, _ctxt),
         contains(new NodeInterfacePair(_iface12)));
   }
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -1613,10 +1613,11 @@ iftunnel_mode
      | IPSEC
    )
    (
-     IPV4
+     IP
+     | IPV4
      | IPV6
      | MULTIPOINT
-   )
+   )?
    NEWLINE
 ;
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -6717,7 +6717,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       } else {
         todo(ctx);
       }
-      if (ctx.IPV4() != null) {
+      if (ctx.IPV4() != null || ctx.IP() != null) {
         tunnel.setProtocol(IpProtocol.IP);
       } else if (ctx.IPV6() != null) {
         tunnel.setProtocol(IpProtocol.IPV6);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -15,7 +15,6 @@ import static org.batfish.representation.cisco.CiscoConversions.generateBgpExpor
 import static org.batfish.representation.cisco.CiscoConversions.generateBgpImportPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.generateGenerationPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.getRsaPubKeyGeneratedName;
-import static org.batfish.representation.cisco.CiscoConversions.getTunnelInterfaceType;
 import static org.batfish.representation.cisco.CiscoConversions.resolveIsakmpProfileIfaceNames;
 import static org.batfish.representation.cisco.CiscoConversions.resolveKeyringIfaceNames;
 import static org.batfish.representation.cisco.CiscoConversions.resolveTunnelIfaceNames;
@@ -2026,7 +2025,10 @@ public final class CiscoConfiguration extends VendorConfiguration {
       String ifaceName, Interface iface, Map<String, IpAccessList> ipAccessLists, Configuration c) {
     InterfaceType ifaceType;
     if (iface.getTunnel() != null) {
-      ifaceType = getTunnelInterfaceType(iface.getTunnel().getMode());
+      ifaceType =
+          iface.getTunnel().getMode() == TunnelMode.IPSEC
+              ? InterfaceType.IPSEC_TUNNEL
+              : InterfaceType.TUNNEL;
     } else {
       ifaceType = computeInterfaceType(iface.getName(), c.getConfigurationFormat());
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -15,6 +15,7 @@ import static org.batfish.representation.cisco.CiscoConversions.generateBgpExpor
 import static org.batfish.representation.cisco.CiscoConversions.generateBgpImportPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.generateGenerationPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.getRsaPubKeyGeneratedName;
+import static org.batfish.representation.cisco.CiscoConversions.getTunnelInterfaceType;
 import static org.batfish.representation.cisco.CiscoConversions.resolveIsakmpProfileIfaceNames;
 import static org.batfish.representation.cisco.CiscoConversions.resolveKeyringIfaceNames;
 import static org.batfish.representation.cisco.CiscoConversions.resolveTunnelIfaceNames;
@@ -2023,9 +2024,14 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
   private org.batfish.datamodel.Interface toInterface(
       String ifaceName, Interface iface, Map<String, IpAccessList> ipAccessLists, Configuration c) {
+    InterfaceType ifaceType;
+    if (iface.getTunnel() != null) {
+      ifaceType = getTunnelInterfaceType(iface.getTunnel().getMode());
+    } else {
+      ifaceType = computeInterfaceType(iface.getName(), c.getConfigurationFormat());
+    }
     org.batfish.datamodel.Interface newIface =
-        new org.batfish.datamodel.Interface(
-            ifaceName, c, computeInterfaceType(iface.getName(), c.getConfigurationFormat()));
+        new org.batfish.datamodel.Interface(ifaceName, c, ifaceType);
     if (newIface.getInterfaceType() == InterfaceType.VLAN) {
       newIface.setVlan(CommonUtil.getInterfaceVlanNumber(ifaceName));
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -57,7 +57,6 @@ import org.batfish.datamodel.IkeKeyType;
 import org.batfish.datamodel.IkePhase1Key;
 import org.batfish.datamodel.IkePhase1Policy;
 import org.batfish.datamodel.IkePhase1Proposal;
-import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6;
 import org.batfish.datamodel.Ip6AccessList;
@@ -119,7 +118,6 @@ import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.visitors.HeaderSpaceConverter;
 import org.batfish.representation.cisco.DistributeList.DistributeListFilterType;
-import org.batfish.representation.cisco.Tunnel.TunnelMode;
 
 /** Utilities that convert Cisco-specific representations to vendor-independent model. */
 @ParametersAreNonnullByDefault
@@ -155,15 +153,6 @@ class CiscoConversions {
       }
     }
     return highestIp;
-  }
-
-  /** Gets the interface type for a given tunnel mode */
-  @Nonnull
-  static InterfaceType getTunnelInterfaceType(@Nonnull TunnelMode tunnelMode) {
-    if (tunnelMode == TunnelMode.IPSEC) {
-      return InterfaceType.IPSEC_TUNNEL;
-    }
-    return InterfaceType.TUNNEL;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -57,6 +57,7 @@ import org.batfish.datamodel.IkeKeyType;
 import org.batfish.datamodel.IkePhase1Key;
 import org.batfish.datamodel.IkePhase1Policy;
 import org.batfish.datamodel.IkePhase1Proposal;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6;
 import org.batfish.datamodel.Ip6AccessList;
@@ -118,6 +119,7 @@ import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.visitors.HeaderSpaceConverter;
 import org.batfish.representation.cisco.DistributeList.DistributeListFilterType;
+import org.batfish.representation.cisco.Tunnel.TunnelMode;
 
 /** Utilities that convert Cisco-specific representations to vendor-independent model. */
 @ParametersAreNonnullByDefault
@@ -153,6 +155,15 @@ class CiscoConversions {
       }
     }
     return highestIp;
+  }
+
+  /** Gets the interface type for a given tunnel mode */
+  @Nonnull
+  static InterfaceType getTunnelInterfaceType(@Nonnull TunnelMode tunnelMode) {
+    if (tunnelMode == TunnelMode.IPSEC) {
+      return InterfaceType.IPSEC_TUNNEL;
+    }
+    return InterfaceType.TUNNEL;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Tunnel.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Tunnel.java
@@ -68,11 +68,11 @@ public final class Tunnel implements Serializable {
     return _sourceInterfaceName;
   }
 
-  public void setDestination(Ip destination) {
+  public void setDestination(@Nullable Ip destination) {
     _destination = destination;
   }
 
-  public void setIpsecProfileName(String name) {
+  public void setIpsecProfileName(@Nullable String name) {
     _ipsecProfileName = name;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Tunnel.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Tunnel.java
@@ -6,9 +6,11 @@ import static org.batfish.datamodel.Interface.UNSET_LOCAL_INTERFACE;
 import java.io.Serializable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
 
+@ParametersAreNonnullByDefault
 public final class Tunnel implements Serializable {
 
   public enum TunnelMode {
@@ -18,34 +20,40 @@ public final class Tunnel implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private Ip _destination;
+  @Nullable private Ip _destination;
 
-  private String _ipsecProfileName;
+  @Nullable private String _ipsecProfileName;
 
-  private TunnelMode _mode;
+  @Nonnull private TunnelMode _mode;
 
-  private IpProtocol _protocol;
+  @Nonnull private IpProtocol _protocol;
 
-  private @Nullable Ip _sourceAddress;
+  @Nullable private Ip _sourceAddress;
 
-  private @Nonnull String _sourceInterfaceName;
+  @Nonnull private String _sourceInterfaceName;
 
   public Tunnel() {
     _sourceInterfaceName = UNSET_LOCAL_INTERFACE;
+    _mode = TunnelMode.GRE;
+    _protocol = IpProtocol.IP;
   }
 
+  @Nullable
   public Ip getDestination() {
     return _destination;
   }
 
+  @Nullable
   public String getIpsecProfileName() {
     return _ipsecProfileName;
   }
 
+  @Nonnull
   public TunnelMode getMode() {
     return _mode;
   }
 
+  @Nonnull
   public IpProtocol getProtocol() {
     return _protocol;
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1889,6 +1889,24 @@ public class CiscoGrammarTest {
   }
 
   @Test
+  public void testIosInterfaceType() throws IOException {
+    Configuration c = parseConfig("ios-interface-type");
+
+    assertThat(c, hasInterface("Tunnel1", hasInterfaceType(InterfaceType.TUNNEL)));
+    assertThat(c, hasInterface("Tunnel2", hasInterfaceType(InterfaceType.TUNNEL)));
+    assertThat(c, hasInterface("Tunnel3", hasInterfaceType(InterfaceType.IPSEC_TUNNEL)));
+    assertThat(c, hasInterface("TenGigabitEthernet0/0", hasInterfaceType(InterfaceType.PHYSICAL)));
+  }
+
+  @Test
+  public void testEosInterfaceType() throws IOException {
+    Configuration c = parseConfig("eos-interface-type");
+
+    assertThat(c, hasInterface("Tunnel2", hasInterfaceType(InterfaceType.TUNNEL)));
+    assertThat(c, hasInterface("Tunnel3", hasInterfaceType(InterfaceType.IPSEC_TUNNEL)));
+  }
+
+  @Test
   public void testIosHttpInspection() throws IOException {
     String hostname = "ios-http-inspection";
     String filename = "configs/" + hostname;

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -54,6 +54,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAdditionalArpI
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllAddresses;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllowedVlans;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDescription;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInterfaceType;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasIsis;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasNativeVlan;
@@ -4654,6 +4655,15 @@ public final class FlatJuniperGrammarTest {
                 DEFAULT_VRF_NAME));
     assertThat(routes.get(DEFAULT_VRF_NAME), equalTo(defaultExpectedRoutes));
     assertThat(routes.get(vrf2Name), equalTo(vrf2ExpectedRoutes));
+  }
+
+  @Test
+  public void testInterfaceType() throws IOException {
+    Configuration c = parseConfig("interface-type");
+
+    assertThat(c, hasInterface("st0.0", hasInterfaceType(InterfaceType.IPSEC_TUNNEL)));
+    assertThat(c, hasInterface("gr-0/0/0.0", hasInterfaceType(InterfaceType.TUNNEL)));
+    assertThat(c, hasInterface("ge-0/0/0.0", hasInterfaceType(InterfaceType.LOGICAL)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/eos-interface-type
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/eos-interface-type
@@ -1,0 +1,19 @@
+!
+boot system flash eos.swi
+hostname eos-interface-type
+!
+interface TenGigabitEthernet0/0
+ ip address 2.3.4.6 255.255.255.0
+!
+interface Tunnel2
+ ip address 2.2.2.2 255.255.255.0
+ tunnel source TenGigabitEthernet0/0
+ tunnel destination 1.2.3.5
+ tunnel mode gre
+!
+interface Tunnel3
+ ip address 3.3.3.3 255.255.255.0
+ tunnel source TenGigabitEthernet0/0
+ tunnel destination 1.2.3.6
+ tunnel mode ipsec
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-type
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-type
@@ -1,0 +1,23 @@
+!
+hostname ios-interface-type
+!
+interface TenGigabitEthernet0/0
+ ip address 2.3.4.6 255.255.255.0
+!
+interface Tunnel1
+ ip address 1.1.1.1 255.255.255.0
+ tunnel source TenGigabitEthernet0/0
+ tunnel destination 1.2.3.4
+!
+interface Tunnel2
+ ip address 2.2.2.2 255.255.255.0
+ tunnel source TenGigabitEthernet0/0
+ tunnel destination 1.2.3.5
+ tunnel mode gre ip
+!
+interface Tunnel3
+ ip address 3.3.3.3 255.255.255.0
+ tunnel source TenGigabitEthernet0/0
+ tunnel destination 1.2.3.6
+ tunnel mode ipsec ipv4
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-type
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-type
@@ -1,0 +1,6 @@
+#
+set system host-name interface-type
+#
+set interfaces st0 unit 0 family inet address 1.2.3.4/30
+set interfaces gr-0/0/0 unit 0 family inet address 1.2.3.5/30
+set interfaces ge-0/0/0 unit 0 family inet address 1.2.3.6/30

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -1950,7 +1950,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "TUNNEL",
+            "type" : "IPSEC_TUNNEL",
             "vrf" : "default"
           },
           "Tunnel2" : {
@@ -1983,7 +1983,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "TUNNEL",
+            "type" : "IPSEC_TUNNEL",
             "vrf" : "default"
           }
         },
@@ -5018,7 +5018,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "VPN",
+            "type" : "IPSEC_TUNNEL",
             "vrf" : "default"
           },
           "vpn2" : {
@@ -5047,7 +5047,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "VPN",
+            "type" : "IPSEC_TUNNEL",
             "vrf" : "default"
           }
         },

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -8281,7 +8281,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "VPN",
+            "type" : "IPSEC_TUNNEL",
             "vrf" : "default"
           },
           "Dot11Radio0" : {


### PR DESCRIPTION
Changes are based on https://docs.google.com/document/d/12nbZh9u88ae0Ed7RzjAhgJfiqpR1QL4tevSdKwHQnvk/edit?usp=sharing

main points: 
1. Detecting IPSec and GRE tunnels as different interface types 
2. removed VPN interface type
3. two interface types for tunnels: IPSEC_TUNNEL and TUNNEL
4. Not detecting tunnel InterfaceType in Cisco on the basis of iface name, but using `Tunnel mode`
5. removed `TUNNEL_INTERFACE_TYPES ` as it will not be needed (we only need `IPSEC_TUNNELS` now )
6. added detection of GRE tunnels in Juniper