### PR TITLE
Cisco OSPF: better distribute list association

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2707,7 +2707,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               ImmutableList.of(MATCH_DEFAULT_ROUTE, new MatchProtocol(RoutingProtocol.AGGREGATE))));
     }
 
-    computeDistributeListPolicies(proc, c, vrfName, proc.getName(), oldConfig);
+    computeDistributeListPolicies(proc, newProcess, c, vrfName, proc.getName(), oldConfig);
 
     // policies for redistributing routes
     ospfExportStatements.addAll(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/iosOspfDistributeListPrefixList
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/iosOspfDistributeListPrefixList
@@ -8,6 +8,7 @@ interface GigabitEthernet1/0
  ip address 10.1.1.1 255.255.255.0
 !
 router ospf 1
+  network 10.1.1.0 0.0.0.255 area 1
   distribute-list prefix filter_1 in GigabitEthernet0/0
   distribute-list prefix filter_1 in GigabitEthernet1/0
   distribute-list prefix filter_2 in

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/iosOspfDistributeListPrefixListGlobal
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/iosOspfDistributeListPrefixListGlobal
@@ -5,6 +5,7 @@ interface GigabitEthernet0/0
  ip address 10.1.1.0 255.255.255.0
 !
 router ospf 1
+  network 10.1.1.0 0.0.0.255 area 1
   distribute-list prefix filter_2 in
 !
 ip prefix-list filter_2 seq 5 deny 2.2.2.0/24

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/iosOspfDistributeListPrefixListInterface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/iosOspfDistributeListPrefixListInterface
@@ -5,6 +5,7 @@ interface GigabitEthernet0/0
  ip address 10.1.1.0 255.255.255.0
 !
 router ospf 1
+  network 10.1.1.0 0.0.0.255 area 1
   distribute-list prefix filter_1 in GigabitEthernet0/0
 !
 ip prefix-list filter_1 seq 5 deny 1.1.1.0/24


### PR DESCRIPTION
Only apply distribute lists to ifaces in the same process.

This also required updating test configs to associate interfaces with the correct OSPF process.
