### PR TITLE
fix bug in pojo topology creation

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Topology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Topology.java
@@ -48,6 +48,10 @@ public class Topology extends BfObject {
           configuration.getAllInterfaces();
       // add interfaces and links
       for (Edge edge : topology.getNodeEdges().get(nodeName)) {
+        if (!edge.getNode1().equals(nodeName)) {
+          // only consider edges where node1 is the source
+          continue;
+        }
         String interface1 = edge.getInt1();
         String interface2 = edge.getInt2();
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
@@ -3,9 +3,15 @@ package org.batfish.datamodel.pojo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.pojo.Aggregate.AggregateType;
 import org.junit.Test;
 
@@ -36,5 +42,59 @@ public class TopologyTest {
     assertThat(topo.getInterfaces().size(), equalTo(1));
     assertThat(topo.getLinks().size(), equalTo(1));
     assertThat(topo.getNodes().size(), equalTo(1));
+  }
+
+  /** Tests that the correct topology is created. */
+  @Test
+  public void testCreate() {
+    NetworkFactory nf = new NetworkFactory();
+
+    Configuration c1 = nf.configurationBuilder().setHostname("c1").build();
+    Configuration c2 = nf.configurationBuilder().setHostname("c2").build();
+    Configuration c3 = nf.configurationBuilder().setHostname("c3").build();
+
+    // create line topology: c1 <-> c2 <-> c3
+    org.batfish.datamodel.Interface c12 =
+        nf.interfaceBuilder().setOwner(c1).setName("to-c2").setType(InterfaceType.UNKNOWN).build();
+    org.batfish.datamodel.Interface c21 =
+        nf.interfaceBuilder().setOwner(c2).setName("to-c1").setType(InterfaceType.UNKNOWN).build();
+    org.batfish.datamodel.Interface c23 =
+        nf.interfaceBuilder().setOwner(c2).setName("to-c3").setType(InterfaceType.UNKNOWN).build();
+    org.batfish.datamodel.Interface c32 =
+        nf.interfaceBuilder().setOwner(c3).setName("to-c2").setType(InterfaceType.UNKNOWN).build();
+
+    org.batfish.datamodel.Topology rawL3Topology =
+        new org.batfish.datamodel.Topology(
+            ImmutableSortedSet.of(
+                new Edge(c12, c21), new Edge(c21, c12), new Edge(c23, c32), new Edge(c32, c23)));
+
+    Topology pojoTopology =
+        Topology.create(
+            "test",
+            ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2, c3.getHostname(), c3),
+            rawL3Topology);
+
+    Node c1Node = new Node(c1.getHostname());
+    Node c2Node = new Node(c2.getHostname());
+    Node c3Node = new Node(c3.getHostname());
+
+    assertThat(pojoTopology.getNodes(), equalTo(ImmutableSet.of(c1Node, c2Node, c3Node)));
+
+    Interface c12Interface = new Interface(c1Node.getId(), c12.getName());
+    Interface c21Interface = new Interface(c2Node.getId(), c21.getName());
+    Interface c23Interface = new Interface(c2Node.getId(), c23.getName());
+    Interface c32Interface = new Interface(c3Node.getId(), c32.getName());
+    assertThat(
+        pojoTopology.getInterfaces(),
+        equalTo(ImmutableSet.of(c12Interface, c21Interface, c23Interface, c32Interface)));
+
+    assertThat(
+        pojoTopology.getLinks(),
+        equalTo(
+            ImmutableSet.of(
+                new Link(c12Interface.getId(), c21Interface.getId()),
+                new Link(c21Interface.getId(), c12Interface.getId()),
+                new Link(c23Interface.getId(), c32Interface.getId()),
+                new Link(c32Interface.getId(), c23Interface.getId()))));
   }
 }

