### PR TITLE
DefinedStructureInfo: delete UNKNOWN_NUM_REFERRERS

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DefinedStructureInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DefinedStructureInfo.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -11,7 +12,6 @@ import javax.annotation.Nonnull;
 
 public class DefinedStructureInfo implements Serializable {
 
-  public static final int UNKNOWN_NUM_REFERRERS = -1;
   private static final String PROP_DEFINITION_LINES = "definitionLines";
   private static final String PROP_NUM_REFERRERS = "numReferrers";
 
@@ -22,8 +22,9 @@ public class DefinedStructureInfo implements Serializable {
   public DefinedStructureInfo(
       @JsonProperty(PROP_DEFINITION_LINES) SortedSet<Integer> definitionLines,
       @JsonProperty(PROP_NUM_REFERRERS) Integer numReferrers) {
+    checkArgument(numReferrers != null, "Missing %s", PROP_NUM_REFERRERS);
     _definitionLines = firstNonNull(definitionLines, new TreeSet<>());
-    _numReferrers = firstNonNull(numReferrers, UNKNOWN_NUM_REFERRERS);
+    _numReferrers = numReferrers;
   }
 
   @JsonProperty(PROP_DEFINITION_LINES)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -96,10 +96,10 @@ public abstract class VendorConfiguration implements Serializable, GenericConfig
           if (def == null) {
             byUsage.forEach(
                 (usage, lines) -> lines.forEach(line -> undefined(type, name, usage, line)));
-          } else if (def.getNumReferrers() != DefinedStructureInfo.UNKNOWN_NUM_REFERRERS) {
+          } else {
             int count = byUsage.values().stream().mapToInt(Multiset::size).sum();
             def.setNumReferrers(def.getNumReferrers() + count);
-          } // else leave as UNKNOWN_NUM_REFERRERS.
+          }
         });
   }
 
@@ -133,11 +133,7 @@ public abstract class VendorConfiguration implements Serializable, GenericConfig
             }
           } else {
             matchingStructures.forEach(
-                info ->
-                    info.setNumReferrers(
-                        info.getNumReferrers() == DefinedStructureInfo.UNKNOWN_NUM_REFERRERS
-                            ? DefinedStructureInfo.UNKNOWN_NUM_REFERRERS
-                            : info.getNumReferrers() + lines.size()));
+                info -> info.setNumReferrers(info.getNumReferrers() + lines.size()));
           }
         });
   }
@@ -260,11 +256,6 @@ public abstract class VendorConfiguration implements Serializable, GenericConfig
     DefinedStructureInfo info =
         byName.computeIfAbsent(name, k -> new DefinedStructureInfo(new TreeSet<>(), 0));
     info.getDefinitionLines().add(line);
-    if (info.getNumReferrers() == DefinedStructureInfo.UNKNOWN_NUM_REFERRERS
-        || numReferrers == DefinedStructureInfo.UNKNOWN_NUM_REFERRERS) {
-      info.setNumReferrers(DefinedStructureInfo.UNKNOWN_NUM_REFERRERS);
-    } else {
-      info.setNumReferrers(info.getNumReferrers() + numReferrers);
-    }
+    info.setNumReferrers(info.getNumReferrers() + numReferrers);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1266,10 +1266,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
 
             // Now update reference count if applicable
             if (info != null) {
-              info.setNumReferrers(
-                  info.getNumReferrers() == DefinedStructureInfo.UNKNOWN_NUM_REFERRERS
-                      ? DefinedStructureInfo.UNKNOWN_NUM_REFERRERS
-                      : info.getNumReferrers() + lines.size());
+              info.setNumReferrers(info.getNumReferrers() + lines.size());
             } else if (!ignoreUndefined) {
               for (int line : lines) {
                 undefined(type, name, usage, line);


### PR DESCRIPTION
This was used very early on, but now we always know the number.