### PR TITLE
Bgp export: fix juniper "from tag"

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -647,7 +647,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     }
     // Apply final post-policy transformations before sending advertisement to neighbor
     BgpProtocolHelper.transformBgpRoutePostExport(
-        transformedOutgoingRouteBuilder, ourConfig, sessionProperties);
+        transformedOutgoingRouteBuilder, sessionProperties.isEbgp(), ourConfig.getLocalAs());
     // Successfully exported route
     R transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();
     return Optional.of(transformedOutgoingRoute);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1878,7 +1878,7 @@ public class VirtualRouter implements Serializable {
 
     // Apply final post-policy transformations before sending advertisement to neighbor
     BgpProtocolHelper.transformBgpRoutePostExport(
-        transformedOutgoingRouteBuilder, ourConfig, sessionProperties);
+        transformedOutgoingRouteBuilder, sessionProperties.isEbgp(), ourConfig.getLocalAs());
 
     // Successfully exported route
     Bgpv4Route transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();
@@ -1956,7 +1956,7 @@ public class VirtualRouter implements Serializable {
 
     // Apply final post-policy transformations before sending advertisement to neighbor
     BgpProtocolHelper.transformBgpRoutePostExport(
-        transformedOutgoingRouteBuilder, ourConfig, sessionProperties);
+        transformedOutgoingRouteBuilder, sessionProperties.isEbgp(), ourConfig.getLocalAs());
 
     // Successfully exported route
     R transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -247,8 +247,8 @@ public final class BgpProtocolHelper {
    * <p>Intended for converting main RIB routes into their BGP equivalents before passing {@code
    * routeDecorator} to the export policy
    *
-   * <p>The builder returned will will have default local preference, incomplete origin type, and
-   * most other fields unset.
+   * <p>The builder returned will have default local preference, incomplete origin type, and most
+   * other fields unset.
    */
   @Nonnull
   public static Bgpv4Route.Builder convertNonBgpRouteToBgpRoute(
@@ -270,26 +270,27 @@ public final class BgpProtocolHelper {
         // TODO: support customization of route preference
         .setLocalPreference(BgpRoute.DEFAULT_LOCAL_PREFERENCE)
         .setReceivedFromIp(protocol == RoutingProtocol.BGP ? nextHopIp : Ip.ZERO)
-        .setNextHopIp(nextHopIp);
+        .setNextHopIp(nextHopIp)
+        .setTag(routeDecorator.getAbstractRoute().getTag());
     // Let everything else default to unset/empty/etc.
   }
 
   /**
-   * Perform BGP export transformations on a given route when sending an advertisement from {@code
-   * fromNeighbor} to {@code toNeighbor} after export policy as applied and route is accepted, but
-   * before route is sent onto the wire.
+   * Perform BGP export transformations on a given route <em>after</em> export policy has been
+   * applied to the route, route was accepted, but before route is sent "onto the wire".
    */
   public static <R extends BgpRoute<B, R>, B extends BgpRoute.Builder<B, R>>
-      void transformBgpRoutePostExport(
-          B routeBuilder, BgpPeerConfig fromNeighbor, BgpSessionProperties sessionProperties) {
-    if (sessionProperties.isEbgp()) {
+      void transformBgpRoutePostExport(B routeBuilder, boolean isEbgp, long localAs) {
+    if (isEbgp) {
       // if eBGP, prepend as-path sender's as-path number
       routeBuilder.setAsPath(
           AsPath.of(
               ImmutableList.<AsSet>builder()
-                  .add(AsSet.of(fromNeighbor.getLocalAs()))
+                  .add(AsSet.of(localAs))
                   .addAll(routeBuilder.getAsPath().getAsSets())
                   .build()));
+      // Tags are non-transitive
+      routeBuilder.setTag(null);
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -1,6 +1,7 @@
 package org.batfish.dataplane.protocols;
 
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.transformBgpRouteOnImport;
+import static org.batfish.dataplane.protocols.BgpProtocolHelper.transformBgpRoutePostExport;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -14,6 +15,7 @@ import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RoutingProtocol;
 import org.junit.Before;
 import org.junit.Test;
@@ -109,5 +111,14 @@ public class BgpProtocolHelperTest {
         "AdminDistance is set",
         builder.getAdmin(),
         equalTo(RoutingProtocol.BGP.getDefaultAdministrativeCost(ConfigurationFormat.CISCO_IOS)));
+  }
+
+  @Test
+  public void testTransformPostExportClearTag() {
+    Builder builder = _baseBgpRouteBuilder.setTag(Integer.MAX_VALUE);
+    transformBgpRoutePostExport(builder, true, 1);
+    assertThat("Tag is cleared", builder.getTag(), equalTo(Route.UNSET_ROUTE_TAG));
+    transformBgpRoutePostExport(builder, false, 1);
+    assertThat("Tag is cleared", builder.getTag(), equalTo(Route.UNSET_ROUTE_TAG));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
@@ -157,7 +157,8 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
    * and the class variables representing the BGP session.
    */
   private void runTransformBgpRoutePostExport(Bgpv4Route.Builder routeBuilder) {
-    BgpProtocolHelper.transformBgpRoutePostExport(routeBuilder, _fromNeighbor, _sessionProperties);
+    BgpProtocolHelper.transformBgpRoutePostExport(
+        routeBuilder, _sessionProperties.isEbgp(), _fromNeighbor.getLocalAs());
   }
 
   /**
@@ -333,5 +334,25 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
     setUpPeers(false);
     transformedBgpRoute = runTransformBgpRoutePreExport(bgpv4Route);
     assertThat(transformedBgpRoute.getWeight(), equalTo(0));
+  }
+
+  @Test
+  public void testNonBgpToBgpKeepTag() {
+    int tag = 100;
+    setUpPeers(false);
+    assertThat(
+        convertNonBgpRouteToBgpRoute(
+                StaticRoute.builder()
+                    .setNetwork(Prefix.ZERO)
+                    .setNextHopInterface("foo")
+                    .setAdministrativeCost(1)
+                    .setTag(tag)
+                    .build(),
+                _fromBgpProcess.getRouterId(),
+                _sessionProperties.getTailIp(),
+                170,
+                RoutingProtocol.BGP)
+            .getTag(),
+        equalTo(tag));
   }
 }


### PR DESCRIPTION
The culprit here was `UseOutputAttributes` which is true for juniper so the tag had to be read from the output route builder, not original route. 

Fix: Make BDP copy the tag to the output builder when export non-bgp routes. 

need to design a saner pipeline here, not clear at all which attributes can/should be read from where and thus copied or not copied.

Fixes #4169 