### PR TITLE
Juniper: OSPF intervals

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -4623,12 +4623,26 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitOai_dead_interval(Oai_dead_intervalContext ctx) {
-    _currentOspfInterface.setOspfDeadInterval(toInt(ctx.DEC()));
+    int seconds = toInt(ctx.DEC());
+    // Must be between 1 and 65535:
+    // https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/dead-interval-edit-protocols-ospf.html
+    if (seconds < 1 || seconds > 65535) {
+      _w.redFlag("Invalid OSPF dead interval, must be 1-65535");
+      return;
+    }
+    _currentOspfInterface.setOspfDeadInterval(seconds);
   }
 
   @Override
   public void exitOai_hello_interval(Oai_hello_intervalContext ctx) {
-    _currentOspfInterface.setOspfHelloInterval(toInt(ctx.DEC()));
+    int seconds = toInt(ctx.DEC());
+    // Must be between 1 and 255:
+    // https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/hello-interval-edit-protocols-ospf.html
+    if (seconds < 1 || seconds > 255) {
+      _w.redFlag("Invalid OSPF hello interval, must be 1-255");
+      return;
+    }
+    _currentOspfInterface.setOspfHelloInterval(seconds);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -323,8 +323,10 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.O_reference_bandwidthCo
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oa_interfaceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oa_nssaContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oa_stubContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oai_dead_intervalContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oai_disableContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oai_enableContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oai_hello_intervalContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oai_interface_typeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oai_passiveContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Oan_default_lsaContext;
@@ -4617,6 +4619,16 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     if (type != null) {
       _currentOspfInterface.setOspfInterfaceType(toOspfInterfaceType(ctx.type));
     }
+  }
+
+  @Override
+  public void exitOai_dead_interval(Oai_dead_intervalContext ctx) {
+    _currentOspfInterface.setOspfDeadInterval(toInt(ctx.DEC()));
+  }
+
+  @Override
+  public void exitOai_hello_interval(Oai_hello_intervalContext ctx) {
+    _currentOspfInterface.setOspfHelloInterval(toInt(ctx.DEC()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -72,8 +72,9 @@ public class Interface implements Serializable {
   @Nullable private Integer _nativeVlan;
   private Ip _ospfArea;
   private Integer _ospfCost;
-  private int _ospfDeadInterval;
+  @Nullable private Integer _ospfDeadInterval;
   @Nullable private Boolean _ospfDisable;
+  @Nullable private Integer _ospfHelloInterval;
   private int _ospfHelloMultiplier;
   private boolean _ospfPassive;
   private OspfInterfaceType _ospfInterfaceType;
@@ -186,13 +187,19 @@ public class Interface implements Serializable {
     return _ospfCost;
   }
 
-  public int getOspfDeadInterval() {
+  @Nullable
+  public Integer getOspfDeadInterval() {
     return _ospfDeadInterval;
   }
 
   @Nullable
   public Boolean getOspfDisable() {
     return _ospfDisable;
+  }
+
+  @Nullable
+  public Integer getOspfHelloInterval() {
+    return _ospfHelloInterval;
   }
 
   public int getOspfHelloMultiplier() {
@@ -347,6 +354,10 @@ public class Interface implements Serializable {
 
   public void setOspfDisable(boolean disable) {
     _ospfDisable = disable;
+  }
+
+  public void setOspfHelloInterval(int seconds) {
+    _ospfHelloInterval = seconds;
   }
 
   public void setOspfHelloMultiplier(int multiplier) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -187,6 +187,7 @@ public class Interface implements Serializable {
     return _ospfCost;
   }
 
+  /** Get the time (in seconds) to wait before neighbors are declared dead */
   @Nullable
   public Integer getOspfDeadInterval() {
     return _ospfDeadInterval;
@@ -197,6 +198,7 @@ public class Interface implements Serializable {
     return _ospfDisable;
   }
 
+  /** Get the time (in seconds) between sending hello messages to neighbors */
   @Nullable
   public Integer getOspfHelloInterval() {
     return _ospfHelloInterval;

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2302,6 +2302,8 @@ public final class FlatJuniperGrammarTest {
     String iface3 = "ge-0/0/3";
     assertThat(ifaces, hasKeys(iface0, iface1, iface2, iface3));
 
+    // Confirm explicitly set hello and dead intervals show up in the VS model
+    // Also confirm intervals that are not set show up as nulls in the VS model
     assertThat(ifaces.get(iface0).getOspfDeadInterval(), nullValue());
     assertThat(ifaces.get(iface0).getOspfHelloInterval(), equalTo(11));
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -85,6 +85,7 @@ import static org.batfish.datamodel.matchers.IsisProcessMatchers.hasOverload;
 import static org.batfish.datamodel.matchers.LineMatchers.hasAuthenticationLoginList;
 import static org.batfish.datamodel.matchers.LiteralIntMatcher.hasVal;
 import static org.batfish.datamodel.matchers.LiteralIntMatcher.isLiteralIntThat;
+import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
 import static org.batfish.datamodel.matchers.NssaSettingsMatchers.hasDefaultOriginateType;
 import static org.batfish.datamodel.matchers.NssaSettingsMatchers.hasSuppressType3;
 import static org.batfish.datamodel.matchers.OspfAreaMatchers.hasInjectDefaultRoute;
@@ -2287,6 +2288,31 @@ public final class FlatJuniperGrammarTest {
     String hostname = "ospf-interface-point-to-point";
     Configuration c = parseConfig(hostname);
     assertThat(c, hasInterface("ge-0/0/0.0", hasOspfPointToPoint(equalTo(true))));
+  }
+
+  @Test
+  public void testJuniperOspfIntervals() {
+    JuniperConfiguration config = parseJuniperConfig("ospf-intervals");
+    Map<String, org.batfish.representation.juniper.Interface> ifaces =
+        config.getMasterLogicalSystem().getInterfaces();
+
+    String iface0 = "ge-0/0/0";
+    String iface1 = "ge-0/0/1";
+    String iface2 = "ge-0/0/2";
+    String iface3 = "ge-0/0/3";
+    assertThat(ifaces, hasKeys(iface0, iface1, iface2, iface3));
+
+    assertThat(ifaces.get(iface0).getOspfDeadInterval(), nullValue());
+    assertThat(ifaces.get(iface0).getOspfHelloInterval(), equalTo(11));
+
+    assertThat(ifaces.get(iface1).getOspfDeadInterval(), equalTo(22));
+    assertThat(ifaces.get(iface1).getOspfHelloInterval(), equalTo(2));
+
+    assertThat(ifaces.get(iface2).getOspfDeadInterval(), equalTo(44));
+    assertThat(ifaces.get(iface2).getOspfHelloInterval(), nullValue());
+
+    assertThat(ifaces.get(iface3).getOspfDeadInterval(), nullValue());
+    assertThat(ifaces.get(iface3).getOspfHelloInterval(), nullValue());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-intervals
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-intervals
@@ -1,0 +1,15 @@
+#
+set system host-name ospf-intervals
+#
+set interfaces ge-0/0/0 unit 0
+set interfaces ge-0/0/1 unit 0
+set interfaces ge-0/0/2 unit 0
+set interfaces ge-0/0/3 unit 0
+#
+set protocols ospf area 0.0.0.0 interface ge-0/0/0 hello-interval 11
+#
+set protocols ospf area 0.0.0.1 interface ge-0/0/1 hello-interval 2
+set protocols ospf area 0.0.0.1 interface ge-0/0/1 dead-interval 22
+#
+set protocols ospf area 0.0.0.2 interface ge-0/0/2 dead-interval 44
+#


### PR DESCRIPTION
Improved VS model support for [OSPF hello](https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/hello-interval-edit-protocols-ospf.html) and [dead intervals](https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/dead-interval-edit-protocols-ospf.html):
* Extract hello intervals
* Update dead intervals to be `null`able
* Add a basic test