### PR TITLE
Setting VRF ID in VRFs and in converted L2 VNI's RDs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -81,6 +81,7 @@ import static org.batfish.representation.cisco_nxos.Interface.newNonVlanInterfac
 import static org.batfish.representation.cisco_nxos.Interface.newVlanInterface;
 import static org.batfish.representation.cisco_nxos.StaticRoute.STATIC_ROUTE_PREFERENCE_RANGE;
 import static org.batfish.representation.cisco_nxos.StaticRoute.STATIC_ROUTE_TRACK_RANGE;
+import static org.batfish.representation.cisco_nxos.Vrf.MANAGEMENT_VRF_ID;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashBasedTable;
@@ -831,6 +832,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   private BgpVrfConfiguration _currentBgpVrfConfiguration;
   private BgpVrfNeighborConfiguration _currentBgpVrfNeighbor;
   private BgpVrfNeighborAddressFamilyConfiguration _currentBgpVrfNeighborAddressFamily;
+  private int _currentContextVrfId = MANAGEMENT_VRF_ID + 1;
   private DefaultVrfOspfProcess _currentDefaultVrfOspfProcess;
   private EvpnVni _currentEvpnVni;
   private Function<Interface, HsrpGroup> _currentHsrpGroupGetter;
@@ -3061,7 +3063,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   public void enterS_vrf_context(S_vrf_contextContext ctx) {
     Optional<String> nameOrErr = toString(ctx, ctx.name);
     if (!nameOrErr.isPresent()) {
-      _currentVrf = new Vrf("dummy");
+      _currentVrf = new Vrf("dummy", _currentContextVrfId++);
       return;
     }
     _currentVrf =
@@ -3071,7 +3073,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
                 nameOrErr.get(),
                 name -> {
                   _configuration.defineStructure(VRF, name, ctx);
-                  return new Vrf(name);
+                  return new Vrf(name, _currentContextVrfId++);
                 });
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -3063,7 +3063,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   public void enterS_vrf_context(S_vrf_contextContext ctx) {
     Optional<String> nameOrErr = toString(ctx, ctx.name);
     if (!nameOrErr.isPresent()) {
-      _currentVrf = new Vrf("dummy", _currentContextVrfId++);
+      _currentVrf = new Vrf("dummy", _currentContextVrfId);
       return;
     }
     _currentVrf =

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Vrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Vrf.java
@@ -20,13 +20,10 @@ public final class Vrf implements Serializable {
 
   // constructor for default VRF and management VRF
   public Vrf(String name) {
-    _name = name;
-    _id = name.equals(DEFAULT_VRF_NAME) ? DEFAULT_VRF_ID : MANAGEMENT_VRF_ID;
-    _addressFamilies = new HashMap<>();
-    _staticRoutes = HashMultimap.create();
+    this(name, name.equals(DEFAULT_VRF_NAME) ? DEFAULT_VRF_ID : MANAGEMENT_VRF_ID);
   }
 
-  // constructor for tenant (context) VRFs
+  // constructor for other VRFs
   public Vrf(String name, int id) {
     _name = name;
     _id = id;
@@ -46,6 +43,10 @@ public final class Vrf implements Serializable {
     return _name;
   }
 
+  /**
+   * @return Numerical ID which represents order in which VRFs are defined. It is used in auto
+   *     derived Route Distinguishers, etc.
+   */
   public int getId() {
     return _id;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Vrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Vrf.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.cisco_nxos;
 
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import java.io.Serializable;
@@ -12,8 +14,22 @@ import org.batfish.datamodel.Prefix;
 /** A virtual routing and forwarding instance. */
 public final class Vrf implements Serializable {
 
+  // https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/7-x/vxlan/configuration/guide/b_Cisco_Nexus_9000_Series_NX-OS_VXLAN_Configuration_Guide_7x/b_Cisco_Nexus_9000_Series_NX-OS_VXLAN_Configuration_Guide_7x_chapter_0100.html#ariaid-title14
+  public static final int DEFAULT_VRF_ID = 1;
+  public static final int MANAGEMENT_VRF_ID = 2;
+
+  // constructor for default VRF and management VRF
   public Vrf(String name) {
     _name = name;
+    _id = name.equals(DEFAULT_VRF_NAME) ? DEFAULT_VRF_ID : MANAGEMENT_VRF_ID;
+    _addressFamilies = new HashMap<>();
+    _staticRoutes = HashMultimap.create();
+  }
+
+  // constructor for tenant (context) VRFs
+  public Vrf(String name, int id) {
+    _name = name;
+    _id = id;
     _addressFamilies = new HashMap<>();
     _staticRoutes = HashMultimap.create();
   }
@@ -28,6 +44,10 @@ public final class Vrf implements Serializable {
 
   public @Nonnull String getName() {
     return _name;
+  }
+
+  public int getId() {
+    return _id;
   }
 
   public @Nullable RouteDistinguisherOrAuto getRd() {
@@ -64,6 +84,7 @@ public final class Vrf implements Serializable {
 
   private final Map<AddressFamily, VrfAddressFamily> _addressFamilies;
   private final @Nonnull String _name;
+  private final int _id;
   private @Nullable RouteDistinguisherOrAuto _rd;
   private boolean _shutdown;
   private final Multimap<Prefix, StaticRoute> _staticRoutes;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -87,6 +87,7 @@ import static org.batfish.representation.cisco_nxos.OspfProcess.DEFAULT_TIMERS_L
 import static org.batfish.representation.cisco_nxos.OspfProcess.DEFAULT_TIMERS_THROTTLE_LSA_HOLD_INTERVAL_MS;
 import static org.batfish.representation.cisco_nxos.OspfProcess.DEFAULT_TIMERS_THROTTLE_LSA_MAX_INTERVAL_MS;
 import static org.batfish.representation.cisco_nxos.OspfProcess.DEFAULT_TIMERS_THROTTLE_LSA_START_INTERVAL_MS;
+import static org.batfish.representation.cisco_nxos.Vrf.DEFAULT_VRF_ID;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.any;
@@ -608,7 +609,7 @@ public final class CiscoNxosGrammarTest {
             Layer2VniConfig.builder()
                 .setVni(1111)
                 .setVrf(DEFAULT_VRF_NAME)
-                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 1111))
+                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 3))
                 .setRouteTarget(ExtendedCommunity.target(1, 1111))
                 .setImportRouteTarget(ExtendedCommunity.target(1, 1111).matchString())
                 .build());
@@ -617,7 +618,7 @@ public final class CiscoNxosGrammarTest {
             Layer3VniConfig.builder()
                 .setVni(3333)
                 .setVrf(DEFAULT_VRF_NAME)
-                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 3333))
+                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 3))
                 .setRouteTarget(ExtendedCommunity.target(1, 3333))
                 .setImportRouteTarget(ExtendedCommunity.target(1, 3333).matchString())
                 .setAdvertiseV4Unicast(false)
@@ -5180,6 +5181,8 @@ public final class CiscoNxosGrammarTest {
     String hostname = "nxos_vrf";
     CiscoNxosConfiguration vc = parseVendorConfig(hostname);
 
+    assertThat(vc.getDefaultVrf(), not(nullValue()));
+    assertThat(vc.getDefaultVrf().getId(), equalTo(DEFAULT_VRF_ID));
     assertThat(vc.getVrfs(), hasKeys("Vrf1", "vrf3"));
     {
       Vrf vrf = vc.getDefaultVrf();
@@ -5188,6 +5191,7 @@ public final class CiscoNxosGrammarTest {
     {
       Vrf vrf = vc.getVrfs().get("Vrf1");
       assertFalse(vrf.getShutdown());
+      assertThat(vrf.getId(), equalTo(3));
       assertThat(
           vrf.getRd(), equalTo(RouteDistinguisherOrAuto.of(RouteDistinguisher.from(65001, 10L))));
       VrfAddressFamily af4 = vrf.getAddressFamily(AddressFamily.IPV4_UNICAST);
@@ -5210,6 +5214,7 @@ public final class CiscoNxosGrammarTest {
     }
     {
       Vrf vrf = vc.getVrfs().get("vrf3");
+      assertThat(vrf.getId(), equalTo(4));
       assertTrue(vrf.getShutdown());
       assertThat(vrf.getRd(), equalTo(RouteDistinguisherOrAuto.auto()));
     }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
@@ -45,9 +45,11 @@ router bgp 1
       remote-as 12121
 !
 interface Vlan1
+  vrf member tenant1
   no shutdown
 !
 interface Vlan3
+  vrf member tenant1
   no shutdown
 !
 interface loopback0


### PR DESCRIPTION
- this was done to make the RouteDistinguisher in converted VNIs follow the convention used by Cisco. Cisco uses IP VRF-IDs to set the route distinguisher in VNIs where `rd auto ` is used.

[Cisco doc](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/7-x/vxlan/configuration/guide/b_Cisco_Nexus_9000_Series_NX-OS_VXLAN_Configuration_Guide_7x/b_Cisco_Nexus_9000_Series_NX-OS_VXLAN_Configuration_Guide_7x_chapter_0100.html#ariaid-title14)