### PR TITLE
Interface: parse "ip forward"

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -314,6 +314,11 @@ if_ip_flow_monitor
    ) NEWLINE
 ;
 
+if_ip_forward
+:
+   NO? IP FORWARD NEWLINE
+;
+
 if_ip_helper_address
 :
    IP HELPER_ADDRESS address = IP_ADDRESS NEWLINE
@@ -1725,6 +1730,7 @@ if_inner
    | if_ip_address_secondary
    | if_ip_dhcp
    | if_ip_flow_monitor
+   | if_ip_forward
    | if_ip_helper_address
    | if_ip_inband_access_group
    | if_ip_igmp

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -648,6 +648,7 @@ import org.batfish.grammar.cisco.CiscoParser.If_eos_mlagContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_access_groupContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_addressContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_address_secondaryContext;
+import org.batfish.grammar.cisco.CiscoParser.If_ip_forwardContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_helper_addressContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_igmpContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_inband_access_groupContext;
@@ -2448,6 +2449,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     String description = getDescription(ctx.description_line());
     for (Interface currentInterface : _currentInterfaces) {
       currentInterface.setDescription(description);
+    }
+  }
+
+  @Override
+  public void enterIf_ip_forward(If_ip_forwardContext ctx) {
+    if (ctx.NO() != null) {
+      todo(ctx);
     }
   }
 

--- a/tests/parsing-tests/networks/unit-tests/configs/cisco_interface
+++ b/tests/parsing-tests/networks/unit-tests/configs/cisco_interface
@@ -73,6 +73,8 @@ interface Ethernet0
  ip dhcp snooping trust
  no ip dhcp snooping trust
  ip flow monitor some-flow-mon output
+ ip forward
+ no ip forward
  ip helper-address 172.16.0.1
  ip helper-address 172.17.0.1
  ip igmp access-group 1

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -1136,7 +1136,7 @@
         "Lines" : {
           "filename" : "configs/cisco_interface",
           "lines" : [
-            324
+            326
           ]
         }
       },
@@ -1148,7 +1148,7 @@
         "Lines" : {
           "filename" : "configs/cisco_interface",
           "lines" : [
-            130
+            132
           ]
         }
       },
@@ -1160,7 +1160,7 @@
         "Lines" : {
           "filename" : "configs/cisco_interface",
           "lines" : [
-            138
+            140
           ]
         }
       },
@@ -1196,7 +1196,7 @@
         "Lines" : {
           "filename" : "configs/cisco_interface",
           "lines" : [
-            92
+            94
           ]
         }
       },
@@ -1208,7 +1208,7 @@
         "Lines" : {
           "filename" : "configs/cisco_interface",
           "lines" : [
-            89
+            91
           ]
         }
       },
@@ -1220,7 +1220,7 @@
         "Lines" : {
           "filename" : "configs/cisco_interface",
           "lines" : [
-            78
+            80
           ]
         }
       },
@@ -1232,7 +1232,7 @@
         "Lines" : {
           "filename" : "configs/cisco_interface",
           "lines" : [
-            80
+            82
           ]
         }
       },
@@ -1244,7 +1244,7 @@
         "Lines" : {
           "filename" : "configs/cisco_interface",
           "lines" : [
-            93
+            95
           ]
         }
       },
@@ -1256,7 +1256,7 @@
         "Lines" : {
           "filename" : "configs/cisco_interface",
           "lines" : [
-            136
+            138
           ]
         }
       },
@@ -1268,7 +1268,7 @@
         "Lines" : {
           "filename" : "configs/cisco_interface",
           "lines" : [
-            126
+            128
           ]
         }
       },
