### PR TITLE
PAN: Further NAT conversion cleanup

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1101,8 +1101,7 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
             String[] ips = endpointValue.split("-");
             return IpRange.range(Ip.parse(ips[0]), Ip.parse(ips[1]));
           case REFERENCE:
-            // Undefined reference
-            w.redFlag("No matching address group/object found for RuleEndpoint: " + endpoint);
+            // Rely on undefined references to surface this issue (endpoint reference not defined)
             return EmptyIpSpace.INSTANCE;
           default:
             w.redFlag("Could not convert RuleEndpoint to IpSpace: " + endpoint);

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoNatTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoNatTest.java
@@ -76,36 +76,18 @@ public class PaloAltoNatTest {
             .setTag("test")
             .setIngressNode(c.getHostname())
             .setIngressInterface(inside1Name)
-            .setDstIp(Ip.parse("1.2.1.2"))
             .setSrcIp(Ip.parse("1.1.1.2"))
+            .setDstIp(Ip.parse("1.2.1.2"))
             .setSrcPort(111)
             .setDstPort(222)
             .setIpProtocol(IpProtocol.TCP)
             .build();
     // This flow is NOT NAT'd (does not match source address constraint)
     Flow insideToOutsideBadSrcIp =
-        Flow.builder()
-            .setTag("test")
-            .setIngressNode(c.getHostname())
-            .setIngressInterface(inside1Name)
-            .setDstIp(Ip.parse("1.2.1.2"))
-            .setSrcIp(Ip.parse("1.2.1.200"))
-            .setSrcPort(111)
-            .setDstPort(222)
-            .setIpProtocol(IpProtocol.TCP)
-            .build();
+        insideToOutside.toBuilder().setSrcIp(Ip.parse("1.2.1.200")).build();
     // This flow is NOT NAT'd (does not match from interface constraint)
     Flow outsideToOutsideBadIngressIface =
-        Flow.builder()
-            .setTag("test")
-            .setIngressNode(c.getHostname())
-            .setIngressInterface(outside2Name)
-            .setDstIp(Ip.parse("1.2.1.2"))
-            .setSrcIp(Ip.parse("1.1.1.2"))
-            .setSrcPort(111)
-            .setDstPort(222)
-            .setIpProtocol(IpProtocol.TCP)
-            .build();
+        insideToOutside.toBuilder().setIngressInterface(outside2Name).build();
 
     SortedMap<Flow, List<Trace>> traces =
         batfish
@@ -146,53 +128,22 @@ public class PaloAltoNatTest {
     Batfish batfish = getBatfish(ImmutableSortedMap.of(c.getHostname(), c), _folder);
     batfish.computeDataPlane();
 
-    Flow hitsPreRulebaseNatRule =
+    Flow.Builder flowBuilder =
         Flow.builder()
             .setTag("test")
             .setIngressNode(c.getHostname())
             .setIngressInterface(inside1Name)
             .setDstIp(Ip.parse("1.2.1.2"))
-            .setSrcIp(Ip.parse("1.1.1.2"))
             .setSrcPort(111)
             .setDstPort(222)
-            .setIpProtocol(IpProtocol.TCP)
-            .build();
-    Flow hitsVsysNatRule =
-        Flow.builder()
-            .setTag("test")
-            .setIngressNode(c.getHostname())
-            .setIngressInterface(inside1Name)
-            .setDstIp(Ip.parse("1.2.1.2"))
-            // Src IP in 1.1.1.2/30
-            .setSrcIp(Ip.parse("1.1.1.1"))
-            .setSrcPort(111)
-            .setDstPort(222)
-            .setIpProtocol(IpProtocol.TCP)
-            .build();
-    Flow hitsPostRulebaseNatRule =
-        Flow.builder()
-            .setTag("test")
-            .setIngressNode(c.getHostname())
-            .setIngressInterface(inside1Name)
-            .setDstIp(Ip.parse("1.2.1.2"))
-            // Src IP in 1.1.1.2/28 but not 1.1.1.2/30
-            .setSrcIp(Ip.parse("1.1.1.6"))
-            .setSrcPort(111)
-            .setDstPort(222)
-            .setIpProtocol(IpProtocol.TCP)
-            .build();
-    Flow doesNotHitNatRule =
-        Flow.builder()
-            .setTag("test")
-            .setIngressNode(c.getHostname())
-            .setIngressInterface(inside1Name)
-            .setDstIp(Ip.parse("1.2.1.2"))
-            // Src IP not in 1.1.1.2/28
-            .setSrcIp(Ip.parse("1.1.1.30"))
-            .setSrcPort(111)
-            .setDstPort(222)
-            .setIpProtocol(IpProtocol.TCP)
-            .build();
+            .setIpProtocol(IpProtocol.TCP);
+    Flow hitsPreRulebaseNatRule = flowBuilder.setSrcIp(Ip.parse("1.1.1.2")).build();
+    // Src IP in 1.1.1.2/30
+    Flow hitsVsysNatRule = flowBuilder.setSrcIp(Ip.parse("1.1.1.1")).build();
+    // Src IP in 1.1.1.2/28 but not 1.1.1.2/30
+    Flow hitsPostRulebaseNatRule = flowBuilder.setSrcIp(Ip.parse("1.1.1.6")).build();
+    // Src IP not in 1.1.1.2/28
+    Flow doesNotHitNatRule = flowBuilder.setSrcIp(Ip.parse("1.1.1.30")).build();
 
     SortedMap<Flow, List<Trace>> traces =
         batfish
@@ -256,36 +207,18 @@ public class PaloAltoNatTest {
             .setTag("test")
             .setIngressNode(c.getHostname())
             .setIngressInterface(outside1Name)
-            .setDstIp(Ip.parse("1.1.1.2"))
             .setSrcIp(Ip.parse("1.2.1.2"))
+            .setDstIp(Ip.parse("1.1.1.2"))
             .setSrcPort(111)
             .setDstPort(222)
             .setIpProtocol(IpProtocol.TCP)
             .build();
     // This flow is NOT NAT'd (does not match source address constraint)
     Flow outsideToInsideBadSrcIp =
-        Flow.builder()
-            .setTag("test")
-            .setIngressNode(c.getHostname())
-            .setIngressInterface(outside1Name)
-            .setDstIp(Ip.parse("1.1.1.2"))
-            .setSrcIp(Ip.parse("1.2.1.200"))
-            .setSrcPort(111)
-            .setDstPort(222)
-            .setIpProtocol(IpProtocol.TCP)
-            .build();
+        outsideToInsideNat.toBuilder().setSrcIp(Ip.parse("1.2.1.200")).build();
     // This flow is NOT NAT'd (does not match from-interface constraint)
     Flow insideToInsideBadIngressIface =
-        Flow.builder()
-            .setTag("test")
-            .setIngressNode(c.getHostname())
-            .setIngressInterface(inside2Name)
-            .setDstIp(Ip.parse("1.1.1.2"))
-            .setSrcIp(Ip.parse("1.2.1.2"))
-            .setSrcPort(111)
-            .setDstPort(222)
-            .setIpProtocol(IpProtocol.TCP)
-            .build();
+        outsideToInsideNat.toBuilder().setIngressInterface(inside2Name).build();
 
     SortedMap<Flow, List<Trace>> traces =
         batfish
@@ -323,8 +256,7 @@ public class PaloAltoNatTest {
     // Interface in OUTSIDE zone has packet policy
     assertThat(outside1Policy, notNullValue());
 
-    // This flow is NAT'd by the pre-rulebase rule and should pass through the firewall
-    Flow outsideToInsideNatPreRulebase =
+    Flow.Builder flowBuilder =
         Flow.builder()
             .setTag("test")
             .setIngressNode(c.getHostname())
@@ -333,34 +265,13 @@ public class PaloAltoNatTest {
             .setSrcIp(Ip.parse("1.2.1.2"))
             .setSrcPort(111)
             .setDstPort(222)
-            .setIpProtocol(IpProtocol.TCP)
-            .build();
-
+            .setIpProtocol(IpProtocol.TCP);
+    // This flow is NAT'd by the pre-rulebase rule and should pass through the firewall
+    Flow outsideToInsideNatPreRulebase = flowBuilder.setSrcIp(Ip.parse("1.2.1.2")).build();
     // This flow is NAT'd by the rulebase rule and should pass through the firewall
-    Flow outsideToInsideNatRulebase =
-        Flow.builder()
-            .setTag("test")
-            .setIngressNode(c.getHostname())
-            .setIngressInterface(outside1Name)
-            .setDstIp(Ip.parse("1.1.1.2"))
-            .setSrcIp(Ip.parse("1.2.1.4"))
-            .setSrcPort(111)
-            .setDstPort(222)
-            .setIpProtocol(IpProtocol.TCP)
-            .build();
-
+    Flow outsideToInsideNatRulebase = flowBuilder.setSrcIp(Ip.parse("1.2.1.4")).build();
     // This flow is NAT'd by the post-rulebase and should pass through the firewall
-    Flow outsideToInsideNatPostRulebase =
-        Flow.builder()
-            .setTag("test")
-            .setIngressNode(c.getHostname())
-            .setIngressInterface(outside1Name)
-            .setDstIp(Ip.parse("1.1.1.2"))
-            .setSrcIp(Ip.parse("1.2.1.5"))
-            .setSrcPort(111)
-            .setDstPort(222)
-            .setIpProtocol(IpProtocol.TCP)
-            .build();
+    Flow outsideToInsideNatPostRulebase = flowBuilder.setSrcIp(Ip.parse("1.2.1.5")).build();
 
     SortedMap<Flow, List<Trace>> traces =
         batfish

--- a/tests/parsing-tests/networks/unit-tests/configs/palo_alto/nat
+++ b/tests/parsing-tests/networks/unit-tests/configs/palo_alto/nat
@@ -30,11 +30,13 @@ policy {
             destination any;
           }
           RULE_2 {
+            to TO_ZONE;
             from FROM_ZONE;
             source SRC_NAME;
             destination DST_NAME;
           }
           RULE_3 {
+            to TO_ZONE;
             source-translation {
               dynamic-ip-and-port {
                 translated-address [ ADDR1 1.1.1.1 2.2.2.0/24 3.3.3.3-4.4.4.4];
@@ -43,6 +45,19 @@ policy {
             from [ FROM_1 FROM_2 ];
             source [ SRC_1 SRC_2];
             destination [ DST_1 DST_2];
+          }
+          MISSING_TO;
+          MISSING_FROM {
+            to TO_ZONE;
+          }
+          MISSING_SOURCE {
+            to TO_ZONE;
+            from FROM_ZONE;
+          }
+          MISSING_DESTINATION {
+            to TO_ZONE;
+            from FROM_ZONE;
+            source SRC_NAME;
           }
         }
       }

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -3855,7 +3855,7 @@
         "Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            43
+            45
           ]
         }
       },
@@ -3867,7 +3867,7 @@
         "Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            43
+            45
           ]
         }
       },
