### PR TITLE
Handle cumulus vxlan-anycast-ip in dataplane

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/Layer2VniConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/Layer2VniConfig.java
@@ -11,6 +11,7 @@ import java.util.Comparator;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 
 /** A Layer 2 {@link VniConfig} */
@@ -21,16 +22,18 @@ public class Layer2VniConfig extends VniConfig
   private Layer2VniConfig(
       int vni,
       String vrf,
+      @Nullable Ip advertisedSourceAddress,
       RouteDistinguisher rd,
       ExtendedCommunity routeTarget,
       String importRouteTarget) {
-    super(vni, vrf, rd, routeTarget, importRouteTarget);
+    super(vni, vrf, rd, advertisedSourceAddress, routeTarget, importRouteTarget);
   }
 
   @JsonCreator
   private static Layer2VniConfig create(
       @Nullable @JsonProperty(PROP_VNI) Integer vni,
       @Nullable @JsonProperty(PROP_VRF) String vrf,
+      @Nullable @JsonProperty(PROP_ADVERTISED_SOURCE_ADDRESS) Ip advertisedSourceAddress,
       @Nullable @JsonProperty(PROP_ROUTE_DISTINGUISHER) RouteDistinguisher rd,
       @Nullable @JsonProperty(PROP_ROUTE_TARGET) ExtendedCommunity routeTarget,
       @Nullable @JsonProperty(PROP_IMPORT_ROUTE_TARGET) String importRouteTarget) {
@@ -39,7 +42,8 @@ public class Layer2VniConfig extends VniConfig
     checkArgument(rd != null, "Missing %s", PROP_ROUTE_DISTINGUISHER);
     checkArgument(routeTarget != null, "Missing %s", PROP_ROUTE_TARGET);
     checkArgument(importRouteTarget != null, "Missing %s", PROP_IMPORT_ROUTE_TARGET);
-    return new Layer2VniConfig(vni, vrf, rd, routeTarget, importRouteTarget);
+    return new Layer2VniConfig(
+        vni, vrf, advertisedSourceAddress, rd, routeTarget, importRouteTarget);
   }
 
   @Override
@@ -89,11 +93,12 @@ public class Layer2VniConfig extends VniConfig
   }
 
   public static final class Builder {
-    @Nullable protected Integer _vni;
-    @Nullable protected String _vrf;
-    @Nullable protected RouteDistinguisher _rd;
-    @Nullable protected ExtendedCommunity _routeTarget;
-    @Nullable protected String _importRouteTarget;
+    @Nullable private Integer _vni;
+    @Nullable private String _vrf;
+    @Nullable private RouteDistinguisher _rd;
+    @Nullable private ExtendedCommunity _routeTarget;
+    @Nullable private String _importRouteTarget;
+    @Nullable private Ip _advertisedSourceAddress;
 
     private Builder() {}
 
@@ -122,6 +127,11 @@ public class Layer2VniConfig extends VniConfig
       return this;
     }
 
+    public Builder setAdvertisedSourceAddress(@Nullable Ip advertisedSourceAddress) {
+      _advertisedSourceAddress = advertisedSourceAddress;
+      return this;
+    }
+
     public Layer2VniConfig build() {
       checkArgument(_vni != null, "Missing %s", PROP_VNI);
       checkArgument(_vrf != null, "Missing %s", PROP_VRF);
@@ -130,6 +140,7 @@ public class Layer2VniConfig extends VniConfig
       return new Layer2VniConfig(
           _vni,
           _vrf,
+          _advertisedSourceAddress,
           _rd,
           _routeTarget,
           firstNonNull(_importRouteTarget, importRtPatternForAnyAs(_vni)));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/Layer3VniConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/Layer3VniConfig.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 
 /** A Layer 3 {@link VniConfig}. */
@@ -27,11 +28,12 @@ public final class Layer3VniConfig extends VniConfig
   private Layer3VniConfig(
       int vni,
       String vrf,
+      @Nullable Ip advertisedSourceAddress,
       RouteDistinguisher rd,
       ExtendedCommunity routeTarget,
       String importRouteTarget,
       boolean advertiseV4Unicast) {
-    super(vni, vrf, rd, routeTarget, importRouteTarget);
+    super(vni, vrf, rd, advertisedSourceAddress, routeTarget, importRouteTarget);
     _advertiseV4Unicast = advertiseV4Unicast;
   }
 
@@ -39,6 +41,7 @@ public final class Layer3VniConfig extends VniConfig
   private static Layer3VniConfig create(
       @Nullable @JsonProperty(PROP_VNI) Integer vni,
       @Nullable @JsonProperty(PROP_VRF) String vrf,
+      @Nullable @JsonProperty(PROP_ADVERTISED_SOURCE_ADDRESS) Ip advertisedSourceAddress,
       @Nullable @JsonProperty(PROP_ROUTE_DISTINGUISHER) RouteDistinguisher rd,
       @Nullable @JsonProperty(PROP_ROUTE_TARGET) ExtendedCommunity routeTarget,
       @Nullable @JsonProperty(PROP_IMPORT_ROUTE_TARGET) String importRouteTarget,
@@ -55,6 +58,7 @@ public final class Layer3VniConfig extends VniConfig
         .setRouteTarget(routeTarget)
         .setImportRouteTarget(importRouteTarget)
         .setAdvertiseV4Unicast(firstNonNull(advertiseV4Unicast, Boolean.FALSE))
+        .setAdvertisedSourceAddress(advertisedSourceAddress)
         .build();
   }
 
@@ -120,6 +124,7 @@ public final class Layer3VniConfig extends VniConfig
     @Nullable private RouteDistinguisher _rd;
     @Nullable private ExtendedCommunity _routeTarget;
     @Nullable private String _importRouteTarget;
+    @Nullable private Ip _advertisedSourceAddress;
     private boolean _advertiseV4Unicast;
 
     private Builder() {}
@@ -154,6 +159,11 @@ public final class Layer3VniConfig extends VniConfig
       return this;
     }
 
