### PR TITLE
NX-OS: has its own default vrf

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -1,8 +1,8 @@
 package org.batfish.grammar.cisco_nxos;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.IpWildcard.ipWithWildcardMask;
+import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.DEFAULT_VRF_NAME;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.getCanonicalInterfaceNamePrefix;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureType.BGP_TEMPLATE_PEER;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureType.BGP_TEMPLATE_PEER_POLICY;
@@ -111,7 +111,6 @@ import org.batfish.common.Warnings;
 import org.batfish.common.Warnings.ParseWarning;
 import org.batfish.common.WellKnownCommunity;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
-import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DscpType;
 import org.batfish.datamodel.IcmpCode;
 import org.batfish.datamodel.IcmpType;
@@ -1476,7 +1475,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
       }
       vrf = vrfOrErr.get();
     } else {
-      vrf = Configuration.DEFAULT_VRF_NAME;
+      vrf = DEFAULT_VRF_NAME;
     }
     List<String> existingServers =
         _configuration.getIpNameServersByUseVrf().computeIfAbsent(vrf, v -> new LinkedList<>());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -4,7 +4,6 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.batfish.datamodel.BumTransportMethod.MULTICAST_GROUP;
 import static org.batfish.datamodel.BumTransportMethod.UNICAST_FLOOD_GROUP;
-import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.Interface.NULL_INTERFACE_NAME;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENGTH;
@@ -199,6 +198,9 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                 .map(String::toLowerCase)
                 .collect(Collectors.joining("|")));
   }
+
+  /** On NX-OS, there is a default VRF named "default". */
+  public static final String DEFAULT_VRF_NAME = "default";
 
   /** Returns canonical prefix of interface name if valid, else {@code null}. */
   public static @Nullable String getCanonicalInterfaceNamePrefix(String prefix) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -3,7 +3,6 @@ package org.batfish.grammar.cisco_nxos;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Maps.immutableEntry;
 import static com.google.common.collect.MoreCollectors.onlyElement;
-import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.Interface.NULL_INTERFACE_NAME;
 import static org.batfish.datamodel.IpWildcard.ipWithWildcardMask;
 import static org.batfish.datamodel.Route.UNSET_NEXT_HOP_INTERFACE;
@@ -75,6 +74,7 @@ import static org.batfish.grammar.cisco_nxos.CiscoNxosControlPlaneExtractor.PACK
 import static org.batfish.grammar.cisco_nxos.CiscoNxosControlPlaneExtractor.TCP_PORT_RANGE;
 import static org.batfish.grammar.cisco_nxos.CiscoNxosControlPlaneExtractor.UDP_PORT_RANGE;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
+import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.DEFAULT_VRF_NAME;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.NULL_VRF_NAME;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.toJavaRegex;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureType.OBJECT_GROUP_IP_ADDRESS;
@@ -3141,7 +3141,7 @@ public final class CiscoNxosGrammarTest {
         vc.getIpNameServersByUseVrf(),
         equalTo(
             ImmutableMap.of(
-                Configuration.DEFAULT_VRF_NAME,
+                DEFAULT_VRF_NAME,
                 ImmutableList.of("192.0.2.2", "192.0.2.1", "dead:beef::1"),
                 "management",
                 ImmutableList.of("192.0.2.3"))));
@@ -3803,12 +3803,7 @@ public final class CiscoNxosGrammarTest {
         assertTrue(
             c.getRoutingPolicies()
                 .get(proc.getExportPolicy())
-                .process(
-                    staticInputRoute,
-                    outputRoute,
-                    Ip.ZERO,
-                    Configuration.DEFAULT_VRF_NAME,
-                    Direction.OUT));
+                .process(staticInputRoute, outputRoute, Ip.ZERO, DEFAULT_VRF_NAME, Direction.OUT));
         assertThat(outputRoute.build().getOspfMetricType(), equalTo(OspfMetricType.E1));
       }
       {
@@ -3825,18 +3820,14 @@ public final class CiscoNxosGrammarTest {
                     staticInputRoute,
                     OspfExternalRoute.builder(),
                     Ip.ZERO,
-                    Configuration.DEFAULT_VRF_NAME,
+                    DEFAULT_VRF_NAME,
                     Direction.OUT));
         // accept generated route
         assertTrue(
             c.getRoutingPolicies()
                 .get(proc.getExportPolicy())
                 .process(
-                    generatedInputRoute,
-                    outputRoute,
-                    Ip.ZERO,
-                    Configuration.DEFAULT_VRF_NAME,
-                    Direction.OUT));
+                    generatedInputRoute, outputRoute, Ip.ZERO, DEFAULT_VRF_NAME, Direction.OUT));
         assertThat(outputRoute.build().getOspfMetricType(), equalTo(OspfMetricType.E1));
       }
       {
@@ -3849,12 +3840,7 @@ public final class CiscoNxosGrammarTest {
         assertTrue(
             c.getRoutingPolicies()
                 .get(proc.getExportPolicy())
-                .process(
-                    staticInputRoute,
-                    outputRoute,
-                    Ip.ZERO,
-                    Configuration.DEFAULT_VRF_NAME,
-                    Direction.OUT));
+                .process(staticInputRoute, outputRoute, Ip.ZERO, DEFAULT_VRF_NAME, Direction.OUT));
         // assign E2 metric-type from route-map
         assertThat(outputRoute.build().getOspfMetricType(), equalTo(OspfMetricType.E2));
       }
@@ -3872,18 +3858,14 @@ public final class CiscoNxosGrammarTest {
                     staticInputRoute,
                     OspfExternalRoute.builder(),
                     Ip.ZERO,
-                    Configuration.DEFAULT_VRF_NAME,
+                    DEFAULT_VRF_NAME,
                     Direction.OUT));
         // accept generated route
         assertTrue(
             c.getRoutingPolicies()
                 .get(proc.getExportPolicy())
                 .process(
-                    generatedInputRoute,
-                    outputRoute,
-                    Ip.ZERO,
-                    Configuration.DEFAULT_VRF_NAME,
-                    Direction.OUT));
+                    generatedInputRoute, outputRoute, Ip.ZERO, DEFAULT_VRF_NAME, Direction.OUT));
         // assign E2 metric-type from route-map
         assertThat(outputRoute.build().getOspfMetricType(), equalTo(OspfMetricType.E2));
       }
@@ -3954,8 +3936,7 @@ public final class CiscoNxosGrammarTest {
       assertTrue(
           c.getRoutingPolicies()
               .get(proc.getExportPolicy())
-              .process(
-                  inputRoute, outputRoute, Ip.ZERO, Configuration.DEFAULT_VRF_NAME, Direction.OUT));
+              .process(inputRoute, outputRoute, Ip.ZERO, DEFAULT_VRF_NAME, Direction.OUT));
       assertThat(outputRoute.build().getOspfMetricType(), equalTo(OspfMetricType.E1));
     }
     // TODO: convert and test OSPF redistribute maximum-prefix
@@ -3972,8 +3953,7 @@ public final class CiscoNxosGrammarTest {
       assertTrue(
           c.getRoutingPolicies()
               .get(proc.getExportPolicy())
-              .process(
-                  inputRoute, outputRoute, Ip.ZERO, Configuration.DEFAULT_VRF_NAME, Direction.OUT));
+              .process(inputRoute, outputRoute, Ip.ZERO, DEFAULT_VRF_NAME, Direction.OUT));
       assertThat(outputRoute.build().getOspfMetricType(), equalTo(OspfMetricType.E1));
     }
     {


### PR DESCRIPTION
This is a vendor-specific concept, start using a vendor-specific constant (even though its value is the same).