### PR TITLE
NXOS: conversion of PBR policies

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -792,16 +792,14 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
         (name, routeMap) -> _c.getRoutingPolicies().put(name, toRoutingPolicy(routeMap)));
 
     // Find which route maps are used for PBR
-    ImmutableSet<String> pbrPolicies =
-        _c.getAllInterfaces().values().stream()
-            .map(org.batfish.datamodel.Interface::getRoutingPolicyName)
-            .filter(Objects::nonNull)
-            .collect(ImmutableSet.toImmutableSet());
-
-    // Convert PBR route maps to packet policies
-    pbrPolicies.stream()
+    _c.getAllInterfaces().values().stream()
+        .map(org.batfish.datamodel.Interface::getRoutingPolicyName)
+        .filter(Objects::nonNull)
+        .distinct()
+        // Extract route map objects
         .map(_routeMaps::get)
         .filter(Objects::nonNull)
+        // Convert PBR route maps to packet policies
         .map(this::toPacketPolicy)
         .forEach(packetPolicy -> _c.getPacketPolicies().put(packetPolicy.getName(), packetPolicy));
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -97,12 +97,22 @@ import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.VniSettings;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AclLineMatchExprs;
+import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.isis.IsisMetricType;
 import org.batfish.datamodel.ospf.NssaSettings;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.ospf.StubSettings;
+import org.batfish.datamodel.packet_policy.BoolExpr;
+import org.batfish.datamodel.packet_policy.FalseExpr;
+import org.batfish.datamodel.packet_policy.FibLookup;
+import org.batfish.datamodel.packet_policy.FibLookupOverrideLookupIp;
+import org.batfish.datamodel.packet_policy.IngressInterfaceVrf;
+import org.batfish.datamodel.packet_policy.PacketMatchExpr;
+import org.batfish.datamodel.packet_policy.PacketPolicy;
+import org.batfish.datamodel.packet_policy.Return;
+import org.batfish.datamodel.packet_policy.TrueExpr;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.expr.AutoAs;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
@@ -780,6 +790,20 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   private void convertRouteMaps() {
     _routeMaps.forEach(
         (name, routeMap) -> _c.getRoutingPolicies().put(name, toRoutingPolicy(routeMap)));
+
+    // Find which route maps are used for PBR
+    ImmutableSet<String> pbrPolicies =
+        _c.getAllInterfaces().values().stream()
+            .map(org.batfish.datamodel.Interface::getRoutingPolicyName)
+            .filter(Objects::nonNull)
+            .collect(ImmutableSet.toImmutableSet());
+
+    // Convert PBR route maps to packet policies
+    pbrPolicies.stream()
+        .map(_routeMaps::get)
+        .filter(Objects::nonNull)
+        .map(this::toPacketPolicy)
+        .forEach(packetPolicy -> _c.getPacketPolicies().put(packetPolicy.getName(), packetPolicy));
   }
 
   private void convertStaticRoutes() {
@@ -1230,6 +1254,13 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
     if (iface.getHsrp() != null) {
       convertHsrp(iface.getHsrp(), newIfaceBuilder);
+    }
+
+    // PBR policy
+    String pbrPolicy = iface.getPbrPolicy();
+    // Do not convert undefined references
+    if (pbrPolicy != null && _routeMaps.get(pbrPolicy) != null) {
+      newIfaceBuilder.setRoutingPolicy(pbrPolicy);
     }
 
     // OSPF properties
@@ -1873,6 +1904,17 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
         .build();
   }
 
+  @Nonnull
+  private PacketPolicy toPacketPolicy(RouteMap routeMap) {
+    return new PacketPolicy(
+        routeMap.getName(),
+        routeMap.getEntries().values().stream()
+            .map(this::toPacketPolicyStatement)
+            .collect(ImmutableList.toImmutableList()),
+        // Default action is to fall through to the destination-based forwarding pipeline
+        new Return(new FibLookup(IngressInterfaceVrf.instance())));
+  }
+
   private @Nonnull Statement toStatement(RouteMapEntry entry) {
     ImmutableList.Builder<Statement> trueStatements = ImmutableList.builder();
     ImmutableList.Builder<BooleanExpr> conjuncts = ImmutableList.builder();
@@ -1892,6 +1934,171 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
       trueStatements.add(ROUTE_MAP_DENY_STATEMENT);
     }
     return new If(new Conjunction(conjuncts.build()), trueStatements.build(), ImmutableList.of());