+    public Builder setAdvertisedSourceAddress(@Nullable Ip advertisedSourceAddress) {
+      _advertisedSourceAddress = advertisedSourceAddress;
+      return this;
+    }
+
     public Layer3VniConfig build() {
       checkArgument(_vni != null, "Missing %s", PROP_VNI);
       checkArgument(_vrf != null, "Missing %s", PROP_VRF);
@@ -165,9 +175,10 @@ public final class Layer3VniConfig extends VniConfig
         Pattern.compile(importRt);
       } catch (PatternSyntaxException e) {
         throw new IllegalArgumentException(
-            String.format("Invalid patthern %s for %s", importRt, PROP_IMPORT_ROUTE_TARGET));
+            String.format("Invalid pattern %s for %s", importRt, PROP_IMPORT_ROUTE_TARGET));
       }
-      return new Layer3VniConfig(_vni, _vrf, _rd, _routeTarget, importRt, _advertiseV4Unicast);
+      return new Layer3VniConfig(
+          _vni, _vrf, _advertisedSourceAddress, _rd, _routeTarget, importRt, _advertiseV4Unicast);
     }
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/VniConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/VniConfig.java
@@ -8,6 +8,8 @@ import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.VniSettings;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 
 /**
@@ -19,12 +21,14 @@ public abstract class VniConfig implements Serializable {
 
   public static final String PROP_VNI = "vni";
   public static final String PROP_VRF = "vrf";
+  public static final String PROP_ADVERTISED_SOURCE_ADDRESS = "advertisedSourceAddress";
   public static final String PROP_ROUTE_DISTINGUISHER = "routeDistinguisher";
   public static final String PROP_ROUTE_TARGET = "routeTarget";
   public static final String PROP_IMPORT_ROUTE_TARGET = "importRouteTarget";
 
   protected final int _vni;
   @Nonnull protected final String _vrf;
+  @Nullable protected final Ip _advertisedSourceAddress;
   @Nonnull protected final RouteDistinguisher _rd;
   @Nonnull protected final ExtendedCommunity _routeTarget;
   @Nonnull protected final String _importRouteTarget;
@@ -33,11 +37,13 @@ public abstract class VniConfig implements Serializable {
       int vni,
       String vrf,
       RouteDistinguisher rd,
+      @Nullable Ip advertisedSourceAddress,
       ExtendedCommunity routeTarget,
       String importRouteTarget) {
     _vni = vni;
     _vrf = vrf;
     _rd = rd;
+    _advertisedSourceAddress = advertisedSourceAddress;
     _routeTarget = routeTarget;
     _importRouteTarget = importRouteTarget;
   }
@@ -50,34 +56,45 @@ public abstract class VniConfig implements Serializable {
   }
 
   @JsonProperty(PROP_VNI)
-  public int getVni() {
+  public final int getVni() {
     return _vni;
   }
 
   /** The VRF to which this VNI belongs */
   @Nonnull
   @JsonProperty(PROP_VRF)
