### PR TITLE
NX-OS: remove adaptive prediction from i_bandwidth

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
@@ -70,7 +70,7 @@ i_bandwidth
   BANDWIDTH
   (
     inherit = INHERIT bw = interface_bandwidth_kbps?
-    | inherit = INHERIT? bw = interface_bandwidth_kbps
+    | bw = interface_bandwidth_kbps
   ) NEWLINE
 ;
 


### PR DESCRIPTION
As before,

    a b?
    | a? b

replaced with

    a b?
    | b