### PR TITLE
EIGRP distribute lists: improve filtering

### DIFF
--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/eigrp-distribute-lists/configs/advertiser
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/eigrp-distribute-lists/configs/advertiser
@@ -2,15 +2,20 @@
 hostname advertiser
 !
 access-list 2 permit 1.1.1.1 0.0.0.255
+access-list 2 permit 4.4.4.4 0.0.0.255
 !
 interface GigabitEthernet0/0
+ description to listener
  ip address 2.2.2.2 255.255.255.0
 !
 interface GigabitEthernet1/0
  ip address 1.1.1.1 255.255.255.0
 !
-interface GigabitEthernet2/0
+interface GigabitEthernet3/0
  ip address 3.3.3.3 255.255.255.0
+!
+interface GigabitEthernet4/0
+ ip address 4.4.4.4 255.255.255.0
 !
 router eigrp 1
   redistribute connected metric 1000 100 100 100 1400

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/eigrp-distribute-lists/configs/farlistener
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/eigrp-distribute-lists/configs/farlistener
@@ -1,0 +1,11 @@
+!
+hostname farlistener
+!
+interface GigabitEthernet0/0
+ description to listener
+ ip address 2.3.3.3 255.255.255.254
+!
+router eigrp 1
+  ! network statement below is needed to make GigabitEthernet0/0 an EIGRP neighbor
+  network 2.3.3.3 0.0.0.1
+!

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/eigrp-distribute-lists/configs/listener
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/eigrp-distribute-lists/configs/listener
@@ -2,9 +2,18 @@
 hostname listener
 !
 interface GigabitEthernet0/0
+ description to advertiser
  ip address 2.2.2.3 255.255.255.0
+!
+interface GigabitEthernet0/1
+ description to farlistener
+ ip address 2.3.3.2 255.255.255.254
 !
 router eigrp 1
   ! network statement below is needed to make GigabitEthernet0/0 an EIGRP neighbor
   network 2.2.2.3 0.0.0.255
+  network 2.3.3.2 0.0.0.1
+  distribute-list 10 out GigabitEthernet0/1
 !
+access-list 10 deny 4.4.4.0 0.0.0.255
+access-list 10 permit 1.1.1.0 0.0.0.255


### PR DESCRIPTION
Filter routes that we are re-propagating in addition to ones we are redistributing.

Fixes #4392 