### PR TITLE
NXOS: Remove unneeded todos

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1547,8 +1547,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
           @Override
           public BooleanExpr visitRouteMapMatchIpAddress(
               RouteMapMatchIpAddress routeMapMatchIpAddress) {
-            // TODO: implement - PBR only?
-            // Ignore
+            // Ignore, as it only applies to PBR and has no effect on route filtering/redistribution
             return BooleanExprs.TRUE;
           }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -3643,7 +3643,7 @@ public final class CiscoNxosGrammarTest {
       Bgpv4Route routeDirect = base.toBuilder().setNetwork(Prefix.parse("192.0.2.1/32")).build();
       assertRoutingPolicyPermitsRoute(rp, routeDirect);
     }
-    // TODO: match ip address - relevant to routing?
+    // Skip match ip address - not relevant to routing
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("match_ip_address_prefix_list");
       assertRoutingPolicyDeniesRoute(rp, base);


### PR DESCRIPTION
Confirmed on nxos `match ip address` in route maps only applies to PBR.

https://www.cisco.com/c/en/us/td/docs/switches/datacenter/sw/nx-os/unicast/configuration/guide/b-7k-Cisco-Nexus-7000-Series-NX-OS-Unicast-Routing-Configuration-Guide-Release/n7k_unicast_config_pbr.pdf