### PR TITLE
don't push enums into the parser rules

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/CommonParser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/CommonParser.java
@@ -109,6 +109,11 @@ public abstract class CommonParser extends BaseParser<AstNode> {
     return CharRange('@', '@');
   }
 
+  /** See class JavaDoc for why this is a CharRange and not Ch */
+  public Rule Dash() {
+    return CharRange('-', '-');
+  }
+
   /** [0-9] */
   public Rule Digit() {
     return CharRange('0', '9');
@@ -117,6 +122,16 @@ public abstract class CommonParser extends BaseParser<AstNode> {
   /** See class JavaDoc for why this is a CharRange and not Ch */
   public Rule Dot() {
     return CharRange('.', '.');
+  }
+
+  /**
+   * A rule for valid enum values. Start with an alphabet character or underscore, and additionally
+   * only contain digits and dashes.
+   */
+  public Rule EnumValue() {
+    return Sequence(
+        FirstOf(AlphabetChar(), Underscore()),
+        ZeroOrMore(FirstOf(AlphabetChar(), Underscore(), Number(), Dash())));
   }
 
   /** See class JavaDoc for why this is a CharRange and not Ch */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/CommonParser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/CommonParser.java
@@ -4,16 +4,12 @@ import static org.batfish.datamodel.Names.SPECIAL_CHARS;
 import static org.batfish.specifier.parboiled.Anchor.Type.OPERATOR_END;
 import static org.batfish.specifier.parboiled.Anchor.Type.STRING_LITERAL;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.IpProtocol;
 import org.batfish.specifier.parboiled.Anchor.Type;
 import org.parboiled.BaseParser;
 import org.parboiled.Parboiled;
@@ -83,23 +79,9 @@ public abstract class CommonParser extends BaseParser<AstNode> {
     }
   }
 
-  /** Initialize an array of rules that match known IpProtocol names */
-  Rule[] initIpProtocolNameRules() {
-    return initValuesRules(
-        Arrays.stream(IpProtocol.values())
-            // allow UNNAMED as well since PacketHeaderConstraints is "canonicalizing" the input
-            // .filter(p -> !p.toString().startsWith("UNNAMED"))
-            .collect(ImmutableList.toImmutableList()));
-  }
-
   /** Initialize an array of case-insenstive rules that match stringified values in a collection. */
   <T> Rule[] initValuesRules(Collection<T> values) {
-    return values.stream()
-        .map(Objects::toString)
-        // longer strings first so that we can match 'longer' instead of stopping at 'long'
-        .sorted(Comparator.comparing(String::length).reversed())
-        .map(this::IgnoreCase)
-        .toArray(Rule[]::new);
+    return values.stream().map(Objects::toString).map(this::IgnoreCase).toArray(Rule[]::new);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/CommonParser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/CommonParser.java
@@ -131,7 +131,7 @@ public abstract class CommonParser extends BaseParser<AstNode> {
   public Rule EnumValue() {
     return Sequence(
         FirstOf(AlphabetChar(), Underscore()),
-        ZeroOrMore(FirstOf(AlphabetChar(), Underscore(), Number(), Dash())));
+        ZeroOrMore(FirstOf(AlphabetChar(), Underscore(), Digit(), Dash())));
   }
 
   /** See class JavaDoc for why this is a CharRange and not Ch */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/IpProtocolIpProtocolAstNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/IpProtocolIpProtocolAstNode.java
@@ -1,11 +1,21 @@
 package org.batfish.specifier.parboiled;
 
 import com.google.common.base.MoreObjects;
+import java.util.Arrays;
 import java.util.Objects;
 import org.batfish.datamodel.IpProtocol;
 
 final class IpProtocolIpProtocolAstNode implements IpProtocolAstNode {
   private final IpProtocol _ipProtocol;
+
+  static boolean isValidName(AstNode astNode) {
+    String name = ((StringAstNode) astNode).getStr();
+    return Arrays.stream(IpProtocol.values()).anyMatch(p -> p.toString().equalsIgnoreCase(name));
+  }
+
+  IpProtocolIpProtocolAstNode(AstNode astNode) {
+    this(((StringAstNode) astNode).getStr());
+  }
 
   IpProtocolIpProtocolAstNode(String nameOrNum) {
     _ipProtocol = IpProtocol.fromString(nameOrNum);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/IpProtocolIpProtocolAstNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/IpProtocolIpProtocolAstNode.java
@@ -8,13 +8,8 @@ import org.batfish.datamodel.IpProtocol;
 final class IpProtocolIpProtocolAstNode implements IpProtocolAstNode {
   private final IpProtocol _ipProtocol;
 
-  static boolean isValidName(AstNode astNode) {
-    String name = ((StringAstNode) astNode).getStr();
+  static boolean isValidName(String name) {
     return Arrays.stream(IpProtocol.values()).anyMatch(p -> p.toString().equalsIgnoreCase(name));
-  }
-
-  IpProtocolIpProtocolAstNode(AstNode astNode) {
-    this(((StringAstNode) astNode).getStr());
   }
 
   IpProtocolIpProtocolAstNode(String nameOrNum) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
@@ -23,6 +23,7 @@ import static org.batfish.specifier.parboiled.ParboiledAutoCompleteSuggestion.to
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,7 @@ import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.CompletionMetadata;
+import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.answers.AutoCompleteUtils;
 import org.batfish.datamodel.answers.AutocompleteSuggestion;
 import org.batfish.datamodel.collections.NodeInterfacePair;
@@ -229,6 +231,8 @@ public final class ParboiledAutoComplete {
       case IP_ADDRESS_MASK:
         // can't help with masks
         return ImmutableSet.of();
+      case IP_PROTOCOL_NAME:
+        return autoCompleteIpProtocolName(pm);
       case IP_PROTOCOL_NUMBER:
         // don't help with numbers
         return ImmutableSet.of();
@@ -310,6 +314,21 @@ public final class ParboiledAutoComplete {
                 .collect(ImmutableSet.toImmutableSet())),
         !matchPrefix.equals(pm.getMatchPrefix()),
         Anchor.Type.ENUM_SET_VALUE,
+        pm.getMatchStartIndex());
+  }
+
+  /** Auto completes ip protocol names. */
+  private Set<ParboiledAutoCompleteSuggestion> autoCompleteIpProtocolName(PotentialMatch pm) {
+    String matchPrefix = unescapeIfNeeded(pm.getMatchPrefix(), pm.getAnchorType());
+
+    return updateSuggestions(
+        AutoCompleteUtils.stringAutoComplete(
+            matchPrefix,
+            Arrays.stream(IpProtocol.values())
+                .map(Object::toString)
+                .collect(ImmutableSet.toImmutableSet())),
+        !matchPrefix.equals(pm.getMatchPrefix()),
+        Anchor.Type.IP_PROTOCOL_NAME,
         pm.getMatchStartIndex());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
@@ -304,30 +304,26 @@ public final class ParboiledAutoComplete {
 
   /** Auto completes enum set values. */
   private Set<ParboiledAutoCompleteSuggestion> autoCompleteEnumSetValue(PotentialMatch pm) {
-    String matchPrefix = unescapeIfNeeded(pm.getMatchPrefix(), pm.getAnchorType());
-
     return updateSuggestions(
         AutoCompleteUtils.stringAutoComplete(
-            matchPrefix,
+            pm.getMatchPrefix(),
             Grammar.getEnumValues(_grammar).stream()
                 .map(Object::toString)
                 .collect(ImmutableSet.toImmutableSet())),
-        !matchPrefix.equals(pm.getMatchPrefix()),
+        false,
         Anchor.Type.ENUM_SET_VALUE,
         pm.getMatchStartIndex());
   }
 
   /** Auto completes ip protocol names. */
   private Set<ParboiledAutoCompleteSuggestion> autoCompleteIpProtocolName(PotentialMatch pm) {
-    String matchPrefix = unescapeIfNeeded(pm.getMatchPrefix(), pm.getAnchorType());
-
     return updateSuggestions(
         AutoCompleteUtils.stringAutoComplete(
-            matchPrefix,
+            pm.getMatchPrefix(),
             Arrays.stream(IpProtocol.values())
                 .map(Object::toString)
                 .collect(ImmutableSet.toImmutableSet())),
-        !matchPrefix.equals(pm.getMatchPrefix()),
+        false,
         Anchor.Type.IP_PROTOCOL_NAME,
         pm.getMatchStartIndex());
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -181,9 +181,9 @@ public class Parser extends CommonParser {
   @Anchor(ENUM_SET_VALUE)
   public <T> Rule EnumSetValue(Collection<T> allValues) {
     return Sequence(
-        NameLiteral(),
-        ACTION(ValueEnumSetAstNode.isValidValue(peek(), allValues)),
-        push(new ValueEnumSetAstNode<T>(pop(), allValues)));
+        EnumValue(),
+        ACTION(ValueEnumSetAstNode.isValidValue(match(), allValues)),
+        push(new ValueEnumSetAstNode<>(match(), allValues)));
   }
 
   @Anchor(ENUM_SET_REGEX)
@@ -694,9 +694,9 @@ public class Parser extends CommonParser {
   @Anchor(IP_PROTOCOL_NAME)
   public Rule IpProtocolName() {
     return Sequence(
-        NameLiteral(),
-        ACTION(IpProtocolIpProtocolAstNode.isValidName(peek())),
-        push(new IpProtocolIpProtocolAstNode(pop())));
+        EnumValue(),
+        ACTION(IpProtocolIpProtocolAstNode.isValidName(match())),
+        push(new IpProtocolIpProtocolAstNode(match())));
   }
 
   @Anchor(IP_PROTOCOL_NUMBER)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ValueEnumSetAstNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ValueEnumSetAstNode.java
@@ -7,6 +7,10 @@ import java.util.Objects;
 final class ValueEnumSetAstNode<T> implements EnumSetAstNode {
   private final T _value;
 
+  ValueEnumSetAstNode(AstNode astNode, Collection<T> allValues) {
+    this(((StringAstNode) astNode).getStr(), allValues);
+  }
+
   ValueEnumSetAstNode(String stringValue, Collection<T> allValues) {
     // find the value in the collection and map to that
     _value =
@@ -15,6 +19,11 @@ final class ValueEnumSetAstNode<T> implements EnumSetAstNode {
             .findAny()
             .orElseThrow(
                 () -> new IllegalArgumentException("Value not found in allValues " + stringValue));
+  }
+
+  public static <T> boolean isValidValue(AstNode valueAst, Collection<T> allValues) {
+    String value = ((StringAstNode) valueAst).getStr();
+    return allValues.stream().anyMatch(p -> p.toString().equalsIgnoreCase(value));
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ValueEnumSetAstNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ValueEnumSetAstNode.java
@@ -7,10 +7,6 @@ import java.util.Objects;
 final class ValueEnumSetAstNode<T> implements EnumSetAstNode {
   private final T _value;
 
-  ValueEnumSetAstNode(AstNode astNode, Collection<T> allValues) {
-    this(((StringAstNode) astNode).getStr(), allValues);
-  }
-
   ValueEnumSetAstNode(String stringValue, Collection<T> allValues) {
     // find the value in the collection and map to that
     _value =
@@ -21,8 +17,7 @@ final class ValueEnumSetAstNode<T> implements EnumSetAstNode {
                 () -> new IllegalArgumentException("Value not found in allValues " + stringValue));
   }
 
-  public static <T> boolean isValidValue(AstNode valueAst, Collection<T> allValues) {
-    String value = ((StringAstNode) valueAst).getStr();
+  public static <T> boolean isValidValue(String value, Collection<T> allValues) {
     return allValues.stream().anyMatch(p -> p.toString().equalsIgnoreCase(value));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AutoCompleteUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AutoCompleteUtilsTest.java
@@ -1258,21 +1258,13 @@ public class AutoCompleteUtilsTest {
         equalTo(ImmutableSet.of("bgp", "ibgp", "ebgp")));
   }
 
-  /**
-   * This test is ignored. At the moment, bgp does not expand to those three desired values. The way
-   * EnumSetSpecifier is setup at the moment, it does not report ibgp and ebgp because bgp fully
-   * matches and we exit the rule.
-   *
-   * <p>TODO: change that behavior
-   */
-  @Ignore
   @Test
   public void testRoutingProtocolSpecAutocompleteFullName() {
     assertThat(
         AutoCompleteUtils.autoComplete(Type.ROUTING_PROTOCOL_SPEC, "bgp", 5).stream()
             .map(AutocompleteSuggestion::getText)
             .collect(Collectors.toSet()),
-        equalTo(ImmutableSet.of("bgp", "ibgp", "ebgp")));
+        equalTo(ImmutableSet.of(",", "bgp", "ibgp", "ebgp")));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/CommonParserTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/CommonParserTest.java
@@ -45,6 +45,39 @@ public class CommonParserTest {
   }
 
   @Test
+  public void testEnumValue() {
+    CommonParser parser = CommonParser.instance();
+    Rule rule = parser.input(parser.EnumValue());
+
+    // legal naked strings
+    assertTrue(matches("a", rule));
+    assertTrue(matches("A", rule));
+    assertTrue(matches("abc", rule));
+    assertTrue(matches("ABC", rule));
+    assertTrue(matches("_startUnderscore", rule));
+    assertTrue(matches("has9number", rule));
+    assertTrue(matches("has-dash", rule));
+
+    // illegal strings
+    assertFalse(matches("", rule)); // empty
+    assertFalse(matches("9numberstart", rule));
+    assertFalse(matches("-dashstart", rule));
+    assertFalse(matches("\"quoted\"", rule));
+    assertFalse(matches("has,", rule));
+    assertFalse(matches("has\\", rule));
+    assertFalse(matches("has&", rule));
+    assertFalse(matches("has(", rule));
+    assertFalse(matches("has)", rule));
+    assertFalse(matches("has[", rule));
+    assertFalse(matches("has]", rule));
+    assertFalse(matches("/startSlash", rule));
+    assertFalse(matches("@startAt", rule));
+    assertFalse(matches("", rule));
+    assertFalse(matches("\"", rule));
+    assertFalse(matches("\"\"", rule));
+  }
+
+  @Test
   public void testNameLiteral() {
     CommonParser parser = CommonParser.instance();
     Rule rule = parser.input(parser.NameLiteral());

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserEnumSetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserEnumSetTest.java
@@ -271,12 +271,15 @@ public class ParserEnumSetTest {
         getPAC("http", Grammar.APPLICATION_SPECIFIER).run(),
         containsInAnyOrder(
             new ParboiledAutoCompleteSuggestion(",", 4, Type.ENUM_SET_SET_OP),
+            new ParboiledAutoCompleteSuggestion(Protocol.HTTP.toString(), 0, Type.ENUM_SET_VALUE),
             new ParboiledAutoCompleteSuggestion(
                 Protocol.HTTPS.toString(), 0, Type.ENUM_SET_VALUE)));
 
     assertThat(
         getPAC("https", Grammar.APPLICATION_SPECIFIER).run(),
-        containsInAnyOrder(new ParboiledAutoCompleteSuggestion(",", 5, Type.ENUM_SET_SET_OP)));
+        containsInAnyOrder(
+            new ParboiledAutoCompleteSuggestion(Protocol.HTTPS.toString(), 0, Type.ENUM_SET_VALUE),
+            new ParboiledAutoCompleteSuggestion(",", 5, Type.ENUM_SET_SET_OP)));
   }
 
   /** Test that we auto complete properly when the query is a non-prefix substring */


### PR DESCRIPTION
pushing enum values into parser rules was generating a lot of pain, e.g., couldn't autocomplete bgp to ibgp. new strategy is to match all names in the parser, and then separately judge if the name is from the expected set. 