### PR TITLE
Use OSPF settings builder in tests

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -150,9 +150,6 @@ public final class Interface extends ComparableStructure<String> {
       if (_nativeVlan != null) {
         iface.setNativeVlan(_nativeVlan);
       }
-
-      OspfInterfaceSettings.Builder ospfSettings = OspfInterfaceSettings.builder();
-
       iface.setOutgoingFilter(_outgoingFilter);
       iface.setOutgoingTransformation(_outgoingTransformation);
       iface.setOwner(_owner);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -179,19 +179,6 @@ public final class Interface extends ComparableStructure<String> {
       iface.setVrf(_vrf);
       if (_vrf != null) {
         _vrf.getInterfaces().put(name, iface);
-        /*
-        if (_active && _ospfProcess != null && _vrf.getOspfProcesses().containsKey(_ospfProcess)) {
-          // OSPF cost is used to recompute interface cost below
-          // So go ahead and apply it if one was provided
-          if (_ospfCost != null) {
-            iface.setOspfSettings(ospfSettings.build());
-          } else if (_ospfSettings != null && _ospfSettings.getCost() != null) {
-            iface.setOspfSettings(_ospfSettings);
-          }
-          int updatedCost = _vrf.getOspfProcesses().get(_ospfProcess).computeInterfaceCost(iface);
-          ospfSettings.setCost(updatedCost);
-        }
-        */
       }
       iface.setVrrpGroups(_vrrpGroups);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfInterfaceSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfInterfaceSettings.java
@@ -134,6 +134,7 @@ public final class OspfInterfaceSettings implements Serializable {
       @Nullable @JsonProperty(PROP_PASSIVE) Boolean passive,
       @Nullable @JsonProperty(PROP_PROCESS) String process) {
     checkArgument(enabled != null, "OSPF enabled must be specified");
+    checkArgument(passive != null, "OSPF passive must be specified");
     return new OspfInterfaceSettings(
         area,
         cost,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfInterfaceSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfInterfaceSettings.java
@@ -134,7 +134,6 @@ public final class OspfInterfaceSettings implements Serializable {
       @Nullable @JsonProperty(PROP_PASSIVE) Boolean passive,
       @Nullable @JsonProperty(PROP_PROCESS) String process) {
     checkArgument(enabled != null, "OSPF enabled must be specified");
-    checkArgument(passive != null, "OSPF passive must be specified");
     return new OspfInterfaceSettings(
         area,
         cost,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfInterfaceSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfInterfaceSettings.java
@@ -18,6 +18,15 @@ public final class OspfInterfaceSettings implements Serializable {
     return new Builder();
   }
 
+  /** Returns a builder with default values for most OSPF settings, useful for tests. */
+  public static @Nonnull Builder defaultSettingsBuilder() {
+    return new Builder()
+        .setEnabled(true)
+        .setPassive(false)
+        .setDeadInterval(40)
+        .setNetworkType(OspfNetworkType.POINT_TO_POINT);
+  }
+
   public static final class Builder {
     private Long _ospfAreaName;
     private Integer _ospfCost;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InterfaceTest.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
-import org.batfish.datamodel.ospf.OspfNetworkType;
+import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -68,23 +68,11 @@ public class InterfaceTest {
         Interface.builder()
             .setMtu(7)
             .setName("ifaceName")
-            .setOspfNetworkType(OspfNetworkType.BROADCAST)
+            .setOspfSettings(OspfInterfaceSettings.defaultSettingsBuilder().build())
             .build();
 
     // test (de)serialization
     Interface iDeserial = BatfishObjectMapper.clone(i, Interface.class);
     assertThat(i, equalTo(iDeserial));
-  }
-
-  @Test
-  public void testOspfNetworkTypeEquals() {
-    Interface.Builder i = Interface.builder().setName("iface");
-    new EqualsTester()
-        .addEqualityGroup(i.build(), Interface.builder().setName("iface").build())
-        .addEqualityGroup(i.setOspfNetworkType(OspfNetworkType.BROADCAST).build())
-        .addEqualityGroup(i.setOspfNetworkType(OspfNetworkType.NON_BROADCAST_MULTI_ACCESS).build())
-        .addEqualityGroup(i.setOspfNetworkType(OspfNetworkType.POINT_TO_MULTIPOINT).build())
-        .addEqualityGroup(i.setOspfNetworkType(OspfNetworkType.POINT_TO_POINT).build())
-        .testEquals();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/NetworkFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/NetworkFactoryTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertThat;
 
 import org.batfish.datamodel.matchers.OspfAreaMatchers;
 import org.batfish.datamodel.ospf.OspfArea;
+import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.ospf.OspfProcess;
 import org.junit.Test;
 
@@ -100,8 +101,16 @@ public class NetworkFactoryTest {
     OspfArea oa1 = oab.build();
     OspfArea oa2 = oab.setOspfProcess(ospfProcess).build();
     Interface iface =
-        nf.interfaceBuilder().setOwner(c).setActive(false).setVrf(vrf).setOspfArea(oa2).build();
-
+        nf.interfaceBuilder()
+            .setOwner(c)
+            .setActive(false)
+            .setVrf(vrf)
+            .setOspfSettings(
+                OspfInterfaceSettings.defaultSettingsBuilder()
+                    .setAreaName(oa2.getAreaNumber())
+                    .build())
+            .build();
+    oa2.addInterface(iface.getName());
     assertThat(oa1.getAreaNumber(), not(equalTo(oa2.getAreaNumber())));
     assertThat(oa1, not(sameInstance(oa2)));
     assertThat(ospfProcess.getAreas().get(oa2.getAreaNumber()), sameInstance(oa2));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfInterfaceSettingsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfInterfaceSettingsTest.java
@@ -47,18 +47,19 @@ public class OspfInterfaceSettingsTest {
 
   @Test
   public void testEquals() {
-    OspfInterfaceSettings.Builder s = OspfInterfaceSettings.builder();
+    OspfInterfaceSettings.Builder s = OspfInterfaceSettings.builder().setPassive(true);
     new EqualsTester()
         .addEqualityGroup(s.build())
         .addEqualityGroup(
-            s.setAreaName(2L).build(), OspfInterfaceSettings.builder().setAreaName(2L).build())
+            s.setAreaName(2L).build(),
+            OspfInterfaceSettings.builder().setPassive(true).setAreaName(2L).build())
         .addEqualityGroup(s.setCost(3).build())
         .addEqualityGroup(s.setDeadInterval(4).build())
         .addEqualityGroup(s.setEnabled(false).build())
         .addEqualityGroup(s.setHelloMultiplier(5).build())
         .addEqualityGroup(s.setInboundDistributeListPolicy("policy").build())
         .addEqualityGroup(s.setNetworkType(OspfNetworkType.POINT_TO_POINT).build())
-        .addEqualityGroup(s.setPassive(true).build())
+        .addEqualityGroup(s.setPassive(false).build())
         .addEqualityGroup(s.setProcess("proc").build())
         .testEquals();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfInterfaceSettingsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfInterfaceSettingsTest.java
@@ -59,6 +59,9 @@ public class OspfInterfaceSettingsTest {
         .addEqualityGroup(s.setHelloMultiplier(5).build())
         .addEqualityGroup(s.setInboundDistributeListPolicy("policy").build())
         .addEqualityGroup(s.setNetworkType(OspfNetworkType.POINT_TO_POINT).build())
+        .addEqualityGroup(s.setNetworkType(OspfNetworkType.BROADCAST).build())
+        .addEqualityGroup(s.setNetworkType(OspfNetworkType.POINT_TO_MULTIPOINT).build())
+        .addEqualityGroup(s.setNetworkType(OspfNetworkType.NON_BROADCAST_MULTI_ACCESS).build())
         .addEqualityGroup(s.setPassive(false).build())
         .addEqualityGroup(s.setProcess("proc").build())
         .testEquals();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfProcessTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfProcessTest.java
@@ -57,16 +57,45 @@ public class OspfProcessTest {
     OspfArea area1 = oab.setNumber(1L).build();
 
     Interface.Builder ib = nf.interfaceBuilder().setOwner(c1);
-    Interface i0 = ib.setName("eth0").setBandwidth(1e3).setOspfArea(area0).build();
-    Interface i1 = ib.setName("eth1").setBandwidth(1e4).setOspfArea(area1).build();
-    Interface i2 = ib.setName("eth2").setBandwidth(1e5).setOspfArea(area1).setActive(false).build();
+    Interface i0 =
+        ib.setName("eth0")
+            .setBandwidth(1e3)
+            .setOspfSettings(
+                OspfInterfaceSettings.defaultSettingsBuilder()
+                    .setAreaName(area0.getAreaNumber())
+                    .build())
+            .build();
+    area0.addInterface("eth0");
+    Interface i1 =
+        ib.setName("eth1")
+            .setBandwidth(1e4)
+            .setOspfSettings(
+                OspfInterfaceSettings.defaultSettingsBuilder()
+                    .setAreaName(area1.getAreaNumber())
+                    .build())
+            .build();
+    area1.addInterface("eth1");
+    Interface i2 =
+        ib.setName("eth2")
+            .setBandwidth(1e5)
+            .setOspfSettings(
+                OspfInterfaceSettings.defaultSettingsBuilder()
+                    .setAreaName(area1.getAreaNumber())
+                    .build())
+            .setActive(false)
+            .build();
+    area1.addInterface("eth2");
     Interface i3 =
         ib.setName("eth3")
             .setBandwidth(1e6)
-            .setOspfArea(area1)
+            .setOspfSettings(
+                OspfInterfaceSettings.defaultSettingsBuilder()
+                    .setAreaName(area1.getAreaNumber())
+                    .setPassive(true)
+                    .build())
             .setActive(true)
-            .setOspfPassive(true)
             .build();
+    area1.addInterface("eth3");
 
     OspfProcess proc =
         opb.setReferenceBandwidth(1e8)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfTopologyUtilsTest.java
@@ -350,9 +350,13 @@ public class OspfTopologyUtilsTest {
     NetworkConfigurations configs =
         buildNetworkConfigurations(
             Ip.parse("1.1.1.1"),
-            OspfInterfaceSettings.builder().setNetworkType(OspfNetworkType.POINT_TO_POINT).build(),
+            OspfInterfaceSettings.defaultSettingsBuilder()
+                .setNetworkType(OspfNetworkType.POINT_TO_POINT)
+                .build(),
             Ip.parse("1.1.1.2"),
-            OspfInterfaceSettings.builder().setNetworkType(OspfNetworkType.BROADCAST).build());
+            OspfInterfaceSettings.defaultSettingsBuilder()
+                .setNetworkType(OspfNetworkType.BROADCAST)
+                .build());
 
     // Confirm we correctly mark a session as incompatible when OSPF network types are mismatched
     Optional<OspfSessionProperties> val =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -239,7 +239,10 @@ public class OspfRoutingProcessTest {
             .setOwner(c)
             .setVrf(vrf)
             .setAddress(ConcreteInterfaceAddress.create(Ip.parse("1.1.1.1"), 24))
-            .setOspfInboundDistributeListPolicy("policy")
+            .setOspfSettings(
+                OspfInterfaceSettings.defaultSettingsBuilder()
+                    .setInboundDistributeListPolicy("policy")
+                    .build())
             .build();
 
     RouteFilterList prefixList =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -64,6 +64,7 @@ import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.ospf.NssaSettings;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.ospf.OspfDefaultOriginateType;
+import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.ospf.OspfNeighborConfig;
 import org.batfish.datamodel.ospf.OspfNeighborConfigId;
@@ -132,39 +133,41 @@ public class OspfRoutingProcessTest {
             .setHostname(HOSTNAME)
             .build();
     Vrf vrf = nf.vrfBuilder().setName(VRF_NAME).setOwner(_c).build();
+    OspfInterfaceSettings.Builder ospf =
+        OspfInterfaceSettings.builder().setProcess("1").setEnabled(true);
     Interface.Builder ib =
         nf.interfaceBuilder()
             .setVrf(vrf)
             .setOwner(_c)
-            .setOspfProcess("1")
-            .setOspfNetworkType(OspfNetworkType.POINT_TO_POINT)
-            .setOspfEnabled(true)
+            .setOspfSettings(ospf.setNetworkType(OspfNetworkType.POINT_TO_POINT).build())
             .setType(InterfaceType.PHYSICAL)
             .setBandwidth(1e8);
     Interface inactiveIface =
         ib.setActive(false)
             .setName(INACTIVE_IFACE_NAME)
             .setAddress(INACTIVE_ADDR)
-            .setOspfCost(10)
+            .setOspfSettings(ospf.setCost(10).build())
             .build();
     ib.setActive(true);
     Interface activeIface =
         ib.setName(ACTIVE_IFACE_NAME)
             .setAddresses(ACTIVE_ADDR_1, ACTIVE_ADDR_2)
-            .setOspfNetworkType(OspfNetworkType.POINT_TO_POINT)
+            .setOspfSettings(ospf.setNetworkType(OspfNetworkType.POINT_TO_POINT).build())
             .build();
     Interface passiveIface =
         ib.setName(PASSIVE_IFACE_NAME)
             .setAddress(PASSIVE_ADDR)
-            .setOspfPassive(true)
-            .setOspfNetworkType(OspfNetworkType.BROADCAST)
+            .setOspfSettings(
+                ospf.setNetworkType(OspfNetworkType.BROADCAST).setPassive(true).build())
             .build();
     Interface ospfDisabled =
         ib.setName(OSPF_DISABLED_IFACE_NAME)
             .setAddress(OSPF_DISABLED_ADDR)
-            .setOspfPassive(false)
-            .setOspfNetworkType(OspfNetworkType.BROADCAST)
-            .setOspfEnabled(false)
+            .setOspfSettings(
+                ospf.setPassive(false)
+                    .setNetworkType(OspfNetworkType.BROADCAST)
+                    .setEnabled(false)
+                    .build())
             .build();
     AREA0_CONFIG =
         OspfArea.builder(nf)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -134,7 +134,7 @@ public class OspfRoutingProcessTest {
             .build();
     Vrf vrf = nf.vrfBuilder().setName(VRF_NAME).setOwner(_c).build();
     OspfInterfaceSettings.Builder ospf =
-        OspfInterfaceSettings.builder().setProcess("1").setEnabled(true);
+        OspfInterfaceSettings.defaultSettingsBuilder().setProcess("1").setEnabled(true);
     Interface.Builder ib =
         nf.interfaceBuilder()
             .setVrf(vrf)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -121,7 +121,7 @@ public class OspfTest {
   }
 
   private static OspfInterfaceSettings.Builder baseOspfSettings() {
-    return OspfInterfaceSettings.defaultSettingsBuilder().setCost(1);
+    return OspfInterfaceSettings.defaultSettingsBuilder().setCost(1).setProcess("1");
   }
 
   /*
@@ -178,7 +178,6 @@ public class OspfTest {
     OspfArea.Builder oabf = nf.ospfAreaBuilder().setNumber(areaF);
     OspfArea.Builder oabg = nf.ospfAreaBuilder().setNumber(areaG);
     Interface.Builder ib = nf.interfaceBuilder();
-    // Builder ospf = OspfInterfaceSettings.builder().setCost(1).setEnabled(true);
 
     Configuration c1 = cb.setHostname(C1_NAME).build();
     Vrf v1 = vb.setOwner(c1).build();
@@ -195,19 +194,13 @@ public class OspfTest {
     ib.setOwner(c1)
         .setVrf(v1)
         .setOspfSettings(
-            baseOspfSettings()
-                .setAreaName(oa1a.getAreaNumber())
-                .setProcess("1")
-                .setPassive(true)
-                .build());
+            baseOspfSettings().setAreaName(oa1a.getAreaNumber()).setPassive(true).build());
     Interface iface = ib.setName(l0Name).setAddress(C1_L0_ADDRESS).build();
     oa1a.addInterface(iface.getName());
-
     ib.setOspfSettings(baseOspfSettings().setProcess("1").setEnabled(false).build())
         .setName(l1Name)
         .setAddress(C1_L1_ADDRESS)
         .build();
-
     iface =
         ib.setOspfSettings(
                 baseOspfSettings().setProcess("1").setAreaName(oa1b.getAreaNumber()).build())
@@ -240,32 +233,24 @@ public class OspfTest {
     ib.setOwner(c2).setVrf(v2);
     iface =
         ib.setOspfSettings(
-                baseOspfSettings()
-                    .setProcess("1")
-                    .setPassive(true)
-                    .setAreaName(oa2c.getAreaNumber())
-                    .build())
+                baseOspfSettings().setPassive(true).setAreaName(oa2c.getAreaNumber()).build())
             .setName(l0Name)
             .setAddress(C2_L0_ADDRESS)
             .build();
     oa2c.addInterface(iface.getName());
-
     ib.setOspfSettings(baseOspfSettings().setProcess("1").setEnabled(false).build())
         .setName(l1Name)
         .setAddress(C2_L1_ADDRESS)
         .build();
-
     ib.setOspfSettings(
         baseOspfSettings().setProcess("1").setAreaName(oa2b.getAreaNumber()).build());
     iface = ib.setName(c2E2To1Name).setAddress(C2_E2_1_ADDRESS).build();
     oa2b.addInterface(iface.getName());
-
     iface =
         ib.setName(c2E2To3Name)
             .setAddress(C2_E2_3_ADDRESS)
             .setOspfSettings(
                 baseOspfSettings()
-                    .setProcess("1")
                     .setAreaName(oa2d.getAreaNumber())
                     .setNetworkType(OspfNetworkType.BROADCAST)
                     .build())
@@ -282,30 +267,22 @@ public class OspfTest {
     OspfArea oa3e = areaD == areaE ? oa3d : oabe.setOspfProcess(op3).build();
     OspfArea oa3f =
         areaD == areaF ? oa3d : areaE == areaF ? oa3e : oabf.setOspfProcess(op3).build();
-
     iface =
         ib.setOwner(c3)
             .setVrf(v3)
             .setOspfSettings(
-                baseOspfSettings()
-                    .setProcess("1")
-                    .setPassive(true)
-                    .setAreaName(oa3e.getAreaNumber())
-                    .build())
+                baseOspfSettings().setPassive(true).setAreaName(oa3e.getAreaNumber()).build())
             .setName(l0Name)
             .setAddress(C3_L0_ADDRESS)
             .build();
     oa3e.addInterface(iface.getName());
-
     ib.setName(l1Name)
         .setAddress(C3_L1_ADDRESS)
-        .setOspfSettings(baseOspfSettings().setProcess("1").setEnabled(false).build())
+        .setOspfSettings(baseOspfSettings().setEnabled(false).build())
         .build();
-
     iface =
         ib.setOspfSettings(
                 baseOspfSettings()
-                    .setProcess("1")
                     .setNetworkType(OspfNetworkType.BROADCAST)
                     .setAreaName(oa3d.getAreaNumber())
                     .build())
@@ -313,14 +290,11 @@ public class OspfTest {
             .setAddress(C3_E3_2_ADDRESS)
             .build();
     oa3d.addInterface(iface.getName());
-
-    // ib.setName(c3E3To4Name).setAddress(C3_E3_4_ADDRESS).setOspfArea(oa3f).build();
     iface =
         ib.setName(c3E3To4Name)
             .setAddress(C3_E3_4_ADDRESS)
             .setOspfSettings(
                 baseOspfSettings()
-                    .setProcess("1")
                     .setNetworkType(OspfNetworkType.BROADCAST)
                     .setAreaName(oa3f.getAreaNumber())
                     .build())
@@ -335,13 +309,11 @@ public class OspfTest {
         opb.setVrf(v4).setExportPolicy(c4ExportPolicy).setRouterId(C4_L1_ADDRESS.getIp()).build();
     OspfArea oa4f = oabf.setOspfProcess(op4).build();
     OspfArea oa4g = areaF == areaG ? oa4f : oabg.setOspfProcess(op4).build();
-
     iface =
         ib.setOwner(c4)
             .setVrf(v4)
             .setOspfSettings(
                 baseOspfSettings()
-                    .setProcess("1")
                     .setPassive(true)
                     .setNetworkType(OspfNetworkType.BROADCAST)
                     .setAreaName(oa4g.getAreaNumber())
@@ -350,21 +322,14 @@ public class OspfTest {
             .setAddress(C4_L0_ADDRESS)
             .build();
     oa4g.addInterface(iface.getName());
-
     ib.setOspfSettings(
-            baseOspfSettings()
-                .setEnabled(false)
-                .setNetworkType(OspfNetworkType.BROADCAST)
-                .setProcess("1")
-                .build())
+            baseOspfSettings().setEnabled(false).setNetworkType(OspfNetworkType.BROADCAST).build())
         .setName(l1Name)
         .setAddress(C4_L1_ADDRESS)
         .build();
-
     iface =
         ib.setOspfSettings(
                 baseOspfSettings()
-                    .setProcess("1")
                     .setNetworkType(OspfNetworkType.BROADCAST)
                     .setAreaName(oa4f.getAreaNumber())
                     .build())

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -7,7 +7,6 @@ import static org.batfish.datamodel.RoutingProtocol.OSPF_IA;
 import static org.batfish.datamodel.ospf.OspfTopologyUtils.computeOspfTopology;
 import static org.batfish.dataplane.ibdp.TestUtils.assertNoRoute;
 import static org.batfish.dataplane.ibdp.TestUtils.assertRoute;
-import static org.batfish.dataplane.ibdp.TestUtils.baseOspfSettings;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
@@ -119,6 +118,10 @@ public class OspfTest {
     exportIfMatchL2Prefix.setFalseStatements(
         ImmutableList.of(Statements.ExitReject.toStaticStatement()));
     return ImmutableList.of(exportIfMatchL2Prefix);
+  }
+
+  private static OspfInterfaceSettings.Builder baseOspfSettings() {
+    return OspfInterfaceSettings.defaultSettingsBuilder().setCost(1);
   }
 
   /*

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -37,6 +37,7 @@ import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.ospf.NssaSettings;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.ospf.OspfDefaultOriginateType;
+import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.ospf.OspfNetworkType;
 import org.batfish.datamodel.ospf.OspfProcess;
@@ -433,16 +434,11 @@ public class OspfTest {
     String i60Name = "Ethernet6/0";
 
     NetworkFactory nf = new NetworkFactory();
+    OspfInterfaceSettings.Builder ospf = baseOspfSettings().setCost(10).setProcess("1");
     Configuration.Builder cb =
         nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     Vrf.Builder vb = nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
-    Interface.Builder ib =
-        nf.interfaceBuilder()
-            .setOspfCost(10)
-            .setOspfEnabled(true)
-            .setOspfNetworkType(OspfNetworkType.POINT_TO_POINT)
-            .setOspfProcess("1")
-            .setBandwidth(100E6);
+    Interface.Builder ib = nf.interfaceBuilder().setOspfSettings(ospf.build()).setBandwidth(100E6);
     OspfProcess.Builder opb = nf.ospfProcessBuilder().setProcessId("1");
     OspfArea.Builder oab = nf.ospfAreaBuilder();
 
@@ -468,24 +464,28 @@ public class OspfTest {
     ib.setOwner(r0).setVrf(v0);
     // i01
     ib.setName(i01Name)
-        .setOspfArea(oaR0A0)
+        .setOspfSettings(ospf.setAreaName(oaR0A0.getAreaNumber()).build())
         .setAddress(ConcreteInterfaceAddress.parse("10.0.1.0/24"))
         .build();
+    oaR0A0.addInterface(i01Name);
     // i02
     ib.setName(i02Name)
-        .setOspfArea(oaR0A1)
+        .setOspfSettings(ospf.setAreaName(oaR0A1.getAreaNumber()).build())
         .setAddress(ConcreteInterfaceAddress.parse("10.0.2.0/24"))
         .build();
+    oaR0A1.addInterface(i02Name);
     // i04
     ib.setName(i04Name)
-        .setOspfArea(oaR0A2)
+        .setOspfSettings(ospf.setAreaName(oaR0A2.getAreaNumber()).build())
         .setAddress(ConcreteInterfaceAddress.parse("10.0.4.0/24"))
         .build();
+    oaR0A2.addInterface(i04Name);
     // i06
     ib.setName(i06Name)
-        .setOspfArea(oaR0A3)
+        .setOspfSettings(ospf.setAreaName(oaR0A3.getAreaNumber()).build())
         .setAddress(ConcreteInterfaceAddress.parse("10.0.6.0/24"))
         .build();
+    oaR0A3.addInterface(i06Name);
 
     // R1
     Configuration r1 = cb.setHostname(r1Name).build();
@@ -496,9 +496,10 @@ public class OspfTest {
     ib.setOwner(r1).setVrf(v1);
     // i10
     ib.setName(i10Name)
-        .setOspfArea(oaR1A0)
+        .setOspfSettings(ospf.setAreaName(oaR1A0.getAreaNumber()).build())
         .setAddress(ConcreteInterfaceAddress.parse("10.0.1.1/24"))
         .build();
+    oaR1A0.addInterface(i10Name);
 
     // R2
     Configuration r2 = cb.setHostname(r2Name).build();
@@ -509,14 +510,16 @@ public class OspfTest {
     ib.setOwner(r2).setVrf(v2);
     // i20
     ib.setName(i20Name)
-        .setOspfArea(oaR2A1)
+        .setOspfSettings(ospf.setAreaName(oaR2A1.getAreaNumber()).build())
         .setAddress(ConcreteInterfaceAddress.parse("10.0.2.2/24"))
         .build();
+    oaR2A1.addInterface(i20Name);
     // i23
     ib.setName(i23Name)
-        .setOspfArea(oaR2A1)
+        .setOspfSettings(ospf.setAreaName(oaR2A1.getAreaNumber()).build())
         .setAddress(ConcreteInterfaceAddress.parse("10.2.3.2/24"))
         .build();
+    oaR2A1.addInterface(i23Name);
 
     // R3
     Configuration r3 = cb.setHostname(r3Name).build();
@@ -527,9 +530,10 @@ public class OspfTest {
     ib.setOwner(r3).setVrf(v3);
     // i32
     ib.setName(i32Name)
-        .setOspfArea(oaR3A1)
+        .setOspfSettings(ospf.setAreaName(oaR3A1.getAreaNumber()).build())
         .setAddress(ConcreteInterfaceAddress.parse("10.2.3.3/24"))
         .build();
+    oaR3A1.addInterface(i32Name);
 
     // R4
     Configuration r4 = cb.setHostname(r4Name).build();
@@ -540,14 +544,16 @@ public class OspfTest {
     ib.setOwner(r4).setVrf(v4);
     // i40
     ib.setName(i40Name)
-        .setOspfArea(oaR4A2)
+        .setOspfSettings(ospf.setAreaName(oaR4A2.getAreaNumber()).build())
         .setAddress(ConcreteInterfaceAddress.parse("10.0.4.4/24"))
         .build();
+    oaR4A2.addInterface(i40Name);
     // i45
     ib.setName(i45Name)
-        .setOspfArea(oaR4A2)
+        .setOspfSettings(ospf.setAreaName(oaR4A2.getAreaNumber()).build())
         .setAddress(ConcreteInterfaceAddress.parse("10.4.5.4/24"))
         .build();
+    oaR4A2.addInterface(i45Name);
 
     // R5
     Configuration r5 = cb.setHostname(r5Name).build();
@@ -558,9 +564,10 @@ public class OspfTest {
     ib.setOwner(r5).setVrf(v5);
     // i54
     ib.setName(i54Name)
-        .setOspfArea(oaR5A2)
+        .setOspfSettings(ospf.setAreaName(oaR5A2.getAreaNumber()).build())
         .setAddress(ConcreteInterfaceAddress.parse("10.4.5.5/24"))
         .build();
+    oaR5A2.addInterface(i54Name);
 
     // R6
     Configuration r6 = cb.setHostname(r6Name).build();
@@ -595,9 +602,10 @@ public class OspfTest {
     ib.setOwner(r6).setVrf(v6);
     // i60
     ib.setName(i60Name)
-        .setOspfArea(oaR6A03)
+        .setOspfSettings(ospf.setAreaName(oaR6A03.getAreaNumber()).build())
         .setAddress(ConcreteInterfaceAddress.parse("10.0.6.6/24"))
         .build();
+    oaR6A03.addInterface(i60Name);
 
     SortedMap<String, Configuration> configurations =
         ImmutableSortedMap.<String, Configuration>naturalOrder()

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -36,6 +36,8 @@ import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.ospf.NssaSettings;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.ospf.OspfDefaultOriginateType;
+import org.batfish.datamodel.ospf.OspfInterfaceSettings;
+import org.batfish.datamodel.ospf.OspfInterfaceSettings.Builder;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.ospf.OspfNetworkType;
 import org.batfish.datamodel.ospf.OspfProcess;
@@ -172,7 +174,8 @@ public class OspfTest {
     OspfArea.Builder oabe = nf.ospfAreaBuilder().setNumber(areaE);
     OspfArea.Builder oabf = nf.ospfAreaBuilder().setNumber(areaF);
     OspfArea.Builder oabg = nf.ospfAreaBuilder().setNumber(areaG);
-    Interface.Builder ib = nf.interfaceBuilder().setOspfCost(1).setOspfEnabled(true);
+    Interface.Builder ib = nf.interfaceBuilder();
+    Builder ospf = OspfInterfaceSettings.builder().setCost(1).setEnabled(true);
 
     Configuration c1 = cb.setHostname(C1_NAME).build();
     Vrf v1 = vb.setOwner(c1).build();
@@ -186,8 +189,16 @@ public class OspfTest {
             .build();
     OspfArea oa1a = oaba.setOspfProcess(op1).build();
     OspfArea oa1b = areaA == areaB ? oa1a : oabb.setOspfProcess(op1).build();
-    ib.setOwner(c1).setVrf(v1).setOspfArea(oa1a).setOspfProcess("1");
-    ib.setOspfPassive(true).setName(l0Name).setAddress(C1_L0_ADDRESS).build();
+    ib.setOwner(c1)
+        .setVrf(v1)
+        .setOspfSettings(
+            ospf.setAreaName(oa1a.getAreaNumber()).setProcess("1").setPassive(true).build());
+    Interface iface = ib.setName(l0Name).setAddress(C1_L0_ADDRESS).build();
+    oa1a.addInterface(iface.getName());
+
+    ib.setOspfSettings(null);
+    ib.setOspfCost(1).setOspfEnabled(true).setOspfProcess("1");
+
     ib.setOspfEnabled(false)
         .setOspfPassive(false)
         .setOspfArea(null)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -293,21 +293,35 @@ public class OspfTest {
             .build();
     oa3e.addInterface(iface.getName());
 
-    // CONVERSION IN PROGRESS
-    ib.setOspfSettings(null);
-    ib.setOspfCost(1).setOspfEnabled(true).setOspfProcess("1");
-    ib.setOspfEnabled(true).setOspfPassive(true).setOspfNetworkType(OspfNetworkType.BROADCAST);
-    // CONVERSION IN PROGRESS
-
-    ib.setOspfEnabled(false)
-        .setOspfPassive(false)
-        .setOspfArea(null)
-        .setName(l1Name)
+    ib.setName(l1Name)
         .setAddress(C3_L1_ADDRESS)
+        .setOspfSettings(baseOspfSettings().setProcess("1").setEnabled(false).build())
         .build();
-    ib.setOspfEnabled(true).setOspfArea(oa3d);
-    ib.setName(c3E3To2Name).setAddress(C3_E3_2_ADDRESS).build();
-    ib.setName(c3E3To4Name).setAddress(C3_E3_4_ADDRESS).setOspfArea(oa3f).build();
+
+    iface =
+        ib.setOspfSettings(
+                baseOspfSettings()
+                    .setProcess("1")
+                    .setNetworkType(OspfNetworkType.BROADCAST)
+                    .setAreaName(oa3d.getAreaNumber())
+                    .build())
+            .setName(c3E3To2Name)
+            .setAddress(C3_E3_2_ADDRESS)
+            .build();
+    oa3d.addInterface(iface.getName());
+
+    // ib.setName(c3E3To4Name).setAddress(C3_E3_4_ADDRESS).setOspfArea(oa3f).build();
+    iface =
+        ib.setName(c3E3To4Name)
+            .setAddress(C3_E3_4_ADDRESS)
+            .setOspfSettings(
+                baseOspfSettings()
+                    .setProcess("1")
+                    .setNetworkType(OspfNetworkType.BROADCAST)
+                    .setAreaName(oa3f.getAreaNumber())
+                    .build())
+            .build();
+    oa3f.addInterface(iface.getName());
 
     Configuration c4 = cb.setHostname(C4_NAME).build();
     Vrf v4 = vb.setOwner(c4).build();
@@ -317,16 +331,43 @@ public class OspfTest {
         opb.setVrf(v4).setExportPolicy(c4ExportPolicy).setRouterId(C4_L1_ADDRESS.getIp()).build();
     OspfArea oa4f = oabf.setOspfProcess(op4).build();
     OspfArea oa4g = areaF == areaG ? oa4f : oabg.setOspfProcess(op4).build();
-    ib.setOwner(c4).setVrf(v4).setOspfArea(oa4g);
-    ib.setOspfPassive(true).setName(l0Name).setAddress(C4_L0_ADDRESS).build();
-    ib.setOspfEnabled(false)
-        .setOspfPassive(false)
-        .setOspfArea(null)
+
+    iface =
+        ib.setOwner(c4)
+            .setVrf(v4)
+            .setOspfSettings(
+                baseOspfSettings()
+                    .setProcess("1")
+                    .setPassive(true)
+                    .setNetworkType(OspfNetworkType.BROADCAST)
+                    .setAreaName(oa4g.getAreaNumber())
+                    .build())
+            .setName(l0Name)
+            .setAddress(C4_L0_ADDRESS)
+            .build();
+    oa4g.addInterface(iface.getName());
+
+    ib.setOspfSettings(
+            baseOspfSettings()
+                .setEnabled(false)
+                .setNetworkType(OspfNetworkType.BROADCAST)
+                .setProcess("1")
+                .build())
         .setName(l1Name)
         .setAddress(C4_L1_ADDRESS)
         .build();
-    ib.setOspfEnabled(true).setOspfArea(oa4f);
-    ib.setName(c4E4To3Name).setAddress(C4_E4_3_ADDRESS).build();
+
+    iface =
+        ib.setOspfSettings(
+                baseOspfSettings()
+                    .setProcess("1")
+                    .setNetworkType(OspfNetworkType.BROADCAST)
+                    .setAreaName(oa4f.getAreaNumber())
+                    .build())
+            .setName(c4E4To3Name)
+            .setAddress(C4_E4_3_ADDRESS)
+            .build();
+    oa4f.addInterface(iface.getName());
 
     SortedMap<String, Configuration> configurations =
         new ImmutableSortedMap.Builder<String, Configuration>(String::compareTo)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -196,17 +196,17 @@ public class OspfTest {
     Interface iface = ib.setName(l0Name).setAddress(C1_L0_ADDRESS).build();
     oa1a.addInterface(iface.getName());
 
-    ib.setOspfSettings(null);
-    ib.setOspfCost(1).setOspfEnabled(true).setOspfProcess("1");
-
-    ib.setOspfEnabled(false)
-        .setOspfPassive(false)
-        .setOspfArea(null)
+    ib.setOspfSettings(ospf.setEnabled(false).setPassive(false).setAreaName(null).build())
         .setName(l1Name)
         .setAddress(C1_L1_ADDRESS)
         .build();
-    ib.setOspfEnabled(true).setOspfArea(oa1b);
-    ib.setName(c1E1To2Name).setAddress(C1_E1_2_ADDRESS).build();
+
+    iface =
+        ib.setOspfSettings(ospf.setEnabled(true).setAreaName(oa1b.getAreaNumber()).build())
+            .setName(c1E1To2Name)
+            .setAddress(C1_E1_2_ADDRESS)
+            .build();
+    oa1b.addInterface(iface.getName());
 
     Configuration c2 = cb.setHostname(C2_NAME).build();
     Vrf v2 = vb.setOwner(c2).build();
@@ -229,14 +229,26 @@ public class OspfTest {
     OspfArea oa2c = areaB == areaC ? oa2b : oabc.setOspfProcess(op2).build();
     OspfArea oa2d =
         areaB == areaD ? oa2b : areaC == areaD ? oa2c : oabd.setOspfProcess(op2).build();
-    ib.setOwner(c2).setVrf(v2).setOspfArea(oa2c);
-    ib.setOspfPassive(true).setName(l0Name).setAddress(C2_L0_ADDRESS).build();
-    ib.setOspfEnabled(false)
-        .setOspfPassive(false)
-        .setOspfArea(null)
+    ib.setOwner(c2).setVrf(v2);
+    iface =
+        ib.setOspfSettings(ospf.setPassive(true).setAreaName(oa2c.getAreaNumber()).build())
+            .setName(l0Name)
+            .setAddress(C2_L0_ADDRESS)
+            .build();
+    oa2c.addInterface(iface.getName());
+
+    ib.setOspfSettings(ospf.setEnabled(false).setPassive(false).setAreaName(null).build())
         .setName(l1Name)
         .setAddress(C2_L1_ADDRESS)
         .build();
+
+    // CONVERSION IN PROGRESS
+    ib.setOspfSettings(null);
+    ib.setOspfCost(1).setOspfEnabled(true).setOspfProcess("1");
+    ib.setOspfEnabled(false).setOspfPassive(false).setOspfArea(null);
+    ib.setOspfEnabled(false).setOspfPassive(false);
+    // CONVERSION IN PROGRESS
+
     ib.setOspfEnabled(true).setOspfArea(oa2b);
     ib.setName(c2E2To1Name)
         .setAddress(C2_E2_1_ADDRESS)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TestUtils.java
@@ -27,8 +27,6 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.matchers.IsisRouteMatchers;
-import org.batfish.datamodel.ospf.OspfInterfaceSettings;
-import org.batfish.datamodel.ospf.OspfNetworkType;
 import org.hamcrest.Matchers;
 
 public class TestUtils {
@@ -130,14 +128,6 @@ public class TestUtils {
             .build();
     nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME).setOwner(c).build();
     return new Node(c);
-  }
-
-  public static OspfInterfaceSettings.Builder baseOspfSettings() {
-    return OspfInterfaceSettings.builder()
-        .setPassive(false)
-        .setNetworkType(OspfNetworkType.POINT_TO_POINT)
-        .setEnabled(true)
-        .setCost(1);
   }
 
   /** Annotates route with {@link Configuration#DEFAULT_VRF_NAME} */

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TestUtils.java
@@ -27,6 +27,8 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.matchers.IsisRouteMatchers;
+import org.batfish.datamodel.ospf.OspfInterfaceSettings;
+import org.batfish.datamodel.ospf.OspfNetworkType;
 import org.hamcrest.Matchers;
 
 public class TestUtils {
@@ -128,6 +130,14 @@ public class TestUtils {
             .build();
     nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME).setOwner(c).build();
     return new Node(c);
+  }
+
+  public static OspfInterfaceSettings.Builder baseOspfSettings() {
+    return OspfInterfaceSettings.builder()
+        .setPassive(false)
+        .setNetworkType(OspfNetworkType.POINT_TO_POINT)
+        .setEnabled(true)
+        .setCost(1);
   }
 
   /** Annotates route with {@link Configuration#DEFAULT_VRF_NAME} */

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/schedule/NodeColoredScheduleTest.java
@@ -85,7 +85,7 @@ public class NodeColoredScheduleTest {
             .setVrf(vrf1)
             .setAddress(ConcreteInterfaceAddress.create(R1_IP, networkBits))
             .setOspfSettings(
-                OspfInterfaceSettings.builder()
+                OspfInterfaceSettings.defaultSettingsBuilder()
                     .setEnabled(true)
                     .setProcess("1")
                     .setAreaName(0L)
@@ -115,7 +115,7 @@ public class NodeColoredScheduleTest {
         ib.setOwner(r2)
             .setVrf(vrf2)
             .setOspfSettings(
-                OspfInterfaceSettings.builder()
+                OspfInterfaceSettings.defaultSettingsBuilder()
                     .setProcess("1")
                     .setEnabled(true)
                     .setCost(1)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/topology/OspfTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/topology/OspfTopologyTest.java
@@ -25,6 +25,7 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.ospf.OspfInterfaceSettings;
+import org.batfish.datamodel.ospf.OspfInterfaceSettings.Builder;
 import org.batfish.datamodel.ospf.OspfNeighborConfig;
 import org.batfish.datamodel.ospf.OspfNeighborConfigId;
 import org.batfish.datamodel.ospf.OspfNetworkType;
@@ -72,7 +73,8 @@ public class OspfTopologyTest {
     NetworkFactory nf = new NetworkFactory();
     Configuration.Builder cb =
         nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
-    Interface.Builder ib = nf.interfaceBuilder().setBandwidth(10e6).setOspfCost(1);
+    Builder ospf = OspfInterfaceSettings.defaultSettingsBuilder().setCost(1);
+    Interface.Builder ib = nf.interfaceBuilder().setBandwidth(10e6);
     Vrf.Builder vb = nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
     OspfProcess.Builder opb = nf.ospfProcessBuilder().setProcessId("1");
     OspfArea.Builder oab = nf.ospfAreaBuilder().setNumber(0).setNonStub();
@@ -85,9 +87,7 @@ public class OspfTopologyTest {
         ib.setAddress(ConcreteInterfaceAddress.parse("1.1.1.0/31"))
             .setVrf(vrf1)
             .setOwner(c1)
-            .setOspfEnabled(true)
-            .setOspfPassive(true)
-            .setOspfProcess("1")
+            .setOspfSettings(ospf.setPassive(true).setProcess("1").build())
             .setName("i12")
             .build();
 
@@ -95,9 +95,7 @@ public class OspfTopologyTest {
         ib.setAddress(ConcreteInterfaceAddress.parse("1.1.1.2/31"))
             .setVrf(vrf1)
             .setOwner(c1)
-            .setOspfEnabled(true)
-            .setOspfPassive(false)
-            .setOspfProcess("1")
+            .setOspfSettings(ospf.setPassive(false).setProcess("1").build())
             .setName("i13")
             .build();
 
@@ -105,9 +103,7 @@ public class OspfTopologyTest {
         ib.setAddress(ConcreteInterfaceAddress.parse("1.1.1.4/31"))
             .setVrf(vrf1)
             .setOwner(c1)
-            .setOspfEnabled(true)
-            .setOspfPassive(false)
-            .setOspfProcess("1")
+            .setOspfSettings(ospf.setProcess("1").build())
             .setActive(false)
             .setName("i14")
             .build();
@@ -125,9 +121,7 @@ public class OspfTopologyTest {
         ib.setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/31"))
             .setVrf(vrf2)
             .setOwner(c2)
-            .setOspfEnabled(true)
-            .setOspfPassive(false)
-            .setOspfProcess("1")
+            .setOspfSettings(ospf.setProcess("1").build())
             .setName("i21")
             .build();
     oab.setInterfaces(Collections.singleton(i21.getName())).setOspfProcess(proc2).build();
@@ -140,9 +134,7 @@ public class OspfTopologyTest {
         ib.setAddress(ConcreteInterfaceAddress.parse("1.1.1.3/31"))
             .setVrf(vrf3)
             .setOwner(c3)
-            .setOspfEnabled(true)
-            .setOspfPassive(false)
-            .setOspfProcess("1")
+            .setOspfSettings(ospf.setProcess("1").build())
             .setName("i31")
             .build();
     oab.setInterfaces(Collections.singleton(i31.getName())).setOspfProcess(proc3).build();
@@ -155,9 +147,7 @@ public class OspfTopologyTest {
         ib.setAddress(ConcreteInterfaceAddress.parse("1.1.1.4/31"))
             .setVrf(vrf4)
             .setOwner(c4)
-            .setOspfEnabled(true)
-            .setOspfPassive(false)
-            .setOspfProcess("1")
+            .setOspfSettings(ospf.setProcess("1").build())
             .setName("i41")
             .build();
     oab.setInterfaces(Collections.singleton(i41.getName())).setOspfProcess(proc4).build();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/topology/OspfTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/topology/OspfTopologyTest.java
@@ -227,7 +227,7 @@ public class OspfTopologyTest {
         .setVrf(vrf)
         .setAddress(ConcreteInterfaceAddress.create(Ip.parse("1.1.1.1"), 31))
         .setOspfSettings(
-            OspfInterfaceSettings.builder()
+            OspfInterfaceSettings.defaultSettingsBuilder()
                 .setNetworkType(OspfNetworkType.POINT_TO_POINT)
                 .setCost(1)
                 .setEnabled(true)
@@ -240,7 +240,7 @@ public class OspfTopologyTest {
         .setOwner(configuration)
         .setVrf(vrf)
         .setOspfSettings(
-            OspfInterfaceSettings.builder()
+            OspfInterfaceSettings.defaultSettingsBuilder()
                 .setNetworkType(OspfNetworkType.POINT_TO_POINT)
                 .setCost(1)
                 .setEnabled(true)

--- a/projects/question/src/test/java/org/batfish/question/ospfarea/OspfAreaConfigurationAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfarea/OspfAreaConfigurationAnswererTest.java
@@ -19,6 +19,7 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.ospf.OspfArea;
+import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.ospf.StubType;
 import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.table.ColumnMetadata;
@@ -55,19 +56,24 @@ public class OspfAreaConfigurationAnswererTest {
         .setName("int1")
         .setOwner(configuration)
         .setBandwidth(2d)
-        .setOspfArea(ospfArea)
-        .setOspfEnabled(true)
-        .setOspfPassive(false)
+        .setOspfSettings(
+            OspfInterfaceSettings.defaultSettingsBuilder()
+                .setAreaName(ospfArea.getAreaNumber())
+                .build())
         .build();
+    ospfArea.addInterface("int1");
     nf.interfaceBuilder()
         .setVrf(vrf)
         .setName("int2")
         .setOwner(configuration)
         .setBandwidth(2d)
-        .setOspfArea(ospfArea)
-        .setOspfEnabled(true)
-        .setOspfPassive(true)
+        .setOspfSettings(
+            OspfInterfaceSettings.defaultSettingsBuilder()
+                .setAreaName(ospfArea.getAreaNumber())
+                .setPassive(true)
+                .build())
         .build();
+    ospfArea.addInterface("int2");
 
     TableMetadata tableMetadata = OspfAreaConfigurationAnswerer.createTableMetadata();
     Multiset<Row> rows =

--- a/projects/question/src/test/java/org/batfish/question/ospfinterface/OspfInterfaceConfigAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfinterface/OspfInterfaceConfigAnswererTest.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Multiset;
 import java.util.List;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
-import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Vrf;
@@ -48,20 +47,19 @@ public class OspfInterfaceConfigAnswererTest {
     Vrf vrf = nf.vrfBuilder().setName("test_vrf").setOwner(configuration).build();
     OspfArea ospfArea =
         nf.ospfAreaBuilder().setInterfaces(ImmutableSet.of("int1")).setNumber(1L).build();
-    Interface iface =
-        nf.interfaceBuilder()
-            .setName("int1")
-            .setOspfSettings(
-                OspfInterfaceSettings.builder()
-                    .setAreaName(ospfArea.getAreaNumber())
-                    .setPassive(true)
-                    .setCost(2)
-                    .setNetworkType(OspfNetworkType.POINT_TO_POINT)
-                    .setHelloMultiplier(2)
-                    .build())
-            .setOwner(configuration)
-            .setVrf(vrf)
-            .build();
+    nf.interfaceBuilder()
+        .setName("int1")
+        .setOspfSettings(
+            OspfInterfaceSettings.builder()
+                .setAreaName(ospfArea.getAreaNumber())
+                .setPassive(true)
+                .setCost(2)
+                .setNetworkType(OspfNetworkType.POINT_TO_POINT)
+                .setHelloMultiplier(2)
+                .build())
+        .setOwner(configuration)
+        .setVrf(vrf)
+        .build();
     ospfArea.addInterface("int1");
     nf.ospfProcessBuilder()
         .setProcessId("ospf_1")

--- a/projects/question/src/test/java/org/batfish/question/ospfinterface/OspfInterfaceConfigAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfinterface/OspfInterfaceConfigAnswererTest.java
@@ -27,6 +27,7 @@ import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.ospf.OspfArea;
+import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.ospf.OspfNetworkType;
 import org.batfish.datamodel.questions.OspfInterfacePropertySpecifier;
 import org.batfish.datamodel.table.ColumnMetadata;
@@ -50,14 +51,18 @@ public class OspfInterfaceConfigAnswererTest {
     Interface iface =
         nf.interfaceBuilder()
             .setName("int1")
-            .setOspfArea(ospfArea)
-            .setOspfPassive(true)
-            .setOspfCost(2)
-            .setOspfNetworkType(OspfNetworkType.POINT_TO_POINT)
+            .setOspfSettings(
+                OspfInterfaceSettings.builder()
+                    .setAreaName(ospfArea.getAreaNumber())
+                    .setPassive(true)
+                    .setCost(2)
+                    .setNetworkType(OspfNetworkType.POINT_TO_POINT)
+                    .setHelloMultiplier(2)
+                    .build())
             .setOwner(configuration)
             .setVrf(vrf)
             .build();
-    iface.getOspfSettings().setHelloMultiplier(2);
+    ospfArea.addInterface("int1");
     nf.ospfProcessBuilder()
         .setProcessId("ospf_1")
         .setAreas(ImmutableSortedMap.of(1L, ospfArea))

--- a/projects/question/src/test/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswererTest.java
@@ -34,6 +34,7 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.ospf.OspfNeighborConfig;
 import org.batfish.datamodel.ospf.OspfNeighborConfigId;
 import org.batfish.datamodel.ospf.OspfSessionProperties;
@@ -72,7 +73,7 @@ public class OspfSessionCompatibilityAnswererTest {
         .setName("int_u")
         .setVrf(vrfU)
         .setOwner(configurationU)
-        .setOspfProcess("U")
+        .setOspfSettings(OspfInterfaceSettings.defaultSettingsBuilder().setProcess("U").build())
         .build();
 
     nf.interfaceBuilder()
@@ -80,7 +81,7 @@ public class OspfSessionCompatibilityAnswererTest {
         .setName("int_v")
         .setVrf(vrfV)
         .setOwner(configurationV)
-        .setOspfProcess("V")
+        .setOspfSettings(OspfInterfaceSettings.defaultSettingsBuilder().setProcess("V").build())
         .build();
 
     nf.ospfProcessBuilder()


### PR DESCRIPTION
Move off of legacy OSPF settings setters and instead use new OSPF settings builder in tests.  Also, remove the legacy setters now that they are unused.

This should make it easier to enforce non-null values for `OspfInterfaceSettings` in the future.
