### PR TITLE
Cisco extractor: allow re-entering of BGP process

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -4097,7 +4097,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
         _dummyPeerGroup = new MasterBgpPeerGroup();
       }
       BgpProcess proc = vrf.getBgpProcess();
-      checkArgument(proc.getProcnum() == procNum);
+      if (proc.getProcnum() != procNum && procNum != 0) {
+        _w.redFlag("Cannot have multiple BGP processes with different ASNs");
+        return;
+      }
       pushPeer(proc.getMasterBgpPeerGroup());
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -6090,4 +6090,17 @@ public class CiscoGrammarTest {
         containsInAnyOrder(
             overlayEdge, overlayEdge.reverse(), underlayEdge, underlayEdge.reverse()));
   }
+
+  @Test
+  public void testRenterBgpStanza() throws IOException {
+    Configuration c = parseConfig("ios-bgp-reenter-process");
+    assertThat(
+        c,
+        hasDefaultVrf(
+            hasBgpProcess(hasActiveNeighbor(Prefix.parse("2.2.2.3/32"), hasRemoteAs(3L)))));
+    assertThat(
+        c,
+        hasDefaultVrf(
+            hasBgpProcess(hasActiveNeighbor(Prefix.parse("2.2.2.4/32"), hasRemoteAs(4L)))));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-reenter-process
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-reenter-process
@@ -1,0 +1,9 @@
+!
+hostname ios-bgp-reenter-process
+!
+router bgp 2
+  neighbor 2.2.2.3 remote-as 3
+!
+router bgp 2
+  neighbor 2.2.2.4 remote-as 4
+!

--- a/tests/parsing-tests/networks/unit-tests/configs/cisco_bgp
+++ b/tests/parsing-tests/networks/unit-tests/configs/cisco_bgp
@@ -6,15 +6,15 @@ ip as-path access-list 10 deny _65535_
 ip as-path access-list 20 permit ^65536$
 ip as-path access-list 30 permit ^4000$
 !
-router bgp 50000
+router bgp 1
  neighbor 10.20.2.2 filter-list 10 out
  end
 !
-router bgp 65538
+router bgp 1
  neighbor 192.168.3.2 filter-list 20 in
  end
 !
-router bgp 65542
+router bgp 1
  neighbor 192.168.4.2 filter-list 40 in
  end
 !

--- a/tests/parsing-tests/networks/unit-tests/configs/cisco_misc
+++ b/tests/parsing-tests/networks/unit-tests/configs/cisco_misc
@@ -34,7 +34,7 @@ configure maintenance profile normal-mode
  no ip pim isolate
 configure maintenance profile maintenance-mode
  ip pim isolate
- router bgp 65601
+ router bgp 12345
   isolate
  router ospf 1
   isolate

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -483,36 +483,6 @@
         }
       },
       {
-        "File_Name" : "configs/cadant_bgp",
-        "Struct_Type" : "undeclared bgp peer",
-        "Ref_Name" : "1.2.3.4",
-        "Context" : "bgp neighbor without remote-as",
-        "Lines" : {
-          "filename" : "configs/cadant_bgp",
-          "lines" : [
-            26,
-            27,
-            28,
-            39
-          ]
-        }
-      },
-      {
-        "File_Name" : "configs/cadant_bgp",
-        "Struct_Type" : "undeclared bgp peer",
-        "Ref_Name" : "dead:beef:0:0:0:0:0:1",
-        "Context" : "bgp neighbor without remote-as",
-        "Lines" : {
-          "filename" : "configs/cadant_bgp",
-          "lines" : [
-            33,
-            34,
-            35,
-            40
-          ]
-        }
-      },
-      {
         "File_Name" : "configs/cadant_interface",
         "Struct_Type" : "ipv4/6 acl",
         "Ref_Name" : "fleep-acl",
@@ -4108,10 +4078,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 333 results",
+      "notes" : "Found 331 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 333
+      "numResults" : 331
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -4652,10 +4652,147 @@
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                  "protocols" : [
-                    "bgp",
-                    "ibgp"
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "comment" : "Redistribute RIP routes into BGP",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                          "protocols" : [
+                            "rip"
+                          ]
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "incomplete"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "comment" : "Redistribute static routes into BGP",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                          "protocols" : [
+                            "static"
+                          ]
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "incomplete"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                      "comment" : "Redistribute connected routes into BGP",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                          "protocols" : [
+                            "connected"
+                          ]
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr",
+                          "expr" : {
+                            "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                            "type" : "True"
+                          },
+                          "postStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "UnsetWriteIntermediateBgpAttributes"
+                            }
+                          ],
+                          "postTrueStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetReadIntermediateBgpAttributes"
+                            },
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                              "originType" : {
+                                "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                                "originType" : "incomplete"
+                              }
+                            }
+                          ],
+                          "preStatements" : [
+                            {
+                              "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                              "type" : "SetWriteIntermediateBgpAttributes"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocols" : [
+                        "bgp",
+                        "ibgp"
+                      ]
+                    }
                   ]
                 },
                 "trueStatements" : [
@@ -4668,6 +4805,38 @@
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
                 "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_PEER_EXPORT_POLICY:default:1.2.3.4~" : {
+            "name" : "~BGP_PEER_EXPORT_POLICY:default:1.2.3.4~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.SetNextHop",
+                "destinationVrf" : false,
+                "expr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.SelfNextHop"
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitReject"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~BGP_COMMON_EXPORT_POLICY:default~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
               }
             ]
           }
