### PR TITLE
Remove OspfArea from interface

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -144,7 +144,6 @@ public final class Interface extends ComparableStructure<String> {
       if (_nativeVlan != null) {
         iface.setNativeVlan(_nativeVlan);
       }
-      iface.setOspfArea(_ospfArea);
       if (_ospfArea != null) {
         _ospfArea.addInterface(name);
         iface.setOspfAreaName(_ospfArea.getAreaNumber());
@@ -1215,18 +1214,8 @@ public final class Interface extends ComparableStructure<String> {
     return _nativeVlan;
   }
 
-  @JsonIgnore
-  @Nullable
-  public OspfArea getOspfArea() {
-    if (_ospfProcess == null
-        || _ospfAreaName == null
-        || !_vrf.getOspfProcesses().containsKey(_ospfProcess)) {
-      return null;
-    }
-    return _vrf.getOspfProcesses().get(_ospfProcess).getAreas().get(_ospfAreaName);
-  }
-
   /** The OSPF area to which this interface belongs. */
+  @Nullable
   @JsonProperty(PROP_OSPF_AREA)
   public Long getOspfAreaName() {
     return _ospfAreaName;
@@ -1633,15 +1622,6 @@ public final class Interface extends ComparableStructure<String> {
   @JsonProperty(PROP_NATIVE_VLAN)
   public void setNativeVlan(@Nullable Integer vlan) {
     _nativeVlan = vlan;
-  }
-
-  @JsonIgnore
-  public void setOspfArea(@Nullable OspfArea ospfArea) {
-    if (ospfArea == null) {
-      _ospfAreaName = null;
-    } else {
-      _ospfAreaName = ospfArea.getAreaNumber();
-    }
   }
 
   @JsonProperty(PROP_OSPF_AREA)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchers.java
@@ -42,7 +42,6 @@ import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasMlagId;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasMtu;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasName;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasNativeVlan;
-import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfArea;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfAreaName;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfCost;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.HasOspfEnabled;
@@ -60,7 +59,6 @@ import org.batfish.datamodel.matchers.InterfaceMatchersImpl.IsOspfPassive;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.IsOspfPointToPoint;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.IsProxyArp;
 import org.batfish.datamodel.matchers.InterfaceMatchersImpl.IsSwitchport;
-import org.batfish.datamodel.ospf.OspfArea;
 import org.hamcrest.Matcher;
 
 public final class InterfaceMatchers {
@@ -315,14 +313,6 @@ public final class InterfaceMatchers {
    */
   public static HasNativeVlan hasNativeVlan(Matcher<? super Integer> subMatcher) {
     return new HasNativeVlan(subMatcher);
-  }
-
-  /**
-   * Provides a matcher that matches if the provided {@code subMatcher} matches the interface's OSPF
-   * area.
-   */
-  public static HasOspfArea hasOspfArea(Matcher<OspfArea> subMatcher) {
-    return new HasOspfArea(subMatcher);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
@@ -17,7 +17,6 @@ import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.eigrp.EigrpInterfaceSettings;
 import org.batfish.datamodel.hsrp.HsrpGroup;
 import org.batfish.datamodel.isis.IsisInterfaceSettings;
-import org.batfish.datamodel.ospf.OspfArea;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
@@ -251,17 +250,6 @@ final class InterfaceMatchersImpl {
     @Nullable
     protected Integer featureValueOf(Interface actual) {
       return actual.getNativeVlan();
-    }
-  }
-
-  static final class HasOspfArea extends FeatureMatcher<Interface, OspfArea> {
-    HasOspfArea(@Nonnull Matcher<? super OspfArea> subMatcher) {
-      super(subMatcher, "an Interface with ospfArea:", "ospfArea");
-    }
-
-    @Override
-    protected OspfArea featureValueOf(Interface actual) {
-      return actual.getOspfArea();
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2661,7 +2661,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                                 .get(vrfName)
                                 .getInterfaces()
                                 .get(ifaceName)
-                                .setOspfArea(area)));
+                                .setOspfAreaName(area.getAreaNumber())));
 
     String ospfExportPolicyName = "~OSPF_EXPORT_POLICY:" + vrfName + "~";
     RoutingPolicy ospfExportPolicy = new RoutingPolicy(ospfExportPolicyName, c);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -854,7 +854,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
                         ifaceName -> {
                           org.batfish.datamodel.Interface iface =
                               _c.getVrfs().get(vrfName).getInterfaces().get(ifaceName);
-                          iface.setOspfArea(area);
+                          iface.setOspfAreaName(area.getAreaNumber());
                           iface.setOspfProcess(newProc.getProcessId());
                         }));
     return newProc;

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
@@ -89,7 +89,7 @@ public class NodeColoredScheduleTest {
         .setAreas(ImmutableSortedMap.of(0L, r1ospfArea))
         .setRouterId(Ip.parse("0.0.0.1"))
         .build();
-    i1.setOspfArea(r1ospfArea);
+    i1.setOspfAreaName(r1ospfArea.getAreaNumber());
     // BGP process and neighbor
     BgpProcess r1Proc = pb.setRouterId(R1_IP).setVrf(vrf1).build();
     nb.setRemoteAs(2L)

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -4678,6 +4678,7 @@ public class CiscoGrammarTest {
     assertThat(c, hasDefaultVrf(hasOspfProcess("1", hasAreas(hasKey(areaNum)))));
     OspfArea area = c.getDefaultVrf().getOspfProcesses().get("1").getAreas().get(areaNum);
     assertThat(area, OspfAreaMatchers.hasInterfaces(hasItem(ifaceName)));
+    assertThat(c, hasInterface(ifaceName, hasOspfAreaName(areaNum)));
     assertThat(c, hasInterface(ifaceName, isOspfPassive(equalTo(false))));
     assertThat(c, hasInterface(ifaceName, isOspfPointToPoint()));
   }
@@ -4708,6 +4709,7 @@ public class CiscoGrammarTest {
     OspfArea area = vrf.getOspfProcesses().get("1").getAreas().get(areaNum);
     assertThat(area, OspfAreaMatchers.hasInterfaces(hasItem(ifaceName)));
     assertThat(c, hasInterface(ifaceName, hasVrf(sameInstance(vrf))));
+    assertThat(c, hasInterface(ifaceName, hasOspfAreaName(areaNum)));
     assertThat(c, hasInterface(ifaceName, isOspfPassive(equalTo(false))));
     assertThat(c, hasInterface(ifaceName, isOspfPointToPoint()));
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -99,7 +99,6 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasIsis;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMlagId;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasNativeVlan;
-import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfArea;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasOspfAreaName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSpeed;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasSwitchPortEncapsulation;
@@ -4679,7 +4678,6 @@ public class CiscoGrammarTest {
     assertThat(c, hasDefaultVrf(hasOspfProcess("1", hasAreas(hasKey(areaNum)))));
     OspfArea area = c.getDefaultVrf().getOspfProcesses().get("1").getAreas().get(areaNum);
     assertThat(area, OspfAreaMatchers.hasInterfaces(hasItem(ifaceName)));
-    assertThat(c, hasInterface(ifaceName, hasOspfArea(sameInstance(area))));
     assertThat(c, hasInterface(ifaceName, isOspfPassive(equalTo(false))));
     assertThat(c, hasInterface(ifaceName, isOspfPointToPoint()));
   }
@@ -4710,7 +4708,6 @@ public class CiscoGrammarTest {
     OspfArea area = vrf.getOspfProcesses().get("1").getAreas().get(areaNum);
     assertThat(area, OspfAreaMatchers.hasInterfaces(hasItem(ifaceName)));
     assertThat(c, hasInterface(ifaceName, hasVrf(sameInstance(vrf))));
-    assertThat(c, hasInterface(ifaceName, hasOspfArea(sameInstance(area))));
     assertThat(c, hasInterface(ifaceName, isOspfPassive(equalTo(false))));
     assertThat(c, hasInterface(ifaceName, isOspfPointToPoint()));
   }
@@ -4792,8 +4789,10 @@ public class CiscoGrammarTest {
     Configuration abr = configurations.get(abrName);
 
     // Sanity check: ensure the ABR does not have suppressType7 set for area 1
+    Long areaNum =
+        abr.getVrfs().get(DEFAULT_VRF_NAME).getInterfaces().get("Ethernet1").getOspfAreaName();
     OspfArea abrToArea1 =
-        abr.getVrfs().get(DEFAULT_VRF_NAME).getInterfaces().get("Ethernet1").getOspfArea();
+        abr.getVrfs().get(DEFAULT_VRF_NAME).getOspfProcesses().get("1").getAreas().get(areaNum);
     assertThat(abrToArea1.getNssa(), hasSuppressType7(false));
 
     batfish.computeDataPlane();
@@ -4825,7 +4824,10 @@ public class CiscoGrammarTest {
     abr = configurations.get(abrName);
 
     // This time the ABR should have suppressType7 set for area 1
-    abrToArea1 = abr.getVrfs().get(DEFAULT_VRF_NAME).getInterfaces().get("Ethernet1").getOspfArea();
+    areaNum =
+        abr.getVrfs().get(DEFAULT_VRF_NAME).getInterfaces().get("Ethernet1").getOspfAreaName();
+    abrToArea1 =
+        abr.getVrfs().get(DEFAULT_VRF_NAME).getOspfProcesses().get("1").getAreas().get(areaNum);
     assertThat(abrToArea1.getNssa(), hasSuppressType7(true));
 
     batfish.computeDataPlane();

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -3159,9 +3159,6 @@ public final class CiscoNxosGrammarTest {
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/1");
       assertTrue(iface.getOspfEnabled());
-      assertThat(
-          iface.getOspfArea(),
-          equalTo(c.getDefaultVrf().getOspfProcesses().get("pi_d").getAreas().get(0L)));
       assertThat(iface.getOspfAreaName(), equalTo(0L));
       assertTrue(iface.getOspfPassive());
       assertFalse(iface.getOspfPointToPoint());
@@ -3169,9 +3166,6 @@ public final class CiscoNxosGrammarTest {
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/2");
       assertTrue(iface.getOspfEnabled());
-      assertThat(
-          iface.getOspfArea(),
-          equalTo(c.getDefaultVrf().getOspfProcesses().get("network").getAreas().get(0L)));
       assertThat(iface.getOspfAreaName(), equalTo(0L));
       assertFalse(iface.getOspfPassive());
       assertFalse(iface.getOspfPointToPoint());
@@ -3179,9 +3173,6 @@ public final class CiscoNxosGrammarTest {
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/3");
       assertTrue(iface.getOspfEnabled());
-      assertThat(
-          iface.getOspfArea(),
-          equalTo(c.getDefaultVrf().getOspfProcesses().get("network").getAreas().get(0L)));
       assertThat(iface.getOspfAreaName(), equalTo(0L));
       assertFalse(iface.getOspfPassive());
       assertTrue(iface.getOspfPointToPoint());


### PR DESCRIPTION
Stop perpetuating the pattern where we store complex objects inside interface when they really belong somewhere else (in this case, OspfProcess)
Name/number of the area still remains in interface