### PR TITLE
Routing policy environment: include EIGRP process

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Environment.java
@@ -24,6 +24,7 @@ import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Route6FilterList;
 import org.batfish.datamodel.RouteFilterList;
+import org.batfish.datamodel.eigrp.EigrpProcess;
 
 public class Environment {
   /**
@@ -78,6 +79,8 @@ public class Environment {
 
   private final Direction _direction;
 
+  @Nullable private final EigrpProcess _eigrpProcess;
+
   private boolean _error;
 
   private BgpRoute.Builder<?, ?> _intermediateBgpAttributes;
@@ -124,6 +127,7 @@ public class Environment {
       boolean defaultAction,
       String defaultPolicy,
       Direction direction,
+      @Nullable EigrpProcess eigrpProcess,
       boolean error,
       BgpRoute.Builder<?, ?> intermediateBgpAttributes,
       Map<String, IpAccessList> ipAccessLists,
@@ -149,6 +153,7 @@ public class Environment {
     _defaultAction = defaultAction;
     _defaultPolicy = defaultPolicy;
     _direction = direction;
+    _eigrpProcess = eigrpProcess;
     _error = error;
     _intermediateBgpAttributes = intermediateBgpAttributes;
     _ipAccessLists = ipAccessLists;
@@ -205,6 +210,11 @@ public class Environment {
 
   public Direction getDirection() {
     return _direction;
+  }
+
+  @Nullable
+  public EigrpProcess getEigrpProcess() {
+    return _eigrpProcess;
   }
 
   public boolean getError() {
@@ -328,6 +338,7 @@ public class Environment {
     private boolean _defaultAction;
     private String _defaultPolicy;
     private Direction _direction;
+    @Nullable private EigrpProcess _eigrpProcess;
     private boolean _error;
     private BgpRoute.Builder<?, ?> _intermediateBgpAttributes;
     private Map<String, Ip6AccessList> _ip6AccessLists;
@@ -389,6 +400,11 @@ public class Environment {
 
     public Builder setDirection(Direction direction) {
       _direction = direction;
+      return this;
+    }
+
+    public Builder setEigrpProcess(@Nullable EigrpProcess eigrpProcess) {
+      _eigrpProcess = eigrpProcess;
       return this;
     }
 
@@ -468,6 +484,7 @@ public class Environment {
           _defaultAction,
           _defaultPolicy,
           _direction,
+          _eigrpProcess,
           _error,
           _intermediateBgpAttributes,
           firstNonNull(_ipAccessLists, ImmutableMap.of()),

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
@@ -26,6 +26,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.eigrp.EigrpProcess;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 
@@ -208,6 +209,26 @@ public class RoutingPolicy implements Serializable {
       @Nullable Prefix peerPrefix,
       String vrf,
       Direction direction) {
+    return process(inputRoute, outputRoute, peerAddress, peerPrefix, null, vrf, direction);
+  }
+
+  public boolean process(
+      @Nonnull AbstractRouteDecorator inputRoute,
+      @Nonnull AbstractRouteBuilder<?, ?> outputRoute,
+      @Nonnull String vrf,
+      @Nonnull EigrpProcess eigrpProcess,
+      Direction direction) {
+    return process(inputRoute, outputRoute, null, null, eigrpProcess, vrf, direction);
+  }
+
+  private boolean process(
+      AbstractRouteDecorator inputRoute,
+      AbstractRouteBuilder<?, ?> outputRoute,
+      @Nullable Ip peerAddress,
+      @Nullable Prefix peerPrefix,
+      @Nullable EigrpProcess eigrpProcess,
+      String vrf,
+      Direction direction) {
     checkState(_owner != null, "Cannot evaluate routing policy without a Configuration");
     Environment environment =
         Environment.builder(_owner, vrf)
@@ -216,6 +237,7 @@ public class RoutingPolicy implements Serializable {
             .setPeerAddress(peerAddress)
             .setDirection(direction)
             .setPeerPrefix(peerPrefix)
+            .setEigrpProcess(eigrpProcess)
             .build();
     Result result = call(environment);
     return result.getBooleanValue() && !(Boolean.TRUE.equals(environment.getSuppressed()));

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -423,7 +423,8 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
   private boolean allowedByExportPolicy(
       EigrpNeighborConfigId neighborConfigId, EigrpRoute eigrpRoute) {
     RoutingPolicy exportPolicy = getOwnExportPolicy(neighborConfigId);
-    return exportPolicy.process(eigrpRoute, eigrpRoute.toBuilder(), null, _vrfName, Direction.OUT);
+    return exportPolicy.process(
+        eigrpRoute, eigrpRoute.toBuilder(), _vrfName, _process, Direction.OUT);
   }
 
   /**
@@ -457,7 +458,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
     }
 
     if (!exportPolicy.process(
-        potentialExportRoute, outputRouteBuilder, null, _vrfName, Direction.OUT)) {
+        potentialExportRoute, outputRouteBuilder, _vrfName, _process, Direction.OUT)) {
       return null;
     }
     outputRouteBuilder.setAdmin(_defaultExternalAdminCost);


### PR DESCRIPTION
This lets us figure out what type of metric needs to be used in the `set metric` statement of a routemap.