### PR TITLE
Cisco NXOS: OSPF interval conversion helpers

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -202,6 +202,21 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                 .collect(Collectors.joining("|")));
   }
 
+  // Defaults from
+  // https://www.cisco.com/c/en/us/support/docs/ip/open-shortest-path-first-ospf/13689-17.html
+  static int DEFAULT_OSPF_HELLO_INTERVAL_P2P_AND_BROADCAST = 10;
+
+  static int DEFAULT_OSPF_HELLO_INTERVAL = 30;
+
+  // Default dead interval is hello interval times 4
+  static int OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER = 4;
+
+  static int DEFAULT_OSPF_DEAD_INTERVAL_P2P_AND_BROADCAST =
+      OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * DEFAULT_OSPF_HELLO_INTERVAL_P2P_AND_BROADCAST;
+
+  static int DEFAULT_OSPF_DEAD_INTERVAL =
+      OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * DEFAULT_OSPF_HELLO_INTERVAL;
+
   /** On NX-OS, there is a default VRF named "default". */
   public static final String DEFAULT_VRF_NAME = "default";
 
@@ -2127,6 +2142,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
     newIface.setOspfSettings(ospfSettings.build());
   }
+
+
 
   private @Nonnull NssaSettings toNssaSettings(OspfAreaNssa ospfAreaNssa) {
     return NssaSettings.builder()

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -23,6 +23,7 @@ import static org.batfish.representation.cisco_nxos.Interface.getDefaultBandwidt
 import static org.batfish.representation.cisco_nxos.Interface.getDefaultSpeed;
 import static org.batfish.representation.cisco_nxos.OspfInterface.DEFAULT_DEAD_INTERVAL_S;
 import static org.batfish.representation.cisco_nxos.OspfInterface.DEFAULT_HELLO_INTERVAL_S;
+import static org.batfish.representation.cisco_nxos.OspfInterface.OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER;
 import static org.batfish.representation.cisco_nxos.OspfMaxMetricRouterLsa.DEFAULT_OSPF_MAX_METRIC;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -204,9 +205,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                 .map(String::toLowerCase)
                 .collect(Collectors.joining("|")));
   }
-
-  // Default dead interval is hello interval times 4
-  static int OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER = 4;
 
   /** On NX-OS, there is a default VRF named "default". */
   public static final String DEFAULT_VRF_NAME = "default";
@@ -2141,17 +2139,14 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
    * more details.
    */
   @VisibleForTesting
