### PR TITLE
Cumulus: kill more parse warnings

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/CumulusNcluLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/CumulusNcluLexer.g4
@@ -67,6 +67,11 @@ ADVERTISE_DEFAULT_GW
   'advertise-default-gw'
 ;
 
+AGENTX
+:
+  'agentx'
+;
+
 ALERTS
 :
   'alerts'
@@ -75,6 +80,11 @@ ALERTS
 ALIAS
 :
   'alias' -> pushMode(M_Alias)
+;
+
+ALWAYS_COMPARE_MED
+:
+  'always-compare-med'
 ;
 
 ARP_ND_SUPPRESS
@@ -395,6 +405,11 @@ REMOTE_AS
 ROUTE
 :
   'route'
+;
+
+ROUTER
+:
+  'router'
 ;
 
 ROUTE_MAP
@@ -971,9 +986,19 @@ M_Printf_IP
   'ip' -> type ( IP )
 ;
 
+M_Printf_DEC
+:
+   F_Digit+ -> type ( DEC )
+;
+
 M_Printf_ROUTE
 :
   'route' -> type ( ROUTE )
+;
+
+M_Printf_ROUTER
+:
+  'router' -> type ( ROUTER )
 ;
 
 M_Printf_VRF

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/CumulusNcluParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/CumulusNcluParser.g4
@@ -31,7 +31,8 @@ s_extra_configuration
 :
   EXTRA_CONFIGURATION_HEADER
   (
-    frr_username
+    frr_router
+    | frr_username
     | frr_vrf
     | // frr_unrecognized must be last
     frr_unrecognized

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/CumulusNclu_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/CumulusNclu_bgp.g4
@@ -17,11 +17,17 @@ a_bgp
 
 b_common
 :
-  b_autonomous_system
+  b_always_compare_med
+  | b_autonomous_system
   | b_ipv4_unicast
   | b_l2vpn
   | b_neighbor
   | b_router_id
+;
+
+b_always_compare_med
+:
+  ALWAYS_COMPARE_MED NEWLINE
 ;
 
 b_autonomous_system

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/CumulusNclu_frr.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/CumulusNclu_frr.g4
@@ -6,6 +6,11 @@ options {
   tokenVocab = CumulusNcluLexer;
 }
 
+frr_router
+:
+  ROUTER frr_null_rest_of_line
+;
+
 frr_vrf
 :
   VRF name = word NEWLINE frrv_ip_route* frr_exit_vrf?

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/CumulusNclu_routing.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/CumulusNclu_routing.g4
@@ -10,12 +10,18 @@ a_routing
 :
   ROUTING
   (
-    r_defaults_datacenter
+    r_agentx
+    | r_defaults_datacenter
     | r_log
     | r_route
     | r_route_map
     | r_service_integrated_vtysh_config
   )
+;
+
+r_agentx
+:
+  AGENTX NEWLINE
 ;
 
 r_defaults_datacenter

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_nclu/CumulusNcluConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_nclu/CumulusNcluConfigurationBuilder.java
@@ -52,6 +52,7 @@ import org.batfish.grammar.cumulus_nclu.CumulusNcluParser.A_timeContext;
 import org.batfish.grammar.cumulus_nclu.CumulusNcluParser.A_vlanContext;
 import org.batfish.grammar.cumulus_nclu.CumulusNcluParser.A_vrfContext;
 import org.batfish.grammar.cumulus_nclu.CumulusNcluParser.A_vxlanContext;
+import org.batfish.grammar.cumulus_nclu.CumulusNcluParser.B_always_compare_medContext;
 import org.batfish.grammar.cumulus_nclu.CumulusNcluParser.B_autonomous_systemContext;
 import org.batfish.grammar.cumulus_nclu.CumulusNcluParser.B_ipv4_unicastContext;
 import org.batfish.grammar.cumulus_nclu.CumulusNcluParser.B_l2vpnContext;
@@ -873,6 +874,11 @@ public class CumulusNcluConfigurationBuilder extends CumulusNcluParserBaseListen
   @Override
   public void exitA_vxlan(A_vxlanContext ctx) {
     _currentVxlans = null;
+  }
+
+  @Override
+  public void exitB_always_compare_med(B_always_compare_medContext ctx) {
+    todo(ctx);
   }
 
   @Override

--- a/tests/parsing-tests/networks/unit-tests/configs/cumulus_nclu
+++ b/tests/parsing-tests/networks/unit-tests/configs/cumulus_nclu
@@ -49,6 +49,7 @@ net add bgp l2vpn evpn neighbor swp2 activate
 net add bgp l2vpn evpn neighbor swp3 activate
 net add bgp router-id 192.0.2.2
 net add bgp vrf vrf1 autonomous-system 65501
+net add bgp vrf vrf1 always-compare-med
 net add bgp vrf vrf1 ipv4 unicast redistribute connected
 net add bgp vrf vrf1 ipv4 unicast redistribute static
 net add bgp vrf vrf1 l2vpn evpn  advertise ipv4 unicast
@@ -111,3 +112,4 @@ net commit
 sudo sh -c "printf 'username cumulus nopassword\n' >> /etc/frr/frr.conf"
 sudo sh -c "printf 'vrf vrf1\n  ip route 0.0.0.0/0 192.0.2.1\n' >> /etc/frr/frr.conf"
 sudo sh -c "printf 'vrf vrf1\n exit-vrf\n' >> /etc/frr/frr.conf"
+sudo sh -c "printf 'router bgp 65000 vrf FOO\n neighbor 1.1.1.1 interface peer-group A_GROUP\n' >> /etc/frr/frr.conf"

--- a/tests/parsing-tests/networks/unit-tests/configs/cumulus_nclu_routing
+++ b/tests/parsing-tests/networks/unit-tests/configs/cumulus_nclu_routing
@@ -1,0 +1,5 @@
+net del all
+#
+net add hostname cumulus_nclu_routing
+#
+net add routing agentx

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -15499,6 +15499,55 @@
           }
         }
       },
