### PR TITLE
Fix router ID comparison in OSPF session compatibility check

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfTopologyUtils.java
@@ -186,7 +186,7 @@ public final class OspfTopologyUtils {
     if (localAreaNum != remoteAreaNum) {
       return Optional.empty();
     }
-    if (localProcess.getRouterId() == remoteProcess.getRouterId()) {
+    if (localProcess.getRouterId().equals(remoteProcess.getRouterId())) {
       return Optional.empty();
     }
     if (localArea.getStubType() != remoteArea.getStubType()) {


### PR DESCRIPTION
Use `.equals` instead of `==` for `Ip` comparison
