### PR TITLE
Transitions: riskier merges for your consideration

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
@@ -140,6 +140,37 @@ public final class Transitions {
     if (t2 == IDENTITY) {
       return t1;
     }
+    if (t1 instanceof Branch) {
+      Branch branch = (Branch) t1;
+      Transition mergeTrue = mergeComposed(branch.getTrueBranch(), t2);
+      Transition mergeFalse = mergeComposed(branch.getFalseBranch(), t2);
+      if (mergeTrue != null && mergeFalse != null) {
+        return branch(branch.getGuard(), mergeTrue, mergeFalse);
+      }
+      // fall through
+    }
+    if (t1 instanceof Composite) {
+      Composite c = (Composite) t1;
+      List<Transition> transitions = c.getTransitions();
+      Transition merged = mergeComposed(transitions.get(transitions.size() - 1), t2);
+      if (merged != null) {
+        Transition[] newTransitions = transitions.toArray(new Transition[0]);
+        newTransitions[newTransitions.length - 1] = merged;
+        return compose(newTransitions);
+      }
+      // fall through
+    }
+    if (t2 instanceof Composite) {
+      Composite c = (Composite) t2;
+      List<Transition> transitions = c.getTransitions();
+      Transition merged = mergeComposed(t1, transitions.get(0));
+      if (merged != null) {
+        Transition[] newTransitions = transitions.toArray(new Transition[0]);
+        newTransitions[0] = merged;
+        return compose(newTransitions);
+      }
+      // fall through
+    }
     if (t1 instanceof Constraint && t2 instanceof Constraint) {
       BDD bdd1 = ((Constraint) t1).getConstraint();
       BDD bdd2 = ((Constraint) t2).getConstraint();

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
@@ -153,6 +153,10 @@ public final class Transitions {
         // True branch can never be taken.
         return compose(t1, branch.getFalseBranch());
       }
+      if (!constraintBdd.diffSat(guard)) {
+        // False branch can never be taken.
+        return compose(t1, branch.getTrueBranch());
+      }
       // fall through
     }
     if (t1 instanceof Constraint && t2 instanceof EraseAndSet) {

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransitionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransitionsTest.java
@@ -14,6 +14,7 @@ import static org.batfish.bddreachability.transition.Transitions.tryMergeDisjunc
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -217,6 +218,29 @@ public class TransitionsTest {
     BDD v0 = var(0);
     BDD v1 = var(1);
     assertEquals(constraint(v0.and(v1)), mergeComposed(constraint(v0), constraint(v1)));
+  }
+
+  @Test
+  public void testMergeComposed_Constraint_Branch() {
+    BDD v0 = var(0);
+    BDD v1 = var(1);
+    BDD v2 = var(2);
+    BDD v3 = var(3);
+    Branch branch = new Branch(v1, constraint(v2), constraint(v3));
+
+    // constraint implies guard => guard and true branch
+    assertThat(mergeComposed(constraint(v1), branch), equalTo(constraint(v1.and(v2))));
+    assertThat(
+        mergeComposed(constraint(v1.and(v0)), branch), equalTo(constraint(v0.and(v1).and(v2))));
+
+    // constraint implies !guard => !guard and false branch
+    assertThat(mergeComposed(constraint(v1.not()), branch), equalTo(constraint(v1.not().and(v3))));
+    assertThat(
+        mergeComposed(constraint(v1.not().and(v0)), branch),
+        equalTo(constraint(v1.not().and(v0).and(v3))));
+
+    // constraint does not imply either guard or !guard => do not merge
+    assertThat(mergeComposed(constraint(v0), branch), nullValue());
   }
 
   @Test


### PR DESCRIPTION
Examples of this operating in real networks

```
t1: Branch{guardTopVar=0, true=EraseAndSet{eraseVars=<32:1, 33:1, 34:1, 35:1, 36:1, 37:1, 38:1, 39:1, 40:1, 41:1, 42:1, 43:1, 44:1, 45:1, 46:1, 47:1, 48:1, 49:1, 50:1, 51:1, 52:1, 53:1, 54:1, 55:1, 56:1, 57:1, 58:1, 59:1, 60:1, 61:1, 62:1, 63:1>, valueVars=<32:1, 33:1, 34:1, 35:1, 36:1, 37:1, 38:1, 39:1, 40:1, 41:1, 42:1, 43:1, 44:1, 45:1, 46:1, 47:1, 48:1, 49:1, 50:1, 51:1, 52:1, 53:1, 54:1, 55:1, 56:1, 57:1, 58:1, 59:1, 60:1, 61:1, 62:1, 63:1>}, false=IDENTITY}

t2: Constraint{topVar=0}

merged: Branch{guardTopVar=0, true=EraseAndSet{eraseVars=<32:1, 33:1, 34:1, 35:1, 36:1, 37:1, 38:1, 39:1, 40:1, 41:1, 42:1, 43:1, 44:1, 45:1, 46:1, 47:1, 48:1, 49:1, 50:1, 51:1, 52:1, 53:1, 54:1, 55:1, 56:1, 57:1, 58:1, 59:1, 60:1, 61:1, 62:1, 63:1>, valueVars=<0:1, 1:1, 2:1, 3:1, 4:1, 5:1, 6:1, 7:1, 8:1, 9:1, 10:1, 11:1, 12:1, 13:1, 14:1, 15:1, 16:1, 17:1, 18:1, 19:1, 20:1, 21:1, 22:1, 23:1, 24:1, 25:1, 26:1, 27:1, 28:1, 29:1, 30:1, 31:1, 32:1, 33:1, 34:1, 35:1, 36:1, 37:1, 38:1, 39:1, 40:1, 41:1, 42:1, 43:1, 44:1, 45:1, 46:1, 47:1, 48:1, 49:1, 50:1, 51:1, 52:1, 53:1, 54:1, 55:1, 56:1, 57:1, 58:1, 59:1, 60:1, 61:1, 62:1, 63:1, 96:1, 97:1, 98:1, 99:1, 100:1, 101:1, 102:1, 103:1>}, false=Constraint{topVar=0}}
```

and

```
t1: Constraint{topVar=0}

t2: Composite{transitions=[Constraint{topVar=149}, Branch{guardTopVar=0, true=IDENTITY, false=EraseAndSet{eraseVars=<32:1, 33:1, 34:1, 35:1, 36:1, 37:1, 38:1, 39:1, 40:1, 41:1, 42:1, 43:1, 44:1, 45:1, 46:1, 47:1, 48:1, 49:1, 50:1, 51:1, 52:1, 53:1, 54:1, 55:1, 56:1, 57:1, 58:1, 59:1, 60:1, 61:1, 62:1, 63:1, 80:1, 81:1, 82:1, 83:1, 84:1, 85:1, 86:1, 87:1, 88:1, 89:1, 90:1, 91:1, 92:1, 93:1, 94:1, 95:1>, valueVars=<32:1, 33:1, 34:1, 35:1, 36:1, 37:1, 38:1, 39:1, 40:1, 41:1, 42:1, 43:1, 44:1, 45:1, 46:1, 47:1, 48:1, 49:1, 50:1, 51:1, 52:1, 53:1, 54:1, 55:1, 56:1, 57:1, 58:1, 59:1, 60:1, 61:1, 62:1, 63:1, 80:1, 81:1, 82:1, 83:1, 84:1, 85:1, 86:1, 87:1, 88:1, 89:1, 90:1, 91:1, 92:1, 93:1, 94:1, 95:1>}}]}

ret: Composite{transitions=[Constraint{topVar=0}, Branch{guardTopVar=0, true=IDENTITY, false=EraseAndSet{eraseVars=<32:1, 33:1, 34:1, 35:1, 36:1, 37:1, 38:1, 39:1, 40:1, 41:1, 42:1, 43:1, 44:1, 45:1, 46:1, 47:1, 48:1, 49:1, 50:1, 51:1, 52:1, 53:1, 54:1, 55:1, 56:1, 57:1, 58:1, 59:1, 60:1, 61:1, 62:1, 63:1, 80:1, 81:1, 82:1, 83:1, 84:1, 85:1, 86:1, 87:1, 88:1, 89:1, 90:1, 91:1, 92:1, 93:1, 94:1, 95:1>, valueVars=<32:1, 33:1, 34:1, 35:1, 36:1, 37:1, 38:1, 39:1, 40:1, 41:1, 42:1, 43:1, 44:1, 45:1, 46:1, 47:1, 48:1, 49:1, 50:1, 51:1, 52:1, 53:1, 54:1, 55:1, 56:1, 57:1, 58:1, 59:1, 60:1, 61:1, 62:1, 63:1, 80:1, 81:1, 82:1, 83:1, 84:1, 85:1, 86:1, 87:1, 88:1, 89:1, 90:1, 91:1, 92:1, 93:1, 94:1, 95:1>}}]}
```


And btw:

```
couldn't merge Composite{transitions=[Constraint{topVar=0}, Branch{guardTopVar=0, true=IDENTITY, false=EraseAndSet{eraseVars=<32:1, 33:1, 34:1, 35:1, 36:1, 37:1, 38:1, 39:1, 40:1, 41:1, 42:1, 43:1, 44:1, 45:1, 46:1, 47:1, 48:1, 49:1, 50:1, 51:1, 52:1, 53:1, 54:1, 55:1, 56:1, 57:1, 58:1, 59:1, 60:1, 61:1, 62:1, 63:1, 80:1, 81:1, 82:1, 83:1, 84:1, 85:1, 86:1, 87:1, 88:1, 89:1, 90:1, 91:1, 92:1, 93:1, 94:1, 95:1>, valueVars=<32:1, 33:1, 34:1, 35:1, 36:1, 37:1, 38:1, 39:1, 40:1, 41:1, 42:1, 43:1, 44:1, 45:1, 46:1, 47:1, 48:1, 49:1, 50:1, 51:1, 52:1, 53:1, 54:1, 55:1, 56:1, 57:1, 58:1, 59:1, 60:1, 61:1, 62:1, 63:1, 80:1, 81:1, 82:1, 83:1, 84:1, 85:1, 86:1, 87:1, 88:1, 89:1, 90:1, 91:1, 92:1, 93:1, 94:1, 95:1>}}]}

and org.batfish.bddreachability.transition.RemoveSourceConstraint@2a92cf4a
```