### PR TITLE
Hotfix L3 VNI crash

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -531,7 +531,11 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
               Vrf vniVrf = _c.getVrfs().get(vniConfig.getVrf());
               assert vniVrf != null; // Invariant guaranteed by proper conversion
               VniSettings vniSettings = vniVrf.getVniSettings().get(vniConfig.getVni());
-              assert vniSettings != null; // Invariant guaranteed by proper conversion
+              // HOTFIX: skip missing L3 vnis (caused by arista)
+              //     assert vniSettings != null; // Invariant guaranteed by proper conversion
+              if (vniSettings == null) {
+                return;
+              }
               if (vniSettings.getSourceAddress() == null) {
                 return;
               }


### PR DESCRIPTION
Arista does not require L3 VNI -> VLAN mapping (unlike previous vendors) so need VI model changes. However, since we currently
do not do type5 routes for arista, hostfix until we tweak the VI model