### PR TITLE
FibLookup: expand to VrfExpr

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java
@@ -31,6 +31,7 @@ import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.packet_policy.FibLookup;
 import org.batfish.datamodel.packet_policy.If;
+import org.batfish.datamodel.packet_policy.LiteralVrfName;
 import org.batfish.datamodel.packet_policy.PacketMatchExpr;
 import org.batfish.datamodel.packet_policy.PacketPolicy;
 import org.batfish.datamodel.packet_policy.Return;
@@ -89,8 +90,9 @@ public class TraceroutePolicyBasedRoutingTest {
                                   HeaderSpace.builder()
                                       .setDstIps(Ip.parse("9.9.9.9").toIpSpace())
                                       .build())),
-                          ImmutableList.of(new Return(new FibLookup(v2.getName()))))),
-                  new Return(new FibLookup(v1.getName())))));
+                          ImmutableList.of(
+                              new Return(new FibLookup(new LiteralVrfName(v2.getName())))))),
+                  new Return(new FibLookup(new LiteralVrfName(v1.getName()))))));
       ingressIface.setRoutingPolicy(ROUTING_POLICY_NAME);
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/FibLookup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/FibLookup.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -17,24 +16,24 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public final class FibLookup implements Action {
 
-  private static final String PROP_VRF_NAME = "vrfName";
+  private static final String PROP_VRF_EXPR = "vrfExpr";
 
-  @Nonnull private final String _vrfName;
+  @Nonnull private final VrfExpr _vrfExpr;
 
-  public FibLookup(String vrfName) {
-    _vrfName = vrfName;
+  public FibLookup(VrfExpr vrfExpr) {
+    _vrfExpr = vrfExpr;
   }
 
   @JsonCreator
-  private static FibLookup jsonCreator(@Nullable @JsonProperty(PROP_VRF_NAME) String vrfName) {
-    checkArgument(vrfName != null, "Missing %s", PROP_VRF_NAME);
+  private static FibLookup jsonCreator(@Nullable @JsonProperty(PROP_VRF_EXPR) VrfExpr vrfName) {
+    checkArgument(vrfName != null, "Missing %s", PROP_VRF_EXPR);
     return new FibLookup(vrfName);
   }
 
-  @JsonProperty(PROP_VRF_NAME)
+  @JsonProperty(PROP_VRF_EXPR)
   @Nonnull
-  public String getVrfName() {
-    return _vrfName;
+  public VrfExpr getVrfExpr() {
+    return _vrfExpr;
   }
 
   @Override
@@ -43,24 +42,24 @@ public final class FibLookup implements Action {
   }
 
   @Override
-  public boolean equals(@Nullable Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof FibLookup)) {
       return false;
     }
     FibLookup fibLookup = (FibLookup) o;
-    return Objects.equals(getVrfName(), fibLookup.getVrfName());
+    return _vrfExpr.equals(fibLookup._vrfExpr);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getVrfName());
+    return _vrfExpr.hashCode();
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("vrfName", _vrfName).toString();
+    return MoreObjects.toStringHelper(FibLookup.class).add(PROP_VRF_EXPR, _vrfExpr).toString();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/IngressInterfaceVrf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/IngressInterfaceVrf.java
@@ -22,7 +22,7 @@ public final class IngressInterfaceVrf implements VrfExpr {
 
   @Override
   public int hashCode() {
-    return super.hashCode();
+    return 0x3e0583f8; // randomly generated
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/IngressInterfaceVrf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/IngressInterfaceVrf.java
@@ -1,0 +1,37 @@
+package org.batfish.datamodel.packet_policy;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.common.base.MoreObjects;
+import javax.annotation.Nullable;
+
+/** Represents VRF of the ingress interface, resolved at the time of policy evaluation */
+public final class IngressInterfaceVrf implements VrfExpr {
+  private static final IngressInterfaceVrf INSTANCE = new IngressInterfaceVrf();
+
+  private IngressInterfaceVrf() {}
+
+  @JsonCreator
+  public static IngressInterfaceVrf instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public <T> T accept(VrfExprVisitor<T> visitor) {
+    return visitor.visitIngressInterfaceVrf(this);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return obj instanceof IngressInterfaceVrf;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(IngressInterfaceVrf.class).toString();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/LiteralVrfName.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/LiteralVrfName.java
@@ -1,0 +1,59 @@
+package org.batfish.datamodel.packet_policy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Represents a literal VRF name */
+public class LiteralVrfName implements VrfExpr {
+  private static final String PROP_VRF_NAME = "vrfName";
+
+  @Nonnull private final String _vrfName;
+
+  public LiteralVrfName(String vrfName) {
+    _vrfName = vrfName;
+  }
+
+  @Nonnull
+  @JsonProperty(PROP_VRF_NAME)
+  public String getVrfName() {
+    return _vrfName;
+  }
+
+  @Override
+  public <T> T accept(VrfExprVisitor<T> visitor) {
+    return visitor.visitLiteralVrfName(this);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LiteralVrfName)) {
+      return false;
+    }
+    LiteralVrfName that = (LiteralVrfName) o;
+    return _vrfName.equals(that._vrfName);
+  }
+
+  @Override
+  public int hashCode() {
+    return _vrfName.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(LiteralVrfName.class).add("_vrfName", _vrfName).toString();
+  }
+
+  @JsonCreator
+  private static LiteralVrfName jsonCreator(@JsonProperty(PROP_VRF_NAME) @Nullable String vrfName) {
+    checkArgument(vrfName != null, "Missing %s", PROP_VRF_NAME);
+    return new LiteralVrfName(vrfName);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/VrfExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/VrfExpr.java
@@ -1,0 +1,14 @@
+package org.batfish.datamodel.packet_policy;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.io.Serializable;
+
+/**
+ * Policy expression that represents a VRF, e.g, for a {@link FibLookup}. When evaluated, should
+ * resolve to a concrete VRF identifier.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
+public interface VrfExpr extends Serializable {
+
+  <T> T accept(VrfExprVisitor<T> visitor);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/VrfExprVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/VrfExprVisitor.java
@@ -1,0 +1,11 @@
+package org.batfish.datamodel.packet_policy;
+
+public interface VrfExprVisitor<T> {
+  default T visit(VrfExpr action) {
+    return action.accept(this);
+  }
+
+  T visitLiteralVrfName(LiteralVrfName expr);
+
+  T visitIngressInterfaceVrf(IngressInterfaceVrf expr);
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FibLookupTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FibLookupTest.java
@@ -16,29 +16,30 @@ public class FibLookupTest {
   @Test
   public void testEquals() {
     new EqualsTester()
-        .addEqualityGroup(new FibLookup("name"), new FibLookup("name"))
-        .addEqualityGroup(new FibLookup("otherName"))
+        .addEqualityGroup(
+            new FibLookup(new LiteralVrfName("name")), new FibLookup(new LiteralVrfName("name")))
+        .addEqualityGroup(new FibLookup(new LiteralVrfName("otherName")))
         .addEqualityGroup(new Object())
         .testEquals();
   }
 
   @Test
   public void testJavaSerialization() {
-    FibLookup fl = new FibLookup("name");
+    FibLookup fl = new FibLookup(new LiteralVrfName("name"));
     assertThat(SerializationUtils.clone(fl), equalTo(fl));
   }
 
   @Test
   public void testJsonSerialization() throws IOException {
-    FibLookup fl = new FibLookup("name");
+    FibLookup fl = new FibLookup(new LiteralVrfName("name"));
     assertThat(BatfishObjectMapper.clone(fl, FibLookup.class), equalTo(fl));
   }
 
   @Test
   public void testToString() {
-    FibLookup fl = new FibLookup("xxxxxx");
+    FibLookup fl = new FibLookup(new LiteralVrfName("xxxxxx"));
     assertTrue(fl.toString().contains(fl.getClass().getSimpleName()));
     assertTrue(fl.toString().contains("vrfName"));
-    assertTrue(fl.toString().contains(fl.getVrfName()));
+    assertTrue(fl.toString().contains("xxxxxx"));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FlowEvaluatorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FlowEvaluatorTest.java
@@ -45,7 +45,7 @@ public final class FlowEvaluatorTest {
 
   @Test
   public void evaluateReturn() {
-    FibLookup fl = new FibLookup("vrf");
+    FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
     FlowResult r =
         FlowEvaluator.evaluate(
             _flow, "Eth0", singletonPolicy(new Return(fl)), ImmutableMap.of(), ImmutableMap.of());
@@ -56,7 +56,7 @@ public final class FlowEvaluatorTest {
 
   @Test
   public void evaluateIfWithMatch() {
-    FibLookup fl = new FibLookup("vrf");
+    FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
     FlowResult r =
         FlowEvaluator.evaluate(
             _flow,
@@ -72,7 +72,7 @@ public final class FlowEvaluatorTest {
 
   @Test
   public void evaluateIfNoMatch() {
-    FibLookup fl = new FibLookup("vrf");
+    FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
     FlowResult r =
         FlowEvaluator.evaluate(
             _flow,
@@ -95,7 +95,7 @@ public final class FlowEvaluatorTest {
         .addEqualityGroup(
             new FlowResult(
                 _flow.toBuilder().setIngressNode("differentNode").build(), Drop.instance()))
-        .addEqualityGroup(new FlowResult(_flow, new FibLookup("aVRF")))
+        .addEqualityGroup(new FlowResult(_flow, new FibLookup(new LiteralVrfName("avrf"))))
         .addEqualityGroup(new Object())
         .testEquals();
   }
@@ -103,17 +103,17 @@ public final class FlowEvaluatorTest {
   @Test
   public void testEvaluateFindsFirstReachableTerminalAction() {
     // Setup policy
-    FibLookup action = new FibLookup("Matched");
+    FibLookup action = new FibLookup(new LiteralVrfName("Matched"));
     PacketPolicy policy =
         new PacketPolicy(
             "policyName",
             ImmutableList.of(
                 new If(
                     new PacketMatchExpr(FalseExpr.INSTANCE),
-                    ImmutableList.of(new Return(new FibLookup("Unreachable")))),
+                    ImmutableList.of(new Return(new FibLookup(new LiteralVrfName("Unreachable"))))),
                 new If(
                     new PacketMatchExpr(TrueExpr.INSTANCE), ImmutableList.of(new Return(action))),
-                new Return(new FibLookup("lastVRF"))),
+                new Return(new FibLookup(new LiteralVrfName("LastVrf")))),
             _defaultAction);
 
     // Test:
@@ -142,7 +142,7 @@ public final class FlowEvaluatorTest {
   public void testIndirection() {
     String aclName = "acl1";
     String ipSpaceName = "ipSpace1";
-    FibLookup fl = new FibLookup("vrf");
+    FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
     FlowResult r =
         FlowEvaluator.evaluate(
             _flow,

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/IngressInterfaceVrfTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/IngressInterfaceVrfTest.java
@@ -1,0 +1,31 @@
+package org.batfish.datamodel.packet_policy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Tests of {@link IngressInterfaceVrf} */
+public class IngressInterfaceVrfTest {
+  @Test
+  public void testEquals() {
+    IngressInterfaceVrf iiv = IngressInterfaceVrf.instance();
+    new EqualsTester().addEqualityGroup(iiv, iiv).addEqualityGroup(new Object()).testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    IngressInterfaceVrf iiv = IngressInterfaceVrf.instance();
+    assertThat(SerializationUtils.clone(iiv), equalTo(iiv));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    IngressInterfaceVrf iiv = IngressInterfaceVrf.instance();
+    assertThat(BatfishObjectMapper.clone(iiv, IngressInterfaceVrf.class), equalTo(iiv));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/LiteralVrfNameTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/LiteralVrfNameTest.java
@@ -1,0 +1,35 @@
+package org.batfish.datamodel.packet_policy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Test of {@link LiteralVrfName} */
+public class LiteralVrfNameTest {
+  @Test
+  public void testEquals() {
+    LiteralVrfName lv = new LiteralVrfName("vrf");
+    new EqualsTester()
+        .addEqualityGroup(lv, lv)
+        .addEqualityGroup(new LiteralVrfName("vrf2"))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    LiteralVrfName lv = new LiteralVrfName("vrf");
+    assertThat(SerializationUtils.clone(lv), equalTo(lv));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    LiteralVrfName lv = new LiteralVrfName("vrf");
+    assertThat(BatfishObjectMapper.clone(lv, LiteralVrfName.class), equalTo(lv));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/LiteralVrfNameTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/LiteralVrfNameTest.java
@@ -15,7 +15,7 @@ public class LiteralVrfNameTest {
   public void testEquals() {
     LiteralVrfName lv = new LiteralVrfName("vrf");
     new EqualsTester()
-        .addEqualityGroup(lv, lv)
+        .addEqualityGroup(lv, lv, new LiteralVrfName("vrf"))
         .addEqualityGroup(new LiteralVrfName("vrf2"))
         .addEqualityGroup(new Object())
         .testEquals();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketPolicyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketPolicyTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 /** Tests of {@link PacketPolicy} */
 public class PacketPolicyTest {
 
-  private final Return _defaultAction = new Return(new FibLookup("default"));
+  private final Return _defaultAction = new Return(new FibLookup(new LiteralVrfName("default")));
 
   @Test
   public void testEquals() {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/ReturnTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/ReturnTest.java
@@ -17,7 +17,7 @@ public class ReturnTest {
     Return r = new Return(Drop.instance());
     new EqualsTester()
         .addEqualityGroup(r, r, new Return(Drop.instance()))
-        .addEqualityGroup(new Return(new FibLookup("vrf")))
+        .addEqualityGroup(new Return(new FibLookup(new LiteralVrfName("vrf"))))
         .addEqualityGroup(new Object())
         .testEquals();
   }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -66,6 +66,9 @@ import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.packet_policy.FibLookup;
+import org.batfish.datamodel.packet_policy.IngressInterfaceVrf;
+import org.batfish.datamodel.packet_policy.LiteralVrfName;
+import org.batfish.datamodel.packet_policy.VrfExprVisitor;
 import org.batfish.datamodel.transformation.ApplyAll;
 import org.batfish.datamodel.transformation.ApplyAny;
 import org.batfish.datamodel.transformation.AssignIpAddressFromPool;
@@ -849,7 +852,23 @@ public final class BDDReachabilityAnalysisFactory {
                           new Edge(
                               preState,
                               new PostInVrf(
-                                  nodeName, transitionByFibLookupEntry.getKey().getVrfName()),
+                                  nodeName,
+                                  transitionByFibLookupEntry
+                                      .getKey()
+                                      .getVrfExpr()
+                                      .accept(
+                                          new VrfExprVisitor<String>() {
+                                            @Override
+                                            public String visitLiteralVrfName(LiteralVrfName expr) {
+                                              return expr.getVrfName();
+                                            }
+
+                                            @Override
+                                            public String visitIngressInterfaceVrf(
+                                                IngressInterfaceVrf expr) {
+                                              return iface.getVrfName();
+                                            }
+                                          })),
                               transitionByFibLookupEntry.getValue()));
             });
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatement.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatement.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.packet_policy.Drop;
 import org.batfish.datamodel.packet_policy.FibLookup;
+import org.batfish.datamodel.packet_policy.LiteralVrfName;
 import org.batfish.datamodel.packet_policy.Return;
 import org.batfish.datamodel.packet_policy.Statement;
 
@@ -32,7 +33,7 @@ public final class TermFwThenToPacketPolicyStatement implements FwThenVisitor<St
   @Override
   @Nullable
   public Statement visitFwThenAccept(FwThenAccept accept) {
-    return _skipRest ? null : new Return(new FibLookup(_vrfToUse));
+    return _skipRest ? null : new Return(new FibLookup(new LiteralVrfName(_vrfToUse)));
   }
 
   @Override
@@ -63,7 +64,9 @@ public final class TermFwThenToPacketPolicyStatement implements FwThenVisitor<St
   @Override
   @Nullable
   public Statement visitThenRoutingInstance(FwThenRoutingInstance routingInstance) {
-    return _skipRest ? null : new Return(new FibLookup(routingInstance.getInstanceName()));
+    return _skipRest
+        ? null
+        : new Return(new FibLookup(new LiteralVrfName(routingInstance.getInstanceName())));
   }
 
   /** Convert all "then" statements in the {@code term} to a list of packet policy statements */

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -79,6 +79,7 @@ import org.batfish.datamodel.flow.TraceWrapperAsAnswerElement;
 import org.batfish.datamodel.packet_policy.Drop;
 import org.batfish.datamodel.packet_policy.FibLookup;
 import org.batfish.datamodel.packet_policy.If;
+import org.batfish.datamodel.packet_policy.LiteralVrfName;
 import org.batfish.datamodel.packet_policy.PacketMatchExpr;
 import org.batfish.datamodel.packet_policy.PacketPolicy;
 import org.batfish.datamodel.packet_policy.Return;
@@ -1314,7 +1315,8 @@ public final class BDDReachabilityAnalysisFactoryTest {
                                 HeaderSpace.builder()
                                     .setDstIps(Prefix.parse("8.8.8.0/24").toIpSpace())
                                     .build())),
-                        ImmutableList.of(new Return(new FibLookup(vrf2.getName()))))),
+                        ImmutableList.of(
+                            new Return(new FibLookup(new LiteralVrfName(vrf2.getName())))))),
                 new Return(Drop.instance()))));
 
     Interface.Builder ib = nf.interfaceBuilder().setOwner(config).setVrf(vrf).setActive(true);

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatementTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/TermFwThenToPacketPolicyStatementTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableList;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.packet_policy.Drop;
 import org.batfish.datamodel.packet_policy.FibLookup;
+import org.batfish.datamodel.packet_policy.LiteralVrfName;
 import org.batfish.datamodel.packet_policy.Return;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +27,7 @@ public class TermFwThenToPacketPolicyStatementTest {
     _fwTerm.getThens().add(FwThenAccept.INSTANCE);
     assertThat(
         TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
-        equalTo(ImmutableList.of(new Return(new FibLookup("someVRF")))));
+        equalTo(ImmutableList.of(new Return(new FibLookup(new LiteralVrfName("someVRF"))))));
   }
 
   @Test
@@ -41,7 +42,7 @@ public class TermFwThenToPacketPolicyStatementTest {
     _fwTerm.getThens().addAll(ImmutableList.of(FwThenAccept.INSTANCE, FwThenNextTerm.INSTANCE));
     assertThat(
         TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
-        equalTo(ImmutableList.of(new Return(new FibLookup("someVRF")))));
+        equalTo(ImmutableList.of(new Return(new FibLookup(new LiteralVrfName("someVRF"))))));
   }
 
   @Test
@@ -77,7 +78,7 @@ public class TermFwThenToPacketPolicyStatementTest {
     _fwTerm.getThens().add(new FwThenRoutingInstance("otherVRF"));
     assertThat(
         TermFwThenToPacketPolicyStatement.convert(_fwTerm, "someVRF"),
-        equalTo(ImmutableList.of(new Return(new FibLookup("otherVRF")))));
+        equalTo(ImmutableList.of(new Return(new FibLookup(new LiteralVrfName("otherVRF"))))));
   }
 
   @Test

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -23005,7 +23005,10 @@
                     "class" : "org.batfish.datamodel.packet_policy.Return",
                     "action" : {
                       "class" : "org.batfish.datamodel.packet_policy.FibLookup",
-                      "vrfName" : "OTHER_INSTANCE"
+                      "vrfExpr" : {
+                        "class" : "org.batfish.datamodel.packet_policy.LiteralVrfName",
+                        "vrfName" : "OTHER_INSTANCE"
+                      }
                     }
                   }
                 ],
@@ -23027,7 +23030,10 @@
                     "class" : "org.batfish.datamodel.packet_policy.Return",
                     "action" : {
                       "class" : "org.batfish.datamodel.packet_policy.FibLookup",
-                      "vrfName" : "default"
+                      "vrfExpr" : {
+                        "class" : "org.batfish.datamodel.packet_policy.LiteralVrfName",
+                        "vrfName" : "default"
+                      }
                     }
                   }
                 ],


### PR DESCRIPTION
FibLookup now returns not just a hardcoded VRF name but a VRF expression that can be evaluated to resolve to a concrete VRF name.

Part of incremental progress towards PBR on Cisco NXOS