### PR TITLE
minor crypto variants

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -4962,6 +4962,11 @@ FQDN
    'fqdn'
 ;
 
+FRAGMENTATION
+:
+   'fragmentation'
+;
+
 FRAGMENTS
 :
    'fragments'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_crypto.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_crypto.g4
@@ -277,6 +277,7 @@ cip_null
 :
    (
       DF_BIT
+      | FRAGMENTATION
       | IKEV1
       | NAT_TRANSPARENCY
       | SECURITY_ASSOCIATION
@@ -389,8 +390,8 @@ cis_policy
    POLICY priority = DEC NEWLINE
    (
       cispol_authentication
-      | cispol_encr        //cisco
-      | cispol_encryption  //aruba
+      | cispol_encryption        //cisco
+      | cispol_encryption_aruba  //aruba
       | cispol_group
       | cispol_hash
       | cispol_lifetime
@@ -420,12 +421,15 @@ cispol_authentication
    ) NEWLINE
 ;
 
-cispol_encr
+cispol_encryption
 :
-   ENCR ike_encryption NEWLINE
+   (
+      ENCR
+      | ENCRYPTION
+    ) ike_encryption NEWLINE
 ;
 
-cispol_encryption
+cispol_encryption_aruba
 :
    ENCRYPTION ike_encryption_aruba NEWLINE
 ;
@@ -475,7 +479,7 @@ cisprf_local_address
 
 cisprf_match
 :
-   MATCH IDENTITY ADDRESS address = IP_ADDRESS mask = IP_ADDRESS NEWLINE
+   MATCH IDENTITY ADDRESS address = IP_ADDRESS mask = IP_ADDRESS? NEWLINE
 ;
 
 cisprf_null

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -545,8 +545,8 @@ import org.batfish.grammar.cisco.CiscoParser.Cis_policyContext;
 import org.batfish.grammar.cisco.CiscoParser.Cis_profileContext;
 import org.batfish.grammar.cisco.CiscoParser.Cisco_configurationContext;
 import org.batfish.grammar.cisco.CiscoParser.Cispol_authenticationContext;
-import org.batfish.grammar.cisco.CiscoParser.Cispol_encrContext;
 import org.batfish.grammar.cisco.CiscoParser.Cispol_encryptionContext;
+import org.batfish.grammar.cisco.CiscoParser.Cispol_encryption_arubaContext;
 import org.batfish.grammar.cisco.CiscoParser.Cispol_groupContext;
 import org.batfish.grammar.cisco.CiscoParser.Cispol_hashContext;
 import org.batfish.grammar.cisco.CiscoParser.Cispol_lifetimeContext;
@@ -2153,12 +2153,12 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   }
 
   @Override
-  public void exitCispol_encr(Cispol_encrContext ctx) {
+  public void exitCispol_encryption(Cispol_encryptionContext ctx) {
     _currentIsakmpPolicy.setEncryptionAlgorithm(toEncryptionAlgorithm(ctx.ike_encryption()));
   }
 
   @Override
-  public void exitCispol_encryption(Cispol_encryptionContext ctx) {
+  public void exitCispol_encryption_aruba(Cispol_encryption_arubaContext ctx) {
     _currentIsakmpPolicy.setEncryptionAlgorithm(toEncryptionAlgorithm(ctx.ike_encryption_aruba()));
   }
 
@@ -2196,8 +2196,9 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitCisprf_match(Cisprf_matchContext ctx) {
+    Ip mask = (ctx.mask == null) ? Ip.parse("255.255.255.255") : toIp(ctx.mask);
     _currentIsakmpProfile.setMatchIdentity(
-        IpWildcard.ipWithWildcardMask(toIp(ctx.address), toIp(ctx.mask).inverted()));
+        IpWildcard.ipWithWildcardMask(toIp(ctx.address), mask.inverted()));
   }
 
   @Override

--- a/tests/parsing-tests/networks/unit-tests/configs/cisco_crypto
+++ b/tests/parsing-tests/networks/unit-tests/configs/cisco_crypto
@@ -151,6 +151,7 @@ crypto ikev2 proposal VPN_PROPOSAL1
  integrity sha512 sha384 sha256
 crypto ikev2 remote-access trustpoint blahblah
 crypto ipsec df-bit clear
+crypto ipsec fragmentation before-encryption
 crypto ipsec ikev1 transform-set ESP-AES-256-MD5 esp-aes-256 esp-md5-hmac
 crypto ipsec ikev2 ipsec-proposal ffffffffff
  protocol esp encryption aes-256
@@ -179,7 +180,9 @@ crypto isakmp key ~99a9aaa_aaaa9aa|||aaaaaaa address 1.2.3.4
 crypto isakmp nat keepalive 30
 crypto isakmp policy 1
   authentication pre-share
+! both 'encr' and 'encryption' are valid
   encr 3des
+  encryption 3des
   group 2
   hash md5
   lifetime 28800
@@ -187,6 +190,8 @@ crypto isakmp policy 1
 crypto isakmp profile myprofile
    keyring VRF:MMS:RMT:UPM:1143
    match identity address 1.2.3.4 255.255.255.255
+! mask is optional   
+   match identity address 1.2.3.4
    reverse-route
    self-identity 2.3.4.6
    vrf VRF:MMS:RMT:UPM:1143

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -842,7 +842,7 @@
         "Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            222
+            227
           ]
         }
       },
