### PR TITLE
NXOS: Convert NVE and NVE VNI to VniSettings

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -2591,28 +2591,39 @@ public final class CiscoNxosGrammarTest {
   }
 
   @Test
-  public void testNveConversion() throws IOException {
-    Configuration c = parseConfig("nxos_nve");
+  public void testNveVnisConversion() throws IOException {
+    Configuration c = parseConfig("nxos_nve_vnis");
 
     assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(10001))));
     assertThat(
         c.getDefaultVrf().getVniSettings().get(10001),
         allOf(
-            hasBumTransportIps(equalTo(ImmutableSortedSet.of())),
+            hasBumTransportIps(equalTo(ImmutableSortedSet.of(Ip.parse("235.0.0.0")))),
             hasBumTransportMethod(equalTo(BumTransportMethod.MULTICAST_GROUP)),
             hasSourceAddress(nullValue()),
             hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
             VniSettingsMatchers.hasVlan(equalTo(2)),
             hasVni(10001)));
 
-    assertThat(c, not(hasDefaultVrf(hasVniSettings(hasKey(20001)))));
+    assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(20001))));
+    assertThat(
+        c.getDefaultVrf().getVniSettings().get(20001),
+        allOf(
+            // L3 mcast IP
+            hasBumTransportIps(equalTo(ImmutableSortedSet.of(Ip.parse("234.0.0.0")))),
+            hasBumTransportMethod(equalTo(BumTransportMethod.MULTICAST_GROUP)),
+            hasSourceAddress(nullValue()),
+            hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
+            VniSettingsMatchers.hasVlan(equalTo(3)),
+            hasVni(20001)));
 
     assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(30001))));
     assertThat(
         c.getDefaultVrf().getVniSettings().get(30001),
         allOf(
-            hasBumTransportIps(equalTo(ImmutableSortedSet.of())),
-            hasBumTransportMethod(equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP)),
+            // L2 mcast IP
+            hasBumTransportIps(equalTo(ImmutableSortedSet.of(Ip.parse("233.0.0.0")))),
+            hasBumTransportMethod(equalTo(BumTransportMethod.MULTICAST_GROUP)),
             hasSourceAddress(nullValue()),
             hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
             VniSettingsMatchers.hasVlan(equalTo(4)),
@@ -2628,6 +2639,9 @@ public final class CiscoNxosGrammarTest {
             hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
             VniSettingsMatchers.hasVlan(equalTo(5)),
             hasVni(40001)));
+
+    // VLAN for VNI 500001 is shutdown
+    assertThat(c, not(hasDefaultVrf(hasVniSettings(hasKey(50001)))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -2579,17 +2579,6 @@ public final class CiscoNxosGrammarTest {
             VniSettingsMatchers.hasVlan(equalTo(2)),
             hasVni(10001)));
 
-    assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(20001))));
-    assertThat(
-        c.getDefaultVrf().getVniSettings().get(20001),
-        allOf(
-            hasBumTransportIps(equalTo(ImmutableSortedSet.of())),
-            hasBumTransportMethod(equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP)),
-            hasSourceAddress(nullValue()),
-            hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
-            VniSettingsMatchers.hasVlan(nullValue()),
-            hasVni(20001)));
-
     assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(30001))));
     assertThat(
         c.getDefaultVrf().getVniSettings().get(30001),
@@ -2598,18 +2587,18 @@ public final class CiscoNxosGrammarTest {
             hasBumTransportMethod(equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP)),
             hasSourceAddress(nullValue()),
             hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
-            VniSettingsMatchers.hasVlan(nullValue()),
+            VniSettingsMatchers.hasVlan(equalTo(4)),
             hasVni(30001)));
 
     assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(40001))));
     assertThat(
         c.getDefaultVrf().getVniSettings().get(40001),
         allOf(
-            hasBumTransportIps(equalTo(ImmutableSortedSet.of())),
+            hasBumTransportIps(equalTo(ImmutableSortedSet.of(Ip.parse("4.0.0.1")))),
             hasBumTransportMethod(equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP)),
             hasSourceAddress(equalTo(Ip.parse("1.1.1.1"))),
             hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
-            VniSettingsMatchers.hasVlan(equalTo(3)),
+            VniSettingsMatchers.hasVlan(equalTo(5)),
             hasVni(40001)));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -2605,6 +2605,8 @@ public final class CiscoNxosGrammarTest {
             VniSettingsMatchers.hasVlan(equalTo(2)),
             hasVni(10001)));
 
