### PR TITLE
NX-OS: define the built-in structures at top level

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -64,6 +64,7 @@ import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.BGP_
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.BGP_SUPPRESS_MAP;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.BGP_TABLE_MAP;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.BGP_UNSUPPRESS_MAP;
+import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.BUILT_IN;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_ROUTE_MAP;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.INTERFACE_CHANNEL_GROUP;
@@ -1238,6 +1239,8 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     // define built-ins at line 0 (before first line of file).
     _configuration.defineStructure(VRF, DEFAULT_VRF_NAME, 0);
     _configuration.defineStructure(VRF, MANAGEMENT_VRF_NAME, 0);
+    _configuration.referenceStructure(VRF, DEFAULT_VRF_NAME, BUILT_IN, 0);
+    _configuration.referenceStructure(VRF, MANAGEMENT_VRF_NAME, BUILT_IN, 0);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1459,6 +1459,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     markConcreteStructure(
         CiscoNxosStructureType.VRF,
         CiscoNxosStructureUsage.AAA_GROUP_SERVER_USE_VRF,
+        CiscoNxosStructureUsage.BUILT_IN,
         CiscoNxosStructureUsage.INTERFACE_VRF_MEMBER,
         CiscoNxosStructureUsage.IP_ROUTE_NEXT_HOP_VRF);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureUsage.java
@@ -41,6 +41,8 @@ public enum CiscoNxosStructureUsage implements StructureUsage {
   BGP_SUPPRESS_MAP("bgp address-family suppress-map"),
   BGP_TABLE_MAP("bgp address-family table-map"),
   BGP_UNSUPPRESS_MAP("bgp address-family unsuppress-map"),
+  /** This {@link CiscoNxosStructureUsage} should be used for ANY built-in structure of any type. */
+  BUILT_IN("built-in structure"),
   EIGRP_REDISTRIBUTE_INSTANCE("eigrp address-family redistribute"),
   EIGRP_REDISTRIBUTE_ROUTE_MAP("eigrp address-family redistribute route-map"),
   INTERFACE_CHANNEL_GROUP("interface channel-group"),


### PR DESCRIPTION
Otherwise we may get undefined references.