@@ -4683,10 +4852,37 @@
             "bgpProcess" : {
               "ebgpAdminCost" : 20,
               "ibgpAdminCost" : 20,
-              "routerId" : "0.0.0.0",
+              "routerId" : "1.2.3.4",
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
               "multipathIbgp" : false,
+              "neighbors" : {
+                "1.2.3.4/32" : {
+                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "clusterId" : 16909060,
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "ipv4UnicastAddressFamily" : {
+                    "addressFamilyCapabilities" : {
+                      "additionalPathsReceive" : false,
+                      "additionalPathsSelectAll" : false,
+                      "additionalPathsSend" : false,
+                      "advertiseExternal" : false,
+                      "advertiseInactive" : true,
+                      "allowLocalAsIn" : false,
+                      "allowRemoteAsOut" : true,
+                      "sendCommunity" : false,
+                      "sendExtendedCommunity" : false
+                    },
+                    "exportPolicy" : "~BGP_PEER_EXPORT_POLICY:default:1.2.3.4~",
+                    "routeReflectorClient" : false
+                  },
+                  "localAs" : 12345,
+                  "peerAddress" : "1.2.3.4",
+                  "remoteAsns" : "12345"
+                }
+              },
               "tieBreaker" : "ARRIVAL_ORDER"
             }
           }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -15158,7 +15158,7 @@
             "      ROUTER:'router'",
             "      BGP:'bgp'",
             "      procnum = (bgp_asn",
-            "        asn = DEC:'50000')",
+            "        asn = DEC:'1')",
             "      NEWLINE:'\\n'",
             "      (router_bgp_stanza_tail",
             "        (neighbor_flat_rb_stanza",
@@ -15179,7 +15179,7 @@
             "      ROUTER:'router'",
             "      BGP:'bgp'",
             "      procnum = (bgp_asn",
-            "        asn = DEC:'65538')",
+            "        asn = DEC:'1')",
             "      NEWLINE:'\\n'",
             "      (router_bgp_stanza_tail",
             "        (neighbor_flat_rb_stanza",
@@ -15200,7 +15200,7 @@
             "      ROUTER:'router'",
             "      BGP:'bgp'",
             "      procnum = (bgp_asn",
-            "        asn = DEC:'65542')",
+            "        asn = DEC:'1')",
             "      NEWLINE:'\\n'",
             "      (router_bgp_stanza_tail",
             "        (neighbor_flat_rb_stanza",
@@ -28834,7 +28834,7 @@
             "          ROUTER:'router'",
             "          (null_rest_of_line",
             "            BGP:'bgp'",
-            "            DEC:'65601'",
+            "            DEC:'12345'",
             "            NEWLINE:'\\n')",
             "          (configure_maintenance_router_null",
             "            ISOLATE:'isolate'",
@@ -77075,7 +77075,7 @@
         "bgp_route_policy" : "WARNINGS",
         "cadant_acl" : "PASSED",
         "cadant_banner" : "PASSED",
-        "cadant_bgp" : "PASSED",
+        "cadant_bgp" : "WARNINGS",
         "cadant_cable" : "PASSED",
         "cadant_interface" : "PASSED",
         "cadant_ip_route" : "PASSED",
@@ -85383,24 +85383,6 @@
                 35
               ]
             }
-          },
-          "undeclared bgp peer" : {
-            "1.2.3.4" : {
-              "bgp neighbor without remote-as" : [
-                26,
-                27,
-                28,
-                39
-              ]
-            },
-            "dead:beef:0:0:0:0:0:1" : {
-              "bgp neighbor without remote-as" : [
-                33,
-                34,
-                35,
-                40
-              ]
-            }
           }
         },
         "configs/cadant_cable" : {
@@ -89821,24 +89803,6 @@
                 35
               ]
             }
-          },
-          "undeclared bgp peer" : {
-            "1.2.3.4" : {
-              "bgp neighbor without remote-as" : [
-                26,
-                27,
-                28,
-                39
-              ]
-            },
-            "dead:beef:0:0:0:0:0:1" : {
-              "bgp neighbor without remote-as" : [
-                33,
-                34,
-                35,
-                40
-              ]
-            }
           }
         },
         "configs/cadant_interface" : {
@@ -91809,6 +91773,14 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Could not determine update source for BGP neighbor: '64.57.21.1'"
+            }
+          ]
+        },
+        "cadant_bgp" : {
+          "Red flags" : [
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Could not determine update source for BGP neighbor: '1.2.3.4'"
             }
           ]
         },


### PR DESCRIPTION
For your consideration: do not erase previous BGP processes upon encountering another `router bgp` line.
Helps process hand-written configs (or appends to the end of the file).

Big ref changes are in Cadant files. Not sure if correct, but erring on the side of Cisco correctness.