### PR TITLE
Fix OSPF session semantics for interfaces with multiple addresses

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfNeighborConfigId.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfNeighborConfigId.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 
 /** Uniquely identifies an OSPF configuration ({@link OspfNeighbor}) in the network. */
@@ -21,11 +22,13 @@ public final class OspfNeighborConfigId implements Serializable {
   private static final String PROP_VRF = "vrf";
   private static final String PROP_PROCESS = "process";
   private static final String PROP_INTERFACE = "interface";
+  private static final String PROP_ADDRESS = "address";
 
   @Nonnull private final String _hostname;
   @Nonnull private final String _vrfName;
   @Nonnull private final String _procName;
   @Nonnull private final String _interfaceName;
+  @Nonnull private final ConcreteInterfaceAddress _address;
 
   /**
    * Create a new unique identifier for an OSPF process
@@ -34,13 +37,19 @@ public final class OspfNeighborConfigId implements Serializable {
    * @param vrfName the name of a VRF on which the neighbor exists
    * @param procName the name of OSPF process on which the neighbor exists
    * @param interfaceName the interface name
+   * @param address the interface address
    */
   public OspfNeighborConfigId(
-      String hostname, String vrfName, String procName, String interfaceName) {
+      String hostname,
+      String vrfName,
+      String procName,
+      String interfaceName,
+      ConcreteInterfaceAddress address) {
     _hostname = hostname;
     _vrfName = vrfName;
     _procName = procName;
     _interfaceName = interfaceName;
+    _address = address;
   }
 
   @JsonCreator
@@ -48,12 +57,14 @@ public final class OspfNeighborConfigId implements Serializable {
       @Nullable @JsonProperty(PROP_HOSTNAME) String hostname,
       @Nullable @JsonProperty(PROP_VRF) String vrf,
       @Nullable @JsonProperty(PROP_PROCESS) String process,
-      @Nullable @JsonProperty(PROP_INTERFACE) String interfaceName) {
+      @Nullable @JsonProperty(PROP_INTERFACE) String interfaceName,
+      @Nullable @JsonProperty(PROP_ADDRESS) ConcreteInterfaceAddress address) {
     checkArgument(hostname != null, "Missing %s", PROP_HOSTNAME);
     checkArgument(vrf != null, "Missing %s", PROP_VRF);
     checkArgument(process != null, "Missing %s", PROP_PROCESS);
     checkArgument(interfaceName != null, "Missing %s", PROP_INTERFACE);
-    return new OspfNeighborConfigId(hostname, vrf, process, interfaceName);
+    checkArgument(address != null, "Missing %s", PROP_ADDRESS);
+    return new OspfNeighborConfigId(hostname, vrf, process, interfaceName, address);
   }
 
   @Nonnull
@@ -81,6 +92,12 @@ public final class OspfNeighborConfigId implements Serializable {
   }
 
   @Nonnull
+  @JsonProperty(PROP_ADDRESS)
+  public ConcreteInterfaceAddress getAddress() {
+    return _address;
+  }
+
+  @Nonnull
   @JsonIgnore
   public NodeInterfacePair getNodeInterfacePair() {
     return NodeInterfacePair.of(getHostname(), getInterfaceName());
@@ -98,12 +115,13 @@ public final class OspfNeighborConfigId implements Serializable {
     return _hostname.equals(other._hostname)
         && _vrfName.equals(other._vrfName)
         && _procName.equals(other._procName)
-        && _interfaceName.equals(other._interfaceName);
+        && _interfaceName.equals(other._interfaceName)
+        && _address.equals(other._address);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_hostname, _vrfName, _interfaceName);
+    return Objects.hash(_hostname, _vrfName, _procName, _interfaceName, _address);
   }
 
   @Override
@@ -113,6 +131,7 @@ public final class OspfNeighborConfigId implements Serializable {
         .add("vrfName", _vrfName)
         .add("procName", _procName)
         .add("interfaceName", _interfaceName)
+        .add(PROP_ADDRESS, _address)
         .toString();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfProcess.java
@@ -52,7 +52,7 @@ public final class OspfProcess implements Serializable {
     @Nullable private Long _maxMetricStubNetworks;
     @Nullable private Long _maxMetricSummaryNetworks;
     @Nullable private Long _maxMetricTransitLinks;
-    @Nullable private Map<String, OspfNeighborConfig> _neighborConfigs;
+    @Nonnull private Map<OspfNeighborConfigId, OspfNeighborConfig> _neighborConfigs;
     @Nullable private String _processId;
     @Nullable private Double _referenceBandwidth;
     @Nullable private Vrf _vrf;
@@ -141,8 +141,9 @@ public final class OspfProcess implements Serializable {
       return this;
     }
 
-    public Builder setNeighborConfigs(Map<String, OspfNeighborConfig> neighbors) {
-      _neighborConfigs = neighbors;
+    public @Nonnull Builder setNeighborConfigs(
+        Map<OspfNeighborConfigId, OspfNeighborConfig> neighborConfigs) {
+      _neighborConfigs = neighborConfigs;
       return this;
     }
 
@@ -243,7 +244,7 @@ public final class OspfProcess implements Serializable {
   @Nullable private Long _maxMetricTransitLinks;
   private transient Map<IpLink, OspfNeighbor> _ospfNeighbors;
   /** Mapping from interface name to an OSPF config */
-  @Nonnull private Map<String, OspfNeighborConfig> _ospfNeighborConfigs;
+  @Nonnull private Map<OspfNeighborConfigId, OspfNeighborConfig> _ospfNeighborConfigs;
 
   @Nonnull private final String _processId;
   @Nonnull private Double _referenceBandwidth;
@@ -261,7 +262,7 @@ public final class OspfProcess implements Serializable {
       @Nullable Long maxMetricStubNetworks,
       @Nullable Long maxMetricSummaryNetworks,
       @Nullable Long maxMetricTransitLinks,
-      Map<String, OspfNeighborConfig> ospfNeighborConfigs,
+      Map<OspfNeighborConfigId, OspfNeighborConfig> ospfNeighborConfigs,
       String processId,
       Double referenceBandwidth,
       @Nullable Boolean rfc1583Compatible,
@@ -462,7 +463,7 @@ public final class OspfProcess implements Serializable {
   }
 
   @JsonIgnore
-  public Map<String, OspfNeighborConfig> getOspfNeighborConfigs() {
+  public Map<OspfNeighborConfigId, OspfNeighborConfig> getOspfNeighborConfigs() {
     return _ospfNeighborConfigs;
   }
 
@@ -537,10 +538,12 @@ public final class OspfProcess implements Serializable {
             .build();
   }
 
+  @JsonIgnore
   public void setExportPolicy(@Nullable String exportPolicy) {
     _exportPolicy = exportPolicy;
   }
 
+  @JsonIgnore
   public void setExportPolicySources(SortedSet<String> exportPolicySources) {
     _exportPolicySources = ImmutableSortedSet.copyOf(exportPolicySources);
   }
@@ -549,6 +552,7 @@ public final class OspfProcess implements Serializable {
    * Overwrite all generated route. See {@link #getGeneratedRoutes} for explanation of generated
    * routes.
    */
+  @JsonIgnore
   public void setGeneratedRoutes(SortedSet<GeneratedRoute> generatedRoutes) {
     _generatedRoutes = ImmutableSortedSet.copyOf(generatedRoutes);
   }
@@ -562,18 +566,22 @@ public final class OspfProcess implements Serializable {
             .build();
   }
 
+  @JsonIgnore
   public void setMaxMetricExternalNetworks(@Nullable Long maxMetricExternalNetworks) {
     _maxMetricExternalNetworks = maxMetricExternalNetworks;
   }
 
+  @JsonIgnore
   public void setMaxMetricStubNetworks(@Nullable Long maxMetricStubNetworks) {
     _maxMetricStubNetworks = maxMetricStubNetworks;
   }
 
+  @JsonIgnore
   public void setMaxMetricSummaryNetworks(@Nullable Long maxMetricSummaryNetworks) {
     _maxMetricSummaryNetworks = maxMetricSummaryNetworks;
   }
 
+  @JsonIgnore
   public void setMaxMetricTransitLinks(@Nullable Long maxMetricTransitLinks) {
     _maxMetricTransitLinks = maxMetricTransitLinks;
   }
@@ -583,18 +591,22 @@ public final class OspfProcess implements Serializable {
     _ospfNeighbors = ospfNeighbors;
   }
 
-  void setOspfNeighborConfigs(Map<String, OspfNeighborConfig> ospfNeighborConfigs) {
-    _ospfNeighborConfigs = ImmutableSortedMap.copyOf(ospfNeighborConfigs);
+  @JsonIgnore
+  void setOspfNeighborConfigs(Map<OspfNeighborConfigId, OspfNeighborConfig> ospfNeighborConfigs) {
+    _ospfNeighborConfigs = ospfNeighborConfigs;
   }
 
+  @JsonIgnore
   public void setReferenceBandwidth(Double referenceBandwidth) {
     _referenceBandwidth = referenceBandwidth;
   }
 
+  @JsonIgnore
   public void setRfc1583Compatible(@Nullable Boolean rfc1583Compatible) {
     _rfc1583Compatible = rfc1583Compatible;
   }
 
+  @JsonIgnore
   public void setRouterId(@Nonnull Ip id) {
     _routerId = id;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfTopology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfTopology.java
@@ -162,7 +162,9 @@ public final class OspfTopology {
     private static final Comparator<OspfNeighborConfigId> ID_COMPARATOR =
         Comparator.comparing(OspfNeighborConfigId::getHostname)
             .thenComparing(OspfNeighborConfigId::getVrfName)
-            .thenComparing(OspfNeighborConfigId::getInterfaceName);
+            .thenComparing(OspfNeighborConfigId::getInterfaceName)
+            .thenComparing(OspfNeighborConfigId::getProcName)
+            .thenComparing(OspfNeighborConfigId::getAddress);
 
     @VisibleForTesting
     EdgeId(OspfNeighborConfigId tail, OspfNeighborConfigId head) {
@@ -203,11 +205,11 @@ public final class OspfTopology {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof EdgeId)) {
         return false;
       }
       EdgeId other = (EdgeId) o;
-      return Objects.equals(_tail, other._tail) && Objects.equals(_head, other._head);
+      return _tail.equals(other._tail) && _head.equals(other._head);
     }
 
     @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfTopologyUtils.java
@@ -145,8 +145,7 @@ public final class OspfTopologyUtils {
     // Iterate over all configurations
     for (Configuration config : configurations.all()) {
       // All VRFs in the configuration
-      for (Entry<String, Vrf> vrfEntry : config.getVrfs().entrySet()) {
-        Vrf vrf = vrfEntry.getValue();
+      for (Vrf vrf : config.getVrfs().values()) {
         for (OspfProcess proc : vrf.getOspfProcesses().values()) {
           proc.getOspfNeighborConfigs()
               .forEach(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/CandidateOspfTopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/CandidateOspfTopologyTest.java
@@ -10,15 +10,20 @@ import com.google.common.graph.MutableValueGraph;
 import com.google.common.graph.ValueGraphBuilder;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.junit.Test;
 
 /** Tests of {@link CandidateOspfTopology} */
 public class CandidateOspfTopologyTest {
 
-  private static OspfNeighborConfigId NODE_A = new OspfNeighborConfigId("a", "b", "c", "d");
-  private static OspfNeighborConfigId NODE_E = new OspfNeighborConfigId("e", "f", "g", "h");
-  private static OspfNeighborConfigId NODE_I = new OspfNeighborConfigId("i", "j", "k", "l");
-  private static OspfNeighborConfigId NODE_M = new OspfNeighborConfigId("m", "n", "o", "p");
+  private static OspfNeighborConfigId NODE_A =
+      new OspfNeighborConfigId("a", "b", "c", "d", ConcreteInterfaceAddress.parse("192.0.2.0/31"));
+  private static OspfNeighborConfigId NODE_E =
+      new OspfNeighborConfigId("e", "f", "g", "h", ConcreteInterfaceAddress.parse("192.0.2.1/31"));
+  private static OspfNeighborConfigId NODE_I =
+      new OspfNeighborConfigId("i", "j", "k", "l", ConcreteInterfaceAddress.parse("192.0.2.4/31"));
+  private static OspfNeighborConfigId NODE_M =
+      new OspfNeighborConfigId("m", "n", "o", "p", ConcreteInterfaceAddress.parse("192.0.2.6/31"));
 
   private static OspfSessionStatus NODE_A_TO_E_STATUS = OspfSessionStatus.ESTABLISHED;
   private static OspfSessionStatus NODE_I_TO_M_STATUS = OspfSessionStatus.NETWORK_TYPE_MISMATCH;
@@ -44,7 +49,9 @@ public class CandidateOspfTopologyTest {
 
   @Test
   public void testGetNeighborsNonExistentNode() {
-    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "p", "i1");
+    OspfNeighborConfigId n =
+        new OspfNeighborConfigId(
+            "h1", "vrf1", "p", "i1", ConcreteInterfaceAddress.parse("192.0.2.8/31"));
     assertThat(nonTrivialTopology().neighbors(n), empty());
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfNeighborConfigIdTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfNeighborConfigIdTest.java
@@ -7,6 +7,7 @@ import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.junit.Test;
 
 /** Tests of {@link OspfNeighborConfigId} */
@@ -15,25 +16,42 @@ public class OspfNeighborConfigIdTest {
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new OspfNeighborConfigId("h", "v", "p", "i"),
-            new OspfNeighborConfigId("h", "v", "p", "i"))
-        .addEqualityGroup(new OspfNeighborConfigId("h2", "v", "p", "i"))
-        .addEqualityGroup(new OspfNeighborConfigId("h", "v2", "p", "i"))
-        .addEqualityGroup(new OspfNeighborConfigId("h", "v", "p2", "i"))
-        .addEqualityGroup(new OspfNeighborConfigId("h", "v", "p", "i2"))
+            new OspfNeighborConfigId(
+                "h", "v", "p", "i", ConcreteInterfaceAddress.parse("192.0.2.0/31")),
+            new OspfNeighborConfigId(
+                "h", "v", "p", "i", ConcreteInterfaceAddress.parse("192.0.2.0/31")))
+        .addEqualityGroup(
+            new OspfNeighborConfigId(
+                "h2", "v", "p", "i", ConcreteInterfaceAddress.parse("192.0.2.0/31")))
+        .addEqualityGroup(
+            new OspfNeighborConfigId(
+                "h", "v2", "p", "i", ConcreteInterfaceAddress.parse("192.0.2.0/31")))
+        .addEqualityGroup(
+            new OspfNeighborConfigId(
+                "h", "v", "p2", "i", ConcreteInterfaceAddress.parse("192.0.2.0/31")))
+        .addEqualityGroup(
+            new OspfNeighborConfigId(
+                "h", "v", "p", "i2", ConcreteInterfaceAddress.parse("192.0.2.0/31")))
+        .addEqualityGroup(
+            new OspfNeighborConfigId(
+                "h", "v", "p", "i2", ConcreteInterfaceAddress.parse("192.0.2.2/31")))
         .addEqualityGroup(new Object())
         .testEquals();
   }
 
   @Test
   public void testJavaSerialization() {
-    OspfNeighborConfigId cid = new OspfNeighborConfigId("h", "v", "p", "i");
+    OspfNeighborConfigId cid =
+        new OspfNeighborConfigId(
+            "h", "v", "p", "i", ConcreteInterfaceAddress.parse("192.0.2.2/31"));
     assertThat(SerializationUtils.clone(cid), equalTo(cid));
   }
 
   @Test
   public void testJsonSerialization() throws IOException {
-    OspfNeighborConfigId cid = new OspfNeighborConfigId("h", "v", "p", "i");
+    OspfNeighborConfigId cid =
+        new OspfNeighborConfigId(
+            "h", "v", "p", "i", ConcreteInterfaceAddress.parse("192.0.2.2/31"));
     assertThat(BatfishObjectMapper.clone(cid, OspfNeighborConfigId.class), equalTo(cid));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfTopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfTopologyTest.java
@@ -13,6 +13,7 @@ import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import javax.annotation.Nonnull;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpLink;
 import org.batfish.datamodel.ospf.OspfTopology.EdgeId;
@@ -25,8 +26,10 @@ public final class OspfTopologyTest {
     MutableValueGraph<OspfNeighborConfigId, OspfSessionProperties> graph =
         ValueGraphBuilder.directed().allowsSelfLoops(false).build();
     graph.putEdgeValue(
-        new OspfNeighborConfigId("a", "b", "c", "d"),
-        new OspfNeighborConfigId("e", "f", "g", "h"),
+        new OspfNeighborConfigId(
+            "a", "b", "c", "d", ConcreteInterfaceAddress.create(Ip.FIRST_CLASS_A_PRIVATE_IP, 1)),
+        new OspfNeighborConfigId(
+            "e", "f", "g", "h", ConcreteInterfaceAddress.create(Ip.FIRST_CLASS_B_PRIVATE_IP, 1)),
         new OspfSessionProperties(
             5L, new IpLink(Ip.FIRST_CLASS_A_PRIVATE_IP, Ip.FIRST_CLASS_B_PRIVATE_IP)));
     return new OspfTopology(graph);
@@ -52,27 +55,35 @@ public final class OspfTopologyTest {
 
   @Test
   public void testGetNeighborsNonExistentNode() {
-    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "p", "i1");
+    OspfNeighborConfigId n =
+        new OspfNeighborConfigId(
+            "h1", "vrf1", "p", "i1", ConcreteInterfaceAddress.parse("192.0.2.0/31"));
     assertThat(EMPTY.neighbors(n), empty());
   }
 
   @Test
   public void testGetIncomingEdgesNonExistentNode() {
-    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "p", "i1");
+    OspfNeighborConfigId n =
+        new OspfNeighborConfigId(
+            "h1", "vrf1", "p", "i1", ConcreteInterfaceAddress.parse("192.0.2.0/31"));
     assertThat(EMPTY.incomingEdges(n), empty());
   }
 
   @Test
   public void testGetIncomingEdges() {
     // Setup: small topo with one edge
-    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "p", "i1");
-    OspfNeighborConfigId n2 = new OspfNeighborConfigId("h2", "vrf2", "p2", "i2");
+    OspfNeighborConfigId n =
+        new OspfNeighborConfigId(
+            "h1", "vrf1", "p", "i1", ConcreteInterfaceAddress.parse("192.0.2.0/31"));
+    OspfNeighborConfigId n2 =
+        new OspfNeighborConfigId(
+            "h2", "vrf2", "p2", "i2", ConcreteInterfaceAddress.parse("192.0.2.1/31"));
     MutableValueGraph<OspfNeighborConfigId, OspfSessionProperties> graph =
         ValueGraphBuilder.directed().build();
     graph.addNode(n);
     graph.addNode(n2);
     OspfSessionProperties session =
-        new OspfSessionProperties(0, new IpLink(Ip.parse("1.1.1.2"), Ip.parse("1.1.1.3")));
+        new OspfSessionProperties(0, new IpLink(Ip.parse("192.0.2.0"), Ip.parse("192.0.2.1")));
     graph.putEdgeValue(n, n2, session);
     OspfTopology topo = new OspfTopology(graph);
 
@@ -84,8 +95,12 @@ public final class OspfTopologyTest {
 
   @Test
   public void testEdgeIdEquals() {
-    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "p", "i1");
-    OspfNeighborConfigId n2 = new OspfNeighborConfigId("h2", "vrf2", "p", "i2");
+    OspfNeighborConfigId n =
+        new OspfNeighborConfigId(
+            "h1", "vrf1", "p", "i1", ConcreteInterfaceAddress.parse("192.0.2.0/31"));
+    OspfNeighborConfigId n2 =
+        new OspfNeighborConfigId(
+            "h2", "vrf2", "p", "i2", ConcreteInterfaceAddress.parse("192.0.2.1/31"));
     new EqualsTester()
         .addEqualityGroup(OspfTopology.makeEdge(n, n2), OspfTopology.makeEdge(n, n2))
         .addEqualityGroup(OspfTopology.makeEdge(n, n))
@@ -96,8 +111,12 @@ public final class OspfTopologyTest {
 
   @Test
   public void testEdgeIdReverse() {
-    OspfNeighborConfigId n = new OspfNeighborConfigId("h1", "vrf1", "p", "i1");
-    OspfNeighborConfigId n2 = new OspfNeighborConfigId("h2", "vrf2", "p", "i2");
+    OspfNeighborConfigId n =
+        new OspfNeighborConfigId(
+            "h1", "vrf1", "p", "i1", ConcreteInterfaceAddress.parse("192.0.2.0/31"));
+    OspfNeighborConfigId n2 =
+        new OspfNeighborConfigId(
+            "h2", "vrf2", "p", "i2", ConcreteInterfaceAddress.parse("192.0.2.1/31"));
     EdgeId edgeId = OspfTopology.makeEdge(n, n2);
     assertThat(edgeId.reverse(), equalTo(OspfTopology.makeEdge(n2, n)));
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -62,7 +62,6 @@ import org.batfish.dataplane.rib.OspfInterAreaRib;
 import org.batfish.dataplane.rib.OspfIntraAreaRib;
 import org.batfish.dataplane.rib.OspfRib;
 import org.batfish.dataplane.rib.RibDelta;
-import org.batfish.dataplane.rib.RibDelta.Builder;
 import org.batfish.dataplane.rib.RouteAdvertisement;
 import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 
@@ -417,13 +416,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   @Nonnull
   private Stream<EdgeId> getIncomingEdgeStream(OspfTopology topology) {
     return _process.getOspfNeighborConfigs().keySet().stream()
-        .flatMap(
-            interfaceName ->
-                topology
-                    .incomingEdges(
-                        new OspfNeighborConfigId(
-                            _c.getHostname(), _vrfName, _process.getProcessId(), interfaceName))
-                    .stream());
+        .flatMap(ospfNeighborConfigId -> topology.incomingEdges(ospfNeighborConfigId).stream());
   }
 
   /**
@@ -489,8 +482,8 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
    * @return the resulting inter-area RIB delta builder.
    */
   @Nonnull
-  private Builder<OspfInterAreaRoute> processInterAreaRoutes() {
-    Builder<OspfInterAreaRoute> interAreaDelta = RibDelta.builder();
+  private RibDelta.Builder<OspfInterAreaRoute> processInterAreaRoutes() {
+    RibDelta.Builder<OspfInterAreaRoute> interAreaDelta = RibDelta.builder();
     _interAreaIncomingRoutes.forEach(
         (edgeId, queue) -> {
           String ifaceName = edgeId.getHead().getInterfaceName();
@@ -546,7 +539,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
    */
   @Nonnull
   private RibDelta<OspfIntraAreaRoute> processIntraAreaRoutes() {
-    Builder<OspfIntraAreaRoute> intraAreaDelta = RibDelta.builder();
+    RibDelta.Builder<OspfIntraAreaRoute> intraAreaDelta = RibDelta.builder();
     _intraAreaIncomingRoutes.forEach(
         (edgeId, queue) -> {
           String ifaceName = edgeId.getHead().getInterfaceName();
@@ -606,7 +599,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   /** Compute inter-area summaries for a single area. */
   @Nonnull
   private RibDelta<OspfInterAreaRoute> computeInterAreaSummariesForArea(OspfArea area) {
-    Builder<OspfInterAreaRoute> deltaBuilder = RibDelta.builder();
+    RibDelta.Builder<OspfInterAreaRoute> deltaBuilder = RibDelta.builder();
     area.getSummaries()
         .forEach(
             (prefix, summary) ->
@@ -1027,7 +1020,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   /** Process type 1 routes from all message queues */
   @Nonnull
   private RibDelta<OspfExternalType1Route> processType1Routes() {
-    Builder<OspfExternalType1Route> type1deltaBuilder = RibDelta.builder();
+    RibDelta.Builder<OspfExternalType1Route> type1deltaBuilder = RibDelta.builder();
     _type1IncomingRoutes.forEach(
         (edgeId, queue) -> {
           String ifaceName = edgeId.getHead().getInterfaceName();
@@ -1067,7 +1060,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   /** Process type 2 routes from all message queues */
   @Nonnull
   private RibDelta<OspfExternalType2Route> processType2Routes() {
-    Builder<OspfExternalType2Route> type2deltaBuilder = RibDelta.builder();
+    RibDelta.Builder<OspfExternalType2Route> type2deltaBuilder = RibDelta.builder();
     _type2IncomingRoutes.forEach(
         (edgeId, queue) -> {
           String headIfaceName = edgeId.getHead().getInterfaceName();
@@ -1333,7 +1326,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
       RibDelta<? extends AnnotatedRoute<AbstractRoute>> mainRibDelta) {
     // Run each generated route through its own generation policy if present, then run the resulting
     // activated routes through the standard OSPF export policy.
-    Builder<OspfExternalRoute> activated = RibDelta.builder();
+    RibDelta.Builder<OspfExternalRoute> activated = RibDelta.builder();
     _process.getGeneratedRoutes().stream()
         .map(r -> activateGeneratedRoute(mainRibDelta, r))
         .filter(Objects::nonNull)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TopologyContextTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/TopologyContextTest.java
@@ -21,6 +21,7 @@ import org.batfish.common.topology.Layer2Topology;
 import org.batfish.common.topology.TunnelTopology;
 import org.batfish.datamodel.BgpPeerConfigId;
 import org.batfish.datamodel.BgpSessionProperties;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.IpsecPeerConfigId;
 import org.batfish.datamodel.IpsecSession;
@@ -64,7 +65,9 @@ public final class TopologyContextTest {
     isisTopology.addNode(new IsisNode("a", "b"));
     MutableValueGraph<OspfNeighborConfigId, OspfSessionProperties> ospfTopology =
         ValueGraphBuilder.directed().build();
-    ospfTopology.addNode(new OspfNeighborConfigId("a", "b", "c", "d"));
+    ospfTopology.addNode(
+        new OspfNeighborConfigId(
+            "a", "b", "c", "d", ConcreteInterfaceAddress.parse("192.0.2.0/31")));
     MutableGraph<VxlanNode> vxlanTopology =
         GraphBuilder.undirected().allowsSelfLoops(false).build();
     vxlanTopology.addNode(new VxlanNode("a", 5));
@@ -130,7 +133,9 @@ public final class TopologyContextTest {
     isisTopology.addNode(new IsisNode("a", "b"));
     MutableValueGraph<OspfNeighborConfigId, OspfSessionProperties> ospfTopology =
         ValueGraphBuilder.directed().build();
-    ospfTopology.addNode(new OspfNeighborConfigId("a", "b", "c", "d"));
+    ospfTopology.addNode(
+        new OspfNeighborConfigId(
+            "a", "b", "c", "d", ConcreteInterfaceAddress.parse("192.0.2.0/31")));
     MutableGraph<VxlanNode> vxlanTopology =
         GraphBuilder.undirected().allowsSelfLoops(false).build();
     vxlanTopology.addNode(new VxlanNode("a", 5));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/topology/OspfTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/topology/OspfTopologyTest.java
@@ -167,9 +167,19 @@ public class OspfTopologyTest {
 
     // Active neighbor relationship
     final OspfNeighborConfigId r1i13 =
-        new OspfNeighborConfigId("r1", Configuration.DEFAULT_VRF_NAME, "1", "i13");
+        new OspfNeighborConfigId(
+            "r1",
+            Configuration.DEFAULT_VRF_NAME,
+            "1",
+            "i13",
+            ConcreteInterfaceAddress.parse("1.1.1.2/31"));
     final OspfNeighborConfigId r3i31 =
-        new OspfNeighborConfigId("r3", Configuration.DEFAULT_VRF_NAME, "1", "i31");
+        new OspfNeighborConfigId(
+            "r3",
+            Configuration.DEFAULT_VRF_NAME,
+            "1",
+            "i31",
+            ConcreteInterfaceAddress.parse("1.1.1.3/31"));
     assertThat(topology.neighbors(r1i13), equalTo(ImmutableSet.of(r3i31)));
     assertThat(topology.neighbors(r3i31), equalTo(ImmutableSet.of(r1i13)));
     assertThat(
@@ -184,28 +194,58 @@ public class OspfTopologyTest {
     // Everyone else has no neighbors
     assertThat(
         topology.neighbors(
-            new OspfNeighborConfigId("r1", Configuration.DEFAULT_VRF_NAME, "p", "i12")),
+            new OspfNeighborConfigId(
+                "r1",
+                Configuration.DEFAULT_VRF_NAME,
+                "p",
+                "i12",
+                ConcreteInterfaceAddress.parse("1.1.1.0/31"))),
         empty());
     assertThat(
         topology.neighbors(
-            new OspfNeighborConfigId("r1", Configuration.DEFAULT_VRF_NAME, "p", "i14")),
+            new OspfNeighborConfigId(
+                "r1",
+                Configuration.DEFAULT_VRF_NAME,
+                "p",
+                "i14",
+                ConcreteInterfaceAddress.parse("1.1.1.4/31"))),
         empty());
     assertThat(
         topology.neighbors(
-            new OspfNeighborConfigId("r2", Configuration.DEFAULT_VRF_NAME, "p", "i21")),
+            new OspfNeighborConfigId(
+                "r2",
+                Configuration.DEFAULT_VRF_NAME,
+                "p",
+                "i21",
+                ConcreteInterfaceAddress.parse("1.1.1.1/31"))),
         empty());
     assertThat(
         topology.neighbors(
-            new OspfNeighborConfigId("r4", Configuration.DEFAULT_VRF_NAME, "p", "i41")),
+            new OspfNeighborConfigId(
+                "r4",
+                Configuration.DEFAULT_VRF_NAME,
+                "p",
+                "i41",
+                ConcreteInterfaceAddress.parse("1.1.1.5/31"))),
         empty());
   }
 
   @Test
   public void testEdgeIdJsonSerialization() throws IOException {
     final OspfNeighborConfigId r1i13 =
-        new OspfNeighborConfigId("r1", Configuration.DEFAULT_VRF_NAME, "1", "i13");
+        new OspfNeighborConfigId(
+            "r1",
+            Configuration.DEFAULT_VRF_NAME,
+            "1",
+            "i13",
+            ConcreteInterfaceAddress.parse("1.1.1.2/31"));
     final OspfNeighborConfigId r3i31 =
-        new OspfNeighborConfigId("r3", Configuration.DEFAULT_VRF_NAME, "1", "i31");
+        new OspfNeighborConfigId(
+            "r3",
+            Configuration.DEFAULT_VRF_NAME,
+            "1",
+            "i31",
+            ConcreteInterfaceAddress.parse("1.1.1.3/31"));
     EdgeId edge = OspfTopology.makeEdge(r1i13, r3i31);
     assertThat(BatfishObjectMapper.clone(edge, EdgeId.class), equalTo(edge));
   }
@@ -231,6 +271,7 @@ public class OspfTopologyTest {
                 .setNetworkType(OspfNetworkType.POINT_TO_POINT)
                 .setCost(1)
                 .setEnabled(true)
+                .setProcess("ospf")
                 .build())
         .build();
 
@@ -267,7 +308,8 @@ public class OspfTopologyTest {
         configuration.getVrfs().get("vrf").getOspfProcesses().get("ospf").getOspfNeighborConfigs(),
         equalTo(
             ImmutableMap.of(
-                "iface1",
+                new OspfNeighborConfigId(
+                    "conf", "vrf", "ospf", "iface1", ConcreteInterfaceAddress.parse("1.1.1.1/31")),
                 OspfNeighborConfig.builder()
                     .setArea(1L)
                     .setHostname("conf")

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -289,9 +289,7 @@ public class EdgesAnswerer extends Answerer {
 
   @VisibleForTesting
   static List<Row> getOspfEdges(
-      Set<String> includeNodes,
-      Set<String> includeRemoteNodes,
-      OspfTopology topology) {
+      Set<String> includeNodes, Set<String> includeRemoteNodes, OspfTopology topology) {
     ImmutableSet.Builder<Row> rows = ImmutableSet.builder();
     topology
         .getGraph()

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -149,7 +149,6 @@ public class EdgesAnswerer extends Answerer {
         return getIsisEdges(includeNodes, includeRemoteNodes, isisTopology);
       case OSPF:
         return getOspfEdges(
-            configurations,
             includeNodes,
             includeRemoteNodes,
             initial
@@ -290,7 +289,6 @@ public class EdgesAnswerer extends Answerer {
 
   @VisibleForTesting
   static List<Row> getOspfEdges(
-      Map<String, Configuration> configurations,
       Set<String> includeNodes,
       Set<String> includeRemoteNodes,
       OspfTopology topology) {

--- a/projects/question/src/main/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswerer.java
@@ -95,10 +95,7 @@ public class OspfSessionCompatibilityAnswerer extends Answerer {
                       .getOspfNeighborConfigs()
                       .keySet()
                       .forEach(
-                          iface -> {
-                            OspfNeighborConfigId ospfNeighborConfigId =
-                                new OspfNeighborConfigId(
-                                    node, vrf.getName(), ospfProcess.getProcessId(), iface);
+                          ospfNeighborConfigId -> {
                             Set<OspfNeighborConfigId> filteredNeighbors =
                                 ospfTopology.neighbors(ospfNeighborConfigId).stream()
                                     .filter(

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -397,6 +397,8 @@ public class EdgesAnswererTest {
     _host2.setVrfs(ImmutableSortedMap.of("vrf2", vrf2));
     Interface i1 = _host1.getAllInterfaces().get("int1");
     i1.setVrf(vrf1);
+    i1.setAddress(ConcreteInterfaceAddress.parse("192.0.2.0/31"));
+    i1.setAllAddresses(ImmutableSet.of(ConcreteInterfaceAddress.parse("192.0.2.0/31")));
     i1.setOspfSettings(
         OspfInterfaceSettings.defaultSettingsBuilder()
             .setCost(1)
@@ -406,6 +408,8 @@ public class EdgesAnswererTest {
             .build());
     Interface i2 = _host2.getAllInterfaces().get("int2");
     i2.setVrf(vrf2);
+    i2.setAddress(ConcreteInterfaceAddress.parse("192.0.2.1/31"));
+    i2.setAllAddresses(ImmutableSet.of(ConcreteInterfaceAddress.parse("192.0.2.1/31")));
     i2.setOspfSettings(
         OspfInterfaceSettings.defaultSettingsBuilder()
             .setCost(1)
@@ -423,7 +427,6 @@ public class EdgesAnswererTest {
                 Edge.of("host2", "int2", "host1", "int1")));
     List<Row> rows =
         getOspfEdges(
-            _configurations,
             _includeNodes,
             _includeRemoteNodes,
             OspfTopologyUtils.computeOspfTopology(

--- a/projects/question/src/test/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfsession/OspfSessionCompatibilityAnswererTest.java
@@ -61,7 +61,7 @@ public class OspfSessionCompatibilityAnswererTest {
     Vrf vrf = nf.vrfBuilder().setName(vrfName).setOwner(configuration).build();
 
     nf.interfaceBuilder()
-        .setAddress(ConcreteInterfaceAddress.create(addr, 31))
+        .setAddress(ConcreteInterfaceAddress.create(addr, 24))
         .setName(iface)
         .setVrf(vrf)
         .setOwner(configuration)
@@ -73,7 +73,8 @@ public class OspfSessionCompatibilityAnswererTest {
         .setProcessId("proc")
         .setNeighborConfigs(
             ImmutableMap.of(
-                iface,
+                new OspfNeighborConfigId(
+                    hostname, vrfName, "proc", iface, ConcreteInterfaceAddress.create(addr, 24)),
                 OspfNeighborConfig.builder()
                     .setArea(1L)
                     .setHostname(hostname)
@@ -92,24 +93,44 @@ public class OspfSessionCompatibilityAnswererTest {
     _configurations =
         ImmutableMap.of(
             "configuration_u",
-            buildConfig(nf, "configuration_u", "vrf_u", "int_u", Ip.parse("1.1.1.2")),
+            buildConfig(nf, "configuration_u", "vrf_u", "int_u", Ip.parse("192.0.2.1")),
             "configuration_v",
-            buildConfig(nf, "configuration_v", "vrf_v", "int_v", Ip.parse("1.1.1.3")),
+            buildConfig(nf, "configuration_v", "vrf_v", "int_v", Ip.parse("192.0.2.2")),
             "configuration_w",
-            buildConfig(nf, "configuration_w", "vrf_w", "int_w", Ip.parse("1.1.1.4")),
+            buildConfig(nf, "configuration_w", "vrf_w", "int_w", Ip.parse("192.0.2.3")),
             "configuration_x",
-            buildConfig(nf, "configuration_x", "vrf_x", "int_x", Ip.parse("1.1.1.5")));
+            buildConfig(nf, "configuration_x", "vrf_x", "int_x", Ip.parse("192.0.2.4")));
 
     MutableValueGraph<OspfNeighborConfigId, OspfSessionStatus> ospfGraph =
         ValueGraphBuilder.directed().allowsSelfLoops(false).build();
 
     ospfGraph.putEdgeValue(
-        new OspfNeighborConfigId("configuration_u", "vrf_u", "proc", "int_u"),
-        new OspfNeighborConfigId("configuration_v", "vrf_v", "proc", "int_v"),
+        new OspfNeighborConfigId(
+            "configuration_u",
+            "vrf_u",
+            "proc",
+            "int_u",
+            ConcreteInterfaceAddress.parse("192.0.2.1/24")),
+        new OspfNeighborConfigId(
+            "configuration_v",
+            "vrf_v",
+            "proc",
+            "int_v",
+            ConcreteInterfaceAddress.parse("192.0.2.2/24")),
         OspfSessionStatus.ESTABLISHED);
     ospfGraph.putEdgeValue(
-        new OspfNeighborConfigId("configuration_w", "vrf_w", "proc", "int_w"),
-        new OspfNeighborConfigId("configuration_x", "vrf_x", "proc", "int_x"),
+        new OspfNeighborConfigId(
+            "configuration_w",
+            "vrf_w",
+            "proc",
+            "int_w",
+            ConcreteInterfaceAddress.parse("192.0.2.3/24")),
+        new OspfNeighborConfigId(
+            "configuration_x",
+            "vrf_x",
+            "proc",
+            "int_x",
+            ConcreteInterfaceAddress.parse("192.0.2.4/24")),
         OspfSessionStatus.NETWORK_TYPE_MISMATCH);
     _ospfTopology = new CandidateOspfTopology(ImmutableValueGraph.copyOf(ospfGraph));
   }
@@ -134,14 +155,14 @@ public class OspfSessionCompatibilityAnswererTest {
                 equalTo(NodeInterfacePair.of("configuration_u", "int_u")),
                 Schema.INTERFACE),
             hasColumn(COL_VRF, equalTo("vrf_u"), Schema.STRING),
-            hasColumn(COL_IP, equalTo(Ip.parse("1.1.1.2")), Schema.IP),
+            hasColumn(COL_IP, equalTo(Ip.parse("192.0.2.1")), Schema.IP),
             hasColumn(COL_AREA, equalTo(1L), Schema.LONG),
             hasColumn(
                 COL_REMOTE_INTERFACE,
                 equalTo(NodeInterfacePair.of("configuration_v", "int_v")),
                 Schema.INTERFACE),
             hasColumn(COL_REMOTE_VRF, equalTo("vrf_v"), Schema.STRING),
-            hasColumn(COL_REMOTE_IP, equalTo(Ip.parse("1.1.1.3")), Schema.IP),
+            hasColumn(COL_REMOTE_IP, equalTo(Ip.parse("192.0.2.2")), Schema.IP),
             hasColumn(COL_REMOTE_AREA, equalTo(1L), Schema.LONG),
             hasColumn(
                 COL_SESSION_STATUS,
@@ -156,14 +177,14 @@ public class OspfSessionCompatibilityAnswererTest {
                 equalTo(NodeInterfacePair.of("configuration_w", "int_w")),
                 Schema.INTERFACE),
             hasColumn(COL_VRF, equalTo("vrf_w"), Schema.STRING),
-            hasColumn(COL_IP, equalTo(Ip.parse("1.1.1.4")), Schema.IP),
+            hasColumn(COL_IP, equalTo(Ip.parse("192.0.2.3")), Schema.IP),
             hasColumn(COL_AREA, equalTo(1L), Schema.LONG),
             hasColumn(
                 COL_REMOTE_INTERFACE,
                 equalTo(NodeInterfacePair.of("configuration_x", "int_x")),
                 Schema.INTERFACE),
             hasColumn(COL_REMOTE_VRF, equalTo("vrf_x"), Schema.STRING),
-            hasColumn(COL_REMOTE_IP, equalTo(Ip.parse("1.1.1.5")), Schema.IP),
+            hasColumn(COL_REMOTE_IP, equalTo(Ip.parse("192.0.2.4")), Schema.IP),
             hasColumn(COL_REMOTE_AREA, equalTo(1L), Schema.LONG),
             hasColumn(
                 COL_SESSION_STATUS,


### PR DESCRIPTION
- Key OSPF sessions additionally on ConcreteInterfaceAddress
- Check compatibility of addresses
- Consider all addresses instead of just primary