### PR TITLE
FRR max-paths within address-family

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -311,6 +311,11 @@ LINE
   'line'
 ;
 
+MAXIMUM_PATHS
+:
+  'maximum-paths'
+;
+
 MESSAGE_DIGEST
 :
   'message-digest'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
@@ -66,9 +66,12 @@ sbaf_ipv4_unicast
   IPV4 UNICAST NEWLINE
   (
     sbafi_aggregate_address
-  | sbafi_network
-  | sbafi_neighbor
-  | sbafi_redistribute
+    // Skeptical that max-paths belongs here.
+    // Adding for now to prevent jumping out of parser context.
+    | sbafi_maximum_paths
+    | sbafi_network
+    | sbafi_neighbor
+    | sbafi_redistribute
   )*
 ;
 
@@ -88,6 +91,11 @@ sbafl_statement
 sbafi_aggregate_address
 :
   AGGREGATE_ADDRESS IP_PREFIX SUMMARY_ONLY? NEWLINE
+;
+
+sbafi_maximum_paths
+:
+  MAXIMUM_PATHS num = uint32 NEWLINE
 ;
 
 sbafi_network

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -170,6 +170,12 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
+  public void testBgpAddressFamily_ipv4UnicastMaximumPaths() {
+    // do not crash
+    parse("router bgp 1\n address-family ipv4 unicast\n maximum-paths 4\nexit-address-family\n");
+  }
+
+  @Test
   public void testBgpAddressFamilyIpv4UnicastNetwork() {
     parseLines(
         "router bgp 1", "address-family ipv4 unicast", "network 1.2.3.4/24", "exit-address-family");


### PR DESCRIPTION
Seeing this in some configs, and it worries me. 

1) normally this type of command is not under address family, but at process level 
2) Docs say Cumulus/FRR has multipath enabled by default, so not sure why this is necessary. 

For this reason, did not bother with extraction
Let me know if you have ideas on how to best to document this.