### PR TITLE
PAN: add log-settings null rules

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -184,6 +184,11 @@ BROADCAST
     'broadcast'
 ;
 
+BSD
+:
+    [Bb][Ss][Dd]
+;
+
 CATEGORY
 :
     'category'
@@ -419,6 +424,11 @@ ETHERNET
     'ethernet'
 ;
 
+FACILITY
+:
+    'facility'
+;
+
 FILTER
 :
     'filter'
@@ -427,6 +437,11 @@ FILTER
 FQDN
 :
     'fqdn'
+;
+
+FORMAT
+:
+    'format'
 ;
 
 FROM
@@ -537,6 +552,11 @@ IBGP
 ICMP
 :
     'icmp'
+;
+
+IETF
+:
+    [Ii][Ee][Tt][Ff]
 ;
 
 IKE
@@ -1114,6 +1134,11 @@ SOURCE_USER
     'source-user'
 ;
 
+SSL
+:
+    [Ss][Ss][Ll]
+;
+
 STATIC
 :
     'static'
@@ -1166,7 +1191,7 @@ TAP
 
 TCP
 :
-    'tcp'
+    [Tt][Cc][Pp]
 ;
 
 TECHNOLOGY
@@ -1209,6 +1234,11 @@ TRANSLATED_ADDRESS
     'translated-address'
 ;
 
+TRANSPORT
+:
+    'transport'
+;
+
 TUNNEL
 :
     'tunnel'
@@ -1226,7 +1256,7 @@ TYPE
 
 UDP
 :
-    'udp'
+    [Uu][Dd][Pp]
 ;
 
 UNITS

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -464,14 +464,14 @@ FILTER
     'filter'
 ;
 
-FQDN
-:
-    'fqdn'
-;
-
 FORMAT
 :
     'format'
+;
+
+FQDN
+:
+    'fqdn'
 ;
 
 FROM

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_log_settings.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_log_settings.g4
@@ -1,0 +1,66 @@
+parser grammar PaloAlto_log_settings;
+
+import PaloAlto_common;
+
+options {
+    tokenVocab = PaloAltoLexer;
+}
+
+s_log_settings
+:
+    LOG_SETTINGS
+    (
+        sl_profiles
+        | sl_syslog
+    )
+;
+
+sl_profiles
+:
+    PROFILES null_rest_of_line
+;
+
+sl_syslog
+:
+    SYSLOG name = variable
+    (
+        sls_server
+    )
+;
+
+sls_server
+:
+    SERVER name = variable
+    (
+        slss_facility
+        | slss_format
+        | slss_port
+        | slss_server
+        | slss_transport
+    )
+;
+
+slss_facility
+:
+    FACILITY facility = variable
+;
+
+slss_format
+:
+    FORMAT format = (BSD | IETF)
+;
+
+slss_port
+:
+    PORT pn = port_number
+;
+
+slss_server
+:
+    SERVER address = variable
+;
+
+slss_transport
+:
+    TRANSPORT protocol = (SSL | TCP | UDP)
+;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_log_settings.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_log_settings.g4
@@ -13,7 +13,7 @@ s_log_settings
         sl_profiles
         | sl_syslog
         | sl_system
-    )
+    )?
 ;
 
 sl_profiles
@@ -26,7 +26,7 @@ sl_syslog
     SYSLOG name = variable
     (
         sls_server
-    )
+    )?
 ;
 
 sl_system

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_log_settings.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_log_settings.g4
@@ -12,6 +12,7 @@ s_log_settings
     (
         sl_profiles
         | sl_syslog
+        | sl_system
     )
 ;
 
@@ -26,6 +27,11 @@ sl_syslog
     (
         sls_server
     )
+;
+
+sl_system
+:
+    SYSTEM null_rest_of_line
 ;
 
 sls_server

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
@@ -1,6 +1,12 @@
 parser grammar PaloAlto_shared;
 
