### PR TITLE
Cisco: OSPF interval conversion helpers

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -127,14 +127,20 @@ import org.batfish.representation.cisco.DistributeList.DistributeListFilterType;
 @ParametersAreNonnullByDefault
 public class CiscoConversions {
 
+  // Defaults from
+  // https://www.cisco.com/c/en/us/support/docs/ip/open-shortest-path-first-ospf/13689-17.html
   static int DEFAULT_OSPF_HELLO_INTERVAL_P2P_AND_BROADCAST = 10;
 
   static int DEFAULT_OSPF_HELLO_INTERVAL = 30;
 
-  static int DEFAULT_OSPF_DEAD_INTERVAL_P2P_AND_BROADCAST =
-      4 * DEFAULT_OSPF_HELLO_INTERVAL_P2P_AND_BROADCAST;
+  // Default dead interval is hello interval times 4
+  static int OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER = 4;
 
-  static int DEFAULT_OSPF_DEAD_INTERVAL = 4 * DEFAULT_OSPF_HELLO_INTERVAL;
+  static int DEFAULT_OSPF_DEAD_INTERVAL_P2P_AND_BROADCAST =
+      OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * DEFAULT_OSPF_HELLO_INTERVAL_P2P_AND_BROADCAST;
+
+  static int DEFAULT_OSPF_DEAD_INTERVAL =
+      OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * DEFAULT_OSPF_HELLO_INTERVAL;
 
   static Ip getHighestIp(Map<String, Interface> allInterfaces) {
     Map<String, Interface> interfacesToCheck;
@@ -1700,7 +1706,7 @@ public class CiscoConversions {
     }
     Integer helloInterval = iface.getOspfHelloInterval();
     if (helloInterval != null) {
-      return 4 * helloInterval;
+      return OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * helloInterval;
     }
     OspfNetworkType networkType = iface.getOspfNetworkType();
     if (networkType == OspfNetworkType.POINT_TO_POINT || networkType == OspfNetworkType.BROADCAST) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -127,6 +127,15 @@ import org.batfish.representation.cisco.DistributeList.DistributeListFilterType;
 @ParametersAreNonnullByDefault
 public class CiscoConversions {
 
+  static int DEFAULT_OSPF_HELLO_INTERVAL_P2P_AND_BROADCAST = 10;
+
+  static int DEFAULT_OSPF_HELLO_INTERVAL = 30;
+
+  static int DEFAULT_OSPF_DEAD_INTERVAL_P2P_AND_BROADCAST =
+      4 * DEFAULT_OSPF_HELLO_INTERVAL_P2P_AND_BROADCAST;
+
+  static int DEFAULT_OSPF_DEAD_INTERVAL = 4 * DEFAULT_OSPF_HELLO_INTERVAL;
+
   static Ip getHighestIp(Map<String, Interface> allInterfaces) {
     Map<String, Interface> interfacesToCheck;
     Map<String, Interface> loopbackInterfaces = new HashMap<>();
@@ -1675,6 +1684,48 @@ public class CiscoConversions {
         action,
         IpWildcard.create(prefix),
         new SubRange(prefix.getPrefixLength(), Prefix.MAX_PREFIX_LENGTH));
+  }
+
+  /**
+   * Helper to infer dead interval from configured OSPF settings on an interface. Check explicitly
+   * set dead interval, infer from hello interval, or infer from OSPF network type, in that order.
+   * See https://www.cisco.com/c/en/us/support/docs/ip/open-shortest-path-first-ospf/13689-17.html
+   * for more details.
+   */
+  @VisibleForTesting
+  static int toOspfDeadInterval(Interface iface) {
+    Integer deadInterval = iface.getOspfDeadInterval();
+    if (deadInterval != null) {
+      return deadInterval;
+    }
+    Integer helloInterval = iface.getOspfHelloInterval();
+    if (helloInterval != null) {
+      return 4 * helloInterval;
+    }
+    OspfNetworkType networkType = iface.getOspfNetworkType();
+    if (networkType == OspfNetworkType.POINT_TO_POINT || networkType == OspfNetworkType.BROADCAST) {
+      return DEFAULT_OSPF_DEAD_INTERVAL_P2P_AND_BROADCAST;
+    }
+    return DEFAULT_OSPF_DEAD_INTERVAL;
+  }
+
+  /**
+   * Helper to infer hello interval from configured OSPF settings on an interface. Check explicitly
+   * set hello interval or infer from OSPF network type, in that order. See
+   * https://www.cisco.com/c/en/us/support/docs/ip/open-shortest-path-first-ospf/13689-17.html for
+   * more details.
+   */
+  @VisibleForTesting
+  static int toOspfHelloInterval(Interface iface) {
+    Integer helloInterval = iface.getOspfHelloInterval();
+    if (helloInterval != null) {
+      return helloInterval;
+    }
+    OspfNetworkType networkType = iface.getOspfNetworkType();
+    if (networkType == OspfNetworkType.POINT_TO_POINT || networkType == OspfNetworkType.BROADCAST) {
+      return DEFAULT_OSPF_HELLO_INTERVAL_P2P_AND_BROADCAST;
+    }
+    return DEFAULT_OSPF_HELLO_INTERVAL;
   }
 
   private CiscoConversions() {} // prevent instantiation of utility class

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
@@ -258,4 +258,19 @@ public class CiscoConversionsTest {
         equalTo(
             "dist-list in OSPF process vrf:p1 uses a prefix-list which is not defined, this dist-list will allow everything"));
   }
+
+  @Test
+  public void testToOspfDeadIntervalExplicit() {}
+
+  @Test
+  public void testToOspfDeadIntervalFromHello() {}
+
+  @Test
+  public void testToOspfDeadIntervalFromType() {}
+
+  @Test
+  public void testToOspfHelloIntervalExplicit() {}
+
+  @Test
+  public void testToOspfHelloIntervalFromType() {}
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
@@ -5,6 +5,7 @@ import static org.batfish.representation.cisco.CiscoConversions.DEFAULT_OSPF_DEA
 import static org.batfish.representation.cisco.CiscoConversions.DEFAULT_OSPF_DEAD_INTERVAL_P2P_AND_BROADCAST;
 import static org.batfish.representation.cisco.CiscoConversions.DEFAULT_OSPF_HELLO_INTERVAL;
 import static org.batfish.representation.cisco.CiscoConversions.DEFAULT_OSPF_HELLO_INTERVAL_P2P_AND_BROADCAST;
+import static org.batfish.representation.cisco.CiscoConversions.OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER;
 import static org.batfish.representation.cisco.CiscoConversions.createAclWithSymmetricalLines;
 import static org.batfish.representation.cisco.CiscoConversions.getMatchingPsk;
 import static org.batfish.representation.cisco.CiscoConversions.sanityCheckDistributeList;
@@ -289,7 +290,8 @@ public class CiscoConversionsTest {
     int helloInterval = 1;
     iface.setOspfHelloInterval(helloInterval);
     // Since the dead interval is not set, it should be inferred as four times the hello interval
-    assertThat(toOspfDeadInterval(iface), equalTo(4 * helloInterval));
+    assertThat(
+        toOspfDeadInterval(iface), equalTo(OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * helloInterval));
   }
 
   @Test


### PR DESCRIPTION
Add conversion helpers for Cisco OSPF hello and dead intervals.

VI model doesn't yet support hello intervals, so actual conversion will come in a subsequent PR.
