### PR TITLE
Associating VNI settings, L2 and L3 VNI configs with the correct VRF

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -958,7 +958,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     }
 
     // null if VRF member specified but is not valid
-    return Optional.ofNullable(_c.getVrfs().get(vrfMemberForVlanIface)).orElse(null);
+    return _c.getVrfs().get(vrfMemberForVlanIface);
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -18,6 +18,7 @@ import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpGene
 import static org.batfish.representation.cisco.CiscoConversions.generateGenerationPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.suppressSummarizedPrefixes;
 import static org.batfish.representation.cisco_nxos.CiscoNxosInterfaceType.PORT_CHANNEL;
+import static org.batfish.representation.cisco_nxos.Conversions.getVrfForL3Vni;
 import static org.batfish.representation.cisco_nxos.Interface.BANDWIDTH_CONVERSION_FACTOR;
 import static org.batfish.representation.cisco_nxos.Interface.getDefaultBandwidth;
 import static org.batfish.representation.cisco_nxos.Interface.getDefaultSpeed;
@@ -919,7 +920,38 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
             .setVni(nveVni.getVni())
             .setVlan(vlan)
             .build();
-    _c.getDefaultVrf().getVniSettings().put(vniSettings.getVni(), vniSettings);
+    if (nveVni.isAssociateVrf()) {
+      Vrf vsTenantVrfForL3Vni = getVrfForL3Vni(_vrfs, nveVni.getVni());
+      if (vsTenantVrfForL3Vni == null || _c.getVrfs().get(vsTenantVrfForL3Vni.getName()) == null) {
+        return;
+      }
+      _c.getVrfs()
+          .get(vsTenantVrfForL3Vni.getName())
+          .getVniSettings()
+          .put(vniSettings.getVni(), vniSettings);
+      return;
+    }
+    org.batfish.datamodel.Vrf viTenantVrfForL2Vni = getVrfForL2Vni(nveVni.getVni(), vlan);
+    if (viTenantVrfForL2Vni == null) {
+      return;
+    }
+    viTenantVrfForL2Vni.getVniSettings().put(vniSettings.getVni(), vniSettings);
+  }
+
+  @Nullable
+  private org.batfish.datamodel.Vrf getVrfForL2Vni(Integer l2Vni, int vlanNumber) {
+    String vrfMemberForVlanIface =
+        Optional.ofNullable(_interfaces.get(String.format("Vlan%d", vlanNumber)))
+            .map(org.batfish.representation.cisco_nxos.Interface::getVrfMember)
+            .orElse(null);
+
+    // interface for this VLAN is not a member of any VRF
+    if (vrfMemberForVlanIface == null) {
+      return _c.getDefaultVrf();
+    }
+
+    // null if VRF member specified but is not valid
+    return Optional.ofNullable(_c.getVrfs().get(vrfMemberForVlanIface)).orElse(null);
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -931,15 +931,22 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
           .put(vniSettings.getVni(), vniSettings);
       return;
     }
-    org.batfish.datamodel.Vrf viTenantVrfForL2Vni = getVrfForL2Vni(nveVni.getVni(), vlan);
+    org.batfish.datamodel.Vrf viTenantVrfForL2Vni = getMemberVrfForVlan(vlan);
     if (viTenantVrfForL2Vni == null) {
       return;
     }
     viTenantVrfForL2Vni.getVniSettings().put(vniSettings.getVni(), vniSettings);
   }
 
+  /**
+   * Gets the {@link org.batfish.datamodel.Vrf} which contains VLAN interface for {@code vlanNumber}
+   * as its member
+   *
+   * @param vlanNumber VLAN number
+   * @return {@link org.batfish.datamodel.Vrf} containing VLAN interface of {@code vlanNumber}
+   */
   @Nullable