@@ -3879,7 +3879,9 @@
         "Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            33
+            34,
+            55,
+            59
           ]
         }
       },
@@ -3891,7 +3893,12 @@
         "Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            27
+            27,
+            33,
+            39,
+            51,
+            54,
+            58
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -3490,6 +3490,52 @@
       },
       {
         "Structure_Type" : "nat rule",
+        "Structure_Name" : "MISSING_DESTINATION~panorama",
+        "Source_Lines" : {
+          "filename" : "configs/palo_alto/nat",
+          "lines" : [
+            57,
+            58,
+            59,
+            60
+          ]
+        }
+      },
+      {
+        "Structure_Type" : "nat rule",
+        "Structure_Name" : "MISSING_FROM~panorama",
+        "Source_Lines" : {
+          "filename" : "configs/palo_alto/nat",
+          "lines" : [
+            50,
+            51
+          ]
+        }
+      },
+      {
+        "Structure_Type" : "nat rule",
+        "Structure_Name" : "MISSING_SOURCE~panorama",
+        "Source_Lines" : {
+          "filename" : "configs/palo_alto/nat",
+          "lines" : [
+            53,
+            54,
+            55
+          ]
+        }
+      },
+      {
+        "Structure_Type" : "nat rule",
+        "Structure_Name" : "MISSING_TO~panorama",
+        "Source_Lines" : {
+          "filename" : "configs/palo_alto/nat",
+          "lines" : [
+            49
+          ]
+        }
+      },
+      {
+        "Structure_Type" : "nat rule",
         "Structure_Name" : "RULE_1~panorama",
         "Source_Lines" : {
           "filename" : "configs/palo_alto/nat",
@@ -3516,7 +3562,8 @@
             32,
             33,
             34,
-            35
+            35,
+            36
           ]
         }
       },
