### PR TITLE
ISPs: prefer confederation ASNs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
@@ -1,5 +1,6 @@
 package org.batfish.common.util;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.batfish.datamodel.BgpPeerConfig.ALL_AS_NUMBERS;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
@@ -570,7 +571,9 @@ public final class IspModelingUtils {
   static BgpActivePeerConfig getBgpPeerOnIsp(BgpActivePeerConfig bgpActivePeerConfig) {
     return BgpActivePeerConfig.builder()
         .setPeerAddress(bgpActivePeerConfig.getLocalIp())
-        .setRemoteAs(bgpActivePeerConfig.getLocalAs())
+        .setRemoteAs(
+            firstNonNull(
+                bgpActivePeerConfig.getConfederationAsn(), bgpActivePeerConfig.getLocalAs()))
         .setLocalIp(bgpActivePeerConfig.getPeerAddress())
         .setLocalAs(bgpActivePeerConfig.getRemoteAsns().least())
         .setIpv4UnicastAddressFamily(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
@@ -138,6 +138,24 @@ public class IspModelingUtilsTest {
   }
 
   @Test
+  public void testPreferConfederationAs() {
+    BgpActivePeerConfig bgpActivePeerConfig =
+        BgpActivePeerConfig.builder()
+            .setPeerAddress(Ip.parse("1.1.1.1"))
+            .setRemoteAs(1L)
+            .setLocalIp(Ip.parse("2.2.2.2"))
+            .setLocalAs(2L)
+            .setConfederation(1000L)
+            .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
+            .build();
+
+    BgpActivePeerConfig reversedPeer = IspModelingUtils.getBgpPeerOnIsp(bgpActivePeerConfig);
+    assertThat(reversedPeer.getPeerAddress(), equalTo(Ip.parse("2.2.2.2")));
+    assertThat(reversedPeer.getLocalIp(), equalTo(Ip.parse("1.1.1.1")));
+    assertThat(reversedPeer, allOf(hasLocalAs(1L), hasRemoteAs(1000L)));
+  }
+
+  @Test
   public void testIsValidBgpPeer() {
     Set<Ip> validLocalIps = ImmutableSet.of(Ip.parse("3.3.3.3"));
     BgpActivePeerConfig invalidPeer =


### PR DESCRIPTION
Since ISPs are external to any network, prefer confederation remote ASes over the peer's local AS.