### PR TITLE
Forwarding analysis: compute VRF owned IPs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
@@ -65,7 +65,7 @@ public final class IpOwners {
   private final Map<String, Map<String, IpSpace>> _vrfOwnedIpSpaces;
 
   public IpOwners(Map<String, Configuration> configurations) {
-    /** Mapping from a hostname to a set of all (including inactive) interfaces that node owns */
+    /* Mapping from a hostname to a set of all (including inactive) interfaces that node owns */
     Map<String, Set<Interface>> allInterfaces =
         ImmutableMap.copyOf(computeNodeInterfaces(configurations));
 
@@ -178,7 +178,7 @@ public final class IpOwners {
    * Compute a mapping of IP addresses to a set of hostnames that "own" this IP (e.g., as a network
    * interface address)
    *
-   * @param configurations {@link Configurations} keyed by hostname
+   * @param configurations map of configurations keyed by hostname
    * @param excludeInactive Whether to exclude inactive interfaces
    * @return A map of {@link Ip}s to a set of hostnames that own this IP
    */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
@@ -1,20 +1,26 @@
 package org.batfish.common.topology;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static org.batfish.common.topology.TopologyUtil.computeIpInterfaceOwners;
 import static org.batfish.common.topology.TopologyUtil.computeNodeInterfaces;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Table;
 import io.opentracing.ActiveSpan;
 import io.opentracing.util.GlobalTracer;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.batfish.common.util.CollectionUtil;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
@@ -26,9 +32,6 @@ import org.batfish.datamodel.Prefix;
 
 /** A utility class for working with IPs owned by network devices. */
 public final class IpOwners {
-
-  /** Mapping from a hostname to a set of all (including inactive) interfaces that node owns */
-  private final Map<String, Set<Interface>> _allInterfaces;
 
   /**
    * Mapping from a IP to hostname to set of interfaces that own that IP (including inactive
@@ -59,17 +62,29 @@ public final class IpOwners {
    */
   private final Map<String, Map<String, IpSpace>> _activeInterfaceHostIps;
 
+  private final Map<String, Map<String, IpSpace>> _vrfOwnedIpSpaces;
+
   public IpOwners(Map<String, Configuration> configurations) {
-    _allInterfaces = ImmutableMap.copyOf(computeNodeInterfaces(configurations));
+    /** Mapping from a hostname to a set of all (including inactive) interfaces that node owns */
+    Map<String, Set<Interface>> allInterfaces =
+        ImmutableMap.copyOf(computeNodeInterfaces(configurations));
 
-    _allDeviceOwnedIps = ImmutableMap.copyOf(computeIpInterfaceOwners(_allInterfaces, false));
-    _activeDeviceOwnedIps = ImmutableMap.copyOf(computeIpInterfaceOwners(_allInterfaces, true));
+    {
+      _allDeviceOwnedIps = ImmutableMap.copyOf(computeIpInterfaceOwners(allInterfaces, false));
+      _activeDeviceOwnedIps = ImmutableMap.copyOf(computeIpInterfaceOwners(allInterfaces, true));
+    }
 
-    _hostToInterfaceToIpSpace =
-        ImmutableMap.copyOf(computeInterfaceOwnedIpSpaces(_activeDeviceOwnedIps));
+    {
+      _hostToInterfaceToIpSpace =
+          ImmutableMap.copyOf(computeInterfaceOwnedIpSpaces(_activeDeviceOwnedIps));
+      _allInterfaceHostIps = computeInterfaceHostSubnetIps(configurations, false);
+      _activeInterfaceHostIps = computeInterfaceHostSubnetIps(configurations, true);
+    }
 
-    _allInterfaceHostIps = computeInterfaceHostSubnetIps(configurations, false);
-    _activeInterfaceHostIps = computeInterfaceHostSubnetIps(configurations, true);
+    {
+      _vrfOwnedIpSpaces =
+          computeVrfOwnedIpSpaces(computeIpVrfOwners(allInterfaces, _activeDeviceOwnedIps));
+    }
   }
 
   /**
@@ -78,11 +93,11 @@ public final class IpOwners {
    */
   private static Map<String, Map<String, IpSpace>> computeInterfaceOwnedIpSpaces(
       Map<Ip, Map<String, Set<String>>> ipInterfaceOwners) {
-    return CollectionUtil.toImmutableMap(
-        TopologyUtil.computeInterfaceOwnedIps(ipInterfaceOwners),
+    return toImmutableMap(
+        computeInterfaceOwnedIps(ipInterfaceOwners),
         Entry::getKey, /* host */
         hostEntry ->
-            CollectionUtil.toImmutableMap(
+            toImmutableMap(
                 hostEntry.getValue(),
                 Entry::getKey, /* interface */
                 ifaceEntry ->
@@ -116,6 +131,226 @@ public final class IpOwners {
                                   .collect(ImmutableList.toImmutableList())),
                           EmptyIpSpace.INSTANCE)));
     }
+  }
+
+  /**
+   * Compute the {@link Ip}s owned by each interface. hostname -&gt; interface name -&gt; {@link
+   * Ip}s.
+   */
+  public static Map<String, Map<String, Set<Ip>>> computeInterfaceOwnedIps(
+      Map<String, Configuration> configurations, boolean excludeInactive) {
+    // TODO: cleanup callers, make this private
+    return computeInterfaceOwnedIps(
+        computeIpInterfaceOwners(computeNodeInterfaces(configurations), excludeInactive));
+  }
+
+  /**
+   * Invert a mapping from {@link Ip} to owner interfaces (Ip -&gt; hostname -&gt; interface name)
+   * to (hostname -&gt; interface name -&gt; Ip).
+   */
+  private static Map<String, Map<String, Set<Ip>>> computeInterfaceOwnedIps(
+      Map<Ip, Map<String, Set<String>>> ipInterfaceOwners) {
+    Map<String, Map<String, Set<Ip>>> ownedIps = new HashMap<>();
+
+    ipInterfaceOwners.forEach(
+        (ip, owners) ->
+            owners.forEach(
+                (host, ifaces) ->
+                    ifaces.forEach(
+                        iface ->
+                            ownedIps
+                                .computeIfAbsent(host, k -> new HashMap<>())
+                                .computeIfAbsent(iface, k -> new HashSet<>())
+                                .add(ip))));
+
+    // freeze
+    return toImmutableMap(
+        ownedIps,
+        Entry::getKey, /* host */
+        hostEntry ->
+            toImmutableMap(
+                hostEntry.getValue(),
+                Entry::getKey, /* interface */
+                ifaceEntry -> ImmutableSet.copyOf(ifaceEntry.getValue())));
+  }
+
+  /**
+   * Compute a mapping of IP addresses to a set of hostnames that "own" this IP (e.g., as a network
+   * interface address)
+   *
+   * @param configurations {@link Configurations} keyed by hostname
+   * @param excludeInactive Whether to exclude inactive interfaces
+   * @return A map of {@link Ip}s to a set of hostnames that own this IP
+   */
+  public static Map<Ip, Set<String>> computeIpNodeOwners(
+      Map<String, Configuration> configurations, boolean excludeInactive) {
+    try (ActiveSpan span =
+        GlobalTracer.get()
+            .buildSpan("TopologyUtil.computeIpNodeOwners excludeInactive=" + excludeInactive)
+            .startActive()) {
+      assert span != null; // avoid unused warning
+
+      return toImmutableMap(
+          computeIpInterfaceOwners(computeNodeInterfaces(configurations), excludeInactive),
+          Entry::getKey, /* Ip */
+          ipInterfaceOwnersEntry ->
+              /* project away interfaces */
+              ipInterfaceOwnersEntry.getValue().keySet());
+    }
+  }
+
+  /**
+   * Compute a mapping from IP address to the interfaces that "own" that IP (e.g., as a network
+   * interface address).
+   *
+   * <p>Takes into account VRRP configuration.
+   *
+   * @param allInterfaces A mapping of interfaces: hostname -&gt; set of {@link Interface}
+   * @param excludeInactive whether to ignore inactive interfaces
+   * @return A map from {@link Ip}s to hostname to set of interface names that own that IP.
+   */
+  @VisibleForTesting
+  static Map<Ip, Map<String, Set<String>>> computeIpInterfaceOwners(
+      Map<String, Set<Interface>> allInterfaces, boolean excludeInactive) {
+    Map<Ip, Map<String, Set<String>>> ipOwners = new HashMap<>();
+    Table<ConcreteInterfaceAddress, Integer, Set<Interface>> vrrpGroups = HashBasedTable.create();
+    allInterfaces.forEach(
+        (hostname, interfaces) ->
+            interfaces.forEach(
+                i -> {
+                  if ((!i.getActive() || i.getBlacklisted()) && excludeInactive) {
+                    return;
+                  }
+                  // collect vrrp info
+                  i.getVrrpGroups()
+                      .forEach(
+                          (groupNum, vrrpGroup) -> {
+                            ConcreteInterfaceAddress address = vrrpGroup.getVirtualAddress();
+                            if (address == null) {
+                              /*
+                               * Invalid VRRP configuration. The VRRP has no source IP address that
+                               * would be used for VRRP election. This interface could never win the
+                               * election, so is not a candidate.
+                               */
+                              return;
+                            }
+                            Set<Interface> candidates = vrrpGroups.get(address, groupNum);
+                            if (candidates == null) {
+                              candidates = Collections.newSetFromMap(new IdentityHashMap<>());
+                              vrrpGroups.put(address, groupNum, candidates);
+                            }
+                            candidates.add(i);
+                          });
+                  // collect prefixes
+                  i.getAllConcreteAddresses().stream()
+                      .map(ConcreteInterfaceAddress::getIp)
+                      .forEach(
+                          ip ->
+                              ipOwners
+                                  .computeIfAbsent(ip, k -> new HashMap<>())
+                                  .computeIfAbsent(hostname, k -> new HashSet<>())
+                                  .add(i.getName()));
+                }));
+    vrrpGroups
+        .cellSet()
+        .forEach(
+            cell -> {
+              ConcreteInterfaceAddress address = cell.getRowKey();
+              assert address != null;
+              Integer groupNum = cell.getColumnKey();
+              assert groupNum != null;
+              Set<Interface> candidates = cell.getValue();
+              assert candidates != null;
+              /*
+               * Compare priorities first. If tied, break tie based on highest interface IP.
+               */
+              Interface vrrpMaster =
+                  Collections.max(
+                      candidates,
+                      Comparator.comparingInt(
+                              (Interface o) -> o.getVrrpGroups().get(groupNum).getPriority())
+                          .thenComparing(o -> o.getConcreteAddress().getIp()));
+              ipOwners
+                  .computeIfAbsent(address.getIp(), k -> new HashMap<>())
+                  .computeIfAbsent(vrrpMaster.getOwner().getHostname(), k -> new HashSet<>())
+                  .add(vrrpMaster.getName());
+            });
+
+    // freeze
+    return toImmutableMap(
+        ipOwners,
+        Entry::getKey,
+        ipOwnersEntry ->
+            toImmutableMap(
+                ipOwnersEntry.getValue(),
+                Entry::getKey, // hostname
+                hostIpOwnersEntry -> ImmutableSet.copyOf(hostIpOwnersEntry.getValue())));
+  }
+
+  /**
+   * Compute a mapping of IP addresses to the VRFs that "own" this IP (e.g., as a network interface
+   * address).
+   *
+   * @param allInterfaces A mapping of enabled interfaces hostname -&gt; interface name -&gt; {@link
+   *     Interface}
+   * @param activeDeviceOwnedIps Mapping from a IP to hostname to set of interfaces that own that IP
+   *     (for active interfaces only)
+   * @return A map of {@link Ip}s to a map of hostnames to vrfs that own the Ip.
+   */
+  @VisibleForTesting
+  static Map<Ip, Map<String, Set<String>>> computeIpVrfOwners(
+      Map<String, Set<Interface>> allInterfaces,
+      Map<Ip, Map<String, Set<String>>> activeDeviceOwnedIps) {
+
+    // Helper mapping: Hostname -> interface name -> vrf name
+    Map<String, Map<String, String>> allInterfaceVrfs =
+        toImmutableMap(
+            allInterfaces,
+            Entry::getKey, /* hostname */
+            nodeInterfaces ->
+                nodeInterfaces.getValue().stream()
+                    .collect(
+                        ImmutableMap.toImmutableMap(Interface::getName, Interface::getVrfName)));
+
+    return toImmutableMap(
+        activeDeviceOwnedIps,
+        Entry::getKey, /* Ip */
+        ipInterfaceOwnersEntry ->
+            toImmutableMap(
+                ipInterfaceOwnersEntry.getValue(),
+                Entry::getKey, /* Hostname */
+                ipNodeInterfaceOwnersEntry ->
+                    ipNodeInterfaceOwnersEntry.getValue().stream()
+                        .map(allInterfaceVrfs.get(ipNodeInterfaceOwnersEntry.getKey())::get)
+                        .collect(ImmutableSet.toImmutableSet())));
+  }
+
+  /**
+   * Invert a mapping from Ip to VRF owners (Ip -&gt; host name -&gt; VRF name) and combine all IPs
+   * owned by each VRF into an IpSpace.
+   */
+  private static Map<String, Map<String, IpSpace>> computeVrfOwnedIpSpaces(
+      Map<Ip, Map<String, Set<String>>> ipVrfOwners) {
+    Map<String, Map<String, AclIpSpace.Builder>> builders = new HashMap<>();
+    ipVrfOwners.forEach(
+        (ip, ipNodeVrfs) ->
+            ipNodeVrfs.forEach(
+                (node, vrfs) ->
+                    vrfs.forEach(
+                        vrf ->
+                            builders
+                                .computeIfAbsent(node, k -> new HashMap<>())
+                                .computeIfAbsent(vrf, k -> AclIpSpace.builder())
+                                .thenPermitting(ip.toIpSpace()))));
+
+    return toImmutableMap(
+        builders,
+        Entry::getKey, /* node */
+        nodeEntry ->
+            toImmutableMap(
+                nodeEntry.getValue(),
+                Entry::getKey, /* vrf */
+                vrfEntry -> vrfEntry.getValue().build()));
   }
 
   /**
@@ -160,5 +395,13 @@ public final class IpOwners {
    */
   public Map<String, Map<String, IpSpace>> getInterfaceOwnedIpSpaces() {
     return _hostToInterfaceToIpSpace;
+  }
+
+  /**
+   * Returns a mapping from hostname to vrf name to a space of IPs owned by that VRF. Only considers
+   * interface IPs. Considers <em>only active</em> interfaces.
+   */
+  public Map<String, Map<String, IpSpace>> getVrfOwnedIpSpaces() {
+    return _vrfOwnedIpSpaces;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -21,12 +21,6 @@ public interface DataPlane extends Serializable {
 
   ForwardingAnalysis getForwardingAnalysis();
 
-  /**
-   * Return the map of Vrfs that own each Ip (as computed during dataplane computation). Map
-   * structure: Ip -&gt; hostname -&gt; set of Vrfs
-   */
-  Map<Ip, Map<String, Set<String>>> getIpVrfOwners();
-
   /** Return the set of all (main) RIBs. Map structure: hostname -&gt; VRF name -&gt; GenericRib */
   SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> getRibs();
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysis.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysis.java
@@ -1,8 +1,15 @@
 package org.batfish.datamodel;
 
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 public interface ForwardingAnalysis {
+  /**
+   * Return IP spaces accepted at each VRF <br>
+   * Mapping: hostname -&gt; vrfName -&gt; space of IPs accepted by that VRF
+   */
+  @Nonnull
+  Map<String, Map<String, IpSpace>> getAcceptsIps();
 
   /** Mapping: hostname -&gt; inInterface -&gt; ipsToArpReplyTo */
   Map<String, Map<String, IpSpace>> getArpReplies();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.plugin.TracerouteEngine;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.common.topology.Layer2Topology;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
@@ -51,8 +52,7 @@ public final class BgpTopologyUtils {
    * TracerouteEngine, Layer2Topology)} for more details.
    *
    * @param configurations configuration keyed by hostname
-   * @param ipOwners Ip owners (see {@link
-   *     org.batfish.common.topology.TopologyUtil#computeIpNodeOwners(Map, boolean)}
+   * @param ipOwners Ip owners (see {@link IpOwners#computeIpNodeOwners(Map, boolean)}
    * @param keepInvalid whether to keep improperly configured neighbors. If performing configuration
    *     checks, you probably want this set to {@code true}, otherwise (e.g., computing dataplane)
    *     you want this to be {@code false}.
@@ -71,8 +71,8 @@ public final class BgpTopologyUtils {
    * BgpSessionProperties}.
    *
    * @param configurations node configurations, keyed by hostname
-   * @param ipOwners network Ip owners (see {@link
-   *     org.batfish.common.topology.TopologyUtil#computeIpNodeOwners(Map, boolean)} for reference)
+   * @param ipOwners network Ip owners (see {@link IpOwners#computeIpNodeOwners(Map, boolean)} for
+   *     reference)
    * @param keepInvalid whether to keep improperly configured neighbors. If performing configuration
    *     checks, you probably want this set to {@code true}, otherwise (e.g., computing dataplane)
    *     you want this to be {@code false}.

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -1,7 +1,7 @@
 package org.batfish.common.topology;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.batfish.common.topology.TopologyUtil.computeIpInterfaceOwners;
+import static org.batfish.common.topology.IpOwners.computeIpInterfaceOwners;
 import static org.batfish.common.topology.TopologyUtil.computeLayer1LogicalTopology;
 import static org.batfish.common.topology.TopologyUtil.computeLayer1PhysicalTopology;
 import static org.batfish.common.topology.TopologyUtil.computeLayer2SelfEdges;
@@ -1235,7 +1235,7 @@ public final class TopologyUtilTest {
 
   /**
    * Tests that inactive and blacklisted interfaces are properly included or excluded from the
-   * output of {@link TopologyUtil#computeIpInterfaceOwners(Map, boolean)}
+   * output of {@link IpOwners#computeIpInterfaceOwners(Map, boolean)}
    */
   @Test
   public void testIpInterfaceOwnersActiveInclusion() {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/VrrpComputationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/VrrpComputationTest.java
@@ -1,7 +1,7 @@
 package org.batfish.common.topology;
 
-import static org.batfish.common.topology.TopologyUtil.computeIpInterfaceOwners;
-import static org.batfish.common.topology.TopologyUtil.computeIpNodeOwners;
+import static org.batfish.common.topology.IpOwners.computeIpInterfaceOwners;
+import static org.batfish.common.topology.IpOwners.computeIpNodeOwners;
 import static org.batfish.common.topology.TopologyUtil.computeNodeInterfaces;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -44,7 +44,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import org.batfish.common.topology.TopologyUtil;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 import org.junit.Before;
 import org.junit.Test;
@@ -130,7 +130,7 @@ public class ForwardingAnalysisImplTest {
             c2.getHostname(),
             ImmutableMap.of(vrf2.getName(), ImmutableMap.of(i2.getName(), ipsRoutedOutI2)));
     Map<String, Map<String, Set<Ip>>> interfaceOwnedIps =
-        TopologyUtil.computeInterfaceOwnedIps(configs, false);
+        IpOwners.computeInterfaceOwnedIps(configs, false);
     Map<String, Map<String, IpSpace>> result =
         computeArpReplies(configurations, ipsRoutedOutInterfaces, interfaceOwnedIps, routableIps);
 
@@ -232,7 +232,7 @@ public class ForwardingAnalysisImplTest {
 
     Map<String, Configuration> configs = ImmutableMap.of(config.getHostname(), config);
     Map<String, Map<String, Set<Ip>>> interfaceOwnedIps =
-        TopologyUtil.computeInterfaceOwnedIps(configs, false);
+        IpOwners.computeInterfaceOwnedIps(configs, false);
     Map<String, IpSpace> result =
         ForwardingAnalysisImpl.computeArpRepliesByInterface(
             interfaces, routableIpsByVrf, ipsRoutedOutInterfaces, interfaceOwnedIps);
@@ -289,7 +289,7 @@ public class ForwardingAnalysisImplTest {
             .build();
 
     Map<String, Map<String, Set<Ip>>> interfaceOwnedIps =
-        TopologyUtil.computeInterfaceOwnedIps(configs, false);
+        IpOwners.computeInterfaceOwnedIps(configs, false);
 
     IpSpace p1IpSpace = IpWildcard.create(P1).toIpSpace();
     IpSpace i1ArpReplies =
@@ -498,7 +498,7 @@ public class ForwardingAnalysisImplTest {
             .including(IpWildcard.create(P1), IpWildcard.create(P2))
             .build();
     Map<String, Map<String, Set<Ip>>> interfaceOwnedIps =
-        TopologyUtil.computeInterfaceOwnedIps(ImmutableMap.of(config.getHostname(), config), false);
+        IpOwners.computeInterfaceOwnedIps(ImmutableMap.of(config.getHostname(), config), false);
     IpSpace noProxyArpResult =
         computeInterfaceArpReplies(
             iNoProxyArp, routableIpsForThisVrf, ipsRoutedThroughInterface, interfaceOwnedIps);
@@ -537,7 +537,7 @@ public class ForwardingAnalysisImplTest {
         ConcreteInterfaceAddress.create(P2.getStartIp(), P2.getPrefixLength());
     Interface i = _ib.setAddresses(primary, secondary).build();
     Map<String, Map<String, Set<Ip>>> interfaceOwnedIps =
-        TopologyUtil.computeInterfaceOwnedIps(configs, false);
+        IpOwners.computeInterfaceOwnedIps(configs, false);
     IpSpace result = computeIpsAssignedToThisInterfaceForArpReplies(i, interfaceOwnedIps);
 
     assertThat(result, containsIp(P1.getStartIp()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
@@ -22,7 +22,6 @@ public class MockDataPlane implements DataPlane {
     @Nonnull
     private SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> _ribs;
 
-    @Nonnull private Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
     @Nonnull private Table<String, String, Set<VniSettings>> _vniSettings;
 
     private Builder() {
@@ -31,7 +30,6 @@ public class MockDataPlane implements DataPlane {
       _evpnRoutes = HashBasedTable.create();
       _fibs = ImmutableMap.of();
       _ribs = ImmutableSortedMap.of();
-      _ipVrfOwners = ImmutableMap.of();
       _vniSettings = HashBasedTable.create();
     }
 
@@ -64,11 +62,6 @@ public class MockDataPlane implements DataPlane {
       return this;
     }
 
-    public Builder setIpVrfOwners(@Nonnull Map<Ip, Map<String, Set<String>>> ipVrfOwners) {
-      _ipVrfOwners = ipVrfOwners;
-      return this;
-    }
-
     public Builder setVniSettings(@Nonnull Table<String, String, Set<VniSettings>> vniSettings) {
       _vniSettings = vniSettings;
       return this;
@@ -90,7 +83,6 @@ public class MockDataPlane implements DataPlane {
   @Nonnull private Table<String, String, Set<EvpnRoute<?, ?>>> _evpnRoutes;
   @Nonnull private final Map<String, Map<String, Fib>> _fibs;
   @Nullable private final ForwardingAnalysis _forwardingAnalysis;
-  @Nonnull private final Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
 
   @Nonnull
   private final SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>>
@@ -104,7 +96,6 @@ public class MockDataPlane implements DataPlane {
     _evpnRoutes = builder._evpnRoutes;
     _fibs = builder._fibs;
     _forwardingAnalysis = builder._forwardingAnalysis;
-    _ipVrfOwners = builder._ipVrfOwners;
     _ribs = ImmutableSortedMap.copyOf(builder._ribs);
     _vniSettings = builder._vniSettings;
   }
@@ -131,12 +122,6 @@ public class MockDataPlane implements DataPlane {
   @Override
   public ForwardingAnalysis getForwardingAnalysis() {
     return _forwardingAnalysis;
-  }
-
-  @Nonnull
-  @Override
-  public Map<Ip, Map<String, Set<String>>> getIpVrfOwners() {
-    return _ipVrfOwners;
   }
 
   @Nonnull

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockForwardingAnalysis.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockForwardingAnalysis.java
@@ -3,23 +3,20 @@ package org.batfish.datamodel;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 
 public class MockForwardingAnalysis implements ForwardingAnalysis {
 
   public static class Builder {
 
+    private Map<String, Map<String, IpSpace>> _acceptedIps;
     private Map<String, Map<String, IpSpace>> _arpReplies;
-
     private Map<
             String, Map<String, Map<AbstractRoute, Map<String, Map<ArpIpChoice, Set<IpSpace>>>>>>
         _arpRequests;
-
     private Map<String, Map<String, Map<Edge, IpSpace>>> _arpTrueEdge;
-
     private Map<String, Map<String, Map<String, IpSpace>>> _nextVrfIps;
-
     private Map<String, Map<String, IpSpace>> _nullRoutedIps;
-
     private Map<String, Map<String, IpSpace>> _routableIps;
 
     private Builder() {
@@ -33,6 +30,11 @@ public class MockForwardingAnalysis implements ForwardingAnalysis {
 
     public MockForwardingAnalysis build() {
       return new MockForwardingAnalysis(this);
+    }
+
+    public Builder setAcceptedIps(Map<String, Map<String, IpSpace>> acceptedIps) {
+      _acceptedIps = acceptedIps;
+      return this;
     }
 
     public Builder setArpReplies(Map<String, Map<String, IpSpace>> arpReplies) {
@@ -72,27 +74,30 @@ public class MockForwardingAnalysis implements ForwardingAnalysis {
     return new Builder();
   }
 
+  private Map<String, Map<String, IpSpace>> _acceptedIps;
   private final Map<String, Map<String, IpSpace>> _arpReplies;
-
   private final Map<
           String, Map<String, Map<AbstractRoute, Map<String, Map<ArpIpChoice, Set<IpSpace>>>>>>
       _arpRequests;
-
   private final Map<String, Map<String, Map<Edge, IpSpace>>> _arpTrueEdge;
-
   private final Map<String, Map<String, Map<String, IpSpace>>> _nextVrfIps;
-
   private final Map<String, Map<String, IpSpace>> _nullRoutedIps;
-
   private final Map<String, Map<String, IpSpace>> _routableIps;
 
   public MockForwardingAnalysis(Builder builder) {
+    _acceptedIps = ImmutableMap.copyOf(builder._acceptedIps);
     _arpReplies = ImmutableMap.copyOf(builder._arpReplies);
     _arpRequests = ImmutableMap.copyOf(builder._arpRequests);
     _arpTrueEdge = ImmutableMap.copyOf(builder._arpTrueEdge);
     _nextVrfIps = ImmutableMap.copyOf(builder._nextVrfIps);
     _nullRoutedIps = ImmutableMap.copyOf(builder._nullRoutedIps);
     _routableIps = ImmutableMap.copyOf(builder._routableIps);
+  }
+
+  @Nonnull
+  @Override
+  public Map<String, Map<String, IpSpace>> getAcceptsIps() {
+    return _acceptedIps;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -57,7 +57,6 @@ import org.batfish.common.bdd.IpAccessListToBdd;
 import org.batfish.common.bdd.IpAccessListToBddImpl;
 import org.batfish.common.bdd.IpSpaceToBDD;
 import org.batfish.common.bdd.MemoizedIpAccessListToBdd;
-import org.batfish.common.topology.TopologyUtil;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.FlowDisposition;
@@ -268,7 +267,8 @@ public final class BDDReachabilityAnalysisFactory {
           computeDispositionBDDs(forwardingAnalysis.getInsufficientInfo(), _dstIpSpaceToBDD);
       _nullRoutedBDDs = computeNullRoutedBDDs(forwardingAnalysis, _dstIpSpaceToBDD);
       _routableBDDs = computeRoutableBDDs(forwardingAnalysis, _dstIpSpaceToBDD);
-      _vrfAcceptBDDs = computeVrfAcceptBDDs(configs, _dstIpSpaceToBDD);
+      _vrfAcceptBDDs =
+          computeVrfAcceptBDDs(configs, forwardingAnalysis.getAcceptsIps(), _dstIpSpaceToBDD);
       _nextVrfBDDs = computeNextVrfBDDs(forwardingAnalysis.getNextVrfIps(), _dstIpSpaceToBDD);
 
       _convertedPacketPolicies = convertPacketPolicies(configs);
@@ -1585,22 +1585,15 @@ public final class BDDReachabilityAnalysisFactory {
   }
 
   private static Map<String, Map<String, BDD>> computeVrfAcceptBDDs(
-      Map<String, Configuration> configs, IpSpaceToBDD ipSpaceToBDD) {
+      Map<String, Configuration> configs,
+      Map<String, Map<String, IpSpace>> acceptIps,
+      IpSpaceToBDD ipSpaceToBDD) {
     try (ActiveSpan span =
         GlobalTracer.get()
             .buildSpan("BDDReachabilityAnalysisFactory.computeVrfAcceptBDDs")
             .startActive()) {
       assert span != null; // avoid unused warning
-      /*
-       * excludeInactive: true
-       * The VRF should not own (i.e. cannot accept packets destined to) the dest IP inactive interfaces. Forwarding
-       * analysis will consider these IPs to be internal to (or owned by) the network, but not owned by any particular
-       * device or link.
-       */
-      Map<String, Map<String, IpSpace>> vrfOwnedIpSpaces =
-          TopologyUtil.computeVrfOwnedIpSpaces(
-              TopologyUtil.computeIpVrfOwners(true, TopologyUtil.computeNodeInterfaces(configs)));
-
+      // Iterate over configs because we want all node/vrf keys to be present in the map
       return toImmutableMap(
           configs,
           Entry::getKey,
@@ -1609,7 +1602,7 @@ public final class BDDReachabilityAnalysisFactory {
                   nodeEntry.getValue().getVrfs(),
                   Entry::getKey,
                   vrfEntry ->
-                      vrfOwnedIpSpaces
+                      acceptIps
                           .getOrDefault(nodeEntry.getKey(), ImmutableMap.of())
                           .getOrDefault(vrfEntry.getKey(), EmptyIpSpace.INSTANCE)
                           .accept(ipSpaceToBDD)));

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -1,10 +1,8 @@
 package org.batfish.dataplane.ibdp;
 
-import static org.batfish.common.topology.TopologyUtil.computeIpNodeOwners;
-import static org.batfish.common.topology.TopologyUtil.computeIpVrfOwners;
+import static org.batfish.common.topology.IpOwners.computeIpNodeOwners;
 import static org.batfish.common.topology.TopologyUtil.computeLayer2Topology;
 import static org.batfish.common.topology.TopologyUtil.computeLayer3Topology;
-import static org.batfish.common.topology.TopologyUtil.computeNodeInterfaces;
 import static org.batfish.common.topology.TopologyUtil.computeRawLayer3Topology;
 import static org.batfish.common.util.CollectionUtil.toImmutableSortedMap;
 import static org.batfish.common.util.IpsecUtil.retainReachableIpsecEdges;
@@ -81,8 +79,6 @@ class IncrementalBdpEngine {
 
       // TODO: switch to topologies and owners from TopologyProvider
       Map<Ip, Set<String>> ipOwners = computeIpNodeOwners(configurations, true);
-      Map<Ip, Map<String, Set<String>>> ipVrfOwners =
-          computeIpVrfOwners(true, computeNodeInterfaces(configurations));
       TopologyContext initialTopologyContext =
           callerTopologyContext
               .toBuilder()
@@ -128,7 +124,6 @@ class IncrementalBdpEngine {
           computeFibs(nodes);
           IncrementalDataPlane partialDataplane =
               dpBuilder
-                  .setIpVrfOwners(ipVrfOwners)
                   .setNodes(nodes)
                   .setLayer3Topology(currentTopologyContext.getLayer3Topology())
                   .build();
@@ -215,7 +210,6 @@ class IncrementalBdpEngine {
           IncrementalDataPlane.builder()
               .setNodes(nodes)
               .setLayer3Topology(currentTopologyContext.getLayer3Topology())
-              .setIpVrfOwners(ipVrfOwners)
               .build();
       _bfLogger.printElapsedTime();
       return new ComputeDataPlaneResult(answerElement, finalDataplane, currentTopologyContext);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -24,7 +24,6 @@ import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.ForwardingAnalysis;
 import org.batfish.datamodel.ForwardingAnalysisImpl;
 import org.batfish.datamodel.GenericRib;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.VniSettings;
@@ -33,14 +32,8 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
 
   public static class Builder {
 
-    private Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
     private Map<String, Node> _nodes;
     private Topology _layer3Topology;
-
-    public Builder setIpVrfOwners(Map<Ip, Map<String, Set<String>>> ipVrfOwners) {
-      _ipVrfOwners = ImmutableMap.copyOf(ipVrfOwners);
-      return this;
-    }
 
     public Builder setNodes(Map<String, Node> nodes) {
       _nodes = ImmutableMap.copyOf(nodes);
@@ -97,8 +90,6 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
   private final Supplier<ForwardingAnalysis> _forwardingAnalysis =
       Suppliers.memoize(new ForwardingAnalysisSupplier());
 
-  private final Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
-
   private final Map<String, Node> _nodes;
 
   private final Topology _layer3Topology;
@@ -111,7 +102,6 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
   @Nonnull private final Table<String, String, Set<VniSettings>> _vniSettings;
 
   private IncrementalDataPlane(Builder builder) {
-    _ipVrfOwners = builder._ipVrfOwners;
     _nodes = builder._nodes;
     _layer3Topology = builder._layer3Topology;
     _bgpRoutes = computeBgpRoutes();
@@ -215,11 +205,6 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
   @Override
   public ForwardingAnalysis getForwardingAnalysis() {
     return _forwardingAnalysis.get();
-  }
-
-  @Override
-  public Map<Ip, Map<String, Set<String>>> getIpVrfOwners() {
-    return _ipVrfOwners;
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -443,7 +443,7 @@ class FlowTracer {
     Ip dstIp = _currentFlow.getDstIp();
 
     // Accept if the flow is destined for this vrf on this host.
-    if (_tracerouteContext.ownsIp(currentNodeName, _vrfName, dstIp)) {
+    if (_tracerouteContext.acceptsIp(currentNodeName, _vrfName, dstIp)) {
       buildAcceptTrace();
       return;
     }
@@ -489,7 +489,7 @@ class FlowTracer {
 
         // Accept if the flow is destined for this vrf on this host.
         String currentNodeName = _currentNode.getName();
-        if (_tracerouteContext.ownsIp(currentNodeName, _vrfName, dstIp)) {
+        if (_tracerouteContext.acceptsIp(currentNodeName, _vrfName, dstIp)) {
           buildAcceptTrace();
           return true;
         }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -5,7 +5,6 @@ import static org.batfish.dataplane.traceroute.TracerouteUtils.buildSessionsByIn
 import static org.batfish.dataplane.traceroute.TracerouteUtils.validateInputs;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,6 +20,7 @@ import javax.annotation.Nonnull;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
@@ -159,12 +159,16 @@ public class TracerouteEngineImplContext {
     return _sessionsByIngressInterface.get(new NodeInterfacePair(node, inputIface));
   }
 
-  boolean ownsIp(String node, String vrf, Ip ip) {
-    return _dataPlane
-        .getIpVrfOwners()
-        .getOrDefault(ip, ImmutableMap.of())
-        .getOrDefault(node, ImmutableSet.of())
-        .contains(vrf);
+  /**
+   * Whether {@code vrf} at {@code node} will accept (NB: not forward) packets destined for {@code
+   * ip}
+   */
+  boolean acceptsIp(String node, String vrf, Ip ip) {
+    return _forwardingAnalysis
+        .getAcceptsIps()
+        .getOrDefault(node, ImmutableMap.of())
+        .getOrDefault(vrf, EmptyIpSpace.INSTANCE)
+        .containsIp(ip, ImmutableMap.of());
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/grammar/routing_table/eos/EosRoutingTableExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/routing_table/eos/EosRoutingTableExtractor.java
@@ -12,7 +12,7 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.common.topology.TopologyUtil;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
@@ -64,7 +64,7 @@ public class EosRoutingTableExtractor extends EosRoutingTableParserBaseListener
     _parser = parser;
     _w = w;
     Map<String, Configuration> configurations = batfish.loadConfigurations();
-    _ipOwners = TopologyUtil.computeIpNodeOwners(configurations, true);
+    _ipOwners = IpOwners.computeIpNodeOwners(configurations, true);
   }
 
   private BatfishException convError(Class<?> type, ParserRuleContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/routing_table/ios/IosRoutingTableExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/routing_table/ios/IosRoutingTableExtractor.java
@@ -15,7 +15,7 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.common.topology.TopologyUtil;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
@@ -68,7 +68,7 @@ public class IosRoutingTableExtractor extends IosRoutingTableParserBaseListener
     _parser = parser;
     _w = w;
     Map<String, Configuration> configurations = batfish.loadConfigurations();
-    _ipOwners = TopologyUtil.computeIpNodeOwners(configurations, true);
+    _ipOwners = IpOwners.computeIpNodeOwners(configurations, true);
   }
 
   private BatfishException convError(Class<?> type, ParserRuleContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/routing_table/nxos/NxosRoutingTableExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/routing_table/nxos/NxosRoutingTableExtractor.java
@@ -12,7 +12,7 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.common.topology.TopologyUtil;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
@@ -67,7 +67,7 @@ public class NxosRoutingTableExtractor extends NxosRoutingTableParserBaseListene
     _parser = parser;
     _w = w;
     Map<String, Configuration> configurations = batfish.loadConfigurations();
-    _ipOwners = TopologyUtil.computeIpNodeOwners(configurations, true);
+    _ipOwners = IpOwners.computeIpNodeOwners(configurations, true);
   }
 
   private BatfishException convError(Class<?> type, ParserRuleContext ctx) {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -1,6 +1,6 @@
 package org.batfish.dataplane.ibdp;
 
-import static org.batfish.common.topology.TopologyUtil.computeIpNodeOwners;
+import static org.batfish.common.topology.IpOwners.computeIpNodeOwners;
 import static org.batfish.common.topology.TopologyUtil.synthesizeL3Topology;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.bgp.BgpTopologyUtils.initBgpTopology;

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
@@ -1,6 +1,6 @@
 package org.batfish.dataplane.ibdp.schedule;
 
-import static org.batfish.common.topology.TopologyUtil.computeIpNodeOwners;
+import static org.batfish.common.topology.IpOwners.computeIpNodeOwners;
 import static org.batfish.datamodel.bgp.BgpTopologyUtils.initBgpTopology;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -271,7 +271,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.common.WellKnownCommunity;
-import org.batfish.common.topology.TopologyUtil;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.common.util.IpsecUtil;
 import org.batfish.config.Settings;
@@ -3473,7 +3473,7 @@ public class CiscoGrammarTest {
                 .build(),
             _folder);
     Map<String, Configuration> configurations = batfish.loadConfigurations();
-    Map<Ip, Set<String>> ipOwners = TopologyUtil.computeIpNodeOwners(configurations, true);
+    Map<Ip, Set<String>> ipOwners = IpOwners.computeIpNodeOwners(configurations, true);
     ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
         BgpTopologyUtils.initBgpTopology(configurations, ipOwners, false, null).getGraph();
 

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -37,10 +37,10 @@ import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.common.topology.Layer1Edge;
 import org.batfish.common.topology.Layer1Node;
 import org.batfish.common.topology.Layer1Topology;
-import org.batfish.common.topology.TopologyUtil;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -277,7 +277,7 @@ public class BatfishTest {
                 .build(),
             _folder);
     Map<String, Configuration> configurations = batfish.loadConfigurations();
-    Map<Ip, Set<String>> ipOwners = TopologyUtil.computeIpNodeOwners(configurations, true);
+    Map<Ip, Set<String>> ipOwners = IpOwners.computeIpNodeOwners(configurations, true);
     assertThat(ipOwners.get(vrrpAddress), equalTo(Collections.singleton("r2")));
   }
 
@@ -450,7 +450,7 @@ public class BatfishTest {
         configs.get("host1").getAllInterfaces().get("Vlan65").getVrrpGroups().keySet(), hasSize(1));
 
     // Tests that computing IP owners with such a bad interface does not crash.
-    TopologyUtil.computeIpNodeOwners(configs, false);
+    IpOwners.computeIpNodeOwners(configs, false);
   }
 
   @Test

--- a/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/VIModelQuestionPlugin.java
@@ -25,10 +25,10 @@ import javax.annotation.Nullable;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.Plugin;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.topology.Layer2Topology;
 import org.batfish.common.topology.Layer3Edge;
-import org.batfish.common.topology.TopologyUtil;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
 import org.batfish.datamodel.BgpSessionProperties;
@@ -186,7 +186,7 @@ public class VIModelQuestionPlugin extends QuestionPlugin {
       SortedMap<String, Configuration> configs = _batfish.loadConfigurations();
       Topology topology =
           _batfish.getTopologyProvider().getInitialLayer3Topology(_batfish.getNetworkSnapshot());
-      Map<Ip, Set<String>> ipOwners = TopologyUtil.computeIpNodeOwners(configs, true);
+      Map<Ip, Set<String>> ipOwners = IpOwners.computeIpNodeOwners(configs, true);
       Layer2Topology layer2Topology =
           _batfish
               .getTopologyProvider()

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswerer.java
@@ -30,8 +30,8 @@ import javax.annotation.Nonnull;
 import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
 import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.common.topology.Layer2Topology;
-import org.batfish.common.topology.TopologyUtil;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
@@ -129,7 +129,7 @@ public class BgpSessionCompatibilityAnswerer extends Answerer {
             .getTopologyProvider()
             .getInitialLayer2Topology(_batfish.getNetworkSnapshot())
             .orElse(null);
-    Map<Ip, Set<String>> ipOwners = TopologyUtil.computeIpNodeOwners(configurations, true);
+    Map<Ip, Set<String>> ipOwners = IpOwners.computeIpNodeOwners(configurations, true);
     ValueGraph<BgpPeerConfigId, BgpSessionProperties> configuredTopology =
         BgpTopologyUtils.initBgpTopology(configurations, ipOwners, true, layer2Topology).getGraph();
 

--- a/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusAnswerer.java
@@ -32,8 +32,8 @@ import javax.annotation.Nonnull;
 import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
 import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.common.topology.Layer2Topology;
-import org.batfish.common.topology.TopologyUtil;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPassivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
@@ -129,7 +129,7 @@ public class BgpSessionStatusAnswerer extends Answerer {
     Set<String> nodes = question.getNodeSpecifier().resolve(_batfish.specifierContext());
     Set<String> remoteNodes =
         question.getRemoteNodeSpecifier().resolve(_batfish.specifierContext());
-    Map<Ip, Set<String>> ipOwners = TopologyUtil.computeIpNodeOwners(configurations, true);
+    Map<Ip, Set<String>> ipOwners = IpOwners.computeIpNodeOwners(configurations, true);
     Layer2Topology layer2Topology =
         _batfish
             .getTopologyProvider()

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -16,12 +16,12 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.common.topology.Layer1Edge;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.topology.Layer2Edge;
 import org.batfish.common.topology.Layer2Topology;
 import org.batfish.common.topology.TopologyProvider;
-import org.batfish.common.topology.TopologyUtil;
 import org.batfish.common.util.IpsecUtil;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
@@ -132,7 +132,7 @@ public class EdgesAnswerer extends Answerer {
       Set<String> includeRemoteNodes,
       EdgeType edgeType,
       boolean initial) {
-    Map<Ip, Set<String>> ipOwners = TopologyUtil.computeIpNodeOwners(configurations, true);
+    Map<Ip, Set<String>> ipOwners = IpOwners.computeIpNodeOwners(configurations, true);
     TopologyProvider topologyProvider = _batfish.getTopologyProvider();
     switch (edgeType) {
       case BGP:

--- a/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/ipowners/IpOwnersAnswerer.java
@@ -1,5 +1,7 @@
 package org.batfish.question.ipowners;
 
+import static org.batfish.common.topology.TopologyUtil.computeNodeInterfaces;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
@@ -10,7 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.common.topology.TopologyUtil;
+import org.batfish.common.topology.IpOwners;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
@@ -39,8 +41,8 @@ class IpOwnersAnswerer extends Answerer {
   public AnswerElement answer() {
     IpOwnersQuestion question = (IpOwnersQuestion) _question;
     Map<String, Configuration> configurations = _batfish.loadConfigurations();
-    Map<Ip, Set<String>> ipNodeOwners = TopologyUtil.computeIpNodeOwners(configurations, false);
-    Map<String, Set<Interface>> interfaces = TopologyUtil.computeNodeInterfaces(configurations);
+    Map<Ip, Set<String>> ipNodeOwners = IpOwners.computeIpNodeOwners(configurations, false);
+    Map<String, Set<Interface>> interfaces = computeNodeInterfaces(configurations);
 
     TableAnswerElement answerElement = new TableAnswerElement(getTableMetadata());
 

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswerer.java
@@ -1,6 +1,6 @@
 package org.batfish.question.routes;
 
-import static org.batfish.common.topology.TopologyUtil.computeIpNodeOwners;
+import static org.batfish.common.topology.IpOwners.computeIpNodeOwners;
 import static org.batfish.datamodel.table.TableDiff.COL_BASE_PREFIX;
 import static org.batfish.datamodel.table.TableDiff.COL_DELTA_PREFIX;
 import static org.batfish.question.routes.RoutesAnswererUtil.getAbstractRouteRowsDiff;


### PR DESCRIPTION
* Move a bunch of logic away from TopologyUtil to IpOwners
* Setup FA to compute VRF-owned IPs spaces, prep for additionalAcceptIps in a VRF
* Use the map returned by FA in Reachability and traceroute
* Cleanup DP interface -- no more ipVrfOwners

Just FYI this work was kicked off because of #4231 