### PR TITLE
NX-OS: no switchport grammar

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
@@ -461,6 +461,11 @@ BIFF
   'biff'
 ;
 
+BLOCK
+:
+  'block'
+;
+
 BOOT
 :
   'boot'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
@@ -749,7 +749,34 @@ i_no_shutdown
 
 i_no_switchport
 :
-  SWITCHPORT NEWLINE
+  SWITCHPORT
+  (
+    inos_access
+    | inos_block
+    | inos_host
+    | inos_switchport
+  )
+;
+
+inos_access
+:
+  ACCESS VLAN NEWLINE
+;
+
+inos_block
+:
+  BLOCK (MULTICAST | UNICAST) NEWLINE
+;
+
+inos_host
+:
+  HOST NEWLINE
+;
+
+inos_switchport
+:
+  // just newline, for `no switchport`
+  NEWLINE
 ;
 
 i_null

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -239,7 +239,6 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_mtuContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_no_autostateContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_no_descriptionContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_no_shutdownContext;
-import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_no_switchportContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_shutdownContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_speed_numberContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_switchport_accessContext;
@@ -277,6 +276,7 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Iipr_ospfContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Il_min_linksContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Inherit_sequence_numberContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Inoipo_passive_interfaceContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Inos_switchportContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Interface_addressContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Interface_bandwidth_kbpsContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Interface_descriptionContext;
@@ -4378,7 +4378,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
-  public void exitI_no_switchport(I_no_switchportContext ctx) {
+  public void exitInos_switchport(Inos_switchportContext ctx) {
     _currentInterfaces.forEach(iface -> iface.setSwitchportMode(SwitchportMode.NONE));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
@@ -19,10 +19,10 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Boot_nxosContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Boot_systemContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Cisco_nxos_configurationContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_ip_addressContext;
-import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_no_switchportContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_switchportContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_switchport_switchportContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.I_vrf_memberContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Inos_switchportContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.No_sysds_switchportContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.S_interface_regularContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.S_versionContext;
@@ -458,7 +458,7 @@ public final class CiscoNxosPreprocessor extends CiscoNxosParserBaseListener {
   }
 
   @Override
-  public void exitI_no_switchport(I_no_switchportContext ctx) {
+  public void exitInos_switchport(Inos_switchportContext ctx) {
     _currentInterfaceSwitchport = false;
     _currentInterfaceLayer3 = true;
   }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_properties
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_properties
@@ -91,4 +91,9 @@ interface Ethernet100/100
   storm-control multicast level 100.00
   storm-control unicast level 100.00
   no storm-control action
+  no switchport access vlan
+  no switchport block multicast
+  no switchport block unicast
+  no switchport host
+  no switchport
   no udld disable


### PR DESCRIPTION
Update preprocessor for renamed rules.