### PR TITLE
Cisco: add support for Wlan- interfaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -233,7 +233,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   private static final Pattern MANAGEMENT_INTERFACES =
       Pattern.compile(
-          "(\\Amgmt)|(\\Amanagement)|(\\Afxp0)|(\\Aem0)|(\\Ame0)|(\\Avme)", CASE_INSENSITIVE);
+          "(\\Amgmt)|(\\Amanagement)|(\\Afxp0)|(\\Aem0)|(\\Ame0)|(\\Avme)|(\\Awlan-ap)",
+          CASE_INSENSITIVE);
 
   private static final Pattern MANAGEMENT_VRFS =
       Pattern.compile("(\\Amgmt)|(\\Amanagement)", CASE_INSENSITIVE);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -301,6 +301,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
           .put("Vlan", "Vlan")
           .put("Vxlan", "Vxlan")
           .put("Wideband-Cable", "Wideband-Cable")
+          .put("Wlan-ap", "Wlan-ap")
+          .put("Wlan-GigabitEthernet", "Wlan-GigabitEthernet")
           .build();
 
   static final boolean DEFAULT_VRRP_PREEMPT = true;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -136,11 +136,14 @@ public class Interface implements Serializable {
       return DEFAULT_LONG_REACH_ETHERNET_SPEED;
     } else if (name.startsWith("TenGigabitEthernet")) {
       return DEFAULT_TEN_GIGABIT_ETHERNET_SPEED;
+    } else if (name.startsWith("Wlan-GigabitEthernet")) {
+      return DEFAULT_GIGABIT_ETHERNET_SPEED;
     } else {
       // Bundle-Ethernet
       // Loopback
       // Port-Channel
       // Vlan
+      // Wlan-ap0 (a management interface)
       // ... others
       return null;
     }

--- a/tests/parsing-tests/networks/unit-tests/configs/cisco_interface
+++ b/tests/parsing-tests/networks/unit-tests/configs/cisco_interface
@@ -345,6 +345,10 @@ interface vlan4094
 !
 interface Wideband-Cable1/2/3:4
 !
+interface Wlan-ap0
+!
+interface Wlan-GigabitEthernet0
+!
 interface ethernet 1/12
 switchport access vlan 3
 !

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -8783,6 +8783,63 @@
             "type" : "UNKNOWN",
             "vrf" : "default"
           },
+          "Wlan-GigabitEthernet0" : {
+            "name" : "Wlan-GigabitEthernet0",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "Wlan-GigabitEthernet0"
+            ],
+            "mtu" : 1500,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "speed" : 1.0E9,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "UNKNOWN",
+            "vrf" : "default"
+          },
+          "Wlan-ap0" : {
+            "name" : "Wlan-ap0",
+            "active" : false,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "declaredNames" : [
+              "Wlan-ap0"
+            ],
+            "mtu" : 1500,
+            "ospfDeadInterval" : 0,
+            "ospfEnabled" : false,
+            "ospfHelloMultiplier" : 0,
+            "ospfPassive" : false,
+            "ospfPointToPoint" : false,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "UNKNOWN",
+            "vrf" : "default"
+          },
           "inside" : {
             "name" : "inside",
             "active" : true,
@@ -8961,6 +9018,8 @@
               "Vlan3",
               "Vlan4094",
               "Wideband-Cable1/2/3:4",
+              "Wlan-GigabitEthernet0",
+              "Wlan-ap0",
               "inside",
               "tunnel-ip6"
             ],

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -25008,6 +25008,24 @@
             "    (s_interface",
             "      INTERFACE:'interface'",
             "      iname = (interface_name",
+            "        name_prefix_alpha = M_Interface_PREFIX:'Wlan-ap'  <== mode:M_Interface",
+            "        (range",
+            "          (subrange",
+            "            low = DEC:'0'  <== mode:M_Interface)))",
+            "      NEWLINE:'\\n'  <== mode:M_Interface))",
+            "  (stanza",
+            "    (s_interface",
+            "      INTERFACE:'interface'",
+            "      iname = (interface_name",
+            "        name_prefix_alpha = M_Interface_PREFIX:'Wlan-GigabitEthernet'  <== mode:M_Interface",
+            "        (range",
+            "          (subrange",
+            "            low = DEC:'0'  <== mode:M_Interface)))",
+            "      NEWLINE:'\\n'  <== mode:M_Interface))",
+            "  (stanza",
+            "    (s_interface",
+            "      INTERFACE:'interface'",
+            "      iname = (interface_name",
             "        name_prefix_alpha = M_Interface_PREFIX:'ethernet'  <== mode:M_Interface",
             "        DEC:'1'  <== mode:M_Interface",
             "        FORWARD_SLASH:'/'  <== mode:M_Interface",
@@ -79663,8 +79681,8 @@
             },
             "Ethernet1/12" : {
               "definitionLines" : [
-                348,
-                349
+                352,
+                353
               ],
               "numReferrers" : 1
             },
@@ -79767,6 +79785,18 @@
             "Wideband-Cable1/2/3:4" : {
               "definitionLines" : [
                 346
+              ],
+              "numReferrers" : 1
+            },
+            "Wlan-GigabitEthernet0" : {
+              "definitionLines" : [
+                350
+              ],
+              "numReferrers" : 1
+            },
+            "Wlan-ap0" : {
+              "definitionLines" : [
+                348
               ],
               "numReferrers" : 1
             },
@@ -86898,7 +86928,7 @@
             },
             "Ethernet1/12" : {
               "interface" : [
-                348
+                352
               ]
             },
             "GigabitEthernet0/0" : {
@@ -86974,6 +87004,16 @@
             "Wideband-Cable1/2/3:4" : {
               "interface" : [
                 346
+              ]
+            },
+            "Wlan-GigabitEthernet0" : {
+              "interface" : [
+                350
+              ]
+            },
+            "Wlan-ap0" : {
+              "interface" : [
+                348
               ]
             },
             "inside" : {


### PR DESCRIPTION
Open source user submitted parse warnings:

- Invalid interface name prefix: 'Wlan-GigabitEthernet'
- Invalid interface name prefix: 'wlan-ap'

These are on Cisco 881w-type WAP+routers.