### PR TITLE
OSPF process: enforce non-null router-id

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
@@ -166,7 +166,7 @@ public final class OspfProcess implements Serializable {
       return this;
     }
 
-    public Builder setRouterId(Ip routerId) {
+    public Builder setRouterId(@Nonnull Ip routerId) {
       _routerId = routerId;
       return this;
     }
@@ -228,7 +228,7 @@ public final class OspfProcess implements Serializable {
   @Nonnull private final String _processId;
   @Nonnull private Double _referenceBandwidth;
   @Nullable private Boolean _rfc1583Compatible;
-  @Nullable private Ip _routerId;
+  @Nonnull private Ip _routerId;
   private int _summaryAdminCost;
 
   @JsonCreator
@@ -250,6 +250,7 @@ public final class OspfProcess implements Serializable {
       @Nullable @JsonProperty(PROP_SUMMARY_ADMIN) Integer summaryAdminCost) {
     checkArgument(processId != null, "Missing %s", PROP_PROCESS_ID);
     checkArgument(referenceBandwidth != null, "Missing %s", PROP_REFERENCE_BANDWIDTH);
+    checkArgument(routerId != null, "Missing %s", PROP_ROUTER_ID);
     _adminCosts =
         ImmutableSortedMap.copyOf(
             firstNonNull(
@@ -422,7 +423,7 @@ public final class OspfProcess implements Serializable {
   }
 
   /** The router-id of this OSPF process */
-  @Nullable
+  @Nonnull
   @JsonProperty(PROP_ROUTER_ID)
   public Ip getRouterId() {
     return _routerId;
@@ -527,7 +528,7 @@ public final class OspfProcess implements Serializable {
     _rfc1583Compatible = rfc1583Compatible;
   }
 
-  public void setRouterId(Ip id) {
+  public void setRouterId(@Nonnull Ip id) {
     _routerId = id;
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTest.java
@@ -86,7 +86,7 @@ public class ConfigurationTest {
     vrf.getGeneratedRoutes().add(gr);
 
     // OSPF
-    OspfProcess ospfProcess = _factory.ospfProcessBuilder().build();
+    OspfProcess ospfProcess = _factory.ospfProcessBuilder().setRouterId(Ip.ZERO).build();
     vrf.setOspfProcesses(Stream.of(ospfProcess));
     RoutingPolicy ospfExportPolicy =
         c.getRoutingPolicies().computeIfAbsent(ospfExportPolicyName, n -> new RoutingPolicy(n, c));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/DeviceTypeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/DeviceTypeTest.java
@@ -85,7 +85,7 @@ public class DeviceTypeTest {
   public void configWithOspfIsRouter() {
     Configuration c = _cb.build();
     Vrf vrf = _vb.setOwner(c).build();
-    _nf.ospfProcessBuilder().setVrf(vrf).build();
+    _nf.ospfProcessBuilder().setRouterId(Ip.ZERO).setVrf(vrf).build();
     postProcessConfiguration(c);
     assertThat(c.getDeviceType(), is(DeviceType.ROUTER));
   }
@@ -94,7 +94,7 @@ public class DeviceTypeTest {
   public void configWithRipIsRouter() {
     Configuration c = _cb.build();
     Vrf vrf = _vb.setOwner(c).build();
-    _nf.ospfProcessBuilder().setVrf(vrf).build();
+    _nf.ospfProcessBuilder().setRouterId(Ip.ZERO).setVrf(vrf).build();
     postProcessConfiguration(c);
     assertThat(c.getDeviceType(), is(DeviceType.ROUTER));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/NetworkFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/NetworkFactoryTest.java
@@ -82,7 +82,7 @@ public class NetworkFactoryTest {
     NetworkFactory nf = new NetworkFactory();
     Configuration c = nf.configurationBuilder().setConfigurationFormat(CONFIG_FORMAT).build();
     Vrf vrf = nf.vrfBuilder().setOwner(c).build();
-    OspfProcess.Builder ob = nf.ospfProcessBuilder();
+    OspfProcess.Builder ob = nf.ospfProcessBuilder().setRouterId(Ip.ZERO);
     OspfProcess o1 = ob.build();
     OspfProcess o2 = ob.setVrf(vrf).build();
     assertThat(o1, not(sameInstance(o2)));
@@ -95,7 +95,7 @@ public class NetworkFactoryTest {
     Configuration c = nf.configurationBuilder().setConfigurationFormat(CONFIG_FORMAT).build();
     Vrf vrf = nf.vrfBuilder().setOwner(c).build();
     OspfProcess.Builder ob = nf.ospfProcessBuilder();
-    OspfProcess ospfProcess = ob.setVrf(vrf).build();
+    OspfProcess ospfProcess = ob.setVrf(vrf).setRouterId(Ip.ZERO).build();
     OspfArea.Builder oab = nf.ospfAreaBuilder();
     OspfArea oa1 = oab.build();
     OspfArea oa2 = oab.setOspfProcess(ospfProcess).build();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfTest.java
@@ -24,7 +24,12 @@ public class VrfTest {
     Vrf vrf = new Vrf("vrf");
     vrf.setOspfProcesses(
         ImmutableSortedMap.of(
-            "ospf", OspfProcess.builder().setProcessId("ospf").setReferenceBandwidth(1d).build()));
+            "ospf",
+            OspfProcess.builder()
+                .setProcessId("ospf")
+                .setRouterId(Ip.ZERO)
+                .setReferenceBandwidth(1d)
+                .build()));
     vrf.setBgpProcess(new BgpProcess(Ip.ZERO, ConfigurationFormat.CISCO_IOS));
     IsoAddress isoAddress = new IsoAddress("49.0001.0100.0500.5005.00");
     vrf.setIsisProcess(IsisProcess.builder().setNetAddress(isoAddress).build());

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfProcessTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfProcessTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
 import org.junit.Rule;
 import org.junit.Test;
@@ -69,6 +70,7 @@ public class OspfProcessTest {
 
     OspfProcess proc =
         opb.setReferenceBandwidth(1e8)
+            .setRouterId(Ip.ZERO)
             .setAreas(ImmutableSortedMap.of(0L, area0, 1L, area1))
             .build();
 
@@ -87,7 +89,11 @@ public class OspfProcessTest {
   public void setAreasMismatchedNumbers() {
     final NetworkFactory networkFactory = new NetworkFactory();
     OspfProcess proc =
-        OspfProcess.builder(networkFactory).setProcessId("1").setReferenceBandwidth(10e8).build();
+        OspfProcess.builder(networkFactory)
+            .setProcessId("1")
+            .setRouterId(Ip.ZERO)
+            .setReferenceBandwidth(10e8)
+            .build();
     _thrown.expect(IllegalArgumentException.class);
     proc.setAreas(
         ImmutableSortedMap.of(1L, OspfArea.builder(networkFactory).setNumber(2L).build()));

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2444,6 +2444,14 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
   private org.batfish.datamodel.ospf.OspfProcess toOspfProcess(
       OspfProcess proc, String vrfName, Configuration c, CiscoConfiguration oldConfig) {
+    Ip routerId = proc.getRouterId();
+    if (routerId == null) {
+      routerId = CiscoConversions.getHighestIp(oldConfig.getInterfaces());
+      if (routerId == Ip.ZERO) {
+        _w.redFlag("No candidates for OSPF router-id");
+        return null;
+      }
+    }
     org.batfish.datamodel.ospf.OspfProcess newProcess =
         org.batfish.datamodel.ospf.OspfProcess.builder()
             .setProcessId(proc.getName())
@@ -2453,6 +2461,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                     c.getConfigurationFormat()))
             .setSummaryAdminCost(
                 RoutingProtocol.OSPF_IA.getSummaryAdministrativeCost(c.getConfigurationFormat()))
+            .setRouterId(routerId)
             .build();
     org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
 
@@ -2661,16 +2670,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
     }
 
     computeDistributeListPolicies(proc, c, vrfName, proc.getName(), oldConfig);
-
-    Ip routerId = proc.getRouterId();
-    if (routerId == null) {
-      routerId = CiscoConversions.getHighestIp(oldConfig.getInterfaces());
-      if (routerId == Ip.ZERO) {
-        _w.redFlag("No candidates for OSPF router-id");
-        return null;
-      }
-    }
-    newProcess.setRouterId(routerId);
 
     // policies for redistributing routes
     ospfExportStatements.addAll(

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -773,6 +773,10 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (firstNonNull(routingInstance.getOspfDisable(), Boolean.FALSE)) {
       return null;
     }
+    Ip ospfRouterId = getOspfRouterId(routingInstance);
+    if (ospfRouterId == null) {
+      return null;
+    }
     OspfProcess newProc =
         OspfProcess.builder()
             // Use routing instance name since OSPF processes are not named
@@ -783,6 +787,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
                     _c.getConfigurationFormat()))
             .setSummaryAdminCost(
                 RoutingProtocol.OSPF_IA.getSummaryAdministrativeCost(_c.getConfigurationFormat()))
+            .setRouterId(ospfRouterId)
             .build();
     String vrfName = routingInstance.getName();
     // export policies
@@ -852,8 +857,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
                           iface.setOspfArea(area);
                           iface.setOspfProcess(newProc.getProcessId());
                         }));
-
-    newProc.setRouterId(getOspfRouterId(routingInstance));
     return newProc;
   }
 
@@ -3205,6 +3208,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
   }
 
+  @Nullable
   private Ip getOspfRouterId(RoutingInstance routingInstance) {
     Ip routerId = routingInstance.getRouterId();
     if (routerId == null) {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpTest.java
@@ -334,7 +334,8 @@ public class EigrpTest {
 
     Interface.Builder nib = nf.interfaceBuilder().setOspfCost(1);
 
-    OspfProcess.Builder opb = nf.ospfProcessBuilder().setProcessId("1");
+    OspfProcess.Builder opb =
+        nf.ospfProcessBuilder().setProcessId("1").setRouterId(R1_L0_ADDR.getIp());
     OspfArea.Builder oab = nf.ospfAreaBuilder().setNumber(area);
     Interface.Builder oib =
         nf.interfaceBuilder().setOspfCost(1).setOspfProcess("1").setOspfEnabled(true);
@@ -394,7 +395,7 @@ public class EigrpTest {
         eib, asn, mode2, R2_E2_3_ADDR, c2E2To3Name, c2E2To3DelayMult, exportPolicyName);
     if (otherProcess == OSPF) {
       // Build OSPF (with redistribute EIGRP)
-      opb.setExportPolicy(exportEigrpIntoOspf.setOwner(c2).build());
+      opb.setRouterId(R2_L0_ADDR.getIp()).setExportPolicy(exportEigrpIntoOspf.setOwner(c2).build());
       oib.setOspfArea(oab.setOspfProcess(opb.build()).build());
       buildOspfLoopbackInterface(oib, R2_L0_ADDR);
       buildOspfExternalInterface(oib, c2E2To1Name, R2_E2_1_ADDR);
@@ -438,7 +439,7 @@ public class EigrpTest {
         eib, asn, mode4, R4_E4_3_ADDR, c4E4To3Name, c4E4To3DelayMult, exportPolicyName);
     if (otherProcess == OSPF) {
       // Build OSPF
-      oib.setOspfArea(oab.setOspfProcess(opb.build()).build());
+      oib.setOspfArea(oab.setOspfProcess(opb.setRouterId(R4_L0_ADDR.getIp()).build()).build());
       buildOspfExternalInterface(oib, c4E4To1Name, R4_E4_1_ADDR);
     } else if (otherProcess == EIGRP) {
       // Build other EIGRP

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -182,6 +182,7 @@ public class OspfRoutingProcessTest {
     OspfProcess ospfProcess =
         nf.ospfProcessBuilder()
             .setProcessId("1")
+            .setRouterId(ACTIVE_ADDR_1.getIp())
             .setReferenceBandwidth(10e9)
             .setVrf(vrf)
             .setAreas(ImmutableSortedMap.of(0L, AREA0_CONFIG, 1L, area1Config))
@@ -334,6 +335,7 @@ public class OspfRoutingProcessTest {
     Builder ospfProcess =
         OspfProcess.builder()
             .setProcessId("1")
+            .setRouterId(Ip.ZERO)
             .setReferenceBandwidth(10e9)
             .setAreas(ImmutableSortedMap.of(0L, AREA0_CONFIG))
             .setMaxMetricTransitLinks(overrideMetric);
@@ -904,6 +906,7 @@ public class OspfRoutingProcessTest {
     final long overrideMetric = 8888L;
     Builder ospfProcess =
         OspfProcess.builder()
+            .setRouterId(Ip.ZERO)
             .setProcessId("1")
             .setReferenceBandwidth(10e9)
             .setAreas(ImmutableSortedMap.of(0L, AREA0_CONFIG))

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -177,7 +177,12 @@ public class OspfTest {
     Vrf v1 = vb.setOwner(c1).build();
     RoutingPolicy c1ExportPolicy =
         rpb.setOwner(c1).setStatements(getExportPolicyStatements(C1_L1_ADDRESS)).build();
-    OspfProcess op1 = opb.setVrf(v1).setProcessId("1").setExportPolicy(c1ExportPolicy).build();
+    OspfProcess op1 =
+        opb.setVrf(v1)
+            .setRouterId(C1_L1_ADDRESS.getIp())
+            .setProcessId("1")
+            .setExportPolicy(c1ExportPolicy)
+            .build();
     OspfArea oa1a = oaba.setOspfProcess(op1).build();
     OspfArea oa1b = areaA == areaB ? oa1a : oabb.setOspfProcess(op1).build();
     ib.setOwner(c1).setVrf(v1).setOspfArea(oa1a).setOspfProcess("1");
@@ -197,6 +202,7 @@ public class OspfTest {
         rpb.setOwner(c2).setStatements(getExportPolicyStatements(C2_L1_ADDRESS)).build();
     OspfProcess op2 =
         opb.setVrf(v2)
+            .setRouterId(C2_L1_ADDRESS.getIp())
             .setMaxMetricExternalNetworks(maxMetricExternalNetworks)
             .setMaxMetricStubNetworks(maxMetricStubNetworks)
             .setMaxMetricSummaryNetworks(maxMetricSummaryNetworks)
@@ -228,7 +234,8 @@ public class OspfTest {
     Vrf v3 = vb.setOwner(c3).build();
     RoutingPolicy c3ExportPolicy =
         rpb.setOwner(c3).setStatements(getExportPolicyStatements(C3_L1_ADDRESS)).build();
-    OspfProcess op3 = opb.setVrf(v3).setExportPolicy(c3ExportPolicy).build();
+    OspfProcess op3 =
+        opb.setVrf(v3).setRouterId(C3_L1_ADDRESS.getIp()).setExportPolicy(c3ExportPolicy).build();
     OspfArea oa3d = oabd.setOspfProcess(op3).build();
     OspfArea oa3e = areaD == areaE ? oa3d : oabe.setOspfProcess(op3).build();
     OspfArea oa3f =
@@ -249,7 +256,8 @@ public class OspfTest {
     Vrf v4 = vb.setOwner(c4).build();
     RoutingPolicy c4ExportPolicy =
         rpb.setOwner(c4).setStatements(getExportPolicyStatements(C4_L1_ADDRESS)).build();
-    OspfProcess op4 = opb.setVrf(v4).setExportPolicy(c4ExportPolicy).build();
+    OspfProcess op4 =
+        opb.setVrf(v4).setExportPolicy(c4ExportPolicy).setRouterId(C4_L1_ADDRESS.getIp()).build();
     OspfArea oa4f = oabf.setOspfProcess(op4).build();
     OspfArea oa4g = areaF == areaG ? oa4f : oabg.setOspfProcess(op4).build();
     ib.setOwner(c4).setVrf(v4).setOspfArea(oa4g);
@@ -343,7 +351,7 @@ public class OspfTest {
     // R0
     Configuration r0 = cb.setHostname(r0Name).build();
     Vrf v0 = vb.setOwner(r0).build();
-    OspfProcess op0 = opb.setVrf(v0).build();
+    OspfProcess op0 = opb.setVrf(v0).setRouterId(Ip.parse("10.0.0.0")).build();
     oab.setOspfProcess(op0);
     OspfArea oaR0A0 = oab.setNumber(0L).setNonStub().build();
     OspfArea oaR0A1 =
@@ -384,7 +392,7 @@ public class OspfTest {
     // R1
     Configuration r1 = cb.setHostname(r1Name).build();
     Vrf v1 = vb.setOwner(r1).build();
-    OspfProcess op1 = opb.setVrf(v1).build();
+    OspfProcess op1 = opb.setVrf(v1).setRouterId(Ip.parse("10.0.1.1")).build();
     oab.setOspfProcess(op1);
     OspfArea oaR1A0 = oab.setNumber(0L).setNonStub().build();
     ib.setOwner(r1).setVrf(v1);
@@ -397,7 +405,7 @@ public class OspfTest {
     // R2
     Configuration r2 = cb.setHostname(r2Name).build();
     Vrf v2 = vb.setOwner(r2).build();
-    OspfProcess op2 = opb.setVrf(v2).build();
+    OspfProcess op2 = opb.setVrf(v2).setRouterId(Ip.parse("10.0.2.2")).build();
     oab.setOspfProcess(op2);
     OspfArea oaR2A1 = oab.setNumber(1L).setStub(StubSettings.builder().build()).build();
     ib.setOwner(r2).setVrf(v2);
@@ -415,7 +423,7 @@ public class OspfTest {
     // R3
     Configuration r3 = cb.setHostname(r3Name).build();
     Vrf v3 = vb.setOwner(r3).build();
-    OspfProcess op3 = opb.setVrf(v3).build();
+    OspfProcess op3 = opb.setVrf(v3).setRouterId(Ip.parse("10.0.3.3")).build();
     oab.setOspfProcess(op3);
     OspfArea oaR3A1 = oab.setNumber(1L).setStub(StubSettings.builder().build()).build();
     ib.setOwner(r3).setVrf(v3);
@@ -428,7 +436,7 @@ public class OspfTest {
     // R4
     Configuration r4 = cb.setHostname(r4Name).build();
     Vrf v4 = vb.setOwner(r4).build();
-    OspfProcess op4 = opb.setVrf(v4).build();
+    OspfProcess op4 = opb.setVrf(v4).setRouterId(Ip.parse("10.0.4.4")).build();
     oab.setOspfProcess(op4);
     OspfArea oaR4A2 = oab.setNumber(2L).setNssa(NssaSettings.builder().build()).build();
     ib.setOwner(r4).setVrf(v4);
@@ -446,7 +454,7 @@ public class OspfTest {
     // R5
     Configuration r5 = cb.setHostname(r5Name).build();
     Vrf v5 = vb.setOwner(r5).build();
-    OspfProcess op5 = opb.setVrf(v5).build();
+    OspfProcess op5 = opb.setVrf(v5).setRouterId(Ip.parse("10.0.5.5")).build();
     oab.setOspfProcess(op5);
     OspfArea oaR5A2 = oab.setNumber(2L).setNssa(NssaSettings.builder().build()).build();
     ib.setOwner(r5).setVrf(v5);
@@ -482,7 +490,8 @@ public class OspfTest {
                             Statements.ExitAccept.toStaticStatement()),
                         ImmutableList.of(Statements.ExitReject.toStaticStatement()))))
             .build();
-    OspfProcess op6 = opb.setVrf(v6).setExportPolicy(exportStatic).build();
+    OspfProcess op6 =
+        opb.setVrf(v6).setRouterId(Ip.parse("10.0.6.6")).setExportPolicy(exportStatic).build();
     oab.setOspfProcess(op6);
     OspfArea oaR6A03 = oab.setNumber(3L).setNonStub().build();
     ib.setOwner(r6).setVrf(v6);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
@@ -69,7 +69,8 @@ public class NodeColoredScheduleTest {
     BgpProcess.Builder pb =
         nf.bgpProcessBuilder().setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS);
     BgpActivePeerConfig.Builder nb = nf.bgpNeighborBuilder();
-    OspfProcess.Builder ob = nf.ospfProcessBuilder().setProcessId("1").setReferenceBandwidth(1e8);
+    OspfProcess.Builder ob =
+        nf.ospfProcessBuilder().setProcessId("1").setReferenceBandwidth(1e8).setRouterId(Ip.ZERO);
     OspfArea.Builder ospfArea = nf.ospfAreaBuilder().setNumber(0);
 
     Configuration r1 = cb.setHostname("r1").build();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/topology/OspfTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/topology/OspfTopologyTest.java
@@ -78,7 +78,7 @@ public class OspfTopologyTest {
     // R1
     Configuration c1 = cb.setHostname("r1").build();
     Vrf vrf1 = vb.setOwner(c1).build();
-    OspfProcess proc1 = opb.setVrf(vrf1).build();
+    OspfProcess proc1 = opb.setVrf(vrf1).setRouterId(Ip.parse("1.1.1.2")).build();
     Interface i12 =
         ib.setAddress(ConcreteInterfaceAddress.parse("1.1.1.0/31"))
             .setVrf(vrf1)
@@ -118,7 +118,7 @@ public class OspfTopologyTest {
     // R2
     Configuration c2 = cb.setHostname("r2").build();
     Vrf vrf2 = vb.setOwner(c2).build();
-    OspfProcess proc2 = opb.setVrf(vrf2).build();
+    OspfProcess proc2 = opb.setVrf(vrf2).setRouterId(Ip.parse("1.1.1.1")).build();
     Interface i21 =
         ib.setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/31"))
             .setVrf(vrf2)
@@ -133,7 +133,7 @@ public class OspfTopologyTest {
     // R3
     Configuration c3 = cb.setHostname("r3").build();
     Vrf vrf3 = vb.setOwner(c3).build();
-    OspfProcess proc3 = opb.setVrf(vrf3).build();
+    OspfProcess proc3 = opb.setVrf(vrf3).setRouterId(Ip.parse("1.1.1.3")).build();
     Interface i31 =
         ib.setAddress(ConcreteInterfaceAddress.parse("1.1.1.3/31"))
             .setVrf(vrf3)
@@ -148,7 +148,7 @@ public class OspfTopologyTest {
     // R4
     Configuration c4 = cb.setHostname("r4").build();
     Vrf vrf4 = vb.setOwner(c4).build();
-    OspfProcess proc4 = opb.setVrf(vrf4).build();
+    OspfProcess proc4 = opb.setVrf(vrf4).setRouterId(Ip.parse("1.1.1.4")).build();
     Interface i41 =
         ib.setAddress(ConcreteInterfaceAddress.parse("1.1.1.4/31"))
             .setVrf(vrf4)
@@ -249,6 +249,7 @@ public class OspfTopologyTest {
                     .setNumber(1L)
                     .setInterfaces(ImmutableList.of("iface1", "iface2"))
                     .build()))
+        .setRouterId(Ip.ZERO)
         .build();
 
     initNeighborConfigs(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-area-default-metric
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-area-default-metric
@@ -1,6 +1,7 @@
 #
 set system host-name ospf-area-default-metric
 #
+set routing-options router-id 1.1.1.1
 set protocols ospf area 0.0.0.1 stub default-metric 10
 set protocols ospf area 0.0.0.2
 #

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -381,8 +381,10 @@ public class EdgesAnswererTest {
   @Test
   public void testGetOspfEdges() {
     NetworkFactory nf = new NetworkFactory();
-    OspfProcess ospf1 = OspfProcess.builder(nf).setReferenceBandwidth(1e8).build();
-    OspfProcess ospf2 = OspfProcess.builder(nf).setReferenceBandwidth(1e8).build();
+    OspfProcess ospf1 =
+        OspfProcess.builder(nf).setRouterId(Ip.parse("1.1.1.1")).setReferenceBandwidth(1e8).build();
+    OspfProcess ospf2 =
+        OspfProcess.builder(nf).setRouterId(Ip.parse("2.2.2.2")).setReferenceBandwidth(1e8).build();
 
     OspfArea.builder(nf).setNumber(1L).setOspfProcess(ospf1).addInterface("int1").build();
     OspfArea.builder(nf).setNumber(1L).setOspfProcess(ospf2).addInterface("int2").build();

--- a/projects/question/src/test/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswererTest.java
@@ -96,6 +96,7 @@ public class OspfSessionCompatibilityAnswererTest {
                     .setVrfName("vrf_u")
                     .setIp(Ip.parse("1.1.1.2"))
                     .build()))
+        .setRouterId(Ip.ZERO)
         .build();
     nf.ospfProcessBuilder()
         .setVrf(vrfV)
@@ -110,6 +111,7 @@ public class OspfSessionCompatibilityAnswererTest {
                     .setVrfName("vrf_v")
                     .setIp(Ip.parse("1.1.1.3"))
                     .build()))
+        .setRouterId(Ip.MAX)
         .build();
     _configurations =
         ImmutableMap.of("configuration_u", configurationU, "configuration_v", configurationV);

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_ospf
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_ospf
@@ -1,5 +1,6 @@
 #
 set system host-name juniper-ospf
+set routing-options router-id 1.1.1.1
 set protocols ospf area 0.1.2.3 interface xe-0/0/20:0.0
 set protocols ospf area 0.1.2.3 interface xe-0/0/20:0.0 ldp-synchronization
 set protocols ospf area 0.1.2.3 interface xe-0/0/20:0.0 ldp-synchronization disable

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_ospf_stub_areas
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_ospf_stub_areas
@@ -1,5 +1,6 @@
 #
 set system host-name juniper_ospf_stub_areas
+set routing-options router-id 1.1.1.1
 #
 set protocols ospf area 0.0.0.46 stub
 set protocols ospf area 0.0.0.46 stub no-summaries

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -3547,12 +3547,12 @@
         "Lines" : {
           "filename" : "configs/juniper_ospf",
           "lines" : [
-            17,
             18,
             19,
             20,
-            22,
-            23
+            21,
+            23,
+            24
           ]
         }
       },
@@ -3564,7 +3564,7 @@
         "Lines" : {
           "filename" : "configs/juniper_ospf",
           "lines" : [
-            15
+            16
           ]
         }
       },
@@ -3576,10 +3576,10 @@
         "Lines" : {
           "filename" : "configs/juniper_ospf",
           "lines" : [
-            3,
             4,
             5,
-            6
+            6,
+            7
           ]
         }
       },
@@ -3591,7 +3591,7 @@
         "Lines" : {
           "filename" : "configs/juniper_ospf",
           "lines" : [
-            7
+            8
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -1492,11 +1492,6 @@
         "defaultCrossZoneAction" : "PERMIT",
         "defaultInboundAction" : "PERMIT",
         "deviceType" : "SWITCH",
-        "routingPolicies" : {
-          "~OSPF_EXPORT_POLICY:default~" : {
-            "name" : "~OSPF_EXPORT_POLICY:default~"
-          }
-        },
         "vendorFamily" : {
           "cisco" : {
             "hostname" : "arista_ospf",
@@ -21724,6 +21719,7 @@
                 "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
                 "processId" : "default",
                 "referenceBandwidth" : 1.0E9,
+                "routerId" : "1.1.1.1",
                 "summaryAdminCost" : 10
               }
             },
@@ -24811,6 +24807,7 @@
                 "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
                 "processId" : "default",
                 "referenceBandwidth" : 1.0E9,
+                "routerId" : "1.1.1.1",
                 "summaryAdminCost" : 10
               }
             }

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -2375,14 +2375,14 @@
       },
       {
         "Filename" : "configs/juniper_ospf",
-        "Line" : 14,
+        "Line" : 15,
         "Text" : "area-range dead:beef::/56 override-metric 100",
         "Parser_Context" : "[oa_area_range o_area o_common p_ospf3 s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/juniper_ospf",
-        "Line" : 14,
+        "Line" : 15,
         "Text" : "area-range dead:beef::/56 override-metric 100",
         "Parser_Context" : "[oa_area_range o_area o_common p_ospf3 s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -63363,6 +63363,17 @@
             "    (set_line_tail",
             "      (statement",
             "        (s_common",
+            "          (s_routing_options",
+            "            ROUTING_OPTIONS:'routing-options'",
+            "            (ro_router_id",
+            "              ROUTER_ID:'router-id'",
+            "              id = IP_ADDRESS:'1.1.1.1')))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
             "          (s_protocols",
             "            PROTOCOLS:'protocols'",
             "            (p_ospf",
@@ -63879,6 +63890,17 @@
             "              HOST_NAME:'host-name'",
             "              (variable",
             "                text = VARIABLE:'juniper_ospf_stub_areas'))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_routing_options",
+            "            ROUTING_OPTIONS:'routing-options'",
+            "            (ro_router_id",
+            "              ROUTER_ID:'router-id'",
+            "              id = IP_ADDRESS:'1.1.1.1')))))",
             "    NEWLINE:'\\n')",
             "  (set_line",
             "    SET:'set'",
@@ -77450,13 +77472,13 @@
           "Parse warnings" : [
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 14,
+              "Line" : 15,
               "Parser_Context" : "[oa_area_range o_area o_common p_ospf3 s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "area-range dead:beef::/56 override-metric 100"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 14,
+              "Line" : 15,
               "Parser_Context" : "[oa_area_range o_area o_common p_ospf3 s_protocols s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "area-range dead:beef::/56 override-metric 100"
             }
@@ -77873,7 +77895,7 @@
         "juniper_misc" : "PASSED",
         "juniper_nat" : "PASSED",
         "juniper_ntp" : "PASSED",
-        "juniper_ospf_stub_areas" : "WARNINGS",
+        "juniper_ospf_stub_areas" : "PASSED",
         "juniper_passwords" : "PASSED",
         "juniper_policy_statement" : "PASSED",
         "juniper_relay" : "PASSED",
@@ -89607,30 +89629,30 @@
           "interface" : {
             "ae16.0" : {
               "ospf area interface" : [
-                17,
                 18,
                 19,
                 20,
-                22,
-                23
+                21,
+                23,
+                24
               ]
             },
             "xe-0/0/1.0" : {
               "ospf area interface" : [
-                15
+                16
               ]
             },
             "xe-0/0/20:0.0" : {
               "ospf area interface" : [
-                3,
                 4,
                 5,
-                6
+                6,
+                7
               ]
             },
             "xe-0/0/21:0.0" : {
               "ospf area interface" : [
-                7
+                8
               ]
             }
           }
@@ -92209,30 +92231,30 @@
           "interface" : {
             "ae16.0" : {
               "ospf area interface" : [
-                17,
                 18,
                 19,
                 20,
-                22,
-                23
+                21,
+                23,
+                24
               ]
             },
             "xe-0/0/1.0" : {
               "ospf area interface" : [
-                15
+                16
               ]
             },
             "xe-0/0/20:0.0" : {
               "ospf area interface" : [
-                3,
                 4,
                 5,
-                6
+                6,
+                7
               ]
             },
             "xe-0/0/21:0.0" : {
               "ospf area interface" : [
-                7
+                8
               ]
             }
           }
@@ -92837,10 +92859,6 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Cannot assign interface xe-0/0/21:0.0 to area 0.1.2.3 because it has no IP address."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "No candidates for OSPF router-id"
             }
           ]
         },
@@ -92897,14 +92915,6 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "missing action in firewall filter: 'ip_options', term: 't1'"
-            }
-          ]
-        },
-        "juniper_ospf_stub_areas" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "No candidates for OSPF router-id"
             }
           ]
         },


### PR DESCRIPTION
Pre-req for having originator ID in routes, doing proper router-id checks during bdp and topology establishment.