### PR TITLE
Cisco NX-OS interface switchport settings

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
@@ -8,14 +8,44 @@ tokens {
   SUBDOMAIN_NAME
 }
 
+ACCESS
+:
+  'access'
+;
+
+ADD
+:
+  'add'
+;
+
 ADDRESS
 :
   'address'
 ;
 
+ALLOWED
+:
+  'allowed'
+;
+
+DOT1Q
+:
+  'dot1q'
+;
+
+ENCAPSULATION
+:
+  'encapsulation'
+;
+
 ETHERNET
 :
   [Ee] [Tt] [Hh] [Ee] [Rr] [Nn] [Ee] [Tt]
+;
+
+EXCEPT
+:
+  'except'
 ;
 
 FEATURE
@@ -75,9 +105,19 @@ MGMT
   [Mm] [Gg] [Mm] [Tt]
 ;
 
+NATIVE
+:
+  'native'
+;
+
 NO
 :
   'no'
+;
+
+NONE
+:
+  'none'
 ;
 
 PORT_CHANNEL
@@ -88,6 +128,11 @@ PORT_CHANNEL
 REDIRECTS
 :
   'redirects'
+;
+
+REMOVE
+:
+  'remove'
 ;
 
 SECONDARY
@@ -105,6 +150,16 @@ SWITCHPORT
   'switchport'
 ;
 
+TRUNK
+:
+  'trunk'
+;
+
+VLAN
+:
+  'vlan'
+;
+
 // Other Tokens
 
 BLANK_LINE
@@ -115,6 +170,11 @@ BLANK_LINE
   {lastTokenType() == NEWLINE|| lastTokenType() == -1}?
 
   F_Newline* -> channel ( HIDDEN )
+;
+
+COMMA
+:
+  ','
 ;
 
 COMMENT_LINE

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_common.g4
@@ -12,7 +12,8 @@ interface_address
 
 interface_name
 :
-  prefix = interface_prefix middle = interface_middle? first = uint8
+  prefix = interface_prefix middle = interface_middle? parent_suffix =
+  interface_parent_suffix? first = uint8
 ;
 
 interface_prefix
@@ -27,12 +28,12 @@ interface_middle
 :
   (
     uint8 FORWARD_SLASH
-  )+ parent_suffix = interface_parent_suffix?
+  )+
 ;
 
 interface_parent_suffix
 :
-  uint8 period = PERIOD
+  num = uint8 period = PERIOD
 ;
 
 ip_address

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
@@ -110,14 +110,22 @@ interface_range
   )?
 ;
 
+/*
+ * These two rules are added only for type safety; they force the Extractor to convert respecting
+ * specific valid VLAN ranges (1-3967 vs. 1-4094) which differs based on the containing rule.
+ *
+ * When adding grammar using vlan IDs, choose the rule corresponding to the correct allowed range.
+ */
 restricted_vlan_id
 :
+// 1-3967
   UINT8
   | UINT16
 ;
 
 vlan_id
 :
+// 1-4094
   UINT8
   | UINT16
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
@@ -10,10 +10,17 @@ s_interface
 :
   INTERFACE irange = interface_range NEWLINE
   (
-    i_ip
+    i_encapsulation
+    | i_ip
     | i_no
     | i_null
+    | i_switchport
   )*
+;
+
+i_encapsulation
+:
+  ENCAPSULATION DOT1Q vlan = restricted_vlan_id NEWLINE
 ;
 
 i_ip
@@ -53,10 +60,80 @@ i_null
   ) null_rest_of_line
 ;
 
