### PR TITLE
Cisco NX-OS allow abbreviation of 'traps' to 'trap' in some cases

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
@@ -3894,6 +3894,19 @@ TRANSPORT
 TRAP
 :
   'trap'
+  // if not preceded by 'enable', followed by 'version' or SNMP community secret
+  {
+    switch(lastTokenType()) {
+      case ACTION:
+      case ENABLE:
+      case LOGGING:
+      case SOURCE_INTERFACE:
+        break;
+      default:
+        pushMode(M_SnmpHostTraps);
+        break;
+    }
+  }
 ;
 
 TRAPS
@@ -3901,8 +3914,14 @@ TRAPS
   'traps'
   // if not preceded by 'enable', followed by 'version' or SNMP community secret
   {
-    if (lastTokenType() != ENABLE && lastTokenType() != SOURCE_INTERFACE && lastTokenType() != LOGGING) {
-      pushMode(M_SnmpHostTraps);
+    switch(lastTokenType()) {
+      case ENABLE:
+      case LOGGING:
+      case SOURCE_INTERFACE:
+        break;
+      default:
+        pushMode(M_SnmpHostTraps);
+        break;
     }
   }
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_snmp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_snmp.g4
@@ -115,7 +115,8 @@ snmpssi_informs
 
 snmpssi_traps
 :
-  TRAPS name = interface_name NEWLINE
+// abbreviation of 'traps' to 'trap' seems to survive on at least one NX-OS v6 config
+  (TRAP | TRAPS) name = interface_name NEWLINE
 ;
 
 snmps_user

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_snmp_server
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_snmp_server
@@ -37,6 +37,8 @@ snmp-server host 192.0.2.2 source-interface mgmt0
 snmp-server host 192.0.2.2 traps version 2c SECRETcommunity2
 snmp-server host 192.0.2.2 use-vrf management
 
+! abbreviation of 'traps' to 'trap' seems to survive on at least one NX-OS v6 config
+snmp-server source-interface trap mgmt0
 snmp-server source-interface traps mgmt0
 
 snmp-server user snmpuser1 network-admin auth md5 authpass1 priv privpass1 localizedkey


### PR DESCRIPTION
- abbreviation appears to survive in NX-OS v6