### PR TITLE
move maven-dependency-plugin version to pluginManagement

### DIFF
--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -170,11 +170,11 @@
           </configuration>
         </plugin>
 
-	      <plugin>
-	        <groupId>org.apache.maven.plugins</groupId>
-	        <artifactId>maven-dependency-plugin</artifactId>
-	        <version>${maven-dependency-plugin.version}</version>
-	      </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>${maven-dependency-plugin.version}</version>
+        </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -170,6 +170,12 @@
           </configuration>
         </plugin>
 
+	      <plugin>
+	        <groupId>org.apache.maven.plugins</groupId>
+	        <artifactId>maven-dependency-plugin</artifactId>
+	        <version>${maven-dependency-plugin.version}</version>
+	      </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
@@ -453,7 +459,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>${maven-dependency-plugin.version}</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
- fixes eclipse warning