### PR TITLE
Update specifier documentation to reference OSPF session status spec

### DIFF
--- a/questions/Parameters.md
+++ b/questions/Parameters.md
@@ -1,8 +1,8 @@
 ## Grammar for rich parameter types   
 
-Batfish questions support parameters with rich specifications for nodes, interfaces etc. The grammar for parameter types is described below. Before reading those grammars, we recommend reading the general notes. 
+Batfish questions support parameters with rich specifications for nodes, interfaces etc. The grammar for parameter types is described below. Before reading those grammars, we recommend reading the general notes.
 
-For many parameters types, there is a "resolver" question that may be used to learn what a given specification expands to. For instance, `resolveNodeSpecifier` is the resolver for `nodeSpec`, and `bfq.resolveNodeSpecifier(nodes="/bor/")` (Pybatfish syntax) will return the set of nodes that match `/bor/`. 
+For many parameters types, there is a "resolver" question that may be used to learn what a given specification expands to. For instance, `resolveNodeSpecifier` is the resolver for `nodeSpec`, and `bfq.resolveNodeSpecifier(nodes="/bor/")` (Pybatfish syntax) will return the set of nodes that match `/bor/`.
 
 * [`applicationSpec`](#application-specifier)
 
@@ -42,17 +42,19 @@ For many parameters types, there is a "resolver" question that may be used to le
 
 * [`ospfProcessPropertySpec`](#ospf-process-property-specifier)
 
+* [`ospfSessionStatusSpec`](#ospf-session-status-specifier)
+
 * [`routingProtocolSpec`](#routing-protocol-specifier)
 
 * [`routingPolicySpec`](#routing-policy-specifier)
 
 * [`vxlanVniPropertySpec`](#vxlan-vni-property-specifier)
 
-## General notes on the grammar 
+## General notes on the grammar
 
 * **Set operations:** Specifiers denote sets of entities (e.g., nodeSpec resolves to a set of nodes). In many cases, the grammar allows for union, intersection, and difference of such sets, respectively, using `,`, `&`, and `\`. Thus, `(node1, node2)\node1` will resolve to `node1`.
 
-* **Escaping names:** Names of entities such as nodes and interfaces must be double-quoted if they begin with a digit (0-9), double quote ('"'), or slash ('/'), or they contain a space or one of `,&()[]@!#$%^;?<>={}`. Thus, the following names are legal: 
+* **Escaping names:** Names of entities such as nodes and interfaces must be double-quoted if they begin with a digit (0-9), double quote ('"'), or slash ('/'), or they contain a space or one of `,&()[]@!#$%^;?<>={}`. Thus, the following names are legal:
   * `as1border1` (no quotes)
   * `as1-border1`
   * `"as1border1"` (quotes unnecessary, but OK)
@@ -74,7 +76,7 @@ Many types such as `applicationSpec` or `mlagIdSpec` are simply sets of values. 
 
 * `/val.*/` specifies a set whose values all match regex `val.*`.
 
-* `val1, val2` specifies a set with exactly those two values. 
+* `val1, val2` specifies a set with exactly those two values.
 
 * `! val1` specifies all values other than that value.
 
@@ -137,7 +139,7 @@ A BGP session compat status specifier follows the [enum set grammar](#set-of-enu
 
 A specification for a set of BGP session statuses.
 
-A BGP session status specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values: 
+A BGP session status specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values:
 
 * `NOT_COMPATIBLE` — the BGP session is not compatibly configured
 * `NOT_ESTABLISHED` — the BGP session configuration is compatible but the session was not established  
@@ -147,7 +149,7 @@ A BGP session status specifier follows the [enum set grammar](#set-of-enums-or-n
 
 A specification for a set of BGP session types.
 
-A BGP session type specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values: `IBGP`, `EBGP_SINGLEHOP`, `EBGP_MULTIHOP`, `EBGP_UNNUMBERED`, `IBGP_UNNUMBERED`, `UNSET`. 
+A BGP session type specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values: `IBGP`, `EBGP_SINGLEHOP`, `EBGP_MULTIHOP`, `EBGP_UNNUMBERED`, `IBGP_UNNUMBERED`, `UNSET`.
 
 ## Disposition Specifier
 
@@ -165,8 +167,8 @@ The following fine-grained disposition values are also supported:
 * Failure dispositions:
     * `Denied_in`: a flow was denied by an input filter (an ACL or a firewall rule) on an interface
     * `Denied_out`: a flow was denied by an output filter on an interface
-    * `No_route`: a flow was dropped because no matching route exists on device 
-    * `Null_routed`: a flow was dropped because it matched a `null` route 
+    * `No_route`: a flow was dropped because no matching route exists on device
+    * `Null_routed`: a flow was dropped because it matched a `null` route
     * `Neighbor_unreachable`: a flow was dropped because it could not reach the next hop (e.g., an ARP failure)
     * `Loop`: the flow encountered a forwarding loop
     * `Insufficient_info`: Batfish does not have enough information to make a determination with certainty (e.g., some device configs are missing)
@@ -181,7 +183,7 @@ A specification for filters (ACLs or firewall rules) in the network.
 
 * `@in(interfaceSpec)` refers to filters that get applied when packets enter the specified interfaces. For example, `@in(Ethernet0/0)` includes filters for incoming packets on interfaces named `Ethernet0/0` on all nodes.
 
-* `@out(interfaceSpec)` is similar except that it indicates filters that get applied when packets exit the specified interfaces. 
+* `@out(interfaceSpec)` is similar except that it indicates filters that get applied when packets exit the specified interfaces.
 
 #### Filter Specifier Grammar
 
@@ -191,10 +193,10 @@ filterSpec :=
 
 filterTerm :=
     filterWithNode
-    | filterWithoutNode 
+    | filterWithoutNode
     | <b>(</b>filterSpec<b>)</b>
 
-filterWithNode := 
+filterWithNode :=
     nodeTerm<b>[</b>filterWithoutNode<b>]</b>
 
 filterWithoutNode :=
@@ -244,10 +246,10 @@ interfaceSpec :=
 
 interfaceTerm :=
     interfaceWithNode
-    | interfaceWithoutNode 
+    | interfaceWithoutNode
     | <b>(</b>interfaceSpec<b>)</b>
 
-interfaceWithNode := 
+interfaceWithNode :=
     nodeTerm<b>[</b>interfaceWithoutNode<b>]</b>
 
 interfaceWithoutNode :=
@@ -276,14 +278,14 @@ A specification for a set of IP protocols.
 
 * IP protocol names from the list below, such as `TCP`,  may be used.
 
-* IP protocol numbers between 0 and 255 (inclusive), such as `6` to denote TCP, may be used. 
+* IP protocol numbers between 0 and 255 (inclusive), such as `6` to denote TCP, may be used.
 
 * A negation operator `!` may be used to denote all IP protocols other than the one specified. The semantics of negation is:
 
    * `!TCP` refers to all IP protocols other than TCP
    * `!TCP, !UDP` refers to all IP protocols other than TCP and UDP
-   * `TCP, !UDP` refers to TCP 
- 
+   * `TCP, !UDP` refers to TCP
+
 #### IP Protocol Specifier Grammar
 
 <pre>
@@ -294,7 +296,7 @@ ipProtocolTerm :=
     ipProtocol
     | <b>!</b>ipProtocol
 
-ipProtocol := 
+ipProtocol :=
     &lt;<i>ip-protocol-name</i>&gt;
     | &lt;<i>ip-protocol-number</i>&gt;
 </pre>
@@ -303,7 +305,7 @@ ipProtocol :=
 
 Batfish understands the following protocol names (with corresponding numbers in parenthesis): `AHP` (51), `AN` (107), `ANY_0_HOP_PROTOCOL` (114), `ANY_DISTRIBUTED_FILE_SYSTEM` (68), `ANY_HOST_INTERNAL_PROTOCOL` (61), `ANY_LOCAL_NETWORK` (63), `ANY_PRIVATE_ENCRYPTION_SCHEME` (99), `ARGUS` (13), `ARIS` (104), `AX25` (93), `BBN_RCC_MON` (10), `BNA` (49), `BR_SAT_MON` (76), `CBT` (7), `CFTP` (62), `CHAOS` (16), `COMPAQ_PEER` (110), `CPHB` (73), `CPNX` (72), `CRTP` (126), `CRUDP` (127), `DCCP` (33), `DCN_MEAS` (19), `DDP` (37), `DDX` (116), `DGP` (86), `EGP` (8), `EIGRP` (88), `EMCON` (14), `ENCAP` (98), `ESP` (50), `ETHERIP` (97), `FC` (133), `FIRE` (125), `GGP` (3), `GMTP` (100), `GRE` (47), `HIP` (139), `HMP` (20), `HOPOPT` (0), `I_NLSP` (52), `IATP` (117), `IPV6_ROUTE` (43), `IPX_IN_IP` (111), `IRTP` (28), `ISIS` (124), `ISO_IP` (80), `ISO_TP4` (29), `KRYPTOLAN` (65), `L2TP` (115), `LARP` (91), `LEAF1` (25), `LEAF2` (26), `MANAET` (138), `MERIT_INP` (32), `MFE_NSP` (31), `MHRP` (48), `MICP` (95), `MOBILE` (55), `MOBILITY` (135), `MPLS_IN_IP` (137), `MTP` (92), `MUX` (18), `NARP` (54), `NETBLT` (30), `NSFNET_IGP` (85), `NVPII` (11), `OSPF` (89), `PGM` (113), `PIM` (103), `PIPE` (131), `PNNI` (102), `PRM` (21), `PTP` (123), `PUP` (12), `PVP` (75), `QNX` (106), `RDP` (27), `ROHC` (142), `RSVP` (46), `RSVP_E2E_IGNORE` (134), `RVD` (66), `SAT_EXPAK` (64), `SAT_MON` (69), `SCC_SP` (96), `SCPS` (105), `SCTP` (132), `SDRP` (42), `SECURE_VMTP` (82), `SHIM6` (140), `SKIP` (57), `SM` (122), `SMP` (121), `SNP` (109), `SPRITE_RPC` (90), `SPS` (130), `SRP` (119), `SSCOPMCE` (128), `ST` (5), `STP` (118), `SUN_ND` (77), `SWIPE` (53), `TCF` (87), `TCP` (6), `THREE_PC` (34), `TLSP` (56), `TPPLUSPLUS` (39), `TRUNK1` (23), `TRUNK2` (24), `TTP` (84), `UDP` (17), `UDP_LITE` (136), `UTI` (120), `VINES` (83), `VISA` (70), `VMTP` (81), `VRRP` (112), `WB_EXPAK` (79), `WB_MON` (78), `WESP` (141), `WSN` (74), `XNET` (15), `XNS_IDP` (22), `XTP` (36).
 
-In addition, a special name `IP` may be used to denote all IP protocols. 
+In addition, a special name `IP` may be used to denote all IP protocols.
 
 
 ## IP Specifier
@@ -337,7 +339,7 @@ ipTerm :=
 
 ## IPSec Session Status Specifier
 
- An IPSec session status specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values:   `IPSEC_SESSION_ESTABLISHED`, `IKE_PHASE1_FAILED`, `IKE_PHASE1_KEY_MISMATCH`, `IPSEC_PHASE2_FAILED`, `MISSING_END_POINT`. 
+ An IPSec session status specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values:   `IPSEC_SESSION_ESTABLISHED`, `IKE_PHASE1_FAILED`, `IKE_PHASE1_KEY_MISMATCH`, `IPSEC_PHASE2_FAILED`, `MISSING_END_POINT`.
 
 ## Location Specifier
 
@@ -347,7 +349,7 @@ There are two types of locations:
 * `InterfaceLocation`: at the interface, used to model packets that originate or terminate at the interface
 * `InterfaceLinkLocation`: on the link connected to the interface, used to model packets before they enter the interface or after they exit
 
-Unless expilcitly specified, questions like `traceroute` and `reachability` will automatically assign IP addresses to packets based on their location. For `InterfaceLocation`, the set of assigned addresses is the interface address(es). This set is empty for interfaces that do not have an assigned address. For `InterfaceLinkLocation`, the set of assigned addresses corresponds to what (hypothetical) hosts attached to that interface can have, which includes all addresses in the subnet except for the address of the interface and the first and last addresses of the subnet. This set is empty for interface subnets that are `/30` or longer (e.g., loopback interfaces). 
+Unless expilcitly specified, questions like `traceroute` and `reachability` will automatically assign IP addresses to packets based on their location. For `InterfaceLocation`, the set of assigned addresses is the interface address(es). This set is empty for interfaces that do not have an assigned address. For `InterfaceLinkLocation`, the set of assigned addresses corresponds to what (hypothetical) hosts attached to that interface can have, which includes all addresses in the subnet except for the address of the interface and the first and last addresses of the subnet. This set is empty for interface subnets that are `/30` or longer (e.g., loopback interfaces).
 
 Locations for which Batfish cannot automatically assign a viable IP are ignored. To force their consideration, explicit source IPs must be specified.
 
@@ -359,7 +361,7 @@ Some examples:
 
 * `@vrf(vrf1)` specifies the `InterfaceLocation` for any interface in `vrf1` on *all* nodes. Any `interfaceFunc` can be used as a location specifier.
 
-* `@enter(as1border1[Ethernet0/0])` specifies the `InterfaceLinkLocation` for packets entering `Ethernet0/0` on `as1border1`. 
+* `@enter(as1border1[Ethernet0/0])` specifies the `InterfaceLinkLocation` for packets entering `Ethernet0/0` on `as1border1`.
 
 #### Location Specifier Grammar
 
@@ -381,18 +383,18 @@ locationInterface :=
 #### Location Specifier Resolver
 
 * `resolveLocationSpecifier` shows the set of locations represented by the given input.
-* `resolveIpsOfLocationSpecifier` shows the mapping from locations to IPs that will be used in `traceroute` and   `reachability` questions when IPs are not explicitly specified. 
+* `resolveIpsOfLocationSpecifier` shows the mapping from locations to IPs that will be used in `traceroute` and   `reachability` questions when IPs are not explicitly specified.
 
 
 ## MLAG ID Specifier
 
 A specification for a set of MLAG domain identifiers.
 
-An MLAG ID specifier follows the [enum set grammar](#set-of-enums-or-names) over the domain ID values that appear in the snapshot. 
+An MLAG ID specifier follows the [enum set grammar](#set-of-enums-or-names) over the domain ID values that appear in the snapshot.
 
 ## Named Structure Specifier
 
-A specification for a set of structure types in Batfish's vendor independent model. 
+A specification for a set of structure types in Batfish's vendor independent model.
 
 A named structure specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values: `AS_PATH_ACCESS_LIST`, `AUTHENTICATION_KEY_CHAIN`, `COMMUNITY_LIST`, `IKE_PHASE1_KEYS`, `IKE_PHASE1_POLICIES`, `IKE_PHASE1_PROPOSALS`, `IP_ACCESS_LIST`, `IP_6_ACCESS_LIST`, `IPSEC_PEER_CONFIGS`, `IPSEC_PHASE2_POLICIES`, `IPSEC_PHASE2_PROPOSALS`, `PBR_POLICY`, `ROUTE_FILTER_LIST`, `ROUTE_6_FILTER_LIST`, `ROUTING_POLICY`, `VRF`, `ZONE`.
 
@@ -401,7 +403,7 @@ A named structure specifier follows the [enum set grammar](#set-of-enums-or-name
 
 A specification for a set of node-level properties (e.g., those returned by the `nodeProperties` question).
 
-A node property specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values: `AS_Path_Access_Lists`, `Authentication_Key_Chains`, `Canonical_IP`, `Community_Lists`, `Configuration_Format`, `Default_Cross_Zone_Action`, `Default_Inbound_Action`, `Device_Type`, `DNS_Servers`, `DNS_Source_Interface`, `Domain_Name`, `Hostname`, `IKE_Phase1_Keys`, `IKE_Phase1_Policies`, `IKE_Phase1_Proposals`, `Interfaces`, `IP_Access_Lists`, `IP_Spaces`, `IP6_Access_Lists`, `IPsec_Peer_Configs`, `IPsec_Phase2_Policies`, `IPsec_Phase2_Proposals`, `IPSec_Vpns`, `Logging_Servers`, `Logging_Source_Interface`, `NTP_Servers`, `NTP_Source_Interface`, `PBR_Policies`, `Route_Filter_Lists`, `Route6_Filter_Lists`, `Routing_Policies`, `SNMP_Source_Interface`, `SNMP_Trap_Servers`, `TACACS_Servers`, `TACACS_Source_Interface`, `Vendor_Family`, `VRFs`, `Zones`. 
+A node property specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values: `AS_Path_Access_Lists`, `Authentication_Key_Chains`, `Canonical_IP`, `Community_Lists`, `Configuration_Format`, `Default_Cross_Zone_Action`, `Default_Inbound_Action`, `Device_Type`, `DNS_Servers`, `DNS_Source_Interface`, `Domain_Name`, `Hostname`, `IKE_Phase1_Keys`, `IKE_Phase1_Policies`, `IKE_Phase1_Proposals`, `Interfaces`, `IP_Access_Lists`, `IP_Spaces`, `IP6_Access_Lists`, `IPsec_Peer_Configs`, `IPsec_Phase2_Policies`, `IPsec_Phase2_Proposals`, `IPSec_Vpns`, `Logging_Servers`, `Logging_Source_Interface`, `NTP_Servers`, `NTP_Source_Interface`, `PBR_Policies`, `Route_Filter_Lists`, `Route6_Filter_Lists`, `Routing_Policies`, `SNMP_Source_Interface`, `SNMP_Trap_Servers`, `TACACS_Servers`, `TACACS_Source_Interface`, `Vendor_Family`, `VRFs`, `Zones`.
 
 
 ## Node Specifier
@@ -439,8 +441,8 @@ nodeFunc :=
 
 Batfish has the following device types.
 
-* `Host`: An end host. 
-* `Internet`: A logical device that represents the Internet. It is present when external connectivity is modeled. 
+* `Host`: An end host.
+* `Internet`: A logical device that represents the Internet. It is present when external connectivity is modeled.
 * `ISP`: A logical devie that represents a neighboring ISP. It is present when external connectivity is modeled.
 * `Router`: A device that does L3 routing and forwarding.
 * `Switch`: A device that only does L2 forwarding.
@@ -456,6 +458,12 @@ An OSPF interface property specifier follows the [enum set grammar](#set-of-enum
 A specification for a set of OSPF process properties.
 
 An OSPF process property specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values: `AREA_BORDER_ROUTER`, `AREAS`, `EXPORT_POLICY_SOURCES`, `REFERENCE_BANDWIDTH`, `RFC_1583_COMPATIBLE`, `ROUTER_ID`.
+
+## OSPF Session Status Specifier
+
+A specification for a set of OSPF session statuses.
+
+An OSPF session status specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values: `AREA_INVALID`, `AREA_MISMATCH`, `AREA_TYPE_MISMATCH`, `DEAD_INTERVAL_MISMATCH`, `DUPLICATE_ROUTER_ID`, `ESTABLISHED`, `HELLO_INTERVAL_MISMATCH`, `MTU_MISMATCH`, `NETWORK_TYPE_MISMATCH`, `NO_SESSION`, `PASSIVE_MISMATCH`, `PROCESS_INVALID`, `UNKNOWN_COMPATIBILITY_ISSUE`.
 
 ## Routing Protocol Specifier
 
@@ -510,4 +518,4 @@ routingPolicyTerm :=
 
  A specification for a set of VXLAN VNI properties.
 
-A VXLAN VNI property specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values: `LOCAL_VTEP_IP`, `MULTICAST_GROUP`, `VLAN`, `VNI`, `VTEP_FLOOD_LIST`, `VXLAN_PORT`. 
+A VXLAN VNI property specifier follows the [enum set grammar](#set-of-enums-or-names) over the following values: `LOCAL_VTEP_IP`, `MULTICAST_GROUP`, `VLAN`, `VNI`, `VTEP_FLOOD_LIST`, `VXLAN_PORT`.


### PR DESCRIPTION
OSPF session status spec was added in https://github.com/batfish/batfish/pull/4694, update `Parameters.md` documentation to reference this.
