### PR TITLE
JNPR: IS-IS enabled unless explicitly disabled

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/IsisLevelSettings.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/IsisLevelSettings.java
@@ -4,8 +4,8 @@ import java.io.Serializable;
 
 public class IsisLevelSettings implements Serializable {
 
-  private boolean _enabled;
-
+  // Enabled by default
+  private boolean _enabled = true;
   private boolean _wideMetricsOnly;
 
   public boolean getEnabled() {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3070,6 +3070,14 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testIsisMinimal() {
+    // This config only has a loopback with an ISO address and "set protocols isis interface lo0.0".
+    // Should contain an IS-IS process even though no level is explicitly configured.
+    Configuration c = parseConfig("isis-minimal");
+    assertThat(c, hasDefaultVrf(hasIsisProcess(notNullValue())));
+  }
+
+  @Test
   public void testJuniperIsisNoIsoAddress() {
     Configuration c = parseConfig("juniper-isis-no-iso");
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-minimal
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-minimal
@@ -1,0 +1,7 @@
+#
+set system host-name isis-minimal
+#
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32 
+set interfaces lo0 unit 0 family iso address 12.1234.1234.1234.1234.00 
+#
+set protocols isis interface lo0


### PR DESCRIPTION
Unless you explicitly `set protocols isis level (1|2) disable`, the level is enabled.