### PR TITLE
Add IPs in OSPF neighbor configs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfNeighborConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfNeighborConfig.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Ip;
 
 /** Configuration for one end of an OSPF adjacency */
 @ParametersAreNonnullByDefault
@@ -17,19 +18,22 @@ public final class OspfNeighborConfig implements Serializable {
   private static final String PROP_AREA = "area";
   private static final String PROP_HOSTNAME = "hostname";
   private static final String PROP_INTERFACE = "interface";
+  private static final String PROP_IP = "ip";
   private static final String PROP_PASSIVE = "passive";
   private static final String PROP_VRF = "vrf";
 
   private final long _area;
-  private final String _interfaceName;
+  @Nonnull private final String _interfaceName;
+  @Nonnull private final Ip _ip;
   private final boolean _isPassive;
-  private final String _hostname;
-  private final String _vrfName;
+  @Nonnull private final String _hostname;
+  @Nonnull private final String _vrfName;
 
   private OspfNeighborConfig(
-      long area, String interfaceName, boolean isPassive, String hostname, String vrfName) {
+      long area, String interfaceName, boolean isPassive, String hostname, String vrfName, Ip ip) {
     _area = area;
     _interfaceName = interfaceName;
+    _ip = ip;
     _isPassive = isPassive;
     _hostname = hostname;
     _vrfName = vrfName;
@@ -39,15 +43,17 @@ public final class OspfNeighborConfig implements Serializable {
   private static OspfNeighborConfig create(
       @Nullable @JsonProperty(PROP_AREA) Long area,
       @Nullable @JsonProperty(PROP_INTERFACE) String interfaceName,
+      @Nullable @JsonProperty(PROP_IP) Ip ip,
       @Nullable @JsonProperty(PROP_PASSIVE) Boolean passive,
       @Nullable @JsonProperty(PROP_HOSTNAME) String hostname,
       @Nullable @JsonProperty(PROP_VRF) String vrf) {
     checkArgument(area != null, "OspfNeighborConfig missing %s", PROP_AREA);
     checkArgument(interfaceName != null, "OspfNeighborConfig missing %s", PROP_INTERFACE);
+    checkArgument(ip != null, "OspfNeighborConfig missing %s", PROP_IP);
     checkArgument(hostname != null, "OspfNeighborConfig missing %s", PROP_HOSTNAME);
     checkArgument(vrf != null, "OspfNeighborConfig missing %s", PROP_VRF);
     return new OspfNeighborConfig(
-        area, interfaceName, firstNonNull(passive, Boolean.FALSE), hostname, vrf);
+        area, interfaceName, firstNonNull(passive, Boolean.FALSE), hostname, vrf, ip);
   }
 
   @JsonProperty(PROP_AREA)
@@ -59,6 +65,12 @@ public final class OspfNeighborConfig implements Serializable {
   @JsonProperty(PROP_INTERFACE)
   public String getInterfaceName() {
     return _interfaceName;
+  }
+
+  @Nonnull
+  @JsonProperty(PROP_IP)
+  public Ip getIp() {
+    return _ip;
   }
 
   @Nonnull
@@ -86,6 +98,7 @@ public final class OspfNeighborConfig implements Serializable {
   public static final class Builder {
     @Nullable private Long _area;
     @Nullable private String _interfaceName;
+    @Nullable private Ip _ip;
     @Nullable private Boolean _isPassive;
     @Nullable private String _hostname;
     @Nullable private String _vrfName;
@@ -99,6 +112,11 @@ public final class OspfNeighborConfig implements Serializable {
 
     public Builder setInterfaceName(@Nonnull String interfaceName) {
       this._interfaceName = interfaceName;
+      return this;
+    }
+
+    public Builder setIp(@Nonnull Ip ip) {
+      _ip = ip;
       return this;
     }
 
@@ -120,10 +138,11 @@ public final class OspfNeighborConfig implements Serializable {
     public OspfNeighborConfig build() {
       checkArgument(_area != null, "OspfNeighborConfig missing %s", PROP_AREA);
       checkArgument(_interfaceName != null, "OspfNeighborConfig missing %s", PROP_INTERFACE);
+      checkArgument(_ip != null, "OspfNeighborConfig missing %s", PROP_IP);
       checkArgument(_hostname != null, "OspfNeighborConfig missing %s", PROP_HOSTNAME);
       checkArgument(_vrfName != null, "OspfNeighborConfig missing %s", PROP_VRF);
       return new OspfNeighborConfig(
-          _area, _interfaceName, firstNonNull(_isPassive, Boolean.FALSE), _hostname, _vrfName);
+          _area, _interfaceName, firstNonNull(_isPassive, Boolean.FALSE), _hostname, _vrfName, _ip);
     }
   }
 
@@ -139,12 +158,13 @@ public final class OspfNeighborConfig implements Serializable {
     return _area == other._area
         && _isPassive == other._isPassive
         && Objects.equals(_interfaceName, other._interfaceName)
+        && Objects.equals(_ip, other._ip)
         && Objects.equals(_hostname, other._hostname)
         && Objects.equals(_vrfName, other._vrfName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_area, _interfaceName, _isPassive, _hostname, _vrfName);
+    return Objects.hash(_area, _interfaceName, _ip, _isPassive, _hostname, _vrfName);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfNeighborConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfNeighborConfigTest.java
@@ -7,6 +7,7 @@ import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.ospf.OspfNeighborConfig.Builder;
 import org.junit.Test;
 
@@ -19,11 +20,13 @@ public class OspfNeighborConfigTest {
             .setArea(1L)
             .setHostname("host")
             .setVrfName("vrf")
-            .setInterfaceName("Ethernet0");
+            .setInterfaceName("Ethernet0")
+            .setIp(Ip.parse("1.1.1.1"));
     new EqualsTester()
         .addEqualityGroup(builder.build(), builder.build())
         .addEqualityGroup(builder.setArea(2L).build())
         .addEqualityGroup(builder.setInterfaceName("Ethernet11").build())
+        .addEqualityGroup(builder.setIp(Ip.parse("2.2.2.2")))
         .addEqualityGroup(builder.setPassive(true).build())
         .addEqualityGroup(builder.setHostname("otherHost").build())
         .addEqualityGroup(builder.setVrfName("otherVRF").build())
@@ -37,6 +40,7 @@ public class OspfNeighborConfigTest {
         OspfNeighborConfig.builder()
             .setArea(1L)
             .setHostname("host")
+            .setIp(Ip.parse("1.1.1.1"))
             .setVrfName("vrf")
             .setInterfaceName("Ethernet0")
             .build();
@@ -49,6 +53,7 @@ public class OspfNeighborConfigTest {
         OspfNeighborConfig.builder()
             .setArea(1L)
             .setHostname("host")
+            .setIp(Ip.parse("1.1.1.1"))
             .setVrfName("vrf")
             .setInterfaceName("Ethernet0")
             .build();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -193,6 +193,7 @@ public class OspfRoutingProcessTest {
                         .setHostname(HOSTNAME)
                         .setVrfName(VRF_NAME)
                         .setInterfaceName(ACTIVE_IFACE_NAME)
+                        .setIp(ACTIVE_ADDR_1.getIp())
                         .setArea(0L)
                         .build()))
             .build();

--- a/projects/question/src/test/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswererTest.java
@@ -94,6 +94,7 @@ public class OspfSessionCompatibilityAnswererTest {
                     .setHostname("configuration_u")
                     .setInterfaceName("int_u")
                     .setVrfName("vrf_u")
+                    .setIp(Ip.parse("1.1.1.2"))
                     .build()))
         .build();
     nf.ospfProcessBuilder()
@@ -107,6 +108,7 @@ public class OspfSessionCompatibilityAnswererTest {
                     .setHostname("configuration_v")
                     .setInterfaceName("int_v")
                     .setVrfName("vrf_v")
+                    .setIp(Ip.parse("1.1.1.3"))
                     .build()))
         .build();
     _configurations =

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -2848,6 +2848,7 @@
                     "area" : 0,
                     "hostname" : "lhr-border-02",
                     "interface" : "Ethernet1/0",
+                    "ip" : "10.10.10.38",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -2855,6 +2856,7 @@
                     "area" : 0,
                     "hostname" : "lhr-border-02",
                     "interface" : "Ethernet1/1",
+                    "ip" : "10.10.10.46",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -2862,6 +2864,7 @@
                     "area" : 0,
                     "hostname" : "lhr-border-02",
                     "interface" : "Loopback0",
+                    "ip" : "10.10.255.8",
                     "passive" : true,
                     "vrf" : "default"
                   }

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -2383,6 +2383,7 @@
                   "area" : 1,
                   "hostname" : "as1border1",
                   "interface" : "GigabitEthernet0/0",
+                  "ip" : "1.0.1.1",
                   "passive" : false,
                   "vrf" : "default"
                 },
@@ -2390,6 +2391,7 @@
                   "area" : 1,
                   "hostname" : "as1border1",
                   "interface" : "Loopback0",
+                  "ip" : "1.1.1.1",
                   "passive" : true,
                   "vrf" : "default"
                 }

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -4710,6 +4710,7 @@
                     "area" : 1,
                     "hostname" : "as1border1",
                     "interface" : "GigabitEthernet0/0",
+                    "ip" : "1.0.1.1",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -4717,6 +4718,7 @@
                     "area" : 1,
                     "hostname" : "as1border1",
                     "interface" : "Loopback0",
+                    "ip" : "1.1.1.1",
                     "passive" : true,
                     "vrf" : "default"
                   }
@@ -6020,6 +6022,7 @@
                     "area" : 1,
                     "hostname" : "as1border2",
                     "interface" : "GigabitEthernet1/0",
+                    "ip" : "1.0.2.1",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -6027,6 +6030,7 @@
                     "area" : 1,
                     "hostname" : "as1border2",
                     "interface" : "Loopback0",
+                    "ip" : "1.2.2.2",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -6509,6 +6513,7 @@
                     "area" : 1,
                     "hostname" : "as1core1",
                     "interface" : "GigabitEthernet0/0",
+                    "ip" : "1.0.2.2",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -6516,6 +6521,7 @@
                     "area" : 1,
                     "hostname" : "as1core1",
                     "interface" : "GigabitEthernet1/0",
+                    "ip" : "1.0.1.2",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -6523,6 +6529,7 @@
                     "area" : 1,
                     "hostname" : "as1core1",
                     "interface" : "Loopback0",
+                    "ip" : "1.10.1.1",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -7805,6 +7812,7 @@
                     "area" : 1,
                     "hostname" : "as2border1",
                     "interface" : "GigabitEthernet1/0",
+                    "ip" : "2.12.11.1",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -7812,6 +7820,7 @@
                     "area" : 1,
                     "hostname" : "as2border1",
                     "interface" : "GigabitEthernet2/0",
+                    "ip" : "2.12.12.1",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -7819,6 +7828,7 @@
                     "area" : 1,
                     "hostname" : "as2border1",
                     "interface" : "Loopback0",
+                    "ip" : "2.1.1.1",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -9092,6 +9102,7 @@
                     "area" : 1,
                     "hostname" : "as2border2",
                     "interface" : "GigabitEthernet1/0",
+                    "ip" : "2.12.22.1",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -9099,6 +9110,7 @@
                     "area" : 1,
                     "hostname" : "as2border2",
                     "interface" : "GigabitEthernet2/0",
+                    "ip" : "2.12.21.1",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -9106,6 +9118,7 @@
                     "area" : 1,
                     "hostname" : "as2border2",
                     "interface" : "Loopback0",
+                    "ip" : "2.1.1.2",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -9771,6 +9784,7 @@
                     "area" : 1,
                     "hostname" : "as2core1",
                     "interface" : "GigabitEthernet0/0",
+                    "ip" : "2.12.11.2",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -9778,6 +9792,7 @@
                     "area" : 1,
                     "hostname" : "as2core1",
                     "interface" : "GigabitEthernet1/0",
+                    "ip" : "2.12.21.2",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -9785,6 +9800,7 @@
                     "area" : 1,
                     "hostname" : "as2core1",
                     "interface" : "GigabitEthernet2/0",
+                    "ip" : "2.23.11.2",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -9792,6 +9808,7 @@
                     "area" : 1,
                     "hostname" : "as2core1",
                     "interface" : "GigabitEthernet3/0",
+                    "ip" : "2.23.12.2",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -9799,6 +9816,7 @@
                     "area" : 1,
                     "hostname" : "as2core1",
                     "interface" : "Loopback0",
+                    "ip" : "2.1.2.1",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -10419,6 +10437,7 @@
                     "area" : 1,
                     "hostname" : "as2core2",
                     "interface" : "GigabitEthernet0/0",
+                    "ip" : "2.12.22.2",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -10426,6 +10445,7 @@
                     "area" : 1,
                     "hostname" : "as2core2",
                     "interface" : "GigabitEthernet1/0",
+                    "ip" : "2.12.12.2",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -10433,6 +10453,7 @@
                     "area" : 1,
                     "hostname" : "as2core2",
                     "interface" : "GigabitEthernet2/0",
+                    "ip" : "2.23.22.2",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -10440,6 +10461,7 @@
                     "area" : 1,
                     "hostname" : "as2core2",
                     "interface" : "GigabitEthernet3/0",
+                    "ip" : "2.23.21.2",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -10447,6 +10469,7 @@
                     "area" : 1,
                     "hostname" : "as2core2",
                     "interface" : "Loopback0",
+                    "ip" : "2.1.2.2",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -12249,6 +12272,7 @@
                     "area" : 1,
                     "hostname" : "as2dist1",
                     "interface" : "GigabitEthernet0/0",
+                    "ip" : "2.23.11.3",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -12256,6 +12280,7 @@
                     "area" : 1,
                     "hostname" : "as2dist1",
                     "interface" : "GigabitEthernet1/0",
+                    "ip" : "2.23.21.3",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -12263,6 +12288,7 @@
                     "area" : 1,
                     "hostname" : "as2dist1",
                     "interface" : "Loopback0",
+                    "ip" : "2.1.3.1",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -13075,6 +13101,7 @@
                     "area" : 1,
                     "hostname" : "as2dist2",
                     "interface" : "GigabitEthernet0/0",
+                    "ip" : "2.23.22.3",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -13082,6 +13109,7 @@
                     "area" : 1,
                     "hostname" : "as2dist2",
                     "interface" : "GigabitEthernet1/0",
+                    "ip" : "2.23.12.3",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -13089,6 +13117,7 @@
                     "area" : 1,
                     "hostname" : "as2dist2",
                     "interface" : "Loopback0",
+                    "ip" : "2.1.3.2",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -14272,6 +14301,7 @@
                     "area" : 1,
                     "hostname" : "as3border1",
                     "interface" : "GigabitEthernet0/0",
+                    "ip" : "3.0.1.1",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -14279,6 +14309,7 @@
                     "area" : 1,
                     "hostname" : "as3border1",
                     "interface" : "Loopback0",
+                    "ip" : "3.1.1.1",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -15386,6 +15417,7 @@
                     "area" : 1,
                     "hostname" : "as3border2",
                     "interface" : "GigabitEthernet1/0",
+                    "ip" : "3.0.2.1",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -15393,6 +15425,7 @@
                     "area" : 1,
                     "hostname" : "as3border2",
                     "interface" : "Loopback0",
+                    "ip" : "3.2.2.2",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -16033,6 +16066,7 @@
                     "area" : 1,
                     "hostname" : "as3core1",
                     "interface" : "GigabitEthernet0/0",
+                    "ip" : "3.0.2.2",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -16040,6 +16074,7 @@
                     "area" : 1,
                     "hostname" : "as3core1",
                     "interface" : "GigabitEthernet1/0",
+                    "ip" : "3.0.1.2",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -16047,6 +16082,7 @@
                     "area" : 1,
                     "hostname" : "as3core1",
                     "interface" : "Loopback0",
+                    "ip" : "3.10.1.1",
                     "passive" : false,
                     "vrf" : "default"
                   }

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -2936,6 +2936,7 @@
                     "area" : 0,
                     "hostname" : "asa_ospf",
                     "interface" : "blah",
+                    "ip" : "192.168.1.0",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -11637,6 +11638,7 @@
                     "area" : 0,
                     "hostname" : "cisco_ospf_multi_process",
                     "interface" : "Ethernet0/0",
+                    "ip" : "2.2.2.0",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -11695,6 +11697,7 @@
                     "area" : 0,
                     "hostname" : "cisco_ospf_multi_process",
                     "interface" : "Ethernet1/0",
+                    "ip" : "3.3.3.0",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -17957,6 +17960,7 @@
                     "area" : 0,
                     "hostname" : "host2",
                     "interface" : "Ethernet0",
+                    "ip" : "2.130.0.1",
                     "passive" : false,
                     "vrf" : "default"
                   },
@@ -17964,6 +17968,7 @@
                     "area" : 0,
                     "hostname" : "host2",
                     "interface" : "Ethernet1",
+                    "ip" : "2.131.0.1",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -19023,6 +19028,7 @@
                     "area" : 0,
                     "hostname" : "interfacemtu",
                     "interface" : "xe-0/0/0:0.0",
+                    "ip" : "10.1.2.3",
                     "passive" : false,
                     "vrf" : "default"
                   }
@@ -28794,6 +28800,7 @@
                     "area" : 1,
                     "hostname" : "nxos_ospf",
                     "interface" : "Ethernet0/0",
+                    "ip" : "1.1.1.2",
                     "passive" : false,
                     "vrf" : "default"
                   }


### PR DESCRIPTION
not modified `OspfNeighborConfigId` because one interface can only give rise to one `OspfNeighborConfig` so hostname, interface and vrf are enough to identify the OSPF neighbor config