### PR TITLE
PAN: add profiles to null rule

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -904,6 +904,11 @@ PRIORITY
     'priority'
 ;
 
+PROFILE_GROUP
+:
+    'profile-group'
+;
+
 PROFILES
 :
     'profiles'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
@@ -11,7 +11,6 @@ s_shared
     SHARED
     (
         ss_common
-        | ss_null
     )
 ;
 
@@ -28,6 +27,7 @@ ss_common
     | s_service_group
     | s_tag
     | ss_log_settings
+    | ss_null
 ;
 
 s_external_list
@@ -110,6 +110,7 @@ ss_null
         | CERTIFICATE
         | CERTIFICATE_PROFILE
         | CONTENT_PREVIEW
+        | PROFILES
         | SERVER_PROFILE
     )
     null_rest_of_line

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
@@ -110,6 +110,7 @@ ss_null
         | CERTIFICATE
         | CERTIFICATE_PROFILE
         | CONTENT_PREVIEW
+        | PROFILE_GROUP
         | PROFILES
         | SERVER_PROFILE
     )

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -9,6 +9,7 @@ set config shared server-profile tacplus MY_TACACS timeout 5
 set config shared service
 set config shared service-group
 set config shared content-preview application amazon-music-streaming category media
+set config shared profiles custom-url-category NAME description foo
 #
 set deviceconfig system type static
 set deviceconfig system update-server updates.paloaltonetworks.com
@@ -58,6 +59,7 @@ set policy panorama application-filter SOFTWARE-UPDATES tunnels-other-apps yes
 set policy panorama application-filter SOFTWARE-UPDATES used-by-malware yes
 set policy panorama application-filter SOFTWARE-UPDATES subcategory software-update
 set policy panorama application-filter SOFTWARE-UPDATES technology client-server
+set policy panorama profiles virus
 #
 set shared botnet configuration http dynamic-dns enabled yes
 set shared botnet configuration other-applications irc yes
@@ -75,3 +77,5 @@ set mgt-config users admin public-key c3NoLX...
 set rulebase security rules RULE1 category streaming
 set rulebase security rules RULE1 hip-profiles any
 set rulebase security rules RULE1 source-user any
+#
+set vsys vsys1 profiles dos-protection

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -79,3 +79,4 @@ set rulebase security rules RULE1 hip-profiles any
 set rulebase security rules RULE1 source-user any
 #
 set vsys vsys1 profiles dos-protection
+set vsys vsys1 profile-group NAME


### PR DESCRIPTION
Parse PAN `profiles` and `profile-group` ([which allow for traffic content inspection](https://docs.paloaltonetworks.com/pan-os/7-1/pan-os-admin/policy/security-profiles.html)).

In the process, moved the `ss_null` rule under the `ss_common` rule to catch the null rules in all contexts that use `ss_common`.
