### PR TITLE
Add prefix tracer to BgpRoutingProcess, generalize export function

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1426,16 +1426,18 @@ public class VirtualRouter implements Serializable {
                               allNodes,
                               session,
                               Type.IPV4_UNICAST);
-                      return !transformedRoute.isPresent()
-                          ? null
-                          // REPLACE does not make sense across routers, update with WITHDRAW
-                          : RouteAdvertisement.<Bgpv4Route>builder()
-                              .setReason(
-                                  adv.getReason() == Reason.REPLACE
-                                      ? Reason.WITHDRAW
-                                      : adv.getReason())
-                              .setRoute(transformedRoute.get())
-                              .build();
+                      // REPLACE does not make sense across routers, update with WITHDRAW
+                      return transformedRoute
+                          .map(
+                              bgpv4Route ->
+                                  RouteAdvertisement.<Bgpv4Route>builder()
+                                      .setReason(
+                                          adv.getReason() == Reason.REPLACE
+                                              ? Reason.WITHDRAW
+                                              : adv.getReason())
+                                      .setRoute(bgpv4Route)
+                                      .build())
+                          .orElse(null);
                     })
                 .filter(Objects::nonNull),
             mainRibExports);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -177,7 +177,7 @@ public class VirtualRouter implements Serializable {
   private transient Rib _generatedRib;
 
   /** Metadata about propagated prefixes to/from neighbors */
-  private PrefixTracer _prefixTracer;
+  @Nonnull private PrefixTracer _prefixTracer;
 
   /** List of all EIGRP processes in this VRF */
   @VisibleForTesting transient ImmutableMap<Long, VirtualEigrpProcess> _virtualEigrpProcesses;
@@ -209,7 +209,8 @@ public class VirtualRouter implements Serializable {
     _vniSettings = ImmutableSet.copyOf(_vrf.getVniSettings().values());
     if (_vrf.getBgpProcess() != null) {
       _bgpRoutingProcess =
-          new BgpRoutingProcess(_vrf.getBgpProcess(), _c, _name, _mainRib, BgpTopology.EMPTY);
+          new BgpRoutingProcess(
+              _vrf.getBgpProcess(), _c, _name, _mainRib, BgpTopology.EMPTY, _prefixTracer);
     }
   }
 
@@ -1415,16 +1416,17 @@ public class VirtualRouter implements Serializable {
                 .getActions()
                 .map(
                     adv -> {
-                      Bgpv4Route transformedRoute =
-                          exportBgpRoute(
-                              adv.getRoute(),
+                      Optional<Bgpv4Route> transformedRoute =
+                          _bgpRoutingProcess.transformBgpRouteOnExport(
+                              adv.getRoute().getRoute(),
                               ourConfigId,
                               remoteConfigId,
                               ourConfig,
                               remoteConfig,
                               allNodes,
-                              session);
-                      return transformedRoute == null
+                              session,
+                              Type.IPV4_UNICAST);
+                      return !transformedRoute.isPresent()
                           ? null
                           // REPLACE does not make sense across routers, update with WITHDRAW
                           : RouteAdvertisement.<Bgpv4Route>builder()
@@ -1432,7 +1434,7 @@ public class VirtualRouter implements Serializable {
                                   adv.getReason() == Reason.REPLACE
                                       ? Reason.WITHDRAW
                                       : adv.getReason())
-                              .setRoute(transformedRoute)
+                              .setRoute(transformedRoute.get())
                               .build();
                     })
                 .filter(Objects::nonNull),
@@ -1705,19 +1707,21 @@ public class VirtualRouter implements Serializable {
                       processNeighborSpecificGeneratedRoute(r, sessionProperties.getHeadIp());
                   if (bgpv4Route == null) {
                     // Route was not activated
-                    return null;
+                    return Optional.<Bgpv4Route>empty();
                   }
                   // Run pre-export transform, export policy, & post-export transform
-                  return exportBgpRoute(
-                      annotateRoute(bgpv4Route),
+                  return _bgpRoutingProcess.transformBgpRouteOnExport(
+                      bgpv4Route,
                       localConfigId,
                       remoteConfigId,
                       localConfig,
                       remoteConfig,
                       allNodes,
-                      sessionProperties);
+                      sessionProperties,
+                      Type.IPV4_UNICAST);
                 })
-            .filter(Objects::nonNull)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
             .map(RouteAdvertisement::new)
             .collect(ImmutableSet.toImmutableSet());
 
@@ -1817,6 +1821,7 @@ public class VirtualRouter implements Serializable {
         .collect(toOrderedHashCode());
   }
 
+  @Nonnull
   PrefixTracer getPrefixTracer() {
     return _prefixTracer;
   }
@@ -1890,86 +1895,6 @@ public class VirtualRouter implements Serializable {
 
     // Successfully exported route
     Bgpv4Route transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();
-    _prefixTracer.sentTo(
-        transformedOutgoingRoute.getNetwork(),
-        remoteConfigId.getHostname(),
-        remoteIp,
-        remoteConfigId.getVrfName(),
-        ourConfig.getIpv4UnicastAddressFamily().getExportPolicy());
-
-    return transformedOutgoingRoute;
-  }
-
-  /**
-   * Given a {@link BgpRoute}, run it through the BGP outbound transformations and export routing
-   * policy.
-   *
-   * @param exportCandidate a route to try and export
-   * @param ourConfig {@link BgpPeerConfig} that sends the route
-   * @param remoteConfig {@link BgpPeerConfig} that will be receiving the route
-   * @param allNodes all nodes in the network
-   * @param sessionProperties {@link BgpSessionProperties} representing the <em>incoming</em> edge:
-   *     i.e. the edge from {@code remoteConfig} to {@code ourConfig}
-   * @return The transformed route as a {@link BgpRoute}, or {@code null} if the route should not be
-   *     exported.
-   */
-  @Nullable
-  private <R extends BgpRoute<B, R>, B extends BgpRoute.Builder<B, R>> R exportBgpRoute(
-      @Nonnull AnnotatedRoute<R> exportCandidate,
-      @Nonnull BgpPeerConfigId ourConfigId,
-      @Nonnull BgpPeerConfigId remoteConfigId,
-      @Nonnull BgpPeerConfig ourConfig,
-      @Nonnull BgpPeerConfig remoteConfig,
-      @Nonnull Map<String, Node> allNodes,
-      @Nonnull BgpSessionProperties sessionProperties) {
-
-    RoutingPolicy exportPolicy =
-        _c.getRoutingPolicies().get(ourConfig.getIpv4UnicastAddressFamily().getExportPolicy());
-    B transformedOutgoingRouteBuilder =
-        BgpProtocolHelper.transformBgpRoutePreExport(
-            ourConfig,
-            remoteConfig,
-            sessionProperties,
-            _vrf.getBgpProcess(),
-            requireNonNull(getRemoteBgpNeighborVR(remoteConfigId, allNodes))._vrf.getBgpProcess(),
-            exportCandidate.getRoute(),
-            Type.IPV4_UNICAST);
-    if (transformedOutgoingRouteBuilder == null) {
-      // This route could not be exported for core bgp protocol reasons
-      return null;
-    }
-
-    // sessionProperties represents the incoming edge, so its tailIp is the remote peer's IP
-    Ip remoteIp = sessionProperties.getTailIp();
-
-    // Process transformed outgoing route by the export policy
-    boolean shouldExport =
-        exportPolicy.process(
-            exportCandidate,
-            transformedOutgoingRouteBuilder,
-            remoteIp,
-            ourConfigId.getRemotePeerPrefix(),
-            ourConfigId.getVrfName(),
-            Direction.OUT);
-
-    if (!shouldExport) {
-      // This route could not be exported due to export policy
-      _prefixTracer.filtered(
-          exportCandidate.getNetwork(),
-          remoteConfigId.getHostname(),
-          remoteIp,
-          remoteConfigId.getVrfName(),
-          ourConfig.getIpv4UnicastAddressFamily().getExportPolicy(),
-          Direction.OUT);
-      return null;
-    }
-
-    // Apply final post-policy transformations before sending advertisement to neighbor
-    BgpProtocolHelper.transformBgpRoutePostExport(
-        transformedOutgoingRouteBuilder, sessionProperties.isEbgp(), ourConfig.getLocalAs());
-
-    // Successfully exported route
-    R transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();
     _prefixTracer.sentTo(
         transformedOutgoingRoute.getNetwork(),
         remoteConfigId.getHostname(),

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -80,7 +80,8 @@ public class BgpRoutingProcessTest {
     _vrf.setBgpProcess(_bgpProcess);
     _vrf2.setBgpProcess(_bgpProcess2);
     _routingProcess =
-        new BgpRoutingProcess(_bgpProcess, _c, DEFAULT_VRF_NAME, new Rib(), BgpTopology.EMPTY);
+        new BgpRoutingProcess(
+            _bgpProcess, _c, DEFAULT_VRF_NAME, new Rib(), BgpTopology.EMPTY, new PrefixTracer());
   }
 
   @Test
@@ -318,7 +319,8 @@ public class BgpRoutingProcessTest {
 
     BgpTopology topology = new BgpTopology(graph);
     BgpRoutingProcess routingProcess =
-        new BgpRoutingProcess(bgpProc, _c, DEFAULT_VRF_NAME, new Rib(), topology);
+        new BgpRoutingProcess(
+            bgpProc, _c, DEFAULT_VRF_NAME, new Rib(), topology, new PrefixTracer());
 
     // No compatible peers for IPv4
     assertThat(


### PR DESCRIPTION
Slowly moving more functionality from VirtualRouter into BgpRoutingProcess. 
Also, finally generalizing export function to take in the proper address family type.