### PR TITLE
ALL_AS_NUMBERS only compatible with nonnull local AS

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
@@ -109,8 +109,7 @@ public abstract class BgpPeerConfig implements Serializable {
 
   /** Check whether the given AS number matches this peer's remote AS numbers. */
   public boolean hasCompatibleRemoteAsns(@Nullable Long asNumber) {
-    return _remoteAsns.equals(ALL_AS_NUMBERS)
-        || (asNumber != null && _remoteAsns.contains(asNumber));
+    return asNumber != null && _remoteAsns.contains(asNumber);
   }
 
   /** Return the {@link RibGroup} applied to this config */


### PR DESCRIPTION
It doesn't make sense to return `true` from `hasCompatibleRemoteAsns()` if the ASN being tested is `null`, even if the peer's remote ASNs are `ALL_AS_NUMBERS`, because a session can't come up with a peer with no local AS configured.