--- a/tests/aws/topology-example-aws.ref
+++ b/tests/aws/topology-example-aws.ref
@@ -158,9 +158,15 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-subnet-f73a8191-subnet-f73a8191",
+      "id" : "interface-node-vpc-925131f4-subnet-62f14104",
+      "name" : "subnet-62f14104",
+      "nodeId" : "node-vpc-925131f4",
+      "type" : "PHYSICAL"
+    },
+    {
+      "id" : "interface-node-vpc-b390fad5-subnet-f73a8191",
       "name" : "subnet-f73a8191",
-      "nodeId" : "node-subnet-f73a8191",
+      "nodeId" : "node-vpc-b390fad5",
       "type" : "PHYSICAL"
     },
     {
@@ -188,6 +194,12 @@
       "type" : "PHYSICAL"
     },
     {
+      "id" : "interface-node-subnet-1641fa70-vpc-b390fad5",
+      "name" : "vpc-b390fad5",
+      "nodeId" : "node-subnet-1641fa70",
+      "type" : "PHYSICAL"
+    },
+    {
       "id" : "interface-node-subnet-7044ff16-vpc-b390fad5",
       "name" : "vpc-b390fad5",
       "nodeId" : "node-subnet-7044ff16",
@@ -204,180 +216,6 @@
       "name" : "vpc-b390fad5",
       "nodeId" : "node-subnet-073b8061",
       "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-subnet-30398256-subnet-30398256",
-      "name" : "subnet-30398256",
-      "nodeId" : "node-subnet-30398256",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-subnet-d9cafabc-vpc-f8fad69d",
-      "name" : "vpc-f8fad69d",
-      "nodeId" : "node-subnet-d9cafabc",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-subnet-7044ff16-es-domain-subnet-7044ff16",
-      "name" : "es-domain-subnet-7044ff16",
-      "nodeId" : "node-subnet-7044ff16",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-subnet-9c8adceb-subnet-9c8adceb",
-      "name" : "subnet-9c8adceb",
-      "nodeId" : "node-subnet-9c8adceb",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-subnet-62f14104-subnet-62f14104",
-      "name" : "subnet-62f14104",
-      "nodeId" : "node-subnet-62f14104",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-vpc-b390fad5-vpc-b390fad5",
-      "name" : "vpc-b390fad5",
-      "nodeId" : "node-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-test-rds-es-domain-subnet-1641fa70",
-      "name" : "es-domain-subnet-1641fa70",
-      "nodeId" : "node-test-rds",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-igw-068fee63-igw-068fee63",
-      "name" : "igw-068fee63",
-      "nodeId" : "node-igw-068fee63",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-subnet-1f315846-subnet-1f315846",
-      "name" : "subnet-1f315846",
-      "nodeId" : "node-subnet-1f315846",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-vpc-925131f4-vpc-925131f4",
-      "name" : "vpc-925131f4",
-      "nodeId" : "node-vpc-925131f4",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-es-domain-test-rds-subnet-1641fa70",
-      "name" : "test-rds-subnet-1641fa70",
-      "nodeId" : "node-es-domain",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-vpc-b390fad5-subnet-1641fa70",
-      "name" : "subnet-1641fa70",
-      "nodeId" : "node-vpc-b390fad5",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-vpc-f8fad69d-subnet-d9cafabc",
-      "name" : "subnet-d9cafabc",
-      "nodeId" : "node-vpc-f8fad69d",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-vgw-81fd279f-vpc-815775e7",
-      "name" : "vpc-815775e7",
-      "nodeId" : "node-vgw-81fd279f",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-igw-fac5839d-vpc-925131f4",
-      "name" : "vpc-925131f4",
-      "nodeId" : "node-igw-fac5839d",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-subnet-1f315846-vpc-f8fad69d",
-      "name" : "vpc-f8fad69d",
-      "nodeId" : "node-subnet-1f315846",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-subnet-1641fa70-test-rds-subnet-1641fa70",
-      "name" : "test-rds-subnet-1641fa70",
-      "nodeId" : "node-subnet-1641fa70",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-subnet-1641fa70-es-domain-subnet-1641fa70",
-      "name" : "es-domain-subnet-1641fa70",
-      "nodeId" : "node-subnet-1641fa70",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-subnet-d9cafabc-subnet-d9cafabc",
-      "name" : "subnet-d9cafabc",
-      "nodeId" : "node-subnet-d9cafabc",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-igw-fac5839d-igw-fac5839d",
-      "name" : "igw-fac5839d",
-      "nodeId" : "node-igw-fac5839d",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-vpc-925131f4-igw-fac5839d",
-      "name" : "igw-fac5839d",
-      "nodeId" : "node-vpc-925131f4",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-es-domain-subnet-7044ff16",
-      "name" : "subnet-7044ff16",
-      "nodeId" : "node-es-domain",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-igw-068fee63-vpc-f8fad69d",
-      "name" : "vpc-f8fad69d",
-      "nodeId" : "node-igw-068fee63",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-test-rds-subnet-1641fa70",
-      "name" : "subnet-1641fa70",
-      "nodeId" : "node-test-rds",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-vpc-925131f4-subnet-62f14104",
-      "name" : "subnet-62f14104",
-      "nodeId" : "node-vpc-925131f4",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-igw-9b93ddfc-igw-9b93ddfc",
-      "name" : "igw-9b93ddfc",
-      "nodeId" : "node-igw-9b93ddfc",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-vpc-b390fad5-subnet-f73a8191",
-      "name" : "subnet-f73a8191",
-      "nodeId" : "node-vpc-b390fad5",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-subnet-1641fa70-vpc-b390fad5",
-      "name" : "vpc-b390fad5",
-      "nodeId" : "node-subnet-1641fa70",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-vgw-81fd279f-vgw-81fd279f",
-      "name" : "vgw-81fd279f",
-      "nodeId" : "node-vgw-81fd279f",
-      "type" : "UNKNOWN"
     },
     {
       "id" : "interface-node-subnet-7044ff16-subnet-7044ff16",
@@ -404,21 +242,9 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-vpc-f8fad69d-vpc-f8fad69d",
+      "id" : "interface-node-subnet-d9cafabc-vpc-f8fad69d",
       "name" : "vpc-f8fad69d",
-      "nodeId" : "node-vpc-f8fad69d",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-subnet-073b8061-subnet-073b8061",
-      "name" : "subnet-073b8061",
-      "nodeId" : "node-subnet-073b8061",
-      "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-subnet-8d0cbdeb-subnet-8d0cbdeb",
-      "name" : "subnet-8d0cbdeb",
-      "nodeId" : "node-subnet-8d0cbdeb",
+      "nodeId" : "node-subnet-d9cafabc",
       "type" : "PHYSICAL"
     },
     {
@@ -434,16 +260,10 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-es-domain-subnet-1641fa70",
+      "id" : "interface-node-vpc-b390fad5-subnet-1641fa70",
       "name" : "subnet-1641fa70",
-      "nodeId" : "node-es-domain",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-vpc-815775e7-vpc-815775e7",
-      "name" : "vpc-815775e7",
-      "nodeId" : "node-vpc-815775e7",
-      "type" : "UNKNOWN"
+      "nodeId" : "node-vpc-b390fad5",
+      "type" : "PHYSICAL"
     },
     {
       "id" : "interface-node-es-domain-es-domain-subnet-7044ff16",
@@ -470,9 +290,33 @@
       "type" : "PHYSICAL"
     },
     {
+      "id" : "interface-node-vpc-f8fad69d-subnet-d9cafabc",
+      "name" : "subnet-d9cafabc",
+      "nodeId" : "node-vpc-f8fad69d",
+      "type" : "PHYSICAL"
+    },
+    {
+      "id" : "interface-node-vgw-81fd279f-vpc-815775e7",
+      "name" : "vpc-815775e7",
+      "nodeId" : "node-vgw-81fd279f",
+      "type" : "PHYSICAL"
+    },
+    {
       "id" : "interface-node-subnet-1641fa70-subnet-1641fa70",
       "name" : "subnet-1641fa70",
       "nodeId" : "node-subnet-1641fa70",
+      "type" : "PHYSICAL"
+    },
+    {
+      "id" : "interface-node-igw-fac5839d-vpc-925131f4",
+      "name" : "vpc-925131f4",
+      "nodeId" : "node-igw-fac5839d",
+      "type" : "PHYSICAL"
+    },
+    {
+      "id" : "interface-node-subnet-1f315846-vpc-f8fad69d",
+      "name" : "vpc-f8fad69d",
+      "nodeId" : "node-subnet-1f315846",
       "type" : "PHYSICAL"
     },
     {
@@ -482,9 +326,21 @@
       "type" : "PHYSICAL"
     },
     {
+      "id" : "interface-node-vpc-925131f4-igw-fac5839d",
+      "name" : "igw-fac5839d",
+      "nodeId" : "node-vpc-925131f4",
+      "type" : "PHYSICAL"
+    },
+    {
       "id" : "interface-node-vpc-b390fad5-subnet-7044ff16",
       "name" : "subnet-7044ff16",
       "nodeId" : "node-vpc-b390fad5",
+      "type" : "PHYSICAL"
+    },
+    {
+      "id" : "interface-node-igw-068fee63-vpc-f8fad69d",
+      "name" : "vpc-f8fad69d",
+      "nodeId" : "node-igw-068fee63",
       "type" : "PHYSICAL"
     },
     {
@@ -502,21 +358,15 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-es-domain-es-domain-subnet-7044ff16",
-      "id" : "link-interface-node-es-domain-subnet-7044ff16-interface-node-es-domain-es-domain-subnet-7044ff16",
-      "srcId" : "interface-node-es-domain-subnet-7044ff16",
+      "dstId" : "interface-node-subnet-1641fa70-vpc-b390fad5",
+      "id" : "link-interface-node-vpc-b390fad5-subnet-1641fa70-interface-node-subnet-1641fa70-vpc-b390fad5",
+      "srcId" : "interface-node-vpc-b390fad5-subnet-1641fa70",
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-igw-fac5839d-vpc-925131f4",
-      "id" : "link-interface-node-igw-fac5839d-igw-fac5839d-interface-node-igw-fac5839d-vpc-925131f4",
-      "srcId" : "interface-node-igw-fac5839d-igw-fac5839d",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-9b93ddfc-vpc-b390fad5",
-      "id" : "link-interface-node-igw-9b93ddfc-igw-9b93ddfc-interface-node-igw-9b93ddfc-vpc-b390fad5",
-      "srcId" : "interface-node-igw-9b93ddfc-igw-9b93ddfc",
+      "dstId" : "interface-node-vgw-81fd279f-vpc-815775e7",
+      "id" : "link-interface-node-vpc-815775e7-vgw-81fd279f-interface-node-vgw-81fd279f-vpc-815775e7",
+      "srcId" : "interface-node-vpc-815775e7-vgw-81fd279f",
       "type" : "UNKNOWN"
     },
     {
@@ -526,15 +376,15 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-8d0cbdeb-vpc-925131f4",
-      "id" : "link-interface-node-subnet-8d0cbdeb-subnet-8d0cbdeb-interface-node-subnet-8d0cbdeb-vpc-925131f4",
-      "srcId" : "interface-node-subnet-8d0cbdeb-subnet-8d0cbdeb",
-      "type" : "PHYSICAL"
-    },
-    {
       "dstId" : "interface-node-subnet-f73a8191-vpc-b390fad5",
       "id" : "link-interface-node-vpc-b390fad5-subnet-f73a8191-interface-node-subnet-f73a8191-vpc-b390fad5",
       "srcId" : "interface-node-vpc-b390fad5-subnet-f73a8191",
+      "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-vpc-b390fad5-igw-9b93ddfc",
+      "id" : "link-interface-node-igw-9b93ddfc-vpc-b390fad5-interface-node-vpc-b390fad5-igw-9b93ddfc",
+      "srcId" : "interface-node-igw-9b93ddfc-vpc-b390fad5",
       "type" : "UNKNOWN"
     },
     {
@@ -562,174 +412,6 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-test-rds-test-rds-subnet-1641fa70",
-      "id" : "link-interface-node-test-rds-es-domain-subnet-1641fa70-interface-node-test-rds-test-rds-subnet-1641fa70",
-      "srcId" : "interface-node-test-rds-es-domain-subnet-1641fa70",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-1641fa70-vpc-b390fad5",
-      "id" : "link-interface-node-subnet-1641fa70-subnet-1641fa70-interface-node-subnet-1641fa70-vpc-b390fad5",
-      "srcId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-vpc-925131f4-subnet-8d0cbdeb",
-      "id" : "link-interface-node-vpc-925131f4-vpc-925131f4-interface-node-vpc-925131f4-subnet-8d0cbdeb",
-      "srcId" : "interface-node-vpc-925131f4-vpc-925131f4",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-7044ff16-vpc-b390fad5",
-      "id" : "link-interface-node-vpc-b390fad5-subnet-7044ff16-interface-node-subnet-7044ff16-vpc-b390fad5",
-      "srcId" : "interface-node-vpc-b390fad5-subnet-7044ff16",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vpc-f8fad69d-subnet-1f315846",
-      "id" : "link-interface-node-vpc-f8fad69d-vpc-f8fad69d-interface-node-vpc-f8fad69d-subnet-1f315846",
-      "srcId" : "interface-node-vpc-f8fad69d-vpc-f8fad69d",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-7044ff16-subnet-7044ff16",
-      "id" : "link-interface-node-subnet-7044ff16-es-domain-subnet-7044ff16-interface-node-subnet-7044ff16-subnet-7044ff16",
-      "srcId" : "interface-node-subnet-7044ff16-es-domain-subnet-7044ff16",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
-      "id" : "link-interface-node-es-domain-es-domain-subnet-1641fa70-interface-node-subnet-1641fa70-subnet-1641fa70",
-      "srcId" : "interface-node-es-domain-es-domain-subnet-1641fa70",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vpc-f8fad69d-igw-068fee63",
-      "id" : "link-interface-node-igw-068fee63-vpc-f8fad69d-interface-node-vpc-f8fad69d-igw-068fee63",
-      "srcId" : "interface-node-igw-068fee63-vpc-f8fad69d",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
-      "id" : "link-interface-node-subnet-1641fa70-es-domain-subnet-1641fa70-interface-node-subnet-1641fa70-subnet-1641fa70",
-      "srcId" : "interface-node-subnet-1641fa70-es-domain-subnet-1641fa70",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d",
-      "id" : "link-interface-node-subnet-9c8adceb-subnet-9c8adceb-interface-node-subnet-9c8adceb-vpc-f8fad69d",
-      "srcId" : "interface-node-subnet-9c8adceb-subnet-9c8adceb",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-vpc-925131f4-subnet-62f14104",
-      "id" : "link-interface-node-subnet-62f14104-vpc-925131f4-interface-node-vpc-925131f4-subnet-62f14104",
-      "srcId" : "interface-node-subnet-62f14104-vpc-925131f4",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-vpc-815775e7-vgw-81fd279f",
-      "id" : "link-interface-node-vpc-815775e7-vpc-815775e7-interface-node-vpc-815775e7-vgw-81fd279f",
-      "srcId" : "interface-node-vpc-815775e7-vpc-815775e7",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vgw-81fd279f-vpc-815775e7",
-      "id" : "link-interface-node-vgw-81fd279f-vgw-81fd279f-interface-node-vgw-81fd279f-vpc-815775e7",
-      "srcId" : "interface-node-vgw-81fd279f-vgw-81fd279f",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-073b8061",
-      "id" : "link-interface-node-subnet-073b8061-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-073b8061",
-      "srcId" : "interface-node-subnet-073b8061-vpc-b390fad5",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-f73a8191",
-      "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-f73a8191",
-      "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-igw-068fee63-vpc-f8fad69d",
-      "id" : "link-interface-node-vpc-f8fad69d-igw-068fee63-interface-node-igw-068fee63-vpc-f8fad69d",
-      "srcId" : "interface-node-vpc-f8fad69d-igw-068fee63",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vpc-925131f4-igw-fac5839d",
-      "id" : "link-interface-node-vpc-925131f4-vpc-925131f4-interface-node-vpc-925131f4-igw-fac5839d",
-      "srcId" : "interface-node-vpc-925131f4-vpc-925131f4",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-7044ff16-subnet-7044ff16",
-      "id" : "link-interface-node-es-domain-es-domain-subnet-7044ff16-interface-node-subnet-7044ff16-subnet-7044ff16",
-      "srcId" : "interface-node-es-domain-es-domain-subnet-7044ff16",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vpc-925131f4-subnet-8d0cbdeb",
-      "id" : "link-interface-node-subnet-8d0cbdeb-vpc-925131f4-interface-node-vpc-925131f4-subnet-8d0cbdeb",
-      "srcId" : "interface-node-subnet-8d0cbdeb-vpc-925131f4",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-vpc-f8fad69d-subnet-9c8adceb",
-      "id" : "link-interface-node-vpc-f8fad69d-vpc-f8fad69d-interface-node-vpc-f8fad69d-subnet-9c8adceb",
-      "srcId" : "interface-node-vpc-f8fad69d-vpc-f8fad69d",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-30398256-vpc-b390fad5",
-      "id" : "link-interface-node-vpc-b390fad5-subnet-30398256-interface-node-subnet-30398256-vpc-b390fad5",
-      "srcId" : "interface-node-vpc-b390fad5-subnet-30398256",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-073b8061",
-      "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-073b8061",
-      "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d",
-      "id" : "link-interface-node-vpc-f8fad69d-subnet-9c8adceb-interface-node-subnet-9c8adceb-vpc-f8fad69d",
-      "srcId" : "interface-node-vpc-f8fad69d-subnet-9c8adceb",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-1641fa70-vpc-b390fad5",
-      "id" : "link-interface-node-vpc-b390fad5-subnet-1641fa70-interface-node-subnet-1641fa70-vpc-b390fad5",
-      "srcId" : "interface-node-vpc-b390fad5-subnet-1641fa70",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-7044ff16",
-      "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-7044ff16",
-      "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vgw-81fd279f-vpc-815775e7",
-      "id" : "link-interface-node-vpc-815775e7-vgw-81fd279f-interface-node-vgw-81fd279f-vpc-815775e7",
-      "srcId" : "interface-node-vpc-815775e7-vgw-81fd279f",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vpc-b390fad5-igw-9b93ddfc",
-      "id" : "link-interface-node-igw-9b93ddfc-vpc-b390fad5-interface-node-vpc-b390fad5-igw-9b93ddfc",
-      "srcId" : "interface-node-igw-9b93ddfc-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-62f14104-vpc-925131f4",
-      "id" : "link-interface-node-subnet-62f14104-subnet-62f14104-interface-node-subnet-62f14104-vpc-925131f4",
-      "srcId" : "interface-node-subnet-62f14104-subnet-62f14104",
-      "type" : "PHYSICAL"
-    },
-    {
       "dstId" : "interface-node-es-domain-es-domain-subnet-1641fa70",
       "id" : "link-interface-node-subnet-1641fa70-subnet-1641fa70-interface-node-es-domain-es-domain-subnet-1641fa70",
       "srcId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
@@ -739,6 +421,12 @@
       "dstId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
       "id" : "link-interface-node-test-rds-test-rds-subnet-1641fa70-interface-node-subnet-1641fa70-subnet-1641fa70",
       "srcId" : "interface-node-test-rds-test-rds-subnet-1641fa70",
+      "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-subnet-7044ff16-vpc-b390fad5",
+      "id" : "link-interface-node-vpc-b390fad5-subnet-7044ff16-interface-node-subnet-7044ff16-vpc-b390fad5",
+      "srcId" : "interface-node-vpc-b390fad5-subnet-7044ff16",
       "type" : "UNKNOWN"
     },
     {
@@ -760,10 +448,10 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-7044ff16-vpc-b390fad5",
-      "id" : "link-interface-node-subnet-7044ff16-subnet-7044ff16-interface-node-subnet-7044ff16-vpc-b390fad5",
-      "srcId" : "interface-node-subnet-7044ff16-subnet-7044ff16",
-      "type" : "PHYSICAL"
+      "dstId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
+      "id" : "link-interface-node-es-domain-es-domain-subnet-1641fa70-interface-node-subnet-1641fa70-subnet-1641fa70",
+      "srcId" : "interface-node-es-domain-es-domain-subnet-1641fa70",
+      "type" : "UNKNOWN"
     },
     {
       "dstId" : "interface-node-vpc-f8fad69d-subnet-d9cafabc",
@@ -773,14 +461,14 @@
     },
     {
       "dstId" : "interface-node-vpc-f8fad69d-igw-068fee63",
-      "id" : "link-interface-node-vpc-f8fad69d-vpc-f8fad69d-interface-node-vpc-f8fad69d-igw-068fee63",
-      "srcId" : "interface-node-vpc-f8fad69d-vpc-f8fad69d",
+      "id" : "link-interface-node-igw-068fee63-vpc-f8fad69d-interface-node-vpc-f8fad69d-igw-068fee63",
+      "srcId" : "interface-node-igw-068fee63-vpc-f8fad69d",
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-30398256-vpc-b390fad5",
-      "id" : "link-interface-node-subnet-30398256-subnet-30398256-interface-node-subnet-30398256-vpc-b390fad5",
-      "srcId" : "interface-node-subnet-30398256-subnet-30398256",
+      "dstId" : "interface-node-vpc-925131f4-subnet-62f14104",
+      "id" : "link-interface-node-subnet-62f14104-vpc-925131f4-interface-node-vpc-925131f4-subnet-62f14104",
+      "srcId" : "interface-node-subnet-62f14104-vpc-925131f4",
       "type" : "PHYSICAL"
     },
     {
@@ -796,9 +484,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-1f315846-vpc-f8fad69d",
-      "id" : "link-interface-node-subnet-1f315846-subnet-1f315846-interface-node-subnet-1f315846-vpc-f8fad69d",
-      "srcId" : "interface-node-subnet-1f315846-subnet-1f315846",
+      "dstId" : "interface-node-vpc-b390fad5-subnet-073b8061",
+      "id" : "link-interface-node-subnet-073b8061-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-073b8061",
+      "srcId" : "interface-node-subnet-073b8061-vpc-b390fad5",
       "type" : "PHYSICAL"
     },
     {
@@ -808,39 +496,9 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-subnet-f73a8191-vpc-b390fad5",
-      "id" : "link-interface-node-subnet-f73a8191-subnet-f73a8191-interface-node-subnet-f73a8191-vpc-b390fad5",
-      "srcId" : "interface-node-subnet-f73a8191-subnet-f73a8191",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-vpc-f8fad69d-subnet-d9cafabc",
-      "id" : "link-interface-node-vpc-f8fad69d-vpc-f8fad69d-interface-node-vpc-f8fad69d-subnet-d9cafabc",
-      "srcId" : "interface-node-vpc-f8fad69d-vpc-f8fad69d",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-es-domain-es-domain-subnet-1641fa70",
-      "id" : "link-interface-node-es-domain-subnet-1641fa70-interface-node-es-domain-es-domain-subnet-1641fa70",
-      "srcId" : "interface-node-es-domain-subnet-1641fa70",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-1641fa70-subnet-1641fa70",
-      "id" : "link-interface-node-subnet-1641fa70-test-rds-subnet-1641fa70-interface-node-subnet-1641fa70-subnet-1641fa70",
-      "srcId" : "interface-node-subnet-1641fa70-test-rds-subnet-1641fa70",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vpc-b390fad5-igw-9b93ddfc",
-      "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-igw-9b93ddfc",
-      "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-30398256",
-      "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-30398256",
-      "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
+      "dstId" : "interface-node-igw-068fee63-vpc-f8fad69d",
+      "id" : "link-interface-node-vpc-f8fad69d-igw-068fee63-interface-node-igw-068fee63-vpc-f8fad69d",
+      "srcId" : "interface-node-vpc-f8fad69d-igw-068fee63",
       "type" : "UNKNOWN"
     },
     {
@@ -850,10 +508,22 @@
       "type" : "PHYSICAL"
     },
     {
+      "dstId" : "interface-node-subnet-7044ff16-subnet-7044ff16",
+      "id" : "link-interface-node-es-domain-es-domain-subnet-7044ff16-interface-node-subnet-7044ff16-subnet-7044ff16",
+      "srcId" : "interface-node-es-domain-es-domain-subnet-7044ff16",
+      "type" : "UNKNOWN"
+    },
+    {
       "dstId" : "interface-node-vpc-815775e7-vgw-81fd279f",
       "id" : "link-interface-node-vgw-81fd279f-vpc-815775e7-interface-node-vpc-815775e7-vgw-81fd279f",
       "srcId" : "interface-node-vgw-81fd279f-vpc-815775e7",
       "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-vpc-925131f4-subnet-8d0cbdeb",
+      "id" : "link-interface-node-subnet-8d0cbdeb-vpc-925131f4-interface-node-vpc-925131f4-subnet-8d0cbdeb",
+      "srcId" : "interface-node-subnet-8d0cbdeb-vpc-925131f4",
+      "type" : "PHYSICAL"
     },
     {
       "dstId" : "interface-node-subnet-1f315846-vpc-f8fad69d",
@@ -862,21 +532,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-es-domain-es-domain-subnet-1641fa70",
-      "id" : "link-interface-node-es-domain-test-rds-subnet-1641fa70-interface-node-es-domain-es-domain-subnet-1641fa70",
-      "srcId" : "interface-node-es-domain-test-rds-subnet-1641fa70",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-subnet-d9cafabc-vpc-f8fad69d",
-      "id" : "link-interface-node-subnet-d9cafabc-subnet-d9cafabc-interface-node-subnet-d9cafabc-vpc-f8fad69d",
-      "srcId" : "interface-node-subnet-d9cafabc-subnet-d9cafabc",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-igw-068fee63-vpc-f8fad69d",
-      "id" : "link-interface-node-igw-068fee63-igw-068fee63-interface-node-igw-068fee63-vpc-f8fad69d",
-      "srcId" : "interface-node-igw-068fee63-igw-068fee63",
+      "dstId" : "interface-node-subnet-30398256-vpc-b390fad5",
+      "id" : "link-interface-node-vpc-b390fad5-subnet-30398256-interface-node-subnet-30398256-vpc-b390fad5",
+      "srcId" : "interface-node-vpc-b390fad5-subnet-30398256",
       "type" : "UNKNOWN"
     },
     {
@@ -886,22 +544,10 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-subnet-073b8061-vpc-b390fad5",
-      "id" : "link-interface-node-subnet-073b8061-subnet-073b8061-interface-node-subnet-073b8061-vpc-b390fad5",
-      "srcId" : "interface-node-subnet-073b8061-subnet-073b8061",
-      "type" : "PHYSICAL"
-    },
-    {
       "dstId" : "interface-node-vpc-b390fad5-subnet-7044ff16",
       "id" : "link-interface-node-subnet-7044ff16-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-7044ff16",
       "srcId" : "interface-node-subnet-7044ff16-vpc-b390fad5",
       "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-test-rds-test-rds-subnet-1641fa70",
-      "id" : "link-interface-node-test-rds-subnet-1641fa70-interface-node-test-rds-test-rds-subnet-1641fa70",
-      "srcId" : "interface-node-test-rds-subnet-1641fa70",
-      "type" : "UNKNOWN"
     },
     {
       "dstId" : "interface-node-es-domain-es-domain-subnet-7044ff16",
@@ -910,15 +556,9 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-vpc-925131f4-subnet-62f14104",
-      "id" : "link-interface-node-vpc-925131f4-vpc-925131f4-interface-node-vpc-925131f4-subnet-62f14104",
-      "srcId" : "interface-node-vpc-925131f4-vpc-925131f4",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-1641fa70",
-      "id" : "link-interface-node-vpc-b390fad5-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-1641fa70",
-      "srcId" : "interface-node-vpc-b390fad5-vpc-b390fad5",
+      "dstId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d",
+      "id" : "link-interface-node-vpc-f8fad69d-subnet-9c8adceb-interface-node-subnet-9c8adceb-vpc-f8fad69d",
+      "srcId" : "interface-node-vpc-f8fad69d-subnet-9c8adceb",
       "type" : "UNKNOWN"
     },
     {

--- a/tests/basic/topology.ref
+++ b/tests/basic/topology.ref
@@ -9,12 +9,6 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-host2-GigabitEthernet3/0",
-      "name" : "GigabitEthernet3/0",
-      "nodeId" : "node-host2",
-      "type" : "UNKNOWN"
-    },
-    {
       "id" : "interface-node-as3border2-GigabitEthernet1/0",
       "name" : "GigabitEthernet1/0",
       "nodeId" : "node-as3border2",
@@ -171,18 +165,6 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-as2dist2-GigabitEthernet3/0",
-      "name" : "GigabitEthernet3/0",
-      "nodeId" : "node-as2dist2",
-      "type" : "UNKNOWN"
-    },
-    {
-      "id" : "interface-node-as2dist1-GigabitEthernet3/0",
-      "name" : "GigabitEthernet3/0",
-      "nodeId" : "node-as2dist1",
-      "type" : "UNKNOWN"
-    },
-    {
       "id" : "interface-node-as2dist2-GigabitEthernet2/0",
       "name" : "GigabitEthernet2/0",
       "nodeId" : "node-as2dist2",
@@ -243,25 +225,19 @@
       "type" : "PHYSICAL"
     },
     {
-      "id" : "interface-node-as2dept1-eth0",
-      "name" : "eth0",
-      "nodeId" : "node-as2dept1",
-      "type" : "UNKNOWN"
-    },
-    {
       "id" : "interface-node-as1border2-GigabitEthernet0/0",
       "name" : "GigabitEthernet0/0",
       "nodeId" : "node-as1border2",
       "type" : "PHYSICAL"
-    },
-    {
-      "id" : "interface-node-host1-GigabitEthernet2/0",
-      "name" : "GigabitEthernet2/0",
-      "nodeId" : "node-host1",
-      "type" : "UNKNOWN"
     }
   ],
   "links" : [
+    {
+      "dstId" : "interface-node-as2border2-GigabitEthernet0/0",
+      "id" : "link-interface-node-as3border1-GigabitEthernet1/0-interface-node-as2border2-GigabitEthernet0/0",
+      "srcId" : "interface-node-as3border1-GigabitEthernet1/0",
+      "type" : "PHYSICAL"
+    },
     {
       "dstId" : "interface-node-as2core2-GigabitEthernet0/0",
       "id" : "link-interface-node-as2border2-GigabitEthernet1/0-interface-node-as2core2-GigabitEthernet0/0",
@@ -272,6 +248,18 @@
       "dstId" : "interface-node-as1border1-GigabitEthernet0/0",
       "id" : "link-interface-node-as1core1-GigabitEthernet1/0-interface-node-as1border1-GigabitEthernet0/0",
       "srcId" : "interface-node-as1core1-GigabitEthernet1/0",
+      "type" : "PHYSICAL"
+    },
+    {
+      "dstId" : "interface-node-as2core1-GigabitEthernet2/0",
+      "id" : "link-interface-node-as2dist1-GigabitEthernet0/0-interface-node-as2core1-GigabitEthernet2/0",
+      "srcId" : "interface-node-as2dist1-GigabitEthernet0/0",
+      "type" : "PHYSICAL"
+    },
+    {
+      "dstId" : "interface-node-as3border2-GigabitEthernet1/0",
+      "id" : "link-interface-node-as3core1-GigabitEthernet0/0-interface-node-as3border2-GigabitEthernet1/0",
+      "srcId" : "interface-node-as3core1-GigabitEthernet0/0",
       "type" : "PHYSICAL"
     },
     {
@@ -293,201 +281,9 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as2dist2-GigabitEthernet2/0",
-      "id" : "link-interface-node-as2dist2-GigabitEthernet1/0-interface-node-as2dist2-GigabitEthernet2/0",
-      "srcId" : "interface-node-as2dist2-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
       "dstId" : "interface-node-as2border1-GigabitEthernet2/0",
       "id" : "link-interface-node-as2core2-GigabitEthernet1/0-interface-node-as2border1-GigabitEthernet2/0",
       "srcId" : "interface-node-as2core2-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2dist2-GigabitEthernet1/0",
-      "id" : "link-interface-node-as2dist2-GigabitEthernet3/0-interface-node-as2dist2-GigabitEthernet1/0",
-      "srcId" : "interface-node-as2dist2-GigabitEthernet3/0",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-as2core2-GigabitEthernet3/0",
-      "id" : "link-interface-node-as2core2-GigabitEthernet1/0-interface-node-as2core2-GigabitEthernet3/0",
-      "srcId" : "interface-node-as2core2-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as1border2-GigabitEthernet1/0",
-      "id" : "link-interface-node-as1core1-GigabitEthernet0/0-interface-node-as1border2-GigabitEthernet1/0",
-      "srcId" : "interface-node-as1core1-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as1border1-GigabitEthernet1/0",
-      "id" : "link-interface-node-as1border1-GigabitEthernet0/0-interface-node-as1border1-GigabitEthernet1/0",
-      "srcId" : "interface-node-as1border1-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2border2-GigabitEthernet1/0",
-      "id" : "link-interface-node-as2border2-GigabitEthernet0/0-interface-node-as2border2-GigabitEthernet1/0",
-      "srcId" : "interface-node-as2border2-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2border2-GigabitEthernet2/0",
-      "id" : "link-interface-node-as2core1-GigabitEthernet1/0-interface-node-as2border2-GigabitEthernet2/0",
-      "srcId" : "interface-node-as2core1-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as1border2-GigabitEthernet1/0",
-      "id" : "link-interface-node-as1border2-GigabitEthernet0/0-interface-node-as1border2-GigabitEthernet1/0",
-      "srcId" : "interface-node-as1border2-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2border1-GigabitEthernet1/0",
-      "id" : "link-interface-node-as2border1-GigabitEthernet0/0-interface-node-as2border1-GigabitEthernet1/0",
-      "srcId" : "interface-node-as2border1-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as3border2-GigabitEthernet1/0",
-      "id" : "link-interface-node-as3border2-GigabitEthernet0/0-interface-node-as3border2-GigabitEthernet1/0",
-      "srcId" : "interface-node-as3border2-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-host2-eth0",
-      "id" : "link-interface-node-host2-GigabitEthernet3/0-interface-node-host2-eth0",
-      "srcId" : "interface-node-host2-GigabitEthernet3/0",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-as2core1-GigabitEthernet3/0",
-      "id" : "link-interface-node-as2core1-GigabitEthernet1/0-interface-node-as2core1-GigabitEthernet3/0",
-      "srcId" : "interface-node-as2core1-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2dist2-GigabitEthernet0/0",
-      "id" : "link-interface-node-as2core2-GigabitEthernet2/0-interface-node-as2dist2-GigabitEthernet0/0",
-      "srcId" : "interface-node-as2core2-GigabitEthernet2/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2border2-GigabitEthernet1/0",
-      "id" : "link-interface-node-as2core2-GigabitEthernet0/0-interface-node-as2border2-GigabitEthernet1/0",
-      "srcId" : "interface-node-as2core2-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2dept1-GigabitEthernet2/0",
-      "id" : "link-interface-node-as2dept1-eth0-interface-node-as2dept1-GigabitEthernet2/0",
-      "srcId" : "interface-node-as2dept1-eth0",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-as2core1-GigabitEthernet3/0",
-      "id" : "link-interface-node-as2dist2-GigabitEthernet1/0-interface-node-as2core1-GigabitEthernet3/0",
-      "srcId" : "interface-node-as2dist2-GigabitEthernet1/0",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-as2core1-GigabitEthernet1/0",
-      "id" : "link-interface-node-as2border2-GigabitEthernet2/0-interface-node-as2core1-GigabitEthernet1/0",
-      "srcId" : "interface-node-as2border2-GigabitEthernet2/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2core2-GigabitEthernet2/0",
-      "id" : "link-interface-node-as2core2-GigabitEthernet0/0-interface-node-as2core2-GigabitEthernet2/0",
-      "srcId" : "interface-node-as2core2-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2border1-GigabitEthernet0/0",
-      "id" : "link-interface-node-as2border1-GigabitEthernet1/0-interface-node-as2border1-GigabitEthernet0/0",
-      "srcId" : "interface-node-as2border1-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2border1-GigabitEthernet2/0",
-      "id" : "link-interface-node-as2border1-GigabitEthernet1/0-interface-node-as2border1-GigabitEthernet2/0",
-      "srcId" : "interface-node-as2border1-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as1border1-GigabitEthernet1/0",
-      "id" : "link-interface-node-as2border1-GigabitEthernet0/0-interface-node-as1border1-GigabitEthernet1/0",
-      "srcId" : "interface-node-as2border1-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as3core1-GigabitEthernet1/0",
-      "id" : "link-interface-node-as3core1-GigabitEthernet0/0-interface-node-as3core1-GigabitEthernet1/0",
-      "srcId" : "interface-node-as3core1-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as1core1-GigabitEthernet1/0",
-      "id" : "link-interface-node-as1core1-GigabitEthernet0/0-interface-node-as1core1-GigabitEthernet1/0",
-      "srcId" : "interface-node-as1core1-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2core2-GigabitEthernet1/0",
-      "id" : "link-interface-node-as2core2-GigabitEthernet2/0-interface-node-as2core2-GigabitEthernet1/0",
-      "srcId" : "interface-node-as2core2-GigabitEthernet2/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2dept1-GigabitEthernet2/0",
-      "id" : "link-interface-node-host1-eth0-interface-node-as2dept1-GigabitEthernet2/0",
-      "srcId" : "interface-node-host1-eth0",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-as3border2-GigabitEthernet0/0",
-      "id" : "link-interface-node-as1border2-GigabitEthernet0/0-interface-node-as3border2-GigabitEthernet0/0",
-      "srcId" : "interface-node-as1border2-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2dept1-GigabitEthernet1/0",
-      "id" : "link-interface-node-as2dept1-GigabitEthernet2/0-interface-node-as2dept1-GigabitEthernet1/0",
-      "srcId" : "interface-node-as2dept1-GigabitEthernet2/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2border2-GigabitEthernet0/0",
-      "id" : "link-interface-node-as3border1-GigabitEthernet1/0-interface-node-as2border2-GigabitEthernet0/0",
-      "srcId" : "interface-node-as3border1-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2core1-GigabitEthernet2/0",
-      "id" : "link-interface-node-as2dist1-GigabitEthernet0/0-interface-node-as2core1-GigabitEthernet2/0",
-      "srcId" : "interface-node-as2dist1-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as3border2-GigabitEthernet1/0",
-      "id" : "link-interface-node-as3core1-GigabitEthernet0/0-interface-node-as3border2-GigabitEthernet1/0",
-      "srcId" : "interface-node-as3core1-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2core1-GigabitEthernet1/0",
-      "id" : "link-interface-node-as2core1-GigabitEthernet2/0-interface-node-as2core1-GigabitEthernet1/0",
-      "srcId" : "interface-node-as2core1-GigabitEthernet2/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2dist1-GigabitEthernet0/0",
-      "id" : "link-interface-node-as2dist1-GigabitEthernet2/0-interface-node-as2dist1-GigabitEthernet0/0",
-      "srcId" : "interface-node-as2dist1-GigabitEthernet2/0",
       "type" : "PHYSICAL"
     },
     {
@@ -509,9 +305,9 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as2core2-GigabitEthernet0/0",
-      "id" : "link-interface-node-as2core2-GigabitEthernet1/0-interface-node-as2core2-GigabitEthernet0/0",
-      "srcId" : "interface-node-as2core2-GigabitEthernet1/0",
+      "dstId" : "interface-node-as1border2-GigabitEthernet1/0",
+      "id" : "link-interface-node-as1core1-GigabitEthernet0/0-interface-node-as1border2-GigabitEthernet1/0",
+      "srcId" : "interface-node-as1core1-GigabitEthernet0/0",
       "type" : "PHYSICAL"
     },
     {
@@ -527,15 +323,15 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as2dist2-GigabitEthernet1/0",
-      "id" : "link-interface-node-as2core1-GigabitEthernet3/0-interface-node-as2dist2-GigabitEthernet1/0",
-      "srcId" : "interface-node-as2core1-GigabitEthernet3/0",
+      "dstId" : "interface-node-as2border2-GigabitEthernet2/0",
+      "id" : "link-interface-node-as2core1-GigabitEthernet1/0-interface-node-as2border2-GigabitEthernet2/0",
+      "srcId" : "interface-node-as2core1-GigabitEthernet1/0",
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as1border2-GigabitEthernet0/0",
-      "id" : "link-interface-node-as1border2-GigabitEthernet0/0-interface-node-as1border2-GigabitEthernet0/0",
-      "srcId" : "interface-node-as1border2-GigabitEthernet0/0",
+      "dstId" : "interface-node-as2dist2-GigabitEthernet1/0",
+      "id" : "link-interface-node-as2core1-GigabitEthernet3/0-interface-node-as2dist2-GigabitEthernet1/0",
+      "srcId" : "interface-node-as2core1-GigabitEthernet3/0",
       "type" : "PHYSICAL"
     },
     {
@@ -545,57 +341,27 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as3border1-GigabitEthernet1/0",
-      "id" : "link-interface-node-as3border1-GigabitEthernet0/0-interface-node-as3border1-GigabitEthernet1/0",
-      "srcId" : "interface-node-as3border1-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as3core1-GigabitEthernet0/0",
-      "id" : "link-interface-node-as3core1-GigabitEthernet1/0-interface-node-as3core1-GigabitEthernet0/0",
-      "srcId" : "interface-node-as3core1-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
       "dstId" : "interface-node-as2core2-GigabitEthernet3/0",
       "id" : "link-interface-node-as2dist1-GigabitEthernet1/0-interface-node-as2core2-GigabitEthernet3/0",
       "srcId" : "interface-node-as2dist1-GigabitEthernet1/0",
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-host1-eth0",
-      "id" : "link-interface-node-host1-GigabitEthernet2/0-interface-node-host1-eth0",
-      "srcId" : "interface-node-host1-GigabitEthernet2/0",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-as2core1-GigabitEthernet0/0",
-      "id" : "link-interface-node-as2core1-GigabitEthernet1/0-interface-node-as2core1-GigabitEthernet0/0",
-      "srcId" : "interface-node-as2core1-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as1core1-GigabitEthernet0/0",
-      "id" : "link-interface-node-as1core1-GigabitEthernet1/0-interface-node-as1core1-GigabitEthernet0/0",
-      "srcId" : "interface-node-as1core1-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2dist1-GigabitEthernet1/0",
-      "id" : "link-interface-node-as2dist1-GigabitEthernet3/0-interface-node-as2dist1-GigabitEthernet1/0",
-      "srcId" : "interface-node-as2dist1-GigabitEthernet3/0",
-      "type" : "UNKNOWN"
-    },
-    {
-      "dstId" : "interface-node-as3border2-GigabitEthernet0/0",
-      "id" : "link-interface-node-as3border2-GigabitEthernet0/0-interface-node-as3border2-GigabitEthernet0/0",
-      "srcId" : "interface-node-as3border2-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
       "dstId" : "interface-node-as2border1-GigabitEthernet0/0",
       "id" : "link-interface-node-as1border1-GigabitEthernet1/0-interface-node-as2border1-GigabitEthernet0/0",
       "srcId" : "interface-node-as1border1-GigabitEthernet1/0",
+      "type" : "PHYSICAL"
+    },
+    {
+      "dstId" : "interface-node-as2dist2-GigabitEthernet0/0",
+      "id" : "link-interface-node-as2core2-GigabitEthernet2/0-interface-node-as2dist2-GigabitEthernet0/0",
+      "srcId" : "interface-node-as2core2-GigabitEthernet2/0",
+      "type" : "PHYSICAL"
+    },
+    {
+      "dstId" : "interface-node-as2border2-GigabitEthernet1/0",
+      "id" : "link-interface-node-as2core2-GigabitEthernet0/0-interface-node-as2border2-GigabitEthernet1/0",
+      "srcId" : "interface-node-as2core2-GigabitEthernet0/0",
       "type" : "PHYSICAL"
     },
     {
@@ -611,15 +377,21 @@
       "type" : "UNKNOWN"
     },
     {
-      "dstId" : "interface-node-as2dept1-GigabitEthernet3/0",
-      "id" : "link-interface-node-as2dept1-eth0-interface-node-as2dept1-GigabitEthernet3/0",
-      "srcId" : "interface-node-as2dept1-eth0",
-      "type" : "UNKNOWN"
-    },
-    {
       "dstId" : "interface-node-as2dept1-GigabitEthernet1/0",
       "id" : "link-interface-node-as2dist2-GigabitEthernet2/0-interface-node-as2dept1-GigabitEthernet1/0",
       "srcId" : "interface-node-as2dist2-GigabitEthernet2/0",
+      "type" : "PHYSICAL"
+    },
+    {
+      "dstId" : "interface-node-as2core1-GigabitEthernet3/0",
+      "id" : "link-interface-node-as2dist2-GigabitEthernet1/0-interface-node-as2core1-GigabitEthernet3/0",
+      "srcId" : "interface-node-as2dist2-GigabitEthernet1/0",
+      "type" : "UNKNOWN"
+    },
+    {
+      "dstId" : "interface-node-as2core1-GigabitEthernet1/0",
+      "id" : "link-interface-node-as2border2-GigabitEthernet2/0-interface-node-as2core1-GigabitEthernet1/0",
+      "srcId" : "interface-node-as2border2-GigabitEthernet2/0",
       "type" : "PHYSICAL"
     },
     {
@@ -629,45 +401,15 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as2dist1-GigabitEthernet2/0",
-      "id" : "link-interface-node-as2dist1-GigabitEthernet0/0-interface-node-as2dist1-GigabitEthernet2/0",
-      "srcId" : "interface-node-as2dist1-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2border2-GigabitEthernet2/0",
-      "id" : "link-interface-node-as2border2-GigabitEthernet1/0-interface-node-as2border2-GigabitEthernet2/0",
-      "srcId" : "interface-node-as2border2-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2dept1-GigabitEthernet0/0",
-      "id" : "link-interface-node-as2dept1-GigabitEthernet2/0-interface-node-as2dept1-GigabitEthernet0/0",
-      "srcId" : "interface-node-as2dept1-GigabitEthernet2/0",
-      "type" : "PHYSICAL"
-    },
-    {
       "dstId" : "interface-node-as2core1-GigabitEthernet0/0",
       "id" : "link-interface-node-as2border1-GigabitEthernet1/0-interface-node-as2core1-GigabitEthernet0/0",
       "srcId" : "interface-node-as2border1-GigabitEthernet1/0",
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as2border2-GigabitEthernet0/0",
-      "id" : "link-interface-node-as2border2-GigabitEthernet1/0-interface-node-as2border2-GigabitEthernet0/0",
-      "srcId" : "interface-node-as2border2-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
       "dstId" : "interface-node-as2dist1-GigabitEthernet2/0",
       "id" : "link-interface-node-as2dept1-GigabitEthernet0/0-interface-node-as2dist1-GigabitEthernet2/0",
       "srcId" : "interface-node-as2dept1-GigabitEthernet0/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as1border1-GigabitEthernet0/0",
-      "id" : "link-interface-node-as1border1-GigabitEthernet1/0-interface-node-as1border1-GigabitEthernet0/0",
-      "srcId" : "interface-node-as1border1-GigabitEthernet1/0",
       "type" : "PHYSICAL"
     },
     {
@@ -683,15 +425,15 @@
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as2dist1-GigabitEthernet0/0",
-      "id" : "link-interface-node-as2core1-GigabitEthernet2/0-interface-node-as2dist1-GigabitEthernet0/0",
-      "srcId" : "interface-node-as2core1-GigabitEthernet2/0",
+      "dstId" : "interface-node-as1border1-GigabitEthernet1/0",
+      "id" : "link-interface-node-as2border1-GigabitEthernet0/0-interface-node-as1border1-GigabitEthernet1/0",
+      "srcId" : "interface-node-as2border1-GigabitEthernet0/0",
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as2dist2-GigabitEthernet0/0",
-      "id" : "link-interface-node-as2dist2-GigabitEthernet2/0-interface-node-as2dist2-GigabitEthernet0/0",
-      "srcId" : "interface-node-as2dist2-GigabitEthernet2/0",
+      "dstId" : "interface-node-as2dist1-GigabitEthernet0/0",
+      "id" : "link-interface-node-as2core1-GigabitEthernet2/0-interface-node-as2dist1-GigabitEthernet0/0",
+      "srcId" : "interface-node-as2core1-GigabitEthernet2/0",
       "type" : "PHYSICAL"
     },
     {
@@ -701,21 +443,21 @@
       "type" : "PHYSICAL"
     },
     {
+      "dstId" : "interface-node-as2dept1-GigabitEthernet2/0",
+      "id" : "link-interface-node-host1-eth0-interface-node-as2dept1-GigabitEthernet2/0",
+      "srcId" : "interface-node-host1-eth0",
+      "type" : "UNKNOWN"
+    },
+    {
       "dstId" : "interface-node-as1core1-GigabitEthernet1/0",
       "id" : "link-interface-node-as1border1-GigabitEthernet0/0-interface-node-as1core1-GigabitEthernet1/0",
       "srcId" : "interface-node-as1border1-GigabitEthernet0/0",
       "type" : "PHYSICAL"
     },
     {
-      "dstId" : "interface-node-as3border1-GigabitEthernet0/0",
-      "id" : "link-interface-node-as3border1-GigabitEthernet1/0-interface-node-as3border1-GigabitEthernet0/0",
-      "srcId" : "interface-node-as3border1-GigabitEthernet1/0",
-      "type" : "PHYSICAL"
-    },
-    {
-      "dstId" : "interface-node-as2core1-GigabitEthernet2/0",
-      "id" : "link-interface-node-as2core1-GigabitEthernet0/0-interface-node-as2core1-GigabitEthernet2/0",
-      "srcId" : "interface-node-as2core1-GigabitEthernet0/0",
+      "dstId" : "interface-node-as3border2-GigabitEthernet0/0",
+      "id" : "link-interface-node-as1border2-GigabitEthernet0/0-interface-node-as3border2-GigabitEthernet0/0",
+      "srcId" : "interface-node-as1border2-GigabitEthernet0/0",
       "type" : "PHYSICAL"
     }
   ],


### PR DESCRIPTION
Bug was that nodeEdges() has a node's edges both where the node is the head and where the node is the tail. The buggy code was assuming that only head edges are present.

@haverma - this explains the oddity you noticed in the topology generated in #4359 