+  }
+
+  @Nonnull
+  private org.batfish.datamodel.packet_policy.Statement toPacketPolicyStatement(
+      RouteMapEntry entry) {
+    RouteMapMatchVisitor<BoolExpr> matchToBoolExpr =
+        new RouteMapMatchVisitor<BoolExpr>() {
+
+          @Override
+          public BoolExpr visitRouteMapMatchAsPath(RouteMapMatchAsPath routeMapMatchAsPath) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public BoolExpr visitRouteMapMatchCommunity(
+              RouteMapMatchCommunity routeMapMatchCommunity) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public BoolExpr visitRouteMapMatchInterface(
+              RouteMapMatchInterface routeMapMatchInterface) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public BoolExpr visitRouteMapMatchIpAddress(
+              RouteMapMatchIpAddress routeMapMatchIpAddress) {
+            if (_ipAccessLists.containsKey(routeMapMatchIpAddress.getName())) {
+              return new PacketMatchExpr(new PermittedByAcl(routeMapMatchIpAddress.getName()));
+            } else {
+              return FalseExpr.instance(); // fail-closed, match nothing
+            }
+          }
+
+          @Override
+          public BoolExpr visitRouteMapMatchIpAddressPrefixList(
+              RouteMapMatchIpAddressPrefixList routeMapMatchIpAddressPrefixList) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public BoolExpr visitRouteMapMatchMetric(RouteMapMatchMetric routeMapMatchMetric) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public BoolExpr visitRouteMapMatchTag(RouteMapMatchTag routeMapMatchTag) {
+            // TODO: somehow applicable to PBR? Documentation and semantics unclear
+            _w.redFlag("'match tag' not supported in PBR policies");
+            return null;
+          }
+        };
+    List<BoolExpr> guardBoolExprs =
+        entry
+            .getMatches()
+            .map(m -> m.accept(matchToBoolExpr))
+            .filter(Objects::nonNull)
+            .collect(ImmutableList.toImmutableList());
+
+    if (guardBoolExprs.isEmpty()) {
+      guardBoolExprs = ImmutableList.of(TrueExpr.instance()); // match anything
+    }
+    RouteMapSetVisitor<org.batfish.datamodel.packet_policy.Statement> setToStatement =
+        new RouteMapSetVisitor<org.batfish.datamodel.packet_policy.Statement>() {
+          @Override
+          public org.batfish.datamodel.packet_policy.Statement visitRouteMapSetAsPathPrependLastAs(
+              RouteMapSetAsPathPrependLastAs routeMapSetAsPathPrependLastAs) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public org.batfish.datamodel.packet_policy.Statement
+              visitRouteMapSetAsPathPrependLiteralAs(
+                  RouteMapSetAsPathPrependLiteralAs routeMapSetAsPathPrependLiteralAs) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public org.batfish.datamodel.packet_policy.Statement visitRouteMapSetCommunity(
+              RouteMapSetCommunity routeMapSetCommunity) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public org.batfish.datamodel.packet_policy.Statement visitRouteMapSetIpNextHopLiteral(
+              RouteMapSetIpNextHopLiteral routeMapSetIpNextHopLiteral) {
+            // TODO: handle "load-share" modifier
+            return new Return(
+                FibLookupOverrideLookupIp.builder()
+                    .setIps(routeMapSetIpNextHopLiteral.getNextHops())
+                    // VRF to lookup in
+                    .setVrfExpr(IngressInterfaceVrf.instance())
+                    // Default action in case none of the next hops can be resolved
+                    .setDefaultAction(new FibLookup(IngressInterfaceVrf.instance()))
+                    .setRequireConnected(true)
+                    .build());
+          }
+
+          @Override
+          public org.batfish.datamodel.packet_policy.Statement visitRouteMapSetIpNextHopUnchanged(
+              RouteMapSetIpNextHopUnchanged routeMapSetIpNextHopUnchanged) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public org.batfish.datamodel.packet_policy.Statement visitRouteMapSetLocalPreference(
+              RouteMapSetLocalPreference routeMapSetLocalPreference) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public org.batfish.datamodel.packet_policy.Statement visitRouteMapSetMetric(
+              RouteMapSetMetric routeMapSetMetric) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public org.batfish.datamodel.packet_policy.Statement visitRouteMapSetMetricType(
+              RouteMapSetMetricType routeMapSetMetricType) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public org.batfish.datamodel.packet_policy.Statement visitRouteMapSetOrigin(
+              RouteMapSetOrigin routeMapSetOrigin) {
+            // Not applicable to PBR
+            return null;
+          }
+
+          @Override
+          public org.batfish.datamodel.packet_policy.Statement visitRouteMapSetTag(
+              RouteMapSetTag routeMapSetTag) {
+            // Not applicable to PBR
+            return null;
+          }
+        };
+    List<org.batfish.datamodel.packet_policy.Statement> trueStatements =
+        entry
+            .getSets()
+            .map(s -> s.accept(setToStatement))
+            .filter(Objects::nonNull)
+            .collect(ImmutableList.toImmutableList());
+    if (trueStatements.size() > 1) {
+      _w.redFlag(
+          "Multiple set statements are not allowed in a single route map statement. Choosing the first one");
+      trueStatements = ImmutableList.of(trueStatements.get(0));
+    }
+    if (guardBoolExprs.size() > 1) {
+      _w.redFlag(
+          "Multiple match conditions are not allowed in a single route map statement. Choosing the first one");
+    }
+    return new org.batfish.datamodel.packet_policy.If(guardBoolExprs.get(0), trueStatements);
   }
 
   private @Nonnull BooleanExpr toBooleanExpr(RouteMapMatch match) {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_ip_policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_ip_policy
@@ -5,4 +5,17 @@ hostname nxos_interface_ip_policy
 interface Ethernet1/1
   ip policy route-map PBR_POLICY
 !
+interface Ethernet1/2
+  ip address 2.2.2.1/24
+!
+ip access-list ACL
+  permit ip any 1.1.1.0/24
+!
+route-map PBR_POLICY permit 10
+  match ip address ACL
+  ! skip for PBR, no effect
+  match metric 10
+  set ip next-hop 2.2.2.2
+  ! also skip for PBR, no effect
+  set tag 50000
 !


### PR DESCRIPTION
1. Convert all route maps that are used for PBR into packet policies
2. Warn if route maps do not conform to ones supported by PBR
3. Attach appropriate names of packet policies to `Interface` in VI