### PR TITLE
Hot fix unsupported Juniper wildcard

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/GroupWildcard.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/GroupWildcard.java
@@ -41,8 +41,8 @@ public class GroupWildcard extends BaseParser<String> {
   Rule CharacterClass() {
     return Sequence(
         Ch('['),
-        // TODO: negation
-        //            Optional(Op_Bang()),
+        // TODO: properly handle negation
+        Optional(Op_Bang()),
         ClassLiterals(),
         Ch(']'),
         push(String.format("[%s]", pop())));


### PR DESCRIPTION
Consume `!` in Juniper wildcard expressions.
Still need to actually handle grammar, but this hot fix gets around crashes when `!` are encountered.
