### PR TITLE
NXOS: setting ipv4 unicast to always true for L3 VNIs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -624,6 +624,8 @@ final class Conversions {
                     exportRtOrAuto.isAuto()
                         ? toRouteTarget(localAs, vniSettings.getVni())
                         : exportRtOrAuto.getExtendedCommunity())
+                // NXOS advertises EVPN type-5 always
+                .setAdvertiseV4Unicast(true)
                 .build());
       }
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -821,10 +821,10 @@ public final class CiscoNxosGrammarTest {
             Layer3VniConfig.builder()
                 .setVni(3333)
                 .setVrf(tenantVrfName)
+                .setAdvertiseV4Unicast(true)
                 .setRouteDistinguisher(RouteDistinguisher.from(routerId, 3))
                 .setRouteTarget(ExtendedCommunity.target(1, 3333))
                 .setImportRouteTarget(ExtendedCommunity.target(1, 3333).matchString())
-                .setAdvertiseV4Unicast(false)
                 .build());
     BgpPeerConfig peer =
         c.getDefaultVrf().getBgpProcess().getActiveNeighbors().get(Prefix.parse("1.1.1.1/32"));


### PR DESCRIPTION
because NXOS always propagates EVPN type 5 routes for all neighbors in non-default VRFs