### PR TITLE
Cisco NX-OS relax interface no bfd parsing

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
@@ -468,7 +468,7 @@ i_no_autostate
 
 i_no_bfd
 :
-  BFD ECHO NEWLINE
+  BFD null_rest_of_line
 ;
 
 i_no_shutdown

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_properties
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_properties
@@ -12,7 +12,7 @@ interface Ethernet1/1
   no ip redirects
   no ipv6 redirects
   bandwidth 10000
-  no bfd echo
+  no bfd
   bfd interval 250 min_rx 250 multiplier 3
   bfd neighbor src-ip 192.0.2.1 dest-ip 192.0.2.2
   delay 10
@@ -31,6 +31,7 @@ interface Ethernet1/1
 
 interface Ethernet1/2
   bandwidth inherit
+  no bfd echo
   no snmp trap link-status
   udld disable
 


### PR DESCRIPTION
- allow zero or tokens after 'no bfd'