### PR TITLE
NX-OS: OSPF redistribute using same form as others

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_ospf.g4
@@ -202,15 +202,9 @@ ro_redistribute
 :
   REDISTRIBUTE
   (
-    ror_direct
+    ror_redistribute_route_map
     | ror_null
-    | ror_static
   )
-;
-
-ror_direct
-:
-  DIRECT ROUTE_MAP rm = route_map_name NEWLINE
 ;
 
 ror_null
@@ -218,9 +212,9 @@ ror_null
   MAXIMUM_PREFIX null_rest_of_line
 ;
 
-ror_static
+ror_redistribute_route_map
 :
-  STATIC ROUTE_MAP rm = route_map_name NEWLINE
+  routing_instance_v4 ROUTE_MAP mapname = route_map_name NEWLINE
 ;
 
 ro_router_id

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -92,6 +92,8 @@ import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.MONI
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.NTP_SOURCE_INTERFACE;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.NVE_SELF_REFERENCE;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.NVE_SOURCE_INTERFACE;
+import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.OSPF_REDISTRIBUTE_INSTANCE;
+import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.OSPF_REDISTRIBUTE_ROUTE_MAP;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.ROUTER_EIGRP_SELF_REFERENCE;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.ROUTE_MAP_CONTINUE;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.ROUTE_MAP_MATCH_AS_PATH;
@@ -456,8 +458,7 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Roa_filter_listContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Roa_nssaContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Roa_rangeContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Roa_stubContext;
-import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ror_directContext;
-import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ror_staticContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ror_redistribute_route_mapContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rot_lsa_arrivalContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rot_lsa_group_pacingContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Rott_lsaContext;
@@ -2104,13 +2105,23 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
-  public void exitRor_direct(Ror_directContext ctx) {
-    toString(ctx, ctx.rm).ifPresent(_currentOspfProcess::setRedistributeDirectRouteMap);
-  }
-
-  @Override
-  public void exitRor_static(Ror_staticContext ctx) {
-    toString(ctx, ctx.rm).ifPresent(_currentOspfProcess::setRedistributeStaticRouteMap);
+  public void exitRor_redistribute_route_map(Ror_redistribute_route_mapContext ctx) {
+    Optional<RoutingProtocolInstance> rpiOrError =
+        toRoutingProtocolInstance(ctx, ctx.routing_instance_v4());
+    Optional<String> mapOrError = toString(ctx, ctx.route_map_name());
+    if (!rpiOrError.isPresent() || !mapOrError.isPresent()) {
+      return;
+    }
+    RoutingProtocolInstance rpi = rpiOrError.get();
+    String map = mapOrError.get();
+    Optional<CiscoNxosStructureType> type = rpi.getProtocol().getRouterStructureType();
+    if (rpi.getTag() != null && type.isPresent()) {
+      _configuration.referenceStructure(
+          type.get(), rpi.getTag(), OSPF_REDISTRIBUTE_INSTANCE, ctx.getStart().getLine());
+    }
+    _configuration.referenceStructure(
+        ROUTE_MAP, map, OSPF_REDISTRIBUTE_ROUTE_MAP, ctx.getStart().getLine());
+    _currentOspfProcess.setRedistributionPolicy(rpi, map);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1457,7 +1457,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
         CiscoNxosStructureUsage.BGP_UNSUPPRESS_MAP,
         CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_ROUTE_MAP,
         CiscoNxosStructureUsage.OSPF_AREA_FILTER_LIST_IN,
-        CiscoNxosStructureUsage.OSPF_AREA_FILTER_LIST_OUT);
+        CiscoNxosStructureUsage.OSPF_AREA_FILTER_LIST_OUT,
+        CiscoNxosStructureUsage.OSPF_REDISTRIBUTE_ROUTE_MAP);
     markConcreteStructure(
         CiscoNxosStructureType.ROUTE_MAP_ENTRY, CiscoNxosStructureUsage.ROUTE_MAP_CONTINUE);
     markConcreteStructure(
@@ -1465,16 +1466,20 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
         CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE,
         CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE,
         CiscoNxosStructureUsage.INTERFACE_IP_ROUTER_EIGRP,
+        CiscoNxosStructureUsage.OSPF_REDISTRIBUTE_INSTANCE,
         CiscoNxosStructureUsage.ROUTER_EIGRP_SELF_REFERENCE);
