### PR TITLE
NXOS: More permissive  line console stanza

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_line.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_line.g4
@@ -24,7 +24,7 @@ s_line
 line_console
 :
   CONSOLE NEWLINE
-  lc_exec_timeout
+  lc_exec_timeout?
 ;
 
 lc_exec_timeout

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_line.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_line.g4
@@ -24,7 +24,9 @@ s_line
 line_console
 :
   CONSOLE NEWLINE
-  lc_exec_timeout?
+  (
+    lc_exec_timeout
+  )*
 ;
 
 lc_exec_timeout

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_line
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_line
@@ -10,3 +10,7 @@ line console
 line vty
   exec-timeout 15
   access-class VTY_ACL in
+!
+line console
+line vty
+


### PR DESCRIPTION
`exec-timeout` is an optional statement after `line console` ([Cisco ref](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus5000/sw/fundamentals/521n11/b_5k_Fund_Config_521N11/b_5k_Fund_Config_521N11_chapter_0110.html))