### PR TITLE
Cisco: OSPF intervals

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -671,6 +671,7 @@ import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_areaContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_costContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_dead_intervalContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_dead_interval_minimalContext;
+import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_hello_intervalContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_networkContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_passive_interfaceContext;
 import org.batfish.grammar.cisco.CiscoParser.If_ip_ospf_shutdownContext;
@@ -6380,6 +6381,14 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     for (Interface currentInterface : _currentInterfaces) {
       currentInterface.setOspfDeadInterval(1);
       currentInterface.setOspfHelloMultiplier(multiplier);
+    }
+  }
+
+  @Override
+  public void exitIf_ip_ospf_hello_interval(If_ip_ospf_hello_intervalContext ctx) {
+    int seconds = toInteger(ctx.seconds);
+    for (Interface currentInterface : _currentInterfaces) {
+      currentInterface.setOspfHelloInterval(seconds);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2061,7 +2061,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
         if (deadInterval != null) {
           newIface.setOspfDeadInterval(deadInterval);
         }
-        Integer helloInterval = iface.getOspfHelloInterval();
         newIface.setOspfHelloMultiplier(iface.getOspfHelloMultiplier());
         newIface.setOspfProcess(proc.getName());
       } else if (iface.getOspfArea() != null

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2057,7 +2057,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
         }
         newIface.setOspfAreaName(iface.getOspfArea());
         newIface.setOspfCost(iface.getOspfCost());
-        newIface.setOspfDeadInterval(iface.getOspfDeadInterval());
+        Integer deadInterval = iface.getOspfDeadInterval();
+        if (deadInterval != null) {
+          newIface.setOspfDeadInterval(deadInterval);
+        }
+        Integer helloInterval = iface.getOspfHelloInterval();
         newIface.setOspfHelloMultiplier(iface.getOspfHelloMultiplier());
         newIface.setOspfProcess(proc.getName());
       } else if (iface.getOspfArea() != null

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -470,11 +470,13 @@ public class Interface implements Serializable {
     return _ospfCost;
   }
 
+  /** Get the time (in seconds) to wait before neighbors are declared dead */
   @Nullable
   public Integer getOspfDeadInterval() {
     return _ospfDeadInterval;
   }
 
+  /** Get the time (in seconds) between sending hello messages to neighbors */
   @Nullable
   public Integer getOspfHelloInterval() {
     return _ospfHelloInterval;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -204,7 +204,9 @@ public class Interface implements Serializable {
 
   private Integer _ospfCost;
 
-  private int _ospfDeadInterval;
+  @Nullable private Integer _ospfDeadInterval;
+
+  @Nullable private Integer _ospfHelloInterval;
 
   private int _ospfHelloMultiplier;
 
@@ -468,8 +470,14 @@ public class Interface implements Serializable {
     return _ospfCost;
   }
 
-  public int getOspfDeadInterval() {
+  @Nullable
+  public Integer getOspfDeadInterval() {
     return _ospfDeadInterval;
+  }
+
+  @Nullable
+  public Integer getOspfHelloInterval() {
+    return _ospfHelloInterval;
   }
 
   public int getOspfHelloMultiplier() {
@@ -658,6 +666,10 @@ public class Interface implements Serializable {
 
   public void setOspfDeadInterval(int seconds) {
     _ospfDeadInterval = seconds;
+  }
+
+  public void setOspfHelloInterval(int seconds) {
+    _ospfHelloInterval = seconds;
   }
 
   public void setOspfHelloMultiplier(int multiplier) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -127,6 +127,7 @@ import static org.batfish.datamodel.matchers.IpsecSessionMatchers.hasNegotiatedI
 import static org.batfish.datamodel.matchers.IsisInterfaceSettingsMatchers.hasLevel2;
 import static org.batfish.datamodel.matchers.LineMatchers.hasAuthenticationLoginList;
 import static org.batfish.datamodel.matchers.LineMatchers.requiresAuthentication;
+import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
 import static org.batfish.datamodel.matchers.MatchHeaderSpaceMatchers.hasHeaderSpace;
 import static org.batfish.datamodel.matchers.MatchHeaderSpaceMatchers.isMatchHeaderSpaceThat;
 import static org.batfish.datamodel.matchers.MlagMatchers.hasId;
@@ -4905,7 +4906,7 @@ public class CiscoGrammarTest {
     String eth3 = "Ethernet0/3";
 
     Map<String, org.batfish.representation.cisco.Interface> ifaces = config.getInterfaces();
-    assertThat(ifaces.keySet(), containsInAnyOrder(eth0, eth1, eth2, eth3));
+    assertThat(ifaces, hasKeys(eth0, eth1, eth2, eth3));
 
     // Confirm explicitly set hello and dead intervals show up in the VS model
     // Also confirm intervals that are not set show up as nulls in the VS model

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -4896,6 +4896,33 @@ public class CiscoGrammarTest {
   }
 
   @Test
+  public void testCiscoOspfIntervals() {
+    CiscoConfiguration config = parseCiscoConfig("ospf-intervals", ConfigurationFormat.CISCO_IOS);
+
+    String eth0 = "Ethernet0/0";
+    String eth1 = "Ethernet0/1";
+    String eth2 = "Ethernet0/2";
+    String eth3 = "Ethernet0/3";
+
+    Map<String, org.batfish.representation.cisco.Interface> ifaces = config.getInterfaces();
+    assertThat(ifaces.keySet(), containsInAnyOrder(eth0, eth1, eth2, eth3));
+
+    // Confirm explicitly set hello and dead intervals show up in the VS model
+    // Also confirm intervals that are not set show up as nulls in the VS model
+    assertThat(ifaces.get(eth0).getOspfDeadInterval(), nullValue());
+    assertThat(ifaces.get(eth0).getOspfHelloInterval(), nullValue());
+
+    assertThat(ifaces.get(eth1).getOspfDeadInterval(), nullValue());
+    assertThat(ifaces.get(eth1).getOspfHelloInterval(), equalTo(11));
+
+    assertThat(ifaces.get(eth2).getOspfDeadInterval(), equalTo(36));
+    assertThat(ifaces.get(eth2).getOspfHelloInterval(), equalTo(12));
+
+    assertThat(ifaces.get(eth3).getOspfDeadInterval(), equalTo(42));
+    assertThat(ifaces.get(eth3).getOspfHelloInterval(), nullValue());
+  }
+
+  @Test
   public void testParsingRecovery() throws IOException {
     String testrigName = "parsing-recovery";
     String hostname = "ios-recovery";

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ospf-intervals
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ospf-intervals
@@ -1,0 +1,15 @@
+!
+hostname ospf-intervals
+!
+interface Ethernet0/0
+!
+interface Ethernet0/1
+ ip ospf hello-interval 11
+!
+interface Ethernet0/2
+ ip ospf hello-interval 12
+ ip ospf dead-interval 36
+!
+interface Ethernet0/3
+ ip ospf dead-interval 42
+!


### PR DESCRIPTION
Improved VS model support for [OSPF hello and dead intervals](https://www.cisco.com/c/en/us/support/docs/ip/open-shortest-path-first-ospf/13689-17.html):
* Extract hello intervals
* Update dead intervals to be `null`able
* Add a basic test