### PR TITLE
Fix buggy toString method in AsSet

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
@@ -14,9 +14,9 @@ import com.google.common.primitives.Longs;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.SortedSet;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.apache.commons.lang3.StringUtils;
 
 /** An immutable class representing a set of AS numbers. */
 @ParametersAreNonnullByDefault
@@ -115,7 +115,6 @@ public class AsSet implements Serializable, Comparable<AsSet> {
     if (_value.length == 1) {
       return Long.toString(_value[0]);
     }
-    return String.format(
-        "{%s}", Arrays.stream(_value).mapToObj(String::valueOf).collect(Collectors.joining(", ")));
+    return "{" + StringUtils.join(_value, ',') + "}";
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
@@ -14,9 +14,9 @@ import com.google.common.primitives.Longs;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.SortedSet;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.apache.commons.lang3.StringUtils;
 
 /** An immutable class representing a set of AS numbers. */
 @ParametersAreNonnullByDefault
@@ -115,6 +115,7 @@ public class AsSet implements Serializable, Comparable<AsSet> {
     if (_value.length == 1) {
       return Long.toString(_value[0]);
     }
-    return "{" + StringUtils.join(_value, ",") + "}";
+    return String.format(
+        "{%s}", Arrays.stream(_value).mapToObj(String::valueOf).collect(Collectors.joining(", ")));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AsSetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AsSetTest.java
@@ -14,7 +14,7 @@ public class AsSetTest {
     long asn = 12345;
     assertThat(AsSet.of(asn).toString(), equalTo(String.valueOf(asn)));
 
-    // For set of ASNs, should return {asn1, asn2, ... lastAsn}
-    assertThat(AsSet.of(1, 2, 3).toString(), equalTo("{1, 2, 3}"));
+    // For set of ASNs, should return {asn1,asn2,...lastAsn}
+    assertThat(AsSet.of(1, 2, 3).toString(), equalTo("{1,2,3}"));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AsSetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AsSetTest.java
@@ -1,0 +1,20 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/** Tests of {@link AsSet} */
+public class AsSetTest {
+
+  @Test
+  public void testToString() {
+    // For single ASN, should just return string of that ASN
+    long asn = 12345;
+    assertThat(AsSet.of(asn).toString(), equalTo(String.valueOf(asn)));
+
+    // For set of ASNs, should return {asn1, asn2, ... lastAsn}
+    assertThat(AsSet.of(1, 2, 3).toString(), equalTo("{1, 2, 3}"));
+  }
+}


### PR DESCRIPTION
Former implementation with `StringUtils.join(_value, ", ")` was using method `<T> String join(@Nullable T... elements)`, where `T` was inferred to be `Object`, so the result was just the default toString() for long[] `_value` with a comma at the end.