### PR TITLE
NXOS: Always generate local routes irrespective of prefix lengths

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRouteMetadata.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRouteMetadata.java
@@ -14,9 +14,13 @@ import javax.annotation.Nullable;
  */
 public final class ConnectedRouteMetadata implements Serializable {
   private static final String PROP_ADMIN = "admin";
+  private static final String PROP_GENERATE_LOCAL_ROUTES = "generateLocalRoutes";
   private static final String PROP_TAG = "tag";
 
   @Nullable private final Integer _admin;
+
+  // if set to true then it can enable generation of local routes even of prefix lengths < 32
+  @Nullable private final Boolean _generateLocalRoutes;
 
   @Nullable private final Long _tag;
 
@@ -24,6 +28,11 @@ public final class ConnectedRouteMetadata implements Serializable {
   @JsonProperty(PROP_ADMIN)
   public Integer getAdmin() {
     return _admin;
+  }
+
+  @Nullable
+  public Boolean getGenerateLocalRoutes() {
+    return _generateLocalRoutes;
   }
 
   @Nullable
@@ -41,7 +50,9 @@ public final class ConnectedRouteMetadata implements Serializable {
       return false;
     }
     ConnectedRouteMetadata that = (ConnectedRouteMetadata) o;
-    return Objects.equals(_admin, that._admin) && Objects.equals(_tag, that._tag);
+    return Objects.equals(_admin, that._admin)
+        && Objects.equals(_generateLocalRoutes, that._generateLocalRoutes)
+        && Objects.equals(_tag, that._tag);
   }
 
   @Override
@@ -49,13 +60,14 @@ public final class ConnectedRouteMetadata implements Serializable {
     return MoreObjects.toStringHelper(ConnectedRouteMetadata.class)
         .omitNullValues()
         .add(PROP_ADMIN, _admin)
+        .add(PROP_GENERATE_LOCAL_ROUTES, _generateLocalRoutes)
         .add(PROP_TAG, _tag)
         .toString();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_admin, _tag);
+    return Objects.hash(_admin, _generateLocalRoutes, _tag);
   }
 
   public static Builder builder() {
@@ -66,13 +78,16 @@ public final class ConnectedRouteMetadata implements Serializable {
   // Private implementation
   /////////////////////////
 
-  private ConnectedRouteMetadata(@Nullable Integer admin, @Nullable Long tag) {
+  private ConnectedRouteMetadata(
+      @Nullable Integer admin, @Nullable Boolean generateLocalRoutes, @Nullable Long tag) {
     _admin = admin;
+    _generateLocalRoutes = generateLocalRoutes;
     _tag = tag;
   }
 
   public static final class Builder {
     @Nullable private Integer _admin;
+    @Nullable private Boolean _generateLocalRoutes;
     @Nullable private Long _tag;
 
     private Builder() {}
@@ -90,6 +105,18 @@ public final class ConnectedRouteMetadata implements Serializable {
     }
 
     @Nonnull
+    public Builder setGenerateLocalRoutes(@Nullable Boolean generateLocalRoutes) {
+      _generateLocalRoutes = generateLocalRoutes;
+      return this;
+    }
+
+    @Nonnull
+    public Builder setGenerateLocalRoutes(boolean generateLocalRoutes) {
+      _generateLocalRoutes = generateLocalRoutes;
+      return this;
+    }
+
+    @Nonnull
     public Builder setTag(@Nullable Long tag) {
       _tag = tag;
       return this;
@@ -103,14 +130,15 @@ public final class ConnectedRouteMetadata implements Serializable {
 
     @Nonnull
     public ConnectedRouteMetadata build() {
-      return new ConnectedRouteMetadata(_admin, _tag);
+      return new ConnectedRouteMetadata(_admin, _generateLocalRoutes, _tag);
     }
   }
 
   @JsonCreator
   private static ConnectedRouteMetadata jsonCreator(
       @Nullable @JsonProperty(PROP_ADMIN) Integer admin,
+      @Nullable @JsonProperty(PROP_GENERATE_LOCAL_ROUTES) Boolean generateLocalRoutes,
       @Nullable @JsonProperty(PROP_TAG) Long tag) {
-    return new ConnectedRouteMetadata(admin, tag);
+    return new ConnectedRouteMetadata(admin, generateLocalRoutes, tag);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRouteMetadata.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRouteMetadata.java
@@ -19,7 +19,8 @@ public final class ConnectedRouteMetadata implements Serializable {
 
   @Nullable private final Integer _admin;
 
-  // if set to true then it can enable generation of local routes even of prefix lengths < 32
+  // If set, controls whether a local route is generated for this connected route. If unset, the
+  // default behavior is to generate local routes for /31 networks or larger
   @Nullable private final Boolean _generateLocalRoutes;
 
   @Nullable private final Long _tag;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteMetadataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteMetadataTest.java
@@ -22,19 +22,23 @@ public class ConnectedRouteMetadataTest {
         .addEqualityGroup(builder.setTag(3).build())
         .addEqualityGroup(builder.setAdmin(3).build())
         .addEqualityGroup(builder.setTag(1).build())
+        .addEqualityGroup(builder.setGenerateLocalRoutes(true).build())
+        .addEqualityGroup(builder.setAdmin(1).setGenerateLocalRoutes(true))
         .addEqualityGroup(new Object())
         .testEquals();
   }
 
   @Test
   public void testJavaSerialization() {
-    ConnectedRouteMetadata crm = ConnectedRouteMetadata.builder().setAdmin(2).setTag(1).build();
+    ConnectedRouteMetadata crm =
+        ConnectedRouteMetadata.builder().setAdmin(2).setGenerateLocalRoutes(true).setTag(1).build();
     assertThat(SerializationUtils.clone(crm), equalTo(crm));
   }
 
   @Test
   public void testJsonSerialization() throws IOException {
-    ConnectedRouteMetadata crm = ConnectedRouteMetadata.builder().setAdmin(2).setTag(1).build();
+    ConnectedRouteMetadata crm =
+        ConnectedRouteMetadata.builder().setAdmin(2).setGenerateLocalRoutes(true).setTag(1).build();
     assertThat(BatfishObjectMapper.clone(crm, ConnectedRouteMetadata.class), equalTo(crm));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -855,13 +855,19 @@ public class VirtualRouter implements Serializable {
    * active or has no valid IP addresses (only addresses with network length of < /32 are
    * considered).
    */
+  @VisibleForTesting
   @Nonnull
-  private static Stream<LocalRoute> generateLocalRoutes(@Nonnull Interface iface) {
+  static Stream<LocalRoute> generateLocalRoutes(@Nonnull Interface iface) {
     if (!iface.getActive()) {
       return Stream.empty();
     }
     return iface.getAllConcreteAddresses().stream()
-        .filter(addr -> addr.getNetworkBits() < Prefix.MAX_PREFIX_LENGTH)
+        .filter(
+            addr ->
+                addr.getNetworkBits() < Prefix.MAX_PREFIX_LENGTH
+                    || (iface.getAddressMetadata().get(addr) != null
+                        && Boolean.TRUE.equals(
+                            iface.getAddressMetadata().get(addr).getGenerateLocalRoutes())))
         .map(
             addr ->
                 generateLocalRoute(addr, iface.getName(), iface.getAddressMetadata().get(addr)));

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -863,8 +863,8 @@ public class VirtualRouter implements Serializable {
     return iface.getAllConcreteAddresses().stream()
         .filter(
             addr ->
-                alwaysGenerateLocalRoutes(iface.getAddressMetadata().get(addr))
-                    || addr.getNetworkBits() < Prefix.MAX_PREFIX_LENGTH)
+                shouldGenerateLocalRoute(
+                    addr.getNetworkBits(), iface.getAddressMetadata().get(addr)))
         .map(
             addr ->
                 generateLocalRoute(addr, iface.getName(), iface.getAddressMetadata().get(addr)));
@@ -875,10 +875,11 @@ public class VirtualRouter implements Serializable {
    * ConnectedRouteMetadata}
    */
   @VisibleForTesting
-  static boolean alwaysGenerateLocalRoutes(
-      @Nullable ConnectedRouteMetadata connectedRouteMetadata) {
-    return connectedRouteMetadata != null
-        && Boolean.TRUE.equals(connectedRouteMetadata.getGenerateLocalRoutes());
+  static boolean shouldGenerateLocalRoute(
+      int prefixLength, @Nullable ConnectedRouteMetadata connectedRouteMetadata) {
+    return (connectedRouteMetadata != null
+            && Boolean.TRUE.equals(connectedRouteMetadata.getGenerateLocalRoutes()))
+        || prefixLength < Prefix.MAX_PREFIX_LENGTH;
   }
 
   /** Generate a connected route for a given address (and associated metadata). */

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1689,6 +1689,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
               (ConcreteInterfaceAddress) addrWithAttr.getAddress(),
               ConnectedRouteMetadata.builder()
                   .setAdmin(addrWithAttr.getRoutePreference())
+                  .setGenerateLocalRoutes(true)
                   .setTag(addrWithAttr.getTag())
                   .build());
         }
@@ -1705,6 +1706,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                       (ConcreteInterfaceAddress) addr.getAddress(),
                       ConnectedRouteMetadata.builder()
                           .setAdmin(addr.getRoutePreference())
+                          .setGenerateLocalRoutes(true)
                           .setTag(addr.getTag())
                           .build()));
       newIfaceBuilder.setAddressMetadata(addressMetadata.build());

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -5,9 +5,9 @@ import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.bgp.BgpTopologyUtils.initBgpTopology;
 import static org.batfish.datamodel.eigrp.EigrpTopologyUtils.initEigrpTopology;
 import static org.batfish.datamodel.isis.IsisTopology.initIsisTopology;
-import static org.batfish.dataplane.ibdp.VirtualRouter.alwaysGenerateLocalRoutes;
 import static org.batfish.dataplane.ibdp.VirtualRouter.generateConnectedRoute;
 import static org.batfish.dataplane.ibdp.VirtualRouter.generateLocalRoute;
+import static org.batfish.dataplane.ibdp.VirtualRouter.shouldGenerateLocalRoute;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -845,10 +845,19 @@ public class VirtualRouterTest {
 
   @Test
   public void testAlwaysGenerateLocalRoutes() {
-    assertFalse(alwaysGenerateLocalRoutes(null));
-    assertFalse(alwaysGenerateLocalRoutes(ConnectedRouteMetadata.builder().build()));
+    assertFalse(shouldGenerateLocalRoute(Prefix.MAX_PREFIX_LENGTH, null));
+    assertFalse(
+        shouldGenerateLocalRoute(
+            Prefix.MAX_PREFIX_LENGTH, ConnectedRouteMetadata.builder().build()));
     assertTrue(
-        alwaysGenerateLocalRoutes(
+        shouldGenerateLocalRoute(
+            Prefix.MAX_PREFIX_LENGTH,
             ConnectedRouteMetadata.builder().setGenerateLocalRoutes(true).build()));
+
+    assertTrue(shouldGenerateLocalRoute(24, null));
+    assertTrue(shouldGenerateLocalRoute(24, ConnectedRouteMetadata.builder().build()));
+    assertTrue(
+        shouldGenerateLocalRoute(
+            24, ConnectedRouteMetadata.builder().setGenerateLocalRoutes(true).build()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -5,9 +5,9 @@ import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.bgp.BgpTopologyUtils.initBgpTopology;
 import static org.batfish.datamodel.eigrp.EigrpTopologyUtils.initEigrpTopology;
 import static org.batfish.datamodel.isis.IsisTopology.initIsisTopology;
+import static org.batfish.dataplane.ibdp.VirtualRouter.alwaysGenerateLocalRoutes;
 import static org.batfish.dataplane.ibdp.VirtualRouter.generateConnectedRoute;
 import static org.batfish.dataplane.ibdp.VirtualRouter.generateLocalRoute;
-import static org.batfish.dataplane.ibdp.VirtualRouter.generateLocalRoutes;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -17,7 +17,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -842,39 +844,11 @@ public class VirtualRouterTest {
   }
 
   @Test
-  public void testGenerateLocalRoutes() {
-    ConcreteInterfaceAddress addr1 =
-        ConcreteInterfaceAddress.create(Ip.parse("1.1.1.1"), Prefix.MAX_PREFIX_LENGTH);
-    ConcreteInterfaceAddress addr2 = ConcreteInterfaceAddress.create(Ip.parse("2.2.2.2"), 24);
-    ConcreteInterfaceAddress addr3 =
-        ConcreteInterfaceAddress.create(Ip.parse("3.3.3.3"), Prefix.MAX_PREFIX_LENGTH);
-    Interface iface =
-        new NetworkFactory()
-            .interfaceBuilder()
-            .setAddresses(addr1, addr2, addr3)
-            .setAddressMetadata(
-                ImmutableMap.of(
-                    addr3, ConnectedRouteMetadata.builder().setGenerateLocalRoutes(true).build()))
-            .build();
-
-    List<LocalRoute> routes = generateLocalRoutes(iface).collect(ImmutableList.toImmutableList());
-
-    // addr1 will not generate any local route because of missing ConnectedRouteMetadata, addr2 will
-    // generate a local route because of < 32 prefix length and add3 will generate a local route
-    // because of setting in ConnectedRouteMetadata
-    assertThat(
-        routes,
-        equalTo(
-            ImmutableList.of(
-                LocalRoute.builder()
-                    .setNextHopInterface(iface.getName())
-                    .setNetwork(Prefix.create(addr2.getIp(), Prefix.MAX_PREFIX_LENGTH))
-                    .setSourcePrefixLength(24)
-                    .build(),
-                LocalRoute.builder()
-                    .setNextHopInterface(iface.getName())
-                    .setNetwork(Prefix.create(addr3.getIp(), Prefix.MAX_PREFIX_LENGTH))
-                    .setSourcePrefixLength(Prefix.MAX_PREFIX_LENGTH)
-                    .build())));
+  public void testAlwaysGenerateLocalRoutes() {
+    assertFalse(alwaysGenerateLocalRoutes(null));
+    assertFalse(alwaysGenerateLocalRoutes(ConnectedRouteMetadata.builder().build()));
+    assertTrue(
+        alwaysGenerateLocalRoutes(
+            ConnectedRouteMetadata.builder().setGenerateLocalRoutes(true).build()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -1455,13 +1455,25 @@ public final class CiscoNxosGrammarTest {
           allOf(
               hasEntry(
                   ConcreteInterfaceAddress.parse("10.0.0.1/24"),
-                  ConnectedRouteMetadata.builder().setAdmin(0).setTag(0).build()),
+                  ConnectedRouteMetadata.builder()
+                      .setAdmin(0)
+                      .setTag(0)
+                      .setGenerateLocalRoutes(true)
+                      .build()),
               hasEntry(
                   ConcreteInterfaceAddress.parse("10.0.0.2/24"),
-                  ConnectedRouteMetadata.builder().setAdmin(0).setTag(0).build()),
+                  ConnectedRouteMetadata.builder()
+                      .setAdmin(0)
+                      .setTag(0)
+                      .setGenerateLocalRoutes(true)
+                      .build()),
               hasEntry(
                   ConcreteInterfaceAddress.parse("10.0.0.3/24"),
-                  ConnectedRouteMetadata.builder().setAdmin(5).setTag(3).build())));
+                  ConnectedRouteMetadata.builder()
+                      .setAdmin(5)
+                      .setTag(3)
+                      .setGenerateLocalRoutes(true)
+                      .build())));
     }
     {
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("Ethernet1/2");

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -27842,6 +27842,7 @@
             "addressMetadata" : {
               "1.2.3.4/24" : {
                 "admin" : 10,
+                "generateLocalRoutes" : true,
                 "tag" : 12345
               }
             },
@@ -27982,6 +27983,7 @@
             "addressMetadata" : {
               "1.1.1.2/31" : {
                 "admin" : 0,
+                "generateLocalRoutes" : true,
                 "tag" : 0
               }
             },


### PR DESCRIPTION
- a related required change was introduction of a flag `generateLocalRoutes` in `ConnectedRouteMetadata.java` which can be set to `true` for vendors like NXOS. If set then dataplane will generate local routes even for prefix lengths < 32