+i_switchport
+:
+  SWITCHPORT
+  (
+    i_switchport_access
+    | i_switchport_trunk_allowed
+    | i_switchport_trunk
+  )
+;
+
+i_switchport_access
+:
+  ACCESS VLAN vlan = restricted_vlan_id NEWLINE
+;
+
+i_switchport_trunk
+:
+  TRUNK
+  (
+    i_switchport_trunk_allowed
+    | i_switchport_trunk_native
+  )
+;
+
+i_switchport_trunk_allowed
+:
+  ALLOWED VLAN
+  (
+    (
+      ADD
+      | REMOVE
+    )? vlans = vlan_id_range
+    | EXCEPT except = vlan_id
+    | NONE
+  ) NEWLINE
+;
+
+i_switchport_trunk_native
+:
+  NATIVE VLAN vlan = restricted_vlan_id NEWLINE
+;
+
 interface_range
 :
   iname = interface_name
   (
     DASH last = uint8
+  )?
+;
+
+restricted_vlan_id
+:
+  UINT8
+  | UINT16
+;
+
+vlan_id
+:
+  UINT8
+  | UINT16
+;
+
+vlan_id_range
+:
+  intervals += vlan_id_interval
+  (
+    COMMA intervals += vlan_id_interval
+  )*
+;
+
+vlan_id_interval
+:
+  low = vlan_id
+  (
+    DASH high = vlan_id
   )?
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -1,8 +1,10 @@
 package org.batfish.grammar.cisco_nxos;
 
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.getCanonicalInterfaceNamePrefix;
+import static org.batfish.representation.cisco_nxos.Interface.VLAN_RANGE;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Range;
 import java.util.List;
 import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
@@ -15,20 +17,32 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.batfish.common.Warnings;
 import org.batfish.common.Warnings.ParseWarning;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.SwitchportMode;
 import org.batfish.grammar.BatfishParseTreeWalker;
 import org.batfish.grammar.ControlPlaneExtractor;
 import org.batfish.grammar.UnrecognizedLineToken;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Cisco_nxos_configurationContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_encapsulationContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_ip_addressContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_no_shutdownContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_no_switchportContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_switchport_accessContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_switchport_trunk_allowedContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_switchport_trunk_nativeContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Interface_addressContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Interface_prefixContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ip_addressContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Restricted_vlan_idContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.S_hostnameContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.S_interfaceContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Uint8Context;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Vlan_idContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Vlan_id_rangeContext;
 import org.batfish.representation.cisco_nxos.CiscoNxosConfiguration;
+import org.batfish.representation.cisco_nxos.CiscoNxosInterfaceType;
 import org.batfish.representation.cisco_nxos.CiscoNxosStructureType;
 import org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage;
 import org.batfish.representation.cisco_nxos.Interface;
@@ -37,6 +51,8 @@ import org.batfish.vendor.VendorConfiguration;
 @ParametersAreNonnullByDefault
 public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseListener
     implements ControlPlaneExtractor {
+
+  private static final IntegerSpace RESTRICTED_VLAN_RANGE = IntegerSpace.of(Range.closed(1, 3967));
 
   private static int toInteger(Uint8Context ctx) {
     return Integer.parseInt(ctx.getText());
@@ -66,6 +82,16 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     _w = warnings;
   }
 
+  private @Nonnull String convErrorMessage(Class<?> type, ParserRuleContext ctx) {
+    return String.format("Could not convert to %s: %s", type.getSimpleName(), getFullText(ctx));
+  }
+
+  private @Nullable <T, U extends T> T convProblem(
+      Class<T> returnType, ParserRuleContext ctx, U defaultReturnValue) {
+    _w.redFlag(convErrorMessage(returnType, ctx));
+    return defaultReturnValue;
+  }
+
   @Override
   public void enterCisco_nxos_configuration(Cisco_nxos_configurationContext ctx) {
     _configuration = new CiscoNxosConfiguration();
@@ -76,15 +102,27 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     int line = ctx.getStart().getLine();
     String declaredName = getFullText(ctx.irange);
     String prefix = ctx.irange.iname.prefix.getText();
-    String canonicalPrefix = getCanonicalInterfaceNamePrefix(prefix);
-    if (canonicalPrefix == null) {
-      _w.redFlag(String.format("Unsupported interface name/range: %s", prefix));
+    CiscoNxosInterfaceType type = toType(ctx.irange.iname.prefix);
+    if (type == null) {
+      _w.redFlag(String.format("Unsupported interface type: %s", prefix));
       _currentInterfaces = ImmutableList.of();
       return;
     }
-    String lead = canonicalPrefix + ctx.irange.iname.middle.getText();
+    String canonicalPrefix = getCanonicalInterfaceNamePrefix(prefix);
+    if (canonicalPrefix == null) {
+      _w.redFlag(String.format("Unsupported interface name/range: %s", declaredName));
+      _currentInterfaces = ImmutableList.of();
+      return;
+    }
+    String middle = ctx.irange.iname.middle != null ? ctx.irange.iname.middle.getText() : "";
+    String parentSuffix =
+        ctx.irange.iname.parent_suffix != null ? ctx.irange.iname.parent_suffix.getText() : "";
+    String lead = String.format("%s%s%s", canonicalPrefix, middle, parentSuffix);
     String parentInterface =
-        ctx.irange.iname.middle.parent_suffix != null ? lead.substring(0, lead.length() - 1) : null;
+        parentSuffix.isEmpty()
+            ? null
+            : String.format(
+                "%s%s%s", canonicalPrefix, middle, ctx.irange.iname.parent_suffix.num.getText());
     int first = toInteger(ctx.irange.iname.first);
     int last = ctx.irange.last != null ? toInteger(ctx.irange.last) : first;
     _currentInterfaces =
@@ -104,10 +142,19 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
                                   n,
                                   CiscoNxosStructureUsage.INTERFACE_SELF_REFERENCE,
                                   line);
-                              return new Interface(n, parentInterface);
+                              return new Interface(n, parentInterface, type);
                             }))
             .collect(ImmutableList.toImmutableList());
     _currentInterfaces.forEach(i -> i.getDeclaredNames().add(declaredName));
