### PR TITLE
Batfish: stop using TreeList

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.commons.collections4.list.TreeList;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.Warnings;
@@ -1752,7 +1751,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
   /** Generate IpAccessList from the specified to-zone's security policies. */
   IpAccessList buildSecurityPolicyAcl(String name, Zone zone) {
-    List<IpAccessListLine> zoneAclLines = new TreeList<>();
+    List<IpAccessListLine> zoneAclLines = new LinkedList<>();
 
     /* Default ACL that allows existing connections should be added to all security policies */
     zoneAclLines.add(

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -43,7 +43,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.commons.collections4.list.TreeList;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.AclIpSpace;
@@ -752,7 +751,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
     IpAccessListLine.Builder ipAccessListLineBuilder =
         IpAccessListLine.builder().setName(rule.getName()).setAction(rule.getAction());
 
-    List<AclLineMatchExpr> conjuncts = new TreeList<>();
+    List<AclLineMatchExpr> conjuncts = new LinkedList<>();
     // Match SRC IPs if specified.
     IpSpace srcIps = ipSpaceFromRuleEndpoints(rule.getSource(), vsys, _w);
     if (srcIps != null) {
@@ -777,7 +776,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
     // Construct source zone (source interface) match expression
     SortedSet<String> ruleFroms = rule.getFrom();
     if (!ruleFroms.isEmpty()) {
-      List<String> srcInterfaces = new TreeList<>();
+      List<String> srcInterfaces = new LinkedList<>();
       for (String zoneName : ruleFroms) {
         if (zoneName.equals(CATCHALL_ZONE_NAME)) {
           for (Zone zone : rule.getVsys().getZones().values()) {
@@ -798,7 +797,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
     // Construct service match expression
     SortedSet<ServiceOrServiceGroupReference> ruleServices = rule.getService();
     if (!ruleServices.isEmpty()) {
-      List<AclLineMatchExpr> serviceDisjuncts = new TreeList<>();
+      List<AclLineMatchExpr> serviceDisjuncts = new LinkedList<>();
       for (ServiceOrServiceGroupReference service : ruleServices) {
         String serviceName = service.getName();
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceGroup.java
@@ -2,10 +2,10 @@ package org.batfish.representation.palo_alto;
 
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeServiceGroupMemberAclName;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import org.apache.commons.collections4.list.TreeList;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpAccessListLine;
@@ -37,7 +37,7 @@ public final class ServiceGroup implements ServiceGroupMember {
   @Override
   public IpAccessList toIpAccessList(
       LineAction action, PaloAltoConfiguration pc, Vsys vsys, Warnings w) {
-    List<IpAccessListLine> lines = new TreeList<>();
+    List<IpAccessListLine> lines = new LinkedList<>();
     for (ServiceOrServiceGroupReference memberReference : _references) {
       // Check for matching object before using built-ins
       String vsysName = memberReference.getVsysName(pc, vsys);


### PR DESCRIPTION
Seems like someone decided that all structures we used should be `Tree`-based? This is a weird one though IMO.