### PR TITLE
Cisco NX-OS stop lexing double-quoted text at newline

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
@@ -4277,9 +4277,15 @@ M_DoubleQuote_DOUBLE_QUOTE
   '"' -> type ( DOUBLE_QUOTE ) , popMode
 ;
 
+M_DoubleQuote_NEWLINE
+:
+// Break out if termination does not occur on same line
+  F_Newline+ -> type ( NEWLINE ) , popMode
+;
+
 M_DoubleQuote_QUOTED_TEXT
 :
-  ~'"'+ -> type ( QUOTED_TEXT )
+  ~["\r\n]+ -> type ( QUOTED_TEXT )
 ;
 
 mode M_Hostname;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -200,6 +200,7 @@ import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.tracking.DecrementPriority;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
+import org.batfish.main.ParserBatfishException;
 import org.batfish.representation.cisco_nxos.ActionIpAccessListLine;
 import org.batfish.representation.cisco_nxos.AddrGroupIpAddressSpec;
 import org.batfish.representation.cisco_nxos.AddressFamily;
@@ -281,6 +282,7 @@ import org.batfish.representation.cisco_nxos.Vrf;
 import org.batfish.representation.cisco_nxos.VrfAddressFamily;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 @ParametersAreNonnullByDefault
@@ -303,6 +305,7 @@ public final class CiscoNxosGrammarTest {
   }
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
+  @Rule public ExpectedException _thrown = ExpectedException.none();
 
   private static @Nonnull OspfExternalRoute.Builder ospfExternalRouteBuilder() {
     return OspfExternalRoute.builder()
@@ -2404,6 +2407,12 @@ public final class CiscoNxosGrammarTest {
       assertThat(line.getAction(), equalTo(LineAction.PERMIT));
       assertThat(line.getRegex(), equalTo("_2_"));
     }
+  }
+
+  @Test
+  public void testIpAsPathAccessListInvalid() {
+    _thrown.expect(ParserBatfishException.class);
+    parseVendorConfig("nxos_ip_as_path_access_list_invalid");
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ip_as_path_access_list_invalid
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ip_as_path_access_list_invalid
@@ -1,0 +1,8 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_ip_as_path_access_list_invalid
+!
+
+!!! Should fail: quote string cannot contain newline
+ip as-path access-list aspacl_bad permit "^1$
+"


### PR DESCRIPTION
- fixes issue where large parts of file get thrown away in absence of
terminating double-quote