### PR TITLE
SetOrigin: ignore non-BGP routes.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetOrigin.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetOrigin.java
@@ -1,74 +1,70 @@
 package org.batfish.datamodel.routing_policy.statement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
 import org.batfish.datamodel.routing_policy.expr.OriginExpr;
 
-public class SetOrigin extends Statement {
+/** Set the origin type on a BGP route */
+@ParametersAreNonnullByDefault
+public final class SetOrigin extends Statement {
   private static final String PROP_ORIGIN_TYPE = "originType";
 
-  private OriginExpr _origin;
+  @Nonnull private OriginExpr _origin;
 
   @JsonCreator
-  private SetOrigin() {}
+  private static SetOrigin jsonCreator(@Nullable @JsonProperty(PROP_ORIGIN_TYPE) OriginExpr expr) {
+    checkArgument(expr != null, "Missing %s", PROP_ORIGIN_TYPE);
+    return new SetOrigin(expr);
+  }
 
   public SetOrigin(OriginExpr origin) {
     _origin = origin;
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
       return true;
     }
-    if (obj == null) {
+    if (!(o instanceof SetOrigin)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    SetOrigin other = (SetOrigin) obj;
-    if (_origin == null) {
-      if (other._origin != null) {
-        return false;
-      }
-    } else if (!_origin.equals(other._origin)) {
-      return false;
-    }
-    return true;
+    SetOrigin other = (SetOrigin) o;
+    return _origin.equals(other._origin);
   }
 
   @Override
+  public int hashCode() {
+    return _origin.hashCode();
+  }
+
+  @Override
+  @Nonnull
   public Result execute(Environment environment) {
+    if (!(environment.getOutputRoute() instanceof BgpRoute.Builder<?, ?>)) {
+      // Do nothing for non-BGP routes
+      return new Result();
+    }
     BgpRoute.Builder<?, ?> bgpRoute = (BgpRoute.Builder<?, ?>) environment.getOutputRoute();
     OriginType originType = _origin.evaluate(environment);
     bgpRoute.setOriginType(originType);
     if (environment.getWriteToIntermediateBgpAttributes()) {
       environment.getIntermediateBgpAttributes().setOriginType(originType);
     }
-    Result result = new Result();
-    return result;
+    return new Result();
   }
 
   @JsonProperty(PROP_ORIGIN_TYPE)
   public OriginExpr getOriginType() {
     return _origin;
-  }
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((_origin == null) ? 0 : _origin.hashCode());
-    return result;
-  }
-
-  @JsonProperty(PROP_ORIGIN_TYPE)
-  public void setOriginType(OriginExpr origin) {
-    _origin = origin;
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/SetOriginTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/SetOriginTest.java
@@ -1,0 +1,55 @@
+package org.batfish.datamodel.routing_policy.statement;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.routing_policy.Environment;
+import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
+import org.junit.Test;
+
+/** Tests of {@link SetOrigin} */
+public class SetOriginTest {
+  @Test
+  public void testEquals() {
+    SetOrigin so = new SetOrigin(new LiteralOrigin(OriginType.INCOMPLETE, 1L));
+    new EqualsTester()
+        .addEqualityGroup(so, so, new SetOrigin(new LiteralOrigin(OriginType.INCOMPLETE, 1L)))
+        .addEqualityGroup(new SetOrigin(new LiteralOrigin(OriginType.IGP, 1L)))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    SetOrigin so = new SetOrigin(new LiteralOrigin(OriginType.INCOMPLETE, 1L));
+    assertThat(SerializationUtils.clone(so), equalTo(so));
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    SetOrigin so = new SetOrigin(new LiteralOrigin(OriginType.INCOMPLETE, 1L));
+    assertThat(BatfishObjectMapper.clone(so, SetOrigin.class), equalTo(so));
+  }
+
+  @Test
+  public void testExecuteNonBgpRoute() {
+    SetOrigin so = new SetOrigin(new LiteralOrigin(OriginType.INCOMPLETE, 1L));
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_NX)
+            .setHostname("c")
+            .build();
+    // Do not crash
+    assertThat(so.execute(Environment.builder(c).build()), notNullValue());
+  }
+}


### PR DESCRIPTION
Helps prevent dataplane crashes