### PR TITLE
OspfRoutingProcess: do not use builder for export policy

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -150,11 +150,10 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
     String exportPolicy = _process.getExportPolicy();
     if (exportPolicy == null || !_c.getRoutingPolicies().containsKey(exportPolicy)) {
       _exportPolicy =
-          RoutingPolicy.builder()
-              .setName(String.format("~Drop_All_OSPF_External_%s~", _process.getProcessId()))
-              .setOwner(_c)
-              .setStatements(ImmutableList.of(Statements.ExitReject.toStaticStatement()))
-              .build();
+          // Can't use the builder, because that attempts to modify configuration. grrr.
+          new RoutingPolicy(
+              String.format("~Drop_All_OSPF_External_%s~", _process.getProcessId()), _c);
+      _exportPolicy.setStatements(ImmutableList.of(Statements.ExitReject.toStaticStatement()));
     } else {
       _exportPolicy = _c.getRoutingPolicies().get(exportPolicy);
     }


### PR DESCRIPTION
builder attempts to modify configuration so we crashed with unsupported operation exception.

FYI the fact that new NXOS converter doesn't set export policy in all cases triggered this.