### PR TITLE
EvpnAddressFamily: add setting for unmatched route propagation

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/AddressFamily.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/AddressFamily.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel.bgp;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -17,6 +18,15 @@ public abstract class AddressFamily implements Serializable {
 
   @JsonIgnore
   public abstract Type getType();
+
+  /** Builder for an {@link AddressFamily} */
+  public abstract static class Builder<B extends Builder<B, F>, F extends AddressFamily> {
+    @Nonnull
+    public abstract B getThis();
+
+    @Nonnull
+    public abstract F build();
+  }
 
   /** BGP address family type */
   public enum Type {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/EvpnAddressFamily.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/EvpnAddressFamily.java
@@ -1,10 +1,12 @@
 package org.batfish.datamodel.bgp;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSortedSet;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
@@ -18,22 +20,30 @@ public final class EvpnAddressFamily extends AddressFamily {
 
   private static final String PROP_L2_VNIS = "l2Vnis";
   private static final String PROP_L3_VNIS = "l3Vnis";
+  private static final String PROP_PROPAGATE_UNMATCHED = "propagateUnmatched";
 
   @Nonnull private final SortedSet<Layer2VniConfig> _l2VNIs;
   @Nonnull private final SortedSet<Layer3VniConfig> _l3VNIs;
+  private final boolean _propagateUnmatched;
 
-  public EvpnAddressFamily(Set<Layer2VniConfig> l2Vnis, Set<Layer3VniConfig> l3Vnis) {
+  private EvpnAddressFamily(
+      Set<Layer2VniConfig> l2Vnis, Set<Layer3VniConfig> l3Vnis, boolean propagateUnmatched) {
     _l2VNIs = ImmutableSortedSet.copyOf(l2Vnis);
     _l3VNIs = ImmutableSortedSet.copyOf(l3Vnis);
+    _propagateUnmatched = propagateUnmatched;
   }
 
   @JsonCreator
   private static EvpnAddressFamily create(
       @Nullable @JsonProperty(PROP_L2_VNIS) Set<Layer2VniConfig> l2Vnis,
-      @Nullable @JsonProperty(PROP_L3_VNIS) Set<Layer3VniConfig> l3Vnis) {
-    return new EvpnAddressFamily(
-        firstNonNull(l2Vnis, ImmutableSortedSet.of()),
-        firstNonNull(l3Vnis, ImmutableSortedSet.of()));
+      @Nullable @JsonProperty(PROP_L3_VNIS) Set<Layer3VniConfig> l3Vnis,
+      @Nullable @JsonProperty(PROP_PROPAGATE_UNMATCHED) Boolean propagateUnmatched) {
+    checkArgument(propagateUnmatched != null, "Missing %s", PROP_PROPAGATE_UNMATCHED);
+    return new Builder()
+        .setL2Vnis(firstNonNull(l2Vnis, ImmutableSortedSet.of()))
+        .setL3Vnis(firstNonNull(l3Vnis, ImmutableSortedSet.of()))
+        .setPropagateUnmatched(propagateUnmatched)
+        .build();
   }
 
   /** L2 VNI associations and config */
@@ -50,6 +60,16 @@ public final class EvpnAddressFamily extends AddressFamily {
     return _l3VNIs;
   }
 
+  /**
+   * Whether or not to re-advertise (propagate) EVPN routes that do not match any VNIs. If true,
+   * such routes will be advertised to neighbors. If false, routes that do not match any VNI will be
+   * dropped.
+   */
+  @JsonProperty(PROP_PROPAGATE_UNMATCHED)
+  public boolean getPropagateUnmatched() {
+    return _propagateUnmatched;
+  }
+
   @Override
   public Type getType() {
     return Type.EVPN;
@@ -64,11 +84,60 @@ public final class EvpnAddressFamily extends AddressFamily {
       return false;
     }
     EvpnAddressFamily that = (EvpnAddressFamily) o;
-    return _l2VNIs.equals(that._l2VNIs) && _l3VNIs.equals(that._l3VNIs);
+    return _l2VNIs.equals(that._l2VNIs)
+        && _l3VNIs.equals(that._l3VNIs)
+        && _propagateUnmatched == that._propagateUnmatched;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_l2VNIs, _l3VNIs);
+    return Objects.hash(_l2VNIs, _l3VNIs, _propagateUnmatched);
+  }
+
+  @Nonnull
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder extends AddressFamily.Builder<Builder, EvpnAddressFamily> {
+    @Nonnull private SortedSet<Layer2VniConfig> _l2Vnis;
+    @Nonnull private SortedSet<Layer3VniConfig> _l3Vnis;
+    @Nullable private Boolean _propagateUnmatched;
+
+    private Builder() {
+      _l2Vnis = ImmutableSortedSet.of();
+      _l3Vnis = ImmutableSortedSet.of();
+    }
+
+    @Nonnull
+    public Builder setL2Vnis(Collection<Layer2VniConfig> l2Vnis) {
+      _l2Vnis = ImmutableSortedSet.copyOf(l2Vnis);
+      return getThis();
+    }
+
+    @Nonnull
+    public Builder setL3Vnis(Collection<Layer3VniConfig> l3Vnis) {
+      _l3Vnis = ImmutableSortedSet.copyOf(l3Vnis);
+      return getThis();
+    }
+
+    @Nonnull
+    public Builder setPropagateUnmatched(boolean propagateUnmatched) {
+      _propagateUnmatched = propagateUnmatched;
+      return getThis();
+    }
+
+    @Nonnull
+    @Override
+    public Builder getThis() {
+      return this;
+    }
+
+    @Nonnull
+    @Override
+    public EvpnAddressFamily build() {
+      checkArgument(_propagateUnmatched != null, "Missing %s", PROP_PROPAGATE_UNMATCHED);
+      return new EvpnAddressFamily(_l2Vnis, _l3Vnis, _propagateUnmatched);
+    }
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
@@ -104,7 +104,12 @@ public class BgpSessionPropertiesTest {
         getAddressFamilyIntersection(
             peer1,
             peerBuilder
-                .setEvpnAddressFamily(new EvpnAddressFamily(ImmutableSet.of(), ImmutableSet.of()))
+                .setEvpnAddressFamily(
+                    EvpnAddressFamily.builder()
+                        .setL2Vnis(ImmutableSet.of())
+                        .setL3Vnis(ImmutableSet.of())
+                        .setPropagateUnmatched(true)
+                        .build())
                 .build()),
         contains(Type.IPV4_UNICAST));
     // Clear ipv4, should get empty intersection back

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/EvpnAddressFamilyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/EvpnAddressFamilyTest.java
@@ -67,12 +67,14 @@ public class EvpnAddressFamilyTest {
 
   @Test
   public void testJsonSerialization() throws IOException {
-    EvpnAddressFamily af =
+    Builder builder =
         builder()
             .setL2Vnis(ImmutableSet.of())
             .setL3Vnis(ImmutableSet.of())
-            .setPropagateUnmatched(true)
-            .build();
-    assertThat(BatfishObjectMapper.clone(af, EvpnAddressFamily.class), equalTo(af));
+            .setPropagateUnmatched(true);
+    EvpnAddressFamily af1 = builder.build();
+    assertThat(BatfishObjectMapper.clone(af1, EvpnAddressFamily.class), equalTo(af1));
+    EvpnAddressFamily af2 = builder.setPropagateUnmatched(false).build();
+    assertThat(BatfishObjectMapper.clone(af2, EvpnAddressFamily.class), equalTo(af2));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/EvpnAddressFamilyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/EvpnAddressFamilyTest.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.bgp;
 
+import static org.batfish.datamodel.bgp.EvpnAddressFamily.builder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -8,6 +9,7 @@ import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.bgp.EvpnAddressFamily.Builder;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.junit.Test;
 
@@ -15,44 +17,62 @@ import org.junit.Test;
 public class EvpnAddressFamilyTest {
   @Test
   public void testEquals() {
-    EvpnAddressFamily af = new EvpnAddressFamily(ImmutableSet.of(), ImmutableSet.of());
+    Builder builder =
+        builder()
+            .setL2Vnis(ImmutableSet.of())
+            .setL3Vnis(ImmutableSet.of())
+            .setPropagateUnmatched(false);
+    EvpnAddressFamily af = builder.build();
     new EqualsTester()
-        .addEqualityGroup(af, af, new EvpnAddressFamily(ImmutableSet.of(), ImmutableSet.of()))
+        .addEqualityGroup(af, af, builder.build())
         .addEqualityGroup(
-            new EvpnAddressFamily(
-                ImmutableSet.of(
-                    Layer2VniConfig.builder()
-                        .setVni(1)
-                        .setVrf("v")
-                        .setRouteDistinguisher(RouteDistinguisher.from(1L, 1))
-                        .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
-                        .build()),
-                ImmutableSet.of()))
+            builder
+                .setL2Vnis(
+                    ImmutableSet.of(
+                        Layer2VniConfig.builder()
+                            .setVni(1)
+                            .setVrf("v")
+                            .setRouteDistinguisher(RouteDistinguisher.from(1L, 1))
+                            .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+                            .build()))
+                .build())
         .addEqualityGroup(
-            new EvpnAddressFamily(
-                ImmutableSet.of(),
-                ImmutableSet.of(
-                    Layer3VniConfig.builder()
-                        .setVni(1)
-                        .setVrf("v")
-                        .setRouteDistinguisher(RouteDistinguisher.from(1L, 1))
-                        .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
-                        .setImportRouteTarget(VniConfig.importRtPatternForAnyAs(1))
-                        .setAdvertiseV4Unicast(false)
-                        .build())))
+            builder
+                .setL3Vnis(
+                    ImmutableSet.of(
+                        Layer3VniConfig.builder()
+                            .setVni(1)
+                            .setVrf("v")
+                            .setRouteDistinguisher(RouteDistinguisher.from(1L, 1))
+                            .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+                            .setImportRouteTarget(VniConfig.importRtPatternForAnyAs(1))
+                            .setAdvertiseV4Unicast(false)
+                            .build()))
+                .build())
+        .addEqualityGroup(builder.setPropagateUnmatched(true).build())
         .addEqualityGroup(new Object())
         .testEquals();
   }
 
   @Test
   public void testJavaSerialization() {
-    EvpnAddressFamily af = new EvpnAddressFamily(ImmutableSet.of(), ImmutableSet.of());
+    EvpnAddressFamily af =
+        builder()
+            .setL2Vnis(ImmutableSet.of())
+            .setL3Vnis(ImmutableSet.of())
+            .setPropagateUnmatched(true)
+            .build();
     assertThat(SerializationUtils.clone(af), equalTo(af));
   }
 
   @Test
   public void testJsonSerialization() throws IOException {
-    EvpnAddressFamily af = new EvpnAddressFamily(ImmutableSet.of(), ImmutableSet.of());
+    EvpnAddressFamily af =
+        builder()
+            .setL2Vnis(ImmutableSet.of())
+            .setL3Vnis(ImmutableSet.of())
+            .setPropagateUnmatched(true)
+            .build();
     assertThat(BatfishObjectMapper.clone(af, EvpnAddressFamily.class), equalTo(af));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -253,7 +253,12 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
                 }
               });
 
-      builder.setEvpnAddressFamily(new EvpnAddressFamily(l2Vnis.build(), l3Vnis.build()));
+      builder.setEvpnAddressFamily(
+          EvpnAddressFamily.builder()
+              .setL2Vnis(l2Vnis.build())
+              .setL3Vnis(l3Vnis.build())
+              .setPropagateUnmatched(true)
+              .build());
     }
     builder.build();
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -146,7 +146,11 @@ public class BgpRoutingProcessTest {
             .setLocalIp(localIp)
             .setLocalAs(2L)
             .setEvpnAddressFamily(
-                new EvpnAddressFamily(ImmutableSet.of(), ImmutableSet.of(vniConfig1, vniConfig2)))
+                EvpnAddressFamily.builder()
+                    .setL2Vnis(ImmutableSet.of())
+                    .setL3Vnis(ImmutableSet.of(vniConfig1, vniConfig2))
+                    .setPropagateUnmatched(true)
+                    .build())
             .build();
     _bgpProcess
         .getActiveNeighbors()
@@ -240,7 +244,11 @@ public class BgpRoutingProcessTest {
             .setLocalIp(localIp)
             .setLocalAs(2L)
             .setEvpnAddressFamily(
-                new EvpnAddressFamily(ImmutableSet.of(), ImmutableSet.of(vniConfig1, vniConfig2)))
+                EvpnAddressFamily.builder()
+                    .setL2Vnis(ImmutableSet.of())
+                    .setL3Vnis(ImmutableSet.of(vniConfig1, vniConfig2))
+                    .setPropagateUnmatched(true)
+                    .build())
             .build();
     _bgpProcess
         .getActiveNeighbors()

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
@@ -137,7 +137,12 @@ public class EvpnTest {
         .setLocalIp(ipNode1)
         .setLocalAs(1L)
         .setBgpProcess(bgpProcess1)
-        .setEvpnAddressFamily(new EvpnAddressFamily(ImmutableSet.of(), ImmutableSet.of(vniConfig1)))
+        .setEvpnAddressFamily(
+            EvpnAddressFamily.builder()
+                .setL2Vnis(ImmutableSet.of())
+                .setL3Vnis(ImmutableSet.of(vniConfig1))
+                .setPropagateUnmatched(true)
+                .build())
         .setExportPolicy(policyName)
         .build();
     nf.bgpNeighborBuilder()
@@ -147,7 +152,12 @@ public class EvpnTest {
         .setLocalIp(ipNode2)
         .setLocalAs(2L)
         .setBgpProcess(bgpProcess2)
-        .setEvpnAddressFamily(new EvpnAddressFamily(ImmutableSet.of(), ImmutableSet.of(vniConfig2)))
+        .setEvpnAddressFamily(
+            EvpnAddressFamily.builder()
+                .setL2Vnis(ImmutableSet.of())
+                .setL3Vnis(ImmutableSet.of(vniConfig2))
+                .setPropagateUnmatched(true)
+                .build())
         .setExportPolicy(policyName)
         .build();
 

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -14412,7 +14412,8 @@
                         "vni" : 10001,
                         "vrf" : "vrf1"
                       }
-                    ]
+                    ],
+                    "propagateUnmatched" : true
                   },
                   "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:swp1~",
                   "ipv4UnicastAddressFamily" : { },
@@ -14445,7 +14446,8 @@
                         "vni" : 10001,
                         "vrf" : "vrf1"
                       }
-                    ]
+                    ],
+                    "propagateUnmatched" : true
                   },
                   "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:swp2~",
                   "ipv4UnicastAddressFamily" : { },
@@ -14478,7 +14480,8 @@
                         "vni" : 10001,
                         "vrf" : "vrf1"
                       }
-                    ]
+                    ],
+                    "propagateUnmatched" : true
                   },
                   "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:swp3~",
                   "group" : "GROUP",


### PR DESCRIPTION
1. Add `propagateUnmatched` to EVPN address family
2. Setup for more complicated builders, since a bunch of common settings will have to be migrated from `BgpPeerConfig` to `AddressFamily`