+      "cumulus_nclu_routing" : {
+        "configurationFormat" : "CUMULUS_NCLU",
+        "name" : "cumulus_nclu_routing",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "SWITCH",
+        "interfaces" : {
+          "lo" : {
+            "name" : "lo",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "mtu" : 1500,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          }
+        },
+        "vendorFamily" : {
+          "cumulus" : {
+            "bridge" : {
+              "pvid" : 1,
+              "vids" : ""
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "interfaces" : [
+              "lo"
+            ]
+          }
+        }
+      },
       "eos_mlag" : {
         "configurationFormat" : "ARISTA",
         "name" : "eos_mlag",

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -576,182 +576,189 @@
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 60,
+        "Line" : 52,
+        "Text" : "always-compare-med",
+        "Parser_Context" : "[b_always_compare_med b_common b_vrf a_bgp s_net_add statement cumulus_nclu_configuration]",
+        "Comment" : "This feature is not currently supported"
+      },
+      {
+        "Filename" : "configs/cumulus_nclu",
+        "Line" : 61,
         "Text" : "dot1x eap-reauth-period 0",
         "Parser_Context" : "[a_dot1x s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 61,
+        "Line" : 62,
         "Text" : "dot1x mab-activation-delay 30",
         "Parser_Context" : "[a_dot1x s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 62,
+        "Line" : 63,
         "Text" : "dot1x radius accounting-port 1234",
         "Parser_Context" : "[a_dot1x s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 63,
+        "Line" : 64,
         "Text" : "dot1x radius authentication-port 2345",
         "Parser_Context" : "[a_dot1x s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 65,
+        "Line" : 66,
         "Text" : "ptp global domain-number 0",
         "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 66,
+        "Line" : 67,
         "Text" : "ptp global logging-level 5",
         "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 67,
+        "Line" : 68,
         "Text" : "ptp global path-trace-enabled no",
         "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 68,
+        "Line" : 69,
         "Text" : "ptp global priority1 255",
         "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 69,
+        "Line" : 70,
         "Text" : "ptp global slave-only no",
         "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 70,
+        "Line" : 71,
         "Text" : "ptp global summary-interval 0",
         "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 71,
+        "Line" : 72,
         "Text" : "ptp global time-stamping",
         "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 72,
+        "Line" : 73,
         "Text" : "ptp global use-syslog yes",
         "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 73,
+        "Line" : 74,
         "Text" : "ptp global verbose no",
         "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 75,
+        "Line" : 76,
         "Text" : "defaults datacenter",
         "Parser_Context" : "[r_defaults_datacenter a_routing s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 76,
+        "Line" : 77,
         "Text" : "log syslog informational",
         "Parser_Context" : "[r_log a_routing s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 79,
+        "Line" : 80,
         "Text" : "service integrated-vtysh-config",
         "Parser_Context" : "[r_service_integrated_vtysh_config a_routing s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 81,
+        "Line" : 82,
         "Text" : "snmp-server listening-address localhost",
         "Parser_Context" : "[a_snmp_server s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 82,
+        "Line" : 83,
         "Text" : "time ntp server 0.pool.ntp.example.com iburst",
         "Parser_Context" : "[a_time s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 83,
+        "Line" : 84,
         "Text" : "time ntp source eth0",
         "Parser_Context" : "[a_time s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 84,
+        "Line" : 85,
         "Text" : "time zone Etc/UTC",
         "Parser_Context" : "[a_time s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 89,
+        "Line" : 90,
         "Text" : "vlan-raw-device bridge",
         "Parser_Context" : "[v_vlan_raw_device a_vlan s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 98,
+        "Line" : 99,
         "Text" : "arp-nd-suppress on",
         "Parser_Context" : "[vxb_arp_nd_suppress vx_bridge a_vxlan s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 99,
+        "Line" : 100,
         "Text" : "learning off",
         "Parser_Context" : "[vxb_learning vx_bridge a_vxlan s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 100,
+        "Line" : 101,
         "Text" : "stp bpduguard",
         "Parser_Context" : "[vx_stp a_vxlan s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 101,
+        "Line" : 102,
         "Text" : "stp portbpdufilter",
         "Parser_Context" : "[vx_stp a_vxlan s_net_add statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/cumulus_nclu",
-        "Line" : 111,
+        "Line" : 112,
         "Text" : "username cumulus nopassword\\n",
         "Parser_Context" : "[frr_username s_extra_configuration statement cumulus_nclu_configuration]",
         "Comment" : "This feature is not currently supported"
@@ -2354,10 +2361,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 330 results",
+      "notes" : "Found 331 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 330
+      "numResults" : 331
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -477,6 +477,9 @@
         "cumulus_nclu_invalid_vxlans" : [
           "configs/cumulus_nclu_invalid_vxlans"
         ],
+        "cumulus_nclu_routing" : [
+          "configs/cumulus_nclu_routing"
+        ],
         "eos_mlag" : [
           "configs/eos_mlag"
         ],
@@ -1052,6 +1055,7 @@
         "configs/cumulus_nclu_invalid_interfaces" : "PASSED",
         "configs/cumulus_nclu_invalid_vrfs" : "PASSED",
         "configs/cumulus_nclu_invalid_vxlans" : "PASSED",
+        "configs/cumulus_nclu_routing" : "PASSED",
         "configs/eos_mlag" : "PASSED",
         "configs/eos_trunk_group" : "PASSED",
         "configs/f5_bigip_imish_malformed" : "PASSED",
@@ -40916,6 +40920,20 @@
             "          name = (word",
             "            NUMBERED_WORD:'vrf1')",
             "          (b_common",
+            "            (b_always_compare_med",
+            "              ALWAYS_COMPARE_MED:'always-compare-med'",
+            "              NEWLINE:'\\n'))))))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_bgp",
+            "        BGP:'bgp'",
+            "        (b_vrf",
+            "          VRF:'vrf'",
+            "          name = (word",
+            "            NUMBERED_WORD:'vrf1')",
+            "          (b_common",
             "            (b_ipv4_unicast",
             "              IPV4:'ipv4'",
             "              UNICAST:'unicast'",
@@ -41661,6 +41679,25 @@
             "        NEWLINE:'\\n'  <== mode:M_Printf",
             "        (frr_exit_vrf",
             "          EXIT_VRF:'exit-vrf'  <== mode:M_Printf",
+            "          NEWLINE:'\\n'  <== mode:M_Printf))",
+            "      EXTRA_CONFIGURATION_FOOTER:'' >> /etc/frr/frr.conf\"'  <== mode:M_Printf",
+            "      NEWLINE:'\\n'))",
+            "  (statement",
+            "    (s_extra_configuration",
+            "      EXTRA_CONFIGURATION_HEADER:'sudo sh -c \"printf ''",
+            "      (frr_router",
+            "        ROUTER:'router'  <== mode:M_Printf",
+            "        (frr_null_rest_of_line",
+            "          WORD:'bgp'  <== mode:M_Printf",
+            "          DEC:'65000'  <== mode:M_Printf",
+            "          VRF:'vrf'  <== mode:M_Printf",
+            "          WORD:'FOO'  <== mode:M_Printf",
+            "          NEWLINE:'\\n'  <== mode:M_Printf",
+            "          WORD:'neighbor'  <== mode:M_Printf",
+            "          IP_ADDRESS:'1.1.1.1'  <== mode:M_Printf",
+            "          WORD:'interface'  <== mode:M_Printf",
+            "          WORD:'peer-group'  <== mode:M_Printf",
+            "          WORD:'A_GROUP'  <== mode:M_Printf",
             "          NEWLINE:'\\n'  <== mode:M_Printf))",
             "      EXTRA_CONFIGURATION_FOOTER:'' >> /etc/frr/frr.conf\"'  <== mode:M_Printf",
             "      NEWLINE:'\\n\\n'))",
@@ -42483,6 +42520,37 @@
             "      (null_rest_of_line",
             "        COMMIT:'commit'",
             "        NEWLINE:'\\n\\n\\n')))",
+            "  EOF:<EOF>)"
+          ]
+        },
+        "configs/cumulus_nclu_routing" : {
+          "sentences" : [
+            "(cumulus_nclu_configuration",
+            "  (statement",
+            "    (s_null",
+            "      NET:'net'",
+            "      (null_rest_of_line",
+            "        DEL:'del'",
+            "        WORD:'all'",
+            "        NEWLINE:'\\n')))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_hostname",
+            "        HOSTNAME:'hostname'",
+            "        hostname = (word",
+            "          WORD:'cumulus_nclu_routing')",
+            "        NEWLINE:'\\n')))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_routing",
+            "        ROUTING:'routing'",
+            "        (r_agentx",
+            "          AGENTX:'agentx'",
+            "          NEWLINE:'\\n\\n'))))",
             "  EOF:<EOF>)"
           ]
         },
