### PR TITLE
Juniper: ignore multipath multiple-as for iBGP

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -823,7 +823,11 @@ public final class FlatJuniperGrammarTest {
   public void testBgpMultipathMultipleAs() throws IOException {
     String testrigName = "multipath-multiple-as";
     List<String> configurationNames =
-        ImmutableList.of("multiple_as_disabled", "multiple_as_enabled", "multiple_as_mixed");
+        ImmutableList.of(
+            "multiple_as_disabled",
+            "multiple_as_enabled",
+            "multiple_as_mixed",
+            "multiple_as_mixed_conflict");
 
     Batfish batfish =
         BatfishTestUtils.getBatfishFromTestrigText(
@@ -850,10 +854,17 @@ public final class FlatJuniperGrammarTest {
             .getDefaultVrf()
             .getBgpProcess()
             .getMultipathEquivalentAsPathMatchMode();
+    MultipathEquivalentAsPathMatchMode mixedConflict =
+        configurations
+            .get("multiple_as_mixed_conflict")
+            .getDefaultVrf()
+            .getBgpProcess()
+            .getMultipathEquivalentAsPathMatchMode();
 
     assertThat(multipleAsDisabled, equalTo(MultipathEquivalentAsPathMatchMode.FIRST_AS));
     assertThat(multipleAsEnabled, equalTo(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
-    assertThat(multipleAsMixed, equalTo(MultipathEquivalentAsPathMatchMode.FIRST_AS));
+    assertThat(multipleAsMixed, equalTo(MultipathEquivalentAsPathMatchMode.PATH_LENGTH));
+    assertThat(mixedConflict, equalTo(MultipathEquivalentAsPathMatchMode.FIRST_AS));
   }
 
   /** Make sure bgp type internal properly sets remote as when non explicitly specified */

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/multipath-multiple-as/configs/multiple_as_mixed_conflict
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs/multipath-multiple-as/configs/multiple_as_mixed_conflict
@@ -1,9 +1,9 @@
 #
-set system host-name multiple_as_mixed
+set system host-name multiple_as_mixed_conflict
 #
 set protocols bgp neighbor 2.2.2.2 peer-as 2
 set protocols bgp neighbor 2.2.2.2 multipath multiple-as
-set protocols bgp neighbor 3.3.3.3 peer-as 1
+set protocols bgp neighbor 3.3.3.3 peer-as 3
 set protocols bgp neighbor 3.3.3.3 multipath
 set routing-options autonomous-system 1
 #

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -38604,7 +38604,7 @@
               "ibgpAdminCost" : 170,
               "routerId" : "192.168.1.2",
               "multipathEbgp" : true,
-              "multipathEquivalentAsPathMatchMode" : "FIRST_AS",
+              "multipathEquivalentAsPathMatchMode" : "PATH_LENGTH",
               "multipathIbgp" : true,
               "neighbors" : {
                 "172.16.3.2/32" : {

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -77118,7 +77118,7 @@
         "variables" : "PASSED",
         "variables_dos" : "PASSED",
         "vlan_access_map4" : "PASSED",
-        "vmx4" : "WARNINGS",
+        "vmx4" : "PASSED",
         "vxlan" : "PASSED"
       },
       "definedStructures" : {
@@ -93471,10 +93471,6 @@
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Currently do not support mixed multipath-multiple-as/non-multipath-multiple-as bgpgroups on Juniper - FORCING NON-MULTIPATH-MULTIPLE-AS"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
               "text" : "Missing local-as for neighbor: 3.4.5.6/32"
             },
             {
@@ -93652,14 +93648,6 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Interface vlan.1 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
-            }
-          ]
-        },
-        "vmx4" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Currently do not support mixed multipath-multiple-as/non-multipath-multiple-as bgpgroups on Juniper - FORCING NON-MULTIPATH-MULTIPLE-AS"
             }
           ]
         }


### PR DESCRIPTION
It seems to be common for users to not configure it for iBGP-only neighbors or peer groups.