### PR TITLE
Cumulus: gracefully ignore peers with no remote AS

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -172,6 +172,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
       BgpVrf bgpVrf,
       org.batfish.datamodel.BgpProcess newProc) {
     if (neighbor.getRemoteAs() == null && neighbor.getRemoteAsType() == null) {
+      getWarnings().redFlag("Skipping invalidly configured BGP peer " + neighbor.getName());
       return;
     }
     RoutingPolicy routingPolicy = computeBgpNeighborRoutingPolicy(neighbor, bgpVrf);
@@ -209,6 +210,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
       org.batfish.datamodel.BgpProcess newProc) {
     if (neighbor.getPeerIp() == null
         || (neighbor.getRemoteAs() == null && neighbor.getRemoteAsType() == null)) {
+      getWarnings().redFlag("Skipping invalidly configured BGP peer " + neighbor.getName());
       return;
     }
     RoutingPolicy routingPolicy = computeBgpNeighborRoutingPolicy(neighbor, bgpVrf);

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -171,6 +171,9 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
       @Nullable Long localAs,
       BgpVrf bgpVrf,
       org.batfish.datamodel.BgpProcess newProc) {
+    if (neighbor.getRemoteAs() == null && neighbor.getRemoteAsType() == null) {
+      return;
+    }
     RoutingPolicy routingPolicy = computeBgpNeighborRoutingPolicy(neighbor, bgpVrf);
     BgpUnnumberedPeerConfig.builder()
         .setBgpProcess(newProc)
@@ -204,7 +207,8 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
       @Nullable Long localAs,
       BgpVrf bgpVrf,
       org.batfish.datamodel.BgpProcess newProc) {
-    if (neighbor.getPeerIp() == null) {
+    if (neighbor.getPeerIp() == null
+        || (neighbor.getRemoteAs() == null && neighbor.getRemoteAsType() == null)) {
       return;
     }
     RoutingPolicy routingPolicy = computeBgpNeighborRoutingPolicy(neighbor, bgpVrf);
@@ -525,7 +529,6 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
                         if (neighbor instanceof BgpInterfaceNeighbor) {
                           BgpInterfaceNeighbor interfaceNeighbor = (BgpInterfaceNeighbor) neighbor;
                           interfaceNeighbor.inheritFrom(bgpVrf.getNeighbors());
-
                           addInterfaceNeighbor(interfaceNeighbor, localAs, bgpVrf, viBgpProcess);
                         } else if (neighbor instanceof BgpIpNeighbor) {
                           BgpIpNeighbor ipNeighbor = (BgpIpNeighbor) neighbor;

--- a/tests/parsing-tests/networks/unit-tests/configs/cumulus_nclu_bgp_no_remote_as
+++ b/tests/parsing-tests/networks/unit-tests/configs/cumulus_nclu_bgp_no_remote_as
@@ -1,0 +1,9 @@
+net del all
+#
+net add hostname cumulus_nclu_bgp_no_remote_as
+#
+net add bgp autonomous-system 65500
+net add bgp router-id 192.0.2.2
+net add bgp neighbor 1.1.1.1 description spam
+net add bgp vrf vrf1 neighbor 1.1.1.2 description eggs
+net commit

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -15244,6 +15244,123 @@
           }
         }
       },
+      "cumulus_nclu_bgp_no_remote_as" : {
+        "configurationFormat" : "CUMULUS_NCLU",
+        "name" : "cumulus_nclu_bgp_no_remote_as",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "ROUTER",
+        "interfaces" : {
+          "lo" : {
+            "name" : "lo",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "mtu" : 1500,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "default"
+          },
+          "vrf1" : {
+            "name" : "vrf1",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "mtu" : 1500,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOOPBACK",
+            "vrf" : "vrf1"
+          }
+        },
+        "routingPolicies" : {
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                  "protocols" : [
+                    "bgp",
+                    "ibgp"
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cumulus" : {
+            "bridge" : {
+              "pvid" : 1,
+              "vids" : ""
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
+              "routerId" : "192.0.2.2",
+              "multipathEbgp" : false,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : false,
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "interfaces" : [
+              "lo"
+            ]
+          },
+          "vrf1" : {
+            "name" : "vrf1",
+            "interfaces" : [
+              "vrf1"
+            ]
+          }
+        }
+      },
       "cumulus_nclu_bgp_no_router_id" : {
         "configurationFormat" : "CUMULUS_NCLU",
         "name" : "cumulus_nclu_bgp_no_router_id",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -92440,6 +92440,14 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Cannot configure BGP session for vrf 'vrf1' because router-id is missing"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Skipping invalidly configured BGP peer 1.1.1.1"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Skipping invalidly configured BGP peer 1.1.1.2"
             }
           ]
         },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -462,6 +462,9 @@
         "cumulus_nclu_bgp_no_address_family" : [
           "configs/cumulus_nclu_bgp_no_address_family"
         ],
+        "cumulus_nclu_bgp_no_remote_as" : [
+          "configs/cumulus_nclu_bgp_no_remote_as"
+        ],
         "cumulus_nclu_bgp_no_router_id" : [
           "configs/cumulus_nclu_bgp_no_router_id"
         ],
@@ -1071,6 +1074,7 @@
         "configs/cumulus_nclu" : "PASSED",
         "configs/cumulus_nclu_bgp" : "PASSED",
         "configs/cumulus_nclu_bgp_no_address_family" : "PASSED",
+        "configs/cumulus_nclu_bgp_no_remote_as" : "PASSED",
         "configs/cumulus_nclu_bgp_no_router_id" : "PASSED",
         "configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip" : "PASSED",
         "configs/cumulus_nclu_bond" : "PASSED",
