### PR TITLE
Palo Alto: separate into its own bazel completely

### DIFF
--- a/projects/batfish/BUILD
+++ b/projects/batfish/BUILD
@@ -43,6 +43,7 @@ java_library(
         "//projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/ios",
         "//projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/nxos",
         "//projects/batfish/src/main/antlr4/org/batfish/grammar/vyos",
+        "//projects/batfish/src/main/java/org/batfish/grammar/palo_alto",
         "//projects/batfish/src/main/java/org/batfish/representation/palo_alto",
         "//projects/bdd",
         "//projects/symbolic",

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/BUILD
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/BUILD
@@ -1,0 +1,24 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@batfish//skylark:pmd_test.bzl", "pmd_test")
+
+java_library(
+    name = "palo_alto",
+    srcs = glob(
+        ["*.java"],
+        exclude = ["BUILD"],
+    ),
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto",
+        "//projects/batfish/src/main/java/org/batfish/representation/palo_alto",
+        "@antlr4_runtime//:compile",
+        "@commons_lang3//:compile",
+        "@guava//:compile",
+    ],
+)
+
+pmd_test(
+    name = "pmd",
+    lib = ":palo_alto",
+)

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/BUILD
@@ -18,6 +18,7 @@ junit_tests(
         "//projects/batfish:batfish_testlib",
         "//projects/batfish-common-protocol:common",
         "//projects/batfish-common-protocol:common_testlib",
+        "//projects/batfish/src/main/java/org/batfish/grammar/palo_alto",
         "//projects/batfish/src/main/java/org/batfish/representation/palo_alto",
         "@antlr4_runtime//:compile",
         "@guava//:compile",


### PR DESCRIPTION
Unless we change grammar (which changes public APIs of the PaloAltoConfigurationBuilder), don't need to rebuild core Batfish module.

Ever closer to proper modularity.