@@ -3526,13 +3573,14 @@
         "Source_Lines" : {
           "filename" : "configs/palo_alto/nat",
           "lines" : [
-            37,
             38,
             39,
             40,
-            43,
-            44,
-            45
+            41,
+            42,
+            45,
+            46,
+            47
           ]
         }
       },
@@ -3789,10 +3837,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 255 results",
+      "notes" : "Found 259 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 255
+      "numResults" : 259
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -71803,6 +71803,28 @@
             "                  (srn_definition",
             "                    name = (variable",
             "                      VARIABLE:'RULE_2')",
+            "                    (srn_to",
+            "                      TO:'to'",
+            "                      zone = (variable",
+            "                        VARIABLE:'TO_ZONE'))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (s_policy",
+            "        POLICY:'policy'",
+            "        (s_policy_panorama",
+            "          PANORAMA:'panorama'",
+            "          (panorama_post_rulebase",
+            "            POST_RULEBASE:'post-rulebase'",
+            "            (rulebase_inner",
+            "              (sr_nat",
+            "                NAT:'nat'",
+            "                (sr_nat_rules",
+            "                  RULES:'rules'",
+            "                  (srn_definition",
+            "                    name = (variable",
+            "                      VARIABLE:'RULE_2')",
             "                    (srn_from",
             "                      FROM:'from'",
             "                      (variable_list",
