### PR TITLE
BDD: fix pom to not warn on serial

### DIFF
--- a/projects/bdd/pom.xml
+++ b/projects/bdd/pom.xml
@@ -44,6 +44,7 @@
             <arg>-Xlint:all</arg>
             <arg>-Xlint:-options</arg>
             <arg>-Xlint:-processing</arg>
+            <arg>-Xlint:-serial</arg>
             <arg>-XDignore.symbol.file</arg>
           </compilerArgs>
           <fork>true</fork>


### PR DESCRIPTION
It doesn't inherit compiler config since we the code has very different style