### PR TITLE
PAN: distinguish interfaces in no virtual-router

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -54,6 +54,7 @@ import org.batfish.datamodel.DefinedStructureInfo;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.InterfaceType;
@@ -65,6 +66,7 @@ import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceMetadata;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
@@ -1151,6 +1153,10 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
           // This is a parent interface. We can't shut it down, so instead we must just clear L2/L3
           // data.
           boolean warn = false;
+          if (iface.getAccessVlan() != null) {
+            warn = true;
+            iface.setAccessVlan(null);
+          }
           if (iface.getAddress() != null) {
             warn = true;
             iface.setAddress(null);
@@ -1159,9 +1165,13 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
             warn = true;
             iface.setAllAddresses(ImmutableSortedSet.of());
           }
-          if (iface.getVlan() != null) {
+          if (!iface.getAllowedVlans().isEmpty()) {
             warn = true;
-            iface.setVlan(null);
+            iface.setAllowedVlans(IntegerSpace.EMPTY);
+          }
+          if (iface.getSwitchportMode() != SwitchportMode.NONE) {
+            warn = true;
+            iface.setSwitchportMode(SwitchportMode.NONE);
           }
           // Only warn if some L2/L3 data actually set.
           if (warn) {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-units
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-units
@@ -5,3 +5,4 @@ set network interface ethernet ethernet1/1 layer3 units ethernet1/1.1 ip 1.1.1.1
 set network interface ethernet ethernet1/1 layer3 units ethernet1/1.2 tag 2
 set network interface ethernet ethernet1/1 layer3 units ethernet1/1.2 ip 1.1.2.1/24
 set network interface ethernet ethernet1/1 layer3 units ethernet1/1.2 mtu 1234
+set network virtual-router VR interface [ ethernet1/1.1 ethernet1/1.2 ]

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -30229,7 +30229,7 @@
         "interfaces" : {
           "ethernet1/1" : {
             "name" : "ethernet1/1",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -30293,7 +30293,7 @@
           },
           "loopback" : {
             "name" : "loopback",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -30334,7 +30334,7 @@
           },
           "tunnel" : {
             "name" : "tunnel",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -30375,7 +30375,7 @@
           },
           "vlan" : {
             "name" : "vlan",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -30572,7 +30572,7 @@
         "interfaces" : {
           "ethernet1/1" : {
             "name" : "ethernet1/1",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -30592,7 +30592,7 @@
           },
           "ethernet1/2" : {
             "name" : "ethernet1/2",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -30619,7 +30619,7 @@
           },
           "ethernet1/3" : {
             "name" : "ethernet1/3",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
@@ -30639,7 +30639,7 @@
           },
           "ethernet1/4" : {
             "name" : "ethernet1/4",
-            "active" : false,
+            "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -77204,7 +77204,7 @@
         "paloalto_applications" : "PASSED",
         "paloalto_interfaces" : "WARNINGS",
         "paloalto_policy" : "PASSED",
-        "paloalto_zones" : "WARNINGS",
+        "paloalto_zones" : "PASSED",
         "pim" : "PASSED",
         "pim_snooping" : "PASSED",
         "prefix_list_ipv4" : "PASSED",
@@ -93763,10 +93763,6 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/1 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
               "text" : "Interface ethernet1/1.4 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
             },
             {
@@ -93775,15 +93771,7 @@
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface loopback is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
               "text" : "Interface loopback.1 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface tunnel is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
             },
             {
               "tag" : "MISCELLANEOUS",
@@ -93791,31 +93779,7 @@
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Interface vlan is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
               "text" : "Interface vlan.1 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            }
-          ]
-        },
-        "paloalto_zones" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/1 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/2 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/3 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface ethernet1/4 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
             }
           ]
         },


### PR DESCRIPTION
Parents are left up but have L2/L3 data cleared.
Children are just shut down.