@@ -71856,6 +71878,28 @@
             "                        (src_or_dst_list_item",
             "                          name = (variable",
             "                            VARIABLE:'DST_NAME'))))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (s_policy",
+            "        POLICY:'policy'",
+            "        (s_policy_panorama",
+            "          PANORAMA:'panorama'",
+            "          (panorama_post_rulebase",
+            "            POST_RULEBASE:'post-rulebase'",
+            "            (rulebase_inner",
+            "              (sr_nat",
+            "                NAT:'nat'",
+            "                (sr_nat_rules",
+            "                  RULES:'rules'",
+            "                  (srn_definition",
+            "                    name = (variable",
+            "                      VARIABLE:'RULE_3')",
+            "                    (srn_to",
+            "                      TO:'to'",
+            "                      zone = (variable",
+            "                        VARIABLE:'TO_ZONE'))))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line",
             "    SET:'set'",
@@ -72108,6 +72152,160 @@
             "                        (src_or_dst_list_item",
             "                          name = (variable",
             "                            VARIABLE:'DST_2'))))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (s_policy",
+            "        POLICY:'policy'",
+            "        (s_policy_panorama",
+            "          PANORAMA:'panorama'",
+            "          (panorama_post_rulebase",
+            "            POST_RULEBASE:'post-rulebase'",
+            "            (rulebase_inner",
+            "              (sr_nat",
+            "                NAT:'nat'",
+            "                (sr_nat_rules",
+            "                  RULES:'rules'",
+            "                  (srn_definition",
+            "                    name = (variable",
+            "                      VARIABLE:'MISSING_TO')))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (s_policy",
+            "        POLICY:'policy'",
+            "        (s_policy_panorama",
+            "          PANORAMA:'panorama'",
+            "          (panorama_post_rulebase",
+            "            POST_RULEBASE:'post-rulebase'",
+            "            (rulebase_inner",
+            "              (sr_nat",
+            "                NAT:'nat'",
+            "                (sr_nat_rules",
+            "                  RULES:'rules'",
+            "                  (srn_definition",
+            "                    name = (variable",
+            "                      VARIABLE:'MISSING_FROM')",
+            "                    (srn_to",
+            "                      TO:'to'",
+            "                      zone = (variable",
+            "                        VARIABLE:'TO_ZONE'))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (s_policy",
+            "        POLICY:'policy'",
+            "        (s_policy_panorama",
+            "          PANORAMA:'panorama'",
+            "          (panorama_post_rulebase",
+            "            POST_RULEBASE:'post-rulebase'",
+            "            (rulebase_inner",
+            "              (sr_nat",
+            "                NAT:'nat'",
+            "                (sr_nat_rules",
+            "                  RULES:'rules'",
+            "                  (srn_definition",
+            "                    name = (variable",
+            "                      VARIABLE:'MISSING_SOURCE')",
+            "                    (srn_to",
+            "                      TO:'to'",
+            "                      zone = (variable",
+            "                        VARIABLE:'TO_ZONE'))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (s_policy",
+            "        POLICY:'policy'",
+            "        (s_policy_panorama",
+            "          PANORAMA:'panorama'",
+            "          (panorama_post_rulebase",
+            "            POST_RULEBASE:'post-rulebase'",
+            "            (rulebase_inner",
+            "              (sr_nat",
+            "                NAT:'nat'",
+            "                (sr_nat_rules",
+            "                  RULES:'rules'",
+            "                  (srn_definition",
+            "                    name = (variable",
+            "                      VARIABLE:'MISSING_SOURCE')",
+            "                    (srn_from",
+            "                      FROM:'from'",
+            "                      (variable_list",
+            "                        (variable_list_item",
+            "                          VARIABLE:'FROM_ZONE')))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (s_policy",
+            "        POLICY:'policy'",
+            "        (s_policy_panorama",
+            "          PANORAMA:'panorama'",
+            "          (panorama_post_rulebase",
+            "            POST_RULEBASE:'post-rulebase'",
+            "            (rulebase_inner",
+            "              (sr_nat",
+            "                NAT:'nat'",
+            "                (sr_nat_rules",
+            "                  RULES:'rules'",
+            "                  (srn_definition",
+            "                    name = (variable",
+            "                      VARIABLE:'MISSING_DESTINATION')",
+            "                    (srn_to",
+            "                      TO:'to'",
+            "                      zone = (variable",
+            "                        VARIABLE:'TO_ZONE'))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (s_policy",
+            "        POLICY:'policy'",
+            "        (s_policy_panorama",
+            "          PANORAMA:'panorama'",
+            "          (panorama_post_rulebase",
+            "            POST_RULEBASE:'post-rulebase'",
+            "            (rulebase_inner",
+            "              (sr_nat",
+            "                NAT:'nat'",
+            "                (sr_nat_rules",
+            "                  RULES:'rules'",
+            "                  (srn_definition",
+            "                    name = (variable",
+            "                      VARIABLE:'MISSING_DESTINATION')",
+            "                    (srn_from",
+            "                      FROM:'from'",
+            "                      (variable_list",
+            "                        (variable_list_item",
+            "                          VARIABLE:'FROM_ZONE')))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (s_policy",
+            "        POLICY:'policy'",
+            "        (s_policy_panorama",
+            "          PANORAMA:'panorama'",
+            "          (panorama_post_rulebase",
+            "            POST_RULEBASE:'post-rulebase'",
+            "            (rulebase_inner",
+            "              (sr_nat",
+            "                NAT:'nat'",
+            "                (sr_nat_rules",
+            "                  RULES:'rules'",
+            "                  (srn_definition",
+            "                    name = (variable",
+            "                      VARIABLE:'MISSING_DESTINATION')",
+            "                    (srn_source",
+            "                      SOURCE:'source'",
+            "                      (src_or_dst_list",
+            "                        (src_or_dst_list_item",
+            "                          name = (variable",
+            "                            VARIABLE:'SRC_NAME'))))))))))))",
             "    NEWLINE:'\\n')",
             "  EOF:<EOF>)"
           ]
