### PR TITLE
EIGRP:  Flip to new EIGRP queue-based computation

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -113,8 +113,6 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
     _rib = new EigrpRib();
     _vrfName = vrfName;
 
-    initInternalRoutes(vrfName, c);
-
     // get EIGRP export policy name
     String exportPolicyName = process.getExportPolicy();
     _exportPolicy = exportPolicyName != null ? c.getRoutingPolicies().get(exportPolicyName) : null;


### PR DESCRIPTION
This flips the computation (calls in `VirtualRouter`, `IncrementalBdpEngine`) to the new route propagation, meaning tests like `EigrpTest` now use the new code.

After #4321 