### PR TITLE
IOS & NXOS: Correct OSPF cost for loopback interfaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -36,6 +36,7 @@ import static org.batfish.representation.cisco.CiscoConversions.toIpsecPhase2Pro
 import static org.batfish.representation.cisco.CiscoConversions.toOspfDeadInterval;
 import static org.batfish.representation.cisco.CiscoConversions.toOspfHelloInterval;
 import static org.batfish.representation.cisco.CiscoConversions.toOspfNetworkType;
+import static org.batfish.representation.cisco.OspfProcess.DEFAULT_LOOPBACK_OSPF_COST;
 import static org.batfish.representation.cisco.eos.AristaRedistributeType.CONNECTED;
 import static org.batfish.representation.cisco.eos.AristaRedistributeType.STATIC;
 
@@ -157,6 +158,7 @@ import org.batfish.datamodel.ospf.OspfAreaSummary;
 import org.batfish.datamodel.ospf.OspfDefaultOriginateType;
 import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.ospf.OspfMetricType;
+import org.batfish.datamodel.ospf.OspfNetworkType;
 import org.batfish.datamodel.ospf.StubType;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
@@ -2661,7 +2663,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
         ospfSettings.setPassive(true);
       }
     }
-    ospfSettings.setCost(vsIface.getOspfCost());
     ospfSettings.setHelloMultiplier(vsIface.getOspfHelloMultiplier());
 
     ospfSettings.setAreaName(areaNum);
