### PR TITLE
Dataplane: use connected route meatadata

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -4016,7 +4016,6 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
       _currentInterfaces.forEach(iface -> iface.setAddress(address));
     }
     if (ctx.tag != null) {
-      warn(ctx, "Unsupported: tag on interface ip address");
       address.setTag(toLong(ctx.tag));
     }
   }


### PR DESCRIPTION
For local and connected routes use the metadata to set the correct tags.

Also, remove NXOS warning that tags on addresses not supported.