### PR TITLE
Cisco NX-OS fix interface ospf cost conversion

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1814,7 +1814,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                     areaId,
                     processName,
                     proc.getPassiveInterfaceDefault(),
-                    iface.getOrCreateOspf());
+                    // If interface being added has no explicit OSPF configuration, use defaults
+                    ospf != null ? ospf : new OspfInterface());
               }
             });
     return interfaces.build();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1790,11 +1790,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                 if (ospf.getArea().equals(areaId) && ospf.getProcess().equals(processName)) {
                   interfaces.add(ifaceName);
                   finalizeInterfaceOspfSettings(
-                      ifaceName,
-                      areaId,
-                      processName,
-                      proc.getPassiveInterfaceDefault(),
-                      iface.getOspf());
+                      ifaceName, areaId, processName, proc.getPassiveInterfaceDefault(), ospf);
                 }
               } else {
                 // Otherwise if OSPF area not explicitly configured on interface, add to this area
@@ -1818,7 +1814,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                     areaId,
                     processName,
                     proc.getPassiveInterfaceDefault(),
-                    iface.getOspf());
+                    iface.getOrCreateOspf());
               }
             });
     return interfaces.build();

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -3384,7 +3384,9 @@ public final class CiscoNxosGrammarTest {
       assertThat(
           proc,
           hasArea(
-              0, OspfAreaMatchers.hasInterfaces(containsInAnyOrder("Ethernet1/2", "Ethernet1/3"))));
+              0,
+              OspfAreaMatchers.hasInterfaces(
+                  containsInAnyOrder("Ethernet1/2", "Ethernet1/3", "Ethernet1/5"))));
     }
     {
       org.batfish.datamodel.ospf.OspfProcess proc = defaultVrf.getOspfProcesses().get("pi_d");
@@ -3451,7 +3453,8 @@ public final class CiscoNxosGrammarTest {
     }
 
     assertThat(
-        c.getAllInterfaces(), hasKeys("Ethernet1/1", "Ethernet1/2", "Ethernet1/3", "Ethernet1/4"));
+        c.getAllInterfaces(),
+        hasKeys("Ethernet1/1", "Ethernet1/2", "Ethernet1/3", "Ethernet1/4", "Ethernet1/5"));
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/1");
       assertThat(iface.getOspfCost(), equalTo(12));
@@ -3749,6 +3752,8 @@ public final class CiscoNxosGrammarTest {
                   IpWildcard.ipWithWildcardMask(Ip.parse("192.168.0.0"), Ip.parse("0.0.255.255")),
                   0L,
                   IpWildcard.create(Prefix.strict("172.16.0.0/24")),
+                  0L,
+                  IpWildcard.create(Prefix.strict("172.16.2.0/24")),
                   0L)));
       assertFalse(proc.getPassiveInterfaceDefault());
     }
@@ -3818,7 +3823,8 @@ public final class CiscoNxosGrammarTest {
     }
 
     assertThat(
-        vc.getInterfaces(), hasKeys("Ethernet1/1", "Ethernet1/2", "Ethernet1/3", "Ethernet1/4"));
+        vc.getInterfaces(),
+        hasKeys("Ethernet1/1", "Ethernet1/2", "Ethernet1/3", "Ethernet1/4", "Ethernet1/5"));
     {
       Interface iface = vc.getInterfaces().get("Ethernet1/1");
       OspfInterface ospf = iface.getOspf();

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ospf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ospf
@@ -148,7 +148,8 @@ router ospf mm_summary_lsa_m
 router ospf network
   ! TODO: confirm second IP is a wildcard
   network 192.168.0.0 0.0.255.255 area 0
-  network 172.16.0.1/24 area 0
+  network 172.16.0.0/24 area 0
+  network 172.16.2.0/24 area 0
 
 !!! passive-interface
 router ospf pi_d
@@ -254,3 +255,5 @@ interface Ethernet1/4
   ip ospf passive-interface
   ! use arbitrary process with active default
   ip router ospf router_id area 0
+interface Ethernet1/5
+  ip address 172.16.2.1/24

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ospf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ospf
@@ -257,3 +257,4 @@ interface Ethernet1/4
   ip router ospf router_id area 0
 interface Ethernet1/5
   ip address 172.16.2.1/24
+  ! No explicit OSPF configuration


### PR DESCRIPTION
- prevent NPE when adding interface without explicit OSPF settings to an
OSPF area via network statement