### PR TITLE
Cumulus EVPN: handle conversion corner cases

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -427,11 +427,15 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
             (vrfName, bgpVrf) ->
                 _c.getVrfs().get(vrfName).setBgpProcess(toBgpProcess(vrfName, bgpVrf)));
 
-    // Create dud processes for other VRFs, so we can have proper RIBs
+    // Create dud processes for other VRFs that use L3 VNIs, so we can have proper RIBs
     _c.getVrfs()
         .forEach(
             (vrfName, vrf) -> {
-              if (vrf.getBgpProcess() == null && _c.getDefaultVrf().getBgpProcess() != null) {
+              Vrf vsVrf = _vrfs.get(vrfName);
+              if (vsVrf != null
+                  && vsVrf.getVni() != null // has L3 VNI
+                  && vrf.getBgpProcess() == null // process does not already exist
+                  && _c.getDefaultVrf().getBgpProcess() != null) { // there is a default BGP proc
                 vrf.setBgpProcess(
                     org.batfish.datamodel.BgpProcess.builder()
                         .setRouterId(_c.getDefaultVrf().getBgpProcess().getRouterId())

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -1584,6 +1584,22 @@ public final class CumulusNcluGrammarTest {
                 .setRouteDistinguisher(RouteDistinguisher.from(Ip.parse("192.0.1.1"), 2))
                 .setRouteTarget(ExtendedCommunity.target(65500, 10004))
                 .setImportRouteTarget(VniConfig.importRtPatternForAnyAs(10004))
+                .setAdvertiseV4Unicast(false)
+                .build(),
+            Layer3VniConfig.builder()
+                .setVni(10005)
+                .setVrf("vrf5")
+                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 3))
+                .setRouteTarget(ExtendedCommunity.target(65500, 10005))
+                .setImportRouteTarget(VniConfig.importRtPatternForAnyAs(10005))
+                .setAdvertiseV4Unicast(false)
+                .build(),
+            Layer3VniConfig.builder()
+                .setVni(10006)
+                .setVrf("vrf6")
+                .setRouteDistinguisher(RouteDistinguisher.from(Ip.parse("192.0.1.1"), 4))
+                .setRouteTarget(ExtendedCommunity.target(65500, 10006))
+                .setImportRouteTarget(VniConfig.importRtPatternForAnyAs(10006))
                 .setAdvertiseV4Unicast(true)
                 .build());
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testconfigs/cumulus_nclu_evpn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testconfigs/cumulus_nclu_evpn
@@ -11,6 +11,7 @@ net add bgp l2vpn evpn advertise-default-gw
 # Neighbor
 net add bgp neighbor swp1 interface remote-as external
 net add bgp l2vpn evpn neighbor swp1 activate
+
 # VNIs for default VRF
 net add vxlan vni10001 vxlan id 10001
 net add vxlan vni10001 vxlan local-tunnelip 192.0.2.11
@@ -19,19 +20,36 @@ net add vxlan vni10001 bridge access 1
 net add vxlan vni10002 vxlan id 10002
 net add vxlan vni10002 vxlan local-tunnelip 192.0.2.12
 net add vxlan vni10002 bridge access 2
+
 # VNIs for vrf1
 net add vrf vrf1 vni 10004
 net add bgp vrf vrf1 router-id 192.0.1.1
 net add vxlan vni10004 vxlan id 10004
 net add vxlan vni10004 vxlan local-tunnelip 192.0.2.14
 net add vxlan vni10004 bridge access 4
-net commit
+
+# VNI for vrf that doesn't appear as a BGP vrf (should still be advertised)
+net add vrf vrf5 vni 10005
+net add vxlan vni10005 vxlan id 10005
+net add vxlan vni10005 vxlan local-tunnelip 192.0.2.15
+net add vxlan vni10005 bridge access 5
+
+# VNIs for vrf6
+net add vrf vrf6 vni 10006
+net add bgp vrf vrf6 router-id 192.0.1.1
+## advertise ipv4 unicast must appear in the tenant VRF config to take effect
+net add bgp vrf vrf6 l2vpn evpn advertise ipv4 unicast
+net add vxlan vni10006 vxlan id 10006
+net add vxlan vni10006 vxlan local-tunnelip 192.0.2.16
+net add vxlan vni10006 bridge access 6
+
 # Unrelated to EVPN vrf
 net add vrf vrf2
 net add interface swp2 vrf vrf2
 net add bgp vrf vrf2 router-id 192.0.2.2
 net add bgp vrf vrf2 neighbor swp2 interface remote-as external
 
+net commit
 
 # The following will append those commands to the appropriate files.
 # There are some configuration commands that are not yet supported by nclu.

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -14705,6 +14705,14 @@
           },
           "mgmt" : {
             "name" : "mgmt",
+            "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
+              "routerId" : "192.0.2.2",
+              "multipathEbgp" : false,
+              "multipathIbgp" : false,
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
             "interfaces" : [
               "eth0",
               "mgmt"

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -14705,14 +14705,6 @@
           },
           "mgmt" : {
             "name" : "mgmt",
-            "bgpProcess" : {
-              "ebgpAdminCost" : 20,
-              "ibgpAdminCost" : 200,
-              "routerId" : "192.0.2.2",
-              "multipathEbgp" : false,
-              "multipathIbgp" : false,
-              "tieBreaker" : "ARRIVAL_ORDER"
-            },
             "interfaces" : [
               "eth0",
               "mgmt"


### PR DESCRIPTION
1. We have to care about L3 VNIs that are attached to VRFs which do not
appear in BGP config
2. As a consequence, creating dud BGP processes so we can properly do
cross-VRF BGP rib merging