### PR TITLE
NX-OS: add EIGRP address-families focusing on redistribution

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_eigrp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_eigrp.g4
@@ -32,8 +32,8 @@ re_common
   | rec_autonomous_system
   | rec_no
   | rec_passive_interface
-  | rec_redistribute
   | rec_shutdown
+  | recaf_ipv4_inner // address-family ipv4 unicast inner lines are valid in the VRF as well.
 ;
 
 re_flush_routes
@@ -83,11 +83,42 @@ rec_address_family
 recaf_ipv4
 :
   IPV4 UNICAST NEWLINE
+  recaf_ipv4_inner*
+;
+
+recaf_ipv4_inner
+:
+  recaf_common
+  | recaf4_redistribute
 ;
 
 recaf_ipv6
 :
   IPV6 UNICAST NEWLINE
+  (
+    recaf_common
+    | recaf6_redistribute
+  )*
+;
+
+recaf_common
+:
+  recaf_router_id
+;
+
+recaf_router_id
+:
+  ROUTER_ID id = ip_address NEWLINE
+;
+
+recaf4_redistribute
+:
+  REDISTRIBUTE routing_instance_v4 ROUTE_MAP map = route_map_name NEWLINE
+;
+
+recaf6_redistribute
+:
+  REDISTRIBUTE routing_instance_v6 ROUTE_MAP map = route_map_name NEWLINE
 ;
 
 rec_autonomous_system
@@ -117,62 +148,6 @@ rec_no_shutdown
 rec_passive_interface
 :
   PASSIVE_INTERFACE DEFAULT NEWLINE
-;
-
-rec_redistribute
-:
-  REDISTRIBUTE
-  (
-    recr_bgp
-    | recr_direct
-    | recr_eigrp
-    | recr_isis
-    | recr_lisp
-//    | recr_maximum_prefix
-    | recr_ospf
-    | recr_rip
-    | recr_static
-  )
-;
-
-recr_bgp
-:
-  BGP asn = bgp_asn ROUTE_MAP map = route_map_name NEWLINE
-;
-
-recr_direct
-:
-  DIRECT ROUTE_MAP map = route_map_name NEWLINE
-;
-
-recr_eigrp
-:
-  EIGRP tag = router_eigrp_process_tag ROUTE_MAP map = route_map_name NEWLINE
-;
-
-recr_isis
-:
-  ISIS source_tag = router_isis_process_tag ROUTE_MAP map = route_map_name NEWLINE
-;
-
-recr_lisp
-:
-  LISP ROUTE_MAP map = route_map_name NEWLINE
-;
-
-recr_ospf
-:
-  OSPF source_tag = router_ospf_name ROUTE_MAP map = route_map_name NEWLINE
-;
-
-recr_rip
-:
-  RIP source_tag = router_rip_process_id ROUTE_MAP map = route_map_name NEWLINE
-;
-
-recr_static
-:
-  STATIC ROUTE_MAP map = route_map_name NEWLINE
 ;
 
 rec_shutdown

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -1009,7 +1009,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   private DefaultVrfOspfProcess _currentDefaultVrfOspfProcess;
   private EigrpProcessConfiguration _currentEigrpProcess;
   private EigrpVrfConfiguration _currentEigrpVrf;
-  private EigrpVrfIpAddressFamilyConfiguration _currentEigrpVrfIp;
+  private EigrpVrfIpAddressFamilyConfiguration _currentEigrpVrfIpAf;
   private EvpnVni _currentEvpnVni;
   private Function<Interface, HsrpGroup> _currentHsrpGroupGetter;
   private Optional<Integer> _currentHsrpGroupNumber;
@@ -2212,14 +2212,14 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
       _currentEigrpProcess = new EigrpProcessConfiguration();
     }
     _currentEigrpVrf = _currentEigrpProcess.getOrCreateVrf(DEFAULT_VRF_NAME);
