### PR TITLE
JNPR: All OSPF routes match "from protocol ospf"

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromProtocol.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromProtocol.java
@@ -29,6 +29,12 @@ public final class PsFromProtocol extends PsFrom {
           RoutingProtocol.ISIS_EL2,
           RoutingProtocol.ISIS_L1,
           RoutingProtocol.ISIS_L2);
+    } else if (_protocol == RoutingProtocol.OSPF) {
+      return new MatchProtocol(
+          RoutingProtocol.OSPF,
+          RoutingProtocol.OSPF_IA,
+          RoutingProtocol.OSPF_E1,
+          RoutingProtocol.OSPF_E2);
     } else {
       return new MatchProtocol(_protocol);
     }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/from-protocols
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/from-protocols
@@ -1,0 +1,10 @@
+#
+set system host-name from-protocols
+#
+set policy-options policy-statement from-isis term t1 from protocol isis
+set policy-options policy-statement from-isis term t1 then accept
+set policy-options policy-statement from-isis then reject
+#
+set policy-options policy-statement from-ospf term t1 from protocol ospf
+set policy-options policy-statement from-ospf term t1 then accept
+set policy-options policy-statement from-ospf then reject


### PR DESCRIPTION
May need to eventually add an OSPF_ANY hack if Juniper allows you to match only OSPF intra-area routes (which is the route type for which we use `RoutingProtocols.OSPF`).