### PR TITLE
PAN: extract tags for address and address-group

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_address.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_address.g4
@@ -19,7 +19,7 @@ s_address_definition
         | sa_fqdn
         | sa_ip_netmask
         | sa_ip_range
-        | sa_null
+        | sa_tag
     )?
 ;
 
@@ -48,8 +48,7 @@ sa_ip_range
     IP_RANGE_LITERAL IP_RANGE
 ;
 
-sa_null
+sa_tag
 :
-    TAG
-    null_rest_of_line
+    TAG tags = variable_list
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_address_group.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_address_group.g4
@@ -17,8 +17,8 @@ s_address_group_definition
     (
         sag_description
         | sag_dynamic
-        | sag_null
         | sag_static
+        | sag_tag
     )?
 ;
 
@@ -30,12 +30,6 @@ sag_description
 sag_dynamic
 :
     DYNAMIC
-    null_rest_of_line
-;
-
-sag_null
-:
-    TAG
     null_rest_of_line
 ;
 
@@ -53,4 +47,9 @@ sag_static
             CLOSE_BRACKET
         )
     )
+;
+
+sag_tag
+:
+    TAG tags = variable_list
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -135,9 +135,11 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sa_descriptionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sa_fqdnContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sa_ip_netmaskContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sa_ip_rangeContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sa_tagContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_descriptionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_dynamicContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_staticContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_tagContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_descriptionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sappg_definitionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sappg_membersContext;
@@ -755,6 +757,28 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitS_address_definition(S_address_definitionContext ctx) {
     _currentAddressObject = null;
+  }
+
+  @Override
+  public void exitSa_tag(Sa_tagContext ctx) {
+    if (_currentAddressObject == null) {
+      return;
+    }
+    for (Variable_list_itemContext var : variables(ctx.variable_list())) {
+      String tag = getText(var);
+      _currentAddressObject.getTags().add(tag);
+    }
+  }
+
+  @Override
+  public void exitSag_tag(Sag_tagContext ctx) {
+    if (_currentAddressGroup == null) {
+      return;
+    }
+    for (Variable_list_itemContext var : variables(ctx.variable_list())) {
+      String tag = getText(var);
+      _currentAddressGroup.getTags().add(tag);
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressGroup.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.IpSpace;
@@ -21,9 +22,12 @@ public final class AddressGroup implements Serializable {
 
   private final String _name;
 
+  @Nonnull private final Set<String> _tags;
+
   public AddressGroup(String name) {
     _name = name;
     _members = new TreeSet<>();
+    _tags = new HashSet<>();
   }
 
   /**
@@ -79,6 +83,11 @@ public final class AddressGroup implements Serializable {
 
   public String getName() {
     return _name;
+  }
+
+  @Nonnull
+  public Set<String> getTags() {
+    return _tags;
   }
 
   public void setDescription(String description) {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
@@ -43,7 +43,9 @@ public final class AddressObject implements Serializable {
   }
 
   @Nonnull
-  public Set<String> getTags() {return _tags;}
+  public Set<String> getTags() {
+    return _tags;
+  }
 
   public void setDescription(String description) {
     _description = description;

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
@@ -1,6 +1,8 @@
 package org.batfish.representation.palo_alto;
 
 import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -17,9 +19,12 @@ public final class AddressObject implements Serializable {
 
   @Nonnull private final String _name;
 
+  @Nonnull private final Set<String> _tags;
+
   public AddressObject(String name) {
     _name = name;
     _ipSpace = EmptyIpSpace.INSTANCE;
+    _tags = new HashSet<>();
   }
 
   @Nullable
@@ -36,6 +41,9 @@ public final class AddressObject implements Serializable {
   public String getName() {
     return _name;
   }
+
+  @Nonnull
+  public Set<String> getTags() {return _tags;}
 
   public void setDescription(String description) {
     _description = description;

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -300,7 +300,8 @@ public final class PaloAltoGrammarTest {
     // check that we parse multiple address objects and tags on the same line correctly
     assertThat(
         addressGroups.get("group2").getMembers(), equalTo(ImmutableSet.of("addr1", "addr2")));
-    assertThat(addressGroups.get("group2").getTags(), contains("tag2", "tag3"));
+    assertThat(
+        addressGroups.get("group2").getTags(), containsInAnyOrder("tag2", "tag with spaces"));
 
     // check that ip spaces were inserted properly
     Configuration viConfig = c.toVendorIndependentConfigurations().get(0);
@@ -422,7 +423,8 @@ public final class PaloAltoGrammarTest {
 
     // check that we parse the IP address and tags right
     assertThat(addressObjects.get("addr2").getIpSpace(), equalTo(Ip.parse("10.1.1.2").toIpSpace()));
-    assertThat(addressObjects.get("addr2").getTags(), contains("tag2", "tag3"));
+    assertThat(
+        addressObjects.get("addr2").getTags(), containsInAnyOrder("tag2", "tag with spaces"));
 
     // check that we parse the IP range right
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -284,8 +284,9 @@ public final class PaloAltoGrammarTest {
         addressGroups.get("group0").getIpSpace(addressObjects, addressGroups),
         equalTo(EmptyIpSpace.INSTANCE));
 
-    // we parsed the description, addr3 is undefined but should not have been discarded
+    // we parsed the description and tag, addr3 is undefined but should not have been discarded
     assertThat(addressGroups.get("group1").getDescription(), equalTo("group1-desc"));
+    assertThat(addressGroups.get("group1").getTags(), contains("tag1"));
     assertThat(
         addressGroups.get("group1").getMembers(),
         equalTo(ImmutableSet.of("addr1", "addr2", "addr3")));
@@ -296,9 +297,10 @@ public final class PaloAltoGrammarTest {
                 addressObjects.get("addr2").getIpSpace(),
                 addressObjects.get("addr1").getIpSpace())));
 
-    // check that we parse multiple address objects on the same line correctly
+    // check that we parse multiple address objects and tags on the same line correctly
     assertThat(
         addressGroups.get("group2").getMembers(), equalTo(ImmutableSet.of("addr1", "addr2")));
+    assertThat(addressGroups.get("group2").getTags(), contains("tag2", "tag3"));
 
     // check that ip spaces were inserted properly
     Configuration viConfig = c.toVendorIndependentConfigurations().get(0);
@@ -410,15 +412,17 @@ public final class PaloAltoGrammarTest {
     // check that we parse the name-only object right
     assertThat(addressObjects.get("addr0").getIpSpace(), equalTo(EmptyIpSpace.INSTANCE));
 
-    // check that we parsed description and prefix right
+    // check that we parsed description, tag, and prefix right
     // note that PA allows non-canonical prefixes
     assertThat(
         addressObjects.get("addr1").getIpSpace(),
         equalTo(Prefix.strict("10.1.1.0/24").toIpSpace()));
     assertThat(addressObjects.get("addr1").getDescription(), equalTo("addr1-desc"));
+    assertThat(addressObjects.get("addr1").getTags(), contains("tag1"));
 
-    // check that we parse the IP address right
+    // check that we parse the IP address and tags right
     assertThat(addressObjects.get("addr2").getIpSpace(), equalTo(Ip.parse("10.1.1.2").toIpSpace()));
+    assertThat(addressObjects.get("addr2").getTags(), contains("tag2", "tag3"));
 
     // check that we parse the IP range right
     assertThat(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-groups
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-groups
@@ -15,4 +15,4 @@ set address-group group1 tag tag1
 
 # defined on the same line
 set address-group group2 static [ addr1 addr2 ]
-set address-group group2 tag [ tag2 tag3]
+set address-group group2 tag [ tag2 "tag with spaces"]

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-groups
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-groups
@@ -11,6 +11,8 @@ set address-group group1 description group1-desc
 set address-group group1 static addr1
 set address-group group1 static addr2
 set address-group group1 static addr3
+set address-group group1 tag tag1
 
 # defined on the same line
 set address-group group2 static [ addr1 addr2 ]
+set address-group group2 tag [ tag2 tag3]

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-objects
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-objects
@@ -4,7 +4,9 @@ set address addr0
 
 set address addr1 ip-netmask 10.1.1.1/24
 set address addr1 description addr1-desc
+set address addr1 tag tag1
 
 set address addr2 ip-netmask 10.1.1.2
+set address addr2 tag [ tag2 tag3]
 
 set address addr3 ip-range 1.1.1.1-1.1.1.2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-objects
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-objects
@@ -7,6 +7,6 @@ set address addr1 description addr1-desc
 set address addr1 tag tag1
 
 set address addr2 ip-netmask 10.1.1.2
-set address addr2 tag [ tag2 tag3]
+set address addr2 tag [ tag2 "tag with spaces"]
 
 set address addr3 ip-range 1.1.1.1-1.1.1.2


### PR DESCRIPTION
Attach tags to `address` and `address-group` objects for PAN.

[Tags are used to reference `address` or `address-group` objects in `dynamic` `address-groups`](https://docs.paloaltonetworks.com/pan-os/7-1/pan-os-admin/policy/monitor-changes-in-the-virtual-environment/use-dynamic-address-groups-in-policy).