@@ -76468,7 +76666,7 @@
         "palo_alto_virtual_routers" : "PASSED",
         "paloalto_applications" : "PASSED",
         "paloalto_interfaces" : "WARNINGS",
-        "paloalto_nat" : "PASSED",
+        "paloalto_nat" : "WARNINGS",
         "paloalto_policy" : "PASSED",
         "paloalto_zones" : "PASSED",
         "pim" : "PASSED",
@@ -83800,6 +83998,36 @@
         },
         "configs/palo_alto/nat" : {
           "nat rule" : {
+            "MISSING_DESTINATION~panorama" : {
+              "definitionLines" : [
+                57,
+                58,
+                59,
+                60
+              ],
+              "numReferrers" : 0
+            },
+            "MISSING_FROM~panorama" : {
+              "definitionLines" : [
+                50,
+                51
+              ],
+              "numReferrers" : 0
+            },
+            "MISSING_SOURCE~panorama" : {
+              "definitionLines" : [
+                53,
+                54,
+                55
+              ],
+              "numReferrers" : 0
+            },
+            "MISSING_TO~panorama" : {
+              "definitionLines" : [
+                49
+              ],
+              "numReferrers" : 0
+            },
             "RULE_1~panorama" : {
               "definitionLines" : [
                 18,
@@ -83820,19 +84048,21 @@
                 32,
                 33,
                 34,
-                35
+                35,
+                36
               ],
               "numReferrers" : 0
             },
             "RULE_3~panorama" : {
               "definitionLines" : [
-                37,
                 38,
                 39,
                 40,
-                43,
-                44,
-                45
+                41,
+                42,
+                45,
+                46,
+                47
               ],
               "numReferrers" : 0
             }
@@ -90223,37 +90453,38 @@
           "address-like" : {
             "ADDR1~panorama" : {
               "rulebase nat rules source-translation" : [
-                40
+                42
               ]
             },
             "DST_1~panorama" : {
               "rulebase nat rules destination" : [
-                45
+                47
               ]
             },
             "DST_2~panorama" : {
               "rulebase nat rules destination" : [
-                45
+                47
               ]
             },
             "DST_NAME~panorama" : {
               "rulebase nat rules destination" : [
-                35
+                36
               ]
             },
             "SRC_1~panorama" : {
               "rulebase nat rules source" : [
-                44
+                46
               ]
             },
             "SRC_2~panorama" : {
               "rulebase nat rules source" : [
-                44
+                46
               ]
             },
             "SRC_NAME~panorama" : {
               "rulebase nat rules source" : [
-                34
+                35,
+                60
               ]
             }
           },
@@ -90265,18 +90496,18 @@
             },
             "1.1.1.1~panorama" : {
               "rulebase nat rules source-translation" : [
-                40
+                42
               ]
             },
             "2.2.2.0/24~panorama" : {
               "rulebase nat rules source-translation" : [
                 24,
-                40
+                42
               ]
             },
             "3.3.3.3-4.4.4.4~panorama" : {
               "rulebase nat rules source-translation" : [
-                40
+                42
               ]
             },
             "any~panorama" : {
@@ -90289,6 +90520,26 @@
             }
           },
           "nat rule" : {
+            "MISSING_DESTINATION~panorama" : {
+              "rulebase nat rules" : [
+                57
+              ]
+            },
+            "MISSING_FROM~panorama" : {
+              "rulebase nat rules" : [
+                50
+              ]
+            },
+            "MISSING_SOURCE~panorama" : {
+              "rulebase nat rules" : [
+                53
+              ]
+            },
+            "MISSING_TO~panorama" : {
+              "rulebase nat rules" : [
+                49
+              ]
+            },
             "RULE_1~panorama" : {
               "rulebase nat rules" : [
                 18
@@ -90301,29 +90552,36 @@
             },
             "RULE_3~panorama" : {
               "rulebase nat rules" : [
-                37
+                38
               ]
             }
           },
           "zone" : {
             "FROM_1~panorama" : {
               "rulebase nat rules from" : [
-                43
+                45
               ]
             },
             "FROM_2~panorama" : {
               "rulebase nat rules from" : [
-                43
+                45
               ]
             },
             "FROM_ZONE~panorama" : {
               "rulebase nat rules from" : [
-                33
+                34,
+                55,
+                59
               ]
             },
             "TO_ZONE~panorama" : {
               "rulebase nat rules to" : [
-                27
+                27,
+                33,
+                39,
+                51,
+                54,
+                58
               ]
             }
           }
@@ -92614,22 +92872,29 @@
           "zone" : {
             "FROM_1~panorama" : {
               "rulebase nat rules from" : [
-                43
+                45
               ]
             },
             "FROM_2~panorama" : {
               "rulebase nat rules from" : [
-                43
+                45
               ]
             },
             "FROM_ZONE~panorama" : {
               "rulebase nat rules from" : [
-                33
+                34,
+                55,
+                59
               ]
             },
             "TO_ZONE~panorama" : {
               "rulebase nat rules to" : [
-                27
+                27,
+                33,
+                39,
+                51,
+                54,
+                58
               ]
             }
           }
@@ -93239,6 +93504,42 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Interface vlan.1 is not in a virtual-router, placing in ~NULL_VRF~ and shutting it down."
+            }
+          ]
+        },
+        "paloalto_nat" : {
+          "Red flags" : [
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "No matching address group/object found for RuleEndpoint: RuleEndpoint{type=REFERENCE, value=SRC_1}"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "No matching address group/object found for RuleEndpoint: RuleEndpoint{type=REFERENCE, value=SRC_2}"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "No matching address group/object found for RuleEndpoint: RuleEndpoint{type=REFERENCE, value=DST_1}"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "No matching address group/object found for RuleEndpoint: RuleEndpoint{type=REFERENCE, value=DST_2}"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "NAT rule MISSING_TO ignored because it has no to zone configured"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "NAT rule MISSING_FROM ignored because it has no from zones configured"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "NAT rule MISSING_SOURCE ignored because it has no source addresses configured"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "NAT rule MISSING_DESTINATION ignored because it has no destination addresses configured"
             }
           ]
         }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -93511,22 +93511,6 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "No matching address group/object found for RuleEndpoint: RuleEndpoint{type=REFERENCE, value=SRC_1}"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "No matching address group/object found for RuleEndpoint: RuleEndpoint{type=REFERENCE, value=SRC_2}"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "No matching address group/object found for RuleEndpoint: RuleEndpoint{type=REFERENCE, value=DST_1}"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "No matching address group/object found for RuleEndpoint: RuleEndpoint{type=REFERENCE, value=DST_2}"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
               "text" : "NAT rule MISSING_TO ignored because it has no to zone configured"
             },
             {


### PR DESCRIPTION
- Removes redundant match src/dst IP guard from dest NAT transformations
- Filters out invalid NAT rules earlier in dest translation pipeline
- Adds warnings for invalid NAT rules and updates ref test to exercise those warnings
- Makes packet policies per zone, not per interface, because policies for any two interfaces in the same zone are currently identical