### PR TITLE
Cumulus: Improve local IP inference for BGP peers

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -405,7 +405,8 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
 
   /** Scan all interfaces, find first that contains given remote IP */
   @Nullable
-  private static Ip computeLocalIpForBgpNeighbor(Ip remoteIp, Configuration c) {
+  @VisibleForTesting
+  static Ip computeLocalIpForBgpNeighbor(Ip remoteIp, Configuration c) {
     // TODO: figure out if the interfaces we look at should be limited to a VRF
     return c.getAllInterfaces().values().stream()
         .flatMap(

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -411,7 +411,10 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
         .flatMap(
             i ->
                 i.getAllConcreteAddresses().stream()
-                    .filter(addr -> addr.getPrefix().containsIp(remoteIp)))
+                    .filter(
+                        addr ->
+                            addr.getPrefix().containsIp(remoteIp)
+                                && !addr.getIp().equals(remoteIp)))
         .findFirst()
         .map(ConcreteInterfaceAddress::getIp)
         .orElse(null);


### PR DESCRIPTION
To determine an active peer's local IP, we currently look for interfaces whose subnet includes its remote IP (that therefore could connect with the intended remote peer), then assign the first such interface's IP as the peer's local IP. This PR improves the process by ruling out an interface whose address *is* the peer's remote IP.