### PR TITLE
Arista EOS 4.23 update VRF definition syntax

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoParser.g4
@@ -3414,10 +3414,12 @@ s_vrf_context
    )*
 ;
 
-// a way to define a VRF on IOS
+// a way to define a VRF on IOS or EOS
 s_vrf_definition
 :
-   VRF DEFINITION? name = variable NEWLINE
+   // DEFINITION is for IOS and older versions of EOS (pre-4.23)
+   // INSTANCE is for EOS 4.23 and later
+   VRF (DEFINITION | INSTANCE)? name = variable NEWLINE
    (
       vrfd_address_family
       | vrfd_description

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -5251,6 +5251,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void enterS_vrf_definition(S_vrf_definitionContext ctx) {
     _currentVrf = ctx.name.getText();
+    initVrf(_currentVrf);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -223,6 +223,7 @@ public class AristaGrammarTest {
     assertThat(vrf.getExportRouteTarget(), equalTo(ExtendedCommunity.target(1L, 1L)));
     assertThat(vrf.getImportRouteTarget(), equalTo(ExtendedCommunity.target(2L, 2L)));
     assertThat(vrf.getLocalAs(), equalTo(65000L));
+    assertThat(config.getVrfs(), hasKey("FOO"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_vrf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_vrf
@@ -8,3 +8,6 @@ router bgp 1
     route-target export 1:1
     route-target import 2:2
     local-as 65000
+
+
+vrf instance FOO

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -5170,6 +5170,9 @@
         "vrfs" : {
           "default" : {
             "name" : "default"
+          },
+          "vrf-foo1" : {
+            "name" : "vrf-foo1"
           }
         }
       },


### PR DESCRIPTION
Note: made a change to init the VRFs upon their definition.
The only ref change is for a cadant file (!) 