### PR TITLE
Arista BGP: route map is not mandatory

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/AristaConversions.java
@@ -165,11 +165,6 @@ final class AristaConversions {
       @Nullable AristaEosVxlan vxlan,
       Warnings warnings) {
 
-    // Handle default activation for v4 unicast by auto-populating all PGs and v4 neighbors in it.
-    if (bgpVrf.getDefaultIpv4Unicast()) {
-      bgpVrf.getOrCreateV4UnicastAf();
-    }
-
     return bgpVrf.getV4neighbors().entrySet().stream()
         .peek(e -> e.getValue().inherit(bgpConfig, bgpVrf, warnings))
         .filter(e -> isActive(getTextDesc(e.getKey(), vrf), bgpVrf, e.getValue(), warnings))

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1969,6 +1969,10 @@ public final class CiscoConfiguration extends VendorConfiguration {
             : EXACT_PATH);
 
     // Process vrf-level address family configuration, such as export policy.
+    if (bgpVrf.getDefaultIpv4Unicast()) {
+      // Handle default activation for v4 unicast.
+      bgpVrf.getOrCreateV4UnicastAf();
+    }
     AristaBgpVrfIpv4UnicastAddressFamily ipv4af = bgpVrf.getV4UnicastAf();
 
     // Next we build up the BGP common export policy.
@@ -2137,7 +2141,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
                                 RoutingProtocol.IBGP,
                                 RoutingProtocol.AGGREGATE)),
                         bgpRedistributeWithEnvironmentExpr(
-                            _routeMaps.containsKey(networkConf.getRouteMap())
+                            networkConf.getRouteMap() != null
+                                    && _routeMaps.containsKey(networkConf.getRouteMap())
                                 ? new CallExpr(networkConf.getRouteMap())
                                 : BooleanExprs.TRUE,
                             OriginType.IGP));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_neighbors
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_neighbors
@@ -39,6 +39,8 @@ router bgp 1
   neighbor 3.3.3.3 remote-as 33
   no neighbor 3.3.3.3 enforce-first-as
 !
+  network 1.2.3.4/32
+!
   neighbor PARSE_ONLY bfd
   neighbor PARSE_ONLY maximum-routes 2222
   neighbor PARSE_ONLY maximum-routes 3333 warning-limit 3000


### PR DESCRIPTION
Fix a crash in that case.

Had to move a bunch of code around and update test substantially to get the coverage I needed.