### PR TITLE
Juniper: support for interfaces inside vlan definition

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperParser.g4
@@ -132,6 +132,7 @@ s_vlans_named
     apply
     | vlt_description
     | vlt_filter
+    | vlt_interface
     | vlt_l3_interface
     | vlt_vlan_id
   )
@@ -161,6 +162,11 @@ vlt_filter
       INPUT
       | OUTPUT
    ) name = variable
+;
+
+vlt_interface
+:
+   INTERFACE interface_id
 ;
 
 vlt_l3_interface

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -110,10 +110,6 @@ public class Interface implements Serializable {
     _vrrpGroups = new TreeMap<>();
   }
 
-  public void addAllowedRanges(List<SubRange> ranges) {
-    _allowedVlans.addAll(ranges);
-  }
-
   public String get8023adInterface() {
     return _agg8023adInterface;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -59,6 +59,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   SECURITY_ZONES_SECURITY_ZONES_INTERFACE("security zones security-zone interfaces"),
   SNMP_COMMUNITY_PREFIX_LIST("snmp community prefix-list"),
   STATIC_ROUTE_NEXT_HOP_INTERFACE("static route next-hop"),
+  VLAN_INTERFACE("vlan interface"),
   VLAN_L3_INTERFACE("vlan l3-interface"),
   VTEP_SOURCE_INTERFACE("routing-instances vtep-source-interface");
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Vlan.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Vlan.java
@@ -1,6 +1,8 @@
 package org.batfish.representation.juniper;
 
 import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -10,12 +12,21 @@ public class Vlan implements Serializable {
 
   private final String _name;
 
-  private @Nullable Integer _vlanId;
-
+  private @Nonnull Set<String> _interfaces;
   private @Nullable String _l3Interface;
+  private @Nullable Integer _vlanId;
 
   public Vlan(String name) {
     _name = name;
+    _interfaces = new HashSet<>(0);
+  }
+
+  public void addInterface(String ifname) {
+    _interfaces.add(ifname);
+  }
+
+  public @Nonnull Set<String> getInterfaces() {
+    return _interfaces;
   }
 
   public @Nullable String getL3Interface() {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2430,7 +2430,7 @@ public final class FlatJuniperGrammarTest {
     Configuration c = parseConfig(hostname);
 
     assertThat(c, hasInterface("ge-0/1/0.0", hasNativeVlan(3)));
-    assertThat(c, hasInterface("ge-0/2/0.0", hasNativeVlan(1)));
+    assertThat(c, hasInterface("ge-0/2/0.0", hasNativeVlan(nullValue())));
     assertThat(c, hasInterface("ge-0/3/0.0", hasNativeVlan(nullValue())));
   }
 
@@ -2518,6 +2518,10 @@ public final class FlatJuniperGrammarTest {
     // Expecting an Interface in ACCESS mode with VLAN 101
     assertThat(c, hasInterface("ge-0/0/0.0", hasSwitchPortMode(SwitchportMode.ACCESS)));
     assertThat(c, hasInterface("ge-0/0/0.0", hasAccessVlan(101)));
+
+    // Expecting an Interface in ACCESS mode with VLAN 103
+    assertThat(c, hasInterface("ge-0/2/0.0", hasSwitchPortMode(SwitchportMode.ACCESS)));
+    assertThat(c, hasInterface("ge-0/2/0.0", hasAccessVlan(103)));
 
     // Expecting an Interface in TRUNK mode with VLANs 1-5
     assertThat(c, hasInterface("ge-0/3/0.0", hasSwitchPortMode(SwitchportMode.TRUNK)));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-vlan
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-vlan
@@ -3,10 +3,16 @@ set system host-name interface-vlan
 #
 set interfaces ge-0/0/0 unit 0 family ethernet-switching vlan members VLAN_TEST
 set interfaces ge-0/1/0 unit 0 family ethernet-switching vlan members VLAN_TEST_UNDEFINED
+set interfaces ge-0/2/0 unit 0 family ethernet-switching
 set interfaces ge-0/3/0 unit 0 family ethernet-switching port-mode trunk
 set interfaces ge-0/3/0 unit 0 family ethernet-switching vlan members 1-5
 set interfaces ge-0/3/0 unit 1 family ethernet-switching interface-mode trunk
 set interfaces ge-0/3/0 unit 1 family ethernet-switching vlan members 6
+set interfaces vlan unit 103 family inet address 192.168.3.35/24
 
 set vlans VLAN_TEST vlan-id 101
 set vlans VLAN_TEST_UNUSED vlan-id 102
+
+set vlans VLAN_WITH_INTERFACES vlan-id 103
+set vlans VLAN_WITH_INTERFACES interface ge-0/2/0.0
+set vlans VLAN_WITH_INTERFACES l3-interface vlan.103

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -3631,6 +3631,30 @@
         }
       },
       {
+        "File_Name" : "configs/juniper_vlan",
+        "Struct_Type" : "interface",
+        "Ref_Name" : "vlan.30",
+        "Context" : "vlan l3-interface",
+        "Lines" : {
+          "filename" : "configs/juniper_vlan",
+          "lines" : [
+            6
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/juniper_vlan",
+        "Struct_Type" : "interface",
+        "Ref_Name" : "vlan.40",
+        "Context" : "vlan l3-interface",
+        "Lines" : {
+          "filename" : "configs/juniper_vlan",
+          "lines" : [
+            8
+          ]
+        }
+      },
+      {
         "File_Name" : "configs/named_and_numbered_lists",
         "Struct_Type" : "ipv4 acl",
         "Ref_Name" : "1",
@@ -4053,10 +4077,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 329 results",
+      "notes" : "Found 331 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 329
+      "numResults" : 331
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -24069,8 +24069,8 @@
             "ripEnabled" : false,
             "ripPassive" : false,
             "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
+            "switchport" : true,
+            "switchportMode" : "ACCESS",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "AGGREGATE_CHILD",
             "vrf" : "default"
@@ -24501,8 +24501,8 @@
             "ripEnabled" : false,
             "ripPassive" : false,
             "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
+            "switchport" : true,
+            "switchportMode" : "ACCESS",
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "LOGICAL",
             "vrf" : "default"

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -92242,6 +92242,20 @@
             }
           }
         },
+        "configs/juniper_vlan" : {
+          "interface" : {
+            "vlan.30" : {
+              "vlan l3-interface" : [
+                6
+              ]
+            },
+            "vlan.40" : {
+              "vlan l3-interface" : [
+                8
+              ]
+            }
+          }
+        },
         "configs/named_and_numbered_lists" : {
           "ipv4 acl" : {
             "1" : {


### PR DESCRIPTION
Fix #4985

* Add support for interfaces declared inside of vlan, like `set vlans LAB-3 interface ge-0/0/20.0`. On an interface in `ACCESS` mode, this sets the (vendor-specific) access vlan name. On an interface in `TRUNK` mode, this adds the vlan to the trunk members.

* Set switchport mode `ACCESS` when interface is added to `family ethernet-switching` for the first time.

* Move setting of VI allowed vlans into the trunk handling conversion code.

* Fix native vlan-id for trunks (1 -> drop untagged frames by default).

* Fix reference tracking for vlan l3-interface