### PR TITLE
IOS: parse EIGRP hello/hold timers

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -339,9 +339,19 @@ if_ip_forward
    NO? IP FORWARD NEWLINE
 ;
 
+if_ip_hello_interval
+:
+   IP HELLO_INTERVAL EIGRP asn = DEC interval = DEC NEWLINE
+;
+
 if_ip_helper_address
 :
    IP HELPER_ADDRESS address = IP_ADDRESS NEWLINE
+;
+
+if_ip_hold_time
+:
+   IP HOLD_TIME EIGRP asn = DEC interval = DEC NEWLINE
 ;
 
 if_ip_inband_access_group
@@ -1776,7 +1786,9 @@ if_inner
    | if_ip_dhcp
    | if_ip_flow_monitor
    | if_ip_forward
+   | if_ip_hello_interval
    | if_ip_helper_address
+   | if_ip_hold_time
    | if_ip_inband_access_group
    | if_ip_igmp
    | if_ip_nat_destination

--- a/tests/parsing-tests/networks/unit-tests/configs/ios_interface_eigrp_settings
+++ b/tests/parsing-tests/networks/unit-tests/configs/ios_interface_eigrp_settings
@@ -1,0 +1,7 @@
+!
+hostname ios_interface_ip_eigrp_settings
+!
+interface Ethernet0
+  ip hello-interval eigrp 1 2
+  ip hold-time eigrp 3 4
+!

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -19823,6 +19823,60 @@
           }
         }
       },
+      "ios_interface_ip_eigrp_settings" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "ios_interface_ip_eigrp_settings",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceType" : "SWITCH",
+        "interfaces" : {
+          "Ethernet0" : {
+            "name" : "Ethernet0",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E7,
+            "declaredNames" : [
+              "Ethernet0"
+            ],
+            "mtu" : 1500,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "speed" : 1.0E7,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "hostname" : "ios_interface_ip_eigrp_settings",
+            "logging" : {
+              "on" : true
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "interfaces" : [
+              "Ethernet0"
+            ]
+          }
+        }
+      },
       "ios_interface_ip_tcp" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_interface_ip_tcp",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -580,6 +580,9 @@
         "ios_interface_ip_authentication" : [
           "configs/ios_interface_ip_autentication"
         ],
+        "ios_interface_ip_eigrp_settings" : [
+          "configs/ios_interface_eigrp_settings"
+        ],
         "ios_interface_ip_tcp" : [
           "configs/ios_interface_ip_tcp"
         ],
@@ -1112,6 +1115,7 @@
         "configs/ios_bgp" : "PASSED",
         "configs/ios_bgp_aggregate_address" : "PASSED",
         "configs/ios_interface" : "PASSED",
+        "configs/ios_interface_eigrp_settings" : "PASSED",
         "configs/ios_interface_ip_autentication" : "PASSED",
         "configs/ios_interface_ip_tcp" : "PASSED",
         "configs/ios_standby" : "PASSED",
@@ -51708,6 +51712,42 @@
             "  EOF:<EOF>)"
           ]
         },
+        "configs/ios_interface_eigrp_settings" : {
+          "sentences" : [
+            "(cisco_configuration",
+            "  (stanza",
+            "    (s_hostname",
+            "      HOSTNAME:'hostname'",
+            "      VARIABLE:'ios_interface_ip_eigrp_settings'",
+            "      NEWLINE:'\\n'))",
+            "  (stanza",
+            "    (s_interface",
+            "      INTERFACE:'interface'",
+            "      iname = (interface_name",
+            "        name_prefix_alpha = M_Interface_PREFIX:'Ethernet'  <== mode:M_Interface",
+            "        (range",
+            "          (subrange",
+            "            low = DEC:'0'  <== mode:M_Interface)))",
+            "      NEWLINE:'\\n'  <== mode:M_Interface",
+            "      (if_inner",
+            "        (if_ip_hello_interval",
+            "          IP:'ip'",
+            "          HELLO_INTERVAL:'hello-interval'",
+            "          EIGRP:'eigrp'",
+            "          asn = DEC:'1'",
+            "          interval = DEC:'2'",
+            "          NEWLINE:'\\n'))",
+            "      (if_inner",
+            "        (if_ip_hold_time",
+            "          IP:'ip'",
+            "          HOLD_TIME:'hold-time'",
+            "          EIGRP:'eigrp'",
+            "          asn = DEC:'3'",
+            "          interval = DEC:'4'",
+            "          NEWLINE:'\\n'))))",
+            "  EOF:<EOF>)"
+          ]
+        },
         "configs/ios_interface_ip_autentication" : {
           "sentences" : [
             "(cisco_configuration",
@@ -77857,6 +77897,7 @@
         "ios_bgp" : "PASSED",
         "ios_interface" : "PASSED",
         "ios_interface_ip_authentication" : "PASSED",
+        "ios_interface_ip_eigrp_settings" : "PASSED",
         "ios_interface_ip_tcp" : "PASSED",
         "ios_standby" : "PASSED",
         "ios_template" : "PASSED",
@@ -82366,6 +82407,18 @@
             }
           }
         },
+        "configs/ios_interface_eigrp_settings" : {
+          "interface" : {
+            "Ethernet0" : {
+              "definitionLines" : [
+                4,
+                5,
+                6
+              ],
+              "numReferrers" : 1
+            }
+          }
+        },
         "configs/ios_interface_ip_autentication" : {
           "interface" : {
             "Ethernet0" : {
@@ -85373,6 +85426,9 @@
         ],
         "configs/ios_interface" : [
           "ios_interface"
+        ],
+        "configs/ios_interface_eigrp_settings" : [
+          "ios_interface_ip_eigrp_settings"
         ],
         "configs/ios_interface_ip_autentication" : [
           "ios_interface_ip_authentication"
@@ -88832,6 +88888,15 @@
             "FOOBAR" : {
               "interface service-policy" : [
                 5
+              ]
+            }
+          }
+        },
+        "configs/ios_interface_eigrp_settings" : {
+          "interface" : {
+            "Ethernet0" : {
+              "interface" : [
+                4
               ]
             }
           }
@@ -93327,6 +93392,7 @@
         "configs/ios_bgp" : "PASSED",
         "configs/ios_bgp_aggregate_address" : "PASSED",
         "configs/ios_interface" : "PASSED",
+        "configs/ios_interface_eigrp_settings" : "PASSED",
         "configs/ios_interface_ip_autentication" : "PASSED",
         "configs/ios_interface_ip_tcp" : "PASSED",
         "configs/ios_standby" : "PASSED",


### PR DESCRIPTION
Prevents us from jumping out of interface context.

Fixes #4048