+
     markConcreteStructure(
         CiscoNxosStructureType.ROUTER_ISIS,
         CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE,
-        CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE);
+        CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE,
+        CiscoNxosStructureUsage.OSPF_REDISTRIBUTE_INSTANCE);
     markConcreteStructure(
         CiscoNxosStructureType.ROUTER_OSPF,
         CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE,
         CiscoNxosStructureUsage.INTERFACE_IP_ROUTER_OSPF,
-        CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE);
+        CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE,
+        CiscoNxosStructureUsage.OSPF_REDISTRIBUTE_INSTANCE);
     markConcreteStructure(
         CiscoNxosStructureType.ROUTER_OSPFV3,
         CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE,
@@ -1482,7 +1487,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     markConcreteStructure(
         CiscoNxosStructureType.ROUTER_RIP,
         CiscoNxosStructureUsage.BGP_REDISTRIBUTE_INSTANCE,
-        CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE);
+        CiscoNxosStructureUsage.EIGRP_REDISTRIBUTE_INSTANCE,
+        CiscoNxosStructureUsage.OSPF_REDISTRIBUTE_INSTANCE);
     markConcreteStructure(
         CiscoNxosStructureType.BGP_TEMPLATE_PEER,
         CiscoNxosStructureUsage.BGP_NEIGHBOR_INHERIT_PEER);
@@ -2158,7 +2164,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     OspfDefaultOriginate defaultOriginate = proc.getDefaultOriginate();
 
     // First try redistributing static routes, which may include default route
