### PR TITLE
Arista: more alternative syntax for EVPN

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Arista_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Arista_bgp.g4
@@ -907,6 +907,7 @@ eos_rbv_route_target
 :
   ROUTE_TARGET
   ( IMPORT | EXPORT )
+  EVPN?
   rt = route_target NEWLINE
 ;
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_evpn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_evpn
@@ -114,8 +114,9 @@ router bgp 65101
    !
    vrf Tenant_B_OPZone
       rd 192.168.255.3:50201
-      route-target import 50201:50201
-      route-target export 50201:50201
+      ! Alternative (older?) syntax where evpn token appears
+      route-target import evpn 50201:50201
+      route-target export evpn 50201:50201
       redistribute connected
    !
 !


### PR DESCRIPTION
Because you can say EVPN. Or skip it. You know, it's like, whatever. ❄️ 