### PR TITLE
PAN: More specific address in AddressObject

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -85,7 +85,6 @@ import org.batfish.datamodel.IkeHashingAlgorithm;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
-import org.batfish.datamodel.IpRange;
 import org.batfish.datamodel.IpsecAuthenticationAlgorithm;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LongSpace;
@@ -1393,9 +1392,9 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitSa_ip_netmask(Sa_ip_netmaskContext ctx) {
     if (ctx.ip_address() != null) {
-      _currentAddressObject.setIpSpace(toIp(ctx.ip_address()).toIpSpace());
+      _currentAddressObject.setIp(toIp(ctx.ip_address()));
     } else if (ctx.IP_PREFIX() != null) {
-      _currentAddressObject.setIpSpace(Prefix.parse(getText(ctx.IP_PREFIX())).toIpSpace());
+      _currentAddressObject.setPrefix(Prefix.parse(getText(ctx.IP_PREFIX())));
     } else {
       warn(ctx, "Cannot understand what follows 'ip-netmask'");
     }
@@ -1404,7 +1403,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitSa_ip_range(Sa_ip_rangeContext ctx) {
     String[] ips = getText(ctx.IP_RANGE()).split("-");
-    _currentAddressObject.setIpSpace(IpRange.range(Ip.parse(ips[0]), Ip.parse(ips[1])));
+    _currentAddressObject.setIpRange(Range.closed(Ip.parse(ips[0]), Ip.parse(ips[1])));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.palo_alto;
 
+import com.google.common.collect.Range;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
@@ -7,24 +8,40 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.EmptyIpSpace;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpRange;
 import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.Prefix;
 
 /** Represents a Palo Alto address object */
 @ParametersAreNonnullByDefault
 public final class AddressObject implements Serializable {
 
+  public enum Type {
+    IP,
+    IP_RANGE,
+    PREFIX
+  }
+
   @Nullable private String _description;
-
-  @Nonnull private IpSpace _ipSpace;
-
   @Nonnull private final String _name;
-
   @Nonnull private final Set<String> _tags;
+  @Nullable private Type _type;
+
+  // Only one can be set
+  @Nullable private Ip _ip;
+  @Nullable private Range<Ip> _ipRange;
+  @Nullable private Prefix _prefix;
 
   public AddressObject(String name) {
     _name = name;
-    _ipSpace = EmptyIpSpace.INSTANCE;
     _tags = new HashSet<>();
+  }
+
+  private void clearAddress() {
+    _ip = null;
+    _ipRange = null;
+    _prefix = null;
   }
 
   @Nullable
@@ -34,7 +51,29 @@ public final class AddressObject implements Serializable {
 
   @Nonnull
   public IpSpace getIpSpace() {
-    return _ipSpace;
+    if (_ip != null) {
+      return _ip.toIpSpace();
+    } else if (_prefix != null) {
+      return _prefix.toIpSpace();
+    } else if (_ipRange != null) {
+      return IpRange.range(_ipRange.lowerEndpoint(), _ipRange.upperEndpoint());
+    }
+    return EmptyIpSpace.INSTANCE;
+  }
+
+  @Nullable
+  public Ip getIp() {
+    return _ip;
+  }
+
+  @Nullable
+  public Range<Ip> getIpRange() {
+    return _ipRange;
+  }
+
+  @Nullable
+  public Prefix getPrefix() {
+    return _prefix;
   }
 
   @Nonnull
@@ -47,11 +86,30 @@ public final class AddressObject implements Serializable {
     return _tags;
   }
 
+  @Nullable
+  public Type getType() {
+    return _type;
+  }
+
   public void setDescription(String description) {
     _description = description;
   }
 
-  public void setIpSpace(IpSpace ipSpace) {
-    _ipSpace = ipSpace;
+  public void setIp(@Nullable Ip ip) {
+    _type = ip == null ? null : Type.IP;
+    clearAddress();
+    _ip = ip;
+  }
+
+  public void setIpRange(@Nullable Range<Ip> ipRange) {
+    _type = ipRange == null ? null : Type.IP_RANGE;
+    clearAddress();
+    _ipRange = ipRange;
+  }
+
+  public void setPrefix(@Nullable Prefix prefix) {
+    _type = prefix == null ? null : Type.PREFIX;
+    clearAddress();
+    _prefix = prefix;
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressObjectTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressObjectTest.java
@@ -1,0 +1,50 @@
+package org.batfish.representation.palo_alto;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNull;
+
+import com.google.common.collect.Range;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.representation.palo_alto.AddressObject.Type;
+import org.junit.Test;
+
+/** Tests of {@link AddressObject} */
+public class AddressObjectTest {
+
+  @Test
+  public void testSetClearsTypeAndMembers() {
+    AddressObject a = new AddressObject("name");
+    assertNull(a.getIp());
+    assertNull(a.getType());
+
+    a.setIp(Ip.ZERO);
+    assertThat(a.getIp(), equalTo(Ip.ZERO));
+    assertThat(a.getType(), equalTo(Type.IP));
+
+    // Setting prefix clears members and updates type
+    a.setPrefix(Prefix.ZERO);
+    assertNull(a.getIp());
+    assertThat(a.getPrefix(), equalTo(Prefix.ZERO));
+    assertThat(a.getType(), equalTo(Type.PREFIX));
+
+    // Setting range clears members and updates type
+    Range<Ip> range = Range.closed(Ip.ZERO, Ip.parse("1.1.1.1"));
+    a.setIpRange(range);
+    assertNull(a.getPrefix());
+    assertThat(a.getIpRange(), equalTo(range));
+    assertThat(a.getType(), equalTo(Type.IP_RANGE));
+
+    // Setting IP clears members and updates type
+    a.setIp(Ip.ZERO);
+    assertNull(a.getIpRange());
+    assertThat(a.getIp(), equalTo(Ip.ZERO));
+    assertThat(a.getType(), equalTo(Type.IP));
+
+    // Setting IP to null clears type and members
+    a.setIp(null);
+    assertNull(a.getIp());
+    assertNull(a.getType());
+  }
+}


### PR DESCRIPTION
Address object can only contain IP, prefix, or IP range, not an arbitrary IP space.