### PR TITLE
NX-OS: preserve original VRF name 

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -3088,7 +3088,7 @@ public final class CiscoNxosGrammarTest {
     String hostname = "nxos_vrf";
     Configuration c = parseConfig(hostname);
 
-    assertThat(c.getVrfs(), hasKeys(DEFAULT_VRF_NAME, NULL_VRF_NAME, "vrf1", "vrf3"));
+    assertThat(c.getVrfs(), hasKeys(DEFAULT_VRF_NAME, NULL_VRF_NAME, "Vrf1", "vrf3"));
     {
       org.batfish.datamodel.Vrf vrf = c.getVrfs().get(DEFAULT_VRF_NAME);
       assertThat(vrf, VrfMatchers.hasInterfaces(empty()));
@@ -3098,7 +3098,7 @@ public final class CiscoNxosGrammarTest {
       assertThat(vrf, VrfMatchers.hasInterfaces(contains("Ethernet1/2")));
     }
     {
-      org.batfish.datamodel.Vrf vrf = c.getVrfs().get("vrf1");
+      org.batfish.datamodel.Vrf vrf = c.getVrfs().get("Vrf1");
       assertThat(
           vrf, VrfMatchers.hasInterfaces(contains("Ethernet1/1", "Ethernet1/3", "Ethernet1/4")));
     }
@@ -3140,13 +3140,13 @@ public final class CiscoNxosGrammarTest {
     String hostname = "nxos_vrf";
     CiscoNxosConfiguration vc = parseVendorConfig(hostname);
 
-    assertThat(vc.getVrfs(), hasKeys("vrf1", "vrf3"));
+    assertThat(vc.getVrfs(), hasKeys("Vrf1", "vrf3"));
     {
       Vrf vrf = vc.getDefaultVrf();
       assertFalse(vrf.getShutdown());
     }
     {
-      Vrf vrf = vc.getVrfs().get("vrf1");
+      Vrf vrf = vc.getVrfs().get("Vrf1");
       assertFalse(vrf.getShutdown());
       assertThat(
           vrf.getRd(), equalTo(RouteDistinguisherOrAuto.of(RouteDistinguisher.from(65001, 10L))));
@@ -3180,7 +3180,7 @@ public final class CiscoNxosGrammarTest {
     {
       Interface iface = vc.getInterfaces().get("Ethernet1/1");
       assertFalse(iface.getShutdown());
-      assertThat(iface.getVrfMember(), equalTo("vrf1"));
+      assertThat(iface.getVrfMember(), equalTo("Vrf1"));
     }
     {
       Interface iface = vc.getInterfaces().get("Ethernet1/2");
@@ -3190,13 +3190,13 @@ public final class CiscoNxosGrammarTest {
     {
       Interface iface = vc.getInterfaces().get("Ethernet1/3");
       assertFalse(iface.getShutdown());
-      assertThat(iface.getVrfMember(), equalTo("vrf1"));
+      assertThat(iface.getVrfMember(), equalTo("Vrf1"));
       assertThat(iface.getAddress(), nullValue());
     }
     {
       Interface iface = vc.getInterfaces().get("Ethernet1/4");
       assertFalse(iface.getShutdown());
-      assertThat(iface.getVrfMember(), equalTo("vrf1"));
+      assertThat(iface.getVrfMember(), equalTo("Vrf1"));
       assertThat(
           iface.getAddress().getAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.4.1/24")));
     }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_vrf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_vrf
@@ -3,13 +3,13 @@
 hostname nxos_vrf
 !
 
-! Add interface to vrf1
+! Add interface to Vrf1
 ! - shutdown = false
 ! - active = true
 interface Ethernet1/1
   no switchport
   no shutdown
-  vrf member vrf1
+  vrf member Vrf1
 !
 
 ! Add interface to non-existent vrf2
@@ -56,6 +56,7 @@ interface Ethernet1/5
 !
 
 !!! Keep VRF definitions under default VRF configuration to avoid accidental leakage
+! Note that VI name should be 'Vrf1' since that is how it was first used above.
 vrf context vrf1
   vni 10001
   rd 65001:10


### PR DESCRIPTION
and lay infra for other case-insensitive structures