### PR TITLE
Improve internet-node multipath support

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
@@ -36,6 +36,7 @@ import org.batfish.datamodel.DeviceType;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LongSpace;
+import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
@@ -262,6 +263,8 @@ public final class IspModelingUtils {
             .setAdminCostsToVendorDefaults(ConfigurationFormat.CISCO_IOS)
             .build();
     bgpProcess.setMultipathEbgp(true);
+    bgpProcess.setMultipathEquivalentAsPathMatchMode(
+        MultipathEquivalentAsPathMatchMode.PATH_LENGTH);
 
     internetConfiguration.setRoutingPolicies(
         ImmutableSortedMap.of(

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -965,6 +965,7 @@
               "ibgpAdminCost" : 200,
               "routerId" : "240.254.254.1",
               "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "PATH_LENGTH",
               "multipathIbgp" : false,
               "neighbors" : {
                 "240.1.1.3/32" : {


### PR DESCRIPTION
Support multiple, equal-length paths in internet-node BGP process.

Fixes an issue where the internet node only support a single route through a single ISP when multiple, equivalent routes exist through multiple ISPs.
