### PR TITLE
add interfaceLinkOwnedIps to specifier context

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
@@ -51,7 +51,7 @@ public interface SpecifierContext {
 
   /**
    * @return the {@link IpSpace}s owned by the link connected to each interface in the network.
-   * Mapping: hostname -&gt; interface name -&gt; IpSpace.
+   *     Mapping: hostname -&gt; interface name -&gt; IpSpace.
    */
   @Nonnull
   Map<String, Map<String, IpSpace>> getInterfaceLinkOwnedIps();
@@ -68,7 +68,4 @@ public interface SpecifierContext {
         .getOrDefault(hostname, ImmutableMap.of())
         .getOrDefault(iface, EmptyIpSpace.INSTANCE);
   }
-
-  /** @return the {@link IpSpace} of IP addresses owned any device in the network. */
-  IpSpace getSnapshotDeviceOwnedIps();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
@@ -1,12 +1,10 @@
 package org.batfish.specifier;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.referencelibrary.ReferenceBook;
 import org.batfish.role.NodeRoleDimension;
@@ -31,10 +29,13 @@ public interface SpecifierContext {
   Optional<NodeRoleDimension> getNodeRoleDimension(@Nullable String dimension);
 
   /**
-   * @return the {@link IpSpace}s owned by each interface in the network. Mapping: hostname -&gt;
-   *     interface name -&gt; IpSpace.
+   * Get the {@link IpSpace} owned by the input interface.
+   *
+   * @param hostname The node the interface belongs to.
+   * @param iface The name of the interface.
+   * @return The {@link IpSpace} owned by the interface.
    */
-  Map<String, Map<String, IpSpace>> getInterfaceOwnedIps();
+  IpSpace getInterfaceOwnedIps(String hostname, String iface);
 
   /**
    * Get the {@link IpSpace} owned by the input interface.
@@ -43,29 +44,5 @@ public interface SpecifierContext {
    * @param iface The name of the interface.
    * @return The {@link IpSpace} owned by the interface.
    */
-  default IpSpace getInterfaceOwnedIps(String hostname, String iface) {
-    return getInterfaceOwnedIps()
-        .getOrDefault(hostname, ImmutableMap.of())
-        .getOrDefault(iface, EmptyIpSpace.INSTANCE);
-  }
-
-  /**
-   * @return the {@link IpSpace}s owned by the link connected to each interface in the network.
-   *     Mapping: hostname -&gt; interface name -&gt; IpSpace.
-   */
-  @Nonnull
-  Map<String, Map<String, IpSpace>> getInterfaceLinkOwnedIps();
-
-  /**
-   * Get the {@link IpSpace} owned by the input interface.
-   *
-   * @param hostname The node the interface belongs to.
-   * @param iface The name of the interface.
-   * @return The {@link IpSpace} owned by the interface.
-   */
-  default IpSpace getInterfaceLinkOwnedIps(String hostname, String iface) {
-    return getInterfaceLinkOwnedIps()
-        .getOrDefault(hostname, ImmutableMap.of())
-        .getOrDefault(iface, EmptyIpSpace.INSTANCE);
-  }
+  IpSpace getInterfaceLinkOwnedIps(String hostname, String iface);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
@@ -49,6 +49,26 @@ public interface SpecifierContext {
         .getOrDefault(iface, EmptyIpSpace.INSTANCE);
   }
 
+  /**
+   * @return the {@link IpSpace}s owned by the link connected to each interface in the network.
+   * Mapping: hostname -&gt; interface name -&gt; IpSpace.
+   */
+  @Nonnull
+  Map<String, Map<String, IpSpace>> getInterfaceLinkOwnedIps();
+
+  /**
+   * Get the {@link IpSpace} owned by the input interface.
+   *
+   * @param hostname The node the interface belongs to.
+   * @param iface The name of the interface.
+   * @return The {@link IpSpace} owned by the interface.
+   */
+  default IpSpace getInterfaceLinkOwnedIps(String hostname, String iface) {
+    return getInterfaceLinkOwnedIps()
+        .getOrDefault(hostname, ImmutableMap.of())
+        .getOrDefault(iface, EmptyIpSpace.INSTANCE);
+  }
+
   /** @return the {@link IpSpace} of IP addresses owned any device in the network. */
   IpSpace getSnapshotDeviceOwnedIps();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContextImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContextImpl.java
@@ -10,16 +10,13 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.common.topology.IpOwners;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.ForwardingAnalysis;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.referencelibrary.ReferenceBook;
 import org.batfish.role.NodeRoleDimension;
@@ -34,26 +31,11 @@ public class SpecifierContextImpl implements SpecifierContext {
 
   private final @Nonnull Supplier<Map<String, Map<String, IpSpace>>> _interfaceLinkOwnedIps;
 
-  private final @Nonnull IpSpace _snapshotDeviceOwnedIps;
-
   public SpecifierContextImpl(@Nonnull IBatfish batfish, @Nonnull NetworkSnapshot networkSnapshot) {
     _batfish = batfish;
     _configs = _batfish.loadConfigurations(networkSnapshot);
-    IpOwners ipOwners = _batfish.getTopologyProvider().getIpOwners(networkSnapshot);
-
-    /* Include inactive interfaces here so their IPs are considered part of the network (even though
-     * they are unreachable). This means when ARP fails for those IPs we'll use NEIGHBOR_UNREACHABLE
-     * or INSUFFICIENT_INFO dispositions rather than DELIVERED_TO_SUBNET or EXITS_NETWORK.
-     */
-    _snapshotDeviceOwnedIps =
-        firstNonNull(
-            AclIpSpace.union(
-                ipOwners.getAllDeviceOwnedIps().keySet().stream()
-                    .map(Ip::toIpSpace)
-                    .collect(Collectors.toList())),
-            EmptyIpSpace.INSTANCE);
-
-    _interfaceOwnedIps = ipOwners.getInterfaceOwnedIpSpaces();
+    _interfaceOwnedIps =
+        _batfish.getTopologyProvider().getIpOwners(networkSnapshot).getInterfaceOwnedIpSpaces();
     _interfaceLinkOwnedIps = Suppliers.memoize(this::computeInterfaceLinkOwnedIps);
   }
 
@@ -127,13 +109,7 @@ public class SpecifierContextImpl implements SpecifierContext {
 
   @Nonnull
   @Override
-  public Map<String,Map<String, IpSpace>> getInterfaceLinkOwnedIps() {
+  public Map<String, Map<String, IpSpace>> getInterfaceLinkOwnedIps() {
     return _interfaceLinkOwnedIps.get();
-  }
-
-  @Override
-  @Nonnull
-  public IpSpace getSnapshotDeviceOwnedIps() {
-    return _snapshotDeviceOwnedIps;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledInputValidator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledInputValidator.java
@@ -15,7 +15,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.CompletionMetadata;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
-import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.answers.InputValidationNotes;
 import org.batfish.datamodel.answers.InputValidationNotes.Validity;
@@ -99,11 +98,6 @@ public final class ParboiledInputValidator {
     @Override
     public Map<String, Map<String, IpSpace>> getInterfaceLinkOwnedIps() {
       return ImmutableMap.of();
-    }
-
-    @Override
-    public IpSpace getSnapshotDeviceOwnedIps() {
-      return EmptyIpSpace.INSTANCE;
     }
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledInputValidator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledInputValidator.java
@@ -95,6 +95,12 @@ public final class ParboiledInputValidator {
       return ImmutableMap.of();
     }
 
+    @Nonnull
+    @Override
+    public Map<String, Map<String, IpSpace>> getInterfaceLinkOwnedIps() {
+      return ImmutableMap.of();
+    }
+
     @Override
     public IpSpace getSnapshotDeviceOwnedIps() {
       return EmptyIpSpace.INSTANCE;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledInputValidator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledInputValidator.java
@@ -15,6 +15,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.CompletionMetadata;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.answers.InputValidationNotes;
 import org.batfish.datamodel.answers.InputValidationNotes.Validity;
@@ -90,14 +91,13 @@ public final class ParboiledInputValidator {
     }
 
     @Override
-    public Map<String, Map<String, IpSpace>> getInterfaceOwnedIps() {
-      return ImmutableMap.of();
+    public IpSpace getInterfaceOwnedIps(String hostname, String iface) {
+      return EmptyIpSpace.INSTANCE;
     }
 
-    @Nonnull
     @Override
-    public Map<String, Map<String, IpSpace>> getInterfaceLinkOwnedIps() {
-      return ImmutableMap.of();
+    public IpSpace getInterfaceLinkOwnedIps(String hostname, String iface) {
+      return EmptyIpSpace.INSTANCE;
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/MockSpecifierContext.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/MockSpecifierContext.java
@@ -92,20 +92,18 @@ public class MockSpecifierContext implements SpecifierContext {
 
   @Override
   @Nonnull
-  public Map<String, Map<String, IpSpace>> getInterfaceOwnedIps() {
-    return _interfaceOwnedIps;
-  }
-
-  @Nonnull
-  @Override
-  public Map<String, Map<String, IpSpace>> getInterfaceLinkOwnedIps() {
-    return _interfaceLinkOwnedIps;
-  }
-
-  @Override
-  @Nonnull
   public Optional<NodeRoleDimension> getNodeRoleDimension(String dimension) {
     return _nodeRoleDimensions.stream().filter(dim -> dim.getName().equals(dimension)).findAny();
+  }
+
+  @Override
+  public IpSpace getInterfaceOwnedIps(String hostname, String iface) {
+    return _interfaceOwnedIps.get(hostname).get(iface);
+  }
+
+  @Override
+  public IpSpace getInterfaceLinkOwnedIps(String hostname, String iface) {
+    return _interfaceLinkOwnedIps.get(hostname).get(iface);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/MockSpecifierContext.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/MockSpecifierContext.java
@@ -30,10 +30,6 @@ public class MockSpecifierContext implements SpecifierContext {
 
     private @Nonnull SortedSet<NodeRoleDimension> _nodeRoleDimensions = ImmutableSortedSet.of();
 
-    private @Nonnull IpSpace _snapshotOwnedIps;
-
-    private @Nonnull Map<String, Map<String, IpSpace>> _vrfOwnedIps = ImmutableMap.of();
-
     private Builder() {}
 
     public Builder setConfigs(Map<String, Configuration> configs) {
@@ -46,8 +42,9 @@ public class MockSpecifierContext implements SpecifierContext {
       return this;
     }
 
-    public Builder setInterfaceLinkOwnedIps(Map<String, Map<String, IpSpace>> interfaceLinkOwnedIps) {
-      _interfaceOwnedIps = interfaceLinkOwnedIps;
+    public Builder setInterfaceLinkOwnedIps(
+        Map<String, Map<String, IpSpace>> interfaceLinkOwnedIps) {
+      _interfaceLinkOwnedIps = interfaceLinkOwnedIps;
       return this;
     }
 
@@ -58,16 +55,6 @@ public class MockSpecifierContext implements SpecifierContext {
 
     public Builder setReferenceBooks(SortedSet<ReferenceBook> referenceBooks) {
       _referenceBooks = ImmutableSortedSet.copyOf(referenceBooks);
-      return this;
-    }
-
-    public Builder setSnapshotOwnedIps(IpSpace snapshotOwnedIps) {
-      _snapshotOwnedIps = snapshotOwnedIps;
-      return this;
-    }
-
-    public Builder setVrfOwnedIps(Map<String, Map<String, IpSpace>> vrfOwnedIps) {
-      _vrfOwnedIps = vrfOwnedIps;
       return this;
     }
 
@@ -89,15 +76,12 @@ public class MockSpecifierContext implements SpecifierContext {
 
   private final @Nonnull SortedSet<ReferenceBook> _referenceBooks;
 
-  private final @Nonnull IpSpace _snapshotOwnedIps;
-
   private MockSpecifierContext(Builder builder) {
     _referenceBooks = builder._referenceBooks;
     _configs = builder._configs;
     _interfaceOwnedIps = builder._interfaceOwnedIps;
     _interfaceLinkOwnedIps = builder._interfaceLinkOwnedIps;
     _nodeRoleDimensions = builder._nodeRoleDimensions;
-    _snapshotOwnedIps = builder._snapshotOwnedIps;
   }
 
   @Override
@@ -116,11 +100,6 @@ public class MockSpecifierContext implements SpecifierContext {
   @Override
   public Map<String, Map<String, IpSpace>> getInterfaceLinkOwnedIps() {
     return _interfaceLinkOwnedIps;
-  }
-
-  @Override
-  public IpSpace getSnapshotDeviceOwnedIps() {
-    return _snapshotOwnedIps;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/MockSpecifierContext.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/MockSpecifierContext.java
@@ -19,17 +19,14 @@ public class MockSpecifierContext implements SpecifierContext {
     return new Builder();
   }
 
-  @Nonnull
-  public Map<String, Map<String, IpSpace>> get_interfaceOwnedIps() {
-    return _interfaceOwnedIps;
-  }
-
   public static final class Builder {
     private @Nonnull SortedSet<ReferenceBook> _referenceBooks = ImmutableSortedSet.of();
 
     private @Nonnull Map<String, Configuration> _configs = ImmutableMap.of();
 
     private @Nonnull Map<String, Map<String, IpSpace>> _interfaceOwnedIps = ImmutableMap.of();
+
+    private @Nonnull Map<String, Map<String, IpSpace>> _interfaceLinkOwnedIps = ImmutableMap.of();
 
     private @Nonnull SortedSet<NodeRoleDimension> _nodeRoleDimensions = ImmutableSortedSet.of();
 
@@ -46,6 +43,11 @@ public class MockSpecifierContext implements SpecifierContext {
 
     public Builder setInterfaceOwnedIps(Map<String, Map<String, IpSpace>> interfaceOwnedIps) {
       _interfaceOwnedIps = interfaceOwnedIps;
+      return this;
+    }
+
+    public Builder setInterfaceLinkOwnedIps(Map<String, Map<String, IpSpace>> interfaceLinkOwnedIps) {
+      _interfaceOwnedIps = interfaceLinkOwnedIps;
       return this;
     }
 
@@ -81,6 +83,8 @@ public class MockSpecifierContext implements SpecifierContext {
 
   private final @Nonnull Map<String, Map<String, IpSpace>> _interfaceOwnedIps;
 
+  private final @Nonnull Map<String, Map<String, IpSpace>> _interfaceLinkOwnedIps;
+
   private final @Nonnull SortedSet<NodeRoleDimension> _nodeRoleDimensions;
 
   private final @Nonnull SortedSet<ReferenceBook> _referenceBooks;
@@ -91,6 +95,7 @@ public class MockSpecifierContext implements SpecifierContext {
     _referenceBooks = builder._referenceBooks;
     _configs = builder._configs;
     _interfaceOwnedIps = builder._interfaceOwnedIps;
+    _interfaceLinkOwnedIps = builder._interfaceLinkOwnedIps;
     _nodeRoleDimensions = builder._nodeRoleDimensions;
     _snapshotOwnedIps = builder._snapshotOwnedIps;
   }
@@ -105,6 +110,12 @@ public class MockSpecifierContext implements SpecifierContext {
   @Nonnull
   public Map<String, Map<String, IpSpace>> getInterfaceOwnedIps() {
     return _interfaceOwnedIps;
+  }
+
+  @Nonnull
+  @Override
+  public Map<String, Map<String, IpSpace>> getInterfaceLinkOwnedIps() {
+    return _interfaceLinkOwnedIps;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TestSpecifierContext.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TestSpecifierContext.java
@@ -2,6 +2,7 @@ package org.batfish.specifier;
 
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.referencelibrary.ReferenceBook;
@@ -16,6 +17,12 @@ public class TestSpecifierContext implements SpecifierContext {
 
   @Override
   public Map<String, Map<String, IpSpace>> getInterfaceOwnedIps() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public Map<String, Map<String, IpSpace>> getInterfaceLinkOwnedIps() {
     throw new UnsupportedOperationException();
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TestSpecifierContext.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TestSpecifierContext.java
@@ -2,7 +2,6 @@ package org.batfish.specifier;
 
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.referencelibrary.ReferenceBook;
@@ -16,18 +15,17 @@ public class TestSpecifierContext implements SpecifierContext {
   }
 
   @Override
-  public Map<String, Map<String, IpSpace>> getInterfaceOwnedIps() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Nonnull
-  @Override
-  public Map<String, Map<String, IpSpace>> getInterfaceLinkOwnedIps() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public Optional<NodeRoleDimension> getNodeRoleDimension(String dimension) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public IpSpace getInterfaceOwnedIps(String hostname, String iface) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public IpSpace getInterfaceLinkOwnedIps(String hostname, String iface) {
     throw new UnsupportedOperationException();
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TestSpecifierContext.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TestSpecifierContext.java
@@ -35,9 +35,4 @@ public class TestSpecifierContext implements SpecifierContext {
   public Optional<ReferenceBook> getReferenceBook(String bookName) {
     throw new UnsupportedOperationException();
   }
-
-  @Override
-  public IpSpace getSnapshotDeviceOwnedIps() {
-    throw new UnsupportedOperationException();
-  }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledIpSpaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledIpSpaceSpecifierTest.java
@@ -13,6 +13,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpRange;
+import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
@@ -91,16 +92,20 @@ public class ParboiledIpSpaceSpecifierTest {
         .setAddress(ConcreteInterfaceAddress.parse("3.3.3.0/24"))
         .build();
 
-    SpecifierContext ctxt =
-        MockSpecifierContext.builder().setConfigs(ImmutableMap.of(node1, n1)).build();
+    IpSpace ipSpace1 = Ip.parse("3.3.3.0").toIpSpace();
 
+    SpecifierContext ctxt =
+        MockSpecifierContext.builder()
+            .setConfigs(ImmutableMap.of(node1, n1))
+            .setInterfaceOwnedIps(ImmutableMap.of(node1, ImmutableMap.of(iface1, ipSpace1)))
+            .build();
     assertThat(
         computeIpSpace(
             new LocationIpSpaceAstNode(
                 InterfaceLocationAstNode.createFromInterfaceWithNode(
                     new NameNodeAstNode(node1), new NameInterfaceAstNode(iface1))),
             ctxt),
-        equalTo(Ip.parse("3.3.3.0").toIpSpace()));
+        equalTo(ipSpace1));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/specifier/IpSpaceSpecifierTest.java
+++ b/projects/batfish/src/test/java/org/batfish/specifier/IpSpaceSpecifierTest.java
@@ -3,11 +3,9 @@ package org.batfish.specifier;
 import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
 import static org.batfish.specifier.IpSpaceAssignmentMatchers.hasEntry;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
@@ -22,7 +20,6 @@ import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.specifier.IpSpaceAssignment.Entry;
@@ -154,8 +151,9 @@ public class IpSpaceSpecifierTest {
     IpSpaceAssignment assignment =
         new LocationIpSpaceSpecifier(AllInterfacesLocationSpecifier.INSTANCE)
             .resolve(ImmutableSet.of(), _context);
-    assertThat(assignment, hasEntry(allOf(
-        containsIp(I1_OWNED_IP),
-        containsIp(I2_OWNED_IP)), equalTo(ImmutableSet.of())));
+    assertThat(
+        assignment,
+        hasEntry(
+            allOf(containsIp(I1_OWNED_IP), containsIp(I2_OWNED_IP)), equalTo(ImmutableSet.of())));
   }
 }


### PR DESCRIPTION
This is based on forwarding analysis, and will include IPs that are
assigned EXITS_NETWORK or DELIVERED_TO_SUBNET when routed out the
interface.