### PR TITLE
for p2mp interfaces, the initial routes are interface IPs instead of

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -343,7 +343,8 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
       }
 
       // Create a route for each interface address
-      // Only create a /32 host address for this interface if 1. it is a loopback and the network type
+      // Only create a /32 host address for this interface if 1. it is a loopback and the network
+      // type
       // is not P2P or 2. its type is p2mp (See RFC 2328 Section 2.1.1)
       Set<OspfIntraAreaRoute> allRoutes =
           (isLoopbackNotInP2PModeOrP2MP(iface)

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -343,10 +343,10 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
       }
 
       // Create a route for each interface address
-      // Only create a /32 host address for this interface if it is a loopback and the network type
-      // is not P2P
+      // Only create a /32 host address for this interface if 1. it is a loopback and the network type
+      // is not P2P or 2. its type is p2mp (See RFC 2328 Section 2.1.1)
       Set<OspfIntraAreaRoute> allRoutes =
-          (isLoopbackNotInP2PMode(iface)
+          (isLoopbackNotInP2PModeOrP2MP(iface)
                   ? Stream.of(
                       ConcreteInterfaceAddress.create(
                           iface.getConcreteAddress().getIp(), Prefix.MAX_PREFIX_LENGTH))
@@ -359,6 +359,11 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
       allRoutes.forEach(r -> deltaBuilder.from(_intraAreaRib.mergeRouteGetDelta(r)));
     }
     return deltaBuilder.build();
+  }
+
+  private static boolean isLoopbackNotInP2PModeOrP2MP(Interface iface) {
+    return isLoopbackNotInP2PMode(iface)
+        || iface.getOspfNetworkType() == OspfNetworkType.POINT_TO_MULTIPOINT;
   }
 
   /**


### PR DESCRIPTION
subnet prefix