-  static int toOspfDeadInterval(Interface iface) {
-    OspfInterface ospf = iface.getOspf();
-    if (ospf != null) {
-      Integer deadInterval = ospf.getDeadIntervalS();
-      if (deadInterval != null) {
-        return deadInterval;
-      }
-      Integer helloInterval = ospf.getHelloIntervalS();
-      if (helloInterval != null) {
-        return OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * helloInterval;
-      }
+  static int toOspfDeadInterval(OspfInterface ospf) {
+    Integer deadInterval = ospf.getDeadIntervalS();
+    if (deadInterval != null) {
+      return deadInterval;
+    }
+    Integer helloInterval = ospf.getHelloIntervalS();
+    if (helloInterval != null) {
+      return OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * helloInterval;
     }
     return DEFAULT_DEAD_INTERVAL_S;
   }
@@ -2163,13 +2158,10 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
    * more details.
    */
   @VisibleForTesting
-  static int toOspfHelloInterval(Interface iface) {
-    OspfInterface ospf = iface.getOspf();
-    if (ospf != null) {
-      Integer helloInterval = ospf.getHelloIntervalS();
-      if (helloInterval != null) {
-        return helloInterval;
-      }
+  static int toOspfHelloInterval(OspfInterface ospf) {
+    Integer helloInterval = ospf.getHelloIntervalS();
+    if (helloInterval != null) {
+      return helloInterval;
     }
     return DEFAULT_HELLO_INTERVAL_S;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
@@ -2,7 +2,6 @@ package org.batfish.representation.cisco_nxos;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Range;
 import java.io.Serializable;
 import java.util.HashSet;
@@ -144,8 +143,7 @@ public final class Interface implements Serializable {
   private final @Nullable Integer _vlan;
   private @Nullable String _vrfMember;
 
-  @VisibleForTesting
-  Interface(
+  private Interface(
       String name,
       @Nullable String parentInterface,
       CiscoNxosInterfaceType type,

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Interface.java
@@ -2,6 +2,7 @@ package org.batfish.representation.cisco_nxos;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Range;
 import java.io.Serializable;
 import java.util.HashSet;
@@ -143,7 +144,8 @@ public final class Interface implements Serializable {
   private final @Nullable Integer _vlan;
   private @Nullable String _vrfMember;
 
-  private Interface(
+  @VisibleForTesting
+  Interface(
       String name,
       @Nullable String parentInterface,
       CiscoNxosInterfaceType type,

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/OspfInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/OspfInterface.java
@@ -1,7 +1,5 @@
 package org.batfish.representation.cisco_nxos;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 import java.io.Serializable;
 import javax.annotation.Nullable;
 
@@ -35,16 +33,16 @@ public final class OspfInterface implements Serializable {
     _cost = cost;
   }
 
-  public int getDeadIntervalS() {
-    return firstNonNull(_deadIntervalS, DEFAULT_DEAD_INTERVAL_S);
+  public @Nullable Integer getDeadIntervalS() {
+    return _deadIntervalS;
   }
 
   public void setDeadIntervalS(int deadInterval) {
     _deadIntervalS = deadInterval;
   }
 
-  public int getHelloIntervalS() {
-    return firstNonNull(_helloIntervalS, DEFAULT_HELLO_INTERVAL_S);
+  public @Nullable Integer getHelloIntervalS() {
+    return _helloIntervalS;
   }
 
   public void setHelloIntervalS(int helloIntervalS) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/OspfInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/OspfInterface.java
@@ -5,9 +5,13 @@ import javax.annotation.Nullable;
 
 public final class OspfInterface implements Serializable {
 
+  // Default dead interval is hello interval times 4
+  static int OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER = 4;
+
   // https://www.cisco.com/c/m/en_us/techdoc/dc/reference/cli/nxos/commands/ospf/ip-ospf-dead-interval.html
-  public static final int DEFAULT_DEAD_INTERVAL_S = 40; // s
   public static final int DEFAULT_HELLO_INTERVAL_S = 10; // s
+  public static final int DEFAULT_DEAD_INTERVAL_S =
+      OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * DEFAULT_HELLO_INTERVAL_S; // 40 s
 
   public @Nullable Long getArea() {
     return _area;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -79,8 +79,6 @@ import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.DEFAU
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.NULL_VRF_NAME;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.toJavaRegex;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureType.OBJECT_GROUP_IP_ADDRESS;
-import static org.batfish.representation.cisco_nxos.OspfInterface.DEFAULT_DEAD_INTERVAL_S;
-import static org.batfish.representation.cisco_nxos.OspfInterface.DEFAULT_HELLO_INTERVAL_S;
 import static org.batfish.representation.cisco_nxos.OspfMaxMetricRouterLsa.DEFAULT_OSPF_MAX_METRIC;
 import static org.batfish.representation.cisco_nxos.OspfNetworkType.BROADCAST;
 import static org.batfish.representation.cisco_nxos.OspfNetworkType.POINT_TO_POINT;
@@ -4431,8 +4429,8 @@ public final class CiscoNxosGrammarTest {
       // TODO: extract and test authentication key-chain
       assertFalse(ospf.getBfd());
       assertThat(ospf.getCost(), nullValue());
-      assertThat(ospf.getDeadIntervalS(), equalTo(DEFAULT_DEAD_INTERVAL_S));
-      assertThat(ospf.getHelloIntervalS(), equalTo(DEFAULT_HELLO_INTERVAL_S));
+      assertThat(ospf.getDeadIntervalS(), nullValue());
+      assertThat(ospf.getHelloIntervalS(), nullValue());
       assertThat(ospf.getPassive(), nullValue());
       assertThat(ospf.getProcess(), nullValue());
       assertThat(ospf.getArea(), nullValue());

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco_nxos/CiscoNxosConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco_nxos/CiscoNxosConfigurationTest.java
@@ -1,10 +1,10 @@
 package org.batfish.representation.cisco_nxos;
 
-import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.toOspfDeadInterval;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.toOspfHelloInterval;
 import static org.batfish.representation.cisco_nxos.OspfInterface.DEFAULT_DEAD_INTERVAL_S;
 import static org.batfish.representation.cisco_nxos.OspfInterface.DEFAULT_HELLO_INTERVAL_S;
+import static org.batfish.representation.cisco_nxos.OspfInterface.OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -15,45 +15,41 @@ public class CiscoNxosConfigurationTest {
 
   @Test
   public void testToOspfDeadIntervalExplicit() {
-    Interface iface = new Interface("FastEthernet0/0", null, CiscoNxosInterfaceType.ETHERNET, null);
-    iface.getOrCreateOspf().setDeadIntervalS(7);
+    OspfInterface ospf = new OspfInterface();
+    ospf.setDeadIntervalS(7);
     // Explicitly set dead interval should be preferred over inference
-    assertThat(toOspfDeadInterval(iface), equalTo(7));
+    assertThat(toOspfDeadInterval(ospf), equalTo(7));
   }
 
   @Test
   public void testToOspfDeadIntervalFromHello() {
-    Interface iface = new Interface("FastEthernet0/0", null, CiscoNxosInterfaceType.ETHERNET, null);
-
+    OspfInterface ospf = new OspfInterface();
     int helloInterval = 1;
-    iface.getOrCreateOspf().setHelloIntervalS(helloInterval);
+    ospf.setHelloIntervalS(helloInterval);
     // Since the dead interval is not set, it should be inferred as four times the hello interval
     assertThat(
-        toOspfDeadInterval(iface), equalTo(OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * helloInterval));
+        toOspfDeadInterval(ospf), equalTo(OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * helloInterval));
   }
 
   @Test
   public void testToOspfDeadIntervalDefault() {
-    Interface iface = new Interface("FastEthernet0/0", null, CiscoNxosInterfaceType.ETHERNET, null);
-
+    OspfInterface ospf = new OspfInterface();
     // Since the dead interval and hello interval are not set, it should be the default value
-    assertThat(toOspfDeadInterval(iface), equalTo(DEFAULT_DEAD_INTERVAL_S));
+    assertThat(toOspfDeadInterval(ospf), equalTo(DEFAULT_DEAD_INTERVAL_S));
   }
 
   @Test
   public void testToOspfHelloIntervalExplicit() {
-    Interface iface = new Interface("FastEthernet0/0", null, CiscoNxosInterfaceType.ETHERNET, null);
-
-    iface.getOrCreateOspf().setHelloIntervalS(7);
+    OspfInterface ospf = new OspfInterface();
+    ospf.setHelloIntervalS(7);
     // Explicitly set hello interval should be preferred over default
-    assertThat(toOspfHelloInterval(iface), equalTo(7));
+    assertThat(toOspfHelloInterval(ospf), equalTo(7));
   }
 
   @Test
   public void testToOspfHelloIntervalDefault() {
-    Interface iface = new Interface("FastEthernet0/0", null, CiscoNxosInterfaceType.ETHERNET, null);
-
+    OspfInterface ospf = new OspfInterface();
     // Since the hello interval is not set, it should be the default value
-    assertThat(toOspfHelloInterval(iface), equalTo(DEFAULT_HELLO_INTERVAL_S));
+    assertThat(toOspfHelloInterval(ospf), equalTo(DEFAULT_HELLO_INTERVAL_S));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco_nxos/CiscoNxosConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco_nxos/CiscoNxosConfigurationTest.java
@@ -1,0 +1,59 @@
+package org.batfish.representation.cisco_nxos;
+
+import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER;
+import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.toOspfDeadInterval;
+import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.toOspfHelloInterval;
+import static org.batfish.representation.cisco_nxos.OspfInterface.DEFAULT_DEAD_INTERVAL_S;
+import static org.batfish.representation.cisco_nxos.OspfInterface.DEFAULT_HELLO_INTERVAL_S;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.Test;
+
+/** Tests for {@link CiscoNxosConfiguration} class */
+public class CiscoNxosConfigurationTest {
+
+  @Test
+  public void testToOspfDeadIntervalExplicit() {
+    Interface iface = new Interface("FastEthernet0/0", null, CiscoNxosInterfaceType.ETHERNET, null);
+    iface.getOrCreateOspf().setDeadIntervalS(7);
+    // Explicitly set dead interval should be preferred over inference
+    assertThat(toOspfDeadInterval(iface), equalTo(7));
+  }
+
+  @Test
+  public void testToOspfDeadIntervalFromHello() {
+    Interface iface = new Interface("FastEthernet0/0", null, CiscoNxosInterfaceType.ETHERNET, null);
+
+    int helloInterval = 1;
+    iface.getOrCreateOspf().setHelloIntervalS(helloInterval);
+    // Since the dead interval is not set, it should be inferred as four times the hello interval
+    assertThat(
+        toOspfDeadInterval(iface), equalTo(OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * helloInterval));
+  }
+
+  @Test
+  public void testToOspfDeadIntervalDefault() {
+    Interface iface = new Interface("FastEthernet0/0", null, CiscoNxosInterfaceType.ETHERNET, null);
+
+    // Since the dead interval and hello interval are not set, it should be the default value
+    assertThat(toOspfDeadInterval(iface), equalTo(DEFAULT_DEAD_INTERVAL_S));
+  }
+
+  @Test
+  public void testToOspfHelloIntervalExplicit() {
+    Interface iface = new Interface("FastEthernet0/0", null, CiscoNxosInterfaceType.ETHERNET, null);
+
+    iface.getOrCreateOspf().setHelloIntervalS(7);
+    // Explicitly set hello interval should be preferred over default
+    assertThat(toOspfHelloInterval(iface), equalTo(7));
+  }
+
+  @Test
+  public void testToOspfHelloIntervalDefault() {
+    Interface iface = new Interface("FastEthernet0/0", null, CiscoNxosInterfaceType.ETHERNET, null);
+
+    // Since the hello interval is not set, it should be the default value
+    assertThat(toOspfHelloInterval(iface), equalTo(DEFAULT_HELLO_INTERVAL_S));
+  }
+}


### PR DESCRIPTION
Add conversion helpers for Cisco NXOS OSPF hello and dead intervals.  In the process, also:
* Update VS model to allow/return `null` for intervals and just ensure non-`null` values in conversion helpers
* Update logic to allow [inferring `dead-interval` from `hello-interval`](https://www.cisco.com/c/en/us/support/docs/ip/open-shortest-path-first-ospf/13689-17.html)

VI model doesn't yet support hello intervals, so actual conversion will come in a subsequent PR.
