### PR TITLE
Use main RIB delta instead of entire main RIB except in the first dataplane iteration

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -255,6 +255,7 @@ class IncrementalBdpEngine {
    */
   private static void computeDependentRoutesIteration(
       Map<String, Node> nodes,
+      int numIterations,
       String iterationLabel,
       Map<String, Node> allNodes,
       TopologyContext topologyContext,
@@ -383,7 +384,7 @@ class IncrementalBdpEngine {
         assert span != null; // avoid unused warning
         nodes.values().stream()
             .flatMap(n -> n.getVirtualRouters().values().stream())
-            .forEach(VirtualRouter::redistribute);
+            .forEach(virtualRouter -> virtualRouter.redistribute(numIterations));
       }
 
       queueRoutesForCrossVrfLeaking(nodes, iterationLabel);
@@ -642,7 +643,12 @@ class IncrementalBdpEngine {
             String iterationlabel =
                 String.format("Iteration %d Schedule %d", _numIterations, nodeSet);
             computeDependentRoutesIteration(
-                iterationNodes, iterationlabel, nodes, topologyContext, networkConfigurations);
+                iterationNodes,
+                _numIterations,
+                iterationlabel,
+                nodes,
+                topologyContext,
+                networkConfigurations);
             ++nodeSet;
           }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -2004,17 +2004,19 @@ public class VirtualRouter implements Serializable {
     return vs.addToFloodList(route.getVniIp());
   }
 
-  void redistribute() {
+  void redistribute(int numIterations) {
     // TODO: expand to processes other than OSPF
     Streams.concat(_ospfProcesses.values().stream(), _eigrpProcesses.values().stream())
         .forEach(
             p ->
                 p.redistribute(
-                    // For the time being use all main RIB routes
-                    // TODO: later switch to just the delta (after iteration 1)
-                    RibDelta.<AnnotatedRoute<AbstractRoute>>builder()
-                        .add(_mainRib.getTypedRoutes())
-                        .build()));
+                    // use all main RIB routes in the first iteration and routes from delta main RIB
+                    // from second iteration
+                    numIterations == 1
+                        ? RibDelta.<AnnotatedRoute<AbstractRoute>>builder()
+                            .add(_mainRib.getTypedRoutes())
+                            .build()
+                        : _mainRibRouteDeltaBuilder.build()));
   }
 
   void mergeEigrpRoutesToMainRib() {


### PR DESCRIPTION
when we are redistributing routes into individual routing processes (OSPF and EIGRP)