### PR TITLE
PAN: add test for hybrid address-group

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -137,6 +137,7 @@ import org.batfish.representation.palo_alto.Tag;
 import org.batfish.representation.palo_alto.VirtualRouter;
 import org.batfish.representation.palo_alto.Vsys;
 import org.batfish.representation.palo_alto.Zone;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -315,6 +316,30 @@ public final class PaloAltoGrammarTest {
         hasIpSpace(
             "group1",
             equalTo(addressGroups.get("group1").getIpSpace(addressObjects, addressGroups))));
+  }
+
+  // TODO: https://github.com/batfish/batfish/issues/4921
+  @Ignore
+  @Test
+  public void testAddressGroupHybrid() {
+    PaloAltoConfiguration c = parsePaloAltoConfig("address-group-hybrid");
+
+    Vsys vsys = c.getVirtualSystems().get(DEFAULT_VSYS_NAME);
+    Map<String, AddressGroup> addressGroups = vsys.getAddressGroups();
+    Map<String, AddressObject> addressObjects = vsys.getAddressObjects();
+
+    Vsys sharedVsys = c.getShared();
+    Map<String, AddressObject> sharedAddressObjects = sharedVsys.getAddressObjects();
+
+    assertThat(addressGroups.keySet(), equalTo(ImmutableSet.of("group")));
+
+    // Confirm hybrid address-group contains both shared and vsys-specific addresses
+    assertThat(
+        addressGroups.get("group").getIpSpace(addressObjects, addressGroups),
+        equalTo(
+            AclIpSpace.union(
+                addressObjects.get("addr").getIpSpace(),
+                sharedAddressObjects.get("shared_addr").getIpSpace())));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-group-hybrid
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-group-hybrid
@@ -1,0 +1,9 @@
+set deviceconfig system hostname address-group-hybrid
+
+# address accessible by any vsys
+set shared address shared_addr ip-netmask 1.1.1.1
+
+# vsys-specific address
+set address addr ip-netmask 10.10.10.10
+
+set address-group group static [ addr shared_addr]


### PR DESCRIPTION
Add test for hybrid `address-group`, testing behavior where an `address-group` contains addresses from different namespaces.

Test does not pass yet, see https://github.com/batfish/batfish/issues/4921.
