### PR TITLE
Add router igmp with vrf to Cisco IOS parsing tests

### DIFF
--- a/tests/parsing-tests/networks/unit-tests/configs/ios_xr_multicast
+++ b/tests/parsing-tests/networks/unit-tests/configs/ios_xr_multicast
@@ -15,6 +15,11 @@ router igmp
 router igmp
  interface all router disable                                                                                                              
 !
+router igmp
+ vrf default
+  interface all router disable
+ !
+!
 router msdp
  peer 169.232.1.3
   connect-source Loopback0


### PR DESCRIPTION
Test case for #4864 