### PR TITLE
IOS: more permissive names for bgp templates (peer/session)

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_bgp.g4
@@ -340,12 +340,12 @@ filter_list_bgp_tail
 
 inherit_peer_policy_bgp_tail
 :
-   INHERIT PEER_POLICY name = variable num = DEC? NEWLINE
+   INHERIT PEER_POLICY name = variable_permissive num = DEC? NEWLINE
 ;
 
 inherit_peer_session_bgp_tail
 :
-   INHERIT PEER_SESSION name = variable NEWLINE
+   INHERIT PEER_SESSION name = variable_permissive NEWLINE
 ;
 
 local_as_bgp_tail
@@ -982,7 +982,7 @@ template_peer_address_family
 
 template_peer_policy_rb_stanza
 :
-   TEMPLATE PEER_POLICY name = VARIABLE NEWLINE
+   TEMPLATE PEER_POLICY name = variable_permissive NEWLINE
    (
       bgp_tail
       | inherit_peer_policy_bgp_tail
@@ -994,7 +994,7 @@ template_peer_policy_rb_stanza
 
 template_peer_session_rb_stanza
 :
-   TEMPLATE PEER_SESSION name = VARIABLE NEWLINE
+   TEMPLATE PEER_SESSION name = variable_permissive NEWLINE
    (
       bgp_tail
       | remote_as_bgp_tail

--- a/tests/parsing-tests/networks/unit-tests/configs/ios_xe_bgp
+++ b/tests/parsing-tests/networks/unit-tests/configs/ios_xe_bgp
@@ -1,0 +1,13 @@
+!
+hostname ios_xe_bgp
+!
+router bgp 22222
+ template peer-policy FOO-BAR:BAZ
+  route-map MAP in
+  send-community both
+ exit-peer-policy
+ template peer-session FOO-BAR_BAZ:QUX
+  remote-as 65444
+ exit-peer-session
+ neighbor 1.1.1.1 inherit peer-session FOO-BAR:BAZ
+ neighbor 1.1.1.1 inherit peer-policy FOO-BAR_BAZ:QUX

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -666,7 +666,7 @@
       {
         "File_Name" : "configs/cisco_bgp",
         "Struct_Type" : "bgp template peer-policy",
-        "Ref_Name" : "p3",
+        "Ref_Name" : "p310",
         "Context" : "inherited BGP peer-policy",
         "Lines" : {
           "filename" : "configs/cisco_bgp",
@@ -2668,6 +2668,42 @@
         }
       },
       {
+        "File_Name" : "configs/ios_xe_bgp",
+        "Struct_Type" : "bgp template peer-policy",
+        "Ref_Name" : "FOO-BAR_BAZ:QUX",
+        "Context" : "inherited BGP peer-policy",
+        "Lines" : {
+          "filename" : "configs/ios_xe_bgp",
+          "lines" : [
+            13
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/ios_xe_bgp",
+        "Struct_Type" : "bgp template peer-session",
+        "Ref_Name" : "FOO-BAR:BAZ",
+        "Context" : "inherited BGP peer-session",
+        "Lines" : {
+          "filename" : "configs/ios_xe_bgp",
+          "lines" : [
+            12
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/ios_xe_bgp",
+        "Struct_Type" : "route-map",
+        "Ref_Name" : "MAP",
+        "Context" : "bgp inbound route-map",
+        "Lines" : {
+          "filename" : "configs/ios_xe_bgp",
+          "lines" : [
+            6
+          ]
+        }
+      },
+      {
         "File_Name" : "configs/ios_xr_bgp",
         "Struct_Type" : "route-policy",
         "Ref_Name" : "ADDITIONAL_PATHS_POLICY",
@@ -4078,10 +4114,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 331 results",
+      "notes" : "Found 334 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 331
+      "numResults" : 334
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -1950,6 +1950,31 @@
         }
       },
       {
+        "Structure_Type" : "bgp template peer-policy",
+        "Structure_Name" : "FOO-BAR:BAZ",
+        "Source_Lines" : {
+          "filename" : "configs/ios_xe_bgp",
+          "lines" : [
+            5,
+            6,
+            7,
+            8
+          ]
+        }
+      },
+      {
+        "Structure_Type" : "bgp template peer-session",
+        "Structure_Name" : "FOO-BAR_BAZ:QUX",
+        "Source_Lines" : {
+          "filename" : "configs/ios_xe_bgp",
+          "lines" : [
+            9,
+            10,
+            11
+          ]
+        }
+      },
+      {
         "Structure_Type" : "bgp af-group",
         "Structure_Name" : "blabbety",
         "Source_Lines" : {
@@ -3710,10 +3735,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 251 results",
+      "notes" : "Found 253 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 251
+      "numResults" : 253
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -19666,6 +19666,62 @@
           }
         }
       },
+      "ios_xe_bgp" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "ios_xe_bgp",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "routingPolicies" : {
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                  "protocols" : [
+                    "bgp",
+                    "ibgp"
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "hostname" : "ios_xe_bgp",
+            "logging" : {
+              "on" : true
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
+              "routerId" : "0.0.0.0",
+              "multipathEbgp" : false,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : false,
+              "tieBreaker" : "ARRIVAL_ORDER"
+            }
+          }
+        }
+      },
       "ios_xr_acl" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_xr_acl",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -583,6 +583,9 @@
         "ios_template" : [
           "configs/ios_template"
         ],
+        "ios_xe_bgp" : [
+          "configs/ios_xe_bgp"
+        ],
         "ios_xr_acl" : [
           "configs/ios_xr_acl"
         ],
@@ -1105,6 +1108,7 @@
         "configs/ios_interface_ip_tcp" : "PASSED",
         "configs/ios_standby" : "PASSED",
         "configs/ios_template" : "PASSED",
+        "configs/ios_xe_bgp" : "PASSED",
         "configs/ios_xr_acl" : "PASSED",
         "configs/ios_xr_bgp" : "PASSED",
         "configs/ios_xr_bgp_neighbor_group" : "PASSED",
@@ -15341,20 +15345,21 @@
             "        (template_peer_policy_rb_stanza",
             "          TEMPLATE:'template'",
             "          PEER_POLICY:'peer-policy'",
-            "          name = VARIABLE:'p1'",
+            "          name = (variable_permissive",
+            "            VARIABLE:'p1')",
             "          NEWLINE:'\\n'",
             "          (inherit_peer_policy_bgp_tail",
             "            INHERIT:'inherit'",
             "            PEER_POLICY:'peer-policy'",
-            "            name = (variable",
+            "            name = (variable_permissive",
             "              VARIABLE:'p2')",
             "            NEWLINE:'\\n')",
             "          (inherit_peer_policy_bgp_tail",
             "            INHERIT:'inherit'",
             "            PEER_POLICY:'peer-policy'",
-            "            name = (variable",
-            "              VARIABLE:'p3')",
-            "            num = DEC:'10'",
+            "            name = (variable_permissive",
+            "              VARIABLE:'p3'",
+            "              DEC:'10')",
             "            NEWLINE:'\\n')",
             "          EXIT_PEER_POLICY:'exit-peer-policy'",
             "          NEWLINE:'\\n'))",
@@ -51759,6 +51764,87 @@
             "  EOF:<EOF>)"
           ]
         },
+        "configs/ios_xe_bgp" : {
+          "sentences" : [
+            "(cisco_configuration",
+            "  (stanza",
+            "    (s_hostname",
+            "      HOSTNAME:'hostname'",
+            "      VARIABLE:'ios_xe_bgp'",
+            "      NEWLINE:'\\n'))",
+            "  (stanza",
+            "    (router_bgp_stanza",
+            "      ROUTER:'router'",
+            "      BGP:'bgp'",
+            "      procnum = (bgp_asn",
+            "        asn = DEC:'22222')",
+            "      NEWLINE:'\\n'",
+            "      (router_bgp_stanza_tail",
+            "        (template_peer_policy_rb_stanza",
+            "          TEMPLATE:'template'",
+            "          PEER_POLICY:'peer-policy'",
+            "          name = (variable_permissive",
+            "            VARIABLE:'FOO-BAR'",
+            "            COLON:':'",
+            "            VARIABLE:'BAZ')",
+            "          NEWLINE:'\\n'",
+            "          (bgp_tail",
+            "            (route_map_bgp_tail",
+            "              ROUTE_MAP:'route-map'",
+            "              name = (variable",
+            "                VARIABLE:'MAP'  <== mode:M_RouteMap)",
+            "              IN:'in'",
+            "              NEWLINE:'\\n'))",
+            "          (bgp_tail",
+            "            (send_community_bgp_tail",
+            "              SEND_COMMUNITY:'send-community'",
+            "              BOTH:'both'",
+            "              NEWLINE:'\\n'))",
+            "          EXIT_PEER_POLICY:'exit-peer-policy'",
+            "          NEWLINE:'\\n'))",
+            "      (router_bgp_stanza_tail",
+            "        (template_peer_session_rb_stanza",
+            "          TEMPLATE:'template'",
+            "          PEER_SESSION:'peer-session'",
+            "          name = (variable_permissive",
+            "            VARIABLE:'FOO-BAR_BAZ'",
+            "            COLON:':'",
+            "            VARIABLE:'QUX')",
+            "          NEWLINE:'\\n'",
+            "          (remote_as_bgp_tail",
+            "            REMOTE_AS:'remote-as'",
+            "            remote = (bgp_asn",
+            "              asn = DEC:'65444')",
+            "            NEWLINE:'\\n')",
+            "          EXIT_PEER_SESSION:'exit-peer-session'",
+            "          NEWLINE:'\\n'))",
+            "      (router_bgp_stanza_tail",
+            "        (neighbor_flat_rb_stanza",
+            "          NEIGHBOR:'neighbor'",
+            "          ip = IP_ADDRESS:'1.1.1.1'  <== mode:M_NEIGHBOR",
+            "          (inherit_peer_session_bgp_tail",
+            "            INHERIT:'inherit'",
+            "            PEER_SESSION:'peer-session'",
+            "            name = (variable_permissive",
+            "              VARIABLE:'FOO-BAR'",
+            "              COLON:':'",
+            "              VARIABLE:'BAZ')",
+            "            NEWLINE:'\\n')))",
+            "      (router_bgp_stanza_tail",
+            "        (neighbor_flat_rb_stanza",
+            "          NEIGHBOR:'neighbor'",
+            "          ip = IP_ADDRESS:'1.1.1.1'  <== mode:M_NEIGHBOR",
+            "          (inherit_peer_policy_bgp_tail",
+            "            INHERIT:'inherit'",
+            "            PEER_POLICY:'peer-policy'",
+            "            name = (variable_permissive",
+            "              VARIABLE:'FOO-BAR_BAZ'",
+            "              COLON:':'",
+            "              VARIABLE:'QUX')",
+            "            NEWLINE:'\\n\\n')))))",
+            "  EOF:<EOF>)"
+          ]
+        },
         "configs/ios_xr_acl" : {
           "sentences" : [
             "(cisco_configuration",
@@ -77308,6 +77394,7 @@
         "ios_interface_ip_tcp" : "PASSED",
         "ios_standby" : "PASSED",
         "ios_template" : "PASSED",
+        "ios_xe_bgp" : "WARNINGS",
         "ios_xr_acl" : "PASSED",
         "ios_xr_bgp" : "PASSED",
         "ios_xr_bgp_neighbor_group" : "WARNINGS",
@@ -81838,6 +81925,29 @@
           }
         },
         "configs/ios_template" : { },
+        "configs/ios_xe_bgp" : {
+          "bgp template peer-policy" : {
+            "FOO-BAR:BAZ" : {
+              "definitionLines" : [
+                5,
+                6,
+                7,
+                8
+              ],
+              "numReferrers" : 0
+            }
+          },
+          "bgp template peer-session" : {
+            "FOO-BAR_BAZ:QUX" : {
+              "definitionLines" : [
+                9,
+                10,
+                11
+              ],
+              "numReferrers" : 0
+            }
+          }
+        },
         "configs/ios_xr_acl" : { },
         "configs/ios_xr_bgp" : { },
         "configs/ios_xr_bgp_neighbor_group" : {
@@ -84771,6 +84881,9 @@
         "configs/ios_template" : [
           "ios_template"
         ],
+        "configs/ios_xe_bgp" : [
+          "ios_xe_bgp"
+        ],
         "configs/ios_xr_acl" : [
           "ios_xr_acl"
         ],
@@ -85725,7 +85838,7 @@
                 36
               ]
             },
