### PR TITLE
BDDReachabilityGraphOptimizer: rewrite for performance

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityGraphOptimizer.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityGraphOptimizer.java
@@ -241,10 +241,12 @@ public class BDDReachabilityGraphOptimizer {
     return ImmutableList.of(prev, next);
   }
 
-  private void removeEdge(StateExpr preState, StateExpr postState, Transition transition) {
-    checkState(_edges.remove(preState, postState) == transition);
-  }
-
+  /**
+   * Returns true iff the given transition is safe to remove, namely that the set of flows after
+   * transitioning the edge can never contain more flows than before transitioning.
+   *
+   * <p>Mathematically, this condition is {@code forall x, x.or(x.transition(t)) == x}.
+   */
   private boolean isRemovableSelfLoop(Transition t) {
     checkState(!_keepSelfLoops);
     if (t == ZERO || t == IDENTITY) {
@@ -254,7 +256,6 @@ public class BDDReachabilityGraphOptimizer {
         || t instanceof AddSourceConstraint
         || t instanceof AddLastHopConstraint
         || t instanceof AddNoLastHopConstraint) {
-      // forall x,y. x.or(x.and(y)) == x
       return true;
     }
     return false;

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityGraphOptimizer.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityGraphOptimizer.java
@@ -8,6 +8,7 @@ import static org.batfish.bddreachability.transition.Transitions.or;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
@@ -160,13 +161,13 @@ public class BDDReachabilityGraphOptimizer {
    * Try to remove the candidate state, and return any neighboring states whose degrees changed as a
    * result.
    */
-  private Set<StateExpr> tryToRemove(StateExpr candidate) {
+  private Collection<StateExpr> tryToRemove(StateExpr candidate) {
     assert !_statesToKeep.contains(candidate);
     Collection<StateExpr> inStates = _inEdges.get(candidate);
     if (inStates.isEmpty()) {
       // root node. prune
       _rootsPruned++;
-      Set<StateExpr> affectedStates = ImmutableSet.copyOf(_outEdges.removeAll(candidate));
+      Collection<StateExpr> affectedStates = _outEdges.removeAll(candidate);
       for (StateExpr oldNext : affectedStates) {
         _edges.remove(candidate, oldNext);
         _inEdges.remove(oldNext, candidate);
@@ -177,7 +178,7 @@ public class BDDReachabilityGraphOptimizer {
     if (outStates.isEmpty()) {
       // leaf node. prune
       _leavesPruned++;
-      Set<StateExpr> affectedStates = ImmutableSet.copyOf(_inEdges.removeAll(candidate));
+      Collection<StateExpr> affectedStates = _inEdges.removeAll(candidate);
       for (StateExpr oldPrev : affectedStates) {
         _edges.remove(oldPrev, candidate);
         _outEdges.remove(oldPrev, candidate);
@@ -237,7 +238,7 @@ public class BDDReachabilityGraphOptimizer {
     _outEdges.remove(candidate, next);
     _inEdges.remove(next, candidate);
 
-    return ImmutableSet.of(prev, next);
+    return ImmutableList.of(prev, next);
   }
 
   private void removeEdge(StateExpr preState, StateExpr postState, Transition transition) {

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityGraphOptimizer.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityGraphOptimizer.java
@@ -244,7 +244,7 @@ public class BDDReachabilityGraphOptimizer {
    * Returns true iff the given transition is safe to remove, namely that the set of flows after
    * transitioning the edge can never contain more flows than before transitioning.
    *
-   * <p>Mathematically, this condition is {@code forall x, x.or(x.transition(t)) == x}.
+   * <p>Mathematically, this condition is {@code forall x, x.or(t.transitForward(x)) == x}.
    */
   private boolean isRemovableSelfLoop(Transition t) {
     checkState(!_keepSelfLoops);


### PR DESCRIPTION
As I mentioned in review for batfish/batfish#3948, iterating over columns in a Table is prohibitively slow. Add the bookkeeping (and accompanying assertions) for incoming and outgoing edges for faster iteration.

The code as implemented with Streams also crashed routinely with ConcurrentModificationException -- because we were keeping a stream alive over a changing collection. Got rid of all that stuff.

To test performance in reality, I connected the optimizer into Loop Detection. On a ~1000 node graph, the optimization time went from > 15m to 2.5seconds.