### PR TITLE
NX-OS: add NxosRoutingProtocol

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -89,6 +89,13 @@ import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.ROUT
 import static org.batfish.representation.cisco_nxos.Interface.VLAN_RANGE;
 import static org.batfish.representation.cisco_nxos.Interface.newNonVlanInterface;
 import static org.batfish.representation.cisco_nxos.Interface.newVlanInterface;
+import static org.batfish.representation.cisco_nxos.NxosRoutingProtocol.DIRECT;
+import static org.batfish.representation.cisco_nxos.NxosRoutingProtocol.EIGRP;
+import static org.batfish.representation.cisco_nxos.NxosRoutingProtocol.ISIS;
+import static org.batfish.representation.cisco_nxos.NxosRoutingProtocol.LISP;
+import static org.batfish.representation.cisco_nxos.NxosRoutingProtocol.OSPF;
+import static org.batfish.representation.cisco_nxos.NxosRoutingProtocol.RIP;
+import static org.batfish.representation.cisco_nxos.NxosRoutingProtocol.STATIC;
 import static org.batfish.representation.cisco_nxos.StaticRoute.STATIC_ROUTE_PREFERENCE_RANGE;
 import static org.batfish.representation.cisco_nxos.StaticRoute.STATIC_ROUTE_TRACK_RANGE;
 import static org.batfish.representation.cisco_nxos.Vrf.MANAGEMENT_VRF_ID;
@@ -134,7 +141,6 @@ import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Prefix6;
-import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.TcpFlags;
 import org.batfish.datamodel.UniverseIpSpace;
@@ -2400,7 +2406,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
         ROUTE_MAP, name, BGP_REDISTRIBUTE_OSPF_ROUTE_MAP, ctx.getStart().getLine());
     _configuration.referenceStructure(
         ROUTER_OSPF, ospfProcess, BGP_REDISTRIBUTE_OSPF_SOURCE_TAG, ctx.getStart().getLine());
-    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(RoutingProtocol.OSPF, name, ospfProcess);
+    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(OSPF, name, ospfProcess);
   }
 
   @Override
@@ -2477,7 +2483,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
         ROUTE_MAP, name, BGP_REDISTRIBUTE_OSPFV3_ROUTE_MAP, ctx.getStart().getLine());
     _configuration.referenceStructure(
         ROUTER_OSPFV3, sourceTag, BGP_REDISTRIBUTE_OSPFV3_SOURCE_TAG, ctx.getStart().getLine());
-    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(RoutingProtocol.OSPF, name, sourceTag);
+    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(OSPF, name, sourceTag);
   }
 
   @Override
@@ -2617,7 +2623,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     String name = nameOrError.get();
     _configuration.referenceStructure(
         ROUTE_MAP, name, BGP_REDISTRIBUTE_DIRECT_ROUTE_MAP, ctx.getStart().getLine());
-    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(RoutingProtocol.CONNECTED, name, null);
+    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(DIRECT, name, null);
   }
 
   @Override
@@ -2633,8 +2639,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
         ROUTE_MAP, mapName, BGP_REDISTRIBUTE_EIGRP_ROUTE_MAP, ctx.getStart().getLine());
     _configuration.referenceStructure(
         ROUTER_EIGRP, sourceTag, BGP_REDISTRIBUTE_EIGRP_SOURCE_TAG, ctx.getStart().getLine());
-    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(
-        RoutingProtocol.EIGRP, mapName, sourceTag);
+    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(EIGRP, mapName, sourceTag);
   }
 
   @Override
@@ -2650,8 +2655,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
         ROUTE_MAP, name, BGP_REDISTRIBUTE_ISIS_ROUTE_MAP, ctx.getStart().getLine());
     _configuration.referenceStructure(
         ROUTER_ISIS, sourceTag, BGP_REDISTRIBUTE_ISIS_SOURCE_TAG, ctx.getStart().getLine());
-    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(
-        RoutingProtocol.ISIS_ANY, name, sourceTag);
+    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(ISIS, name, sourceTag);
   }
 
   @Override
@@ -2663,7 +2667,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     String name = nameOrError.get();
     _configuration.referenceStructure(
         ROUTE_MAP, name, BGP_REDISTRIBUTE_LISP_ROUTE_MAP, ctx.getStart().getLine());
-    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(RoutingProtocol.LISP, name, null);
+    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(LISP, name, null);
   }
 
   @Override