@@ -74162,157 +74230,163 @@
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 60,
-              "Parser_Context" : "[a_dot1x s_net_add statement cumulus_nclu_configuration]",
-              "Text" : "dot1x eap-reauth-period 0"
+              "Line" : 52,
+              "Parser_Context" : "[b_always_compare_med b_common b_vrf a_bgp s_net_add statement cumulus_nclu_configuration]",
+              "Text" : "always-compare-med"
             },
             {
               "Comment" : "This feature is not currently supported",
               "Line" : 61,
               "Parser_Context" : "[a_dot1x s_net_add statement cumulus_nclu_configuration]",
-              "Text" : "dot1x mab-activation-delay 30"
+              "Text" : "dot1x eap-reauth-period 0"
             },
             {
               "Comment" : "This feature is not currently supported",
               "Line" : 62,
               "Parser_Context" : "[a_dot1x s_net_add statement cumulus_nclu_configuration]",
-              "Text" : "dot1x radius accounting-port 1234"
+              "Text" : "dot1x mab-activation-delay 30"
             },
             {
               "Comment" : "This feature is not currently supported",
               "Line" : 63,
               "Parser_Context" : "[a_dot1x s_net_add statement cumulus_nclu_configuration]",
-              "Text" : "dot1x radius authentication-port 2345"
+              "Text" : "dot1x radius accounting-port 1234"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 65,
-              "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
-              "Text" : "ptp global domain-number 0"
+              "Line" : 64,
+              "Parser_Context" : "[a_dot1x s_net_add statement cumulus_nclu_configuration]",
+              "Text" : "dot1x radius authentication-port 2345"
             },
             {
               "Comment" : "This feature is not currently supported",
               "Line" : 66,
               "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
-              "Text" : "ptp global logging-level 5"
+              "Text" : "ptp global domain-number 0"
             },
             {
               "Comment" : "This feature is not currently supported",
               "Line" : 67,
               "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
-              "Text" : "ptp global path-trace-enabled no"
+              "Text" : "ptp global logging-level 5"
             },
             {
               "Comment" : "This feature is not currently supported",
               "Line" : 68,
               "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
-              "Text" : "ptp global priority1 255"
+              "Text" : "ptp global path-trace-enabled no"
             },
             {
               "Comment" : "This feature is not currently supported",
               "Line" : 69,
               "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
-              "Text" : "ptp global slave-only no"
+              "Text" : "ptp global priority1 255"
             },
             {
               "Comment" : "This feature is not currently supported",
               "Line" : 70,
               "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
-              "Text" : "ptp global summary-interval 0"
+              "Text" : "ptp global slave-only no"
             },
             {
               "Comment" : "This feature is not currently supported",
               "Line" : 71,
               "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
-              "Text" : "ptp global time-stamping"
+              "Text" : "ptp global summary-interval 0"
             },
             {
               "Comment" : "This feature is not currently supported",
               "Line" : 72,
               "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
-              "Text" : "ptp global use-syslog yes"
+              "Text" : "ptp global time-stamping"
             },
             {
               "Comment" : "This feature is not currently supported",
               "Line" : 73,
               "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
+              "Text" : "ptp global use-syslog yes"
+            },
+            {
+              "Comment" : "This feature is not currently supported",
+              "Line" : 74,
+              "Parser_Context" : "[a_ptp s_net_add statement cumulus_nclu_configuration]",
               "Text" : "ptp global verbose no"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 75,
+              "Line" : 76,
               "Parser_Context" : "[r_defaults_datacenter a_routing s_net_add statement cumulus_nclu_configuration]",
               "Text" : "defaults datacenter"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 76,
+              "Line" : 77,
               "Parser_Context" : "[r_log a_routing s_net_add statement cumulus_nclu_configuration]",
               "Text" : "log syslog informational"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 79,
+              "Line" : 80,
               "Parser_Context" : "[r_service_integrated_vtysh_config a_routing s_net_add statement cumulus_nclu_configuration]",
               "Text" : "service integrated-vtysh-config"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 81,
+              "Line" : 82,
               "Parser_Context" : "[a_snmp_server s_net_add statement cumulus_nclu_configuration]",
               "Text" : "snmp-server listening-address localhost"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 82,
+              "Line" : 83,
               "Parser_Context" : "[a_time s_net_add statement cumulus_nclu_configuration]",
               "Text" : "time ntp server 0.pool.ntp.example.com iburst"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 83,
+              "Line" : 84,
               "Parser_Context" : "[a_time s_net_add statement cumulus_nclu_configuration]",
               "Text" : "time ntp source eth0"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 84,
+              "Line" : 85,
               "Parser_Context" : "[a_time s_net_add statement cumulus_nclu_configuration]",
               "Text" : "time zone Etc/UTC"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 89,
+              "Line" : 90,
               "Parser_Context" : "[v_vlan_raw_device a_vlan s_net_add statement cumulus_nclu_configuration]",
               "Text" : "vlan-raw-device bridge"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 98,
+              "Line" : 99,
               "Parser_Context" : "[vxb_arp_nd_suppress vx_bridge a_vxlan s_net_add statement cumulus_nclu_configuration]",
               "Text" : "arp-nd-suppress on"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 99,
+              "Line" : 100,
               "Parser_Context" : "[vxb_learning vx_bridge a_vxlan s_net_add statement cumulus_nclu_configuration]",
               "Text" : "learning off"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 100,
+              "Line" : 101,
               "Parser_Context" : "[vx_stp a_vxlan s_net_add statement cumulus_nclu_configuration]",
               "Text" : "stp bpduguard"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 101,
+              "Line" : 102,
               "Parser_Context" : "[vx_stp a_vxlan s_net_add statement cumulus_nclu_configuration]",
               "Text" : "stp portbpdufilter"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 111,
+              "Line" : 112,
               "Parser_Context" : "[frr_username s_extra_configuration statement cumulus_nclu_configuration]",
               "Text" : "username cumulus nopassword\\n"
             }