-    _currentEigrpVrfIp = _currentEigrpVrf.getVrfIpv4AddressFamily();
+    _currentEigrpVrfIpAf = _currentEigrpVrf.getVrfIpv4AddressFamily();
   }
 
   @Override
   public void exitRouter_eigrp(Router_eigrpContext ctx) {
     _currentEigrpProcess = null;
     _currentEigrpVrf = null;
-    _currentEigrpVrfIp = null;
+    _currentEigrpVrfIpAf = null;
   }
 
   @Override
@@ -3205,13 +3205,13 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
       // Dummy so parsing doesn't crash.
       _currentEigrpVrf = new EigrpVrfConfiguration();
     }
-    _currentEigrpVrfIp = _currentEigrpVrf.getVrfIpv4AddressFamily();
+    _currentEigrpVrfIpAf = _currentEigrpVrf.getVrfIpv4AddressFamily();
   }
 
   @Override
   public void exitRe_vrf(Re_vrfContext ctx) {
     _currentEigrpVrf = _currentEigrpProcess.getOrCreateVrf(DEFAULT_VRF_NAME);
-    _currentEigrpVrfIp = _currentEigrpVrf.getVrfIpv4AddressFamily();
+    _currentEigrpVrfIpAf = _currentEigrpVrf.getVrfIpv4AddressFamily();
   }
 
   @Override
@@ -3222,22 +3222,22 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
 
   @Override
   public void enterRecaf_ipv4(Recaf_ipv4Context ctx) {
-    _currentEigrpVrfIp = _currentEigrpVrf.getOrCreateV4AddressFamily();
+    _currentEigrpVrfIpAf = _currentEigrpVrf.getOrCreateV4AddressFamily();
   }
 
   @Override
   public void exitRecaf_ipv4(Recaf_ipv4Context ctx) {
-    _currentEigrpVrfIp = _currentEigrpVrf.getVrfIpv4AddressFamily();
+    _currentEigrpVrfIpAf = _currentEigrpVrf.getVrfIpv4AddressFamily();
   }
 
   @Override
   public void enterRecaf_ipv6(Recaf_ipv6Context ctx) {
-    _currentEigrpVrfIp = _currentEigrpVrf.getOrCreateV6AddressFamily();
+    _currentEigrpVrfIpAf = _currentEigrpVrf.getOrCreateV6AddressFamily();
   }
 
   @Override
   public void exitRecaf_ipv6(Recaf_ipv6Context ctx) {
-    _currentEigrpVrfIp = _currentEigrpVrf.getVrfIpv4AddressFamily();
+    _currentEigrpVrfIpAf = _currentEigrpVrf.getVrfIpv4AddressFamily();
   }
 
   @Override
@@ -3257,7 +3257,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     }
     _configuration.referenceStructure(
         ROUTE_MAP, map, EIGRP_REDISTRIBUTE_ROUTE_MAP, ctx.getStart().getLine());
-    _currentEigrpVrfIp.setRedistributionPolicy(rpi, map);
+    _currentEigrpVrfIpAf.setRedistributionPolicy(rpi, map);
   }
 
   @Override
@@ -3277,7 +3277,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     }
     _configuration.referenceStructure(
         ROUTE_MAP, map, EIGRP_REDISTRIBUTE_ROUTE_MAP, ctx.getStart().getLine());
-    _currentEigrpVrfIp.setRedistributionPolicy(rpi, map);
+    _currentEigrpVrfIpAf.setRedistributionPolicy(rpi, map);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1334,6 +1334,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
         CiscoNxosStructureUsage.BGP_SUPPRESS_MAP,
         CiscoNxosStructureUsage.BGP_TABLE_MAP,
         CiscoNxosStructureUsage.BGP_UNSUPPRESS_MAP,
