### PR TITLE
NXOS: Fix RDs for L2 VNIs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Vrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Vrf.java
@@ -12,6 +12,12 @@ import org.batfish.datamodel.Prefix;
 /** A virtual routing and forwarding instance. */
 public final class Vrf implements Serializable {
 
+  /**
+   * Offset used to compute Route Distinguisher for VNIs associated with MAC VRFs (L2 VNIs)
+   * https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/7-x/vxlan/configuration/guide/b_Cisco_Nexus_9000_Series_NX-OS_VXLAN_Configuration_Guide_7x/b_Cisco_Nexus_9000_Series_NX-OS_VXLAN_Configuration_Guide_7x_chapter_0100.html
+   */
+  public static final int MAC_VRF_OFFSET = 32767;
+
   public Vrf(String name, int id) {
     _name = name;
     _id = id;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -1066,14 +1066,14 @@ public final class CiscoNxosGrammarTest {
             Layer2VniConfig.builder()
                 .setVni(1111)
                 .setVrf(tenantVrfName)
-                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 3))
+                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 32768))
                 .setRouteTarget(ExtendedCommunity.target(1, 1111))
                 .setImportRouteTarget(ExtendedCommunity.target(1, 1111).matchString())
                 .build(),
             Layer2VniConfig.builder()
                 .setVni(2222)
                 .setVrf(DEFAULT_VRF_NAME)
-                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 1))
+                .setRouteDistinguisher(RouteDistinguisher.from(routerId, 32769))
                 .setRouteTarget(ExtendedCommunity.target(1, 2222))
                 .setImportRouteTarget(ExtendedCommunity.target(1, 2222).matchString())
                 .build());


### PR DESCRIPTION
Cisco says ([here](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/7-x/vxlan/configuration/guide/b_Cisco_Nexus_9000_Series_NX-OS_VXLAN_Configuration_Guide_7x/b_Cisco_Nexus_9000_Series_NX-OS_VXLAN_Configuration_Guide_7x_chapter_0100.html)) that route distinguisher for L2 VNIs should be a combination of Router ID and `32767 + VLAN number for the VNI` (and not the VRF ID)