@@ -76299,6 +76373,7 @@
         "cumulus_nclu_invalid_interfaces" : "PASSED",
         "cumulus_nclu_invalid_vrfs" : "PASSED",
         "cumulus_nclu_invalid_vxlans" : "PASSED",
+        "cumulus_nclu_routing" : "PASSED",
         "eos_mlag" : "PASSED",
         "eos_trunk_group" : "PASSED",
         "f5_bigip_imish_malformed" : "WARNINGS",
@@ -79068,7 +79143,7 @@
           "route-map" : {
             "rm1" : {
               "definitionLines" : [
-                78
+                79
               ],
               "numReferrers" : 1
             }
@@ -79076,7 +79151,7 @@
           "vlan" : {
             "vlan4" : {
               "definitionLines" : [
-                86
+                87
               ],
               "numReferrers" : 6
             }
@@ -79092,19 +79167,19 @@
               "definitionLines" : [
                 51
               ],
-              "numReferrers" : 10
+              "numReferrers" : 11
             }
           },
           "vxlan" : {
             "vni10001" : {
               "definitionLines" : [
-                97
+                98
               ],
               "numReferrers" : 1
             },
             "vni10004" : {
               "definitionLines" : [
-                103
+                104
               ],
               "numReferrers" : 1
             }
@@ -79271,6 +79346,7 @@
             }
           }
         },