-    Optional.ofNullable(proc.getRedistributeStaticRouteMap())
+    Optional.ofNullable(proc.getRedistributionPolicy(RoutingProtocolInstance.staticc()))
+        .map(RedistributionPolicy::getRouteMap)
         .filter(_c.getRoutingPolicies()::containsKey)
         .ifPresent(
             routeMapName -> {
@@ -2200,7 +2207,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
       exportStatementsBuilder.add(new If(guard, defaultOriginateStatements.build()));
     }
     // Then try remaining redistribution policies
-    Optional.ofNullable(proc.getRedistributeDirectRouteMap())
+    Optional.ofNullable(proc.getRedistributionPolicy(RoutingProtocolInstance.direct()))
+        .map(RedistributionPolicy::getRouteMap)
         .filter(_c.getRoutingPolicies()::containsKey)
         .ifPresent(
             routeMapName -> {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureUsage.java
@@ -69,6 +69,8 @@ public enum CiscoNxosStructureUsage implements StructureUsage {
   NVE_SOURCE_INTERFACE("interface nve source-interface"),
   OSPF_AREA_FILTER_LIST_IN("router ospf area filter-list in"),
   OSPF_AREA_FILTER_LIST_OUT("router ospf area filter-list out"),
+  OSPF_REDISTRIBUTE_INSTANCE("ospf redistribute"),
+  OSPF_REDISTRIBUTE_ROUTE_MAP("ospf redistribute route-map"),
   ROUTE_MAP_CONTINUE("route-map continue"),
   ROUTE_MAP_MATCH_AS_PATH("route-map match as-path"),
   ROUTE_MAP_MATCH_COMMUNITY("route-map match community"),

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/OspfProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/OspfProcess.java
@@ -1,7 +1,9 @@
 package org.batfish.representation.cisco_nxos;
 
+import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -68,20 +70,28 @@ public abstract class OspfProcess implements Serializable {
     _passiveInterfaceDefault = passiveInterfaceDefault;
   }
 
-  public @Nullable String getRedistributeDirectRouteMap() {
-    return _redistributeDirectRouteMap;
+  /** Return all redistribution policies. */
+  public final @Nonnull List<RedistributionPolicy> getRedistributionPolicies() {
+    return ImmutableList.copyOf(_redistributionPolicies.values());
   }
 
-  public void setRedistributeDirectRouteMap(@Nullable String redistributeDirectRouteMap) {
-    _redistributeDirectRouteMap = redistributeDirectRouteMap;
+  /** Return all redistribution policies for the given protocol. */
+  public final @Nonnull List<RedistributionPolicy> getRedistributionPolicies(
+      NxosRoutingProtocol protocol) {
+    return _redistributionPolicies.values().stream()
+        .filter(rp -> rp.getInstance().getProtocol() == protocol)
+        .collect(ImmutableList.toImmutableList());
   }
 
-  public @Nullable String getRedistributeStaticRouteMap() {
-    return _redistributeStaticRouteMap;
+  /** Return the redistribution policy for the given instance, if one has been configured. */
+  public final @Nullable RedistributionPolicy getRedistributionPolicy(
+      RoutingProtocolInstance protocol) {
+    return _redistributionPolicies.get(protocol);
   }
 
-  public void setRedistributeStaticRouteMap(@Nullable String redistributeStaticRouteMap) {
-    _redistributeStaticRouteMap = redistributeStaticRouteMap;
+  /** Set the redistribution policy for the given instance. */
+  public final void setRedistributionPolicy(RoutingProtocolInstance instance, String routeMap) {
+    _redistributionPolicies.put(instance, new RedistributionPolicy(instance, routeMap));
   }
 
   public @Nullable Ip getRouterId() {
@@ -147,8 +157,7 @@ public abstract class OspfProcess implements Serializable {
   private @Nullable OspfMaxMetricRouterLsa _maxMetricRouterLsa;
   private final @Nonnull Map<IpWildcard, Long> _networks;
   private boolean _passiveInterfaceDefault;
-  private @Nullable String _redistributeDirectRouteMap;
-  private @Nullable String _redistributeStaticRouteMap;
+  private final Map<RoutingProtocolInstance, RedistributionPolicy> _redistributionPolicies;
   private @Nullable Ip _routerId;
   private final @Nonnull Map<Prefix, OspfSummaryAddress> _summaryAddresses;
   private int _timersLsaArrivalMbps;
@@ -161,6 +170,7 @@ public abstract class OspfProcess implements Serializable {
     _areas = new HashMap<>();
     _autoCostReferenceBandwidthMbps = DEFAULT_AUTO_COST_REFERENCE_BANDWIDTH_MBPS;
     _networks = new HashMap<>();
+    _redistributionPolicies = new HashMap<>();
     _summaryAddresses = new HashMap<>();
     _timersLsaArrivalMbps = DEFAULT_TIMERS_LSA_ARRIVAL_MS;
     _timersLsaGroupPacingS = DEFAULT_TIMERS_LSA_GROUP_PACING_S;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -4810,13 +4810,18 @@ public final class CiscoNxosGrammarTest {
     }
     {
       OspfProcess proc = vc.getOspfProcesses().get("r_direct");
-      assertThat(proc.getRedistributeDirectRouteMap(), equalTo("rm1"));
+      assertThat(proc.getRedistributionPolicies(), hasSize(1));
+      assertThat(
+          proc.getRedistributionPolicy(RoutingProtocolInstance.direct()),
+          equalTo(new RedistributionPolicy(RoutingProtocolInstance.direct(), "rm1")));
     }
     // TODO: extract and test redistribute maximum-prefix
     {
       OspfProcess proc = vc.getOspfProcesses().get("r_static");
-      assertThat(proc.getRedistributeStaticRouteMap(), equalTo("rm1"));
-      assertThat(proc.getRouterId(), nullValue());
+      assertThat(proc.getRedistributionPolicies(), hasSize(1));
+      assertThat(
+          proc.getRedistributionPolicy(RoutingProtocolInstance.staticc()),
+          equalTo(new RedistributionPolicy(RoutingProtocolInstance.staticc(), "rm1")));
     }
     {
       OspfProcess proc = vc.getOspfProcesses().get("router_id");


### PR DESCRIPTION
Adds back in reference tracking and support for more than just two hardcoded protocols.