@@ -854,7 +854,7 @@
         "Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            159
+            160
           ]
         }
       },
@@ -866,7 +866,7 @@
         "Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            241
+            246
           ]
         }
       },
@@ -878,7 +878,7 @@
         "Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            237
+            242
           ]
         }
       },
@@ -890,7 +890,7 @@
         "Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            162
+            163
           ]
         }
       },
@@ -902,7 +902,7 @@
         "Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            188
+            191
           ]
         }
       },
@@ -914,7 +914,7 @@
         "Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            224
+            229
           ]
         }
       },
@@ -926,7 +926,7 @@
         "Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            235
+            240
           ]
         }
       },
@@ -938,7 +938,7 @@
         "Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            219
+            224
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -555,11 +555,11 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            158,
             159,
             160,
             161,
-            162
+            162,
+            163
           ]
         }
       },
@@ -569,9 +569,9 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            167,
             168,
-            169
+            169,
+            170
           ]
         }
       },
@@ -581,7 +581,7 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            170
+            171
           ]
         }
       },
@@ -591,7 +591,7 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            171
+            172
           ]
         }
       },
@@ -601,7 +601,7 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            172
+            173
           ]
         }
       },
@@ -611,7 +611,7 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            173
+            174
           ]
         }
       },
@@ -621,8 +621,8 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            212,
-            213
+            217,
+            218
           ]
         }
       },
@@ -653,12 +653,12 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            218,
-            219,
-            220,
-            221,
-            222,
-            223
+            223,
+            224,
+            225,
+            226,
+            227,
+            228
           ]
         }
       },
@@ -668,15 +668,15 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            233,
-            234,
-            235,
-            236,
-            237,
             238,
             239,
             240,
-            241
+            241,
+            242,
+            243,
+            244,
+            245,
+            246
           ]
         }
       },
