### PR TITLE
Bazel: fix for skylark breaking change

### DIFF
--- a/skylark/junit.bzl
+++ b/skylark/junit.bzl
@@ -35,7 +35,7 @@ def _SafeIndex(l, val):
     return -1
 
 def _AsClassName(fname):
-    fname = [x.path for x in fname.files][0]
+    fname = [x.path for x in fname.files.to_list()][0]
     toks = fname[:-5].split("/")
     findex = -1
     for s in _PREFIXES:


### PR DESCRIPTION
```
Starting local Bazel server and connecting to it...
INFO: Invocation ID: ac6c8092-b332-42cd-94d6-372727ceb39a
ERROR: /Users/dan/git-workspace/batfish/projects/allinone/BUILD:68:1: in _GenSuite rule //projects/allinone:DetectLoopsTestTestSuite:
Traceback (most recent call last):
	File "/Users/dan/git-workspace/batfish/projects/allinone/BUILD", line 68
		_GenSuite(name = 'DetectLoopsTestTestSuite')
	File "/Users/dan/git-workspace/batfish/skylark/junit.bzl", line 55, in _impl
		",".join([_AsClassName(x) for x in ctx.at...])
	File "/Users/dan/git-workspace/batfish/skylark/junit.bzl", line 56, in ",".join
		_AsClassName(x)
	File "/Users/dan/git-workspace/batfish/skylark/junit.bzl", line 38, in _AsClassName
		[x.path for x in fname.files]
type 'depset' is not iterable. Use the `to_list()` method to get a list. Use --incompatible_depset_is_not_iterable=false to temporarily disable this check.
ERROR: Analysis of target '//projects/allinone:DetectLoopsTestTestSuite' failed; build aborted: Analysis of target '//projects/allinone:DetectLoopsTestTestSuite' failed; build aborted
INFO: Elapsed time: 10.162s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (49 packages loaded, 460 targets configured)
```