### PR TITLE
ASA: allow service-object with implicit destination

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_common.g4
@@ -686,7 +686,7 @@ service_specifier_tcp_udp
       | TCP_UDP
       | UDP
    )
-   (SOURCE src_ps = port_specifier)? (DESTINATION dst_ps = port_specifier)?
+   (SOURCE src_ps = port_specifier)? (DESTINATION? dst_ps = port_specifier)?
 ;
 
 subrange

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1099,10 +1099,13 @@ public class CiscoGrammarTest {
     Flow flowIcmpPass = createIcmpFlow(IcmpType.ECHO_REQUEST);
     Flow flowIcmpFail = createIcmpFlow(IcmpType.ECHO_REPLY);
     Flow flowInlinePass1 = createFlow(IpProtocol.UDP, 1, 1234);
-    Flow flowInlinePass2 = createFlow(IpProtocol.UDP, 3020, 1); // cifs
+    Flow flowInlinePass2 = createFlow(IpProtocol.UDP, 1, 1235);
+    Flow flowInlinePass3 = createFlow(IpProtocol.UDP, 3, 1236);
+    Flow flowInlinePass4 = createFlow(IpProtocol.UDP, 3020, 1); // cifs
     Flow flowTcpPass = createFlow(IpProtocol.TCP, 65535, 1);
     Flow flowUdpPass = createFlow(IpProtocol.UDP, 65535, 1);
     Flow flowTcpFail = createFlow(IpProtocol.TCP, 65534, 1);
+    Flow flowUdpFail = createFlow(IpProtocol.UDP, 1, 1236);
 
     /* Confirm service objects have the correct number of referrers */
     assertThat(ccae, hasNumReferrers(filename, SERVICE_OBJECT, "OS_TCPUDP", 1));
@@ -1122,6 +1125,9 @@ public class CiscoGrammarTest {
     assertThat(c, hasIpAccessList(ogsAclName, not(accepts(flowTcpFail, null, c))));
     assertThat(c, hasIpAccessList(ogsAclName, accepts(flowInlinePass1, null, c)));
     assertThat(c, hasIpAccessList(ogsAclName, accepts(flowInlinePass2, null, c)));
+    assertThat(c, hasIpAccessList(ogsAclName, accepts(flowInlinePass3, null, c)));
+    assertThat(c, hasIpAccessList(ogsAclName, accepts(flowInlinePass4, null, c)));
+    assertThat(c, hasIpAccessList(ogsAclName, not(accepts(flowUdpFail, null, c))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/asa-service-object
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/asa-service-object
@@ -11,6 +11,8 @@ object service OS_ICMP
 object-group service OGS1
  service-object object OS_TCPUDP
  service-object udp destination eq 1234
+ service-object udp eq 1235              ! destination is optional on command entry
+ service-object udp source eq 3 eq 1236  ! .. even if source is present
  service-object udp source eq cifs
 !
 object-group service OGS_UNDEF

--- a/tests/parsing-tests/networks/unit-tests/configs/asa_object_groups
+++ b/tests/parsing-tests/networks/unit-tests/configs/asa_object_groups
@@ -8,5 +8,8 @@ object network server02
 !
 object network range-10.0.0.10-20
   range 10.0.0.10 10.0.0.20
+!
+object-group service service-ssh
+  service-object tcp eq ssh
 
 access-list ALLOW_SERVER02 extended permit tcp any object server02

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -149,7 +149,7 @@
         "Source_Lines" : {
           "filename" : "configs/asa_object_groups",
           "lines" : [
-            12
+            15
           ]
         }
       },
@@ -161,6 +161,17 @@
           "lines" : [
             9,
             10
+          ]
+        }
+      },
+      {
+        "Structure_Type" : "object-group service",
+        "Structure_Name" : "service-ssh",
+        "Source_Lines" : {
+          "filename" : "configs/asa_object_groups",
+          "lines" : [
+            12,
+            13
           ]
         }
       },
@@ -3688,10 +3699,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 249 results",
+      "notes" : "Found 250 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 249
+      "numResults" : 250
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -2762,6 +2762,33 @@
             ],
             "sourceName" : "ALLOW_SERVER02",
             "sourceType" : "extended ipv4 access-list"
+          },
+          "~SERVICE_OBJECT_GROUP~service-ssh~" : {
+            "name" : "~SERVICE_OBJECT_GROUP~service-ssh~",
+            "lines" : [
+              {
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.OrMatchExpr",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "dstPorts" : [
+                          "22-22"
+                        ],
+                        "ipProtocols" : [
+                          "TCP"
+                        ],
+                        "negate" : false
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "sourceName" : "service-ssh",
+            "sourceType" : "object-group service"
           }
         },
         "ipSpaceMetadata" : {

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -8210,6 +8210,24 @@
             "          RANGE:'range'",
             "          IP_ADDRESS:'10.0.0.10'",
             "          end = IP_ADDRESS:'10.0.0.20'",
+            "          NEWLINE:'\\n'))))",
+            "  (stanza",
+            "    (s_object_group",
+            "      OBJECT_GROUP:'object-group'",
+            "      (og_service",
+            "        SERVICE:'service'  <== mode:M_ObjectGroup",
+            "        name = (variable_group_id",
+            "          VARIABLE:'service-ssh')",
+            "        NEWLINE:'\\n'",
+            "        (ogs_service_object",
+            "          SERVICE_OBJECT:'service-object'",
+            "          (service_specifier",
+            "            (service_specifier_tcp_udp",
+            "              TCP:'tcp'",
+            "              dst_ps = (port_specifier",
+            "                EQ:'eq'",
+            "                (port",
+            "                  SSH:'ssh'))))",
             "          NEWLINE:'\\n\\n'))))",
             "  (stanza",
             "    (extended_access_list_stanza",
@@ -77571,7 +77589,7 @@
           "extended ipv4 access-list" : {
             "ALLOW_SERVER02" : {
               "definitionLines" : [
-                12
+                15
               ],
               "numReferrers" : 0
             }
@@ -77590,6 +77608,15 @@
                 7
               ],
               "numReferrers" : 1
+            }
+          },
+          "object-group service" : {
+            "service-ssh" : {
+              "definitionLines" : [
+                12,
+                13
+              ],
+              "numReferrers" : 0
             }
           }
         },
@@ -85177,7 +85204,7 @@
           "object network" : {
             "server02" : {
               "extended access-list network object" : [
-                12
+                15
               ]
             }
           }


### PR DESCRIPTION
Though it will show with "definition", ASA at least 9.7(1) allows you to skip
that clause when defining service objects:

If you enter this:

    object-group service service-ssh
     service-object tcp eq ssh
     service-object tcp source eq www eq ftp

It will be acceped and show as this:

    object-group service service-ssh
     service-object tcp destination eq ssh
     service-object tcp source eq www destination eq ftp