### PR TITLE
JNPR IS-IS: Enable levels by default; no "enable" command

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_isis.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_isis.g4
@@ -54,7 +54,6 @@ is_level
   )
   (
     isl_disable
-    | isl_enable
     | isl_null
     | isl_wide_metrics_only
   )
@@ -122,7 +121,6 @@ isi_level
   LEVEL DEC
   (
     isil_disable
-    | isil_enable
     | isil_hello_authentication_key
     | isil_hello_authentication_type
     | isil_hello_interval
@@ -170,11 +168,6 @@ isil_disable
   DISABLE
 ;
 
-isil_enable
-:
-  ENABLE
-;
-
 isil_hello_authentication_key
 :
   HELLO_AUTHENTICATION_KEY key = string
@@ -218,11 +211,6 @@ isil_te_metric
 isl_disable
 :
   DISABLE
-;
-
-isl_enable
-:
-  ENABLE
 ;
 
 isl_null

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2428,6 +2428,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void enterIs_interface(Is_interfaceContext ctx) {
     _currentIsisInterface = initInterface(ctx.id);
+    _currentIsisInterface.initIsisSettings();
     _configuration.referenceStructure(
         INTERFACE, _currentIsisInterface.getName(), ISIS_INTERFACE, getLine(ctx.id.getStop()));
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -299,7 +299,6 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isi_point_to_pointConte
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isib_minimum_intervalContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isib_multiplierContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_disableContext;
-import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_enableContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_hello_authentication_keyContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_hello_authentication_typeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Isil_hello_intervalContext;
@@ -2431,7 +2430,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     _currentIsisInterface = initInterface(ctx.id);
     _configuration.referenceStructure(
         INTERFACE, _currentIsisInterface.getName(), ISIS_INTERFACE, getLine(ctx.id.getStop()));
-    _currentIsisInterface.getIsisSettings().setEnabled(true);
   }
 
   @Override
@@ -2448,7 +2446,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       default:
         throw new BatfishException("invalid level: " + level);
     }
-    _currentIsisLevelSettings.setEnabled(true);
   }
 
   @Override
@@ -2466,7 +2463,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       default:
         throw new BatfishException("invalid IS-IS level: " + level);
     }
-    _currentIsisInterfaceLevelSettings.setEnabled(true);
   }
 
   @Override