+  }
+
+  @Override
+  public void exitI_encapsulation(I_encapsulationContext ctx) {
+    Integer vlanId = toRestrictedVlanId(ctx, ctx.vlan);
+    if (vlanId == null) {
+      return;
+    }
+    _currentInterfaces.forEach(iface -> iface.setEncapsulationVlan(vlanId));
   }
 
   @Override
@@ -125,6 +172,72 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   @Override
   public void exitI_no_shutdown(I_no_shutdownContext ctx) {
     _currentInterfaces.forEach(iface -> iface.setShutdown(false));
+  }
+
+  @Override
+  public void exitI_no_switchport(I_no_switchportContext ctx) {
+    _currentInterfaces.forEach(iface -> iface.setSwitchportMode(SwitchportMode.NONE));
+  }
+
+  @Override
+  public void exitI_switchport_access(I_switchport_accessContext ctx) {
+    Integer vlanId = toRestrictedVlanId(ctx, ctx.vlan);
+    if (vlanId == null) {
+      return;
+    }
+    _currentInterfaces.forEach(
+        iface -> {
+          iface.setSwitchportMode(SwitchportMode.ACCESS);
+          iface.setAccessVlan(vlanId);
+        });
+  }
+
+  @Override
+  public void exitI_switchport_trunk_allowed(I_switchport_trunk_allowedContext ctx) {
+    IntegerSpace vlans;
+    if (ctx.vlans != null) {
+      vlans = ctx.vlans != null ? toVlanIdRange(ctx, ctx.vlans) : null;
+      if (vlans == null) {
+        // invalid VLAN in range
+        return;
+      }
+    } else if (ctx.except != null) {
+      Integer except = toVlanId(ctx, ctx.except);
+      if (except == null) {
+        // invalid VLAN to exclude
+        return;
+      }
+      vlans = VLAN_RANGE.difference(IntegerSpace.of(except));
+    } else if (ctx.NONE() != null) {
+      vlans = IntegerSpace.EMPTY;
+    } else {
+      todo(ctx);
+      return;
+    }
+    _currentInterfaces.forEach(
+        iface -> {
+          iface.setSwitchportMode(SwitchportMode.TRUNK);
+          if (ctx.ADD() != null) {
+            iface.setAllowedVlans(iface.getAllowedVlans().union(vlans));
+          } else if (ctx.REMOVE() != null) {
+            iface.setAllowedVlans(iface.getAllowedVlans().difference(vlans));
+          } else {
+            iface.setAllowedVlans(vlans);
+          }
+        });
+  }
+
+  @Override
+  public void exitI_switchport_trunk_native(I_switchport_trunk_nativeContext ctx) {
+    Integer vlanId = toRestrictedVlanId(ctx, ctx.vlan);
+    if (vlanId == null) {
+      return;
+    }
+    _currentInterfaces.forEach(
+        iface -> {
+          iface.setSwitchportMode(SwitchportMode.TRUNK);
+          iface.setNativeVlan(vlanId);
+        });
   }
 
   @Override