@@ -2669,6 +2670,13 @@ public final class CiscoConfiguration extends VendorConfiguration {
     org.batfish.datamodel.ospf.OspfNetworkType networkType =
         toOspfNetworkType(vsIface.getOspfNetworkType(), _w);
     ospfSettings.setNetworkType(networkType);
+    if (vsIface.getOspfCost() == null
+        && iface.isLoopback()
+        && networkType != OspfNetworkType.POINT_TO_POINT) {
+      ospfSettings.setCost(DEFAULT_LOOPBACK_OSPF_COST);
+    } else {
+      ospfSettings.setCost(vsIface.getOspfCost());
+    }
     ospfSettings.setHelloInterval(toOspfHelloInterval(vsIface, networkType));
     ospfSettings.setDeadInterval(toOspfDeadInterval(vsIface, networkType));
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/OspfProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/OspfProcess.java
@@ -26,13 +26,13 @@ public class OspfProcess implements Serializable {
 
   private static final OspfMetricType DEFAULT_DEFAULT_INFORMATION_METRIC_TYPE = OspfMetricType.E2;
 
-  public static final long DEFAULT_MAX_METRIC_EXTERNAL_LSA = 0xFF0000L;
-
-  public static final long DEFAULT_MAX_METRIC_SUMMARY_LSA = 0xFF0000L;
-
   // Although not clearly documented; from GNS3 emulation and Cisco forum
   // (https://community.cisco.com/t5/switching/ospf-cost-calculation/td-p/2917356)
   public static final int DEFAULT_LOOPBACK_OSPF_COST = 1;
+
+  public static final long DEFAULT_MAX_METRIC_EXTERNAL_LSA = 0xFF0000L;
+
+  public static final long DEFAULT_MAX_METRIC_SUMMARY_LSA = 0xFF0000L;
 
   private static final double DEFAULT_REFERENCE_BANDWIDTH_10_MBPS = 10E6D;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/OspfProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/OspfProcess.java
@@ -30,6 +30,10 @@ public class OspfProcess implements Serializable {
 
   public static final long DEFAULT_MAX_METRIC_SUMMARY_LSA = 0xFF0000L;
 
+  // Although not clearly documented; from GNS3 emulation and Cisco forum
+  // (https://community.cisco.com/t5/switching/ospf-cost-calculation/td-p/2917356)
+  public static final int DEFAULT_LOOPBACK_OSPF_COST = 1;
+
   private static final double DEFAULT_REFERENCE_BANDWIDTH_10_MBPS = 10E6D;
 
   private static final double DEFAULT_REFERENCE_BANDWIDTH_100_MBPS = 100E6D;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -16,7 +16,6 @@ import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpComm
 import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpGenerationPolicyName;
 import static org.batfish.representation.cisco.CiscoConversions.generateGenerationPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.suppressSummarizedPrefixes;
-import static org.batfish.representation.cisco.OspfProcess.DEFAULT_LOOPBACK_OSPF_COST;
 import static org.batfish.representation.cisco_nxos.CiscoNxosInterfaceType.PORT_CHANNEL;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.CLASS_MAP_CP_MATCH_ACCESS_GROUP;
 import static org.batfish.representation.cisco_nxos.Conversions.getVrfForL3Vni;
@@ -28,6 +27,7 @@ import static org.batfish.representation.cisco_nxos.OspfInterface.DEFAULT_DEAD_I
 import static org.batfish.representation.cisco_nxos.OspfInterface.DEFAULT_HELLO_INTERVAL_S;
 import static org.batfish.representation.cisco_nxos.OspfInterface.OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER;
 import static org.batfish.representation.cisco_nxos.OspfMaxMetricRouterLsa.DEFAULT_OSPF_MAX_METRIC;
+import static org.batfish.representation.cisco_nxos.OspfProcess.DEFAULT_LOOPBACK_OSPF_COST;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -16,6 +16,7 @@ import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpComm
 import static org.batfish.representation.cisco.CiscoConfiguration.computeBgpGenerationPolicyName;
 import static org.batfish.representation.cisco.CiscoConversions.generateGenerationPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.suppressSummarizedPrefixes;
+import static org.batfish.representation.cisco.OspfProcess.DEFAULT_LOOPBACK_OSPF_COST;
 import static org.batfish.representation.cisco_nxos.CiscoNxosInterfaceType.PORT_CHANNEL;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.CLASS_MAP_CP_MATCH_ACCESS_GROUP;
 import static org.batfish.representation.cisco_nxos.Conversions.getVrfForL3Vni;
@@ -2409,7 +2410,15 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
         ospf.getPassive() != null
             ? ospf.getPassive()
             : passiveInterfaceDefault || newIface.getName().startsWith("loopback"));
-    ospfSettings.setNetworkType(toOspfNetworkType(ospf.getNetwork()));
+    org.batfish.datamodel.ospf.OspfNetworkType networkType = toOspfNetworkType(ospf.getNetwork());
+    ospfSettings.setNetworkType(networkType);
+    if (ospf.getCost() == null
+        && newIface.isLoopback()
+        && networkType != org.batfish.datamodel.ospf.OspfNetworkType.POINT_TO_POINT) {
+      ospfSettings.setCost(DEFAULT_LOOPBACK_OSPF_COST);
+    } else {
+      ospfSettings.setCost(ospf.getCost());
+    }
     ospfSettings.setDeadInterval(toOspfDeadInterval(ospf));
     ospfSettings.setHelloInterval(toOspfHelloInterval(ospf));
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/OspfProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/OspfProcess.java
@@ -14,6 +14,10 @@ import org.batfish.datamodel.Prefix;
 public abstract class OspfProcess implements Serializable {
 
   public static final int DEFAULT_AUTO_COST_REFERENCE_BANDWIDTH_MBPS = 40_000; // Mbps
+
+  // Although not clearly documented; from GNS3 emulation and Cisco forum
+  // (https://community.cisco.com/t5/switching/ospf-cost-calculation/td-p/2917356)
+  public static final int DEFAULT_LOOPBACK_OSPF_COST = 1;
   public static final int DEFAULT_TIMERS_LSA_ARRIVAL_MS = 1000; // ms
 
   // https://www.cisco.com/c/m/en_us/techdoc/dc/reference/cli/nxos/commands/ospf/timers-lsa-group-pacing-ospf.html

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -3055,6 +3055,14 @@ public class CiscoGrammarTest {
   }
 
   @Test
+  public void testIosOspfCostLoopback() throws IOException {
+    Configuration c = parseConfig("ios-ospf-cost-loopback");
+
+    assertThat(c.getAllInterfaces().get("Loopback61").getOspfSettings(), not(nullValue()));
+    assertThat(c.getAllInterfaces().get("Loopback61").getOspfSettings().getCost(), equalTo(1));
+  }
+
+  @Test
   public void testIosOspfStubSettings() throws IOException {
     Configuration c = parseConfig("ios-ospf-stub-settings");
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -4499,6 +4499,14 @@ public final class CiscoNxosGrammarTest {
   }
 
   @Test
+  public void testNxosOspfCostLoopback() throws IOException {
+    Configuration c = parseConfig("nxos-ospf-cost-loopback");
+
+    assertThat(c.getAllInterfaces().get("loopback61").getOspfSettings(), not(nullValue()));
+    assertThat(c.getAllInterfaces().get("loopback61").getOspfSettings().getCost(), equalTo(1));
+  }
+
+  @Test
   public void testOspfConversion() throws IOException {
     String hostname = "nxos_ospf";
     Configuration c = parseConfig(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-ospf-cost-loopback
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-ospf-cost-loopback
@@ -1,0 +1,11 @@
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname ios-ospf-cost-loopback
+!
+interface Loopback61
+ ip address 192.168.61.4 255.255.255.0
+!
+router ospf 4
+ router-id 4.4.4.4
+ network 192.168.61.4 0.0.0.0 area 14
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos-ospf-cost-loopback
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos-ospf-cost-loopback
@@ -1,0 +1,10 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos-ospf-cost-loopback
+feature ospf
+!
+interface loopback61
+  ip address 192.168.61.5/24
+  ip router ospf 5 area 0.0.0.15
+router ospf 5
+  router-id 5.5.5.5


### PR DESCRIPTION
As per Cisco forum (https://community.cisco.com/t5/switching/ospf-cost-calculation/td-p/2917356) and GNS3 emulation results, the default OSPF cost for Loopback interfaces should be 1.
