### PR TITLE
RoutePolicyPrependAsPath: stop crashing by choosing default number

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MultipliedAs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MultipliedAs.java
@@ -16,9 +16,8 @@ public final class MultipliedAs extends AsPathListExpr {
   private static final String PROP_EXPR = "expr";
   private static final String PROP_NUMBER = "number";
 
-  @Nonnull private AsExpr _expr;
-
-  @Nonnull private IntExpr _number;
+  @Nonnull private final AsExpr _expr;
+  @Nonnull private final IntExpr _number;
 
   @JsonCreator
   private static MultipliedAs jsonCreator(
@@ -35,7 +34,7 @@ public final class MultipliedAs extends AsPathListExpr {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
     } else if (!(obj instanceof MultipliedAs)) {
@@ -75,13 +74,5 @@ public final class MultipliedAs extends AsPathListExpr {
     result = prime * result + _expr.hashCode();
     result = prime * result + _number.hashCode();
     return result;
-  }
-
-  public void setExpr(AsExpr expr) {
-    _expr = expr;
-  }
-
-  public void setNumber(IntExpr number) {
-    _number = number;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RoutePolicyPrependAsPath.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RoutePolicyPrependAsPath.java
@@ -1,21 +1,25 @@
 package org.batfish.representation.cisco;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.routing_policy.expr.AsExpr;
 import org.batfish.datamodel.routing_policy.expr.IntExpr;
+import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.datamodel.routing_policy.expr.MultipliedAs;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 
 public class RoutePolicyPrependAsPath extends RoutePolicyStatement {
 
-  private AsExpr _expr;
+  @Nonnull private AsExpr _expr;
+  @Nullable private IntExpr _number;
 
-  private IntExpr _number;
-
-  public RoutePolicyPrependAsPath(AsExpr expr, IntExpr number) {
+  public RoutePolicyPrependAsPath(@Nonnull AsExpr expr, @Nullable IntExpr number) {
     _expr = expr;
     _number = number;
   }
@@ -23,6 +27,8 @@ public class RoutePolicyPrependAsPath extends RoutePolicyStatement {
   @Override
   public void applyTo(
       List<Statement> statements, CiscoConfiguration cc, Configuration c, Warnings w) {
-    statements.add(new PrependAsPath(new MultipliedAs(_expr, _number)));
+    statements.add(
+        // prepend once by default, unless number modifier is present. TODO: verify this is correct
+        new PrependAsPath(new MultipliedAs(_expr, firstNonNull(_number, new LiteralInt(1)))));
   }
 }


### PR DESCRIPTION
Hacky fix, but save us from NPEs/random jackson errors.