### PR TITLE
cumulus: recognize send-community (extended)

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -143,6 +143,11 @@ EXPANDED
   'expanded' -> pushMode(M_Word)
 ;
 
+EXTENDED
+:
+  'extended'
+;
+
 EXTERNAL
 :
   'external'
@@ -315,6 +320,11 @@ ROUTER
 ROUTER_ID
 :
   'router-id'
+;
+
+SEND_COMMUNITY
+:
+  'send-community'
 ;
 
 SET

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
@@ -172,6 +172,7 @@ sbafi_neighbor
     sbafin_activate
   | sbafin_next_hop_self
   | sbafin_route_reflector_client
+  | sbafin_send_community
   | sbafin_soft_reconfiguration
   | sbafin_route_map
   )
@@ -191,6 +192,11 @@ sbafin_next_hop_self
 sbafin_route_reflector_client
 :
   ROUTE_REFLECTOR_CLIENT
+;
+
+sbafin_send_community
+:
+  SEND_COMMUNITY EXTENDED?
 ;
 
 sbafin_soft_reconfiguration

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -331,6 +331,21 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
+  public void testBgpAddressFamilyNeighborSendCommunity() {
+    // No extraction because these are already enabled by default
+    parseLines(
+        "router bgp 1",
+        "address-family ipv4 unicast",
+        "neighbor N send-community",
+        "exit-address-family");
+    parseLines(
+        "router bgp 1",
+        "address-family ipv4 unicast",
+        "neighbor N send-community extended",
+        "exit-address-family");
+  }
+
+  @Test
   public void testBgpAddressFamilyNeighborSoftReconfiguration() {
     parseLines(
         "router bgp 1",


### PR DESCRIPTION
Both are enabled by default, so parse without extraction.