### PR TITLE
Minor cleanups to Interface

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -94,17 +94,20 @@ public final class Interface extends ComparableStructure<String> {
       String name = _name != null ? _name : generateName();
       Interface iface =
           _type == null ? new Interface(name, _owner) : new Interface(name, _owner, _type);
-      ImmutableSet.Builder<InterfaceAddress> allAddresses = ImmutableSet.builder();
       if (_accessVlan != null) {
         iface.setAccessVlan(_accessVlan);
       }
       iface.setActive(_active);
+
+      // Set addresses. If the primary address is missing from allAddresses, add it.
+      ImmutableSet.Builder<InterfaceAddress> allAddresses = ImmutableSet.builder();
       if (_address != null) {
         iface.setAddress(_address);
         allAddresses.add(_address);
       }
-      iface.setAdditionalArpIps(_additionalArpIps);
       iface.setAllAddresses(allAddresses.addAll(_secondaryAddresses).build());
+
+      iface.setAdditionalArpIps(_additionalArpIps);
       if (_allowedVlans != null) {
         iface.setAllowedVlans(_allowedVlans);
       }
@@ -813,7 +816,7 @@ public final class Interface extends ComparableStructure<String> {
     this(name, null);
   }
 
-  public Interface(String name, Configuration owner) {
+  private Interface(String name, Configuration owner) {
     this(name, owner, InterfaceType.UNKNOWN);
 
     // Determine interface type after setting owner
@@ -823,7 +826,7 @@ public final class Interface extends ComparableStructure<String> {
             : computeInterfaceType(_key, _owner.getConfigurationFormat());
   }
 
-  public Interface(String name, Configuration owner, @Nonnull InterfaceType interfaceType) {
+  private Interface(String name, Configuration owner, @Nonnull InterfaceType interfaceType) {
     super(name);
     _active = true;
     _additionalArpIps = EmptyIpSpace.INSTANCE;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -1739,6 +1739,14 @@ public final class Interface extends ComparableStructure<String> {
     _zoneName = zoneName;
   }
 
+  public void addVrrpGroup(Integer num, @Nonnull VrrpGroup group) {
+    _vrrpGroups =
+        ImmutableSortedMap.<Integer, VrrpGroup>naturalOrder()
+            .putAll(_vrrpGroups)
+            .put(num, group)
+            .build();
+  }
+
   /** Blacklist this interface, making it inactive and blacklisted */
   public void blacklist() {
     setActive(false);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -743,7 +743,7 @@ public final class Interface extends ComparableStructure<String> {
   private boolean _active;
   private @Nonnull IpSpace _additionalArpIps;
   private IntegerSpace _allowedVlans;
-  private SortedSet<InterfaceAddress> _allAddresses;
+  @Nonnull private SortedSet<InterfaceAddress> _allAddresses;
   /** Cache of all concrete addresses */
   @Nullable private transient Set<ConcreteInterfaceAddress> _allConcreteAddresses;
   /** Cache of all link-local addresses */
@@ -992,6 +992,7 @@ public final class Interface extends ComparableStructure<String> {
     return _allLinkLocalAddresses;
   }
 
+  @Nonnull
   public Set<InterfaceAddress> getAllAddresses() {
     return _allAddresses;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -812,11 +812,6 @@ public final class Interface extends ComparableStructure<String> {
   private String _zoneName;
   private String _hsrpVersion;
 
-  @SuppressWarnings("unused")
-  private Interface() {
-    this(null, null);
-  }
-
   @JsonCreator
   public Interface(@JsonProperty(PROP_NAME) String name) {
     this(name, null);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -40,83 +40,44 @@ public final class Interface extends ComparableStructure<String> {
   public static class Builder extends NetworkFactoryBuilder<Interface> {
 
     private @Nullable Integer _accessVlan;
-
     private boolean _active;
-
     private InterfaceAddress _address;
-
     private @Nullable IntegerSpace _allowedVlans;
-
     @Nullable private Double _bandwidth;
-
     private boolean _blacklisted;
-
     private SortedSet<String> _declaredNames;
-
     @Nonnull private Set<Dependency> _dependencies = ImmutableSet.of();
-
     @Nullable private EigrpInterfaceSettings _eigrp;
-
     @Nullable private Integer _encapsulationVlan;
-
     private Map<Integer, HsrpGroup> _hsrpGroups;
-
     private String _hsrpVersion;
-
     private FirewallSessionInterfaceInfo _firewallSessionInterfaceInfo;
-
     private String _ospfInboundDistributeListPolicy;
-
     private IpAccessList _incomingFilter;
-
     private Transformation _incomingTransformation;
-
     private IsisInterfaceSettings _isis;
-
     private @Nullable Integer _mlagId;
-
     private String _name;
-
     private @Nullable Integer _nativeVlan;
-
     private OspfArea _ospfArea;
-
     private Integer _ospfCost;
-
     private boolean _ospfEnabled;
-
     private boolean _ospfPassive;
-
     private boolean _ospfPointToPoint;
-
     private String _ospfProcess;
-
     private IpAccessList _outgoingFilter;
-
     private Transformation _outgoingTransformation;
-
     private Configuration _owner;
-
     private IpAccessList _postTransformationIncomingFilter;
-
     private boolean _proxyArp;
-
     private IpAccessList _preTransformationOutgoingFilter;
-
     private Set<InterfaceAddress> _secondaryAddresses;
-
     private @Nullable Boolean _switchport;
-
     private @Nullable SwitchportMode _switchportMode;
-
     private @Nonnull IpSpace _additionalArpIps;
-
     private InterfaceType _type;
-
     private @Nullable Integer _vlan;
-
     private Vrf _vrf;
-
     private SortedMap<Integer, VrrpGroup> _vrrpGroups;
 
     Builder(NetworkFactory networkFactory) {
@@ -525,16 +486,11 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   private static final int DEFAULT_MTU = 1500;
-
   public static final String DYNAMIC_INTERFACE_NAME = "dynamic";
-
   public static final String NULL_INTERFACE_NAME = "null_interface";
-
   public static final Set<InterfaceType> TUNNEL_INTERFACE_TYPES =
       ImmutableSet.of(InterfaceType.TUNNEL, InterfaceType.VPN);
-
   public static final String UNSET_LOCAL_INTERFACE = "unset_local_interface";
-
   public static final String INVALID_LOCAL_INTERFACE = "invalid_local_interface";
   private static final String PROP_ACCESS_VLAN = "accessVlan";
   private static final String PROP_ACTIVE = "active";
@@ -788,133 +744,72 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   @Nullable private Integer _accessVlan;
-
   private boolean _active;
-
   private @Nonnull IpSpace _additionalArpIps;
-
   private IntegerSpace _allowedVlans;
-
   private SortedSet<InterfaceAddress> _allAddresses;
-
   /** Cache of all concrete addresses */
   @Nullable private transient Set<ConcreteInterfaceAddress> _allConcreteAddresses;
   /** Cache of all link-local addresses */
   @Nullable private transient Set<LinkLocalAddress> _allLinkLocalAddresses;
-
   private boolean _autoState;
-
   @Nullable private Double _bandwidth;
-
   private transient boolean _blacklisted;
-
   private String _channelGroup;
-
   private SortedSet<String> _channelGroupMembers;
-
   private String _cryptoMap;
-
   private SortedSet<String> _declaredNames;
-
   /** Set of interface dependencies required for this interface to active */
   @Nonnull private Set<Dependency> _dependencies;
 
   private String _description;
-
   private List<Ip> _dhcpRelayAddresses;
-
   @Nullable private EigrpInterfaceSettings _eigrp;
-
   @Nullable private Integer _encapsulationVlan;
-
   @Nullable private FirewallSessionInterfaceInfo _firewallSessionInterfaceInfo;
-
   private Map<Integer, HsrpGroup> _hsrpGroups;
-
   private IpAccessList _inboundFilter;
-
   private transient String _inboundFilterName;
-
   private IpAccessList _incomingFilter;
-
   private transient String _incomingFilterName;
-
   private Transformation _incomingTransformation;
-
   private InterfaceType _interfaceType;
-
   private IsisInterfaceSettings _isis;
-
   @Nullable private Integer _mlagId;
-
   private int _mtu;
-
   @Nullable private Integer _nativeVlan;
-
   @Nullable private Long _ospfAreaName;
-
   private Integer _ospfCost;
-
   private int _ospfDeadInterval;
-
   private boolean _ospfEnabled;
-
   private int _ospfHelloMultiplier;
-
   @Nullable private String _ospfInboundDistributeListPolicy;
-
   private boolean _ospfPassive;
-
   private boolean _ospfPointToPoint;
-
   @Nullable private String _ospfProcess;
-
   private IpAccessList _outgoingFilter;
-
   private transient String _outgoingFilterName;
-
   private Transformation _outgoingTransformation;
-
   private Configuration _owner;
-
   private InterfaceAddress _address;
-
   private IpAccessList _postTransformationIncomingFilter;
-
   private transient String _postTransformationIncomingFilterName;
-
   private boolean _proxyArp;
-
   private IpAccessList _preTransformationOutgoingFilter;
-
   private transient String _preTransformationOutgoingFilterName;
-
   private boolean _ripEnabled;
-
   private boolean _ripPassive;
-
   private String _routingPolicyName;
-
   private boolean _spanningTreePortfast;
-
   private @Nullable Double _speed;
-
   private boolean _switchport;
-
   private SwitchportMode _switchportMode;
-
   private SwitchportEncapsulationType _switchportTrunkEncapsulation;
-
   private Integer _vlan;
-
   private Vrf _vrf;
-
   private transient String _vrfName;
-
   private SortedMap<Integer, VrrpGroup> _vrrpGroups;
-
   private String _zoneName;
-
   private String _hsrpVersion;
 
   @SuppressWarnings("unused")

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -1472,8 +1472,12 @@ public final class Interface extends ComparableStructure<String> {
     _bandwidth = bandwidth;
   }
 
+  /**
+   * To be used by the builder only. Use {@link #blacklist()} for public blacklisting, it enforces
+   * that the interface is inactive if blacklisted.
+   */
   @JsonIgnore
-  public void setBlacklisted(boolean blacklisted) {
+  private void setBlacklisted(boolean blacklisted) {
     _blacklisted = blacklisted;
   }
 
@@ -1790,7 +1794,7 @@ public final class Interface extends ComparableStructure<String> {
   /** Blacklist this interface, making it inactive and blacklisted */
   public void blacklist() {
     setActive(false);
-    setBlacklisted(true);
+    _blacklisted = true;
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -809,7 +809,7 @@ public final class Interface extends ComparableStructure<String> {
   private String _hsrpVersion;
 
   @JsonCreator
-  public Interface(@JsonProperty(PROP_NAME) String name) {
+  private Interface(@Nullable @JsonProperty(PROP_NAME) String name) {
     this(name, null);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -751,6 +751,7 @@ public final class Interface extends ComparableStructure<String> {
   @Nullable private transient Set<ConcreteInterfaceAddress> _allConcreteAddresses;
   /** Cache of all link-local addresses */
   @Nullable private transient Set<LinkLocalAddress> _allLinkLocalAddresses;
+
   private boolean _autoState;
   @Nullable private Double _bandwidth;
   private transient boolean _blacklisted;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -30,7 +30,6 @@ import org.batfish.common.util.ComparableStructure;
 import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
 import org.batfish.datamodel.eigrp.EigrpInterfaceSettings;
 import org.batfish.datamodel.hsrp.HsrpGroup;
-import org.batfish.datamodel.isis.IsisInterfaceMode;
 import org.batfish.datamodel.isis.IsisInterfaceSettings;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.transformation.Transformation;
@@ -515,9 +514,6 @@ public final class Interface extends ComparableStructure<String> {
   private static final String PROP_INCOMING_TRANSFORMATION = "incomingTransformation";
   private static final String PROP_INTERFACE_TYPE = "type";
   private static final String PROP_ISIS = "isis";
-  private static final String PROP_ISIS_COST = "isisCost";
-  private static final String PROP_ISIS_L1_INTERFACE_MODE = "isisL1InterfaceMode";
-  private static final String PROP_ISIS_L2_INTERFACE_MODE = "isisL2InterfaceMode";
   private static final String PROP_MLAG_ID = "mlagId";
   private static final String PROP_MTU = "mtu";
   private static final String PROP_NATIVE_VLAN = "nativeVlan";
@@ -1138,34 +1134,6 @@ public final class Interface extends ComparableStructure<String> {
     return _isis;
   }
 
-  /** The IS-IS cost of this interface. */
-  @JsonProperty(PROP_ISIS_COST)
-  @Deprecated
-  public Integer getIsisCost() {
-    return null;
-  }
-
-  /**
-   * Specifies whether this interface is active, passive, or unconfigured with respect to IS-IS
-   * level 1.
-   */
-  @JsonProperty(PROP_ISIS_L1_INTERFACE_MODE)
-  @Deprecated
-  public IsisInterfaceMode getIsisL1InterfaceMode() {
-    return null;
-  }
-
-  /**
-   * Specifies whether this interface is active, passive, or unconfigured with respect to IS-IS
-   * level 2.
-   */
-  @JsonProperty(PROP_ISIS_L2_INTERFACE_MODE)
-  @Deprecated
-  public IsisInterfaceMode getIsisL2InterfaceMode() {
-    // TODO: deprecate properly
-    return null;
-  }
-
   @JsonProperty(PROP_MLAG_ID)
   @Nullable
   public Integer getMlagId() {
@@ -1582,24 +1550,6 @@ public final class Interface extends ComparableStructure<String> {
   @JsonProperty(PROP_ISIS)
   public void setIsis(@Nullable IsisInterfaceSettings isis) {
     _isis = isis;
-  }
-
-  @JsonProperty(PROP_ISIS_COST)
-  @Deprecated
-  public void setIsisCost(Integer isisCost) {
-    // TODO: deprecate properly
-  }
-
-  @JsonProperty(PROP_ISIS_L1_INTERFACE_MODE)
-  @Deprecated
-  public void setIsisL1InterfaceMode(IsisInterfaceMode mode) {
-    // TODO: deprecate properly
-  }
-
-  @JsonProperty(PROP_ISIS_L2_INTERFACE_MODE)
-  @Deprecated
-  public void setIsisL2InterfaceMode(IsisInterfaceMode mode) {
-    // TODO: deprecate properly
   }
 
   @JsonProperty(PROP_MLAG_ID)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -844,12 +844,6 @@ public final class Interface extends ComparableStructure<String> {
     _vrrpGroups = new TreeMap<>();
   }
 
-  public void addAllowedRanges(List<SubRange> ranges) {
-    IntegerSpace.Builder b = IntegerSpace.builder().including(_allowedVlans);
-    ranges.forEach(b::including);
-    _allowedVlans = b.build();
-  }
-
   @Override
   public boolean equals(Object o) {
     if (o == this) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CompletionMetadataUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CompletionMetadataUtilsTest.java
@@ -51,7 +51,9 @@ public final class CompletionMetadataUtilsTest {
       String nodeName, ConfigurationFormat configFormat, String... interfaceNames) {
     Configuration config = new Configuration(nodeName, configFormat);
     for (String interfaceName : interfaceNames) {
-      config.getAllInterfaces().put(interfaceName, new Interface(interfaceName, config));
+      config
+          .getAllInterfaces()
+          .put(interfaceName, Interface.builder().setName(interfaceName).setOwner(config).build());
     }
     return config;
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IpsecUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IpsecUtilTest.java
@@ -149,20 +149,20 @@ public class IpsecUtilTest {
         ImmutableSortedMap.naturalOrder();
     c1.setInterfaces(
         interfaceBuilder
-            .put("Tunnel1", new Interface("Tunnel1", c1))
-            .put("Tunnel3", new Interface("Tunnel3", c1))
-            .put("interface5", new Interface("interface5", c1))
-            .put("Tunnel9", new Interface("Tunnel9", c1))
-            .put("Tunnel7", new Interface("Tunnel7", c1))
+            .put("Tunnel1", Interface.builder().setName("Tunnel1").setOwner(c1).build())
+            .put("Tunnel3", Interface.builder().setName("Tunnel3").setOwner(c1).build())
+            .put("interface5", Interface.builder().setName("interface5").setOwner(c1).build())
+            .put("Tunnel9", Interface.builder().setName("Tunnel9").setOwner(c1).build())
+            .put("Tunnel7", Interface.builder().setName("Tunnel7").setOwner(c1).build())
             .build());
     interfaceBuilder = ImmutableSortedMap.naturalOrder();
     c2.setInterfaces(
         interfaceBuilder
-            .put("Tunnel2", new Interface("Tunnel2", c2))
-            .put("Tunnel4", new Interface("Tunnel4", c2))
-            .put("interface6", new Interface("interface6", c2))
-            .put("Tunnel8", new Interface("Tunnel8", c2))
-            .put("Tunnel10", new Interface("Tunnel10", c2))
+            .put("Tunnel2", Interface.builder().setName("Tunnel2").setOwner(c2).build())
+            .put("Tunnel4", Interface.builder().setName("Tunnel4").setOwner(c2).build())
+            .put("interface6", Interface.builder().setName("interface6").setOwner(c2).build())
+            .put("Tunnel8", Interface.builder().setName("Tunnel8").setOwner(c2).build())
+            .put("Tunnel10", Interface.builder().setName("Tunnel10").setOwner(c2).build())
             .build());
 
     _configurations.put("host1", c1);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java
@@ -15,7 +15,7 @@ public class VerboseEdgeTest {
    */
   @Test
   public void testEquals() {
-    Interface i1 = new Interface("eth0");
+    Interface i1 = new Interface("eth0", null);
     VerboseEdge edge1 = new VerboseEdge(i1, i1, Edge.of("node1", "eth0", "node2", "eth0"));
     assertEquals(edge1, edge1);
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java
@@ -15,7 +15,7 @@ public class VerboseEdgeTest {
    */
   @Test
   public void testEquals() {
-    Interface i1 = Interface.builder().setName("eth0").setOwner(null).build();
+    Interface i1 = Interface.builder().setName("eth0").build();
     VerboseEdge edge1 = new VerboseEdge(i1, i1, Edge.of("node1", "eth0", "node2", "eth0"));
     assertEquals(edge1, edge1);
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VerboseEdgeTest.java
@@ -15,7 +15,7 @@ public class VerboseEdgeTest {
    */
   @Test
   public void testEquals() {
-    Interface i1 = new Interface("eth0", null);
+    Interface i1 = Interface.builder().setName("eth0").setOwner(null).build();
     VerboseEdge edge1 = new VerboseEdge(i1, i1, Edge.of("node1", "eth0", "node2", "eth0"));
     assertEquals(edge1, edge1);
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
@@ -127,7 +127,7 @@ public class PropertySpecifierTest {
   @Test
   public void fillPropertyMap() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
-    configuration.setInterfaces(ImmutableSortedMap.of("i1", new Interface("i1")));
+    configuration.setInterfaces(ImmutableSortedMap.of("i1", new Interface("i1", null)));
     String property = NodePropertySpecifier.INTERFACES;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
@@ -157,7 +157,7 @@ public class PropertySpecifierTest {
   public void testFillPropertyMapForAllInterfaceProperties() {
     // all interface properties should be process correctly without throwing exceptions
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
-    Interface i1 = new Interface("i1");
+    Interface i1 = new Interface("i1", null);
     configuration.setInterfaces(ImmutableSortedMap.of("i1", i1));
     InterfacePropertySpecifier.JAVA_MAP
         .entrySet()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
@@ -128,7 +128,7 @@ public class PropertySpecifierTest {
   public void fillPropertyMap() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
     configuration.setInterfaces(
-        ImmutableSortedMap.of("i1", Interface.builder().setName("i1").setOwner(null).build()));
+        ImmutableSortedMap.of("i1", Interface.builder().setName("i1").build()));
     String property = NodePropertySpecifier.INTERFACES;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
@@ -158,7 +158,7 @@ public class PropertySpecifierTest {
   public void testFillPropertyMapForAllInterfaceProperties() {
     // all interface properties should be process correctly without throwing exceptions
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
-    Interface i1 = Interface.builder().setName("i1").setOwner(null).build();
+    Interface i1 = Interface.builder().setName("i1").build();
     configuration.setInterfaces(ImmutableSortedMap.of("i1", i1));
     InterfacePropertySpecifier.JAVA_MAP
         .entrySet()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/PropertySpecifierTest.java
@@ -127,7 +127,8 @@ public class PropertySpecifierTest {
   @Test
   public void fillPropertyMap() {
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
-    configuration.setInterfaces(ImmutableSortedMap.of("i1", new Interface("i1", null)));
+    configuration.setInterfaces(
+        ImmutableSortedMap.of("i1", Interface.builder().setName("i1").setOwner(null).build()));
     String property = NodePropertySpecifier.INTERFACES;
     PropertyDescriptor<Configuration> propertyDescriptor =
         NodePropertySpecifier.JAVA_MAP.get(property);
@@ -157,7 +158,7 @@ public class PropertySpecifierTest {
   public void testFillPropertyMapForAllInterfaceProperties() {
     // all interface properties should be process correctly without throwing exceptions
     Configuration configuration = new Configuration("hostname", ConfigurationFormat.CISCO_IOS);
-    Interface i1 = new Interface("i1", null);
+    Interface i1 = Interface.builder().setName("i1").setOwner(null).build();
     configuration.setInterfaces(ImmutableSortedMap.of("i1", i1));
     InterfacePropertySpecifier.JAVA_MAP
         .entrySet()

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -969,8 +969,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
                   "WARNING: Disabling unusable vlan interface because no switch port is assigned "
                       + "to it: \"%s:%d\"\n",
                   hostname, vlanNumber);
-              iface.setActive(false);
-              iface.setBlacklisted(true);
+              iface.blacklist();
             }
           }
         }
@@ -2052,8 +2051,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
               for (Interface iface : configuration.getAllInterfaces().values()) {
                 if (MANAGEMENT_INTERFACES.matcher(iface.getName()).find()
                     || MANAGEMENT_VRFS.matcher(iface.getVrfName()).find()) {
-                  iface.setActive(false);
-                  iface.setBlacklisted(true);
+                  iface.blacklist();
                 }
               }
             });

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Route.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Route.java
@@ -221,7 +221,8 @@ public class Route implements Serializable {
             ConcreteInterfaceAddress remoteVpcIfaceAddress =
                 ConcreteInterfaceAddress.create(
                     peeringLink.getEndIp(), peeringLink.getPrefixLength());
-            Interface remoteVpcIface = new Interface(remoteVpcIfaceName, remoteVpcCfgNode);
+            Interface remoteVpcIface =
+                Interface.builder().setName(remoteVpcIfaceName).setOwner(remoteVpcCfgNode).build();
             remoteVpcCfgNode.getAllInterfaces().put(remoteVpcIfaceName, remoteVpcIface);
             remoteVpcCfgNode
                 .getDefaultVrf()

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnGateway.java
@@ -54,7 +54,8 @@ public class VpnGateway implements AwsVpcEntity, Serializable {
       // add the interface to the vpc router
       Configuration vpcConfigNode = awsConfiguration.getConfigurationNodes().get(vpcId);
       String vpcIfaceName = _vpnGatewayId;
-      Interface vpcIface = new Interface(vpcIfaceName, vpcConfigNode);
+      Interface vpcIface =
+          Interface.builder().setName(vpcIfaceName).setOwner(vpcConfigNode).build();
       ConcreteInterfaceAddress vpcIfaceAddress =
           ConcreteInterfaceAddress.create(vpcLink.getEndIp(), vpcLink.getPrefixLength());
       vpcIface.setAddress(vpcIfaceAddress);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2022,8 +2022,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
   private org.batfish.datamodel.Interface toInterface(
       String ifaceName, Interface iface, Map<String, IpAccessList> ipAccessLists, Configuration c) {
     org.batfish.datamodel.Interface newIface =
-        new org.batfish.datamodel.Interface(
-            ifaceName, c, computeInterfaceType(iface.getName(), c.getConfigurationFormat()));
+        org.batfish.datamodel.Interface.builder()
+            .setName(ifaceName)
+            .setOwner(c)
+            .setType(computeInterfaceType(iface.getName(), c.getConfigurationFormat()))
+            .build();
     if (newIface.getInterfaceType() == InterfaceType.VLAN) {
       newIface.setVlan(CommonUtil.getInterfaceVlanNumber(ifaceName));
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -647,7 +647,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                                 + ifaceName
                                 + "' due to missing prefix");
                       }
-                      iface.getVrrpGroups().put(groupNum, newGroup);
+                      iface.addVrrpGroup(groupNum, newGroup);
                     });
           }
         });

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -470,7 +470,11 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
 
   private void convertLoopback() {
     org.batfish.datamodel.Interface newIface =
-        new org.batfish.datamodel.Interface(LOOPBACK_INTERFACE_NAME, _c, InterfaceType.LOOPBACK);
+        org.batfish.datamodel.Interface.builder()
+            .setName(LOOPBACK_INTERFACE_NAME)
+            .setOwner(_c)
+            .setType(InterfaceType.LOOPBACK)
+            .build();
     newIface.setActive(true);
     if (!_loopback.getAddresses().isEmpty()) {
       newIface.setAddress(_loopback.getAddresses().get(0));
@@ -523,7 +527,11 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
 
   private org.batfish.datamodel.Interface convertVrfLoopbackInterface(Vrf vrf) {
     org.batfish.datamodel.Interface newIface =
-        new org.batfish.datamodel.Interface(vrf.getName(), _c, InterfaceType.LOOPBACK);
+        org.batfish.datamodel.Interface.builder()
+            .setName(vrf.getName())
+            .setOwner(_c)
+            .setType(InterfaceType.LOOPBACK)
+            .build();
     newIface.setActive(true);
     if (!vrf.getAddresses().isEmpty()) {
       newIface.setAddress(vrf.getAddresses().get(0));
@@ -864,7 +872,11 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
   private @Nonnull org.batfish.datamodel.Interface toInterface(Bond bond) {
     String name = bond.getName();
     org.batfish.datamodel.Interface newIface =
-        new org.batfish.datamodel.Interface(name, _c, InterfaceType.AGGREGATED);
+        org.batfish.datamodel.Interface.builder()
+            .setName(name)
+            .setOwner(_c)
+            .setType(InterfaceType.AGGREGATED)
+            .build();
 
     bond.getSlaves().forEach(slave -> _c.getAllInterfaces().get(slave).setChannelGroup(name));
     newIface.setChannelGroupMembers(bond.getSlaves());
@@ -889,7 +901,11 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
   private @Nonnull org.batfish.datamodel.Interface toInterface(Interface iface) {
     String name = iface.getName();
     org.batfish.datamodel.Interface newIface =
-        new org.batfish.datamodel.Interface(name, _c, InterfaceType.PHYSICAL);
+        org.batfish.datamodel.Interface.builder()
+            .setName(name)
+            .setOwner(_c)
+            .setType(InterfaceType.PHYSICAL)
+            .build();
     applyCommonInterfaceSettings(iface, newIface);
 
     applyBridgeSettings(iface.getBridge(), newIface);
@@ -904,7 +920,11 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
       Interface iface, String superInterfaceName) {
     String name = iface.getName();
     org.batfish.datamodel.Interface newIface =
-        new org.batfish.datamodel.Interface(name, _c, InterfaceType.LOGICAL);
+        org.batfish.datamodel.Interface.builder()
+            .setName(name)
+            .setOwner(_c)
+            .setType(InterfaceType.LOGICAL)
+            .build();
     newIface.setDependencies(
         ImmutableSet.of(new Dependency(superInterfaceName, DependencyType.BIND)));
     newIface.setEncapsulationVlan(iface.getEncapsulationVlan());
@@ -914,7 +934,11 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
 
   private org.batfish.datamodel.Interface toInterface(Vlan vlan) {
     org.batfish.datamodel.Interface newIface =
-        new org.batfish.datamodel.Interface(vlan.getName(), _c, InterfaceType.VLAN);
+        org.batfish.datamodel.Interface.builder()
+            .setName(vlan.getName())
+            .setOwner(_c)
+            .setType(InterfaceType.VLAN)
+            .build();
     newIface.setActive(true);
     newIface.setVlan(vlan.getVlanId());
 

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
@@ -1167,7 +1167,7 @@ public class F5BigipConfiguration extends VendorConfiguration {
 
   private @Nonnull org.batfish.datamodel.Interface toInterface(Interface iface) {
     org.batfish.datamodel.Interface newIface =
-        new org.batfish.datamodel.Interface(iface.getName(), _c);
+        org.batfish.datamodel.Interface.builder().setName(iface.getName()).setOwner(_c).build();
     Double speed = iface.getSpeed();
     newIface.setActive(!Boolean.TRUE.equals(iface.getDisabled()));
     newIface.setSpeed(speed);
@@ -1179,7 +1179,11 @@ public class F5BigipConfiguration extends VendorConfiguration {
 
   private org.batfish.datamodel.Interface toInterface(Trunk trunk) {
     org.batfish.datamodel.Interface newIface =
-        new org.batfish.datamodel.Interface(trunk.getName(), _c, InterfaceType.AGGREGATED);
+        org.batfish.datamodel.Interface.builder()
+            .setName(trunk.getName())
+            .setOwner(_c)
+            .setType(InterfaceType.AGGREGATED)
+            .build();
     newIface.setDependencies(
         trunk.getInterfaces().stream()
             .filter(_interfaces::containsKey)
@@ -1192,7 +1196,11 @@ public class F5BigipConfiguration extends VendorConfiguration {
 
   private @Nonnull org.batfish.datamodel.Interface toInterface(Vlan vlan) {
     org.batfish.datamodel.Interface newIface =
-        new org.batfish.datamodel.Interface(vlan.getName(), _c, InterfaceType.VLAN);
+        org.batfish.datamodel.Interface.builder()
+            .setName(vlan.getName())
+            .setOwner(_c)
+            .setType(InterfaceType.VLAN)
+            .build();
     // TODO: Possibly add dependencies on ports allowing this VLAN
     newIface.setVlan(vlan.getTag());
     newIface.setBandwidth(Interface.DEFAULT_BANDWIDTH);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1307,7 +1307,12 @@ public final class JuniperConfiguration extends VendorConfiguration {
   private org.batfish.datamodel.Interface toInterfaceNonUnit(Interface iface) {
     String name = iface.getName();
     org.batfish.datamodel.Interface newIface =
-        org.batfish.datamodel.Interface.builder().setName(name).setOwner(_c).build();
+        org.batfish.datamodel.Interface.builder()
+            .setName(name)
+            .setType(
+                org.batfish.datamodel.Interface.computeInterfaceType(
+                    name, _c.getConfigurationFormat()))
+            .build();
     newIface.setDeclaredNames(ImmutableSortedSet.of(name));
     newIface.setDescription(iface.getDescription());
 
@@ -3106,6 +3111,9 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
     _c.getAllInterfaces().put(ifaceName, viIface);
     vrf.getInterfaces().put(ifaceName, viIface);
+    if (viIface.getOwner() == null) {
+      viIface.setOwner(_c);
+    }
   }
 
   private org.batfish.datamodel.Zone toZone(Zone zone) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1306,7 +1306,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
    */
   private org.batfish.datamodel.Interface toInterfaceNonUnit(Interface iface) {
     String name = iface.getName();
-    org.batfish.datamodel.Interface newIface = new org.batfish.datamodel.Interface(name, _c);
+    org.batfish.datamodel.Interface newIface =
+        org.batfish.datamodel.Interface.builder().setName(name).setOwner(_c).build();
     newIface.setDeclaredNames(ImmutableSortedSet.of(name));
     newIface.setDescription(iface.getDescription());
 
@@ -1331,7 +1332,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
   private org.batfish.datamodel.Interface toInterface(Interface iface) {
     String name = iface.getName();
-    org.batfish.datamodel.Interface newIface = new org.batfish.datamodel.Interface(name, _c);
+    org.batfish.datamodel.Interface newIface =
+        org.batfish.datamodel.Interface.builder().setName(name).setOwner(_c).build();
     newIface.setDeclaredNames(ImmutableSortedSet.of(name));
     newIface.setDescription(iface.getDescription());
     Integer mtu = iface.getMtu();

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -901,7 +901,11 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
   private org.batfish.datamodel.Interface toInterface(Interface iface) {
     String name = iface.getName();
     org.batfish.datamodel.Interface newIface =
-        new org.batfish.datamodel.Interface(name, _c, batfishInterfaceType(iface.getType(), _w));
+        org.batfish.datamodel.Interface.builder()
+            .setName(name)
+            .setOwner(_c)
+            .setType(batfishInterfaceType(iface.getType(), _w))
+            .build();
     Integer mtu = iface.getMtu();
     if (mtu != null) {
       newIface.setMtu(mtu);

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
@@ -294,7 +294,8 @@ public class VyosConfiguration extends VendorConfiguration {
 
   private org.batfish.datamodel.Interface toInterface(Interface iface) {
     String name = iface.getName();
-    org.batfish.datamodel.Interface newIface = new org.batfish.datamodel.Interface(name, _c);
+    org.batfish.datamodel.Interface newIface =
+        org.batfish.datamodel.Interface.builder().setName(name).setOwner(_c).build();
     newIface.setDeclaredNames(ImmutableSortedSet.of(name));
     newIface.setActive(true); // TODO: may have to change
     newIface.setBandwidth(iface.getBandwidth());

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -527,8 +527,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
             hasEntry(equalTo(vrf.getName()), equalTo(PKT.getFactory().zero()))));
 
     // when interface is blacklisted, its Ip does not belong to the VRF
-    iface.setActive(true);
-    iface.setBlacklisted(true);
+    iface.blacklist();
     batfish = BatfishTestUtils.getBatfish(configs, temp);
     batfish.computeDataPlane();
     factory =

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTestUtils.java
@@ -224,7 +224,9 @@ public class BatfishTestUtils {
       String nodeName, ConfigurationFormat configFormat, String... interfaceNames) {
     Configuration config = new Configuration(nodeName, configFormat);
     for (String interfaceName : interfaceNames) {
-      config.getAllInterfaces().put(interfaceName, new Interface(interfaceName, config));
+      config
+          .getAllInterfaces()
+          .put(interfaceName, Interface.builder().setName(interfaceName).setOwner(config).build());
     }
     return config;
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -123,7 +123,7 @@ public class JuniperConfigurationTest {
    */
   private static org.batfish.datamodel.Interface createInterface(Configuration c) {
     org.batfish.datamodel.Interface iface =
-        org.batfish.datamodel.Interface.builder().setName("iface").setOwner(null).build();
+        org.batfish.datamodel.Interface.builder().setName("iface").build();
     Vrf vrf = new Vrf("vrf");
     vrf.setInterfaces(ImmutableSortedMap.of("iface", iface));
     c.setVrfs(ImmutableMap.of("vrf", vrf));

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -122,7 +122,8 @@ public class JuniperConfigurationTest {
    * @return the created interface
    */
   private static org.batfish.datamodel.Interface createInterface(Configuration c) {
-    org.batfish.datamodel.Interface iface = new org.batfish.datamodel.Interface("iface", null);
+    org.batfish.datamodel.Interface iface =
+        org.batfish.datamodel.Interface.builder().setName("iface").setOwner(null).build();
     Vrf vrf = new Vrf("vrf");
     vrf.setInterfaces(ImmutableSortedMap.of("iface", iface));
     c.setVrfs(ImmutableMap.of("vrf", vrf));

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -122,7 +122,7 @@ public class JuniperConfigurationTest {
    * @return the created interface
    */
   private static org.batfish.datamodel.Interface createInterface(Configuration c) {
-    org.batfish.datamodel.Interface iface = new org.batfish.datamodel.Interface("iface");
+    org.batfish.datamodel.Interface iface = new org.batfish.datamodel.Interface("iface", null);
     Vrf vrf = new Vrf("vrf");
     vrf.setInterfaces(ImmutableSortedMap.of("iface", iface));
     c.setVrfs(ImmutableMap.of("vrf", vrf));

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/Graph.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/Graph.java
@@ -500,7 +500,7 @@ public class Graph {
       for (StaticRoute sr : srs) {
         String name = sr.getNextHopInterface();
         // Create null route interface
-        Interface iface = new Interface(name);
+        Interface iface = new Interface(name, null);
         iface.setActive(true);
         iface.setAddress(
             ConcreteInterfaceAddress.create(
@@ -570,7 +570,7 @@ public class Graph {
    * iBGP control plane edge in the network.
    */
   private Interface createIbgpInterface(BgpActivePeerConfig n, String peer) {
-    Interface iface = new Interface("iBGP-" + peer);
+    Interface iface = new Interface("iBGP-" + peer, null);
     iface.setActive(true);
     // TODO is this valid.
     iface.setAddress(ConcreteInterfaceAddress.create(n.getPeerAddress(), Prefix.MAX_PREFIX_LENGTH));

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/Graph.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/Graph.java
@@ -500,7 +500,7 @@ public class Graph {
       for (StaticRoute sr : srs) {
         String name = sr.getNextHopInterface();
         // Create null route interface
-        Interface iface = new Interface(name, null);
+        Interface iface = Interface.builder().setName(name).setOwner(null).build();
         iface.setActive(true);
         iface.setAddress(
             ConcreteInterfaceAddress.create(
@@ -570,7 +570,7 @@ public class Graph {
    * iBGP control plane edge in the network.
    */
   private Interface createIbgpInterface(BgpActivePeerConfig n, String peer) {
-    Interface iface = new Interface("iBGP-" + peer, null);
+    Interface iface = Interface.builder().setName("iBGP-" + peer).setOwner(null).build();
     iface.setActive(true);
     // TODO is this valid.
     iface.setAddress(ConcreteInterfaceAddress.create(n.getPeerAddress(), Prefix.MAX_PREFIX_LENGTH));

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/Graph.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/Graph.java
@@ -500,7 +500,7 @@ public class Graph {
       for (StaticRoute sr : srs) {
         String name = sr.getNextHopInterface();
         // Create null route interface
-        Interface iface = Interface.builder().setName(name).setOwner(null).build();
+        Interface iface = Interface.builder().setName(name).build();
         iface.setActive(true);
         iface.setAddress(
             ConcreteInterfaceAddress.create(
@@ -570,7 +570,7 @@ public class Graph {
    * iBGP control plane edge in the network.
    */
   private Interface createIbgpInterface(BgpActivePeerConfig n, String peer) {
-    Interface iface = Interface.builder().setName("iBGP-" + peer).setOwner(null).build();
+    Interface iface = Interface.builder().setName("iBGP-" + peer).build();
     iface.setActive(true);
     // TODO is this valid.
     iface.setAddress(ConcreteInterfaceAddress.create(n.getPeerAddress(), Prefix.MAX_PREFIX_LENGTH));

--- a/projects/question/src/test/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/interfaceproperties/InterfacePropertiesAnswererTest.java
@@ -49,11 +49,11 @@ public class InterfacePropertiesAnswererTest {
   public void getProperties() {
     Configuration conf1 = new Configuration("node1", ConfigurationFormat.CISCO_IOS);
 
-    Interface iface1 = new Interface("iface1", conf1);
+    Interface iface1 = Interface.builder().setName("iface1").setOwner(conf1).build();
     iface1.setDescription("desc desc desc");
     iface1.setActive(false);
 
-    Interface iface2 = new Interface("iface2", conf1);
+    Interface iface2 = Interface.builder().setName("iface2").setOwner(conf1).build();
     iface2.setDescription("blah blah blah");
 
     conf1.getAllInterfaces().putAll(ImmutableMap.of("iface1", iface1, "iface2", iface2));


### PR DESCRIPTION
I wanted to get rid of some setters (namely `setAddress`, `setAllAddresses`). That proved to be too much of a burden to not break a lot of conversion code, but at least I got this minor cleanup out of it. Might revisit getting rid of setters later.

Each commit can be viewed separately for clarity.