### PR TITLE
IOS: Make route filter lists from ACLs used in EIGRP redistribution

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -4456,11 +4456,19 @@ public final class CiscoConfiguration extends VendorConfiguration {
           }
         }
       }
-      // check EIGRP distribute lists
+      // check EIGRP policies
+      // distribute lists
       if (vrf.getEigrpProcesses().values().stream()
           .flatMap(
               eigrpProcess -> eigrpProcess.getOutboundInterfaceDistributeLists().values().stream())
           .anyMatch(distributeList -> distributeList.getFilterName().equals(aclName))) {
+        return true;
+      }
+      // EIGRP redistribution policy
+      if (vrf.getEigrpProcesses().values().stream()
+          .map(EigrpProcess::getRedistributionPolicies)
+          .flatMap(redisrPolicies -> redisrPolicies.values().stream())
+          .anyMatch(rm -> containsIpAccessList(aclName, rm.getRouteMap()))) {
         return true;
       }
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -356,6 +356,7 @@ import org.batfish.datamodel.eigrp.ClassicMetric;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
 import org.batfish.datamodel.eigrp.EigrpNeighborConfig;
+import org.batfish.datamodel.eigrp.EigrpProcessMode;
 import org.batfish.datamodel.eigrp.WideMetric;
 import org.batfish.datamodel.matchers.CommunityListLineMatchers;
 import org.batfish.datamodel.matchers.CommunityListMatchers;
@@ -6584,5 +6585,24 @@ public class CiscoGrammarTest {
     Configuration c = parseConfig("ios-interface-unshut");
     assertThat(c, hasInterface("Ethernet0", isActive(true)));
     assertThat(c, hasInterface("Ethernet1", isActive(false)));
+  }
+
+  @Test
+  public void testIosEigrpAclUsedForRouting() throws IOException {
+    Configuration c = parseConfig("ios-eigrp-match-acl");
+    assertThat(c, hasRouteFilterList("ACL", anything()));
+    assertTrue(
+        c.getRoutingPolicies()
+            .get("REDISTRIBUTE_MAP")
+            .process(
+                new ConnectedRoute(Prefix.ZERO, "dummy", 0),
+                EigrpExternalRoute.builder(),
+                DEFAULT_VRF_NAME,
+                org.batfish.datamodel.eigrp.EigrpProcess.builder()
+                    .setAsNumber(1)
+                    .setMode(EigrpProcessMode.CLASSIC)
+                    .setRouterId(Ip.ZERO)
+                    .build(),
+                Direction.OUT));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-eigrp-match-acl
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-eigrp-match-acl
@@ -1,0 +1,15 @@
+!
+hostname ios-eigrp-match-acl
+!
+ip access-list extended ACL
+  permit ip any any
+!
+route-map REDISTRIBUTE_MAP permit 10
+ match ip address ACL
+!
+interface GigabitEthernet0/0
+ ip address 2.2.2.2 255.255.255.0
+!
+router eigrp 1
+  redistribute connected route-map REDISTRIBUTE_MAP
+  network 2.2.2.2 0.0.0.255


### PR DESCRIPTION
If EIGRP process has a redistribution route-map, scan it for ACLs and
make those into route filter lists.