### PR TITLE
Begin differentiating candidate and established BGP topologies

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyProvider.java
@@ -6,6 +6,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.bgp.BgpTopology;
+import org.batfish.datamodel.bgp.CandidateBgpTopology;
 import org.batfish.datamodel.ipsec.IpsecTopology;
 import org.batfish.datamodel.ospf.OspfTopology;
 import org.batfish.datamodel.vxlan.VxlanTopology;
@@ -23,6 +24,13 @@ public interface TopologyProvider {
    */
   @Nonnull
   BgpTopology getBgpTopology(NetworkSnapshot snapshot);
+
+  /**
+   * Returns the {@link CandidateBgpTopology} for a given snapshot. Candidate topology may include
+   * misconfigured and orphaned peers, as well edges for sessions that can't be established
+   */
+  @Nonnull
+  CandidateBgpTopology getCandidateBgpTopology(NetworkSnapshot snapshot);
 
   /**
    * Return the {@link IpsecTopology} for a given {@link NetworkSnapshot} which just contains the

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopology.java
@@ -20,7 +20,7 @@ import org.batfish.common.topology.ValueEdge;
 import org.batfish.datamodel.BgpPeerConfigId;
 import org.batfish.datamodel.BgpSessionProperties;
 
-/** A topology representing all BGP peerings. */
+/** A topology representing all valid BGP peerings. */
 @ParametersAreNonnullByDefault
 public final class BgpTopology {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/CandidateBgpTopology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/CandidateBgpTopology.java
@@ -1,0 +1,33 @@
+package org.batfish.datamodel.bgp;
+
+import com.google.common.graph.ImmutableValueGraph;
+import com.google.common.graph.ValueGraph;
+import com.google.common.graph.ValueGraphBuilder;
+import java.util.Set;
+import org.batfish.datamodel.BgpPeerConfigId;
+
+/** Topology representing potential BGP peerings, even if some may be misconfigured. */
+public class CandidateBgpTopology {
+  public static final CandidateBgpTopology EMPTY =
+      new CandidateBgpTopology(ValueGraphBuilder.directed().allowsSelfLoops(false).build());
+
+  private final ValueGraph<BgpPeerConfigId, Annotation> _graph;
+
+  public CandidateBgpTopology(ValueGraph<BgpPeerConfigId, Annotation> graph) {
+    _graph = ImmutableValueGraph.copyOf(graph);
+  }
+
+  public ValueGraph<BgpPeerConfigId, Annotation> getGraph() {
+    return _graph;
+  }
+
+  public Set<BgpPeerConfigId> nodes() {
+    return _graph.nodes();
+  }
+
+  /** Container to describe properties of a potential peering */
+  // TODO: whatever session compat question does right now, can go in here.
+  public static final class Annotation {
+    public Annotation() {}
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -34,6 +34,8 @@ import org.batfish.datamodel.answers.MajorIssueConfig;
 import org.batfish.datamodel.answers.ParseEnvironmentBgpTablesAnswerElement;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.bgp.BgpTopology;
+import org.batfish.datamodel.bgp.BgpTopologyUtils;
+import org.batfish.datamodel.bgp.CandidateBgpTopology;
 import org.batfish.datamodel.collections.BgpAdvertisementsByVrf;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.ipsec.IpsecTopology;
@@ -136,6 +138,15 @@ public class IBatfishTestAdapter implements IBatfish {
     @Override
     public BgpTopology getBgpTopology(NetworkSnapshot snapshot) {
       throw new UnsupportedOperationException();
+    }
+
+    @Nonnull
+    @Override
+    public CandidateBgpTopology getCandidateBgpTopology(NetworkSnapshot snapshot) {
+      return BgpTopologyUtils.computeCandidateTopology(
+          _batfish.loadConfigurations(_batfish.getNetworkSnapshot()),
+          getIpOwners(_batfish.getNetworkSnapshot()).getIpVrfOwners(),
+          getInitialLayer2Topology(_batfish.getNetworkSnapshot()).orElse(null));
     }
 
     @Override

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswererUtilsTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionAnswererUtilsTest.java
@@ -129,7 +129,6 @@ public final class BgpSessionAnswererUtilsTest {
     Ip unnumIp = Ip.parse("169.254.0.1");
     peer = peerBuilder.setLocalIp(unnumIp).build();
     BgpPeerConfigId id2 = new BgpPeerConfigId("c2", "vrf", "iface2");
-    BgpUnnumberedPeerConfig peer2 = peerBuilder.setPeerInterface("iface2").build();
     topology.addNode(id2);
     topology.putEdgeValue(id, id2, new Annotation());
     topology.putEdgeValue(id2, id, new Annotation());
@@ -139,7 +138,6 @@ public final class BgpSessionAnswererUtilsTest {
 
     // With multiple edges, status should be MULTIPLE_REMOTES
     BgpPeerConfigId id3 = new BgpPeerConfigId("c3", "vrf", "iface3");
-    BgpUnnumberedPeerConfig peer3 = peerBuilder.setPeerInterface("iface3").build();
     topology.addNode(id3);
     topology.putEdgeValue(id, id3, new Annotation());
     topology.putEdgeValue(id3, id, new Annotation());

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityAnswererTest.java
@@ -145,13 +145,6 @@ public class BgpSessionCompatibilityAnswererTest {
 
     // Remote active peer
     BgpPeerConfigId remotePeerId = new BgpPeerConfigId("c2", "vrf2", localIp.toPrefix(), false);
-    BgpActivePeerConfig remotePeer =
-        BgpActivePeerConfig.builder()
-            .setLocalAs(2L)
-            .setRemoteAs(1L)
-            .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
-            .build();
-
     Map<Ip, Map<String, Set<String>>> ipVrfOwners =
         ImmutableMap.of(
             localIp,
@@ -379,15 +372,6 @@ public class BgpSessionCompatibilityAnswererTest {
 
     // Remote unnumbered peer
     BgpPeerConfigId remoteId = new BgpPeerConfigId("c2", "vrf2", "iface2");
-    BgpUnnumberedPeerConfig remote =
-        BgpUnnumberedPeerConfig.builder()
-            .setPeerInterface("iface2")
-            .setLocalAs(2L)
-            .setRemoteAs(1L)
-            .setLocalIp(unnumIp)
-            .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
-            .build();
-
     MutableValueGraph<BgpPeerConfigId, Annotation> bgpTopology =
         ValueGraphBuilder.directed().allowsSelfLoops(false).build();
     bgpTopology.putEdgeValue(peerId, remoteId, new Annotation());


### PR DESCRIPTION
Towards making `BgpSessionProperties` only used for valid/established sessions.