@@ -152,6 +265,62 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   public void processParseTree(ParserRuleContext tree) {
     ParseTreeWalker walker = new BatfishParseTreeWalker(_parser);
     walker.walk(this, tree);
+  }
+
+  private void todo(ParserRuleContext ctx) {
+    _w.todo(ctx, getFullText(ctx), _parser);
+  }
+
+  private @Nullable Integer toRestrictedVlanId(
+      ParserRuleContext messageCtx, Restricted_vlan_idContext ctx) {
+    int vlan = Integer.parseInt(ctx.getText());
+    if (!RESTRICTED_VLAN_RANGE.contains(vlan)) {
+      _w.redFlag(
+          String.format(
+              "Expected VLAN in range %s, but got '%d' in: %s",
+              RESTRICTED_VLAN_RANGE, vlan, getFullText(messageCtx)));
+      return null;
+    }
+    return vlan;
+  }
+
+  private @Nullable CiscoNxosInterfaceType toType(Interface_prefixContext ctx) {
+    if (ctx.ETHERNET() != null) {
+      return CiscoNxosInterfaceType.ETHERNET;
+    } else if (ctx.LOOPBACK() != null) {
+      return CiscoNxosInterfaceType.LOOPBACK;
+    } else if (ctx.MGMT() != null) {
+      return CiscoNxosInterfaceType.MGMT;
+    } else if (ctx.PORT_CHANNEL() != null) {
+      return CiscoNxosInterfaceType.PORT_CHANNEL;
+    }
+    return convProblem(CiscoNxosInterfaceType.class, ctx, null);
+  }
+
+  private @Nullable Integer toVlanId(ParserRuleContext messageCtx, Vlan_idContext ctx) {
+    int vlan = Integer.parseInt(ctx.getText());
+    if (!VLAN_RANGE.contains(vlan)) {
+      _w.redFlag(
+          String.format(
+              "Expected VLAN in range %s, but got '%d' in: %s",
+              VLAN_RANGE, vlan, getFullText(messageCtx)));
+      return null;
+    }
+    return vlan;
+  }
+
+  private @Nullable IntegerSpace toVlanIdRange(
+      ParserRuleContext messageCtx, Vlan_id_rangeContext ctx) {
+    String rangeText = ctx.getText();
+    IntegerSpace value = IntegerSpace.parse(rangeText);
+    if (!VLAN_RANGE.contains(value)) {
+      _w.redFlag(
+          String.format(
+              "Expected VLANs in range %s, but got '%d' in: %s",
+              VLAN_RANGE, rangeText, getFullText(messageCtx)));
+      return null;
+    }
+    return value;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -316,7 +316,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     if (!VLAN_RANGE.contains(value)) {
       _w.redFlag(
           String.format(
-              "Expected VLANs in range %s, but got '%d' in: %s",
+              "Expected VLANs in range %s, but got '%s' in: %s",
               VLAN_RANGE, rangeText, getFullText(messageCtx)));
       return null;
     }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -87,7 +87,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   private @Nullable <T, U extends T> T convProblem(
-      Class<T> returnType, ParserRuleContext ctx, U defaultReturnValue) {
+      Class<T> returnType, ParserRuleContext ctx, @Nullable U defaultReturnValue) {
     _w.redFlag(convErrorMessage(returnType, ctx));
     return defaultReturnValue;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -49,7 +49,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
             .put("mgmt", "mgmt")
             .put("Null", "Null")
             .put("nve", "nve")
-            .put("Port-channel", "Port-channel")
+            .put("port-channel", "port-channel")
             .put("Vlan", "Vlan")
             .build();
     CISCO_NXOS_INTERFACE_PREFIXES_REGEX =

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosInterfaceType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosInterfaceType.java
@@ -1,0 +1,9 @@
+package org.batfish.representation.cisco_nxos;
+
+public enum CiscoNxosInterfaceType {
+  ETHERNET,
+  LOOPBACK,
+  MGMT,
+  PORT_CHANNEL,
+  VLAN
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
@@ -15,6 +15,19 @@ public final class Interface implements Serializable {
 
   public static final IntegerSpace VLAN_RANGE = IntegerSpace.of(Range.closed(1, 4094));
 
+  /**
+   * Returns the shutdown status for an interface when shutdown is not explicitly configured. Once
+   * explicitly configured, inference no longer applies for the life of the interface.
+   *
+   * <ul>
+   *   <li>Ethernet and port-channel parent interfaces are active by default iff they are in
+   *       switchport mode.
+   *   <li>Ethernet and port-channel subinterfaces are shut down by default.
+   *   <li>loopback interfaces are active by default.
+   *   <li>mgmt interfaces are active by default.
+   *   <li>vlan interfaces are shut down by default.
+   * </ul>
+   */
   private static boolean defaultShutdown(
       SwitchportMode switchportMode, CiscoNxosInterfaceType type) {
     switch (type) {
@@ -22,9 +35,11 @@ public final class Interface implements Serializable {
       case PORT_CHANNEL:
         return switchportMode == SwitchportMode.NONE;
 
+      case VLAN:
+        return true;
+
       case LOOPBACK:
       case MGMT:
-      case VLAN:
       default:
         return false;
     }
@@ -53,7 +68,7 @@ public final class Interface implements Serializable {
     initDefaultSwitchportSettings(parentInterface != null, type);
 
     // Set defaults for individual switchport modes
-    // - only effective when correspoinding switchport mode is active
+    // - only effective when corresponding switchport mode is active
     _accessVlan = 1;
     _nativeVlan = 1;
     _allowedVlans = VLAN_RANGE;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
@@ -1,29 +1,66 @@
 package org.batfish.representation.cisco_nxos;
 
+import com.google.common.collect.Range;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.SwitchportMode;
 
 /** A layer-2- or layer-3-capable network interface */
 public final class Interface implements Serializable {
 
+  public static final IntegerSpace VLAN_RANGE = IntegerSpace.of(Range.closed(1, 4094));
+
+  private static boolean defaultShutdown(
+      SwitchportMode switchportMode, CiscoNxosInterfaceType type) {
+    switch (type) {
+      case ETHERNET:
+      case PORT_CHANNEL:
+        return switchportMode == SwitchportMode.NONE;
+
+      case LOOPBACK:
+      case MGMT:
+      case VLAN:
+      default:
+        return false;
+    }
+  }
+
+  private @Nullable Integer _accessVlan;
   private @Nullable InterfaceAddress _address;
+  private @Nullable IntegerSpace _allowedVlans;
   private final @Nonnull Set<String> _declaredNames;
+  private @Nullable Integer _encapsulationVlan;
   private final @Nonnull String _name;
+  private @Nullable Integer _nativeVlan;
   private final @Nullable String _parentInterface;
   private final @Nonnull Set<InterfaceAddress> _secondaryAddresses;
-  private boolean _shutdown;
+  private @Nullable Boolean _shutdown;
+  private @Nonnull SwitchportMode _switchportMode;
+  private final @Nonnull CiscoNxosInterfaceType _type;
   private @Nullable String _vrfMember;
 
-  public Interface(String name, String parentInterface) {
+  public Interface(String name, String parentInterface, CiscoNxosInterfaceType type) {
     _name = name;
     _parentInterface = parentInterface;
     _declaredNames = new HashSet<>();
     _secondaryAddresses = new HashSet<>();
-    _shutdown = true;
+    _type = type;
+    initDefaultSwitchportSettings(parentInterface != null, type);
+
+    // Set defaults for individual switchport modes
+    // - only effective when correspoinding switchport mode is active
+    _accessVlan = 1;
+    _nativeVlan = 1;
+    _allowedVlans = VLAN_RANGE;
+  }
+
+  public @Nullable Integer getAccessVlan() {
+    return _accessVlan;
   }
 
   /** The primary IPv4 address of the interface. */
@@ -31,12 +68,24 @@ public final class Interface implements Serializable {
     return _address;
   }
 
+  public @Nullable IntegerSpace getAllowedVlans() {
+    return _allowedVlans;
+  }
+
   public @Nonnull Set<String> getDeclaredNames() {
     return _declaredNames;
   }
 
+  public @Nullable Integer getEncapsulationVlan() {
+    return _encapsulationVlan;
+  }
+
   public @Nonnull String getName() {
     return _name;
+  }
+
+  public @Nullable Integer getNativeVlan() {
+    return _nativeVlan;
   }
 
   public @Nullable String getParentInterface() {
@@ -49,18 +98,63 @@ public final class Interface implements Serializable {
   }
 
   public boolean getShutdown() {
-    return _shutdown;
+    return _shutdown != null ? _shutdown : defaultShutdown(_switchportMode, _type);
+  }
+
+  public SwitchportMode getSwitchportMode() {
+    return _switchportMode;
   }
 
   public @Nullable String getVrfMember() {
     return _vrfMember;
   }
 
-  public void setAddress(InterfaceAddress address) {
+  private void initDefaultSwitchportSettings(boolean isSubinterface, CiscoNxosInterfaceType type) {
+    switch (type) {
+      case ETHERNET:
+      case PORT_CHANNEL:
+        if (isSubinterface) {
+          // this is a subinterface
+          _switchportMode = SwitchportMode.NONE;
+        } else {
+          // this is a parent interface
+          _switchportMode = SwitchportMode.ACCESS;
+        }
+        break;
+
+      case LOOPBACK:
+      case MGMT:
+      default:
+        _switchportMode = SwitchportMode.NONE;
+        break;
+    }
+  }
+
+  public void setAccessVlan(@Nullable Integer accessVlan) {
+    _accessVlan = accessVlan;
+  }
+
+  public void setAddress(@Nullable InterfaceAddress address) {
     _address = address;
   }
 
-  public void setShutdown(boolean shutdown) {
+  public void setAllowedVlans(@Nullable IntegerSpace allowedVlans) {
+    _allowedVlans = allowedVlans;
+  }
+
+  public void setEncapsulationVlan(@Nullable Integer encapsulationVlan) {
+    _encapsulationVlan = encapsulationVlan;
+  }
+
+  public void setNativeVlan(@Nullable Integer nativeVlan) {
+    _nativeVlan = nativeVlan;
+  }
+
+  public void setShutdown(@Nullable Boolean shutdown) {
     _shutdown = shutdown;
+  }
+
+  public void setSwitchportMode(SwitchportMode switchportMode) {
+    _switchportMode = switchportMode;
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -435,4 +435,39 @@ public final class CiscoNxosGrammarTest {
       assertThat(iface.getAllowedVlans(), equalTo(IntegerSpace.of(Range.closed(1, 2))));
     }
   }
+
+  @Test
+  public void testInterfaceSwitchportExtractionInvalid() {
+    String hostname = "nxos_interface_switchport_invalid";
+    CiscoNxosConfiguration vc = parseVendorConfig(hostname);
+
+    assertThat(
+        vc.getInterfaces(),
+        hasKeys("Ethernet1/1", "Ethernet1/2", "Ethernet1/2.1", "Ethernet1/3", "Ethernet1/4"));
+
+    {
+      Interface iface = vc.getInterfaces().get("Ethernet1/1");
+      assertFalse(iface.getShutdown());
+      assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.ACCESS));
+      assertThat(iface.getAccessVlan(), equalTo(1));
+    }
+    {
+      Interface iface = vc.getInterfaces().get("Ethernet1/2.1");
+      assertTrue(iface.getShutdown());
+      assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.NONE));
+      assertThat(iface.getEncapsulationVlan(), nullValue());
+    }
+    {
+      Interface iface = vc.getInterfaces().get("Ethernet1/1");
+      assertFalse(iface.getShutdown());
+      assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.ACCESS));
+      assertThat(iface.getAccessVlan(), equalTo(1));
+    }
+    {
+      Interface iface = vc.getInterfaces().get("Ethernet1/1");
+      assertFalse(iface.getShutdown());
+      assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.ACCESS));
+      assertThat(iface.getAccessVlan(), equalTo(1));
+    }
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -195,9 +195,9 @@ public final class CiscoNxosGrammarTest {
             "Ethernet1/10",
             "loopback0",
             "mgmt0",
-            "Port-channel1",
-            "Port-channel2",
-            "Port-channel2.1"));
+            "port-channel1",
+            "port-channel2",
+            "port-channel2.1"));
 
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/1");
@@ -217,7 +217,7 @@ public final class CiscoNxosGrammarTest {
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.NONE));
     }
     {
-      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Port-channel1");
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("port-channel1");
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.ACCESS));
       assertThat(iface.getAccessVlan(), equalTo(1));
