### PR TITLE
Cumulus: fix route target derivation for 4-byte ASNs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -215,7 +215,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
         for (VniSettings vxlan : _c.getVrfs().get(bgpVrf.getVrfName()).getVniSettings().values()) {
           RouteDistinguisher rd =
               RouteDistinguisher.from(newProc.getRouterId(), vniToIndex.get(vxlan.getVni()));
-          ExtendedCommunity rt = ExtendedCommunity.target(localAs, vxlan.getVni());
+          ExtendedCommunity rt = toRouteTarget(localAs, vxlan.getVni());
           // Advertise L2 VNIs
           l2Vnis.add(
               Layer2VniConfig.builder()
@@ -238,7 +238,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
                       RouteDistinguisher.from(
                           _c.getVrfs().get(vrf.getName()).getBgpProcess().getRouterId(),
                           vniToIndex.get(l3Vni));
-                  ExtendedCommunity rt = ExtendedCommunity.target(localAs, l3Vni);
+                  ExtendedCommunity rt = toRouteTarget(localAs, l3Vni);
                   l3Vnis.add(
                       Layer3VniConfig.builder()
                           .setVni(l3Vni)
@@ -921,6 +921,15 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
         .map(entry -> toRoutingPolicyStatement(entry))
         .forEach(builder::addStatement);
     return builder.addStatement(Statements.ReturnFalse.toStaticStatement()).build();
+  }
+
+  /**
+   * Convert AS number and VXLAN ID to an extended route target community. If the AS number is a
+   * 4-byte as, only the lower 2 bytes are used.
+   */
+  @Nonnull
+  private ExtendedCommunity toRouteTarget(long asn, long vxlanId) {
+    return ExtendedCommunity.target(asn & 0xFFFFL, vxlanId);
   }
 
   private @Nonnull Statement toRoutingPolicyStatement(RouteMapEntry entry) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -926,6 +926,10 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
   /**
    * Convert AS number and VXLAN ID to an extended route target community. If the AS number is a
    * 4-byte as, only the lower 2 bytes are used.
+   *
+   * <p>See <a
+   * href="https://docs.cumulusnetworks.com/display/DOCS/Ethernet+Virtual+Private+Network+-+EVPN#EthernetVirtualPrivateNetwork-EVPN-RD-auto-derivationAuto-derivationofRDsandRTs">
+   * cumulus documentation</a> for detailed explanation.
    */
   @Nonnull
   private ExtendedCommunity toRouteTarget(long asn, long vxlanId) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -1463,4 +1463,23 @@ public final class CumulusNcluGrammarTest {
     assertThat(vrf2BgpPeer.getIpv4UnicastAddressFamily(), notNullValue());
     assertThat(vrf2BgpPeer.getEvpnAddressFamily(), nullValue());
   }
+
+  @Test
+  public void testEvpnConversions4byteAS() throws IOException {
+    Configuration c = parseConfig("cumulus_nclu_evpn_4byte_as");
+
+    BgpUnnumberedPeerConfig bgpPeer =
+        c.getDefaultVrf().getBgpProcess().getInterfaceNeighbors().get("swp1");
+    Ip routerId = Ip.parse("192.0.0.0");
+    ImmutableSortedSet<Layer2VniConfig> expectedL2Vnis =
+        ImmutableSortedSet.of(
+            Layer2VniConfig.builder()
+                .setVni(70001)
+                .setVrf(DEFAULT_VRF_NAME)
+                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 0))
+                // Using lower 2 bytes of the AS number
+                .setRouteTarget(ExtendedCommunity.target(34, 70001))
+                .build());
+    assertThat(bgpPeer.getEvpnAddressFamily().getL2VNIs(), equalTo(expectedL2Vnis));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testconfigs/cumulus_nclu_evpn_4byte_as
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testconfigs/cumulus_nclu_evpn_4byte_as
@@ -1,0 +1,16 @@
+net del all
+#
+net add hostname cumulus_nclu_evpn_4byte_as
+#
+net add interface swp1
+net add bgp autonomous-system 65570
+net add bgp router-id 192.0.0.0
+# Neighbor
+net add bgp neighbor swp1 interface remote-as external
+net add bgp l2vpn evpn advertise-all-vni
+net add bgp l2vpn evpn neighbor swp1 activate
+# VNIs for default VRF
+net add vxlan vni70001 vxlan id 70001
+net add vxlan vni70001 vxlan local-tunnelip 192.0.2.11
+net add vxlan vni70001 bridge access 7
+


### PR DESCRIPTION
Says to use lower two bytes only:

https://docs.cumulusnetworks.com/display/DOCS/Ethernet+Virtual+Private+Network+-+EVPN#EthernetVirtualPrivateNetwork-EVPN-RD-auto-derivationAuto-derivationofRDsandRTs