@@ -686,7 +686,7 @@
         "Source_Lines" : {
           "filename" : "configs/cisco_crypto",
           "lines" : [
-            215
+            220
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -3425,12 +3425,12 @@
             "            AUTHENTICATION:'authentication'",
             "            RSA_SIG:'rsa-sig'  <== mode:M_Authentication",
             "            NEWLINE:'\\n')",
-            "          (cispol_encryption",
+            "          (cispol_encryption_aruba",
             "            ENCRYPTION:'encryption'",
             "            (ike_encryption_aruba",
             "              AES128:'aes128')",
             "            NEWLINE:'\\n')",
-            "          (cispol_encryption",
+            "          (cispol_encryption_aruba",
             "            ENCRYPTION:'encryption'",
             "            (ike_encryption_aruba",
             "              AES256:'aes256')",
@@ -18925,6 +18925,16 @@
             "      (crypto_ipsec",
             "        IPSEC:'ipsec'",
             "        (cip_null",
+            "          FRAGMENTATION:'fragmentation'",
+            "          (null_rest_of_line",
+            "            VARIABLE:'before-encryption'",
+            "            NEWLINE:'\\n')))))",
+            "  (stanza",
+            "    (s_crypto",
+            "      CRYPTO:'crypto'",
+            "      (crypto_ipsec",
+            "        IPSEC:'ipsec'",
+            "        (cip_null",
             "          IKEV1:'ikev1'",
             "          (null_rest_of_line",
             "            TRANSFORM_SET:'transform-set'",
@@ -19175,8 +19185,13 @@
             "            AUTHENTICATION:'authentication'",
             "            PRE_SHARE:'pre-share'  <== mode:M_Authentication",
             "            NEWLINE:'\\n')",
-            "          (cispol_encr",
+            "          (cispol_encryption",
             "            ENCR:'encr'",
+            "            (ike_encryption",
+            "              THREE_DES:'3des')",
+            "            NEWLINE:'\\n')",
+            "          (cispol_encryption",
+            "            ENCRYPTION:'encryption'",
             "            (ike_encryption",
             "              THREE_DES:'3des')",
             "            NEWLINE:'\\n')",
@@ -19221,6 +19236,12 @@
             "            ADDRESS:'address'",
             "            address = IP_ADDRESS:'1.2.3.4'",
             "            mask = IP_ADDRESS:'255.255.255.255'",
+            "            NEWLINE:'\\n')",
+            "          (cisprf_match",
+            "            MATCH:'match'",
+            "            IDENTITY:'identity'",
+            "            ADDRESS:'address'",
+            "            address = IP_ADDRESS:'1.2.3.4'",
             "            NEWLINE:'\\n')",
             "          (cisprf_null",
             "            REVERSE_ROUTE:'reverse-route'",
@@ -79084,11 +79105,11 @@
           "crypto ipsec profile" : {
             "abcdefg" : {
               "definitionLines" : [
-                158,
                 159,
                 160,
                 161,
-                162
+                162,
+                163
               ],
               "numReferrers" : 0
             }
@@ -79096,33 +79117,33 @@
           "crypto ipsec transform-set" : {
             "ESP-3DES-MD5" : {
               "definitionLines" : [
-                167,
                 168,
-                169
+                169,
+                170
               ],
               "numReferrers" : 0
             },
             "IPSEC_AES_256" : {
               "definitionLines" : [
-                170
+                171
               ],
               "numReferrers" : 0
             },
             "cipts1" : {
               "definitionLines" : [
-                171
+                172
               ],
               "numReferrers" : 0
             },
             "cipts2" : {
               "definitionLines" : [
-                172
+                173
               ],
               "numReferrers" : 0
             },
             "noAuthHeader" : {
               "definitionLines" : [
-                173
+                174
               ],
               "numReferrers" : 0
             }
@@ -79130,12 +79151,14 @@
           "crypto isakmp policy" : {
             "1" : {
               "definitionLines" : [
-                180,
                 181,
                 182,
                 183,
                 184,
-                185
+                185,
+                186,
+                187,
+                188
               ],
               "numReferrers" : 1
             }
@@ -79143,13 +79166,15 @@
           "crypto isakmp profile" : {
             "myprofile" : {
               "definitionLines" : [
-                187,
-                188,
-                189,
                 190,
                 191,
                 192,
-                193
+                193,
+                194,
+                195,
+                196,
+                197,
+                198
               ],
               "numReferrers" : 1
             }
@@ -79157,8 +79182,8 @@
           "crypto keyring" : {
             "VRF:ABC:DEF:GHI:1234" : {
               "definitionLines" : [
-                212,
-                213
+                217,
+                218
               ],
               "numReferrers" : 0
             }
@@ -79166,11 +79191,6 @@
           "crypto named rsa pubkey" : {
             "a.example.com" : {
               "definitionLines" : [
-                198,
-                199,
-                200,
-                201,
-                202,
                 203,
                 204,
                 205,
@@ -79179,7 +79199,12 @@
                 208,
                 209,
                 210,
-                211
+                211,
+                212,
+                213,
+                214,
+                215,
+                216
               ],
               "numReferrers" : 1
             }
@@ -79209,32 +79234,32 @@
           "crypto-map-set" : {
             "VPN" : {
               "definitionLines" : [
-                218,
-                219,
-                220,
-                221,
-                222,
-                223
+                223,
+                224,
+                225,
+                226,
+                227,
+                228
               ],
               "numReferrers" : 0
             },
             "VPNMAP" : {
               "definitionLines" : [
-                233,
-                234,
-                235,
-                236,
-                237,
                 238,
                 239,
                 240,
-                241
+                241,
+                242,
+                243,
+                244,
+                245,
+                246
               ],
               "numReferrers" : 0
             },
             "myothermap" : {
               "definitionLines" : [
-                215
+                220
               ],
               "numReferrers" : 0
             }
@@ -86653,79 +86678,79 @@
             },
             "bleep" : {
               "crypto map ipsec-isakmp transform-set" : [
-                222
+                227
               ]
             },
             "hijklmnop" : {
               "ipsec profile set transform-set" : [
-                159
+                160
               ]
             },
             "mytransformset" : {
               "crypto map ipsec-isakmp transform-set" : [
-                241
+                246
               ]
             }
           },
           "crypto isakmp policy" : {
             "1" : {
               "isakmp policy" : [
-                180
+                181
               ]
             }
           },
           "crypto isakmp profile" : {
             "myisakmpprofile" : {
               "crypto map ipsec-isakmp isakmp-profile" : [
-                237
+                242
               ]
             },
             "myprofile" : {
               "isakmp profile" : [
-                187
+                190
               ]
             },
             "someOtherprofile" : {
               "ipsec profile set isakmp-profile" : [
-                162
+                163
               ]
             }
           },
           "crypto keyring" : {
             "VRF:MMS:RMT:UPM:1143" : {
               "isakmp profile keyring" : [
-                188
+                191
               ]
             }
           },
           "crypto named rsa pubkey" : {
             "a.example.com" : {
               "named rsa pubkey" : [
-                198
+                203
               ]
             }
           },
           "crypto-dynamic-map-set" : {
             "bippety" : {
               "crypto map ipsec-isakmp crypto-dynamic-map-set" : [
-                224
+                229
               ]
             },
             "mydefaultcryptomap" : {
               "crypto map ipsec-isakmp crypto-dynamic-map-set" : [
-                215
+                220
               ]
             }
           },
           "ipv4/6 acl" : {
             "myvpnacl" : {
               "crypto map ipsec-isakmp acl" : [
-                235
+                240
               ]
             },
             "someacl" : {
               "crypto map ipsec-isakmp acl" : [
-                219
+                224
               ]
             }
           }
@@ -90916,55 +90941,55 @@
           "crypto ipsec transform-set" : {
             "bleep" : {
               "crypto map ipsec-isakmp transform-set" : [
-                222
+                227
               ]
             },
             "hijklmnop" : {
               "ipsec profile set transform-set" : [
-                159
+                160
               ]
             },
             "mytransformset" : {
               "crypto map ipsec-isakmp transform-set" : [
-                241
+                246
               ]
             }
           },
           "crypto isakmp profile" : {
             "myisakmpprofile" : {
               "crypto map ipsec-isakmp isakmp-profile" : [
-                237
+                242
               ]
             },
             "someOtherprofile" : {
               "ipsec profile set isakmp-profile" : [
-                162
+                163
               ]
             }
           },
           "crypto keyring" : {
             "VRF:MMS:RMT:UPM:1143" : {
               "isakmp profile keyring" : [
-                188
+                191
               ]
             }
           },
           "crypto-dynamic-map-set" : {
             "bippety" : {
               "crypto map ipsec-isakmp crypto-dynamic-map-set" : [
-                224
+                229
               ]
             }
           },
           "ipv4/6 acl" : {
             "myvpnacl" : {
               "crypto map ipsec-isakmp acl" : [
-                235
+                240
               ]
             },
             "someacl" : {
               "crypto map ipsec-isakmp acl" : [
-                219
+                224
               ]
             }
           }


### PR DESCRIPTION
Found some variants of crypto commands in AWS's auto-generated IOS conf:
1/ `crypto ipsec fragmentation before-encryption` is a valid command. parsing and ignoring.

2/ `encryption` is valid under
```
crypto isakmp policy 1
  encryption 3des
```
earlier, batfish only supported `encr`

3/ netmask is optional for identity address as below
```
crypto isakmp profile myprofile
   match identity address 1.2.3.4
```

https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r4-2/security/command/reference/b_syssec_cr41crs_chapter_011.html