@@ -240,12 +240,12 @@ public final class CiscoNxosGrammarTest {
       assertThat(iface.getEncapsulationVlan(), equalTo(2));
     }
     {
-      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Port-channel2");
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("port-channel2");
       assertThat(iface, isActive());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.NONE));
     }
     {
-      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Port-channel2.1");
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("port-channel2.1");
       assertThat(iface, isActive(false));
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.NONE));
       assertThat(iface.getEncapsulationVlan(), nullValue());
@@ -327,9 +327,9 @@ public final class CiscoNxosGrammarTest {
             "Ethernet1/10",
             "loopback0",
             "mgmt0",
-            "Port-channel1",
-            "Port-channel2",
-            "Port-channel2.1"));
+            "port-channel1",
+            "port-channel2",
+            "port-channel2.1"));
 
     {
       Interface iface = vc.getInterfaces().get("Ethernet1/1");
@@ -348,7 +348,7 @@ public final class CiscoNxosGrammarTest {
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.NONE));
     }
     {
-      Interface iface = vc.getInterfaces().get("Port-channel1");
+      Interface iface = vc.getInterfaces().get("port-channel1");
       assertFalse(iface.getShutdown());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.ACCESS));
       assertThat(iface.getAccessVlan(), equalTo(1));
@@ -371,12 +371,12 @@ public final class CiscoNxosGrammarTest {
       assertThat(iface.getEncapsulationVlan(), equalTo(2));
     }
     {
-      Interface iface = vc.getInterfaces().get("Port-channel2");
+      Interface iface = vc.getInterfaces().get("port-channel2");
       assertFalse(iface.getShutdown());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.NONE));
     }
     {
-      Interface iface = vc.getInterfaces().get("Port-channel2.1");
+      Interface iface = vc.getInterfaces().get("port-channel2.1");
       assertTrue(iface.getShutdown());
       assertThat(iface.getSwitchportMode(), equalTo(SwitchportMode.NONE));
       assertThat(iface.getEncapsulationVlan(), nullValue());

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_switchport
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_switchport
@@ -1,0 +1,156 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_interface_switchport
+!
+! Ethernet interface with no configuration:
+! - shutdown = false
+! - switchport = true
+! - switchport mode = access
+! - switchport access vlan = 1 
+interface Ethernet1/1
+!
+
+! Loopback interface with no configuration
+! - shutdown = false
+! - switchport = false
+! - switchport mode = NONE
+interface Loopback0
+!
+
+! Management interface with no configuration
+! - shutdown = false
+! - switchport = false
+! - switchport mode = NONE
+interface mgmt0
+  no shutdown
+!
+
+! Port-channel interface with no configuration:
+! - shutdown = false
+! - switchport = true
+! - switchport mode = access
+! - switchport access vlan = 1 
+interface Port-channel1
+!
+
+! Ethernet interface with no switchport and no shutdown:
+! - shutdown = false
+! - switchport = false
+! - switchport mode = NONE
+interface Ethernet1/2
+  no switchport
+  no shutdown
+!
+
+! Ethernet subinterface with no configuration:
+! - shutdown = true
+! - switchport = false
+! - switchport mode = NONE
+! - encapsulation vlan = null (1, untagged)
+interface Ethernet1/2.1
+!
+
+! Ethernet subinterface with encapsulation vlan:
+! - shutdown = true
+! - switchport = false
+! - switchport mode = NONE
+! - encapsulation vlan = 2 (tagged)
+interface Ethernet1/2.2
+  encapsulation dot1q 2
+!
+
+! Port-channel interface with no switchport and no shutdown:
+! - shutdown = false
+! - switchport = false
+! - switchport mode = NONE
+interface Port-channel2
+  no switchport
+  no shutdown
+!
+
+! Port-channel subinterface with no configuration:
+! - shutdown = true
+! - switchport = false
+! - switchport mode = NONE
+interface Port-channel2.1
+!
+
+! Ethernet interface with no shutdown before no switchport (no shutdown is remembered):
+! - shutdown = false
+! - switchport = false
+! - switchport mode = NONE
+interface Ethernet1/3
+  no shutdown
+  no switchport
+!  
+  
+! Ethernet interface with access vlan
+! - shutdown = false
+! - switchport = true
+! - switchport mode = ACCESS
+! - switchport access vlan = 2
+interface Ethernet1/4
+  switchport access vlan 2
+!
+
+! Ethernet interface with native vlan
+! - shutdown = false
+! - switchport = true
+! - switchport mode = TRUNK
+! - switchport native vlan = 2
+! - switchport allowed vlans = 1-4094
+interface Ethernet1/5
+  switchport trunk native vlan 2
+!
+
+! Ethernet interface with allowed vlans
+! - shutdown = false
+! - switchport = true
+! - switchport mode = TRUNK
+! - switchport native vlan = 1
+! - switchport allowed vlans = 1-3
+interface Ethernet1/6
+  switchport trunk allowed vlan 1-3
+!
+
+! Ethernet interface with allowed vlans set and appended
+! - shutdown = false
+! - switchport = true
+! - switchport mode = TRUNK
+! - switchport native vlan = 1
+! - switchport allowed vlans = 1-3
+interface Ethernet1/7
+  switchport trunk allowed vlan 1-3
+  switchport trunk allowed vlan add 4
+!
+
+! Ethernet interface with allowed vlans blacklist
+! - shutdown = false
+! - switchport = true
+! - switchport mode = TRUNK
+! - switchport native vlan = 1
+! - switchport allowed vlans = 1-4093
+interface Ethernet1/8
+  switchport trunk allowed vlan except 4094
+!
+
+! Ethernet interface with allowed vlans none
+! - shutdown = false
+! - switchport = true
+! - switchport mode = TRUNK
+! - switchport native vlan = 1
+! - switchport allowed vlans = {}
+interface Ethernet1/9
+  switchport trunk allowed vlan none
+!
+
+! Ethernet interface with allowed vlans set and reduced
+! - shutdown = false
+! - switchport = true
+! - switchport mode = TRUNK
+! - switchport native vlan = 1
+! - switchport allowed vlans = 1-3
+interface Ethernet1/10
+  switchport trunk allowed vlan 1-3
+  switchport trunk allowed vlan remove 3
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_switchport
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_switchport
@@ -25,12 +25,12 @@ interface mgmt0
   no shutdown
 !
 
-! Port-channel interface with no configuration:
+! port-channel interface with no configuration:
 ! - shutdown = false
 ! - switchport = true
 ! - switchport mode = access
 ! - switchport access vlan = 1 
-interface Port-channel1
+interface port-channel1
 !
 
 ! Ethernet interface with no switchport and no shutdown:
@@ -59,20 +59,20 @@ interface Ethernet1/2.2
   encapsulation dot1q 2
 !
 
-! Port-channel interface with no switchport and no shutdown:
+! port-channel interface with no switchport and no shutdown:
 ! - shutdown = false
 ! - switchport = false
 ! - switchport mode = NONE
-interface Port-channel2
+interface port-channel2
   no switchport
   no shutdown
 !
 
-! Port-channel subinterface with no configuration:
+! port-channel subinterface with no configuration:
 ! - shutdown = true
 ! - switchport = false
 ! - switchport mode = NONE
-interface Port-channel2.1
+interface port-channel2.1
 !
 
 ! Ethernet interface with no shutdown before no switchport (no shutdown is remembered):

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_switchport_invalid
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_switchport_invalid
@@ -1,0 +1,36 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_interface_switchport_invalid
+!
+
+! Ethernet interface with invalid access vlan > 3967
+! - switchport mode = access
+! - switchport access vlan = 1 (access setting does not take)
+interface Ethernet1/1
+  switchport access vlan 4000
+!
+
+! Ethernet subinterface with invalid encapsulation VLAN > 3967
+! - parent interface has switchport disabled to allow subinterface
+! - switchport mode = none
+! - encapsulation vlan = null (encapsulation setting does not take)
+interface Ethernet1/2
+  no switchport  
+!
+interface Ethernet1/2.1
+  encapsulation dot1q 4000
+!
+
+! Ethernet interface with invalid native vlan > 3967
+! - switchport mode = access (trunk setting does not take)
+! - switchport access vlan = 1 (trunk setting does not take)
+interface Ethernet1/3
+  switchport trunk native vlan 4000
+!
+
+! Ethernet interface with invalid allowed vlan > 4094
+! - switchport mode = access (trunk setting does not take)
+! - switchport access vlan = 1 (trunk setting does not take)
+interface Ethernet1/4
+  switchport trunk allowed vlan 4100
+!


### PR DESCRIPTION
- default switchport mode for interface type
- default shutdown for switchport mode and interface type
- access mode
  - access vlan
- trunk mode
  - native vlan
  - allowed vlans
- fix interface name processing