### PR TITLE
NX-OS: cleanup interface definition and reference

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureUsage.java
@@ -47,7 +47,7 @@ public enum CiscoNxosStructureUsage implements StructureUsage {
   INTERFACE_IP_POLICY("interface ip policy"),
   INTERFACE_IP_ROUTER_EIGRP("interface ip router eigrp"),
   INTERFACE_IP_ROUTER_OSPF("interface ip router ospf"),
-  INTERFACE_SELF_REFERENCE("interface self-reference"),
+  INTERFACE_SELF_REFERENCE("interface"),
   INTERFACE_VLAN("interface vlan"),
   INTERFACE_VRF_MEMBER("interface vrf member"),
   IP_ACCESS_LIST_DESTINATION_ADDRGROUP("ip access-list destination addrgroup"),


### PR DESCRIPTION
1. Every time we enter the interface rule, it should count as definition and reference
2. Single-source-of-truth for interface name
3. Make interface-self-reference only include actual syntax