### PR TITLE
FilterLineReachability: stop rejecting empty filter sets

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
@@ -66,12 +66,6 @@ public class FilterLineReachabilityAnswerer extends Answerer {
 
     Map<String, Set<IpAccessList>> specifiedAcls = getSpecifiedFilters(question, ctxt);
 
-    // did we get any filters at all?
-    if (specifiedAcls.values().stream().allMatch(fset -> fset.size() == 0)) {
-      throw new IllegalArgumentException(
-          "Did not find any filters that meets the specified criteria. (Tips: Set 'ignoreGenerated' to false if you want to analyze combined filters; use 'resolveFilterSpecifier' question to see which filters your nodes and filters match.)");
-    }
-
     SortedMap<String, Configuration> configurations = _batfish.loadConfigurations();
     List<AclSpecs> aclSpecs = getAclSpecs(configurations, specifiedAcls, answerRows);
     answerAclReachability(aclSpecs, answerRows);


### PR DESCRIPTION
It's okay to run an algorithm on an empty set. If the caller wants to ensure
that something matches the filter, they should probably resolve the specifier
first.