-  public String getVrf() {
+  public final String getVrf() {
     return _vrf;
+  }
+
+  /**
+   * Overrides which IP address to advertise for this VNI. If {@code null}, the {@link
+   * VniSettings#getSourceAddress()} should be used by default
+   */
+  @Nullable
+  @JsonProperty(PROP_ADVERTISED_SOURCE_ADDRESS)
+  public final Ip getAdvertisedSourceAddress() {
+    return _advertisedSourceAddress;
   }
 
   /** {@link RouteDistinguisher} to use when advertising this VNI */
   @Nonnull
   @JsonProperty(PROP_ROUTE_DISTINGUISHER)
-  public RouteDistinguisher getRouteDistinguisher() {
+  public final RouteDistinguisher getRouteDistinguisher() {
     return _rd;
   }
 
   /** Route target to use when advertising this VNI (i.e., the export route target) */
   @Nonnull
   @JsonProperty(PROP_ROUTE_TARGET)
-  public ExtendedCommunity getRouteTarget() {
+  public final ExtendedCommunity getRouteTarget() {
     return _routeTarget;
   }
 
   /** The import route target pattern. Can be compiled into a {@link Pattern} */
   @Nonnull
-  public String getImportRouteTarget() {
+  @JsonProperty(PROP_IMPORT_ROUTE_TARGET)
+  public final String getImportRouteTarget() {
     return _importRouteTarget;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/VniConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/VniConfig.java
@@ -9,7 +9,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.VniSettings;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 
 /**
@@ -69,7 +68,7 @@ public abstract class VniConfig implements Serializable {
 
   /**
    * Overrides which IP address to advertise for this VNI. If {@code null}, the {@link
-   * VniSettings#getSourceAddress()} should be used by default
+   * org.batfish.datamodel.VniSettings#getSourceAddress()} should be used by default
    */
   @Nullable
   @JsonProperty(PROP_ADVERTISED_SOURCE_ADDRESS)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Layer2VniConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Layer2VniConfigTest.java
@@ -7,6 +7,7 @@ import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.junit.Test;
 
@@ -28,6 +29,7 @@ public class Layer2VniConfigTest {
         .addEqualityGroup(builder.setRouteDistinguisher(RouteDistinguisher.from(65555L, 2)).build())
         .addEqualityGroup(builder.setRouteTarget(ExtendedCommunity.of(0, 2, 2)).build())
         .addEqualityGroup(builder.setImportRouteTarget("^1:1$").build())
+        .addEqualityGroup(builder.setAdvertisedSourceAddress(Ip.ZERO))
         .addEqualityGroup(new Object())
         .testEquals();
   }
@@ -40,6 +42,7 @@ public class Layer2VniConfigTest {
             .setVrf("v")
             .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
             .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+            .setAdvertisedSourceAddress(Ip.ZERO)
             .build();
     assertThat(SerializationUtils.clone(vni), equalTo(vni));
   }
@@ -52,6 +55,7 @@ public class Layer2VniConfigTest {
             .setVrf("v")
             .setRouteDistinguisher(RouteDistinguisher.from(65555L, 1))
             .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
+            .setAdvertisedSourceAddress(Ip.ZERO)
             .build();
     assertThat(BatfishObjectMapper.clone(vni, Layer2VniConfig.class), equalTo(vni));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Layer3VniConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Layer3VniConfigTest.java
@@ -8,6 +8,7 @@ import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,6 +37,7 @@ public class Layer3VniConfigTest {
         .addEqualityGroup(builder.setRouteTarget(ExtendedCommunity.of(0, 2, 1)).build())
         .addEqualityGroup(builder.setImportRouteTarget(importRtPatternForAnyAs(2)).build())
         .addEqualityGroup(builder.setAdvertiseV4Unicast(true).build())
+        .addEqualityGroup(builder.setAdvertisedSourceAddress(Ip.ZERO))
         .testEquals();
   }
 
@@ -49,6 +51,7 @@ public class Layer3VniConfigTest {
             .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
             .setImportRouteTarget(importRtPatternForAnyAs(1))
             .setAdvertiseV4Unicast(false)
+            .setAdvertisedSourceAddress(Ip.ZERO)
             .build();
     assertThat(SerializationUtils.clone(vni), equalTo(vni));
   }
@@ -63,6 +66,7 @@ public class Layer3VniConfigTest {
             .setRouteTarget(ExtendedCommunity.of(0, 1, 1))
             .setImportRouteTarget(importRtPatternForAnyAs(1))
             .setAdvertiseV4Unicast(false)
+            .setAdvertisedSourceAddress(Ip.ZERO)
             .build();
     assertThat(BatfishObjectMapper.clone(vni, Layer3VniConfig.class), equalTo(vni));
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -247,6 +247,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
                   .setVrf(bgpVrf.getVrfName())
                   .setRouteDistinguisher(rd)
                   .setRouteTarget(rt)
+                  .setAdvertisedSourceAddress(_loopback.getClagVxlanAnycastIp())
                   .build());
         }
       }
@@ -271,6 +272,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
                           .setRouteTarget(rt)
                           .setImportRouteTarget(importRtPatternForAnyAs(l3Vni))
                           .setAdvertiseV4Unicast(evpnConfig.getAdvertiseIpv4Unicast() != null)
+                          .setAdvertisedSourceAddress(_loopback.getClagVxlanAnycastIp())
                           .build());
                 }
               });

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -98,21 +98,13 @@ public class BgpRoutingProcessTest {
   @Test
   public void testInitEvpnType3Route() {
     Ip ip = Ip.parse("1.1.1.1");
+    Ip advertiseIp = Ip.parse("1.2.2.2");
     ExtendedCommunity routeTarget = ExtendedCommunity.target(1, 1);
     RouteDistinguisher routeDistinguisher = RouteDistinguisher.from(ip, 1);
     int admin = 20;
     EvpnType3Route route =
-        initEvpnType3Route(
-            admin,
-            VniSettings.builder()
-                .setVlan(1)
-                .setVni(10001)
-                .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
-                .setSourceAddress(ip)
-                .build(),
-            routeTarget,
-            routeDistinguisher,
-            ip);
+        initEvpnType3Route(admin, advertiseIp, routeTarget, routeDistinguisher, ip);
+
     assertThat(
         route,
         equalTo(
@@ -123,7 +115,7 @@ public class BgpRoutingProcessTest {
                 .setProtocol(RoutingProtocol.BGP)
                 .setOriginType(OriginType.EGP)
                 .setLocalPreference(BgpRoute.DEFAULT_LOCAL_PREFERENCE)
-                .setVniIp(ip)
+                .setVniIp(advertiseIp)
                 .setOriginatorIp(ip)
                 .build()));
   }
@@ -143,11 +135,13 @@ public class BgpRoutingProcessTest {
             .setImportRouteTarget(VniConfig.importRtPatternForAnyAs(vni))
             .setAdvertiseV4Unicast(false);
     Layer3VniConfig vniConfig1 = vniConfigBuilder.build();
+    Ip advertiseIpVni2 = Ip.parse("3.3.3.3");
     Layer3VniConfig vniConfig2 =
         vniConfigBuilder
             .setVni(vni2)
             .setVrf(_vrf2.getName())
             .setRouteTarget(ExtendedCommunity.target(65500, vni2))
+            .setAdvertisedSourceAddress(advertiseIpVni2)
             .build();
     BgpActivePeerConfig evpnPeer =
         BgpActivePeerConfig.builder()
@@ -216,7 +210,7 @@ public class BgpRoutingProcessTest {
             .collect(ImmutableSet.toImmutableSet()),
         contains(
             EvpnType3Route.builder()
-                .setVniIp(localIp)
+                .setVniIp(advertiseIpVni2)
                 .setRouteDistinguisher(RouteDistinguisher.from(_bgpProcess.getRouterId(), 2))
                 .setCommunities(ImmutableSet.of(ExtendedCommunity.target(65500, vni2)))
                 .setLocalPreference(Bgpv4Route.DEFAULT_LOCAL_PREFERENCE)

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -14451,6 +14451,7 @@
                     "l3Vnis" : [
                       {
                         "advertiseV4Unicast" : true,
+                        "advertisedSourceAddress" : "192.0.2.7",
                         "importRouteTarget" : "^\\d+:10001$",
                         "routeDistinguisher" : "192.0.2.3:0",
                         "routeTarget" : "2:65500:10001",
@@ -14508,6 +14509,7 @@
                     "l3Vnis" : [
                       {
                         "advertiseV4Unicast" : true,
+                        "advertisedSourceAddress" : "192.0.2.7",
                         "importRouteTarget" : "^\\d+:10001$",
                         "routeDistinguisher" : "192.0.2.3:0",
                         "routeTarget" : "2:65500:10001",
@@ -14565,6 +14567,7 @@
                     "l3Vnis" : [
                       {
                         "advertiseV4Unicast" : true,
+                        "advertisedSourceAddress" : "192.0.2.7",
                         "importRouteTarget" : "^\\d+:10001$",
                         "routeDistinguisher" : "192.0.2.3:0",
                         "routeTarget" : "2:65500:10001",


### PR DESCRIPTION
Change type3 route propagation to use the anycast IP instead of the
VNI's source address.