### PR TITLE
PaloAlto: dynamic address-group filters

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -344,6 +344,11 @@ ETHERNET
     'ethernet'
 ;
 
+FILTER
+:
+    'filter'
+;
+
 FQDN
 :
     'fqdn'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_address_group.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_address_group.g4
@@ -29,8 +29,12 @@ sag_description
 
 sag_dynamic
 :
-    DYNAMIC
-    null_rest_of_line
+    DYNAMIC sagd_filter?
+;
+
+sagd_filter
+:
+    FILTER filter = variable
 ;
 
 sag_static

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -140,6 +140,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_descriptionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_dynamicContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_staticContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_tagContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sagd_filterContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_descriptionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sappg_definitionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sappg_membersContext;
@@ -777,6 +778,11 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   }
 
   @Override
+  public void exitSagd_filter(Sagd_filterContext ctx) {
+    _currentAddressGroup.setFilter(getText(ctx.filter));
+  }
+
+  @Override
   public void enterS_tag(S_tagContext ctx) {
     String name = getText(ctx.name);
     _currentTag = _currentVsys.getTags().computeIfAbsent(name, Tag::new);
@@ -923,7 +929,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       if (objectName.equals(_currentAddressGroup.getName())) {
         warn(ctx, String.format("The address group '%s' cannot contain itself", objectName));
       } else {
-        _currentAddressGroup.getMembers().add(objectName);
+        _currentAddressGroup.addMember(objectName);
 
         // Use constructed name so same-named defs across vsys are unique
         String uniqueName = computeObjectName(_currentVsys.getName(), objectName);

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -137,7 +137,6 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sa_ip_netmaskContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sa_ip_rangeContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sa_tagContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_descriptionContext;
-import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_dynamicContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_staticContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_tagContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sagd_filterContext;
@@ -915,11 +914,6 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitSag_description(Sag_descriptionContext ctx) {
     _currentAddressGroup.setDescription(getText(ctx.description));
-  }
-
-  @Override
-  public void exitSag_dynamic(Sag_dynamicContext ctx) {
-    warn(ctx, "Dynamic address groups are not currently supported");
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressGroup.java
@@ -26,7 +26,6 @@ public final class AddressGroup implements Serializable {
    */
   public enum Type {
     DYNAMIC,
-    EMPTY,
     STATIC
   }
 
@@ -46,7 +45,7 @@ public final class AddressGroup implements Serializable {
     _name = name;
     _members = new TreeSet<>();
     _tags = new HashSet<>();
-    _type = Type.EMPTY;
+    _type = null;
   }
 
   /**
@@ -177,6 +176,7 @@ public final class AddressGroup implements Serializable {
   /** Add a member to the set of member address objects for this static address-group. */
   public void addMember(String member) {
     if (_type != Type.STATIC) {
+      // Handle the case where a dynamic address-group is replaced by a static one
       _type = Type.STATIC;
       _filter = null;
     }
@@ -207,6 +207,7 @@ public final class AddressGroup implements Serializable {
   /** Set filter for this dynamic address-group. */
   public void setFilter(String filter) {
     if (_type != Type.DYNAMIC) {
+      // Handle the case where a static address-group is replaced by a dynamic one
       _type = Type.DYNAMIC;
       _members.clear();
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressGroup.java
@@ -101,8 +101,7 @@ public final class AddressGroup implements Serializable {
   }
 
   /** Returns descendant objects for a dynamic address-group. */
-  @VisibleForTesting
-  Set<String> getDynamicDescendantObjects(
+  private Set<String> getDynamicDescendantObjects(
       Map<String, AddressObject> addressObjects,
       Map<String, AddressGroup> addressGroups,
       Set<String> alreadyTraversedGroups) {
@@ -132,8 +131,8 @@ public final class AddressGroup implements Serializable {
     return descendantObjects;
   }
 
-  @VisibleForTesting
-  Set<String> getStaticDescendantObjects(
+  /** Returns descendant objects for a static address-group. */
+  private Set<String> getStaticDescendantObjects(
       Map<String, AddressObject> addressObjects,
       Map<String, AddressGroup> addressGroups,
       Set<String> alreadyTraversedGroups) {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressGroup.java
@@ -39,13 +39,12 @@ public final class AddressGroup implements Serializable {
 
   @Nonnull private final Set<String> _tags;
 
-  private Type _type;
+  @Nullable private Type _type;
 
   public AddressGroup(String name) {
     _name = name;
     _members = new TreeSet<>();
     _tags = new HashSet<>();
-    _type = null;
   }
 
   /**
@@ -196,6 +195,7 @@ public final class AddressGroup implements Serializable {
     return _tags;
   }
 
+  @Nullable
   public Type getType() {
     return _type;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressGroup.java
@@ -60,20 +60,39 @@ public final class AddressGroup implements Serializable {
       return ImmutableSet.of();
     }
     alreadyTraversedGroups.add(_name);
-    Set<String> descendantObjects = new HashSet<>();
     if (_type == Type.STATIC) {
-      for (String member : _members) {
-        if (addressObjects.containsKey(member)) {
-          descendantObjects.add(member);
-        } else if (addressGroups.containsKey(member)) {
-          descendantObjects.addAll(
-              addressGroups
-                  .get(member)
-                  .getDescendantObjects(addressObjects, addressGroups, alreadyTraversedGroups));
-        }
-      }
+      return getStaticDescendantObjects(addressObjects, addressGroups, alreadyTraversedGroups);
     } else if (_type == Type.DYNAMIC) {
-      // TODO write this logic
+      return getDynamicDescendantObjects(addressObjects, addressGroups, alreadyTraversedGroups);
+    }
+    return ImmutableSet.of();
+  }
+
+  private Set<String> getDynamicDescendantObjects(
+      Map<String, AddressObject> addressObjects,
+      Map<String, AddressGroup> addressGroups,
+      Set<String> alreadyTraversedGroups) {
+    // Guaranteed by caller / type is dynamic
+    assert _filter != null;
+    String[] conjuncts = _filter.split("and");
+    // TODO flesh out logic
+    return ImmutableSet.of();
+  }
+
+  private Set<String> getStaticDescendantObjects(
+      Map<String, AddressObject> addressObjects,
+      Map<String, AddressGroup> addressGroups,
+      Set<String> alreadyTraversedGroups) {
+    Set<String> descendantObjects = new HashSet<>();
+    for (String member : _members) {
+      if (addressObjects.containsKey(member)) {
+        descendantObjects.add(member);
+      } else if (addressGroups.containsKey(member)) {
+        descendantObjects.addAll(
+            addressGroups
+                .get(member)
+                .getDescendantObjects(addressObjects, addressGroups, alreadyTraversedGroups));
+      }
     }
     return descendantObjects;
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -322,12 +322,19 @@ public final class PaloAltoGrammarTest {
     PaloAltoConfiguration c = parsePaloAltoConfig("address-group-dynamic");
 
     Vsys vsys = c.getVirtualSystems().get(DEFAULT_VSYS_NAME);
+    Map<String, AddressObject> addressObjects = vsys.getAddressObjects();
     Map<String, AddressGroup> addressGroups = vsys.getAddressGroups();
 
     // Confirm filter was attached to the dynamic address-group
     assertThat(addressGroups.keySet(), contains("group"));
-    assertThat(addressGroups.get("group").getType(), equalTo(AddressGroup.Type.DYNAMIC));
-    assertThat(addressGroups.get("group").getFilter(), equalTo("'tagA' and tag1"));
+    AddressGroup ag = addressGroups.get("group");
+    assertThat(ag.getType(), equalTo(AddressGroup.Type.DYNAMIC));
+    assertThat(ag.getFilter(), equalTo("'tagA' and tag1"));
+
+    // Confirm the filter resolves to the correct IpSpace, containing only the one matching address
+    assertThat(
+        ag.getIpSpace(addressObjects, addressGroups),
+        equalTo(addressObjects.get("addr1").getIpSpace()));
     // TODO add conversion and IP space test too
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -335,7 +335,6 @@ public final class PaloAltoGrammarTest {
     assertThat(
         ag.getIpSpace(addressObjects, addressGroups),
         equalTo(addressObjects.get("addr1").getIpSpace()));
-    // TODO add conversion and IP space test too
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -318,6 +318,20 @@ public final class PaloAltoGrammarTest {
   }
 
   @Test
+  public void testAddressGroupDynamic() {
+    PaloAltoConfiguration c = parsePaloAltoConfig("address-group-dynamic");
+
+    Vsys vsys = c.getVirtualSystems().get(DEFAULT_VSYS_NAME);
+    Map<String, AddressGroup> addressGroups = vsys.getAddressGroups();
+
+    // Confirm filter was attached to the dynamic address-group
+    assertThat(addressGroups.keySet(), contains("group"));
+    assertThat(addressGroups.get("group").getType(), equalTo(AddressGroup.Type.DYNAMIC));
+    assertThat(addressGroups.get("group").getFilter(), equalTo("'tagA' and tag1"));
+    // TODO add conversion and IP space test too
+  }
+
+  @Test
   public void testAddressGroupsNested() {
     PaloAltoConfiguration c = parsePaloAltoConfig("address-groups-nested");
 

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressGroupTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressGroupTest.java
@@ -19,7 +19,7 @@ public class AddressGroupTest {
         ImmutableMap.of("ad1", new AddressObject("ad1"), "ad2", new AddressObject("ad2"));
 
     // only one of the address objects is a member
-    ag.getMembers().add("ad1");
+    ag.addMember("ad1");
     assertThat(
         ag.getDescendantObjects(addressObjects, ImmutableMap.of(), new HashSet<>()),
         equalTo(ImmutableSet.of("ad1")));
@@ -40,9 +40,10 @@ public class AddressGroupTest {
 
     // parent -> child -> {parent, grandChild}
     // grandChild -> {child, ad1}
-    addressGroups.get("parentGroup").getMembers().add("childGroup");
-    addressGroups.get("childGroup").getMembers().add("grandchildGroup");
-    addressGroups.get("grandchildGroup").getMembers().addAll(ImmutableSet.of("childGroup", "ad1"));
+    addressGroups.get("parentGroup").addMember("childGroup");
+    addressGroups.get("childGroup").addMember("grandchildGroup");
+    addressGroups.get("grandchildGroup").addMember("childGroup");
+    addressGroups.get("grandchildGroup").addMember("ad1");
 
     assertThat(
         addressGroups
@@ -70,8 +71,8 @@ public class AddressGroupTest {
     Map<String, AddressObject> addressObjects =
         ImmutableMap.of("ad1", new AddressObject("ad1"), "ad2", new AddressObject("ad2"));
 
-    addressGroups.get("parentGroup").getMembers().add("childGroup");
-    addressGroups.get("childGroup").getMembers().add("ad1");
+    addressGroups.get("parentGroup").addMember("childGroup");
+    addressGroups.get("childGroup").addMember("ad1");
 
     assertThat(
         addressGroups

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressGroupTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressGroupTest.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.palo_alto;
 
+import static org.batfish.representation.palo_alto.AddressGroup.getFilterConjuncts;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -7,6 +9,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Test;
 
 /** Tests for {@link AddressGroup} */
@@ -79,5 +82,54 @@ public class AddressGroupTest {
             .get("parentGroup")
             .getDescendantObjects(addressObjects, addressGroups, new HashSet<>()),
         equalTo(ImmutableSet.of("ad1")));
+  }
+
+  @Test
+  public void testGetDynamicDescendantObjectsConjunction() {
+    String filter = "'tag1' and 'tag2'";
+    AddressGroup ag = new AddressGroup("name");
+    ag.setFilter(filter);
+
+    AddressGroup agMatch = new AddressGroup("agMatch");
+    agMatch.getTags().add("tag1");
+    agMatch.getTags().add("tag2");
+    AddressObject aoMatch = new AddressObject("aoMatch");
+
+    AddressGroup agOther = new AddressGroup("agOther");
+    agOther.getTags().add("tag1");
+    AddressObject aoOther = new AddressObject("aoOther");
+    aoOther.getTags().add("tag1");
+
+    AddressObject aoMatchDirect = new AddressObject("aoMatchDirect");
+    aoMatchDirect.getTags().add("tag1");
+    aoMatchDirect.getTags().add("tag2");
+
+    Map<String, AddressGroup> ags =
+        ImmutableMap.of(
+            "agMatch", agMatch,
+            "agOther", agOther);
+    Map<String, AddressObject> aos =
+        ImmutableMap.of(
+            "aoMatch", aoMatch,
+            "aoMatchDirect", aoMatchDirect,
+            "aoOther", aoOther);
+    agMatch.addMember("aoMatch");
+    agOther.addMember("aoOther");
+
+    // Tag conjunction should evaluate to IpSpace containing the addresses with all tags
+    Set<String> matches = ag.getDescendantObjects(aos, ags, new HashSet<>());
+    assertThat(matches, contains("aoMatch", "aoMatchDirect"));
+  }
+
+  @Test
+  public void testGetFilterConjunctsNoQuotes() {
+    String filter = "tag";
+    assertThat(getFilterConjuncts(filter), contains("tag"));
+  }
+
+  @Test
+  public void testGetFilterConjuncts() {
+    String filter = "'tag1' and 'tag2'";
+    assertThat(getFilterConjuncts(filter), contains("tag1", "tag2"));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-group-dynamic
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-group-dynamic
@@ -1,0 +1,10 @@
+set deviceconfig system hostname address-group-dynamic
+
+set address addr1 ip-netmask 1.0.0.1
+set address addr1 tag [ tag1 tagA]
+set address addr2 ip-netmask 1.0.0.2
+set address addr2 tag [ tag2 tagA]
+set address addr3 ip-netmask 2.0.0.1
+set address addr3 tag tag1
+
+set address-group group dynamic filter "'tagA' and tag1"

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-group-dynamic
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-group-dynamic
@@ -7,4 +7,5 @@ set address addr2 tag [ tag2 tagA]
 set address addr3 ip-netmask 2.0.0.1
 set address addr3 tag tag1
 
+# Filter matches only addr1
 set address-group group dynamic filter "'tagA' and tag1"


### PR DESCRIPTION
Add support for basic dynamic `address-group` filters (just filters expressing conjuncts for now).

Also in this PR:
* Update some type annotations for `AddressGroup`
* Add `Type` (`STATIC`, `DYNAMIC`, `EMPTY`) to `AddressGroup`
* Move from `getMembers().add(...)` to `addMember(...)` to help enforce address-group typing
