### PR TITLE
Add next hop interface in route row attribute

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/routes/RouteRowAttribute.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RouteRowAttribute.java
@@ -24,6 +24,8 @@ import org.batfish.datamodel.Route;
 public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   @Nullable private final String _nextHop;
 
+  @Nullable private final String _nextHopInterface;
+
   @Nullable private final AsPath _asPath;
 
   @Nullable private final Integer _adminDistance;
@@ -40,6 +42,7 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
 
   private RouteRowAttribute(
       String nextHop,
+      String nextHopInterface,
       Integer adminDistance,
       Long metric,
       AsPath asPath,
@@ -48,6 +51,7 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
       String originalProtocol,
       Long tag) {
     _nextHop = nextHop;
+    _nextHopInterface = nextHopInterface;
     _adminDistance = adminDistance;
     _metric = metric;
     _asPath = asPath;
@@ -88,6 +92,11 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   }
 
   @Nullable
+  public String getNextHopInterface() {
+    return _nextHopInterface;
+  }
+
+  @Nullable
   public String getOriginProtocol() {
     return _originProtocol;
   }
@@ -103,6 +112,7 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
 
   private static final Comparator<RouteRowAttribute> COMPARATOR =
       comparing(RouteRowAttribute::getNextHop, nullsLast(String::compareTo))
+          .thenComparing(RouteRowAttribute::getNextHopInterface, nullsLast(String::compareTo))
           .thenComparing(RouteRowAttribute::getAdminDistance, nullsLast(Integer::compareTo))
           .thenComparing(RouteRowAttribute::getMetric, nullsLast(Long::compareTo))
           .thenComparing(RouteRowAttribute::getAsPath, nullsLast(AsPath::compareTo))
@@ -128,6 +138,7 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
     }
     RouteRowAttribute that = (RouteRowAttribute) o;
     return Objects.equals(_nextHop, that._nextHop)
+        && Objects.equals(_nextHopInterface, that._nextHopInterface)
         && Objects.equals(_adminDistance, that._adminDistance)
         && Objects.equals(_metric, that._metric)
         && Objects.equals(_asPath, that._asPath)
@@ -141,6 +152,7 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   public int hashCode() {
     return Objects.hash(
         _nextHop,
+        _nextHopInterface,
         _adminDistance,
         _metric,
         _asPath,
@@ -153,6 +165,8 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
   /** Builder for {@link RouteRowAttribute} */
   public static final class Builder {
     @Nullable private String _nextHop;
+
+    @Nullable private String _nextHopInterface;
 
     @Nullable private Integer _adminDistance;
 
@@ -174,6 +188,7 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
       }
       return new RouteRowAttribute(
           _nextHop,
+          _nextHopInterface,
           _adminDistance,
           _metric,
           _asPath,
@@ -215,6 +230,11 @@ public class RouteRowAttribute implements Comparable<RouteRowAttribute> {
 
     public Builder setNextHop(String nextHop) {
       _nextHop = nextHop;
+      return this;
+    }
+
+    public Builder setNextHopInterface(String nextHopInterface) {
+      _nextHopInterface = nextHopInterface;
       return this;
     }
 

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
@@ -597,6 +597,7 @@ public class RoutesAnswererUtil {
                                         RouteRowAttribute.builder()
                                             .setNextHop(
                                                 computeNextHopNode(route.getNextHopIp(), ipOwners))
+                                            .setNextHopInterface(route.getNextHopInterface())
                                             .setAdminDistance(route.getAdministrativeCost())
                                             .setMetric(route.getMetric())
                                             .setTag(route.getTag())

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
@@ -64,6 +64,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.OspfExternalType2Route;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
@@ -504,10 +505,18 @@ public class RoutesAnswererUtilTest {
         ImmutableMap.of(
             new RouteRowSecondaryKey(Ip.parse("1.1.1.2"), "ospfE2"),
             ImmutableSortedSet.of(
-                RouteRowAttribute.builder().setAdminDistance(10).setMetric(30L).build()),
+                RouteRowAttribute.builder()
+                    .setAdminDistance(10)
+                    .setMetric(30L)
+                    .setNextHopInterface(Route.UNSET_NEXT_HOP_INTERFACE)
+                    .build()),
             new RouteRowSecondaryKey(Ip.parse("1.1.1.3"), "ospfE2"),
             ImmutableSortedSet.of(
-                RouteRowAttribute.builder().setAdminDistance(10).setMetric(20L).build()));
+                RouteRowAttribute.builder()
+                    .setAdminDistance(10)
+                    .setMetric(20L)
+                    .setNextHopInterface(Route.UNSET_NEXT_HOP_INTERFACE)
+                    .build()));
     // matching the secondary key
     assertThat(innerGroup, equalTo(expectedInnerMap));
   }


### PR DESCRIPTION
- this will avoid collapsing attribute changes when the only change is for next hop interface