### PR TITLE
NX-OS: refine M_Vrf

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
@@ -2017,14 +2017,7 @@ VNI
 
 VRF
 :
-  'vrf'
-  // If not first word on line, should be followed by VRF name
-  {
-    if (!(lastTokenType() == NEWLINE || lastTokenType() == -1)) {
-      pushMode(M_Word);
-    }
-  }
-
+  'vrf' -> pushMode( M_Vrf )
 ;
 
 WAIT_IGP_CONVERGENCE
@@ -2558,6 +2551,33 @@ M_Remark_REMARK_TEXT
 ;
 
 M_Remark_WS
+:
+  F_Whitespace+ -> channel ( HIDDEN )
+;
+
+mode M_Vrf;
+
+M_Vrf_CONTEXT
+:
+  'context' -> type ( CONTEXT )
+;
+
+M_Vrf_MEMBER
+:
+  'member' -> type ( MEMBER )
+;
+
+M_Vrf_NEWLINE
+:
+  F_Newline -> type ( NEWLINE ), popMode
+;
+
+M_Vrf_WORD
+:
+  F_Word -> type ( WORD ) , popMode
+;
+
+M_Vrf_WS
 :
   F_Whitespace+ -> channel ( HIDDEN )
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
@@ -2569,7 +2569,7 @@ M_Vrf_MEMBER
 
 M_Vrf_NEWLINE
 :
-  F_Newline -> type ( NEWLINE ), popMode
+  F_Newline+ -> type ( NEWLINE ), popMode
 ;
 
 M_Vrf_WORD


### PR DESCRIPTION
Makes all of the following parse correctly:

```
vrf context foo

interface bar
  vrf member foo

router bgp 1
  vrf foo
```

Before, the last one did not parse because we only allowed names without member
or context when vrf was not first on the line. (adding support in subsequent PR)

Luckily, NX-OS disallows context or member as vrf names.