### PR TITLE
Link-local topology fixes

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -9,7 +9,6 @@ import static org.batfish.common.topology.TopologyUtil.computeLayer2Topology;
 import static org.batfish.common.topology.TopologyUtil.computeRawLayer3Topology;
 import static org.batfish.common.topology.TopologyUtil.computeVniInterNodeEdges;
 import static org.batfish.common.topology.TopologyUtil.computeVniName;
-import static org.batfish.common.topology.TopologyUtil.synthesizeL3Topology;
 import static org.batfish.datamodel.matchers.EdgeMatchers.hasHead;
 import static org.batfish.datamodel.matchers.EdgeMatchers.hasNode1;
 import static org.batfish.datamodel.matchers.EdgeMatchers.hasNode2;
@@ -30,6 +29,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.MutableGraph;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -1344,7 +1344,7 @@ public final class TopologyUtilTest {
   }
 
   @Test
-  public void testSynthesizeTopology_linkLocalAddresses() {
+  public void testComputeLayer3Topology_linkLocalAddresses() {
     _cb.setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     Configuration c1 = _cb.build();
     Configuration c2 = _cb.build();
@@ -1352,7 +1352,15 @@ public final class TopologyUtilTest {
     Interface i1 = _ib.setOwner(c1).setAddress(LinkLocalAddress.of(ip)).build();
     Interface i2 = _ib.setOwner(c2).setAddress(LinkLocalAddress.of(ip)).build();
 
-    Topology t = synthesizeL3Topology(ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2));
+    Topology t =
+        computeRawLayer3Topology(
+            new Layer1Topology(
+                Collections.singleton(
+                    new Layer1Edge(
+                        new Layer1Node(c1.getHostname(), i1.getName()),
+                        new Layer1Node(c2.getHostname(), i2.getName())))),
+            Layer2Topology.EMPTY,
+            ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2));
     Edge edge =
         new Edge(
             new NodeInterfacePair(c1.getHostname(), i1.getName()),

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -160,8 +160,7 @@ class IncrementalBdpEngine {
                       initialTopologyContext.getRawLayer1PhysicalTopology(),
                       newLayer2Topology,
                       configurations),
-                  toEdgeSet(newIpsecTopology, configurations),
-                  configurations);
+                  toEdgeSet(newIpsecTopology, configurations));
 
           // Initialize BGP topology
           BgpTopology newBgpTopology =

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -966,7 +966,10 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
         org.batfish.datamodel.Interface.builder()
             .setName(name)
             .setOwner(_c)
-            .setType(InterfaceType.LOGICAL)
+            .setType(
+                iface.getType() == CumulusInterfaceType.BOND_SUBINTERFACE
+                    ? InterfaceType.AGGREGATE_CHILD
+                    : InterfaceType.LOGICAL)
             .build();
     newIface.setDependencies(
         ImmutableSet.of(new Dependency(superInterfaceName, DependencyType.BIND)));

--- a/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
@@ -266,7 +266,6 @@ public final class TopologyProviderImpl implements TopologyProvider {
             .buildSpan("TopologyProviderImpl::computeInitialLayer3Topology")
             .startActive()) {
       assert span != null; // avoid unused warning
-      Map<String, Configuration> configurations = _batfish.loadConfigurations(networkSnapshot);
       return TopologyUtil.computeLayer3Topology(
           getRawLayer3Topology(networkSnapshot), ImmutableSet.of());
     }

--- a/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/topology/TopologyProviderImpl.java
@@ -268,7 +268,7 @@ public final class TopologyProviderImpl implements TopologyProvider {
       assert span != null; // avoid unused warning
       Map<String, Configuration> configurations = _batfish.loadConfigurations(networkSnapshot);
       return TopologyUtil.computeLayer3Topology(
-          getRawLayer3Topology(networkSnapshot), ImmutableSet.of(), configurations);
+          getRawLayer3Topology(networkSnapshot), ImmutableSet.of());
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/FixedPointTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/FixedPointTopologyTest.java
@@ -177,8 +177,7 @@ public final class FixedPointTopologyTest {
         .setLayer3Topology(
             computeLayer3Topology(
                 computeRawLayer3Topology(Optional.of(l1), Optional.of(l2), configs),
-                ImmutableSet.of(),
-                configs))
+                ImmutableSet.of()))
         .setOspfTopology(OspfTopology.EMPTY)
         .setRawLayer1PhysicalTopology(Optional.of(l1))
         .build();

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -28,6 +28,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllowedVlans;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDependencies;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDescription;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasEncapsulationVlan;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasInterfaceType;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMlagId;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasNativeVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSpeed;
@@ -90,6 +91,7 @@ import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6;
 import org.batfish.datamodel.LineAction;
@@ -932,6 +934,11 @@ public final class CumulusNcluGrammarTest {
     assertThat(c.getAllInterfaces().get("bond1").getChannelGroupMembers(), contains("swp1"));
     assertThat(c.getAllInterfaces().get("bond2").getChannelGroupMembers(), contains("swp2"));
     assertThat(c.getAllInterfaces().get("bond3").getChannelGroupMembers(), contains("swp3"));
+
+    // type
+    assertThat(c, hasInterface("bond3", hasInterfaceType(InterfaceType.AGGREGATED)));
+    assertThat(c, hasInterface("bond3.4094", hasInterfaceType(InterfaceType.AGGREGATE_CHILD)));
+    assertThat(c, hasInterface("swp5.1", hasInterfaceType(InterfaceType.LOGICAL)));
   }
 
   @Test

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -13641,6 +13641,7 @@
             ],
             "allowedVlans" : "",
             "autostate" : true,
+            "bandwidth" : 8.0E10,
             "encapsulationVlan" : 4094,
             "mtu" : 1500,
             "ospfDeadInterval" : 0,
@@ -13656,7 +13657,7 @@
             "switchport" : false,
             "switchportMode" : "NONE",
             "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "LOGICAL",
+            "type" : "AGGREGATE_CHILD",
             "vrf" : "default"
           },
           "bond2" : {


### PR DESCRIPTION
1. Be more concervative in link-local edge establishment. Choose
candidates only if L1 topology is present
2. Special case subinterfaces of aggregate interfaces (they will not
appear in L1, lorical or physical).
3. Fix setting interface types for aggregate subinterfaces on Cumulus