-  private org.batfish.datamodel.Vrf getVrfForL2Vni(Integer l2Vni, int vlanNumber) {
+  private org.batfish.datamodel.Vrf getMemberVrfForVlan(int vlanNumber) {
     String vrfMemberForVlanIface =
         Optional.ofNullable(_interfaces.get(String.format("Vlan%d", vlanNumber)))
             .map(org.batfish.representation.cisco_nxos.Interface::getVrfMember)

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -461,6 +461,8 @@ final class Conversions {
     }
     ImmutableSortedSet.Builder<Layer2VniConfig> layer2Vnis = ImmutableSortedSet.naturalOrder();
 
+    // looping over all VRFs in VI configuration so we can get all VNI settings which were valid and
+    // mapped to some VRF (including the default VRF)
     for (Vrf tenantVrf : c.getVrfs().values()) {
       for (VniSettings vniSettings : tenantVrf.getVniSettings().values()) {
         if (!isLayer2Vni(vsConfig.getNves(), vniSettings.getVni())) {
@@ -546,6 +548,8 @@ final class Conversions {
     }
     ImmutableSortedSet.Builder<Layer3VniConfig> layer3Vnis = ImmutableSortedSet.naturalOrder();
 
+    // looping over all VRFs in VI configuration so we can get all VNI settings which were valid and
+    // mapped to some VRF (including the default VRF)
     for (Vrf tenantVrf : c.getVrfs().values()) {
       for (VniSettings vniSettings : tenantVrf.getVniSettings().values()) {
         if (!isLayer3Vni(vsConfig.getNves(), vniSettings.getVni())) {
@@ -554,6 +558,8 @@ final class Conversions {
 
         org.batfish.representation.cisco_nxos.Vrf vsTenantVrfForL3Vni =
             getVrfForL3Vni(vsConfig.getVrfs(), vniSettings.getVni());
+        // there should be a tenant VRF for this VNI and that VRF should have an IPv4 AF
+        // (other being IPv6 which we do not support); if not true then skip this VNI
         if (vsTenantVrfForL3Vni == null
             || !vsTenantVrfForL3Vni.getAddressFamilies().containsKey(AddressFamily.IPV4_UNICAST)) {
           continue;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -33,6 +33,7 @@ import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDefaultVrf
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasHostname;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterfaces;
+import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasVrf;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasNumReferrers;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasRouteFilterLists;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasUndefinedReference;
@@ -740,13 +741,14 @@ public final class CiscoNxosGrammarTest {
   public void testEvpnL2L3Vni() throws IOException {
     Configuration c = parseConfig("nxos_l2_l3_vnis");
 
+    String tenantVrfName = "tenant1";
     Ip routerId = Ip.parse("10.1.1.1");
     // All defined VXLAN Vnis
     ImmutableSortedSet<Layer2VniConfig> expectedL2Vnis =
         ImmutableSortedSet.of(
             Layer2VniConfig.builder()
                 .setVni(1111)
-                .setVrf(DEFAULT_VRF_NAME)
+                .setVrf(tenantVrfName)
                 .setRouteDistinguisher(RouteDistinguisher.from(routerId, 3))
                 .setRouteTarget(ExtendedCommunity.target(1, 1111))
                 .setImportRouteTarget(ExtendedCommunity.target(1, 1111).matchString())
@@ -755,7 +757,7 @@ public final class CiscoNxosGrammarTest {
         ImmutableSortedSet.of(
             Layer3VniConfig.builder()
                 .setVni(3333)
-                .setVrf(DEFAULT_VRF_NAME)
+                .setVrf(tenantVrfName)
                 .setRouteDistinguisher(RouteDistinguisher.from(routerId, 3))
                 .setRouteTarget(ExtendedCommunity.target(1, 3333))
                 .setImportRouteTarget(ExtendedCommunity.target(1, 3333).matchString())
@@ -3386,9 +3388,9 @@ public final class CiscoNxosGrammarTest {
             VniSettingsMatchers.hasVlan(equalTo(2)),
             hasVni(10001)));
 
-    assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(20001))));
+    assertThat(c, hasVrf("tenant1", hasVniSettings(hasKey(20001))));
     assertThat(
-        c.getDefaultVrf().getVniSettings().get(20001),
+        c.getVrfs().get("tenant1").getVniSettings().get(20001),
         allOf(
             // L3 mcast IP
             hasBumTransportIps(equalTo(ImmutableSortedSet.of(Ip.parse("234.0.0.0")))),
@@ -3398,9 +3400,9 @@ public final class CiscoNxosGrammarTest {
             VniSettingsMatchers.hasVlan(equalTo(3)),
             hasVni(20001)));
 
-    assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(30001))));
+    assertThat(c, hasVrf("tenant1", hasVniSettings(hasKey(30001))));
     assertThat(
-        c.getDefaultVrf().getVniSettings().get(30001),
+        c.getVrfs().get("tenant1").getVniSettings().get(30001),
         allOf(
             // L2 mcast IP
             hasBumTransportIps(equalTo(ImmutableSortedSet.of(Ip.parse("233.0.0.0")))),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -752,6 +752,13 @@ public final class CiscoNxosGrammarTest {
                 .setRouteDistinguisher(RouteDistinguisher.from(routerId, 3))
                 .setRouteTarget(ExtendedCommunity.target(1, 1111))
                 .setImportRouteTarget(ExtendedCommunity.target(1, 1111).matchString())
+                .build(),
+            Layer2VniConfig.builder()
+                .setVni(2222)
+                .setVrf(DEFAULT_VRF_NAME)
+                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 1))
+                .setRouteTarget(ExtendedCommunity.target(1, 2222))
+                .setImportRouteTarget(ExtendedCommunity.target(1, 2222).matchString())
                 .build());
     ImmutableSortedSet<Layer3VniConfig> expectedL3Vnis =
         ImmutableSortedSet.of(
@@ -3388,9 +3395,10 @@ public final class CiscoNxosGrammarTest {
             VniSettingsMatchers.hasVlan(equalTo(2)),
             hasVni(10001)));
 
-    assertThat(c, hasVrf("tenant1", hasVniSettings(hasKey(20001))));
+    String tenant1 = "tenant1"; // 20001 is an L3 VNI so it should be mapped to a VRF
+    assertThat(c, hasVrf(tenant1, hasVniSettings(hasKey(20001))));
     assertThat(
-        c.getVrfs().get("tenant1").getVniSettings().get(20001),
+        c.getVrfs().get(tenant1).getVniSettings().get(20001),
         allOf(
             // L3 mcast IP
             hasBumTransportIps(equalTo(ImmutableSortedSet.of(Ip.parse("234.0.0.0")))),
@@ -3400,9 +3408,9 @@ public final class CiscoNxosGrammarTest {
             VniSettingsMatchers.hasVlan(equalTo(3)),
             hasVni(20001)));
 
-    assertThat(c, hasVrf("tenant1", hasVniSettings(hasKey(30001))));
+    assertThat(c, hasDefaultVrf(hasVniSettings(hasKey(30001))));
     assertThat(
-        c.getVrfs().get("tenant1").getVniSettings().get(30001),
+        c.getDefaultVrf().getVniSettings().get(30001),
         allOf(
             // L2 mcast IP
             hasBumTransportIps(equalTo(ImmutableSortedSet.of(Ip.parse("233.0.0.0")))),

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
@@ -7,6 +7,11 @@ vlan 1
   name Name-Of-Vlan-1
   vn-segment 1111
 !
+!! VLAN interface for vlan 2 is not mapped to any interface so L2 VNI 2222 will go in default VRF
+vlan 2
+  name Name-Of-Vlan-2
+  vn-segment 2222
+!
 vlan 3
   name Name-Of-Vlan-3
   vn-segment 3333
@@ -23,6 +28,9 @@ interface nve1
   member vni 1111
     suppress-arp
     ingress-replication protocol bgp
+  member vni 2222
+      suppress-arp
+      ingress-replication protocol bgp
   member vni 3333 associate-vrf
 !
 router bgp 1
@@ -48,6 +56,9 @@ interface Vlan1
   vrf member tenant1
   no shutdown
 !
+interface Vlan2
+  no shutdown
+!
 interface Vlan3
   vrf member tenant1
   no shutdown
@@ -60,4 +71,9 @@ evpn
     rd auto
     route-target import auto
     route-target export auto
+  vni 2222 l2
+      rd auto
+      route-target import auto
+      route-target export auto
+
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
@@ -7,7 +7,7 @@ vlan 1
   name Name-Of-Vlan-1
   vn-segment 1111
 !
-!! VLAN interface for vlan 2 is not mapped to any interface so L2 VNI 2222 will go in default VRF
+!! VLAN interface for vlan 2 is not mapped to any VRF so L2 VNI 2222 will go in default VRF
 vlan 2
   name Name-Of-Vlan-2
   vn-segment 2222

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve_vnis
@@ -30,6 +30,7 @@ vlan 6
 interface loopback0
   ip address 1.1.1.1/32
 !
+!! a VRF is needed for an L3 VNI, otherwise the VNI will be ignored
 vrf context tenant1
   vni 20001
   rd auto
@@ -81,7 +82,6 @@ interface Vlan3
   no shutdown
 !
 interface Vlan4
-  vrf member tenant1
   no shutdown
 !
 interface Vlan5

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_nve_vnis
@@ -30,6 +30,11 @@ vlan 6
 interface loopback0
   ip address 1.1.1.1/32
 !
+vrf context tenant1
+  vni 20001
+  rd auto
+  address-family ipv4 unicast
+    route-target both auto evpn
 interface nve1
   no shutdown
   global mcast-group 233.0.0.0 L2
@@ -76,6 +81,7 @@ interface Vlan3
   no shutdown
 !
 interface Vlan4
+  vrf member tenant1
   no shutdown
 !
 interface Vlan5


### PR DESCRIPTION
all VNI settings were being put into default VRF and also VRF in L2 and L3 VNI configs was being set to default VRF. 
This was not consistent with the actual behavior where the VRF association should be done keeping in mind the tenant VRF to which the VNI belongs to