### PR TITLE
PAN interface outgoing filter fix

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessListLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessListLine.java
@@ -126,11 +126,11 @@ public final class IpAccessListLine implements Serializable {
     return Stream.of(
         IpAccessListLine.accepting()
             .setMatchCondition(new PermittedByAcl(aclName, false))
-            .setName(aclName + "-EXPLICTLY-PERMITTED")
+            .setName(aclName + "-EXPLICITLY-PERMITTED")
             .build(),
         IpAccessListLine.rejecting()
             .setMatchCondition(not(new PermittedByAcl(aclName, true)))
-            .setName(aclName + "-EXPLICTLY-DENIED")
+            .setName(aclName + "-EXPLICITLY-DENIED")
             .build());
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -6,6 +6,7 @@ import static com.google.common.base.Predicates.not;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 import static org.batfish.datamodel.IpAccessListLine.accepting;
 import static org.batfish.datamodel.IpAccessListLine.rejecting;
+import static org.batfish.datamodel.IpAccessListLine.takingExplicitActionsOf;
 import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.ORIGINATING_FROM_DEVICE;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
@@ -1223,19 +1224,18 @@ public final class PaloAltoConfiguration extends VendorConfiguration {
     if (sharedGatewayOptional.isPresent()) {
       Vsys sharedGateway = sharedGatewayOptional.get();
       String sgName = sharedGateway.getName();
-      aclLines.add(
-          accepting(permittedByAcl(computeOutgoingFilterName(computeObjectName(sgName, sgName)))));
+      takingExplicitActionsOf(computeOutgoingFilterName(computeObjectName(sgName, sgName)))
+          .forEach(aclLines::add);
       newIface.setFirewallSessionInterfaceInfo(
           new FirewallSessionInterfaceInfo(
               true, sharedGateway.getImportedInterfaces(), null, null));
     } else if (zone != null) {
       newIface.setZoneName(zone.getName());
       if (zone.getType() == Type.LAYER3) {
-        aclLines.add(
-            accepting(
-                permittedByAcl(
-                    computeOutgoingFilterName(
-                        computeObjectName(zone.getVsys().getName(), zone.getName())))));
+        takingExplicitActionsOf(
+                computeOutgoingFilterName(
+                    computeObjectName(zone.getVsys().getName(), zone.getName())))
+            .forEach(aclLines::add);
         newIface.setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(true, zone.getInterfaceNames(), null, null));
       }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -52,6 +52,7 @@ import static org.batfish.representation.palo_alto.PaloAltoConfiguration.NULL_VR
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.PANORAMA_VSYS_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.SHARED_VSYS_NAME;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeObjectName;
+import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeOutgoingFilterName;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeServiceGroupMemberAclName;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.APPLICATION_GROUP_OR_APPLICATION;
 import static org.batfish.representation.palo_alto.PaloAltoStructureType.EXTERNAL_LIST;
@@ -83,6 +84,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -92,6 +94,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.IOException;
@@ -118,6 +121,7 @@ import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.DiffieHellmanGroup;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.EncryptionAlgorithm;
+import org.batfish.datamodel.FilterResult;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.IcmpType;
 import org.batfish.datamodel.IkeHashingAlgorithm;
@@ -129,6 +133,7 @@ import org.batfish.datamodel.IpAccessListLine;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpRange;
 import org.batfish.datamodel.IpsecAuthenticationAlgorithm;
+import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
@@ -1497,6 +1502,58 @@ public final class PaloAltoGrammarTest {
 
     // Confirm flow from the device itself is permitted
     assertThat(c, hasInterface(if1name, hasOutgoingFilter(accepts(fromDevicePermitted, null, c))));
+  }
+
+  @Test
+  public void testSecurityRulesNotExplicitlyMatched() {
+    /*
+    Setup: Device has an interface in a zone with intrazone security rules. If flows leaving the
+    interface match an intrazone rule, its action should be taken (whether permit or deny). Other
+    flows should fall through to the rest of the interface outgoing filter.
+     */
+    String hostname = "security-no-explicit-match";
+    Configuration c = parseConfig(hostname);
+    String ifaceName = "ethernet1/1.1";
+    IpAccessList ifaceOutgoingAccessList =
+        c.getIpAccessLists().get(computeOutgoingFilterName(ifaceName));
+
+    Flow notMatchingZoneSecurity =
+        Flow.builder()
+            .setTag("test")
+            .setIngressNode(c.getHostname())
+            .setDstIp(Ip.parse("10.10.10.10"))
+            .setSrcIp(Ip.parse("10.10.10.20"))
+            .setSrcPort(111)
+            .setDstPort(222)
+            .setIpProtocol(IpProtocol.TCP)
+            .build();
+    Flow rejectedByZoneSecurity =
+        notMatchingZoneSecurity.toBuilder().setSrcIp(Ip.parse("2.2.2.2")).build();
+    Flow acceptedByZoneSecurity =
+        notMatchingZoneSecurity.toBuilder().setSrcIp(Ip.parse("3.3.3.3")).build();
+
+    // Interface outgoing filter ends with an OriginatingFromDevice match.
+    // If flow doesn't match zone rules, it should fall through to that.
+    int lastLineIndex = ifaceOutgoingAccessList.getLines().size() - 1;
+    FilterResult originatingFromDeviceResult =
+        ifaceOutgoingAccessList.filter(
+            notMatchingZoneSecurity, null, c.getIpAccessLists(), ImmutableMap.of());
+    assertThat(originatingFromDeviceResult.getAction(), equalTo(LineAction.PERMIT));
+    assertThat(originatingFromDeviceResult.getMatchLine(), equalTo(lastLineIndex));
+
+    // Flow is from interface inside the zone and is rejected by zone security rules
+    FilterResult rejectedByZoneSecurityResult =
+        ifaceOutgoingAccessList.filter(
+            rejectedByZoneSecurity, ifaceName, c.getIpAccessLists(), ImmutableMap.of());
+    assertThat(rejectedByZoneSecurityResult.getAction(), equalTo(LineAction.DENY));
+    assertThat(rejectedByZoneSecurityResult.getMatchLine(), lessThan(lastLineIndex));
+
+    // Flow is from interface inside the zone and is permitted by zone security rules
+    FilterResult acceptedByZoneSecurityResult =
+        ifaceOutgoingAccessList.filter(
+            acceptedByZoneSecurity, ifaceName, c.getIpAccessLists(), ImmutableMap.of());
+    assertThat(acceptedByZoneSecurityResult.getAction(), equalTo(LineAction.PERMIT));
+    assertThat(acceptedByZoneSecurityResult.getMatchLine(), lessThan(lastLineIndex));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1514,7 +1514,7 @@ public final class PaloAltoGrammarTest {
     String hostname = "security-no-explicit-match";
     Configuration c = parseConfig(hostname);
     String ifaceName = "ethernet1/1.1";
-    IpAccessList ifaceOutgoingAccessList =
+    IpAccessList ifaceOutgoingFilter =
         c.getIpAccessLists().get(computeOutgoingFilterName(ifaceName));
 
     Flow notMatchingZoneSecurity =
@@ -1534,23 +1534,23 @@ public final class PaloAltoGrammarTest {
 
     // Interface outgoing filter ends with an OriginatingFromDevice match.
     // If flow doesn't match zone rules, it should fall through to that.
-    int lastLineIndex = ifaceOutgoingAccessList.getLines().size() - 1;
+    int lastLineIndex = ifaceOutgoingFilter.getLines().size() - 1;
     FilterResult originatingFromDeviceResult =
-        ifaceOutgoingAccessList.filter(
+        ifaceOutgoingFilter.filter(
             notMatchingZoneSecurity, null, c.getIpAccessLists(), ImmutableMap.of());
     assertThat(originatingFromDeviceResult.getAction(), equalTo(LineAction.PERMIT));
     assertThat(originatingFromDeviceResult.getMatchLine(), equalTo(lastLineIndex));
 
     // Flow is from interface inside the zone and is rejected by zone security rules
     FilterResult rejectedByZoneSecurityResult =
-        ifaceOutgoingAccessList.filter(
+        ifaceOutgoingFilter.filter(
             rejectedByZoneSecurity, ifaceName, c.getIpAccessLists(), ImmutableMap.of());
     assertThat(rejectedByZoneSecurityResult.getAction(), equalTo(LineAction.DENY));
     assertThat(rejectedByZoneSecurityResult.getMatchLine(), lessThan(lastLineIndex));
 
     // Flow is from interface inside the zone and is permitted by zone security rules
     FilterResult acceptedByZoneSecurityResult =
-        ifaceOutgoingAccessList.filter(
+        ifaceOutgoingFilter.filter(
             acceptedByZoneSecurity, ifaceName, c.getIpAccessLists(), ImmutableMap.of());
     assertThat(acceptedByZoneSecurityResult.getAction(), equalTo(LineAction.PERMIT));
     assertThat(acceptedByZoneSecurityResult.getMatchLine(), lessThan(lastLineIndex));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/security-no-explicit-match
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/security-no-explicit-match
@@ -1,0 +1,72 @@
+policy {
+  panorama {
+  }
+}
+config {
+  devices {
+    localhost.localdomain {
+      network {
+        interface {
+          ethernet {
+            ethernet1/1 {
+              layer3 {
+                units {
+                  ethernet1/1.1 {
+                    ip {
+                      1.1.1.2/24;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        virtual-router {
+          vr1 {
+            interface [ ethernet1/1.1];
+          }
+        }
+      }
+      deviceconfig {
+        system {
+          hostname security-no-explicit-match;
+        }
+      }
+      vsys {
+        vsys1 {
+          rulebase {
+            security {
+              rules {
+                DENY {
+                  to any;
+                  from any;
+                  source 2.2.2.2/32;
+                  destination any;
+                  application any;
+                  service any;
+                  action deny;
+                }
+                PERMIT {
+                  to any;
+                  from any;
+                  source 3.3.3.3/32;
+                  destination any;
+                  application any;
+                  service any;
+                  action allow;
+                }
+              }
+            }
+          }
+          zone {
+            ZONE {
+              network {
+                layer3 [ ethernet1/1.1];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -32463,7 +32463,20 @@
                   "class" : "org.batfish.datamodel.acl.PermittedByAcl",
                   "aclName" : "~zl3~vsys10~OUTGOING_FILTER~",
                   "defaultAccept" : false
-                }
+                },
+                "name" : "~zl3~vsys10~OUTGOING_FILTER~-EXPLICITLY-PERMITTED"
+              },
+              {
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.NotMatchExpr",
+                  "operand" : {
+                    "class" : "org.batfish.datamodel.acl.PermittedByAcl",
+                    "aclName" : "~zl3~vsys10~OUTGOING_FILTER~",
+                    "defaultAccept" : true
+                  }
+                },
+                "name" : "~zl3~vsys10~OUTGOING_FILTER~-EXPLICITLY-DENIED"
               },
               {
                 "action" : "PERMIT",


### PR DESCRIPTION
If interfaces belong to a shared gateway or zone, flows leaving that interface that are denied by the gateway or zone outgoing filter must be dropped. However, `PermittedByAcl` falls through on explicit denies in the referenced filter. This PR modifies how the interface outgoing filter references its gateway/zone's outgoing filter so that explicit denies are no longer ignored.