### PR TITLE
Add a WillNotCommit parse status

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/WillNotCommitException.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/WillNotCommitException.java
@@ -1,0 +1,17 @@
+package org.batfish.common;
+
+/**
+ * Thrown if Batfish determines during parsing a file that a device would reject (not commmit) a
+ * given configuration
+ */
+public class WillNotCommitException extends BatfishException {
+
+  /**
+   * Create a new exception
+   *
+   * @param offendingText line text that would be rejected by the device
+   */
+  public WillNotCommitException(String offendingText) {
+    super("Would not be able to commit the following line: " + offendingText);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseStatus.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ParseStatus.java
@@ -7,14 +7,24 @@ import java.util.List;
 import org.batfish.common.BatfishException;
 
 public enum ParseStatus {
+  /** The file was empty, we have nothing to do */
   EMPTY,
+  /** Batfish has encountered an unrecoverable error during parsing */
   FAILED,
+  /** File was explicitly ignored by the user */
   IGNORED,
+  /** File is part of an unused overlay configuration */
   ORPHANED,
+  /** Some syntax was unrecognized, but Batfish processed the file */
   PARTIALLY_UNRECOGNIZED,
+  /** File was fully parsed */
   PASSED,
+  /** Batfish could not detect the file format */
   UNKNOWN,
-  UNSUPPORTED;
+  /** Batfish does not support the format/vendor config in the file */
+  UNSUPPORTED,
+  /** Configuration would be rejected by a device (failed to commit) because it is invalid */
+  WILL_NOT_COMMIT;
 
   private static final List<ParseStatus> ORDERED =
       ImmutableList.of(
@@ -47,6 +57,8 @@ public enum ParseStatus {
         return "File format is unknown";
       case UNSUPPORTED:
         return "File format is known but unsupported";
+      case WILL_NOT_COMMIT:
+        return "File contains configuration that will be rejected by a device";
       default:
         throw new BatfishException(
             String.format("Unhandled parse status explanation for status: %s", status));

--- a/projects/question/src/main/java/org/batfish/question/initialization/InitIssuesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/initialization/InitIssuesAnswerer.java
@@ -111,6 +111,7 @@ public class InitIssuesAnswerer extends Answerer {
         case PARTIALLY_UNRECOGNIZED:
           // Other issues are already in the table for these files (e.g. stack trace, parse warn)
           continue;
+        case WILL_NOT_COMMIT:
         default:
           rows.add(
               getRow(


### PR DESCRIPTION
Identifies files that would be rejected by the device because they
contain invalid config.

lmk if I missed special handling in other parts of the stack.