@@ -1280,7 +1280,7 @@
         "Lines" : {
           "filename" : "configs/cisco_interface",
           "lines" : [
-            280
+            282
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -338,14 +338,21 @@
       },
       {
         "Filename" : "configs/cisco_interface",
-        "Line" : 279,
+        "Line" : 77,
+        "Text" : "no ip forward",
+        "Parser_Context" : "[if_ip_forward if_inner s_interface stanza cisco_configuration]",
+        "Comment" : "This feature is not currently supported"
+      },
+      {
+        "Filename" : "configs/cisco_interface",
+        "Line" : 281,
         "Text" : "zone-member t1",
         "Parser_Context" : "[if_zone_member if_inner s_interface stanza cisco_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cisco_interface",
-        "Line" : 315,
+        "Line" : 317,
         "Text" : "mode gre multipoint",
         "Parser_Context" : "[iftunnel_mode if_tunnel if_inner s_interface stanza cisco_configuration]",
         "Comment" : "This feature is not currently supported"
@@ -2340,10 +2347,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 328 results",
+      "notes" : "Found 329 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 328
+      "numResults" : 329
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -23105,6 +23105,17 @@
             "          OUTPUT:'output'",
             "          NEWLINE:'\\n'))",
             "      (if_inner",
+            "        (if_ip_forward",
+            "          IP:'ip'",
+            "          FORWARD:'forward'",
+            "          NEWLINE:'\\n'))",
+            "      (if_inner",
+            "        (if_ip_forward",
+            "          NO:'no'",
+            "          IP:'ip'",
+            "          FORWARD:'forward'",
+            "          NEWLINE:'\\n'))",
+            "      (if_inner",
             "        (if_ip_helper_address",
             "          IP:'ip'",
             "          HELPER_ADDRESS:'helper-address'",
@@ -73793,13 +73804,19 @@
           "Parse warnings" : [
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 279,
+              "Line" : 77,
+              "Parser_Context" : "[if_ip_forward if_inner s_interface stanza cisco_configuration]",
+              "Text" : "no ip forward"
+            },
+            {
+              "Comment" : "This feature is not currently supported",
+              "Line" : 281,
               "Parser_Context" : "[if_zone_member if_inner s_interface stanza cisco_configuration]",
               "Text" : "zone-member t1"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 315,
+              "Line" : 317,
               "Parser_Context" : "[iftunnel_mode if_tunnel if_inner s_interface stanza cisco_configuration]",
               "Text" : "mode gre multipoint"
             }
@@ -77565,25 +77582,25 @@
           "interface" : {
             "Async1" : {
               "definitionLines" : [
-                282
+                284
               ],
               "numReferrers" : 1
             },
             "Cable1/2/3:4" : {
               "definitionLines" : [
-                284
+                286
               ],
               "numReferrers" : 1
             },
             "Crypto-Engine1/2/3" : {
               "definitionLines" : [
-                286
+                288
               ],
               "numReferrers" : 1
             },
             "Dot11Radio0" : {
               "definitionLines" : [
-                288
+                290
               ],
               "numReferrers" : 1
             },
@@ -77862,58 +77879,58 @@
                 277,
                 278,
                 279,
-                280
+                280,
+                281,
+                282
               ],
               "numReferrers" : 1
             },
             "Ethernet1/11" : {
               "definitionLines" : [
-                290
+                292
               ],
               "numReferrers" : 1
             },
             "Ethernet1/12" : {
               "definitionLines" : [
-                346,
-                347
+                348,
+                349
               ],
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
               "definitionLines" : [
-                292,
-                293,
                 294,
                 295,
-                296
+                296,
+                297,
+                298
               ],
               "numReferrers" : 1
             },
             "Loopback0" : {
               "definitionLines" : [
-                298,
-                299,
                 300,
-                301
+                301,
+                302,
+                303
               ],
               "numReferrers" : 1
             },
             "Modular-Cable1/2/3:4" : {
               "definitionLines" : [
-                303
+                305
               ],
               "numReferrers" : 1
             },
             "Null0" : {
               "definitionLines" : [
-                305
+                307
               ],
               "numReferrers" : 1
             },
             "Tunnel0" : {
               "definitionLines" : [
-                309,
-                310,
                 311,
                 312,
                 313,
@@ -77923,73 +77940,75 @@
                 317,
                 318,
                 319,
-                320
+                320,
+                321,
+                322
               ],
               "numReferrers" : 1
             },
             "Vlan1" : {
               "definitionLines" : [
-                330
+                332
               ],
               "numReferrers" : 1
             },
             "Vlan1005" : {
               "definitionLines" : [
-                336
+                338
               ],
               "numReferrers" : 1
             },
             "Vlan1006" : {
               "definitionLines" : [
-                338
+                340
               ],
               "numReferrers" : 1
             },
             "Vlan111" : {
               "definitionLines" : [
-                321
+                323
               ],
               "numReferrers" : 1
             },
             "Vlan1234" : {
               "definitionLines" : [
-                340
+                342
               ],
               "numReferrers" : 1
             },
             "Vlan2" : {
               "definitionLines" : [
-                332
+                334
               ],
               "numReferrers" : 1
             },
             "Vlan3" : {
               "definitionLines" : [
-                334
+                336
               ],
               "numReferrers" : 1
             },
             "Vlan4094" : {
               "definitionLines" : [
-                342
+                344
               ],
               "numReferrers" : 1
             },
             "Wideband-Cable1/2/3:4" : {
               "definitionLines" : [
-                344
+                346
               ],
               "numReferrers" : 1
             },
             "inside" : {
               "definitionLines" : [
-                293
+                295
               ],
               "numReferrers" : 1
             },
             "tunnel-ip6" : {
               "definitionLines" : [
-                307
+                309
               ],
               "numReferrers" : 1
             }
@@ -77997,11 +78016,11 @@
           "vxlan" : {
             "Vxlan1" : {
               "definitionLines" : [
-                323,
-                324,
                 325,
                 326,
-                327
+                327,
+                328,
+                329
               ],
               "numReferrers" : 1
             }
@@ -84871,27 +84890,27 @@
           "interface" : {
             "Async1" : {
               "interface" : [
-                282
+                284
               ]
             },
             "Cable1/2/3:4" : {
               "interface" : [
-                284
+                286
               ]
             },
             "Cellular0" : {
               "tunnel source" : [
-                318
+                320
               ]
             },
             "Crypto-Engine1/2/3" : {
               "interface" : [
-                286
+                288
               ]
             },
             "Dot11Radio0" : {
               "interface" : [
-                288
+                290
               ]
             },
             "Ethernet0" : {
@@ -84899,119 +84918,119 @@
                 7
               ],
               "tunnel source" : [
-                319
+                321
               ]
             },
             "Ethernet1/11" : {
               "interface" : [
-                290
+                292
               ]
             },
             "Ethernet1/12" : {
               "interface" : [
-                346
+                348
               ]
             },
             "GigabitEthernet0/0" : {
               "interface" : [
-                292
+                294
               ]
             },
             "Loopback0" : {
               "interface" : [
-                298
+                300
               ]
             },
             "Loopback1" : {
               "vxlan source-interface" : [
-                324
+                326
               ]
             },
             "Modular-Cable1/2/3:4" : {
               "interface" : [
-                303
+                305
               ]
             },
             "Null0" : {
               "interface" : [
-                305
+                307
               ]
             },
             "Tunnel0" : {
               "interface" : [
-                309
+                311
               ]
             },
             "Vlan1" : {
               "interface" : [
-                330
+                332
               ]
             },
             "Vlan1005" : {
               "interface" : [
-                336
+                338
               ]
             },
             "Vlan1006" : {
               "interface" : [
-                338
+                340
               ]
             },
             "Vlan111" : {
               "interface" : [
-                321
+                323
               ]
             },
             "Vlan1234" : {
               "interface" : [
-                340
+                342
               ]
             },
             "Vlan2" : {
               "interface" : [
-                332
+                334
               ]
             },
             "Vlan3" : {
               "interface" : [
-                334
+                336
               ]
             },
             "Vlan4094" : {
               "interface" : [
-                342
+                344
               ]
             },
             "Wideband-Cable1/2/3:4" : {
               "interface" : [
-                344
+                346
               ]
             },
             "inside" : {
               "interface" : [
-                293
+                295
               ]
             },
             "tunnel-ip6" : {
               "interface" : [
-                307
+                309
               ]
             }
           },
           "ipv4 acl" : {
             "167" : {
               "interface ip verify access-list" : [
-                130
+                132
               ]
             },
             "310-systems" : {
               "interface outgoing ip access-list" : [
-                138
+                140
               ]
             },
             "abc" : {
               "ip nat source dynamic access-list" : [
-                93
+                95
               ]
             },
             "ag1" : {
@@ -85026,64 +85045,64 @@
             },
             "def" : {
               "ip nat source dynamic access-list" : [
-                92
+                94
               ]
             },
             "mynatacl" : {
               "ip nat destination acl" : [
-                89
+                91
               ]
             }
           },
           "ipv4/6 acl" : {
             "1" : {
               "interface igmp access-group acl" : [
-                78
+                80
               ]
             },
             "hpaccesslist" : {
               "interface igmp host-proxy access-list" : [
-                80
+                82
               ]
             }
           },
           "nat pool" : {
             "beeble" : {
               "ip nat source pool" : [
-                93
+                95
               ]
             }
           },
           "route-map" : {
             "SITEMAP" : {
               "interface ip vrf sitemap" : [
-                136
+                138
               ]
             },
             "eigrp-leak-map" : {
               "interface summary-address eigrp leak-map" : [
-                126
+                128
               ]
             }
           },
           "vxlan" : {
             "Vxlan1" : {
               "vxlan" : [
-                323
+                325
               ]
             }
           },
           "zone" : {
             "t1" : {
               "interface zone-member" : [
-                279
+                281
               ]
             }
           },
           "zone security" : {
             "z1" : {
               "interface zone-member security" : [
-                280
+                282
               ]
             }
           }
@@ -88930,19 +88949,19 @@
           "interface" : {
             "Loopback1" : {
               "vxlan source-interface" : [
-                324
+                326
               ]
             }
           },
           "ipv4 acl" : {
             "167" : {
               "interface ip verify access-list" : [
-                130
+                132
               ]
             },
             "310-systems" : {
               "interface outgoing ip access-list" : [
-                138
+                140
               ]
             },
             "ag1" : {
@@ -88957,50 +88976,50 @@
             },
             "def" : {
               "ip nat source dynamic access-list" : [
-                92
+                94
               ]
             },
             "mynatacl" : {
               "ip nat destination acl" : [
-                89
+                91
               ]
             }
           },
           "ipv4/6 acl" : {
             "1" : {
               "interface igmp access-group acl" : [
-                78
+                80
               ]
             },
             "hpaccesslist" : {
               "interface igmp host-proxy access-list" : [
-                80
+                82
               ]
             }
           },
           "nat pool" : {
             "beeble" : {
               "ip nat source pool" : [
-                93
+                95
               ]
             }
           },
           "route-map" : {
             "SITEMAP" : {
               "interface ip vrf sitemap" : [
-                136
+                138
               ]
             },
             "eigrp-leak-map" : {
               "interface summary-address eigrp leak-map" : [
-                126
+                128
               ]
             }
           },
           "zone security" : {
             "z1" : {
               "interface zone-member security" : [
-                280
+                282
               ]
             }
           }


### PR DESCRIPTION
Saves us from loosing the right parser context.
By default changes nothing. Warn if it disables forwarding (which we currently don't handle).