@@ -4462,11 +4458,6 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitIsil_disable(Isil_disableContext ctx) {
     _currentIsisInterfaceLevelSettings.setEnabled(false);
-  }
-
-  @Override
-  public void exitIsil_enable(Isil_enableContext ctx) {
-    _currentIsisInterfaceLevelSettings.setEnabled(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2428,7 +2428,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void enterIs_interface(Is_interfaceContext ctx) {
     _currentIsisInterface = initInterface(ctx.id);
-    _currentIsisInterface.initIsisSettings();
+    _currentIsisInterface.getOrInitIsisSettings();
     _configuration.referenceStructure(
         INTERFACE, _currentIsisInterface.getName(), ISIS_INTERFACE, getLine(ctx.id.getStop()));
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -169,6 +169,14 @@ public class Interface implements Serializable {
     return _isisSettings;
   }
 
+  /** Initializes {@link IsisInterfaceSettings} for this interface if not already initialized */
+  public IsisInterfaceSettings getOrInitIsisSettings() {
+    if (_isisSettings == null) {
+      _isisSettings = new IsisInterfaceSettings();
+    }
+    return _isisSettings;
+  }
+
   public IsoAddress getIsoAddress() {
     return _isoAddress;
   }
@@ -311,13 +319,6 @@ public class Interface implements Serializable {
     }
     if (_redundantParentInterface == null) {
       _redundantParentInterface = bestower._redundantParentInterface;
-    }
-  }
-
-  /** Initializes {@link IsisInterfaceSettings} for this interface if not already initialized */
-  public void initIsisSettings() {
-    if (_isisSettings == null) {
-      _isisSettings = new IsisInterfaceSettings();
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -71,7 +71,7 @@ public class Interface implements Serializable {
   private @Nullable String _incomingFilter;
   private @Nullable List<String> _incomingFilterList;
   private transient boolean _inherited;
-  @Nonnull private final IsisInterfaceSettings _isisSettings;
+  @Nullable private IsisInterfaceSettings _isisSettings;
   private IsoAddress _isoAddress;
   private Integer _mtu;
   private final String _name;
@@ -104,7 +104,6 @@ public class Interface implements Serializable {
     _allAddresses = new LinkedHashSet<>();
     _allAddressIps = new LinkedHashSet<>();
     _bandwidth = getDefaultBandwidthByName(name);
-    _isisSettings = new IsisInterfaceSettings();
     _name = name;
     _ospfInterfaceType = OspfInterfaceType.BROADCAST;
     _ospfNeighbors = new HashSet<>();
@@ -165,7 +164,7 @@ public class Interface implements Serializable {
     return _incomingFilterList;
   }
 
-  @Nonnull
+  @Nullable
   public IsisInterfaceSettings getIsisSettings() {
     return _isisSettings;
   }
@@ -312,6 +311,13 @@ public class Interface implements Serializable {
     }
     if (_redundantParentInterface == null) {
       _redundantParentInterface = bestower._redundantParentInterface;
+    }
+  }
+
+  /** Initializes {@link IsisInterfaceSettings} for this interface if not already initialized */
+  public void initIsisSettings() {
+    if (_isisSettings == null) {
+      _isisSettings = new IsisInterfaceSettings();
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/IsisInterfaceLevelSettings.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/IsisInterfaceLevelSettings.java
@@ -6,20 +6,14 @@ import org.batfish.datamodel.isis.IsisHelloAuthenticationType;
 
 public class IsisInterfaceLevelSettings implements Serializable {
 
-  private boolean _enabled;
-
+  // Enabled by default
+  private boolean _enabled = true;
   @Nullable private String _helloAuthenticationKey;
-
   @Nullable private IsisHelloAuthenticationType _helloAuthenticationType;
-
   @Nullable private Integer _helloInterval;
-
   @Nullable private Integer _holdTime;
-
   @Nullable private Long _metric;
-
   private boolean _passive;
-
   @Nullable private Long _teMetric;
 
   public boolean getEnabled() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/IsisInterfaceSettings.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/IsisInterfaceSettings.java
@@ -5,17 +5,12 @@ import java.io.Serializable;
 public class IsisInterfaceSettings implements Serializable {
 
   private Integer _bfdLivenessDetectionMinimumInterval;
-
   private Integer _bfdLivenessDetectionMultiplier;
-
-  private boolean _enabled;
-
+  // Enabled by default
+  private boolean _enabled = true;
   private final IsisInterfaceLevelSettings _level1Settings;
-
   private final IsisInterfaceLevelSettings _level2Settings;
-
   private boolean _passive;
-
   private boolean _pointToPoint;
 
   public IsisInterfaceSettings() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -846,7 +846,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
   private org.batfish.datamodel.isis.IsisInterfaceSettings toIsisInterfaceSettings(
       @Nonnull IsisSettings settings, Interface iface, boolean level1, boolean level2) {
     IsisInterfaceSettings interfaceSettings = iface.getIsisSettings();
-    if (!interfaceSettings.getEnabled()) {
+    if (interfaceSettings == null || !interfaceSettings.getEnabled()) {
       return null;
     }
     // If a reference bandwidth is set, calculate default cost as (reference bandwidth) / (interface

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -889,11 +889,16 @@ public final class JuniperConfiguration extends VendorConfiguration {
         .build();
   }
 
+  @Nullable
   private org.batfish.datamodel.isis.IsisInterfaceLevelSettings toIsisInterfaceLevelSettings(
       IsisLevelSettings levelSettings,
       IsisInterfaceSettings interfaceSettings,
       IsisInterfaceLevelSettings interfaceLevelSettings,
       long defaultCost) {
+    // Process and interface settings have already been checked to ensure IS-IS is enabled on iface
+    if (!interfaceLevelSettings.getEnabled()) {
+      return null;
+    }
     long cost = firstNonNull(interfaceLevelSettings.getMetric(), defaultCost);
     if (!levelSettings.getWideMetricsOnly()) {
       cost = Math.min(cost, MAX_ISIS_COST_WITHOUT_WIDE_METRICS);

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -154,8 +154,7 @@ public class JuniperConfigurationTest {
       @Nullable Double referenceBandwidth) {
     Interface iface = new Interface("iface");
     iface.setBandwidth(ifaceBandwidth);
-    iface.initIsisSettings();
-    iface.getIsisSettings().setEnabled(true);
+    iface.getOrInitIsisSettings().setEnabled(true);
     if (configuredIfaceIsisMetric != null) {
       iface.getIsisSettings().getLevel1Settings().setMetric(configuredIfaceIsisMetric);
     }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -154,6 +154,7 @@ public class JuniperConfigurationTest {
       @Nullable Double referenceBandwidth) {
     Interface iface = new Interface("iface");
     iface.setBandwidth(ifaceBandwidth);
+    iface.initIsisSettings();
     iface.getIsisSettings().setEnabled(true);
     if (configuredIfaceIsisMetric != null) {
       iface.getIsisSettings().getLevel1Settings().setMetric(configuredIfaceIsisMetric);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-disabled-l1
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-disabled-l1
@@ -1,0 +1,9 @@
+#
+set system host-name isis-disabled-l1
+#
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32 
+set interfaces lo0 unit 0 family iso address 12.1234.1234.1234.1234.00 
+#
+set protocols isis interface lo0
+set protocols isis level 1 disable
+set protocols isis level 1 wide-metrics-only

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-interface-and-level-disable
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-interface-and-level-disable
@@ -1,0 +1,20 @@
+#
+set system host-name isis-interface-and-level-disable
+#
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32 
+set interfaces lo0 unit 0 family iso address 12.1234.1234.1234.1234.00
+#
+set interfaces ge-0/0/0 unit 0 family inet address 2.2.2.0/24 
+set interfaces ge-0/0/0 unit 0 family iso address 12.1234.1234.1234.1234.01
+#
+set interfaces ge-0/0/1 unit 0 family inet address 3.3.3.0/24 
+set interfaces ge-0/0/1 unit 0 family iso address 12.1234.1234.1234.1234.02
+#
+set interfaces ge-0/0/2 unit 0 family inet address 4.4.4.0/24 
+set interfaces ge-0/0/2 unit 0 family iso address 12.1234.1234.1234.1234.03
+#
+set protocols isis interface ge-0/0/0.0 disable
+set protocols isis interface ge-0/0/0.0 level 1 metric 30
+set protocols isis interface ge-0/0/1.0 level 1 disable
+set protocols isis interface ge-0/0/1.0 level 1 metric 30
+set protocols isis interface ge-0/0/2.0


### PR DESCRIPTION
Despite Batfish's support for it, there is no `enable` option at either [`[edit protocols isis level <level-number>]`](https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/level-edit-protocols-isis.html) or [`[edit protocols isis interface <iface-name> level <level-number>]`](https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/level-edit-protocols-isis-interface.html).

All IS-IS levels are enabled unless explicitly disabled in the process or interface. If `level <level-number> disable` is configured for either the process or the interface, the level is always disabled, regardless of what else is configured for the process or interface.