+        CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_ROUTE_MAP,
         CiscoNxosStructureUsage.OSPF_AREA_FILTER_LIST_IN,
         CiscoNxosStructureUsage.OSPF_AREA_FILTER_LIST_OUT);
     markConcreteStructure(
@@ -1341,15 +1342,24 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     markConcreteStructure(
         CiscoNxosStructureType.ROUTER_EIGRP,
         CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE,
+        CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE,
         CiscoNxosStructureUsage.ROUTER_EIGRP_SELF_REFERENCE);
     markConcreteStructure(
-        CiscoNxosStructureType.ROUTER_ISIS, CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE);
+        CiscoNxosStructureType.ROUTER_ISIS,
+        CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE,
+        CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE);
     markConcreteStructure(
-        CiscoNxosStructureType.ROUTER_OSPF, CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE);
+        CiscoNxosStructureType.ROUTER_OSPF,
+        CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE,
+        CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE);
     markConcreteStructure(
-        CiscoNxosStructureType.ROUTER_OSPFV3, CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE);
+        CiscoNxosStructureType.ROUTER_OSPFV3,
+        CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE,
+        CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE);
     markConcreteStructure(
-        CiscoNxosStructureType.ROUTER_RIP, CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE);
+        CiscoNxosStructureType.ROUTER_RIP,
+        CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE,
+        CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE);
     markConcreteStructure(
         CiscoNxosStructureType.BGP_TEMPLATE_PEER,
         CiscoNxosStructureUsage.BGP_NEIGHBOR_INHERIT_PEER);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureUsage.java
