### PR TITLE
Arista vxlan: do not default to multicast

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -4369,15 +4369,15 @@ public final class CiscoConfiguration extends VendorConfiguration {
     // Prefer VLAN-specific or general flood address (in that order) over multicast address
     SortedSet<Ip> bumTransportIps =
         firstNonNull(vxlan.getVlanFloodAddresses().get(vlan), vxlan.getFloodAddresses());
+
+    // default to unicast flooding unless specified otherwise
     BumTransportMethod bumTransportMethod = BumTransportMethod.UNICAST_FLOOD_GROUP;
 
-    if (bumTransportIps.isEmpty()) {
-      Ip multicastAddress = vxlan.getMulticastGroup();
-      bumTransportIps =
-          multicastAddress == null
-              ? ImmutableSortedSet.of()
-              : ImmutableSortedSet.of(multicastAddress);
+    // Check if multicast is enabled
+    Ip multicastAddress = vxlan.getMulticastGroup();
+    if (bumTransportIps.isEmpty() && multicastAddress != null) {
       bumTransportMethod = BumTransportMethod.MULTICAST_GROUP;
+      bumTransportIps = ImmutableSortedSet.of(multicastAddress);
     }
 
     return VniSettings.builder()

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -7,6 +7,7 @@ import static org.batfish.datamodel.matchers.VrfMatchers.hasName;
 import static org.batfish.grammar.cisco.CiscoCombinedParser.DEBUG_FLAG_USE_ARISTA_BGP;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
@@ -27,11 +28,13 @@ import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.common.util.CommonUtil;
 import org.batfish.config.Settings;
+import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.VniSettings;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.grammar.cisco.CiscoCombinedParser;
@@ -338,6 +341,16 @@ public class AristaGrammarTest {
   public void testVxlanExtraction() {
     CiscoConfiguration config = parseVendorConfig("arista_vxlan");
     assertThat(config.getEosVxlan().getVrfToVni(), hasEntry("TENANT", 10000));
+    assertThat(config.getEosVxlan().getVlanVnis(), hasEntry(1, 10001));
+  }
+
+  @Test
+  public void testVxlanConversion() throws IOException {
+    Configuration config = parseConfig("arista_vxlan");
+    VniSettings vniSettings = config.getDefaultVrf().getVniSettings().get(10001);
+    assertThat(
+        vniSettings.getBumTransportMethod(), equalTo(BumTransportMethod.UNICAST_FLOOD_GROUP));
+    assertThat(vniSettings.getBumTransportIps(), empty());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_vxlan
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_vxlan
@@ -4,3 +4,4 @@ hostname arista_vxlan
 !
 interface Vxlan1
   vxlan vrf TENANT vni 10000
+  vxlan vlan 1 vni 10001


### PR DESCRIPTION
Unless multicast is specified, no need to assume that's the default. 