+    assertThat(c, not(hasDefaultVrf(hasVniSettings(hasKey(20001)))));
+
     assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(30001))));
     assertThat(
         c.getDefaultVrf().getVniSettings().get(30001),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -7,6 +7,7 @@ import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.Interface.NULL_INTERFACE_NAME;
 import static org.batfish.datamodel.IpWildcard.ipWithWildcardMask;
 import static org.batfish.datamodel.Route.UNSET_NEXT_HOP_INTERFACE;
+import static org.batfish.datamodel.VniSettings.DEFAULT_UDP_PORT;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDscp;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstPort;
@@ -22,6 +23,7 @@ import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasA
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasNextHopInterface;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasNextHopIp;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
+import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasHostname;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterfaces;
@@ -51,6 +53,12 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isAutoState;
 import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
 import static org.batfish.datamodel.matchers.StaticRouteMatchers.hasTag;
+import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasBumTransportIps;
+import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasBumTransportMethod;
+import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasSourceAddress;
+import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasUdpPort;
+import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasVni;
+import static org.batfish.datamodel.matchers.VrfMatchers.hasVniSettings;
 import static org.batfish.grammar.cisco_nxos.CiscoNxosCombinedParser.DEBUG_FLAG_USE_NEW_CISCO_NXOS_PARSER;
 import static org.batfish.grammar.cisco_nxos.CiscoNxosControlPlaneExtractor.PACKET_LENGTH_RANGE;
 import static org.batfish.grammar.cisco_nxos.CiscoNxosControlPlaneExtractor.TCP_PORT_RANGE;
@@ -90,6 +98,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Range;
 import java.io.IOException;
@@ -115,6 +124,7 @@ import org.batfish.common.util.CommonUtil;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.AsPathAccessList;
 import org.batfish.datamodel.AsPathAccessListLine;
+import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.CommunityList;
 import org.batfish.datamodel.CommunityListLine;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
@@ -148,6 +158,7 @@ import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.matchers.HsrpGroupMatchers;
 import org.batfish.datamodel.matchers.RouteFilterListMatchers;
+import org.batfish.datamodel.matchers.VniSettingsMatchers;
 import org.batfish.datamodel.matchers.VrfMatchers;
 import org.batfish.datamodel.routing_policy.expr.LiteralCommunityConjunction;
 import org.batfish.datamodel.tracking.DecrementPriority;
@@ -2551,6 +2562,55 @@ public final class CiscoNxosGrammarTest {
       assertThat(vniConfig.getMcastGroup(), nullValue());
       assertThat(vniConfig.getPeerIps(), equalTo(ImmutableSet.of(Ip.parse("4.0.0.1"))));
     }
+  }
+
+  @Test
+  public void testNveConversion() throws IOException {
+    Configuration c = parseConfig("nxos_nve");
+
+    assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(10001))));
+    assertThat(
+        c.getDefaultVrf().getVniSettings().get(10001),
+        allOf(
+            hasBumTransportIps(equalTo(ImmutableSortedSet.of())),
+            hasBumTransportMethod(equalTo(BumTransportMethod.MULTICAST_GROUP)),
+            hasSourceAddress(nullValue()),
+            hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
+            VniSettingsMatchers.hasVlan(equalTo(2)),
+            hasVni(10001)));
+
+    assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(20001))));
+    assertThat(
+        c.getDefaultVrf().getVniSettings().get(20001),
+        allOf(
+            hasBumTransportIps(equalTo(ImmutableSortedSet.of())),
+            hasBumTransportMethod(equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP)),
+            hasSourceAddress(nullValue()),
+            hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
+            VniSettingsMatchers.hasVlan(nullValue()),
+            hasVni(20001)));
+
+    assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(30001))));
+    assertThat(
+        c.getDefaultVrf().getVniSettings().get(30001),
+        allOf(
+            hasBumTransportIps(equalTo(ImmutableSortedSet.of())),
+            hasBumTransportMethod(equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP)),
+            hasSourceAddress(nullValue()),
+            hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
+            VniSettingsMatchers.hasVlan(nullValue()),
+            hasVni(30001)));
+
+    assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(40001))));
+    assertThat(
+        c.getDefaultVrf().getVniSettings().get(40001),
+        allOf(
+            hasBumTransportIps(equalTo(ImmutableSortedSet.of())),
+            hasBumTransportMethod(equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP)),
+            hasSourceAddress(equalTo(Ip.parse("1.1.1.1"))),
+            hasUdpPort(equalTo(DEFAULT_UDP_PORT)),
+            VniSettingsMatchers.hasVlan(equalTo(3)),
+            hasVni(40001)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve
@@ -6,6 +6,16 @@ hostname nxos_nve
 feature vn-segment-vlan-based
 feature nv overlay
 !
+vlan 2
+  name Name-Of-Vlan-2
+  vn-segment 10001
+!
+vlan 3
+  name Name-Of-Vlan-3
+  vn-segment 40001
+!
+interface loopback4
+  ip address 1.1.1.1/32
 !
 interface nve1-2
   no shutdown

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve
@@ -6,24 +6,6 @@ hostname nxos_nve
 feature vn-segment-vlan-based
 feature nv overlay
 !
-vlan 2
-  name Name-Of-Vlan-2
-  vn-segment 10001
-!
-vlan 3
-  name Name-Of-Vlan-3
-  vn-segment 20001
-!
-vlan 4
-  name Name-Of-Vlan-4
-  vn-segment 30001
-!
-vlan 5
-  name Name-Of-Vlan-5
-  vn-segment 40001
-!
-interface loopback4
-  ip address 1.1.1.1/32
 !
 interface nve1-2
   no shutdown
@@ -60,16 +42,4 @@ interface nve4
     peer-ip 4.0.0.1
   !! This line will be rejected since we have a peer configured with ingress-replication protocol static
   host-reachability protocol bgp
-!
-interface Vlan2
-  no shutdown
-!
-!! Shutting down VLAN 3 (NVE 2)
-interface Vlan3
-!
-interface Vlan4
-  no shutdown
-!
-interface Vlan5
-  no shutdown
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve
@@ -12,6 +12,14 @@ vlan 2
 !
 vlan 3
   name Name-Of-Vlan-3
+  vn-segment 20001
+!
+vlan 4
+  name Name-Of-Vlan-4
+  vn-segment 30001
+!
+vlan 5
+  name Name-Of-Vlan-5
   vn-segment 40001
 !
 interface loopback4
@@ -52,4 +60,16 @@ interface nve4
     peer-ip 4.0.0.1
   !! This line will be rejected since we have a peer configured with ingress-replication protocol static
   host-reachability protocol bgp
+!
+interface Vlan2
+  no shutdown
+!
+!! Shutting down VLAN 3 (NVE 2)
+interface Vlan3
+!
+interface Vlan4
+  no shutdown
+!
+interface Vlan5
+  no shutdown
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve_vnis
@@ -1,0 +1,85 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_nve_vnis
+!
+! Required to enable NVE devices
+feature vn-segment-vlan-based
+feature nv overlay
+!
+!! Although Cisco limits one NVE interface per switch, for testing purposes we declare multiple NVEs in this config
+vlan 2
+  name Name-Of-Vlan-2
+  vn-segment 10001
+!
+vlan 3
+  name Name-Of-Vlan-3
+  vn-segment 20001
+!
+vlan 4
+  name Name-Of-Vlan-4
+  vn-segment 30001
+!
+vlan 5
+  name Name-Of-Vlan-5
+  vn-segment 40001
+!
+vlan 6
+  name Name-Of-Vlan-6
+  vn-segment 50001
+!
+interface loopback0
+  ip address 1.1.1.1/32
+!
+interface nve1
+  no shutdown
+  global mcast-group 233.0.0.0 L2
+  global mcast-group 234.0.0.0 L3
+  member vni 10001
+    mcast-group 235.0.0.0
+    ingress-replication protocol bgp
+interface nve2
+  no shutdown
+  !! mcast L3 will be inherited because of associate-vrf
+  global mcast-group 233.0.0.0 L2
+  global mcast-group 234.0.0.0 L3
+  member vni 20001 associate-vrf
+    ingress-replication protocol bgp
+interface nve3
+  no shutdown
+  !! mcast L2 will be inherited because of no associate-vrf
+  global mcast-group 233.0.0.0 L2
+  global mcast-group 234.0.0.0 L3
+  member vni 30001
+    ingress-replication protocol bgp
+interface nve4
+  no shutdown
+  global mcast-group 233.0.0.0 L2
+  global mcast-group 234.0.0.0 L3
+  source-interface loopback0
+  member vni 40001
+     !! mcast will be ignored because of static ingress-replication protocol, peer IP will be used
+     ingress-replication protocol static
+     peer-ip 4.0.0.1
+!
+interface nve5
+  no shutdown
+  global mcast-group 233.0.0.0 L2
+  global mcast-group 234.0.0.0 L3
+  !! VLAN for VNI=50001 is shutdown
+  member vni 50001
+    mcast-group 235.0.0.0
+    ingress-replication protocol bgp
+interface Vlan2
+  no shutdown
+!
+interface Vlan3
+  no shutdown
+!
+interface Vlan4
+  no shutdown
+!
+interface Vlan5
+  no shutdown
+!
+interface Vlan6
+!


### PR DESCRIPTION
NXOS also uses the same default UDP port 4789 for VXLan, [here](https://www.cisco.com/c/en/us/products/collateral/switches/nexus-9000-series-switches/white-paper-c11-729383.html).