### PR TITLE
Update BGP next hop propagation

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -50,6 +50,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.VniSettings;
 import org.batfish.datamodel.Vrf;
@@ -958,7 +959,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
         sessionProperties.getConfedSessionType(),
         sessionProperties.getHeadAs(),
         sessionProperties.getHeadIp(),
-        sessionProperties.getHeadIp());
+        Route.UNSET_ROUTE_NEXT_HOP_IP);
 
     // Successfully exported route
     Bgpv4Route transformedOutgoingRoute = transformedOutgoingRouteBuilder.build();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -319,12 +319,14 @@ public final class BgpProtocolHelper {
 
     // Skip setting our own next hop if it has already been set by the routing policy
     if (routeBuilder.getNextHopIp().equals(UNSET_ROUTE_NEXT_HOP_IP)) {
-      if (isEbgp && confedSessionType != ConfedSessionType.WITHIN_CONFED) { // "Pure" eBGP
+      if (isEbgp) {
         routeBuilder.setNextHopIp(localIp);
-      } else {
-        // iBGP session (or eBGP within confederation):
-        // if original route has next-hop ip, preserve it. If not, set our own.
-        // Note: implementation of next-hop-self in the general case is delegated to routing policy
+      } else { // iBGP session
+        /*
+        Note: implementation of next-hop-self in the general case is delegated to routing
+        policy.
+        If original route has next-hop ip, preserve it. If not, set our own.
+        */
         routeBuilder.setNextHopIp(
             originalRouteNhip.equals(UNSET_ROUTE_NEXT_HOP_IP) ? localIp : originalRouteNhip);
       }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -235,11 +235,11 @@ public class BgpProtocolHelperTest {
         _baseBgpRouteBuilder, true, ConfedSessionType.ACROSS_CONFED_BORDER, 1, nextHopIp, DEST_IP);
     assertThat(_baseBgpRouteBuilder.getNextHopIp(), equalTo(nextHopIp));
 
-    // eBGP within confederation -- no change
+    // eBGP within confederation -- change
     _baseBgpRouteBuilder.setNextHopIp(null);
     transformBgpRoutePostExport(
         _baseBgpRouteBuilder, true, ConfedSessionType.WITHIN_CONFED, 1, nextHopIp, DEST_IP);
-    assertThat(_baseBgpRouteBuilder.getNextHopIp(), equalTo(DEST_IP));
+    assertThat(_baseBgpRouteBuilder.getNextHopIp(), equalTo(nextHopIp));
 
     // iBGP no confederation -- no change
     _baseBgpRouteBuilder.setNextHopIp(null);


### PR DESCRIPTION
Since the RFC language is vague on whether next hop *must* be preserved
over eBGP within a confederation, align to GNS3 observations (at least
for juniper) and revert to overriding the next hop