### PR TITLE
Re-add "plain" tunnels in post-DP L3 topology

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyContainer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyContainer.java
@@ -33,4 +33,8 @@ public interface TopologyContainer {
 
   @Nonnull
   VxlanTopology getVxlanTopology();
+
+  /** See {@link TunnelTopology} */
+  @Nonnull
+  TunnelTopology getTunnelTopology();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyProvider.java
@@ -134,4 +134,7 @@ public interface TopologyProvider {
    */
   @Nonnull
   VxlanTopology getVxlanTopology(NetworkSnapshot snapshot);
+
+  @Nonnull
+  TunnelTopology getInitialTunnelTopology(NetworkSnapshot snapshot);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -23,17 +23,22 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.common.plugin.TracerouteEngine;
+import org.batfish.common.topology.TunnelTopology.Builder;
 import org.batfish.common.util.CollectionUtil;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.InterfaceType;
@@ -45,6 +50,7 @@ import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.VniSettings;
 import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.flow.TraceAndReverseFlow;
 import org.batfish.datamodel.ipsec.IpsecTopology;
 import org.batfish.datamodel.vxlan.VxlanNode;
 import org.batfish.datamodel.vxlan.VxlanTopology;
@@ -557,6 +563,55 @@ public final class TopologyUtil {
    * <p>Ignores {@code Loopback} interfaces and inactive interfaces.
    */
   public static Topology synthesizeL3Topology(Map<String, Configuration> configurations) {
+    Map<Prefix, List<Interface>> prefixInterfaces = computeInterfacesBucketByPrefix(configurations);
+
+    ImmutableSortedSet.Builder<Edge> edges = ImmutableSortedSet.naturalOrder();
+    for (Entry<Prefix, List<Interface>> bucketEntry : prefixInterfaces.entrySet()) {
+      Prefix p = bucketEntry.getKey();
+      Set<Interface> candidateInterfaces = candidateInterfacesForPrefix(prefixInterfaces, p);
+
+      for (Interface iface1 : bucketEntry.getValue()) {
+        for (Interface iface2 : candidateInterfaces) {
+          // No device self-adjacencies in the same VRF.
+          if (!isValidLayer3Adjacency(iface1, iface2)) {
+            continue;
+          }
+          // Additionally, don't connect if any of the two endpoint interfaces have Tunnel or VPN
+          // interfaceTypes
+          if (TUNNEL_INTERFACE_TYPES.contains(iface1.getInterfaceType())
+              || TUNNEL_INTERFACE_TYPES.contains(iface2.getInterfaceType())) {
+            continue;
+          }
+          edges.add(new Edge(iface1, iface2));
+        }
+      }
+    }
+    return new Topology(edges.build());
+  }
+
+  /**
+   * Collect all interfaces that have subnets overlapping P iff they have an IP address in P. Use an
+   * IdentityHashSet to prevent duplicates.
+   */
+  @Nonnull
+  private static Set<Interface> candidateInterfacesForPrefix(
+      Map<Prefix, List<Interface>> prefixBuckets, Prefix p) {
+    Set<Interface> candidateInterfaces = Sets.newIdentityHashSet();
+    IntStream.range(0, Prefix.MAX_PREFIX_LENGTH)
+        .mapToObj(
+            i -> prefixBuckets.getOrDefault(Prefix.create(p.getStartIp(), i), ImmutableList.of()))
+        .flatMap(Collection::stream)
+        .filter(
+            iface ->
+                iface.getAllConcreteAddresses().stream().anyMatch(ia -> p.containsIp(ia.getIp())))
+        .forEach(candidateInterfaces::add);
+    return candidateInterfaces;
+  }
+
+  /** Bucket Interfaces that are not loopbacks and not /32s by their prefix */
+  @Nonnull
+  private static Map<Prefix, List<Interface>> computeInterfacesBucketByPrefix(
+      Map<String, Configuration> configurations) {
     Map<Prefix, List<Interface>> prefixInterfaces = new HashMap<>();
     configurations.forEach(
         (nodeName, node) -> {
@@ -575,47 +630,20 @@ public final class TopologyUtil {
             }
           }
         });
+    return prefixInterfaces;
+  }
 
-    ImmutableSortedSet.Builder<Edge> edges = ImmutableSortedSet.naturalOrder();
-    for (Entry<Prefix, List<Interface>> bucketEntry : prefixInterfaces.entrySet()) {
-      Prefix p = bucketEntry.getKey();
-
-      // Collect all interfaces that have subnets overlapping P iff they have an IP address in P.
-      // Use an IdentityHashSet to prevent duplicates.
-      Set<Interface> candidateInterfaces = Sets.newIdentityHashSet();
-      IntStream.range(0, Prefix.MAX_PREFIX_LENGTH)
-          .mapToObj(
-              i ->
-                  prefixInterfaces.getOrDefault(
-                      Prefix.create(p.getStartIp(), i), ImmutableList.of()))
-          .flatMap(Collection::stream)
-          .filter(
-              iface ->
-                  iface.getAllConcreteAddresses().stream().anyMatch(ia -> p.containsIp(ia.getIp())))
-          .forEach(candidateInterfaces::add);
-
-      for (Interface iface1 : bucketEntry.getValue()) {
-        for (Interface iface2 : candidateInterfaces) {
-          // No device self-adjacencies in the same VRF.
-          if (iface1.getOwner() == iface2.getOwner()
-              && iface1.getVrfName().equals(iface2.getVrfName())) {
-            continue;
-          }
-
-          // Don't connect interfaces that have any IP address in common
-          if (haveIpInCommon(iface1, iface2)) {
-            continue;
-          }
-          // don't connect if any of the two endpoint interfaces have Tunnel or VPN interfaceTypes
-          if (TUNNEL_INTERFACE_TYPES.contains(iface1.getInterfaceType())
-              || TUNNEL_INTERFACE_TYPES.contains(iface2.getInterfaceType())) {
-            continue;
-          }
-          edges.add(new Edge(iface1, iface2));
-        }
-      }
+  /**
+   * Check if the link between two given interfaces is a valid layer 3 edge (e.g., not a self loop,
+   * doesn't have overlapping IPs)
+   */
+  private static boolean isValidLayer3Adjacency(Interface iface1, Interface iface2) {
+    // No device self-adjacencies in the same VRF.
+    if (iface1.getOwner() == iface2.getOwner() && iface1.getVrfName().equals(iface2.getVrfName())) {
+      return false;
     }
-    return new Topology(edges.build());
+    // Don't connect interfaces that have any IP address in common
+    return !haveIpInCommon(iface1, iface2);
   }
 
   public static @Nonnull Layer1Topology computeLayer1LogicalTopology(
@@ -625,5 +653,93 @@ public final class TopologyUtil {
             .map(pEdge -> pEdge.toLogicalEdge(NetworkConfigurations.of(configurations)))
             .filter(Objects::nonNull)
             .collect(ImmutableSet.toImmutableSet()));
+  }
+
+  /**
+   * Compute candidate tunnel topology (see {@link TunnelTopology} for definition). Includes all
+   * possibly valid edges (according to IP addresse and interface types), but not verified using
+   * reachability checks.
+   */
+  @Nonnull
+  public static TunnelTopology computeInitialTunnelTopology(
+      Map<String, Configuration> configurations) {
+    Map<Prefix, List<Interface>> prefixInterfaces = computeInterfacesBucketByPrefix(configurations);
+    TunnelTopology.Builder builder = TunnelTopology.builder();
+    for (Entry<Prefix, List<Interface>> bucketEntry : prefixInterfaces.entrySet()) {
+      Prefix p = bucketEntry.getKey();
+      Set<Interface> candidateInterfaces = candidateInterfacesForPrefix(prefixInterfaces, p);
+
+      for (Interface iface1 : bucketEntry.getValue()) {
+        for (Interface iface2 : candidateInterfaces) {
+          if (!isValidLayer3Adjacency(iface1, iface2)) {
+            continue;
+          }
+
+          // connect only if of both of the endpoints have Tunnel interface type
+          if (iface1.getInterfaceType() == InterfaceType.TUNNEL
+              && iface2.getInterfaceType() == InterfaceType.TUNNEL) {
+            builder.add(new NodeInterfacePair(iface1), new NodeInterfacePair(iface2));
+          }
+        }
+      }
+    }
+    return builder.build();
+  }
+
+  /** Return a {@link TunnelTopology} where tunnel endpoints can reach each other. */
+  @Nonnull
+  public static TunnelTopology pruneUnreachableTunnelEdges(
+      TunnelTopology initialTunnelTopology,
+      NetworkConfigurations configurations,
+      TracerouteEngine tracerouteEngine) {
+    Builder builder = TunnelTopology.builder();
+    initialTunnelTopology
+        .getGraph()
+        .edges()
+        .forEach(
+            edge -> {
+              if (tracerouteForTunnelEdge(configurations, tracerouteEngine, edge)) {
+                builder.add(edge.nodeU(), edge.nodeV());
+              }
+            });
+    return builder.build();
+  }
+
+  /** Traceroute between two tunnel interfaces. Returns true if traceroute succeeds. */
+  private static boolean tracerouteForTunnelEdge(
+      NetworkConfigurations configurations,
+      TracerouteEngine tracerouteEngine,
+      EndpointPair<NodeInterfacePair> edge) {
+    NodeInterfacePair src = edge.nodeU();
+    NodeInterfacePair dst = edge.nodeV();
+    Interface startInterface =
+        configurations
+            .getInterface(src.getHostname(), src.getInterface())
+            .orElseThrow(
+                () -> new IllegalStateException(String.format("Invalid tunnel interface %s", src)));
+    Interface dstInterface =
+        configurations
+            .getInterface(dst.getHostname(), dst.getInterface())
+            .orElseThrow(
+                () -> new IllegalStateException(String.format("Invalid tunnel interface %s", dst)));
+    // TODO: see if traceroute flow needs to be customized (ICMP ping? some GRE port?
+    //   something else?)
+    Flow flow =
+        Flow.builder()
+            .setTag("Tunnel reachability check")
+            .setIngressNode(src.getHostname())
+            .setIngressVrf(startInterface.getVrfName())
+            .setDstIp(dstInterface.getConcreteAddress().getIp())
+            .build();
+    SortedMap<Flow, List<TraceAndReverseFlow>> tracerouteResult =
+        tracerouteEngine.computeTracesAndReverseFlows(ImmutableSet.of(flow), false);
+    List<TraceAndReverseFlow> traceAndReverseFlows = tracerouteResult.get(flow);
+    return traceAndReverseFlows != null
+        && traceAndReverseFlows.stream().anyMatch(TopologyUtil::isSuccessfulFlow);
+  }
+
+  private static boolean isSuccessfulFlow(TraceAndReverseFlow tr) {
+    return tr.getTrace().getDisposition() == FlowDisposition.ACCEPTED
+        && tr.getReverseFlow() != null;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -750,7 +750,17 @@ public final class TopologyUtil {
         tracerouteEngine.computeTracesAndReverseFlows(ImmutableSet.of(flow), false);
     List<TraceAndReverseFlow> traceAndReverseFlows = tracerouteResult.get(flow);
     return traceAndReverseFlows != null
-        && traceAndReverseFlows.stream().anyMatch(TopologyUtil::isSuccessfulFlow);
+        && traceAndReverseFlows.stream()
+            .filter(TopologyUtil::isSuccessfulFlow)
+            .map(
+                // Go backward direction
+                tr ->
+                    tracerouteEngine
+                        .computeTracesAndReverseFlows(ImmutableSet.of(tr.getReverseFlow()), false)
+                        .get(tr.getReverseFlow()))
+            .filter(Objects::nonNull)
+            .flatMap(List::stream)
+            .anyMatch(TopologyUtil::isSuccessfulFlow);
   }
 
   private static boolean isSuccessfulFlow(TraceAndReverseFlow tr) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TunnelTopology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TunnelTopology.java
@@ -1,0 +1,83 @@
+package org.batfish.common.topology;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.graph.Graph;
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.ImmutableGraph;
+import com.google.common.graph.MutableGraph;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+
+/**
+ * Topology for containing edges between generic tunnels (e.g., GRE, IP-in-IP) that do not require
+ * complex compatibility checks (but <em>do</em> require reachability to be established). Does not
+ * include IPSec tunnel edges.
+ *
+ * <p>This graph is undirected.
+ */
+@ParametersAreNonnullByDefault
+public final class TunnelTopology {
+  public static final TunnelTopology EMPTY =
+      new TunnelTopology(GraphBuilder.undirected().allowsSelfLoops(false).build());
+
+  @Nonnull private Graph<NodeInterfacePair> _graph;
+
+  private TunnelTopology(Graph<NodeInterfacePair> graph) {
+    _graph = ImmutableGraph.copyOf(graph);
+  }
+
+  @Nonnull
+  public Graph<NodeInterfacePair> getGraph() {
+    return _graph;
+  }
+
+  /** Represent this topology as a set of layer 3 {@link Edge edges}. */
+  public Set<Edge> asEdgeSet() {
+    return _graph.edges().stream()
+        .map(endpointPair -> new Edge(endpointPair.nodeU(), endpointPair.nodeV()))
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TunnelTopology)) {
+      return false;
+    }
+    TunnelTopology that = (TunnelTopology) o;
+    return _graph.equals(that._graph);
+  }
+
+  @Override
+  public int hashCode() {
+    return _graph.hashCode();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    @Nonnull private MutableGraph<NodeInterfacePair> _graph;
+
+    private Builder() {
+      _graph = GraphBuilder.directed().allowsSelfLoops(false).build();
+    }
+
+    /** Add an edge to the topology */
+    public Builder add(NodeInterfacePair nodeU, NodeInterfacePair nodeV) {
+      _graph.putEdge(nodeU, nodeV);
+      return this;
+    }
+
+    public TunnelTopology build() {
+      return new TunnelTopology(_graph);
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -20,6 +20,7 @@ import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.topology.Layer2Topology;
 import org.batfish.common.topology.TopologyProvider;
 import org.batfish.common.topology.TopologyUtil;
+import org.batfish.common.topology.TunnelTopology;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
@@ -88,6 +89,12 @@ public class IBatfishTestAdapter implements IBatfish {
 
     @Override
     public VxlanTopology getVxlanTopology(NetworkSnapshot snapshot) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Nonnull
+    @Override
+    public TunnelTopology getInitialTunnelTopology(NetworkSnapshot snapshot) {
       throw new UnsupportedOperationException();
     }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -55,6 +55,7 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.TunnelConfiguration;
 import org.batfish.datamodel.VniSettings;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.collections.NodeInterfacePair;
@@ -1387,20 +1388,44 @@ public final class TopologyUtilTest {
     Ip ip1 = Ip.parse("1.1.1.1");
     Ip ip2 = Ip.parse("1.1.1.2");
     Ip ip3 = Ip.parse("1.1.1.3");
+    Ip ip4 = Ip.parse("1.1.1.4");
     int subnetMask = 24;
+    Ip underlayIp1 = Ip.parse("4.4.4.1");
+    Ip underlayIp2 = Ip.parse("4.4.4.2");
     Interface i1 =
         _ib.setOwner(c1)
             .setAddress(ConcreteInterfaceAddress.create(ip1, subnetMask))
             .setType(InterfaceType.TUNNEL)
+            .setTunnelConfig(
+                TunnelConfiguration.builder()
+                    .setSourceAddress(underlayIp1)
+                    .setDestinationAddress(underlayIp2)
+                    .build())
             .build();
     Interface i2 =
         _ib.setOwner(c2)
             .setAddress(ConcreteInterfaceAddress.create(ip2, subnetMask))
             .setType(InterfaceType.TUNNEL)
+            .setTunnelConfig(
+                TunnelConfiguration.builder()
+                    .setSourceAddress(underlayIp2)
+                    .setDestinationAddress(underlayIp1)
+                    .build())
             .build();
+    // Dangling physical interface
     _ib.setOwner(c2)
         .setAddress(ConcreteInterfaceAddress.create(ip3, subnetMask))
         .setType(InterfaceType.PHYSICAL)
+        .build();
+    // Dangling tunnel interface, underlay src/dst config should not match any tunnels
+    _ib.setOwner(c2)
+        .setAddress(ConcreteInterfaceAddress.create(ip4, subnetMask))
+        .setType(InterfaceType.TUNNEL)
+        .setTunnelConfig(
+            TunnelConfiguration.builder()
+                .setSourceAddress(Ip.parse("4.4.4.4"))
+                .setDestinationAddress(underlayIp1)
+                .build())
         .build();
 
     assertThat(

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/TopologyContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/TopologyContext.java
@@ -8,6 +8,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.topology.Layer2Topology;
 import org.batfish.common.topology.TopologyContainer;
+import org.batfish.common.topology.TunnelTopology;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.eigrp.EigrpTopology;
@@ -31,6 +32,7 @@ public final class TopologyContext implements TopologyContainer {
     private @Nonnull Topology _layer3Topology;
     private @Nonnull OspfTopology _ospfTopology;
     private @Nonnull Optional<Layer1Topology> _rawLayer1PhysicalTopology;
+    @Nonnull private TunnelTopology _tunnelTopology;
     private @Nonnull VxlanTopology _vxlanTopology;
 
     public @Nonnull TopologyContext build() {
@@ -44,6 +46,7 @@ public final class TopologyContext implements TopologyContainer {
           _layer3Topology,
           _ospfTopology,
           _rawLayer1PhysicalTopology,
+          _tunnelTopology,
           _vxlanTopology);
     }
 
@@ -57,6 +60,7 @@ public final class TopologyContext implements TopologyContainer {
       _layer3Topology = Topology.EMPTY;
       _ospfTopology = OspfTopology.EMPTY;
       _rawLayer1PhysicalTopology = Optional.empty();
+      _tunnelTopology = TunnelTopology.EMPTY;
       _vxlanTopology = VxlanTopology.EMPTY;
     }
 
@@ -107,6 +111,11 @@ public final class TopologyContext implements TopologyContainer {
       return this;
     }
 
+    public Builder setTunnelTopology(TunnelTopology tunnelTopology) {
+      _tunnelTopology = tunnelTopology;
+      return this;
+    }
+
     public @Nonnull Builder setVxlanTopology(VxlanTopology vxlanTopology) {
       _vxlanTopology = vxlanTopology;
       return this;
@@ -126,6 +135,7 @@ public final class TopologyContext implements TopologyContainer {
   private final @Nonnull Topology _layer3Topology;
   private final @Nonnull OspfTopology _ospfTopology;
   private final @Nonnull Optional<Layer1Topology> _rawLayer1PhysicalTopology;
+  @Nonnull private final TunnelTopology _tunnelTopology;
   private final @Nonnull VxlanTopology _vxlanTopology;
 
   private TopologyContext(
@@ -138,6 +148,7 @@ public final class TopologyContext implements TopologyContainer {
       Topology layer3Topology,
       OspfTopology ospfTopology,
       Optional<Layer1Topology> rawLayer1PhysicalTopology,
+      TunnelTopology tunnelTopology,
       VxlanTopology vxlanTopology) {
     _bgpTopology = bgpTopology;
     _eigrpTopology = eigrpTopology;
@@ -149,6 +160,7 @@ public final class TopologyContext implements TopologyContainer {
     _ospfTopology = ospfTopology;
     _rawLayer1PhysicalTopology = rawLayer1PhysicalTopology;
     _vxlanTopology = vxlanTopology;
+    _tunnelTopology = tunnelTopology;
   }
 
   @Override
@@ -199,6 +211,12 @@ public final class TopologyContext implements TopologyContainer {
   }
 
   @Override
+  @Nonnull
+  public TunnelTopology getTunnelTopology() {
+    return _tunnelTopology;
+  }
+
+  @Override
   public boolean equals(@Nullable Object obj) {
     if (this == obj) {
       return true;
@@ -216,6 +234,7 @@ public final class TopologyContext implements TopologyContainer {
         && _layer3Topology.equals(rhs._layer3Topology)
         && _ospfTopology.equals(rhs._ospfTopology)
         && _rawLayer1PhysicalTopology.equals(rhs._rawLayer1PhysicalTopology)
+        && _tunnelTopology.equals(rhs._tunnelTopology)
         && _vxlanTopology.equals(rhs._vxlanTopology);
   }
 
@@ -231,6 +250,7 @@ public final class TopologyContext implements TopologyContainer {
         _layer3Topology,
         _ospfTopology,
         _rawLayer1PhysicalTopology,
+        _tunnelTopology,
         _vxlanTopology);
   }
 
@@ -245,6 +265,7 @@ public final class TopologyContext implements TopologyContainer {
         .setLayer3Topology(_layer3Topology)
         .setOspfTopology(_ospfTopology)
         .setRawLayer1PhysicalTopology(_rawLayer1PhysicalTopology)
+        .setTunnelTopology(_tunnelTopology)
         .setVxlanTopology(_vxlanTopology);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TopologyContextTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TopologyContextTest.java
@@ -18,6 +18,7 @@ import org.batfish.common.topology.Layer1Edge;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.topology.Layer2Node;
 import org.batfish.common.topology.Layer2Topology;
+import org.batfish.common.topology.TunnelTopology;
 import org.batfish.datamodel.BgpPeerConfigId;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Edge;
@@ -25,6 +26,7 @@ import org.batfish.datamodel.IpsecPeerConfigId;
 import org.batfish.datamodel.IpsecSession;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.bgp.BgpTopology;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.eigrp.EigrpEdge;
 import org.batfish.datamodel.eigrp.EigrpInterface;
 import org.batfish.datamodel.eigrp.EigrpTopology;
@@ -71,7 +73,7 @@ public final class TopologyContextTest {
         .addEqualityGroup(base, base, builder.build())
         .addEqualityGroup(builder.setBgpTopology(new BgpTopology(bgpTopology)).build())
         .addEqualityGroup(builder.setEigrpTopology(new EigrpTopology(eigrpTopology)).build())
-        .addEqualityGroup(builder.setIpsecTopology(new IpsecTopology(ipsecTopology)))
+        .addEqualityGroup(builder.setIpsecTopology(new IpsecTopology(ipsecTopology)).build())
         .addEqualityGroup(builder.setIsisTopology(new IsisTopology(isisTopology)).build())
         .addEqualityGroup(
             builder
@@ -96,6 +98,13 @@ public final class TopologyContextTest {
                 .setRawLayer1PhysicalTopology(
                     Optional.of(
                         new Layer1Topology(ImmutableList.of(new Layer1Edge("a", "b", "c", "d")))))
+                .build())
+        .addEqualityGroup(
+            builder
+                .setTunnelTopology(
+                    TunnelTopology.builder()
+                        .add(new NodeInterfacePair("n1", "i1"), new NodeInterfacePair("n2", "i2"))
+                        .build())
                 .build())
         .addEqualityGroup(builder.setVxlanTopology(new VxlanTopology(vxlanTopology)).build())
         .testEquals();
@@ -138,6 +147,10 @@ public final class TopologyContextTest {
         .setOspfTopology(new OspfTopology(ospfTopology))
         .setRawLayer1PhysicalTopology(
             Optional.of(new Layer1Topology(ImmutableList.of(new Layer1Edge("a", "b", "c", "d")))))
+        .setTunnelTopology(
+            TunnelTopology.builder()
+                .add(new NodeInterfacePair("n1", "i1"), new NodeInterfacePair("n2", "i2"))
+                .build())
         .setVxlanTopology(new VxlanTopology(vxlanTopology));
 
     assertThat(builder.build(), equalTo(builder.build().toBuilder().build()));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -6040,12 +6040,6 @@ public class CiscoGrammarTest {
                 .build(),
             _folder);
 
-    Edge underlayEdge =
-        Edge.of(
-            "n1-no-static-route",
-            "TenGigabitEthernet0/0",
-            "n2-no-static-route",
-            "TenGigabitEthernet0/0");
     Edge overlayEdge = Edge.of("n1-no-static-route", "Tunnel1", "n2-no-static-route", "Tunnel1");
 
     // Overlay edge present in initial tunnel topology
@@ -6076,9 +6070,6 @@ public class CiscoGrammarTest {
                 .build(),
             _folder);
 
-    Edge underlayEdge =
-        Edge.of(
-            "n1-static-route", "TenGigabitEthernet0/0", "n2-static-route", "TenGigabitEthernet0/0");
     Edge overlayEdge = Edge.of("n1-static-route", "Tunnel1", "n2-static-route", "Tunnel1");
 
     // Overlay edge present in initial tunnel topology

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -6060,7 +6060,7 @@ public class CiscoGrammarTest {
     // NO overlay edge in final L3 topology
     assertThat(
         batfish.getTopologyProvider().getLayer3Topology(batfish.getNetworkSnapshot()).getEdges(),
-        containsInAnyOrder(underlayEdge, underlayEdge.reverse()));
+        empty());
   }
 
   @Test
@@ -6093,7 +6093,6 @@ public class CiscoGrammarTest {
     // overlay edge in final L3 topology as well
     assertThat(
         batfish.getTopologyProvider().getLayer3Topology(batfish.getNetworkSnapshot()).getEdges(),
-        containsInAnyOrder(
-            underlayEdge, underlayEdge.reverse(), overlayEdge, overlayEdge.reverse()));
+        containsInAnyOrder(overlayEdge, overlayEdge.reverse()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -6070,6 +6070,9 @@ public class CiscoGrammarTest {
                 .build(),
             _folder);
 
+    Edge underlayEdge =
+        Edge.of(
+            "n1-static-route", "TenGigabitEthernet0/1", "n2-static-route", "TenGigabitEthernet0/1");
     Edge overlayEdge = Edge.of("n1-static-route", "Tunnel1", "n2-static-route", "Tunnel1");
 
     // Overlay edge present in initial tunnel topology
@@ -6084,6 +6087,7 @@ public class CiscoGrammarTest {
     // overlay edge in final L3 topology as well
     assertThat(
         batfish.getTopologyProvider().getLayer3Topology(batfish.getNetworkSnapshot()).getEdges(),
-        containsInAnyOrder(overlayEdge, overlayEdge.reverse()));
+        containsInAnyOrder(
+            overlayEdge, overlayEdge.reverse(), underlayEdge, underlayEdge.reverse()));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n1-no-static-route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n1-no-static-route
@@ -1,0 +1,12 @@
+!
+!
+hostname n1-no-static-route
+!
+interface TenGigabitEthernet0/0
+  ip address 1.1.1.1 255.255.255.0
+!
+interface Tunnel1
+  ip address 9.9.9.1 255.255.255.0
+  tunnel source TenGigabitEthernet0/0
+  tunnel destination 1.1.1.2
+  tunnel mode gre ipv4

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n1-no-static-route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n1-no-static-route
@@ -3,10 +3,17 @@
 hostname n1-no-static-route
 !
 interface TenGigabitEthernet0/0
+  no shutdown
   ip address 1.1.1.1 255.255.255.0
 !
+interface TenGigabitEthernet0/1
+  no shutdown
+  description link to n2
+  ip address 3.3.3.3 255.255.255.254
+!
 interface Tunnel1
+  no shutdown
   ip address 9.9.9.1 255.255.255.0
   tunnel source TenGigabitEthernet0/0
-  tunnel destination 1.1.1.2
+  tunnel destination 1.1.2.2
   tunnel mode gre ipv4

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n1-static-route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n1-static-route
@@ -11,4 +11,4 @@ interface Tunnel1
   tunnel destination 1.1.1.2
   tunnel mode gre ipv4
 !
-ip route 9.9.9.2 255.255.255.255 TenGigabitEthernet0/0
+ip route 1.1.2.2 255.255.255.255 TenGigabitEthernet0/0

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n1-static-route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n1-static-route
@@ -3,12 +3,19 @@
 hostname n1-static-route
 !
 interface TenGigabitEthernet0/0
+  no shutdown
   ip address 1.1.1.1 255.255.255.0
 !
+interface TenGigabitEthernet0/1
+  no shutdown
+  description link to n2
+  ip address 3.3.3.2 255.255.255.254
+!
 interface Tunnel1
+  no shutdown
   ip address 9.9.9.1 255.255.255.0
   tunnel source TenGigabitEthernet0/0
-  tunnel destination 1.1.1.2
+  tunnel destination 1.1.2.2
   tunnel mode gre ipv4
 !
-ip route 1.1.2.2 255.255.255.255 TenGigabitEthernet0/0
+ip route 1.1.2.2 255.255.255.255 TenGigabitEthernet0/1

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n1-static-route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n1-static-route
@@ -1,0 +1,14 @@
+!
+!
+hostname n1-static-route
+!
+interface TenGigabitEthernet0/0
+  ip address 1.1.1.1 255.255.255.0
+!
+interface Tunnel1
+  ip address 9.9.9.1 255.255.255.0
+  tunnel source TenGigabitEthernet0/0
+  tunnel destination 1.1.1.2
+  tunnel mode gre ipv4
+!
+ip route 9.9.9.2 255.255.255.255 TenGigabitEthernet0/0

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n2-no-static-route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n2-no-static-route
@@ -3,9 +3,16 @@
 hostname n2-no-static-route
 !
 interface TenGigabitEthernet0/0
+  no shutdown
   ip address 1.1.2.2 255.255.255.0
 !
+interface TenGigabitEthernet0/1
+  no shutdown
+  description link to n1
+  ip address 3.3.3.4 255.255.255.254
+!
 interface Tunnel1
+  no shutdown
   ip address 9.9.9.2 255.255.255.0
   tunnel source TenGigabitEthernet0/0
   tunnel destination 1.1.1.1

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n2-no-static-route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n2-no-static-route
@@ -3,7 +3,7 @@
 hostname n2-no-static-route
 !
 interface TenGigabitEthernet0/0
-  ip address 1.1.1.2 255.255.255.0
+  ip address 1.1.2.2 255.255.255.0
 !
 interface Tunnel1
   ip address 9.9.9.2 255.255.255.0

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n2-no-static-route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n2-no-static-route
@@ -1,0 +1,12 @@
+!
+!
+hostname n2-no-static-route
+!
+interface TenGigabitEthernet0/0
+  ip address 1.1.1.2 255.255.255.0
+!
+interface Tunnel1
+  ip address 9.9.9.2 255.255.255.0
+  tunnel source TenGigabitEthernet0/0
+  tunnel destination 1.1.1.1
+  tunnel mode gre ipv4

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n2-static-route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n2-static-route
@@ -3,7 +3,7 @@
 hostname n2-static-route
 !
 interface TenGigabitEthernet0/0
-  ip address 1.1.1.2 255.255.255.0
+  ip address 1.1.2.2 255.255.255.0
 !
 interface Tunnel1
   ip address 9.9.9.2 255.255.255.0
@@ -11,4 +11,4 @@ interface Tunnel1
   tunnel destination 1.1.1.1
   tunnel mode gre ipv4
 !
-ip route 9.9.9.1 255.255.255.255 TenGigabitEthernet0/0
+ip route 1.1.1.2 255.255.255.255 TenGigabitEthernet0/0

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n2-static-route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n2-static-route
@@ -3,12 +3,19 @@
 hostname n2-static-route
 !
 interface TenGigabitEthernet0/0
+  no shutdown
   ip address 1.1.2.2 255.255.255.0
 !
+interface TenGigabitEthernet0/1
+  no shutdown
+  description link to n1
+  ip address 3.3.3.3 255.255.255.254
+!
 interface Tunnel1
+  no shutdown
   ip address 9.9.9.2 255.255.255.0
   tunnel source TenGigabitEthernet0/0
   tunnel destination 1.1.1.1
   tunnel mode gre ipv4
 !
-ip route 1.1.1.2 255.255.255.255 TenGigabitEthernet0/0
+ip route 1.1.1.1 255.255.255.255 TenGigabitEthernet0/1

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n2-static-route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/ios-tunnels/configs/n2-static-route
@@ -1,0 +1,14 @@
+!
+!
+hostname n2-static-route
+!
+interface TenGigabitEthernet0/0
+  ip address 1.1.1.2 255.255.255.0
+!
+interface Tunnel1
+  ip address 9.9.9.2 255.255.255.0
+  tunnel source TenGigabitEthernet0/0
+  tunnel destination 1.1.1.1
+  tunnel mode gre ipv4
+!
+ip route 9.9.9.1 255.255.255.255 TenGigabitEthernet0/0


### PR DESCRIPTION
Keep a topology of non-IPsec tunnels, re-add edges during dataplane
computation.