### PR TITLE
Juniper: OSPF interval conversion helpers

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -167,10 +167,14 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
   public static final String ACL_NAME_SECURITY_POLICY = "~SECURITY_POLICIES_TO~";
 
+  // See
+  // https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/hello-interval-edit-protocols-ospf.html
   static final int DEFAULT_NBMA_HELLO_INTERVAL = 30;
 
   static final int DEFAULT_HELLO_INTERVAL = 10;
 
+  // See
+  // https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/dead-interval-edit-protocols-ospf.html
   static final int DEFAULT_NBMA_DEAD_INTERVAL = 4 * DEFAULT_NBMA_HELLO_INTERVAL;
 
   static final int DEFAULT_DEAD_INTERVAL = 4 * DEFAULT_HELLO_INTERVAL;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -926,7 +926,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     }
     Integer helloInterval = iface.getOspfHelloInterval();
     if (helloInterval != null) {
-      return 4 * helloInterval;
+      return OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * helloInterval;
     }
     if (iface.getOspfInterfaceType() == OspfInterfaceType.NBMA) {
       return DEFAULT_NBMA_DEAD_INTERVAL;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -173,11 +173,16 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
   static final int DEFAULT_HELLO_INTERVAL = 10;
 
+  // Default dead interval is hello interval times 4
+  static int OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER = 4;
+
   // See
   // https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/dead-interval-edit-protocols-ospf.html
-  static final int DEFAULT_NBMA_DEAD_INTERVAL = 4 * DEFAULT_NBMA_HELLO_INTERVAL;
+  static final int DEFAULT_NBMA_DEAD_INTERVAL =
+      OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * DEFAULT_NBMA_HELLO_INTERVAL;
 
-  static final int DEFAULT_DEAD_INTERVAL = 4 * DEFAULT_HELLO_INTERVAL;
+  static final int DEFAULT_DEAD_INTERVAL =
+      OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * DEFAULT_HELLO_INTERVAL;
 
   private static final IpAccessList ACL_EXISTING_CONNECTION =
       IpAccessList.builder()

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -145,6 +145,7 @@ import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.representation.juniper.BgpGroup.BgpGroupType;
+import org.batfish.representation.juniper.Interface.OspfInterfaceType;
 import org.batfish.representation.juniper.Zone.AddressBookType;
 import org.batfish.vendor.VendorConfiguration;
 
@@ -165,6 +166,14 @@ public final class JuniperConfiguration extends VendorConfiguration {
   public static final String ACL_NAME_SCREEN_ZONE = "~SCREEN_ZONE~";
 
   public static final String ACL_NAME_SECURITY_POLICY = "~SECURITY_POLICIES_TO~";
+
+  static final int DEFAULT_NBMA_HELLO_INTERVAL = 30;
+
+  static final int DEFAULT_HELLO_INTERVAL = 10;
+
+  static final int DEFAULT_NBMA_DEAD_INTERVAL = 4 * DEFAULT_NBMA_HELLO_INTERVAL;
+
+  static final int DEFAULT_DEAD_INTERVAL = 4 * DEFAULT_HELLO_INTERVAL;
 
   private static final IpAccessList ACL_EXISTING_CONNECTION =
       IpAccessList.builder()
@@ -891,6 +900,47 @@ public final class JuniperConfiguration extends VendorConfiguration {
     ospfSettings.setNetworkType(toOspfNetworkType(vsIface.getOspfInterfaceType()));
 
     iface.setOspfSettings(ospfSettings.build());
+  }
+
+  /**
+   * Helper to infer dead interval from configured OSPF settings on an interface. Check explicitly
+   * set dead interval, infer from hello interval, or infer from OSPF interface type, in that order.
+   * See
+   * https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/dead-interval-edit-protocols-ospf.html
+   * for more details.
+   */
+  @VisibleForTesting
+  static int toOspfDeadInterval(Interface iface) {
+    Integer deadInterval = iface.getOspfDeadInterval();
+    if (deadInterval != null) {
+      return deadInterval;
+    }
+    Integer helloInterval = iface.getOspfHelloInterval();
+    if (helloInterval != null) {
+      return 4 * helloInterval;
+    }
+    if (iface.getOspfInterfaceType() == OspfInterfaceType.NBMA) {
+      return DEFAULT_NBMA_DEAD_INTERVAL;
+    }
+    return DEFAULT_DEAD_INTERVAL;
+  }
+
+  /**
+   * Helper to infer hello interval from configured OSPF settings on an interface. Check explicitly
+   * set hello interval or infer from OSPF interface type, in that order. See
+   * https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/hello-interval-edit-protocols-ospf.html
+   * for more details.
+   */
+  @VisibleForTesting
+  static int toOspfHelloInterval(Interface iface) {
+    Integer helloInterval = iface.getOspfHelloInterval();
+    if (helloInterval != null) {
+      return helloInterval;
+    }
+    if (iface.getOspfInterfaceType() == OspfInterfaceType.NBMA) {
+      return DEFAULT_NBMA_HELLO_INTERVAL;
+    }
+    return DEFAULT_HELLO_INTERVAL;
   }
 
   private org.batfish.datamodel.ospf.OspfArea.Builder toOspfAreaBuilder(

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -16,6 +16,7 @@ import static org.batfish.representation.juniper.JuniperConfiguration.DEFAULT_IS
 import static org.batfish.representation.juniper.JuniperConfiguration.DEFAULT_NBMA_DEAD_INTERVAL;
 import static org.batfish.representation.juniper.JuniperConfiguration.DEFAULT_NBMA_HELLO_INTERVAL;
 import static org.batfish.representation.juniper.JuniperConfiguration.MAX_ISIS_COST_WITHOUT_WIDE_METRICS;
+import static org.batfish.representation.juniper.JuniperConfiguration.OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER;
 import static org.batfish.representation.juniper.JuniperConfiguration.buildScreen;
 import static org.batfish.representation.juniper.JuniperConfiguration.toOspfDeadInterval;
 import static org.batfish.representation.juniper.JuniperConfiguration.toOspfHelloInterval;
@@ -488,7 +489,8 @@ public class JuniperConfigurationTest {
     int helloInterval = 1;
     iface.setOspfHelloInterval(helloInterval);
     // Since the dead interval is not set, it should be inferred as four times the hello interval
-    assertThat(toOspfDeadInterval(iface), equalTo(4 * helloInterval));
+    assertThat(
+        toOspfDeadInterval(iface), equalTo(OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * helloInterval));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -513,7 +513,7 @@ public class JuniperConfigurationTest {
   @Test
   public void testToOspfHelloIntervalFromType() {
     Interface iface = new Interface("ge-0/0/0");
-    // Since the hello intervalis not set, it should be inferred from the network type
+    // Since the hello interval is not set, it should be inferred from the network type
     iface.setOspfInterfaceType(OspfInterfaceType.P2P);
     assertThat(toOspfHelloInterval(iface), equalTo(DEFAULT_HELLO_INTERVAL));
     iface.setOspfInterfaceType(OspfInterfaceType.NBMA);


### PR DESCRIPTION
Add conversion helpers for Juniper OSPF hello and dead intervals.

VI model doesn't yet support hello intervals, so actual conversion will come in a subsequent PR.