@@ -39,6 +39,8 @@ public enum CiscoNxosStructureUsage implements StructureUsage {
   BGP_SUPPRESS_MAP("bgp address-family suppress-map"),
   BGP_TABLE_MAP("bgp address-family table-map"),
   BGP_UNSUPPRESS_MAP("bgp address-family unsuppress-map"),
+  EIGRP_REDISTRIBUTE_INSTANCE("eigrp address-family redistribute"),
+  EIGRP_REDISTRIBUTE_ROUTE_MAP("eigrp address-family redistribute route-map"),
   INTERFACE_CHANNEL_GROUP("interface channel-group"),
   INTERFACE_IP_ACCESS_GROUP_IN("interface ip access-group in"),
   INTERFACE_IP_ACCESS_GROUP_OUT("interface ip access-group out"),

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/EigrpVrfConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/EigrpVrfConfiguration.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.cisco_nxos;
 
 import java.io.Serializable;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -11,7 +12,9 @@ import javax.annotation.Nullable;
  */
 public final class EigrpVrfConfiguration implements Serializable {
 
-  public EigrpVrfConfiguration() {}
+  public EigrpVrfConfiguration() {
+    _vrfIpv4AddressFamilyConfiguration = new EigrpVrfIpv4AddressFamilyConfiguration();
+  }
 
   public @Nullable Integer getAsn() {
     return _asn;
@@ -21,9 +24,58 @@ public final class EigrpVrfConfiguration implements Serializable {
     _asn = asn;
   }
 
+  /**
+   * On NX-OS, you can enter many of the configurations for the IPv4 Unicast address family directly
+   * in the VRF or in the {@code address-family ipv4 unicast} subsection. The rules about which
+   * combinations are allowed is ugly, and we didn't handle it yet.
+   *
+   * <p>This is for commands entered at {@code config-router-af} or {@code * config-router-vrf-af}.
+   *
+   * @see #getVrfIpv4AddressFamily() for commands entered at {@code config-router} or {@code
+   *     config-router-vrf}.
+   */
+  public @Nullable EigrpVrfIpv4AddressFamilyConfiguration getV4AddressFamily() {
+    return _v4AddressFamily;
+  }
+
+  public @Nonnull EigrpVrfIpv4AddressFamilyConfiguration getOrCreateV4AddressFamily() {
+    if (_v4AddressFamily == null) {
+      _v4AddressFamily = new EigrpVrfIpv4AddressFamilyConfiguration();
+    }
+    return _v4AddressFamily;
+  }
+
+  public @Nullable EigrpVrfIpv6AddressFamilyConfiguration getV6AddressFamily() {
+    return _v6AddressFamily;
+  }
+
+  public @Nonnull EigrpVrfIpv6AddressFamilyConfiguration getOrCreateV6AddressFamily() {
+    if (_v6AddressFamily == null) {
+      _v6AddressFamily = new EigrpVrfIpv6AddressFamilyConfiguration();
+    }
+    return _v6AddressFamily;
+  }
+
+  /**
+   * On NX-OS, you can enter many of the configurations for the IPv4 Unicast address family directly
+   * in the VRF or in the {@code address-family ipv4 unicast} subsection. The rules about which
+   * combinations are allowed is ugly, and we didn't handle it yet.
+   *
+   * <p>This is for commands entered at {@code config-router} or {@code config-router-vrf}.
+   *
+   * @see #getV4AddressFamily() for commands entered at {@code config-router-af} or {@code
+   *     config-router-vrf-af}.
+   */
+  public @Nonnull EigrpVrfIpv4AddressFamilyConfiguration getVrfIpv4AddressFamily() {
+    return _vrfIpv4AddressFamilyConfiguration;
+  }
+
   ///////////////////////////////////
   // Private implementation details
   ///////////////////////////////////
 
   private @Nullable Integer _asn;
+  private @Nullable EigrpVrfIpv4AddressFamilyConfiguration _v4AddressFamily;
+  private @Nullable EigrpVrfIpv6AddressFamilyConfiguration _v6AddressFamily;
+  private final @Nonnull EigrpVrfIpv4AddressFamilyConfiguration _vrfIpv4AddressFamilyConfiguration;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/EigrpVrfIpAddressFamilyConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/EigrpVrfIpAddressFamilyConfiguration.java
@@ -1,0 +1,48 @@
+package org.batfish.representation.cisco_nxos;
+
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Represents the EIGRP configuration for IPv4 or IPv6 address families at the VRF level.
+ *
+ * <p>Child classes such as {@link EigrpVrfIpv4AddressFamilyConfiguration} contain the
+ * v4/v6-specific code.
+ */
+public abstract class EigrpVrfIpAddressFamilyConfiguration implements Serializable {
+
+  public EigrpVrfIpAddressFamilyConfiguration() {
+    _redistributionPolicies = new HashMap<>();
+  }
+
+  /** Return all redistribution policies. */
+  public final @Nonnull List<RedistributionPolicy> getRedistributionPolicies() {
+    return ImmutableList.copyOf(_redistributionPolicies.values());
+  }
+
+  /** Return all redistribution policies for the given protocol. */
+  public final @Nonnull List<RedistributionPolicy> getRedistributionPolicies(
+      NxosRoutingProtocol protocol) {
+    return _redistributionPolicies.values().stream()
+        .filter(rp -> rp.getInstance().getProtocol() == protocol)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  /** Return the redistribution policy for the given instance, if one has been configured. */
+  public final @Nullable RedistributionPolicy getRedistributionPolicy(
+      RoutingProtocolInstance protocol) {
+    return _redistributionPolicies.get(protocol);
+  }
+
+  /** Set the redistribution policy for the given instance. */
+  public final void setRedistributionPolicy(RoutingProtocolInstance instance, String routeMap) {
+    _redistributionPolicies.put(instance, new RedistributionPolicy(instance, routeMap));
+  }
+
+  private final Map<RoutingProtocolInstance, RedistributionPolicy> _redistributionPolicies;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/EigrpVrfIpv4AddressFamilyConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/EigrpVrfIpv4AddressFamilyConfiguration.java
@@ -1,0 +1,8 @@
+package org.batfish.representation.cisco_nxos;
+
+/** Represents the EIGRP configuration for an IPv4 unicast address family at the VRF level. */
+public final class EigrpVrfIpv4AddressFamilyConfiguration
+    extends EigrpVrfIpAddressFamilyConfiguration {
+
+  public EigrpVrfIpv4AddressFamilyConfiguration() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/EigrpVrfIpv6AddressFamilyConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/EigrpVrfIpv6AddressFamilyConfiguration.java
@@ -1,0 +1,8 @@
+package org.batfish.representation.cisco_nxos;
+
+/** Represents the EIGRP configuration for an IPv6 unicast address family at the VRF level. */
+public final class EigrpVrfIpv6AddressFamilyConfiguration
+    extends EigrpVrfIpAddressFamilyConfiguration {
+
+  public EigrpVrfIpv6AddressFamilyConfiguration() {}
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -237,6 +237,8 @@ import org.batfish.representation.cisco_nxos.CiscoNxosStructureType;
 import org.batfish.representation.cisco_nxos.DefaultVrfOspfProcess;
 import org.batfish.representation.cisco_nxos.EigrpProcessConfiguration;
 import org.batfish.representation.cisco_nxos.EigrpVrfConfiguration;
+import org.batfish.representation.cisco_nxos.EigrpVrfIpv4AddressFamilyConfiguration;
+import org.batfish.representation.cisco_nxos.EigrpVrfIpv6AddressFamilyConfiguration;
 import org.batfish.representation.cisco_nxos.Evpn;
 import org.batfish.representation.cisco_nxos.EvpnVni;
 import org.batfish.representation.cisco_nxos.ExtendedCommunityOrAuto;
@@ -841,11 +843,30 @@ public final class CiscoNxosGrammarTest {
         EigrpVrfConfiguration vrf = proc.getVrf(DEFAULT_VRF_NAME);
         assertThat(vrf, notNullValue());
         assertThat(vrf.getAsn(), nullValue());
+
+        assertThat(vrf.getV4AddressFamily(), nullValue());
+        assertThat(vrf.getV6AddressFamily(), nullValue());
+        EigrpVrfIpv4AddressFamilyConfiguration vrfV4 = vrf.getVrfIpv4AddressFamily();
+        assertThat(vrfV4, notNullValue());
+        assertThat(vrfV4.getRedistributionPolicies(), hasSize(8));
       }
       {
         EigrpVrfConfiguration vrf = proc.getVrf("VRF");
         assertThat(vrf, notNullValue());
         assertThat(vrf.getAsn(), equalTo(12345));
+
+        EigrpVrfIpv4AddressFamilyConfiguration v4 = vrf.getV4AddressFamily();
+        assertThat(v4, notNullValue());
+        assertThat(v4.getRedistributionPolicies(), hasSize(4));
+
+        EigrpVrfIpv6AddressFamilyConfiguration v6 = vrf.getV6AddressFamily();
+        assertThat(v6, notNullValue());
+        assertThat(
+            v6.getRedistributionPolicies(),
+            contains(new RedistributionPolicy(RoutingProtocolInstance.ospfv3("OSPFv3"), "RMV6")));
+
+        assertThat(vrf.getVrfIpv4AddressFamily(), notNullValue());
+        assertThat(vrf.getVrfIpv4AddressFamily().getRedistributionPolicies(), empty());
       }
     }
     {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_eigrp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_eigrp
@@ -28,10 +28,13 @@ router eigrp EIGRP1234
     autonomous-system 12345
     passive-interface default
     no passive-interface default
-    redistribute bgp 1.3 route-map RM
-    redistribute direct route-map RM
-    redistribute eigrp EIGRP4321 route-map RM
-    redistribute static route-map RM
+    address-family ipv4 unicast
+      redistribute bgp 2 route-map RMV
+      redistribute direct route-map RMV
+      redistribute eigrp EIGRPVRF route-map RMV
+      redistribute static route-map RMV
+    address-family ipv6 unicast
+      redistribute ospfv3 OSPFv3 route-map RMV6
     shutdown
     no shutdown
 router eigrp 123


### PR DESCRIPTION
* Default VRF V4 address-family
* Configuration under `address-family ipv4 unicast`
* Configuration under `address-family ipv6 unicast`

Have not yet addressed conflicts between configuration in the VRF and V4
families.