### PR TITLE
Storing route-targets as extended community instead of route distinguisher

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_common.g4
@@ -206,6 +206,18 @@ router_ospf_name
   WORD
 ;
 
+route_target
+:
+  hi0 = uint16 COLON lo0 = uint32
+  | hi2 = uint32 COLON lo2 = uint16
+;
+
+route_target_or_auto
+:
+  AUTO
+  | route_target
+;
+
 standard_community
 :
   literal = literal_standard_community

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_evpn.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_evpn.g4
@@ -30,5 +30,5 @@ evv_rd
 
 evv_route_target
 :
-  ROUTE_TARGET dir = both_export_import rd = route_distinguisher_or_auto NEWLINE
+  ROUTE_TARGET dir = both_export_import rt = route_target_or_auto NEWLINE
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_vrf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_vrf.g4
@@ -52,7 +52,7 @@ vcaf4u_null
 
 vcaf4u_route_target
 :
-  ROUTE_TARGET both_export_import rd = route_distinguisher_or_auto EVPN? NEWLINE
+  ROUTE_TARGET both_export_import rt = route_target_or_auto EVPN? NEWLINE
 ;
 
 vcaf6u_null
@@ -65,7 +65,7 @@ vcaf6u_null
 
 vcaf6u_route_target
 :
-  ROUTE_TARGET both_export_import rd = route_distinguisher_or_auto EVPN? NEWLINE
+  ROUTE_TARGET both_export_import rt = route_target_or_auto EVPN? NEWLINE
 ;
 
 vc_ip

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/EvpnVni.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/EvpnVni.java
@@ -11,20 +11,20 @@ public final class EvpnVni implements Serializable {
     _vni = vni;
   }
 
