### PR TITLE
Remove EIGRP internal iterations from DP answer element

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/IncrementalBdpAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/IncrementalBdpAnswerElement.java
@@ -14,7 +14,6 @@ public class IncrementalBdpAnswerElement extends DataPlaneAnswerElement {
   private static final String PROP_BGP_MULTIPATH_RIB_ROUTES_BY_ITERATION =
       "bgpMultipathRibRoutesByIteration";
   private static final String PROP_DEPENDENT_ROUTES_ITERATIONS = "dependentRoutesIterations";
-  private static final String PROP_EIGRP_INTERNAL_ITERATIONS = "eigrpInternalIterations";
   private static final String PROP_OSPF_INTERNAL_ITERATIONS = "ospfInternalIterations";
   private static final String PROP_WARNINGS = "warnings";
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/IncrementalBdpAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/IncrementalBdpAnswerElement.java
@@ -19,19 +19,11 @@ public class IncrementalBdpAnswerElement extends DataPlaneAnswerElement {
   private static final String PROP_WARNINGS = "warnings";
 
   private SortedMap<Integer, Integer> _bgpBestPathRibRoutesByIteration;
-
   private SortedMap<Integer, Integer> _bgpMultipathRibRoutesByIteration;
-
   private int _dependentRoutesIterations;
-
-  private int _eigrpInternalIterations;
-
   private SortedMap<Integer, Integer> _mainRibRoutesByIteration;
-
   private int _ospfInternalIterations;
-
   private String _version;
-
   private Warnings _warnings;
 
   public IncrementalBdpAnswerElement() {
@@ -54,11 +46,6 @@ public class IncrementalBdpAnswerElement extends DataPlaneAnswerElement {
   @JsonProperty(PROP_DEPENDENT_ROUTES_ITERATIONS)
   public int getDependentRoutesIterations() {
     return _dependentRoutesIterations;
-  }
-
-  @JsonProperty(PROP_EIGRP_INTERNAL_ITERATIONS)
-  public int getEigrpInternalIterations() {
-    return _eigrpInternalIterations;
   }
 
   @JsonProperty(MAIN_RIB_ROUTES_BY_ITERATION)
@@ -92,11 +79,6 @@ public class IncrementalBdpAnswerElement extends DataPlaneAnswerElement {
   public void setBgpMultipathRibRoutesByIteration(
       SortedMap<Integer, Integer> bgpMultipathRibRoutesByIteration) {
     _bgpMultipathRibRoutesByIteration = bgpMultipathRibRoutesByIteration;
-  }
-
-  @JsonProperty(PROP_EIGRP_INTERNAL_ITERATIONS)
-  public void setEigrpInternalIterations(int eigrpInternalIterations) {
-    _eigrpInternalIterations = eigrpInternalIterations;
   }
 
   @JsonProperty(PROP_DEPENDENT_ROUTES_ITERATIONS)

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -530,7 +530,6 @@ class IncrementalBdpEngine {
       assert span != null; // avoid unused warning
 
       int numOspfInternalIterations;
-      int numEigrpInternalIterations;
 
       /*
        * For each virtual router, setup the initial easy-to-do routes, init protocol-based RIBs,
@@ -547,8 +546,7 @@ class IncrementalBdpEngine {
       }
 
       // EIGRP internal routes
-      numEigrpInternalIterations =
-          initEigrpInternalRoutes(nodes, topologyContext, networkConfigurations);
+      initEigrpInternalRoutes(nodes, topologyContext, networkConfigurations);
 
       // OSPF internal routes
       numOspfInternalIterations = initOspfInternalRoutes(nodes, topologyContext.getOspfTopology());
@@ -575,7 +573,6 @@ class IncrementalBdpEngine {
 
       // Set iteration stats in the answer
       ae.setOspfInternalIterations(numOspfInternalIterations);
-      ae.setEigrpInternalIterations(numEigrpInternalIterations);
     }
   }
 
@@ -802,7 +799,7 @@ class IncrementalBdpEngine {
    * @param networkConfigurations All configurations in the network
    * @return the number of iterations it took for internal EIGRP routes to converge
    */
-  private static int initEigrpInternalRoutes(
+  private static void initEigrpInternalRoutes(
       Map<String, Node> nodes,
       TopologyContext topologyContext,
       NetworkConfigurations networkConfigurations) {
@@ -850,7 +847,6 @@ class IncrementalBdpEngine {
           .flatMap(n -> n.getVirtualRouters().values().stream())
           .forEach(VirtualRouter::importEigrpInternalRoutes);
     }
-    return eigrpInternalIterations;
   }
 
   /**

--- a/tests/basic/genDp.ref
+++ b/tests/basic/genDp.ref
@@ -21,7 +21,6 @@
         "7" : 122
       },
       "dependentRoutesIterations" : 7,
-      "eigrpInternalIterations" : 1,
       "mainRibRoutesByIteration" : {
         "1" : 207,
         "2" : 271,


### PR DESCRIPTION
In preparation to moving EIGRP fully into dependent routes computation,
no need to separately keep track of EIGRP internal iterations.