### PR TITLE
Make dummy BGP processes for VRFs with L3 VNIs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -123,6 +123,12 @@ final class Conversions {
       return vrfConfig.getRouterId();
     }
 
+    return inferRouterId(vrf, w);
+  }
+
+  /** Infers router ID on Cisco NX-OS when not configured in a routing process */
+  @Nonnull
+  static Ip inferRouterId(Vrf vrf, Warnings w) {
     String messageBase =
         String.format(
             "Router-id is not manually configured for BGP process in VRF %s", vrf.getName());

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -802,6 +802,7 @@ public final class CiscoNxosGrammarTest {
     assertThat(peer.getEvpnAddressFamily(), notNullValue());
     assertThat(peer.getEvpnAddressFamily().getL2VNIs(), equalTo(expectedL2Vnis));
     assertThat(peer.getEvpnAddressFamily().getL3VNIs(), equalTo(expectedL3Vnis));
+    assertThat(c.getVrfs().get(tenantVrfName).getBgpProcess(), notNullValue());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_l2_l3_vnis
@@ -17,10 +17,13 @@ vlan 3
   vn-segment 3333
 !
 vrf context tenant1
+  !! this VRF does not appear under "router bgp"
+  !! but should still have a BGP process
   vni 3333
   rd auto
   address-family ipv4 unicast
     route-target both auto evpn
+!
 interface nve1
   no shutdown
   host-reachability protocol bgp


### PR DESCRIPTION
This way we will actually propagate routes for those VRFs/VNIs and not crash in dataplane.