### PR TITLE
Allow AsSets to be of confederation type.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
@@ -4,6 +4,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.base.Predicates;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -89,6 +90,14 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
             .collect(ImmutableList.toImmutableList()));
   }
 
+  /** Returns a new {@link AsPath} with all confederation {@link AsSet AS sets} removed */
+  public AsPath removeConfederations() {
+    return AsPath.of(
+        _asSets.stream()
+            .filter(asSet -> !asSet.isConfederationAsSet())
+            .collect(ImmutableList.toImmutableList()));
+  }
+
   @Override
   public int compareTo(AsPath rhs) {
     return Comparators.lexicographical(Ordering.<AsSet>natural()).compare(_asSets, rhs._asSets);
@@ -128,8 +137,11 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
     return _asSets.hashCode();
   }
 
+  /**
+   * Return the size (i.e., length) for this AS path as required for BGP path selection algorithm
+   */
   public int size() {
-    return _asSets.size();
+    return (int) _asSets.stream().filter(Predicates.not(AsSet::isConfederationAsSet)).count();
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsPath.java
@@ -137,10 +137,12 @@ public final class AsPath implements Serializable, Comparable<AsPath> {
     return _asSets.hashCode();
   }
 
-  /**
-   * Return the size (i.e., length) for this AS path as required for BGP path selection algorithm
-   */
   public int size() {
+    return _asSets.size();
+  }
+
+  /** Return the length for this AS path as required for BGP path selection algorithm */
+  public int length() {
     return (int) _asSets.stream().filter(Predicates.not(AsSet::isConfederationAsSet)).count();
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AsSet.java
@@ -146,7 +146,7 @@ public class AsSet implements Serializable, Comparable<AsSet> {
 
   @JsonIgnore
   public boolean isEmpty() {
-    return _value.length == 0;
+    return size() == 0;
   }
 
   /** Returns true if this AsSet is of type {@code AS_CONFED_SEQUENCE} or {@code AS_CONFED_SET} */

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AsPathTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AsPathTest.java
@@ -1,0 +1,41 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+/** Tests of {@link AsPath} */
+public class AsPathTest {
+  @Test
+  public void testRemoveConfederations() {
+    AsPath path = AsPath.of(AsSet.of(1L));
+    AsPath updated = path.removeConfederations();
+    assertThat(path, equalTo(updated));
+
+    path = AsPath.of(AsSet.confed(1L));
+    updated = path.removeConfederations();
+    assertThat(updated, equalTo(AsPath.empty()));
+
+    path = AsPath.of(ImmutableList.of(AsSet.confed(1L), AsSet.of(2L)));
+    updated = path.removeConfederations();
+    assertThat(updated, equalTo(AsPath.ofSingletonAsSets(2L)));
+
+    path = AsPath.of(ImmutableList.of(AsSet.confed(1L), AsSet.of(2L), AsSet.confed(3L)));
+    updated = path.removeConfederations();
+    assertThat(updated, equalTo(AsPath.ofSingletonAsSets(2L)));
+  }
+
+  @Test
+  public void testAsPathLength() {
+    AsPath path = AsPath.of(AsSet.confed(1L));
+    assertThat(path.size(), equalTo(0));
+
+    path = AsPath.of(ImmutableList.of(AsSet.confed(1L), AsSet.of(2L)));
+    assertThat(path.size(), equalTo(1));
+
+    path = AsPath.of(ImmutableList.of(AsSet.confed(1L), AsSet.of(2L, 3L), AsSet.confed(3L)));
+    assertThat(path.size(), equalTo(1));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AsPathTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AsPathTest.java
@@ -30,12 +30,14 @@ public class AsPathTest {
   @Test
   public void testAsPathLength() {
     AsPath path = AsPath.of(AsSet.confed(1L));
-    assertThat(path.size(), equalTo(0));
+    assertThat(path.length(), equalTo(0));
 
     path = AsPath.of(ImmutableList.of(AsSet.confed(1L), AsSet.of(2L)));
-    assertThat(path.size(), equalTo(1));
+    assertThat(path.length(), equalTo(1));
+    assertThat(path.size(), equalTo(2));
 
     path = AsPath.of(ImmutableList.of(AsSet.confed(1L), AsSet.of(2L, 3L), AsSet.confed(3L)));
-    assertThat(path.size(), equalTo(1));
+    assertThat(path.length(), equalTo(1));
+    assertThat(path.size(), equalTo(3));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AsSetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AsSetTest.java
@@ -1,8 +1,15 @@
 package org.batfish.datamodel;
 
+import static org.batfish.datamodel.AsSet.confed;
+import static org.batfish.datamodel.AsSet.confedEmpty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 /** Tests of {@link AsSet} */
@@ -16,5 +23,35 @@ public class AsSetTest {
 
     // For set of ASNs, should return {asn1,asn2,...lastAsn}
     assertThat(AsSet.of(1, 2, 3).toString(), equalTo("{1,2,3}"));
+  }
+
+  @Test
+  public void testConfed() {
+    AsSet set = confedEmpty();
+    assertTrue(set.isEmpty());
+    assertTrue(set.isConfederationAsSet());
+
+    set = confed(1L);
+    assertFalse(set.isEmpty());
+    assertTrue(set.isConfederationAsSet());
+  }
+
+  @Test
+  public void testEquals() {
+    AsSet set = AsSet.of(1);
+    new EqualsTester()
+        .addEqualityGroup(set, set, AsSet.of(1))
+        .addEqualityGroup(AsSet.of(2))
+        .addEqualityGroup(confed(2))
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    AsSet set = AsSet.of(1);
+    assertThat(BatfishObjectMapper.clone(set, AsSet.class), equalTo(set));
+    set = AsSet.confed(1);
+    assertThat(BatfishObjectMapper.clone(set, AsSet.class), equalTo(set));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -99,7 +99,6 @@ public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
             // Aggregates (for non-juniper devices, won't appear on Juniper)
             .thenComparing(r -> getAggregatePreference(r.getProtocol()))
             // AS path: prefer shorter
-            // NOTE: if BGP confederations were supported, confederation segments have a length of 0
             // TODO: support `bestpath as-path ignore` (both cisco, juniper)
             .thenComparing(r -> r.getAsPath().size(), Comparator.reverseOrder())
             // Prefer certain origin type Internal over External over Incomplete

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -100,7 +100,7 @@ public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
             .thenComparing(r -> getAggregatePreference(r.getProtocol()))
             // AS path: prefer shorter
             // TODO: support `bestpath as-path ignore` (both cisco, juniper)
-            .thenComparing(r -> r.getAsPath().size(), Comparator.reverseOrder())
+            .thenComparing(r -> r.getAsPath().length(), Comparator.reverseOrder())
             // Prefer certain origin type Internal over External over Incomplete
             .thenComparing(r -> r.getOriginType().getPreference())
             // Prefer eBGP over iBGP
@@ -189,7 +189,7 @@ public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
         AsSet rhsFirstAsSet = rhs.getAsSets().isEmpty() ? AsSet.empty() : rhs.getAsSets().get(0);
         return lhsFirstAsSet.equals(rhsFirstAsSet) ? 0 : -1;
       case PATH_LENGTH:
-        assert lhs.size() == rhs.size();
+        assert lhs.length() == rhs.length();
         return 0;
       default:
         throw new IllegalStateException(

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -26788,9 +26788,12 @@
                 "class" : "org.batfish.datamodel.GeneratedRoute",
                 "administrativeCost" : 130,
                 "asPath" : [
-                  [
-                    8060932
-                  ]
+                  {
+                    "asns" : [
+                      8060932
+                    ],
+                    "confederation" : false
+                  }
                 ],
                 "discard" : true,
                 "generationPolicy" : "~AGGREGATE_ROUTE_POLICY:20.0.0.0/8~",
@@ -26803,10 +26806,13 @@
                 "class" : "org.batfish.datamodel.GeneratedRoute",
                 "administrativeCost" : 130,
                 "asPath" : [
-                  [
-                    8060932,
-                    29884423
-                  ]
+                  {
+                    "asns" : [
+                      8060932,
+                      29884423
+                    ],
+                    "confederation" : false
+                  }
                 ],
                 "discard" : true,
                 "generationPolicy" : "~AGGREGATE_ROUTE_POLICY:30.0.0.0/8~",


### PR DESCRIPTION
* Went with boolean instead of subclassing to:
    * avoid JsonTypeInfo
    * easier caching
* Added new logic to purge confederation AsSets from AsPath