-  public @Nullable RouteDistinguisherOrAuto getExportRt() {
+  public @Nullable ExtendedCommunityOrAuto getExportRt() {
     return _exportRt;
   }
 
-  public void setExportRt(@Nullable RouteDistinguisherOrAuto exportRt) {
+  public void setExportRt(@Nullable ExtendedCommunityOrAuto exportRt) {
     _exportRt = exportRt;
   }
 
   @Nullable
-  public RouteDistinguisherOrAuto getImportRt() {
+  public ExtendedCommunityOrAuto getImportRt() {
     return _importRt;
   }
 
-  public void setImportRt(@Nullable RouteDistinguisherOrAuto importRt) {
+  public void setImportRt(@Nullable ExtendedCommunityOrAuto importRt) {
     _importRt = importRt;
   }
 
@@ -46,6 +46,6 @@ public final class EvpnVni implements Serializable {
 
   private final int _vni;
   private @Nullable RouteDistinguisherOrAuto _rd;
-  private @Nullable RouteDistinguisherOrAuto _exportRt;
-  private @Nullable RouteDistinguisherOrAuto _importRt;
+  private @Nullable ExtendedCommunityOrAuto _exportRt;
+  private @Nullable ExtendedCommunityOrAuto _importRt;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/ExtendedCommunityOrAuto.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/ExtendedCommunityOrAuto.java
@@ -1,0 +1,56 @@
+package org.batfish.representation.cisco_nxos;
+
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.bgp.community.ExtendedCommunity;
+
+/** Either {@code auto} or an explicit {@link ExtendedCommunity}. */
+public final class ExtendedCommunityOrAuto implements Serializable {
+
+  private static final ExtendedCommunityOrAuto AUTO = new ExtendedCommunityOrAuto(null);
+
+  public static ExtendedCommunityOrAuto auto() {
+    return AUTO;
+  }
+
+  public static ExtendedCommunityOrAuto of(@Nonnull ExtendedCommunity extendedCommunity) {
+    return new ExtendedCommunityOrAuto(extendedCommunity);
+  }
+
+  public boolean isAuto() {
+    return _extendedCommunity == null;
+  }
+
+  @Nullable
+  public ExtendedCommunity getExtendedCommunity() {
+    return _extendedCommunity;
+  }
+
+  //////////////////////////////////////////
+  ///// Private implementation details /////
+  //////////////////////////////////////////
+
+  private ExtendedCommunityOrAuto(@Nullable ExtendedCommunity ec) {
+    _extendedCommunity = ec;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof ExtendedCommunityOrAuto)) {
+      return false;
+    }
+    ExtendedCommunityOrAuto that = (ExtendedCommunityOrAuto) o;
+    return Objects.equals(_extendedCommunity, that._extendedCommunity);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(_extendedCommunity);
+  }
+
+  @Nullable private final ExtendedCommunity _extendedCommunity;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/VrfAddressFamily.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/VrfAddressFamily.java
@@ -10,37 +10,37 @@ public final class VrfAddressFamily implements Serializable {
     _type = type;
   }
 
-  public @Nullable RouteDistinguisherOrAuto getExportRt() {
+  public @Nullable ExtendedCommunityOrAuto getExportRt() {
     return _exportRt;
   }
 
-  public void setExportRt(@Nullable RouteDistinguisherOrAuto exportRt) {
+  public void setExportRt(@Nullable ExtendedCommunityOrAuto exportRt) {
     _exportRt = exportRt;
   }
 
-  public @Nullable RouteDistinguisherOrAuto getExportRtEvpn() {
+  public @Nullable ExtendedCommunityOrAuto getExportRtEvpn() {
     return _exportRtEvpn;
   }
 
-  public void setExportRtEvpn(@Nullable RouteDistinguisherOrAuto exportRtEvpn) {
+  public void setExportRtEvpn(@Nullable ExtendedCommunityOrAuto exportRtEvpn) {
     _exportRtEvpn = exportRtEvpn;
   }
 
   @Nullable
-  public RouteDistinguisherOrAuto getImportRt() {
+  public ExtendedCommunityOrAuto getImportRt() {
     return _importRt;
   }
 
-  public void setImportRt(@Nullable RouteDistinguisherOrAuto importRt) {
+  public void setImportRt(@Nullable ExtendedCommunityOrAuto importRt) {
     _importRt = importRt;
   }
 
   @Nullable
-  public RouteDistinguisherOrAuto getImportRtEvpn() {
+  public ExtendedCommunityOrAuto getImportRtEvpn() {
     return _importRtEvpn;
   }
 
-  public void setImportRtEvpn(@Nullable RouteDistinguisherOrAuto importRtEvpn) {
+  public void setImportRtEvpn(@Nullable ExtendedCommunityOrAuto importRtEvpn) {
     _importRtEvpn = importRtEvpn;
   }
 
@@ -53,8 +53,8 @@ public final class VrfAddressFamily implements Serializable {
   //////////////////////////////////////////
 
   private final AddressFamily _type;
-  private @Nullable RouteDistinguisherOrAuto _exportRt;
-  private @Nullable RouteDistinguisherOrAuto _exportRtEvpn;
-  private @Nullable RouteDistinguisherOrAuto _importRt;
-  private @Nullable RouteDistinguisherOrAuto _importRtEvpn;
+  private @Nullable ExtendedCommunityOrAuto _exportRt;
+  private @Nullable ExtendedCommunityOrAuto _exportRtEvpn;
+  private @Nullable ExtendedCommunityOrAuto _importRt;
+  private @Nullable ExtendedCommunityOrAuto _importRtEvpn;
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -175,6 +175,7 @@ import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
+import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.matchers.HsrpGroupMatchers;
 import org.batfish.datamodel.matchers.NssaSettingsMatchers;
@@ -211,6 +212,7 @@ import org.batfish.representation.cisco_nxos.CiscoNxosStructureType;
 import org.batfish.representation.cisco_nxos.DefaultVrfOspfProcess;
 import org.batfish.representation.cisco_nxos.Evpn;
 import org.batfish.representation.cisco_nxos.EvpnVni;
+import org.batfish.representation.cisco_nxos.ExtendedCommunityOrAuto;
 import org.batfish.representation.cisco_nxos.FragmentsBehavior;
 import org.batfish.representation.cisco_nxos.HsrpGroup;
 import org.batfish.representation.cisco_nxos.IcmpOptions;
@@ -603,18 +605,18 @@ public final class CiscoNxosGrammarTest {
     {
       EvpnVni vni = evpn.getVni(1);
       assertThat(vni.getRd(), equalTo(RouteDistinguisherOrAuto.auto()));
-      assertThat(vni.getExportRt(), equalTo(RouteDistinguisherOrAuto.auto()));
-      assertThat(vni.getImportRt(), equalTo(RouteDistinguisherOrAuto.auto()));
+      assertThat(vni.getExportRt(), equalTo(ExtendedCommunityOrAuto.auto()));
+      assertThat(vni.getImportRt(), equalTo(ExtendedCommunityOrAuto.auto()));
     }
     {
       EvpnVni vni = evpn.getVni(2);
       assertThat(vni.getRd(), nullValue());
       assertThat(
           vni.getExportRt(),
-          equalTo(RouteDistinguisherOrAuto.of(RouteDistinguisher.from(65002, 1L))));
+          equalTo(ExtendedCommunityOrAuto.of(ExtendedCommunity.target(65002L, 1L))));
       assertThat(
           vni.getImportRt(),
-          equalTo(RouteDistinguisherOrAuto.of(RouteDistinguisher.from(65002, 2L))));
+          equalTo(ExtendedCommunityOrAuto.of(ExtendedCommunity.target(65002L, 2L))));
     }
     {
       EvpnVni vni = evpn.getVni(3);
@@ -623,10 +625,10 @@ public final class CiscoNxosGrammarTest {
           equalTo(RouteDistinguisherOrAuto.of(RouteDistinguisher.from(Ip.parse("3.3.3.3"), 0))));
       assertThat(
           vni.getExportRt(),
-          equalTo(RouteDistinguisherOrAuto.of(RouteDistinguisher.from(65003, 2L))));
+          equalTo(ExtendedCommunityOrAuto.of(ExtendedCommunity.target(65003L, 2L))));
       assertThat(
           vni.getImportRt(),
-          equalTo(RouteDistinguisherOrAuto.of(RouteDistinguisher.from(65003, 1L))));
+          equalTo(ExtendedCommunityOrAuto.of(ExtendedCommunity.target(65003L, 1L))));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -4979,22 +4979,22 @@ public final class CiscoNxosGrammarTest {
       assertThat(
           vrf.getRd(), equalTo(RouteDistinguisherOrAuto.of(RouteDistinguisher.from(65001, 10L))));
       VrfAddressFamily af4 = vrf.getAddressFamily(AddressFamily.IPV4_UNICAST);
-      assertThat(af4.getImportRtEvpn(), equalTo(RouteDistinguisherOrAuto.auto()));
-      assertThat(af4.getExportRtEvpn(), equalTo(RouteDistinguisherOrAuto.auto()));
+      assertThat(af4.getImportRtEvpn(), equalTo(ExtendedCommunityOrAuto.auto()));
+      assertThat(af4.getExportRtEvpn(), equalTo(ExtendedCommunityOrAuto.auto()));
       assertThat(
           af4.getImportRt(),
-          equalTo(RouteDistinguisherOrAuto.of(RouteDistinguisher.from(11, 65536L))));
+          equalTo(ExtendedCommunityOrAuto.of(ExtendedCommunity.target(11L, 65536L))));
       assertThat(af4.getExportRt(), nullValue());
 
       VrfAddressFamily af6 = vrf.getAddressFamily(AddressFamily.IPV6_UNICAST);
       assertThat(
           af6.getImportRtEvpn(),
-          equalTo(RouteDistinguisherOrAuto.of(RouteDistinguisher.from(65001, 11L))));
+          equalTo(ExtendedCommunityOrAuto.of(ExtendedCommunity.target(65001L, 11L))));
       assertThat(
           af6.getExportRtEvpn(),
-          equalTo(RouteDistinguisherOrAuto.of(RouteDistinguisher.from(65001, 11L))));
-      assertThat(af6.getImportRt(), equalTo(RouteDistinguisherOrAuto.auto()));
-      assertThat(af6.getExportRt(), equalTo(RouteDistinguisherOrAuto.auto()));
+          equalTo(ExtendedCommunityOrAuto.of(ExtendedCommunity.target(65001L, 11L))));
+      assertThat(af6.getImportRt(), equalTo(ExtendedCommunityOrAuto.auto()));
+      assertThat(af6.getExportRt(), equalTo(ExtendedCommunityOrAuto.auto()));
     }
     {
       Vrf vrf = vc.getVrfs().get("vrf3");


### PR DESCRIPTION
- since it is not possible to get an extended community back from a route distinguisher as type information is lost (- not retrievable from a route distinguisher)

- only parsing and extracting type 0 and type 2 route targets, since VI support is currently for these two types through `ExtendedCommunity` and type 1 is rare as route-targets.