### PR TITLE
PAN: Match NAT rules even if they don't transform

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/NatRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/NatRule.java
@@ -68,10 +68,6 @@ public final class NatRule implements Serializable {
     return _to;
   }
 
-  public boolean doesSourceTranslation() {
-    return _sourceTranslation != null && _sourceTranslation.getDynamicIpAndPort() != null;
-  }
-
   public void setDestinationTranslation(DestinationTranslation destinationTranslation) {
     _destinationTranslation = destinationTranslation;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -448,8 +448,8 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
                   // TODO: Check real behavior in this scenario
                   _w.redFlag(
                       String.format(
-                          "NAT rule %s ignored for source translation because its source translation pool is empty",
-                          r.getName()));
+                          "NAT rule %s of VSYS %s will not apply source translation because its source translation pool is empty",
+                          r.getName(), vsys.getName()));
                 } else {
                   t.apply(
                       new AssignIpAddressFromPool(
@@ -1328,8 +1328,8 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
           // TODO: Check real behavior in this scenario
           _w.redFlag(
               String.format(
-                  "NAT rule %s ignored for destination translation because its destination translation pool is empty",
-                  rule.getName()));
+                  "NAT rule %s of VSYS %s will not apply destination translation because its destination translation pool is empty",
+                  rule.getName(), vsys.getName()));
         } else {
           Transformation transform =
               new Transformation(

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoNatTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoNatTest.java
@@ -310,4 +310,71 @@ public class PaloAltoNatTest {
     // Confirm the dst IP was rewritten by the post-rulebase rule
     assertThat(postRulebaseDetail.getTransformedFlow().getDstIp(), equalTo(Ip.parse("1.1.1.101")));
   }
+
+  @Test
+  public void testNatNoopRules() throws IOException {
+    /*
+    Setup: 4 NAT rules
+    - First rule matches src 1.1.1.2, does nothing
+    - Second rule matches src 1.1.1.2/30, translates source only
+    - Third rule matches src 1.1.1.2/28, translates dest only
+    Only one NAT rule should be applied to each flow.
+     */
+    Configuration c = parseConfig("nat-match-noop-rules");
+    Batfish batfish = getBatfish(ImmutableSortedMap.of(c.getHostname(), c), _folder);
+    batfish.computeDataPlane();
+    String ingressIfaceName = "ethernet1/1.1"; // 1.1.1.3/24
+
+    // Create flows to match each rule
+    Ip dstIp = Ip.parse("1.2.1.2");
+    Ip matchNoopSrcIp = Ip.parse("1.1.1.2");
+    Ip matchSrcTransRuleIp = Ip.parse("1.1.1.3");
+    Ip matchDstTransRuleIp = Ip.parse("1.1.1.6");
+    Flow.Builder flowBuilder =
+        Flow.builder()
+            .setTag("test")
+            .setIngressNode(c.getHostname())
+            .setIngressInterface(ingressIfaceName)
+            .setDstIp(dstIp)
+            .setSrcPort(111)
+            .setDstPort(222)
+            .setIpProtocol(IpProtocol.TCP);
+    Flow matchesNoopRule = flowBuilder.setSrcIp(matchNoopSrcIp).build();
+    Flow matchesSrcTranslationRule = flowBuilder.setSrcIp(matchSrcTransRuleIp).build();
+    Flow matchesDstTranslationRule = flowBuilder.setSrcIp(matchDstTransRuleIp).build();
+
+    SortedMap<Flow, List<Trace>> traces =
+        batfish
+            .getTracerouteEngine()
+            .computeTraces(
+                ImmutableSet.of(
+                    matchesNoopRule,
+                    matchesSrcTranslationRule,
+                    matchesDstTranslationRule),
+                false);
+
+    // All translated IPs will match these translated addresses
+    Ip newSrcIp = Ip.parse("1.1.1.99");
+    Ip newDstIp = Ip.parse("1.2.1.99");
+
+    // First flow should not be NAT'd, should not get past security rules
+    assertFalse( traces.get(matchesNoopRule).get(0).getDisposition().isSuccessful());
+
+    // Second flow should have only its source IP translated
+    Trace matchSrcTranslation = traces.get(matchesSrcTranslationRule).get(0);
+    ExitOutputIfaceStepDetail matchSrcTranslationDetail =
+        (ExitOutputIfaceStepDetail)
+            Iterables.getLast(matchSrcTranslation.getHops().get(0).getSteps()).getDetail();
+    assertThat(matchSrcTranslationDetail.getTransformedFlow().getSrcIp(), equalTo(newSrcIp));
+    assertThat(matchSrcTranslationDetail.getTransformedFlow().getDstIp(), equalTo(dstIp));
+
+    // Third flow should have only its dest IP translated
+    Trace matchDstTranslation = traces.get(matchesDstTranslationRule).get(0);
+    ExitOutputIfaceStepDetail matchDstTranslationDetail =
+        (ExitOutputIfaceStepDetail)
+            Iterables.getLast(matchDstTranslation.getHops().get(0).getSteps()).getDetail();
+    assertThat(
+        matchDstTranslationDetail.getTransformedFlow().getSrcIp(), equalTo(matchDstTransRuleIp));
+    assertThat(matchDstTranslationDetail.getTransformedFlow().getDstIp(), equalTo(newDstIp));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nat-match-noop-rules
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nat-match-noop-rules
@@ -1,0 +1,161 @@
+policy {
+  panorama {
+  }
+}
+config {
+  devices {
+    localhost.localdomain {
+      network {
+        interface {
+          ethernet {
+            ethernet1/1 {
+              layer3 {
+                units {
+                  ethernet1/1.1 {
+                    ip {
+                      1.1.1.3/24;
+                    }
+                  }
+                }
+              }
+            }
+            ethernet1/2 {
+              layer3 {
+                units {
+                  ethernet1/2.1 {
+                    ip {
+                      1.2.1.3/24;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        virtual-router {
+          vr1 {
+            interface [ ethernet1/1.1 ethernet1/2.1];
+          }
+        }
+      }
+      deviceconfig {
+        system {
+          hostname nat-match-noop-rules;
+        }
+      }
+      vsys {
+        vsys1 {
+          address {
+            SOURCE_ADDR {
+              ip-netmask 1.1.1.2/32;
+            }
+            SOURCE_ADDR_30 {
+              ip-netmask 1.1.1.2/30;
+            }
+            SOURCE_ADDR_28 {
+              ip-netmask 1.1.1.2/28;
+            }
+            SOURCE_ADDR_24 {
+              ip-netmask 1.1.1.2/24;
+            }
+            NEW_SRC_ADDR {
+              ip-netmask 1.1.1.99/32;
+            }
+            NEW_DST_ADDR {
+              ip-netmask 1.2.1.99/32;
+            }
+          }
+          rulebase {
+            nat {
+              rules {
+                NOOP {
+                  to OUTSIDE;
+                  from INSIDE;
+                  source SOURCE_ADDR;
+                  destination any;
+                }
+                TRANSLATE_SRC {
+                  source-translation {
+                    dynamic-ip-and-port {
+                      translated-address NEW_SRC_ADDR;
+                    }
+                  }
+                  to OUTSIDE;
+                  from INSIDE;
+                  source SOURCE_ADDR_30;
+                  destination any;
+                }
+                TRANSLATE_DST {
+                  destination-translation {
+                    translated-address NEW_DST_ADDR;
+                  }
+                  to OUTSIDE;
+                  from INSIDE;
+                  source SOURCE_ADDR_28;
+                  destination any;
+                }
+                TRANSLATE_SRC_AND_DST {
+                  source-translation {
+                    dynamic-ip-and-port {
+                      translated-address NEW_SRC_ADDR;
+                    }
+                  }
+                  destination-translation {
+                    translated-address NEW_DST_ADDR;
+                  }
+                  to OUTSIDE;
+                  from INSIDE;
+                  source SOURCE_ADDR_24;
+                  destination any;
+                }
+              }
+            }
+            security {
+              rules {
+                PERMIT_TRANSLATED_SRC {
+                  to any;
+                  from any;
+                  source NEW_SRC_ADDR;
+                  destination any;
+                  application any;
+                  service any;
+                  action allow;
+                }
+                PERMIT_TRANSLATED_DST {
+                  to any;
+                  from any;
+                  source any;
+                  destination NEW_DST_ADDR;
+                  application any;
+                  service any;
+                  action allow;
+                }
+                DENY_ALL {
+                  to any;
+                  from any;
+                  source any;
+                  destination any;
+                  application any;
+                  service any;
+                  action deny;
+                }
+              }
+            }
+          }
+          zone {
+            INSIDE {
+              network {
+                layer3 [ ethernet1/1.1];
+              }
+            }
+            OUTSIDE {
+              network {
+                layer3 [ ethernet1/2.1];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nat-rules-empty-pool
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/nat-rules-empty-pool
@@ -1,0 +1,144 @@
+policy {
+  panorama {
+  }
+}
+config {
+  devices {
+    localhost.localdomain {
+      network {
+        interface {
+          ethernet {
+            ethernet1/1 {
+              layer3 {
+                units {
+                  ethernet1/1.1 {
+                    ip {
+                      1.1.1.3/24;
+                    }
+                  }
+                }
+              }
+            }
+            ethernet1/2 {
+              layer3 {
+                units {
+                  ethernet1/2.1 {
+                    ip {
+                      1.2.1.3/24;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        virtual-router {
+          vr1 {
+            interface [ ethernet1/1.1 ethernet1/2.1];
+          }
+        }
+      }
+      deviceconfig {
+        system {
+          hostname nat-rules-empty-pool;
+        }
+      }
+      vsys {
+        vsys1 {
+          address {
+            SOURCE_ADDR {
+              ip-netmask 1.1.1.2/32;
+            }
+            SOURCE_ADDR_30 {
+              ip-netmask 1.1.1.2/30;
+            }
+            NEW_SRC_ADDR {
+              ip-netmask 1.1.1.99/32;
+            }
+            NEW_DST_ADDR {
+              ip-netmask 1.2.1.99/32;
+            }
+            EMPTY_ADDR;
+          }
+          rulebase {
+            nat {
+              rules {
+                EMPTY_NAT_POOLS {
+                  source-translation {
+                    dynamic-ip-and-port {
+                      translated-address EMPTY_ADDR;
+                    }
+                  }
+                  destination-translation {
+                    translated-address EMPTY_ADDR;
+                  }
+                  to OUTSIDE;
+                  from INSIDE;
+                  source SOURCE_ADDR;
+                  destination any;
+                }
+                TRANSLATE_SRC_AND_DST {
+                  source-translation {
+                    dynamic-ip-and-port {
+                      translated-address NEW_SRC_ADDR;
+                    }
+                  }
+                  destination-translation {
+                    translated-address NEW_DST_ADDR;
+                  }
+                  to OUTSIDE;
+                  from INSIDE;
+                  source SOURCE_ADDR_30;
+                  destination any;
+                }
+              }
+            }
+            security {
+              rules {
+                PERMIT_TRANSLATED_SRC {
+                  to any;
+                  from any;
+                  source NEW_SRC_ADDR;
+                  destination any;
+                  application any;
+                  service any;
+                  action allow;
+                }
+                PERMIT_TRANSLATED_DST {
+                  to any;
+                  from any;
+                  source any;
+                  destination NEW_DST_ADDR;
+                  application any;
+                  service any;
+                  action allow;
+                }
+                DENY_ALL {
+                  to any;
+                  from any;
+                  source any;
+                  destination any;
+                  application any;
+                  service any;
+                  action deny;
+                }
+              }
+            }
+          }
+          zone {
+            INSIDE {
+              network {
+                layer3 [ ethernet1/1.1];
+              }
+            }
+            OUTSIDE {
+              network {
+                layer3 [ ethernet1/2.1];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently during dest NAT we only allow packets to match NAT rules that apply a destination transformation, and during source NAT we only allow matching rules that apply a source transformation. With this PR, those limitations will no longer exist; packets can match NAT rules that do not perform a transformation.

After #5046.