### PR TITLE
Juniper: apply-path should match terminal wildcards too

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/Hierarchy.java
@@ -719,8 +719,9 @@ public final class Hierarchy {
         int currentDepth,
         List<HierarchyChildNode> prefixes) {
       if (currentDepth == path._nodes.size() - 1) {
+        HierarchyChildNode currentPathNode = path._nodes.get(currentDepth);
         for (HierarchyChildNode currentChild : currentNode.getChildren().values()) {
-          if (!currentChild.isWildcard()) {
+          if (!currentChild.isWildcard() && currentPathNode.matches(currentChild)) {
             prefixes.add(currentChild);
           }
         }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3398,8 +3398,10 @@ public final class FlatJuniperGrammarTest {
     String loopback = "lo0.0";
     String prefix1 = "1.1.1.1/32";
     String prefix2 = "3.3.3.3/32";
+    String prefix3 = "88.1.2.3/32";
     String prefixList1 = "p1";
     String prefixList2 = "p2";
+    String prefixList3 = "p3";
     Prefix neighborPrefix = Prefix.parse("2.2.2.2/32");
 
     Configuration c = parseConfig(hostname);
@@ -3422,6 +3424,13 @@ public final class FlatJuniperGrammarTest {
     assertThat(c, hasRouteFilterList(prefixList2, permits(Prefix.parse(prefix2))));
     assertThat(c, hasRouteFilterLists(not(hasKey("<*>"))));
 
+    /* prefix-list p3 should get only address from ge-0/0/0.0*/
+    assertThat(c, hasRouteFilterList(prefixList3, permits(Prefix.parse(prefix3))));
+    assertThat(
+        c, hasRouteFilterList(prefixList3, RouteFilterListMatchers.rejects(Prefix.parse(prefix1))));
+    assertThat(
+        c, hasRouteFilterList(prefixList3, RouteFilterListMatchers.rejects(Prefix.parse(prefix2))));
+
     /* The wildcard-looking BGP group name should not be pruned since its parse-tree node was not created via preprocessor. */
     assertThat(c, hasDefaultVrf(hasBgpProcess(hasNeighbors(hasKey(neighborPrefix)))));
   }
@@ -3442,7 +3451,7 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         ccae,
         hasDefinedStructureWithDefinitionLines(
-            filename, PREFIX_LIST, "p1", containsInAnyOrder(4, 9)));
+            filename, PREFIX_LIST, "p1", containsInAnyOrder(4, 9, 10)));
     assertThat(
         ccae,
         hasDefinedStructureWithDefinitionLines(filename, PREFIX_LIST, "p2", containsInAnyOrder(5)));
@@ -3451,7 +3460,7 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         ccae,
         hasUndefinedReferenceWithReferenceLines(
-            filename, INTERFACE, "et-0/0/0.0", OSPF_AREA_INTERFACE, containsInAnyOrder(6, 14)));
+            filename, INTERFACE, "et-0/0/0.0", OSPF_AREA_INTERFACE, containsInAnyOrder(6, 17)));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-wildcards
@@ -6,8 +6,11 @@ set groups g2 policy-options prefix-list <*> 3.3.3.3/32
 set groups g3 protocols ospf area <*> interface <*> authentication md5 0 key "foo"
 set interfaces lo0 unit 0 apply-groups g1
 set interfaces lo0 unit 0 description <SCRUBBED>
+set interfaces ge-0/0/0 unit 0 family inet address 88.1.2.3
 set policy-options prefix-list p1 apply-path "interfaces <*> unit <*> family inet address <*>"
 set policy-options prefix-list p2 apply-groups g2
+## only ge-0/0/0.0's address should be here
+set policy-options prefix-list p3 apply-path "interfaces <*> unit <*> family inet address <88.*>"
 set routing-options autonomous-system 1
 set protocols bgp group <SCRUBBED> neighbor 2.2.2.2 peer-as 2
 set protocols ospf apply-groups g3


### PR DESCRIPTION
To clarify. Before #5061 we only handled `<*>` as the wildcard so existing apply-path code worked without uncovering this bug. Terminal wildcard nodes in the apply-path should be executing matching logic on candidate child hierarchy nodes.