### PR TITLE
Arista: create BGP peers/neighbors declared inside address-family

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -2557,11 +2557,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void enterEos_rb_af_evpn_neighbor(Eos_rb_af_evpn_neighborContext ctx) {
     if (ctx.v4 != null) {
-      _currentAristaBgpNeighborAddressFamily =
-          _currentAristaBgpVrfAf.getOrCreateNeighbor(toIp(ctx.v4));
+      Ip address = toIp(ctx.v4);
+      _currentAristaBgpVrf.getOrCreateV4Neighbor(address); // ensure peer exists
+      _currentAristaBgpNeighborAddressFamily = _currentAristaBgpVrfAf.getOrCreateNeighbor(address);
     } else if (ctx.pg != null) {
-      _currentAristaBgpNeighborAddressFamily =
-          _currentAristaBgpVrfAf.getOrCreatePeerGroup(ctx.pg.getText());
+      String name = ctx.pg.getText();
+      _currentAristaBgpProcess.getOrCreatePeerGroup(name); // ensure peer exists
+      _currentAristaBgpNeighborAddressFamily = _currentAristaBgpVrfAf.getOrCreatePeerGroup(name);
     } else if (ctx.v6 != null) {
       _currentAristaBgpNeighborAddressFamily =
           _currentAristaBgpVrfAf.getOrCreateNeighbor(toIp6(ctx.v6));
@@ -2579,11 +2581,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void enterEos_rb_af_evpn_no_neighbor(Eos_rb_af_evpn_no_neighborContext ctx) {
     if (ctx.v4 != null) {
-      _currentAristaBgpNeighborAddressFamily =
-          _currentAristaBgpVrfAf.getOrCreateNeighbor(toIp(ctx.v4));
+      Ip address = toIp(ctx.v4);
+      _currentAristaBgpVrf.getOrCreateV4Neighbor(address); // ensure peer exists
+      _currentAristaBgpNeighborAddressFamily = _currentAristaBgpVrfAf.getOrCreateNeighbor(address);
     } else if (ctx.pg != null) {
-      _currentAristaBgpNeighborAddressFamily =
-          _currentAristaBgpVrfAf.getOrCreatePeerGroup(ctx.pg.getText());
+      String name = ctx.pg.getText();
+      _currentAristaBgpProcess.getOrCreatePeerGroup(name); // ensure peer exists
+      _currentAristaBgpNeighborAddressFamily = _currentAristaBgpVrfAf.getOrCreatePeerGroup(name);
     } else if (ctx.v6 != null) {
       _currentAristaBgpNeighborAddressFamily =
           _currentAristaBgpVrfAf.getOrCreateNeighbor(toIp6(ctx.v6));
@@ -2611,11 +2615,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void enterEos_rbafipv4u_neighbor(Eos_rbafipv4u_neighborContext ctx) {
     if (ctx.v4 != null) {
-      _currentAristaBgpNeighborAddressFamily =
-          _currentAristaBgpVrfAf.getOrCreateNeighbor(toIp(ctx.v4));
+      Ip address = toIp(ctx.v4);
+      _currentAristaBgpVrf.getOrCreateV4Neighbor(address); // ensure peer exists
+      _currentAristaBgpNeighborAddressFamily = _currentAristaBgpVrfAf.getOrCreateNeighbor(address);
     } else if (ctx.pg != null) {
-      _currentAristaBgpNeighborAddressFamily =
-          _currentAristaBgpVrfAf.getOrCreatePeerGroup(ctx.pg.getText());
+      String name = ctx.pg.getText();
+      _currentAristaBgpProcess.getOrCreatePeerGroup(name); // ensure peer exists
+      _currentAristaBgpNeighborAddressFamily = _currentAristaBgpVrfAf.getOrCreatePeerGroup(name);
     } else if (ctx.v6 != null) {
       _currentAristaBgpNeighborAddressFamily =
           _currentAristaBgpVrfAf.getOrCreateNeighbor(toIp6(ctx.v6));
@@ -2643,11 +2649,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void enterEos_rbafipv4_no_neighbor(Eos_rbafipv4_no_neighborContext ctx) {
     if (ctx.v4 != null) {
-      _currentAristaBgpNeighborAddressFamily =
-          _currentAristaBgpVrfAf.getOrCreateNeighbor(toIp(ctx.v4));
+      Ip address = toIp(ctx.v4);
+      _currentAristaBgpVrf.getOrCreateV4Neighbor(address); // ensure peer exists
+      _currentAristaBgpNeighborAddressFamily = _currentAristaBgpVrfAf.getOrCreateNeighbor(address);
     } else if (ctx.pg != null) {
-      _currentAristaBgpNeighborAddressFamily =
-          _currentAristaBgpVrfAf.getOrCreatePeerGroup(ctx.pg.getText());
+      String name = ctx.pg.getText();
+      _currentAristaBgpProcess.getOrCreatePeerGroup(name); // ensure peer exists
+      _currentAristaBgpNeighborAddressFamily = _currentAristaBgpVrfAf.getOrCreatePeerGroup(name);
     } else if (ctx.v6 != null) {
       _currentAristaBgpNeighborAddressFamily =
           _currentAristaBgpVrfAf.getOrCreateNeighbor(toIp6(ctx.v6));

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/eos/AristaBgpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/eos/AristaBgpProcess.java
@@ -33,6 +33,11 @@ public final class AristaBgpProcess implements Serializable {
   }
 
   @Nonnull
+  public AristaBgpPeerGroupNeighbor getOrCreatePeerGroup(String name) {
+    return _peerGroups.computeIfAbsent(name, AristaBgpPeerGroupNeighbor::new);
+  }
+
+  @Nonnull
   public Map<String, AristaBgpVlanAwareBundle> getVlanAwareBundles() {
     return _vlanAwareBundles;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/eos/AristaBgpVrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/eos/AristaBgpVrf.java
@@ -224,6 +224,11 @@ public final class AristaBgpVrf implements Serializable {
     return _v4neighbors;
   }
 
+  @Nonnull
+  public AristaBgpV4Neighbor getOrCreateV4Neighbor(Ip address) {
+    return _v4neighbors.computeIfAbsent(address, AristaBgpV4Neighbor::new);
+  }
+
   @Nullable
   public AristaBgpVrfIpv4UnicastAddressFamily getV4UnicastAf() {
     return _v4UnicastAf;

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -235,13 +235,14 @@ public class AristaGrammarTest {
   @Test
   public void testAddressFamilyExtraction() {
     CiscoConfiguration config = parseVendorConfig("arista_bgp_af");
-    AristaBgpVrfIpv4UnicastAddressFamily ipv4af =
-        config.getAristaBgp().getDefaultVrf().getV4UnicastAf();
+    AristaBgpVrf vrf = config.getAristaBgp().getDefaultVrf();
+    AristaBgpVrfIpv4UnicastAddressFamily ipv4af = vrf.getV4UnicastAf();
     assertThat(ipv4af, notNullValue());
     AristaBgpVrfEvpnAddressFamily evpnaf = config.getAristaBgp().getDefaultVrf().getEvpnAf();
     assertThat(evpnaf, notNullValue());
 
     {
+      assertThat(vrf.getV4neighbors(), hasKey(Ip.parse("1.1.1.1")));
       AristaBgpNeighborAddressFamily v4 = ipv4af.getNeighbor(Ip.parse("1.1.1.1"));
       assertThat(v4, notNullValue());
       assertThat(v4.getActivate(), equalTo(Boolean.TRUE));
@@ -250,6 +251,7 @@ public class AristaGrammarTest {
       assertThat(evpn.getActivate(), equalTo(Boolean.TRUE));
     }
     {
+      assertThat(vrf.getV4neighbors(), hasKey(Ip.parse("2.2.2.2")));
       AristaBgpNeighborAddressFamily v4 = ipv4af.getNeighbor(Ip.parse("2.2.2.2"));
       assertThat(v4, notNullValue());
       assertThat(v4.getActivate(), equalTo(Boolean.FALSE));
@@ -257,6 +259,7 @@ public class AristaGrammarTest {
       assertThat(evpn, nullValue());
     }
     {
+      assertThat(config.getAristaBgp().getPeerGroups(), hasKey("PG"));
       AristaBgpNeighborAddressFamily v4 = ipv4af.getPeerGroup("PG");
       assertThat(v4, nullValue());
       AristaBgpNeighborAddressFamily evpn = evpnaf.getPeerGroup("PG");


### PR DESCRIPTION
On a real device, this will cause them to be created at the appropriate vrf/global level.