### PR TITLE
NXOS: handle no default-originate

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_bgp.g4
@@ -604,6 +604,7 @@ rb_n_af_inner
   | rb_n_af_maximum_prefix
   | rb_n_af_next_hop_self
   | rb_n_af_next_hop_third_party
+  | rb_n_af_no_default_originate
   | rb_n_af_prefix_list
   | rb_n_af_route_map
   | rb_n_af_route_reflector_client
@@ -725,6 +726,11 @@ rb_n_af_next_hop_self
 rb_n_af_next_hop_third_party
 :
   NEXT_HOP_THIRD_PARTY NEWLINE
+;
+
+rb_n_af_no_default_originate
+:
+  NO DEFAULT_ORIGINATE NEWLINE
 ;
 
 rb_n_af_prefix_list

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -344,6 +344,7 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_n_af_filter_listContext
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_n_af_inheritContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_n_af_next_hop_selfContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_n_af_next_hop_third_partyContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_n_af_no_default_originateContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_n_af_prefix_listContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_n_af_route_mapContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rb_n_af_route_reflector_clientContext;
@@ -2943,6 +2944,11 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   @Override
   public void exitRb_n_af_next_hop_third_party(Rb_n_af_next_hop_third_partyContext ctx) {
     _currentBgpVrfNeighborAddressFamily.setNextHopThirdParty(true);
+  }
+
+  @Override
+  public void exitRb_n_af_no_default_originate(Rb_n_af_no_default_originateContext ctx) {
+    _currentBgpVrfNeighborAddressFamily.setDefaultOriginate(false);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -573,6 +573,19 @@ public final class CiscoNxosGrammarTest {
   }
 
   @Test
+  public void testBgpDefaultOriginateExtraction() {
+    CiscoNxosConfiguration vc = parseVendorConfig("nxos_bgp_default_originate");
+    assertFalse(
+        vc.getBgpGlobalConfiguration()
+            .getVrfs()
+            .get(DEFAULT_VRF_NAME)
+            .getNeighbors()
+            .get(Ip.parse("1.2.3.0"))
+            .getIpv4UnicastAddressFamily()
+            .getDefaultOriginate());
+  }
+
+  @Test
   public void testSwitchnameConversion() throws IOException {
     String hostname = "nxos_switchname";
     Configuration c = parseConfig(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_bgp_default_originate
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_bgp_default_originate
@@ -1,0 +1,10 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_bgp_default_originate
+feature bgp
+!
+router bgp 65000
+  address-family ipv4 unicast
+  neighbor 1.2.3.0 remote-as 65001
+    address-family ipv4 unicast
+      no default-originate


### PR DESCRIPTION
1. Keeps us in the right parser context
2. Actually important for route propagation