@@ -2679,7 +2683,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
         ROUTE_MAP, name, BGP_REDISTRIBUTE_RIP_ROUTE_MAP, ctx.getStart().getLine());
     _configuration.referenceStructure(
         ROUTER_RIP, sourceTag, BGP_REDISTRIBUTE_RIP_SOURCE_TAG, ctx.getStart().getLine());
-    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(RoutingProtocol.RIP, name, sourceTag);
+    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(RIP, name, sourceTag);
   }
 
   @Override
@@ -2691,7 +2695,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     String name = nameOrError.get();
     _configuration.referenceStructure(
         ROUTE_MAP, name, BGP_REDISTRIBUTE_STATIC_ROUTE_MAP, ctx.getStart().getLine());
-    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(RoutingProtocol.STATIC, name, null);
+    _currentBgpVrfIpAddressFamily.setRedistributionPolicy(STATIC, name, null);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/BgpVrfIpAddressFamilyConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/BgpVrfIpAddressFamilyConfiguration.java
@@ -3,7 +3,6 @@ package org.batfish.representation.cisco_nxos;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.RoutingProtocol;
 
 /**
  * Represents the BGP configuration for IPv4 or IPv6 address families at the VRF level.
@@ -92,12 +91,12 @@ public abstract class BgpVrfIpAddressFamilyConfiguration extends BgpVrfAddressFa
   }
 
   @Nullable
-  public final BgpRedistributionPolicy getRedistributionPolicy(RoutingProtocol protocol) {
+  public final BgpRedistributionPolicy getRedistributionPolicy(NxosRoutingProtocol protocol) {
     return _redistributionPolicies.get(protocol);
   }
 
   public final void setRedistributionPolicy(
-      RoutingProtocol protocol, String routeMap, @Nullable String sourceTag) {
+      NxosRoutingProtocol protocol, String routeMap, @Nullable String sourceTag) {
     BgpRedistributionPolicy policy = new BgpRedistributionPolicy(routeMap, sourceTag);
     _redistributionPolicies.put(protocol, policy);
   }
@@ -118,6 +117,6 @@ public abstract class BgpVrfIpAddressFamilyConfiguration extends BgpVrfAddressFa
   private int _distanceLocal;
   private int _maximumPathsEbgp;
   private int _maximumPathsIbgp;
-  private final Map<RoutingProtocol, BgpRedistributionPolicy> _redistributionPolicies;
+  private final Map<NxosRoutingProtocol, BgpRedistributionPolicy> _redistributionPolicies;
   private boolean _suppressInactive;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -557,7 +557,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
     // Export RIP routes that should be redistributed.
     BgpRedistributionPolicy ripPolicy =
-        ipv4af == null ? null : ipv4af.getRedistributionPolicy(RoutingProtocol.RIP);
+        ipv4af == null ? null : ipv4af.getRedistributionPolicy(NxosRoutingProtocol.RIP);
     if (ripPolicy != null) {
       String routeMap = ripPolicy.getRouteMap();
       org.batfish.representation.cisco_nxos.RouteMap map = _routeMaps.get(routeMap);
@@ -575,7 +575,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
     // Export static routes that should be redistributed.
     BgpRedistributionPolicy staticPolicy =
-        ipv4af == null ? null : ipv4af.getRedistributionPolicy(RoutingProtocol.STATIC);
+        ipv4af == null ? null : ipv4af.getRedistributionPolicy(NxosRoutingProtocol.STATIC);
     if (staticPolicy != null) {
       String routeMap = staticPolicy.getRouteMap();
       RouteMap map = _routeMaps.get(routeMap);
@@ -592,7 +592,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
     // Export connected routes that should be redistributed.
     BgpRedistributionPolicy connectedPolicy =
-        ipv4af == null ? null : ipv4af.getRedistributionPolicy(RoutingProtocol.CONNECTED);
+        ipv4af == null ? null : ipv4af.getRedistributionPolicy(NxosRoutingProtocol.DIRECT);
     if (connectedPolicy != null) {
       String routeMap = connectedPolicy.getRouteMap();
       RouteMap map = _routeMaps.get(routeMap);
@@ -609,7 +609,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
     // Export OSPF routes that should be redistributed.
     BgpRedistributionPolicy ospfPolicy =
-        ipv4af == null ? null : ipv4af.getRedistributionPolicy(RoutingProtocol.OSPF);
+        ipv4af == null ? null : ipv4af.getRedistributionPolicy(NxosRoutingProtocol.OSPF);
     if (ospfPolicy != null) {
       String routeMap = ospfPolicy.getRouteMap();
       RouteMap map = _routeMaps.get(routeMap);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/NxosRoutingProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/NxosRoutingProtocol.java
@@ -1,0 +1,14 @@
+package org.batfish.representation.cisco_nxos;
+
+/** NX-OS routing protocols. */
+public enum NxosRoutingProtocol {
+  BGP,
+  DIRECT,
+  EIGRP,
+  ISIS,
+  LISP,
+  OSPF,
+  OSPFv3,
+  RIP,
+  STATIC,
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/RouteMapMatchSourceProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/RouteMapMatchSourceProtocol.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.RoutingProtocol;
 
 /**
  * A {@link RouteMapMatch} that matches routes based on protocol name. Arbitrary strings are
@@ -28,12 +27,12 @@ public final class RouteMapMatchSourceProtocol implements RouteMapMatch {
     return _sourceProtocol;
   }
 
-  public @Nonnull Optional<Collection<RoutingProtocol>> toRoutingProtocols() {
+  public @Nonnull Optional<Collection<NxosRoutingProtocol>> toRoutingProtocols() {
     switch (_sourceProtocol) {
       case "connected":
-        return Optional.of(ImmutableSet.of(RoutingProtocol.CONNECTED));
+        return Optional.of(ImmutableSet.of(NxosRoutingProtocol.DIRECT));
       case "static":
-        return Optional.of(ImmutableSet.of(RoutingProtocol.STATIC));
+        return Optional.of(ImmutableSet.of(NxosRoutingProtocol.STATIC));
       default:
         return Optional.empty();
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/RouteMapMatchSourceProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/RouteMapMatchSourceProtocol.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.RoutingProtocol;
 
 /**
  * A {@link RouteMapMatch} that matches routes based on protocol name. Arbitrary strings are
@@ -27,12 +28,12 @@ public final class RouteMapMatchSourceProtocol implements RouteMapMatch {
     return _sourceProtocol;
   }
 
-  public @Nonnull Optional<Collection<NxosRoutingProtocol>> toRoutingProtocols() {
+  public @Nonnull Optional<Collection<RoutingProtocol>> toRoutingProtocols() {
     switch (_sourceProtocol) {
       case "connected":
-        return Optional.of(ImmutableSet.of(NxosRoutingProtocol.DIRECT));
+        return Optional.of(ImmutableSet.of(RoutingProtocol.CONNECTED));
       case "static":
-        return Optional.of(ImmutableSet.of(NxosRoutingProtocol.STATIC));
+        return Optional.of(ImmutableSet.of(RoutingProtocol.STATIC));
       default:
         return Optional.empty();
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -266,6 +266,7 @@ import org.batfish.representation.cisco_nxos.Nve;
 import org.batfish.representation.cisco_nxos.Nve.HostReachabilityProtocol;
 import org.batfish.representation.cisco_nxos.Nve.IngressReplicationProtocol;
 import org.batfish.representation.cisco_nxos.NveVni;
+import org.batfish.representation.cisco_nxos.NxosRoutingProtocol;
 import org.batfish.representation.cisco_nxos.ObjectGroupIpAddress;
 import org.batfish.representation.cisco_nxos.ObjectGroupIpAddressLine;
 import org.batfish.representation.cisco_nxos.OspfArea;
@@ -513,10 +514,10 @@ public final class CiscoNxosGrammarTest {
       BgpVrfIpv4AddressFamilyConfiguration ipv4u = vrf.getIpv4UnicastAddressFamily();
       assertThat(ipv4u, notNullValue());
       assertThat(
-          ipv4u.getRedistributionPolicy(RoutingProtocol.CONNECTED),
+          ipv4u.getRedistributionPolicy(NxosRoutingProtocol.DIRECT),
           equalTo(new BgpRedistributionPolicy("DIR_MAP", null)));
       assertThat(
-          ipv4u.getRedistributionPolicy(RoutingProtocol.OSPF),
+          ipv4u.getRedistributionPolicy(NxosRoutingProtocol.OSPF),
           equalTo(new BgpRedistributionPolicy("OSPF_MAP", "ospf_proc")));
 
       BgpVrfL2VpnEvpnAddressFamilyConfiguration l2vpn = vrf.getL2VpnEvpnAddressFamily();


### PR DESCRIPTION
Note normally I would not add the Nxos prefix, but so many files use both it
seems worth keeping.