-            "p3" : {
+            "p310" : {
               "inherited BGP peer-policy" : [
                 37
               ]
@@ -88234,6 +88347,29 @@
             }
           }
         },
+        "configs/ios_xe_bgp" : {
+          "bgp template peer-policy" : {
+            "FOO-BAR_BAZ:QUX" : {
+              "inherited BGP peer-policy" : [
+                13
+              ]
+            }
+          },
+          "bgp template peer-session" : {
+            "FOO-BAR:BAZ" : {
+              "inherited BGP peer-session" : [
+                12
+              ]
+            }
+          },
+          "route-map" : {
+            "MAP" : {
+              "bgp inbound route-map" : [
+                6
+              ]
+            }
+          }
+        },
         "configs/ios_xr_bgp" : {
           "route-policy" : {
             "ADDITIONAL_PATHS_POLICY" : {
@@ -90065,7 +90201,7 @@
                 36
               ]
             },
-            "p3" : {
+            "p310" : {
               "inherited BGP peer-policy" : [
                 37
               ]
@@ -91119,6 +91255,29 @@
             }
           }
         },
+        "configs/ios_xe_bgp" : {
+          "bgp template peer-policy" : {
+            "FOO-BAR_BAZ:QUX" : {
+              "inherited BGP peer-policy" : [
+                13
+              ]
+            }
+          },
+          "bgp template peer-session" : {
+            "FOO-BAR:BAZ" : {
+              "inherited BGP peer-session" : [
+                12
+              ]
+            }
+          },
+          "route-map" : {
+            "MAP" : {
+              "bgp inbound route-map" : [
+                6
+              ]
+            }
+          }
+        },
         "configs/ios_xr_bgp" : {
           "route-policy" : {
             "ADDITIONAL_PATHS_POLICY" : {
@@ -92104,6 +92263,14 @@
             }
           ]
         },
+        "ios_xe_bgp" : {
+          "Red flags" : [
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "No remote-as set for peer: 1.1.1.1"
+            }
+          ]
+        },
         "ios_xr_bgp_neighbor_group" : {
           "Red flags" : [
             {
@@ -92615,6 +92782,7 @@
         "configs/ios_interface_ip_tcp" : "PASSED",
         "configs/ios_standby" : "PASSED",
         "configs/ios_template" : "PASSED",
+        "configs/ios_xe_bgp" : "PASSED",
         "configs/ios_xr_acl" : "PASSED",
         "configs/ios_xr_bgp" : "PASSED",
         "configs/ios_xr_bgp_neighbor_group" : "PASSED",


### PR DESCRIPTION
Helps us not leave router bgp context.