### PR TITLE
Cumulus: Do not fail the file on invalid bonds

### DIFF
--- a/tests/parsing-errors-tests/networks/single-fail/configs/cumulus_nclu_invalid_bonds
+++ b/tests/parsing-errors-tests/networks/single-fail/configs/cumulus_nclu_invalid_bonds
@@ -1,5 +1,0 @@
-net del all
-#
-net add hostname cumulus_nclu_invalid_bonds
-# Slaves assigned to multiple bonds
-net add bond B1,B2 bond slaves swp1-10

--- a/tests/parsing-errors-tests/no-verbose.ref
+++ b/tests/parsing-errors-tests/no-verbose.ref
@@ -6,7 +6,6 @@
         "configs/as1r1.cfg" : "FAILED",
         "configs/as1r2.cfg" : "PASSED",
         "configs/as2r1.cfg" : "PASSED",
-        "configs/cumulus_nclu_invalid_bonds" : "WILL_NOT_COMMIT",
         "configs/cumulus_nclu_range" : "FAILED"
       }
     }

--- a/tests/parsing-errors-tests/parsing-error.ref
+++ b/tests/parsing-errors-tests/parsing-error.ref
@@ -6,7 +6,6 @@
         "configs/as1r1.cfg" : "FAILED",
         "configs/as1r2.cfg" : "PASSED",
         "configs/as2r1.cfg" : "PASSED",
-        "configs/cumulus_nclu_invalid_bonds" : "WILL_NOT_COMMIT",
         "configs/cumulus_nclu_range" : "FAILED"
       }
     }

--- a/tests/parsing-errors-tests/recovery-no-verbose.ref
+++ b/tests/parsing-errors-tests/recovery-no-verbose.ref
@@ -6,7 +6,6 @@
         "configs/as1r1.cfg" : "PARTIALLY_UNRECOGNIZED",
         "configs/as1r2.cfg" : "PASSED",
         "configs/as2r1.cfg" : "PASSED",
-        "configs/cumulus_nclu_invalid_bonds" : "WILL_NOT_COMMIT",
         "configs/cumulus_nclu_range" : "PARTIALLY_UNRECOGNIZED"
       },
       "warnings" : {

--- a/tests/parsing-errors-tests/recovery-parsing-error.ref
+++ b/tests/parsing-errors-tests/recovery-parsing-error.ref
@@ -6,7 +6,6 @@
         "configs/as1r1.cfg" : "PARTIALLY_UNRECOGNIZED",
         "configs/as1r2.cfg" : "PASSED",
         "configs/as2r1.cfg" : "PASSED",
-        "configs/cumulus_nclu_invalid_bonds" : "WILL_NOT_COMMIT",
         "configs/cumulus_nclu_range" : "PARTIALLY_UNRECOGNIZED"
       }
     }


### PR DESCRIPTION
Since our glob parsing is subpar, try to be graceful on "invalid" bond
combinations instead for filing the file