-import PaloAlto_application, PaloAlto_common, PaloAlto_service, PaloAlto_service_group, PaloAlto_tag;
+import
+    PaloAlto_application,
+    PaloAlto_common,
+    PaloAlto_log_settings,
+    PaloAlto_service,
+    PaloAlto_service_group,
+    PaloAlto_tag;
 
 options {
     tokenVocab = PaloAltoLexer;
@@ -24,10 +30,10 @@ ss_common
     | s_application_filter
     | s_application_group
     | s_external_list
+    | s_log_settings
     | s_service
     | s_service_group
     | s_tag
-    | ss_log_settings
 ;
 
 s_external_list
@@ -94,14 +100,6 @@ seltip_url
     URL url = variable
 ;
 
-ss_log_settings
-:
-    LOG_SETTINGS
-    (
-        ssl_syslog
-    )
-;
-
 ss_null
 :
     (
@@ -113,25 +111,4 @@ ss_null
         | SERVER_PROFILE
     )
     null_rest_of_line
-;
-
-ssl_syslog
-:
-    SYSLOG name = variable
-    (
-        ssls_server
-    )
-;
-
-ssls_server
-:
-    SERVER name = variable
-    (
-        sslss_server
-    )
-;
-
-sslss_server
-:
-    SERVER address = variable
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -188,6 +188,9 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sdsd_serversContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sdsn_ntp_server_addressContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Selt_ipContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Set_line_config_devicesContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sl_syslogContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sls_serverContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Slss_serverContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sn_shared_gateway_definitionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sni_ethernet_definitionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sni_loopbackContext;
@@ -227,9 +230,6 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_portContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_protocolContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_source_portContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sservgrp_membersContext;
-import org.batfish.grammar.palo_alto.PaloAltoParser.Ssl_syslogContext;
-import org.batfish.grammar.palo_alto.PaloAltoParser.Ssls_serverContext;
-import org.batfish.grammar.palo_alto.PaloAltoParser.Sslss_serverContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.St_commentsContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Svi_visible_vsysContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Svin_interfaceContext;
@@ -1932,28 +1932,28 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   }
 
   @Override
-  public void enterSsl_syslog(Ssl_syslogContext ctx) {
+  public void enterSl_syslog(Sl_syslogContext ctx) {
     _currentSyslogServerGroupName = getText(ctx.name);
   }
 
   @Override
-  public void exitSsl_syslog(Ssl_syslogContext ctx) {
+  public void exitSl_syslog(Sl_syslogContext ctx) {
     _currentSyslogServerGroupName = null;
   }
 
   @Override
-  public void enterSsls_server(Ssls_serverContext ctx) {
+  public void enterSls_server(Sls_serverContext ctx) {
     _currentSyslogServer =
         _currentVsys.getSyslogServer(_currentSyslogServerGroupName, getText(ctx.name));
   }
 
   @Override
-  public void exitSsls_server(Ssls_serverContext ctx) {
+  public void exitSls_server(Sls_serverContext ctx) {
     _currentSyslogServer = null;
   }
 
   @Override
-  public void exitSslss_server(Sslss_serverContext ctx) {
+  public void exitSlss_server(Slss_serverContext ctx) {
     _currentSyslogServer.setAddress(getText(ctx.address));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Vsys.java
@@ -173,7 +173,17 @@ public final class Vsys implements Serializable {
   /** Returns a list of all syslog server addresses. */
   SortedSet<String> getSyslogServerAddresses() {
     SortedSet<String> servers = new TreeSet<>();
-    _syslogServerGroups.values().forEach(g -> g.values().forEach(s -> servers.add(s.getAddress())));
+    _syslogServerGroups
+        .values()
+        .forEach(
+            g ->
+                g.values()
+                    .forEach(
+                        s -> {
+                          if (s.getAddress() != null) {
+                            servers.add(s.getAddress());
+                          }
+                        }));
     return servers;
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -75,3 +75,9 @@ set mgt-config users admin public-key c3NoLX...
 set rulebase security rules RULE1 category streaming
 set rulebase security rules RULE1 hip-profiles any
 set rulebase security rules RULE1 source-user any
+#
+set vsys vsys1 log-settings syslog NAME server NAME facility LOG_LOCAL0
+set vsys vsys1 log-settings syslog NAME server NAME format IETF
+set vsys vsys1 log-settings syslog NAME server NAME port 65535
+set vsys vsys1 log-settings syslog NAME server NAME transport UDP
+set vsys vsys1 log-settings profiles NAME match-list ML_NAME log-type foo

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -10,6 +10,7 @@ set config shared service
 set config shared service-group
 set config shared content-preview application amazon-music-streaming category media
 set config shared profiles custom-url-category NAME description foo
+set config shared log-settings system critical send-email
 #
 set deviceconfig system type static
 set deviceconfig system update-server updates.paloaltonetworks.com

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71313,7 +71313,7 @@
             "                  MEMBERS:'members'",
             "                  (variable_list",
             "                    (variable_list_item",
-            "                      VARIABLE:'ssl')))))))))",
+            "                      SSL:'ssl')))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line",
             "    SET:'set'",


### PR DESCRIPTION
Parse more PAN `log-settings`.

In the process, made a few tokens case-insensitive (to work with capitalized auto-complete values) and fixed a NPE.
