### PR TITLE
Juniper: implement filter input-list and output-list

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -598,6 +598,7 @@ import org.batfish.representation.juniper.BaseApplication.Term;
 import org.batfish.representation.juniper.BgpGroup;
 import org.batfish.representation.juniper.BgpGroup.BgpGroupType;
 import org.batfish.representation.juniper.CommunityMember;
+import org.batfish.representation.juniper.ConcreteFirewallFilter;
 import org.batfish.representation.juniper.DhcpRelayGroup;
 import org.batfish.representation.juniper.DhcpRelayServerGroup;
 import org.batfish.representation.juniper.Family;
@@ -1946,7 +1947,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   private DhcpRelayGroup _currentDhcpRelayGroup;
 
-  private FirewallFilter _currentFilter;
+  private ConcreteFirewallFilter _currentFilter;
 
   private Family _currentFirewallFamily;
 
@@ -2034,7 +2035,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   private Zone _currentZone;
 
-  private FirewallFilter _currentZoneInboundFilter;
+  private ConcreteFirewallFilter _currentZoneInboundFilter;
 
   private String _currentZoneInterface;
 
@@ -2252,14 +2253,14 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void enterF_filter(F_filterContext ctx) {
-    String name = ctx.name.getText();
-    Map<String, FirewallFilter> filters = _currentLogicalSystem.getFirewallFilters();
-    _currentFilter = filters.get(name);
     if (_currentFirewallFamily == null) {
       _currentFirewallFamily = Family.INET;
     }
+    String name = ctx.name.getText();
+    Map<String, FirewallFilter> filters = _currentLogicalSystem.getFirewallFilters();
+    _currentFilter = (ConcreteFirewallFilter) filters.get(name);
     if (_currentFilter == null) {
-      _currentFilter = new FirewallFilter(name, _currentFirewallFamily);
+      _currentFilter = new ConcreteFirewallFilter(name, _currentFirewallFamily);
       filters.put(name, _currentFilter);
     }
     _configuration.defineFlattenedStructure(FIREWALL_FILTER, name, ctx, _parser);
@@ -3324,7 +3325,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
         // Policy for traffic originating from this device
         _currentFilter = _currentToZone.getFromHostFilter();
         if (_currentFilter == null) {
-          _currentFilter = new FirewallFilter(policyName, Family.INET);
+          _currentFilter = new ConcreteFirewallFilter(policyName, Family.INET);
           _currentLogicalSystem.getFirewallFilters().put(policyName, _currentFilter);
           _currentToZone.setFromHostFilter(_currentFilter);
         }
@@ -3332,7 +3333,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
         // Policy for traffic destined for this device
         _currentFilter = _currentFromZone.getToHostFilter();
         if (_currentFilter == null) {
-          _currentFilter = new FirewallFilter(policyName, Family.INET);
+          _currentFilter = new ConcreteFirewallFilter(policyName, Family.INET);
           _currentLogicalSystem.getFirewallFilters().put(policyName, _currentFilter);
           _currentFromZone.setToHostFilter(_currentFilter);
         }
@@ -3340,7 +3341,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
         // Policy for thru traffic
         _currentFilter = _currentFromZone.getToZonePolicies().get(toName);
         if (_currentFilter == null) {
-          _currentFilter = new FirewallFilter(policyName, Family.INET);
+          _currentFilter = new ConcreteFirewallFilter(policyName, Family.INET);
           _currentLogicalSystem.getFirewallFilters().put(policyName, _currentFilter);
           _currentFromZone.getToZonePolicies().put(toName, _currentFilter);
         }
@@ -3361,9 +3362,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void enterSep_global(Sep_globalContext ctx) {
     _currentFilter =
-        _currentLogicalSystem
-            .getFirewallFilters()
-            .computeIfAbsent(ACL_NAME_GLOBAL_POLICY, n -> new FirewallFilter(n, Family.INET));
+        (ConcreteFirewallFilter)
+            _currentLogicalSystem
+                .getFirewallFilters()
+                .computeIfAbsent(
+                    ACL_NAME_GLOBAL_POLICY, n -> new ConcreteFirewallFilter(n, Family.INET));
   }
 
   @Override
@@ -3419,7 +3422,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
                 + _currentZone.getName()
                 + "~INTERFACE~"
                 + _currentZoneInterface;
-        _currentZoneInboundFilter = new FirewallFilter(name, Family.INET);
+        _currentZoneInboundFilter = new ConcreteFirewallFilter(name, Family.INET);
         _currentLogicalSystem.getFirewallFilters().put(name, _currentZoneInboundFilter);
         _currentZone
             .getInboundInterfaceFilters()

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/CompositeFirewallFilter.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/CompositeFirewallFilter.java
@@ -1,0 +1,43 @@
+package org.batfish.representation.juniper;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+/** A firewall filter on Juniper */
+public final class CompositeFirewallFilter extends FirewallFilter {
+
+  public CompositeFirewallFilter(String name, @Nonnull List<FirewallFilter> inner) {
+    super(name);
+    _inner = ImmutableList.copyOf(inner);
+    checkArgument(!_inner.isEmpty(), "Invalid composite firewall-filter with no members");
+    Set<Family> families =
+        _inner.stream().map(FirewallFilter::getFamily).collect(Collectors.toSet());
+    checkArgument(
+        families.size() == 1,
+        "All member lists in a composite firewall-filter must have the same family: %s",
+        families);
+  }
+
+  @Override
+  public Family getFamily() {
+    assert !_inner.isEmpty(); // in constructor.
+    return _inner.get(0).getFamily();
+  }
+
+  @Nonnull
+  public List<FirewallFilter> getInner() {
+    return _inner;
+  }
+
+  @Override
+  public boolean isUsedForFBF() {
+    return _inner.stream().anyMatch(FirewallFilter::isUsedForFBF);
+  }
+
+  private final @Nonnull List<FirewallFilter> _inner;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/CompositeFirewallFilter.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/CompositeFirewallFilter.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
-/** A firewall filter on Juniper */
+/** A firewall filter on Juniper that is a concatenation of its member filters. */
 public final class CompositeFirewallFilter extends FirewallFilter {
 
   public CompositeFirewallFilter(String name, @Nonnull List<FirewallFilter> inner) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/ConcreteFirewallFilter.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/ConcreteFirewallFilter.java
@@ -1,0 +1,53 @@
+package org.batfish.representation.juniper;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/** A firewall filter on Juniper */
+public final class ConcreteFirewallFilter extends FirewallFilter {
+
+  private final Family _family;
+
+  /*
+   * This is important filtering information for security policies (i.e. security policies only
+   * apply to specific from-zones)
+   */
+  private String _fromZone;
+  private boolean _usedForFBF;
+  private final Map<String, FwTerm> _terms;
+
+  public ConcreteFirewallFilter(String name, Family family) {
+    super(name);
+    _family = family;
+    _fromZone = null;
+    _terms = new LinkedHashMap<>();
+  }
+
+  @Override
+  public Family getFamily() {
+    return _family;
+  }
+
+  public @Nullable String getFromZone() {
+    return _fromZone;
+  }
+
+  /** Whether or not this filter is used for Filter-Based Forwarding (FBF) */
+  @Override
+  public boolean isUsedForFBF() {
+    return _usedForFBF;
+  }
+
+  public Map<String, FwTerm> getTerms() {
+    return _terms;
+  }
+
+  public void setUsedForFBF(boolean usedForFBF) {
+    _usedForFBF = usedForFBF;
+  }
+
+  public void setFromZone(String fromZone) {
+    _fromZone = fromZone;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/ConcreteFirewallFilter.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/ConcreteFirewallFilter.java
@@ -4,7 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-/** A firewall filter on Juniper */
+/** A firewall filter on Juniper. */
 public final class ConcreteFirewallFilter extends FirewallFilter {
 
   private final Family _family;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FirewallFilter.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FirewallFilter.java
@@ -3,7 +3,7 @@ package org.batfish.representation.juniper;
 import java.io.Serializable;
 import javax.annotation.Nonnull;
 
-/** A firewall filter on Juniper */
+/** The VS structure for things that are ACL-like. */
 public abstract class FirewallFilter implements Serializable {
   public final @Nonnull String getName() {
     return _name;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FirewallFilter.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FirewallFilter.java
@@ -1,57 +1,23 @@
 package org.batfish.representation.juniper;
 
 import java.io.Serializable;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 /** A firewall filter on Juniper */
-public final class FirewallFilter implements Serializable {
-
-  private final Family _family;
-
-  /*
-   * This is important filtering information for security policies (i.e. security policies only
-   * apply to specific from-zones)
-   */
-  private String _fromZone;
-  private final String _name;
-  private boolean _usedForFBF;
-  private final Map<String, FwTerm> _terms;
-
-  public FirewallFilter(String name, Family family) {
-    _family = family;
-    _fromZone = null;
-    _name = name;
-    _terms = new LinkedHashMap<>();
-  }
-
-  public Family getFamily() {
-    return _family;
-  }
-
-  public @Nullable String getFromZone() {
-    return _fromZone;
-  }
-
-  public String getName() {
+public abstract class FirewallFilter implements Serializable {
+  public final @Nonnull String getName() {
     return _name;
   }
 
-  /** Whether or not this filter is used for Filter-Based Forwarding (FBF) */
-  public boolean isUsedForFBF() {
-    return _usedForFBF;
+  public abstract Family getFamily();
+
+  public abstract boolean isUsedForFBF();
+
+  // Private implementation details.
+
+  protected FirewallFilter(@Nonnull String name) {
+    _name = name;
   }
 
-  public Map<String, FwTerm> getTerms() {
-    return _terms;
-  }
-
-  public void setUsedForFBF(boolean usedForFBF) {
-    _usedForFBF = usedForFBF;
-  }
-
-  public void setFromZone(String fromZone) {
-    _fromZone = fromZone;
-  }
+  private final @Nonnull String _name;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwTerm.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwTerm.java
@@ -3,6 +3,7 @@ package org.batfish.representation.juniper;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public final class FwTerm implements Serializable {
@@ -48,7 +49,7 @@ public final class FwTerm implements Serializable {
     return _fromIpOptions;
   }
 
-  public @Nullable FwFromIpOptions getOrCreateFromIpOptions() {
+  public @Nonnull FwFromIpOptions getOrCreateFromIpOptions() {
     if (_fromIpOptions == null) {
       _fromIpOptions = new FwFromIpOptions();
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -336,7 +336,7 @@ public class Interface implements Serializable {
     _description = description;
   }
 
-  public void setIncomingFilter(@Nonnull String accessListName) {
+  public void setIncomingFilter(@Nullable String accessListName) {
     _incomingFilter = accessListName;
     _incomingFilterList = null;
   }
@@ -393,7 +393,7 @@ public class Interface implements Serializable {
     _ospfInterfaceType = ospfInterfaceType;
   }
 
-  public void setOutgoingFilter(@Nonnull String accessListName) {
+  public void setOutgoingFilter(@Nullable String accessListName) {
     _outgoingFilter = accessListName;
     _outgoingFilterList = null;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Zone.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Zone.java
@@ -20,21 +20,21 @@ public final class Zone implements Serializable {
 
   private AddressBookType _addressBookType;
 
-  private FirewallFilter _fromHostFilter;
+  private ConcreteFirewallFilter _fromHostFilter;
 
   private final Map<String, FirewallFilter> _fromZonePolicies;
 
-  private final FirewallFilter _inboundFilter;
+  private final ConcreteFirewallFilter _inboundFilter;
 
-  private final Map<String, FirewallFilter> _inboundInterfaceFilters;
+  private final Map<String, ConcreteFirewallFilter> _inboundInterfaceFilters;
 
   private final List<String> _interfaces;
 
   private final String _name;
 
-  private FirewallFilter _toHostFilter;
+  private ConcreteFirewallFilter _toHostFilter;
 
-  private final Map<String, FirewallFilter> _toZonePolicies;
+  private final Map<String, ConcreteFirewallFilter> _toZonePolicies;
 
   private final Set<String> _screens;
 
@@ -42,7 +42,7 @@ public final class Zone implements Serializable {
     _name = name;
     _addressBook = globalAddressBook;
     _addressBookType = AddressBookType.GLOBAL;
-    _inboundFilter = new FirewallFilter("~INBOUND_ZONE_FILTER~" + name, Family.INET);
+    _inboundFilter = new ConcreteFirewallFilter("~INBOUND_ZONE_FILTER~" + name, Family.INET);
     _inboundInterfaceFilters = new TreeMap<>();
     _interfaces = new ArrayList<>();
     _fromZonePolicies = new TreeMap<>();
@@ -69,7 +69,7 @@ public final class Zone implements Serializable {
     return _addressBookType;
   }
 
-  public FirewallFilter getFromHostFilter() {
+  public ConcreteFirewallFilter getFromHostFilter() {
     return _fromHostFilter;
   }
 
@@ -81,11 +81,11 @@ public final class Zone implements Serializable {
     return _screens;
   }
 
-  public FirewallFilter getInboundFilter() {
+  public ConcreteFirewallFilter getInboundFilter() {
     return _inboundFilter;
   }
 
-  public Map<String, FirewallFilter> getInboundInterfaceFilters() {
+  public Map<String, ConcreteFirewallFilter> getInboundInterfaceFilters() {
     return _inboundInterfaceFilters;
   }
 
@@ -97,19 +97,19 @@ public final class Zone implements Serializable {
     return _name;
   }
 
-  public FirewallFilter getToHostFilter() {
+  public ConcreteFirewallFilter getToHostFilter() {
     return _toHostFilter;
   }
 
-  public Map<String, FirewallFilter> getToZonePolicies() {
+  public Map<String, ConcreteFirewallFilter> getToZonePolicies() {
     return _toZonePolicies;
   }
 
-  public void setFromHostFilter(FirewallFilter fromHostFilter) {
+  public void setFromHostFilter(ConcreteFirewallFilter fromHostFilter) {
     _fromHostFilter = fromHostFilter;
   }
 
-  public void setToHostFilter(FirewallFilter toHostFilter) {
+  public void setToHostFilter(ConcreteFirewallFilter toHostFilter) {
     _toHostFilter = toHostFilter;
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/CompositeFirewallFilterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/CompositeFirewallFilterTest.java
@@ -34,8 +34,8 @@ public class CompositeFirewallFilterTest {
 
     CompositeFirewallFilter barfoo =
         new CompositeFirewallFilter("comp", ImmutableList.of(bar, foo));
-    assertThat(foobar.getFamily(), equalTo(Family.INET));
-    assertThat(foobar.isUsedForFBF(), equalTo(true));
+    assertThat(barfoo.getFamily(), equalTo(Family.INET));
+    assertThat(barfoo.isUsedForFBF(), equalTo(true));
 
     CompositeFirewallFilter barbarOnly =
         new CompositeFirewallFilter("comp", ImmutableList.of(bar, barOnly));

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/CompositeFirewallFilterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/CompositeFirewallFilterTest.java
@@ -1,0 +1,55 @@
+package org.batfish.representation.juniper;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Tests of {@link CompositeFirewallFilter}. */
+public class CompositeFirewallFilterTest {
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+
+  @Test
+  public void testGetters() {
+    ConcreteFirewallFilter foo = new ConcreteFirewallFilter("foo", Family.INET);
+    foo.setUsedForFBF(true);
+    ConcreteFirewallFilter bar = new ConcreteFirewallFilter("bar", Family.INET);
+    bar.setUsedForFBF(false);
+
+    CompositeFirewallFilter fooOnly = new CompositeFirewallFilter("comp", ImmutableList.of(foo));
+    assertThat(fooOnly.getFamily(), equalTo(Family.INET));
+    assertThat(fooOnly.isUsedForFBF(), equalTo(true));
+
+    CompositeFirewallFilter barOnly = new CompositeFirewallFilter("comp", ImmutableList.of(bar));
+    assertThat(barOnly.getFamily(), equalTo(Family.INET));
+    assertThat(barOnly.isUsedForFBF(), equalTo(false));
+
+    CompositeFirewallFilter foobar =
+        new CompositeFirewallFilter("comp", ImmutableList.of(foo, bar));
+    assertThat(foobar.getFamily(), equalTo(Family.INET));
+    assertThat(foobar.isUsedForFBF(), equalTo(true));
+
+    CompositeFirewallFilter barfoo =
+        new CompositeFirewallFilter("comp", ImmutableList.of(bar, foo));
+    assertThat(foobar.getFamily(), equalTo(Family.INET));
+    assertThat(foobar.isUsedForFBF(), equalTo(true));
+
+    CompositeFirewallFilter barbarOnly =
+        new CompositeFirewallFilter("comp", ImmutableList.of(bar, barOnly));
+    assertThat(barbarOnly.getFamily(), equalTo(Family.INET));
+    assertThat(barbarOnly.isUsedForFBF(), equalTo(false));
+  }
+
+  @Test
+  public void testVerifiesFamily() {
+    ConcreteFirewallFilter v4 = new ConcreteFirewallFilter("v4", Family.INET);
+    ConcreteFirewallFilter v6 = new ConcreteFirewallFilter("v6", Family.INET6);
+
+    _thrown.expectMessage(
+        "All member lists in a composite firewall-filter must have the same family");
+    new CompositeFirewallFilter("bad", ImmutableList.of(v4, v6));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -72,7 +72,7 @@ public class JuniperConfigurationTest {
   @Test
   public void testToIpAccessList() {
     JuniperConfiguration config = createConfig();
-    FirewallFilter filter = new FirewallFilter("filter", Family.INET);
+    ConcreteFirewallFilter filter = new ConcreteFirewallFilter("filter", Family.INET);
     IpAccessList emptyAcl = config.toIpAccessList(filter);
 
     FwTerm term = new FwTerm("term");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-filters
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/firewall-filters
@@ -5,7 +5,7 @@ set firewall filter FILTER1 term TERM from source-address 1.2.3.6
 set firewall filter FILTER1 term TERM then accept
 set firewall filter FILTER2 term TERM from source-address 1.2.3.6
 set firewall filter FILTER2 term TERM from source-address 1.2.3.5
-set firewall filter FILTER2 term TERM then accept
+set firewall filter FILTER2 term TERM then reject
 set firewall filter FILTER_UNUSED term TERM from source-address 1.2.3.6
 set firewall filter FILTER_UNUSED term TERM then accept
 set interfaces xe-0/0/0 unit 0 family inet address 1.2.3.4/24
@@ -16,7 +16,7 @@ set interfaces xe-0/0/1 unit 0 family inet filter output FILTER2
 set interfaces xe-0/0/2 unit 0 family inet address 3.2.3.4/24
 set interfaces xe-0/0/2 unit 0 family inet filter output FILTER_UNDEF
 set interfaces xe-0/0/3 unit 0 family inet address 4.2.3.4/24
-set interfaces xe-0/0/3 unit 0 family inet filter input-list A
-set interfaces xe-0/0/3 unit 0 family inet filter input-list B
-set interfaces xe-0/0/3 unit 0 family inet filter output-list B
-set interfaces xe-0/0/3 unit 0 family inet filter output-list A
+set interfaces xe-0/0/3 unit 0 family inet filter input-list FILTER1
+set interfaces xe-0/0/3 unit 0 family inet filter input-list FILTER2
+set interfaces xe-0/0/3 unit 0 family inet filter output-list FILTER2
+set interfaces xe-0/0/3 unit 0 family inet filter output-list FILTER1


### PR DESCRIPTION
* separate FirewallFilter into Concrete and Composite
* adapt extraction, vs model, conversion for these
* implement composite versions of access list and packet policy conversion
* add test