### PR TITLE
handle missing devices in reachability analysis

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -671,6 +671,10 @@ public final class BDDReachabilityAnalysisFactory {
 
   private Stream<Edge> generateRules_NodeDropNoRoute_DropNoRoute(Set<String> finalNodes) {
     return finalNodes.stream()
+        /* In differential context, nodes can be added or removed. This can lead to a finalNode
+         * that doesn't exist in _configs.
+         */
+        .filter(_configs::containsKey)
         .map(
             node ->
                 new Edge(

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/LocationToOriginationStateExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/LocationToOriginationStateExpr.java
@@ -22,6 +22,14 @@ class LocationToOriginationStateExpr implements LocationVisitor<Optional<StateEx
   @Override
   public Optional<StateExpr> visitInterfaceLinkLocation(
       @Nonnull InterfaceLinkLocation interfaceLinkLocation) {
+    Configuration config = _configs.get(interfaceLinkLocation.getNodeName());
+    if (config == null) {
+      return Optional.empty();
+    }
+    Interface iface = config.getAllInterfaces().get(interfaceLinkLocation.getInterfaceName());
+    if (iface == null) {
+      return Optional.empty();
+    }
     return Optional.of(
         new OriginateInterfaceLink(
             interfaceLinkLocation.getNodeName(), interfaceLinkLocation.getInterfaceName()));


### PR DESCRIPTION
Previously would crash if final nodes or start locations contained
missing devices. This can happen in differential analysis.