### PR TITLE
PacketPolicy: add True and False expressions

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/BoolExprVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/BoolExprVisitor.java
@@ -8,4 +8,8 @@ public interface BoolExprVisitor<T> {
   }
 
   T visitPacketMatchExpr(PacketMatchExpr expr);
+
+  T visitTrueExpr(TrueExpr expr);
+
+  T visitFalseExpr(FalseExpr expr);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/FalseExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/FalseExpr.java
@@ -1,0 +1,31 @@
+package org.batfish.datamodel.packet_policy;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import javax.annotation.Nullable;
+
+/** The boolean false identity */
+public final class FalseExpr implements BoolExpr {
+  private static final FalseExpr INSTANCE = new FalseExpr();
+
+  private FalseExpr() {}
+
+  @JsonCreator
+  public static FalseExpr instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0xb91c5aba;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return obj instanceof FalseExpr;
+  }
+
+  @Override
+  public <T> T accept(BoolExprVisitor<T> tBoolExprVisitor) {
+    return tBoolExprVisitor.visitFalseExpr(this);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/FlowEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/FlowEvaluator.java
@@ -37,6 +37,16 @@ public final class FlowEvaluator {
       return Evaluator.matches(
           expr.getExpr(), _currentFlow.build(), _srcInterface, _availableAcls, _namedIpSpaces);
     }
+
+    @Override
+    public Boolean visitTrueExpr(TrueExpr expr) {
+      return true;
+    }
+
+    @Override
+    public Boolean visitFalseExpr(FalseExpr expr) {
+      return false;
+    }
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/TrueExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/TrueExpr.java
@@ -1,0 +1,31 @@
+package org.batfish.datamodel.packet_policy;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import javax.annotation.Nullable;
+
+/** True boolean identity */
+public final class TrueExpr implements BoolExpr {
+  private static final TrueExpr INSTANCE = new TrueExpr();
+
+  @JsonCreator
+  private TrueExpr() {}
+
+  public static TrueExpr instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0x6683f3a1;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return obj instanceof TrueExpr;
+  }
+
+  @Override
+  public <T> T accept(BoolExprVisitor<T> tBoolExprVisitor) {
+    return tBoolExprVisitor.visitTrueExpr(this);
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FalseExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FalseExprTest.java
@@ -1,0 +1,33 @@
+package org.batfish.datamodel.packet_policy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Tests of {@link FalseExpr} */
+public class FalseExprTest {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(FalseExpr.instance(), FalseExpr.instance())
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(SerializationUtils.clone(FalseExpr.instance()), equalTo(FalseExpr.instance()));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    assertThat(
+        BatfishObjectMapper.clone(FalseExpr.instance(), FalseExpr.class),
+        equalTo(FalseExpr.instance()));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FlowEvaluatorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FlowEvaluatorTest.java
@@ -167,4 +167,38 @@ public final class FlowEvaluatorTest {
     assertThat(r.getAction(), equalTo(fl));
     assertThat(r.getFinalFlow(), equalTo(_flow));
   }
+
+  @Test
+  public void testTrue() {
+    FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
+    FlowResult r =
+        FlowEvaluator.evaluate(
+            _flow,
+            "Eth0",
+            singletonPolicy(
+                new If(
+                    org.batfish.datamodel.packet_policy.TrueExpr.instance(),
+                    ImmutableList.of(new Return(fl)))),
+            ImmutableMap.of(),
+            ImmutableMap.of());
+    assertThat(r.getAction(), equalTo(fl));
+    assertThat(r.getFinalFlow(), equalTo(_flow));
+  }
+
+  @Test
+  public void testFalse() {
+    FibLookup fl = new FibLookup(new LiteralVrfName("vrf"));
+    FlowResult r =
+        FlowEvaluator.evaluate(
+            _flow,
+            "Eth0",
+            singletonPolicy(
+                new If(
+                    org.batfish.datamodel.packet_policy.FalseExpr.instance(),
+                    ImmutableList.of(new Return(fl)))),
+            ImmutableMap.of(),
+            ImmutableMap.of());
+    assertThat(r.getAction(), equalTo(_defaultAction.getAction()));
+    assertThat(r.getFinalFlow(), equalTo(_flow));
+  }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/TrueExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/TrueExprTest.java
@@ -1,0 +1,34 @@
+package org.batfish.datamodel.packet_policy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Tests of {@link TrueExpr} */
+public class TrueExprTest {
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(TrueExpr.instance(), TrueExpr.instance())
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    assertThat(SerializationUtils.clone(TrueExpr.instance()), equalTo(TrueExpr.instance()));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    assertThat(
+        BatfishObjectMapper.clone(TrueExpr.instance(), TrueExpr.class),
+        equalTo(TrueExpr.instance()));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/PacketPolicyToBdd.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/PacketPolicyToBdd.java
@@ -18,12 +18,14 @@ import org.batfish.datamodel.packet_policy.Action;
 import org.batfish.datamodel.packet_policy.ActionVisitor;
 import org.batfish.datamodel.packet_policy.BoolExprVisitor;
 import org.batfish.datamodel.packet_policy.Drop;
+import org.batfish.datamodel.packet_policy.FalseExpr;
 import org.batfish.datamodel.packet_policy.FibLookup;
 import org.batfish.datamodel.packet_policy.If;
 import org.batfish.datamodel.packet_policy.PacketMatchExpr;
 import org.batfish.datamodel.packet_policy.PacketPolicy;
 import org.batfish.datamodel.packet_policy.Return;
 import org.batfish.datamodel.packet_policy.StatementVisitor;
+import org.batfish.datamodel.packet_policy.TrueExpr;
 
 /**
  * Provides the ability to convert a {@link PacketPolicy} into sets of BDDs corresponding to a
@@ -135,6 +137,16 @@ class PacketPolicyToBdd {
     @Override
     public BDD visitPacketMatchExpr(PacketMatchExpr expr) {
       return _ipAccessListToBdd.toBdd(expr.getExpr());
+    }
+
+    @Override
+    public BDD visitTrueExpr(TrueExpr expr) {
+      return _ipAccessListToBdd.getBDDPacket().getFactory().one();
+    }
+
+    @Override
+    public BDD visitFalseExpr(FalseExpr expr) {
+      return _ipAccessListToBdd.getBDDPacket().getFactory().zero();
     }
   }
 


### PR DESCRIPTION
Still incremental progress towards NXOS PBR.
Need to be able to fail close/open in different scenarios to having these identities to use inside `If` statements is helpful.