### PR TITLE
BgpPeerConfig: add forgotten JsonProp annotation

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
@@ -134,6 +134,7 @@ public abstract class BgpPeerConfig implements Serializable {
 
   /** Confederation AS number. Only present if the peer is inside a BGP confederation */
   @Nullable
+  @JsonProperty(PROP_CONFEDERATION_AS)
   public Long getConfederationAsn() {
     return _confederationAsn;
   }


### PR DESCRIPTION
This is to hotfix the crash of `viModel`
Going to write some serialization tests for peer configs later.