### PR TITLE
Cisco NX-OS interface ipv6 ignores

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
@@ -1827,6 +1827,11 @@ LT
   'lt'
 ;
 
+MANAGED_CONFIG_FLAG
+:
+  'managed-config-flag'
+;
+
 MASK
 :
   'mask'
@@ -2088,6 +2093,11 @@ NAT_FLOW
 NATIVE
 :
   'native'
+;
+
+ND
+:
+  'nd'
 ;
 
 ND_NA
@@ -2367,6 +2377,11 @@ OSPF
 OSPFV3
 :
   'ospfv3'
+;
+
+OTHER_CONFIG_FLAG
+:
+  'other-config-flag'
 ;
 
 OUT
@@ -2757,6 +2772,11 @@ REFERENCE_BANDWIDTH
 REFLECTION
 :
   'reflection'
+;
+
+RELAY
+:
+  'relay'
 ;
 
 RELOAD

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
@@ -453,6 +453,7 @@ i_ipv6
   IPV6
   (
     iip6_address
+    | iip6_null
     | iip6_traffic_filter
   )
 ;
@@ -477,6 +478,14 @@ i_ipv6_address_concrete
 i_ipv6_address_dhcp
 :
   DHCP NEWLINE
+;
+
+iip6_null
+:
+  (
+    DHCP
+    | ND
+  ) null_rest_of_line
 ;
 
 iip6_traffic_filter

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -865,6 +865,18 @@ public final class CiscoNxosGrammarTest {
   }
 
   @Test
+  public void testInterfaceIpv6DhcpRelayExtraction() {
+    // TODO: make into extraction test
+    assertThat(parseVendorConfig("nxos_interface_ipv6_dhcp_relay"), notNullValue());
+  }
+
+  @Test
+  public void testInterfaceIpv6NdExtraction() {
+    // TODO: make into extraction test
+    assertThat(parseVendorConfig("nxos_interface_ipv6_nd"), notNullValue());
+  }
+
+  @Test
   public void testInterfaceMulticastParsing() {
     // TODO: make into extraction test
     assertThat(parseVendorConfig("nxos_interface_multicast"), notNullValue());

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_ipv6_dhcp_relay
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_ipv6_dhcp_relay
@@ -1,0 +1,9 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_interface_ipv6_dhcp_relay
+!
+
+interface Ethernet1/1
+  no switchport
+  ipv6 dhcp relay address dead:beef::1
+  ipv6 dhcp relay address dead:beef::2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_ipv6_nd
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_ipv6_nd
@@ -1,0 +1,10 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_interface_ipv6_nd
+!
+
+interface Ethernet1/1
+  no switchport
+  no ip redirects
+  ipv6 nd managed-config-flag
+  ipv6 nd other-config-flag


### PR DESCRIPTION
- dhcp
- nd (neighbor-discovery)