@@ -41930,6 +41934,94 @@
             "  EOF:<EOF>)"
           ]
         },
+        "configs/cumulus_nclu_bgp_no_remote_as" : {
+          "sentences" : [
+            "(cumulus_nclu_configuration",
+            "  (statement",
+            "    (s_null",
+            "      NET:'net'",
+            "      (null_rest_of_line",
+            "        DEL:'del'",
+            "        WORD:'all'",
+            "        NEWLINE:'\\n')))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_hostname",
+            "        HOSTNAME:'hostname'",
+            "        hostname = (word",
+            "          WORD:'cumulus_nclu_bgp_no_remote_as')",
+            "        NEWLINE:'\\n')))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_bgp",
+            "        BGP:'bgp'",
+            "        (b_common",
+            "          (b_autonomous_system",
+            "            AUTONOMOUS_SYSTEM:'autonomous-system'",
+            "            as = (uint32",
+            "              d = DEC:'65500')",
+            "            NEWLINE:'\\n')))))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_bgp",
+            "        BGP:'bgp'",
+            "        (b_common",
+            "          (b_router_id",
+            "            ROUTER_ID:'router-id'",
+            "            id = (ip_address",
+            "              IP_ADDRESS:'192.0.2.2')",
+            "            NEWLINE:'\\n')))))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_bgp",
+            "        BGP:'bgp'",
+            "        (b_common",
+            "          (b_neighbor",
+            "            NEIGHBOR:'neighbor'",
+            "            name = (word",
+            "              IP_ADDRESS:'1.1.1.1')",
+            "            (bn_peer",
+            "              (bnp_description",
+            "                DESCRIPTION:'description'",
+            "                text = WORD:'spam'",
+            "                NEWLINE:'\\n')))))))",
+            "  (statement",
+            "    (s_net_add",
+            "      NET:'net'",
+            "      ADD:'add'",
+            "      (a_bgp",
+            "        BGP:'bgp'",
+            "        (b_vrf",
+            "          VRF:'vrf'",
+            "          name = (word",
+            "            NUMBERED_WORD:'vrf1')",
+            "          (b_common",
+            "            (b_neighbor",
+            "              NEIGHBOR:'neighbor'",
+            "              name = (word",
+            "                IP_ADDRESS:'1.1.1.2')",
+            "              (bn_peer",
+            "                (bnp_description",
+            "                  DESCRIPTION:'description'",
+            "                  text = WORD:'eggs'",
+            "                  NEWLINE:'\\n'))))))))",
+            "  (statement",
+            "    (s_null",
+            "      NET:'net'",
+            "      (null_rest_of_line",
+            "        COMMIT:'commit'",
+            "        NEWLINE:'\\n\\n')))",
+            "  EOF:<EOF>)"
+          ]
+        },
         "configs/cumulus_nclu_bgp_no_router_id" : {
           "sentences" : [
             "(cumulus_nclu_configuration",
@@ -77448,6 +77540,7 @@
         "cumulus_nclu" : "WARNINGS",
         "cumulus_nclu_bgp" : "WARNINGS",
         "cumulus_nclu_bgp_no_address_family" : "PASSED",
+        "cumulus_nclu_bgp_no_remote_as" : "WARNINGS",
         "cumulus_nclu_bgp_no_router_id" : "PASSED",
         "cumulus_nclu_bgp_no_router_id_or_loopback_ip" : "WARNINGS",
         "cumulus_nclu_bond" : "PASSED",
@@ -80299,6 +80392,16 @@
           }
         },
         "configs/cumulus_nclu_bgp_no_address_family" : { },
+        "configs/cumulus_nclu_bgp_no_remote_as" : {
+          "vrf" : {
+            "vrf1" : {
+              "definitionLines" : [
+                8
+              ],
+              "numReferrers" : 1
+            }
+          }
+        },
         "configs/cumulus_nclu_bgp_no_router_id" : {
           "loopback" : {
             "lo" : {
@@ -84869,6 +84972,9 @@
         "configs/cumulus_nclu_bgp_no_address_family" : [
           "cumulus_nclu_bgp_no_address_family"
         ],
+        "configs/cumulus_nclu_bgp_no_remote_as" : [
+          "cumulus_nclu_bgp_no_remote_as"
+        ],
         "configs/cumulus_nclu_bgp_no_router_id" : [
           "cumulus_nclu_bgp_no_router_id"
         ],
@@ -87515,6 +87621,15 @@
           }
         },
         "configs/cumulus_nclu_bgp" : {
+          "vrf" : {
+            "vrf1" : {
+              "bgp vrf" : [
+                8
+              ]
+            }
+          }
+        },
+        "configs/cumulus_nclu_bgp_no_remote_as" : {
           "vrf" : {
             "vrf1" : {
               "bgp vrf" : [
@@ -92320,6 +92435,14 @@
             }
           ]
         },
+        "cumulus_nclu_bgp_no_remote_as" : {
+          "Red flags" : [
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Cannot configure BGP session for vrf 'vrf1' because router-id is missing"
+            }
+          ]
+        },
         "cumulus_nclu_bgp_no_router_id_or_loopback_ip" : {
           "Red flags" : [
             {
@@ -92867,6 +92990,7 @@
         "configs/cumulus_nclu" : "PASSED",
         "configs/cumulus_nclu_bgp" : "PASSED",
         "configs/cumulus_nclu_bgp_no_address_family" : "PASSED",
+        "configs/cumulus_nclu_bgp_no_remote_as" : "PASSED",
         "configs/cumulus_nclu_bgp_no_router_id" : "PASSED",
         "configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip" : "PASSED",
         "configs/cumulus_nclu_bond" : "PASSED",


### PR DESCRIPTION
Instead of failing the whole file, resorting to ignoring invalid peers during conversion.