+        "configs/cumulus_nclu_routing" : { },
         "configs/eos_mlag" : {
           "interface" : {
             "Port-Channel1" : {
@@ -83564,6 +83640,9 @@
         "configs/cumulus_nclu_invalid_vxlans" : [
           "cumulus_nclu_invalid_vxlans"
         ],
+        "configs/cumulus_nclu_routing" : [
+          "cumulus_nclu_routing"
+        ],
         "configs/eos_mlag" : [
           "eos_mlag"
         ],
@@ -86003,7 +86082,7 @@
           "abstract interface" : {
             "lo" : {
               "route-map match interface" : [
-                78
+                79
               ]
             },
             "swp1" : {
@@ -86132,12 +86211,12 @@
           "vlan" : {
             "vlan4" : {
               "vlan self-reference" : [
-                86,
                 87,
                 88,
                 89,
                 90,
-                91
+                91,
+                92
               ]
             }
           },
@@ -86150,9 +86229,9 @@
                 7
               ],
               "vrf self-reference" : [
-                92,
                 93,
-                95
+                94,
+                96
               ]
             },
             "vrf1" : {
@@ -86161,28 +86240,29 @@
                 52,
                 53,
                 54,
-                55
+                55,
+                56
               ],
               "vlan vrf" : [
-                90
+                91
               ],
               "vrf self-reference" : [
-                94,
                 95,
-                112,
-                113
+                96,
+                113,
+                114
               ]
             }
           },
           "vxlan" : {
             "vni10001" : {
               "vxlan self-reference" : [
-                97
+                98
               ]
             },
             "vni10004" : {
               "vxlan self-reference" : [
-                103
+                104
               ]
             }
           }
@@ -91372,6 +91452,7 @@
         "configs/cumulus_nclu_invalid_interfaces" : "PASSED",
         "configs/cumulus_nclu_invalid_vrfs" : "PASSED",
         "configs/cumulus_nclu_invalid_vxlans" : "PASSED",
+        "configs/cumulus_nclu_routing" : "PASSED",
         "configs/eos_mlag" : "PASSED",
         "configs/eos_trunk_group" : "PASSED",
         "configs/f5_bigip_imish_malformed" : "PASSED",


### PR DESCRIPTION
* agentx -- related to SNMP, can ignore
* always-compare-med -- make explicit we don't support that
* Eat more FRR lines