### PR TITLE
Juniper: Support qualified next hop

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -4691,7 +4691,7 @@ Q931
 
 QUALIFIED_NEXT_HOP
 :
-   'qualified-next-hop'
+   'qualified-next-hop' -> pushMode(M_Interface)
 ;
 
 QUICK_START_OPTION

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
@@ -653,7 +653,12 @@ rosr_preference
 
 rosr_qualified_next_hop
 :
-   QUALIFIED_NEXT_HOP nexthop = IP_ADDRESS rosr_common?
+   QUALIFIED_NEXT_HOP
+   (
+      IP_ADDRESS
+      | interface_id
+   )
+   rosrqnh_common?
 ;
 
 rosr_readvertise
@@ -677,6 +682,30 @@ rosr_retain
 ;
 
 rosr_tag
+:
+   TAG tag = DEC
+;
+
+rosrqnh_common
+:
+   (
+      rosrqnhc_metric
+      | rosrqnhc_preference
+      | rosrqnhc_tag
+   )
+;
+
+rosrqnhc_metric
+:
+   METRIC metric = DEC
+;
+
+rosrqnhc_preference
+:
+   PREFERENCE pref = DEC
+;
+
+rosrqnhc_tag
 :
    TAG tag = DEC
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -696,6 +696,7 @@ import org.batfish.representation.juniper.NatRuleThenOff;
 import org.batfish.representation.juniper.NatRuleThenPool;
 import org.batfish.representation.juniper.NatRuleThenPrefix;
 import org.batfish.representation.juniper.NatRuleThenPrefixName;
+import org.batfish.representation.juniper.NextHop;
 import org.batfish.representation.juniper.NoPortTranslation;
 import org.batfish.representation.juniper.NodeDevice;
 import org.batfish.representation.juniper.NssaSettings;
@@ -741,7 +742,6 @@ import org.batfish.representation.juniper.PsThenOrigin;
 import org.batfish.representation.juniper.PsThenPreference;
 import org.batfish.representation.juniper.PsThenReject;
 import org.batfish.representation.juniper.QualifiedNextHop;
-import org.batfish.representation.juniper.QualifiedNextHop.QualifiedNextHopKey;
 import org.batfish.representation.juniper.RegexCommunityMember;
 import org.batfish.representation.juniper.RibGroup;
 import org.batfish.representation.juniper.Route4FilterLine;
@@ -5294,14 +5294,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void enterRosr_qualified_next_hop(Rosr_qualified_next_hopContext ctx) {
     if (ctx.IP_ADDRESS() != null) {
       Ip ip = Ip.parse(ctx.IP_ADDRESS().getText());
-      _currentQualifiedNextHop =
-          _currentStaticRoute.getOrCreateQualifiedNextHop(new QualifiedNextHopKey(ip));
+      _currentQualifiedNextHop = _currentStaticRoute.getOrCreateQualifiedNextHop(new NextHop(ip));
       return;
     }
     assert ctx.interface_id() != null;
     String ifaceName = getInterfaceFullName(ctx.interface_id());
     _currentQualifiedNextHop =
-        _currentStaticRoute.getOrCreateQualifiedNextHop(new QualifiedNextHopKey(ifaceName));
+        _currentStaticRoute.getOrCreateQualifiedNextHop(new NextHop(ifaceName));
     _configuration.referenceStructure(
         INTERFACE,
         ifaceName,

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -2568,21 +2568,49 @@ public final class JuniperConfiguration extends VendorConfiguration {
     return thenStatements;
   }
 
-  private org.batfish.datamodel.StaticRoute toStaticRoute(StaticRoute route) {
+  private List<org.batfish.datamodel.StaticRoute> toStaticRoutes(StaticRoute route) {
+    ImmutableList.Builder<org.batfish.datamodel.StaticRoute> viStaticRoutes =
+        ImmutableList.builder();
+
     String nextHopInterface =
         route.getDrop()
             ? org.batfish.datamodel.Interface.NULL_INTERFACE_NAME
             : route.getNextHopInterface();
 
-    return org.batfish.datamodel.StaticRoute.builder()
-        .setNetwork(route.getPrefix())
-        .setNextHopIp(firstNonNull(route.getNextHopIp(), Route.UNSET_ROUTE_NEXT_HOP_IP))
-        .setNextHopInterface(nextHopInterface)
-        .setAdministrativeCost(route.getDistance())
-        .setMetric(route.getMetric())
-        .setTag(firstNonNull(route.getTag(), Route.UNSET_ROUTE_TAG))
-        .setNonForwarding(firstNonNull(route.getNoInstall(), Boolean.FALSE))
-        .build();
+    // static route corresponding to the next hop
+    viStaticRoutes.add(
+        org.batfish.datamodel.StaticRoute.builder()
+            .setNetwork(route.getPrefix())
+            .setNextHopIp(firstNonNull(route.getNextHopIp(), Route.UNSET_ROUTE_NEXT_HOP_IP))
+            .setNextHopInterface(nextHopInterface)
+            .setAdministrativeCost(route.getDistance())
+            .setMetric(route.getMetric())
+            .setTag(firstNonNull(route.getTag(), Route.UNSET_ROUTE_TAG))
+            .setNonForwarding(firstNonNull(route.getNoInstall(), Boolean.FALSE))
+            .build());
+
+    // populating static routes from each qualified next hop while overriding applicable properties
+    for (QualifiedNextHop qualifiedNextHop : route.getQualifiedNextHops().values()) {
+      viStaticRoutes.add(
+          org.batfish.datamodel.StaticRoute.builder()
+              .setNetwork(route.getPrefix())
+              .setNextHopIp(
+                  firstNonNull(qualifiedNextHop.getNextHopIp(), Route.UNSET_ROUTE_NEXT_HOP_IP))
+              .setNextHopInterface(
+                  route.getDrop()
+                      ? org.batfish.datamodel.Interface.NULL_INTERFACE_NAME
+                      : qualifiedNextHop.getNextHopInterface())
+              .setAdministrativeCost(
+                  firstNonNull(qualifiedNextHop.getPreference(), route.getDistance()))
+              .setMetric(firstNonNull(qualifiedNextHop.getMetric(), route.getMetric()))
+              .setTag(
+                  firstNonNull(
+                      qualifiedNextHop.getTag(),
+                      firstNonNull(route.getTag(), Route.UNSET_ROUTE_TAG)))
+              .setNonForwarding(firstNonNull(route.getNoInstall(), Boolean.FALSE))
+              .build());
+    }
+    return viStaticRoutes.build();
   }
 
   @Override
@@ -2961,8 +2989,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
       // static routes
       for (StaticRoute route : ri.getRibs().get(RIB_IPV4_UNICAST).getStaticRoutes().values()) {
-        org.batfish.datamodel.StaticRoute newStaticRoute = toStaticRoute(route);
-        vrf.getStaticRoutes().add(newStaticRoute);
+        vrf.getStaticRoutes().addAll(toStaticRoutes(route));
       }
 
       // aggregate routes

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -2568,9 +2568,8 @@ public final class JuniperConfiguration extends VendorConfiguration {
     return thenStatements;
   }
 
-  private List<org.batfish.datamodel.StaticRoute> toStaticRoutes(StaticRoute route) {
-    ImmutableList.Builder<org.batfish.datamodel.StaticRoute> viStaticRoutes =
-        ImmutableList.builder();
+  private Set<org.batfish.datamodel.StaticRoute> toStaticRoutes(StaticRoute route) {
+    ImmutableSet.Builder<org.batfish.datamodel.StaticRoute> viStaticRoutes = ImmutableSet.builder();
 
     String nextHopInterface =
         route.getDrop()
@@ -2595,11 +2594,12 @@ public final class JuniperConfiguration extends VendorConfiguration {
           org.batfish.datamodel.StaticRoute.builder()
               .setNetwork(route.getPrefix())
               .setNextHopIp(
-                  firstNonNull(qualifiedNextHop.getNextHopIp(), Route.UNSET_ROUTE_NEXT_HOP_IP))
+                  firstNonNull(
+                      qualifiedNextHop.getNextHop().getNextHopIp(), Route.UNSET_ROUTE_NEXT_HOP_IP))
               .setNextHopInterface(
                   route.getDrop()
                       ? org.batfish.datamodel.Interface.NULL_INTERFACE_NAME
-                      : qualifiedNextHop.getNextHopInterface())
+                      : qualifiedNextHop.getNextHop().getNextHopInterface())
               .setAdministrativeCost(
                   firstNonNull(qualifiedNextHop.getPreference(), route.getDistance()))
               .setMetric(firstNonNull(qualifiedNextHop.getMetric(), route.getMetric()))

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NextHop.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NextHop.java
@@ -1,0 +1,49 @@
+package org.batfish.representation.juniper;
+
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
+
+/** Represents a next-hop for Juniper static routes */
+public class NextHop implements Serializable {
+  @Nullable private Ip _nextHopIp;
+  @Nullable private String _nextHopInterface;
+
+  public NextHop(@Nonnull String nextHopInterface) {
+    _nextHopInterface = nextHopInterface;
+  }
+
+  public NextHop(@Nonnull Ip nextHopIp) {
+    _nextHopIp = nextHopIp;
+  }
+
+  @Nullable
+  public String getNextHopInterface() {
+    return _nextHopInterface;
+  }
+
+  @Nullable
+  public Ip getNextHopIp() {
+    return _nextHopIp;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof NextHop)) {
+      return false;
+    }
+    NextHop that = (NextHop) o;
+    return Objects.equals(_nextHopIp, that._nextHopIp)
+        && Objects.equals(_nextHopInterface, that._nextHopInterface);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_nextHopIp, _nextHopInterface);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/QualifiedNextHop.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/QualifiedNextHop.java
@@ -1,0 +1,107 @@
+package org.batfish.representation.juniper;
+
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
+
+/** Represents a qualified next-hop configured for a {@link StaticRoute} */
+public class QualifiedNextHop implements Serializable {
+  /**
+   * {@link QualifiedNextHop} in a {@link StaticRoute} are keyed by either next hop IP or next hop
+   * interface
+   */
+  public static class QualifiedNextHopKey implements Serializable {
+    @Nullable private Ip _nextHopIp;
+    @Nullable private String _nextHopInterface;
+
+    public QualifiedNextHopKey(@Nonnull String nextHopInterface) {
+      _nextHopInterface = nextHopInterface;
+    }
+
+    public QualifiedNextHopKey(@Nonnull Ip nextHopIp) {
+      _nextHopIp = nextHopIp;
+    }
+
+    @Nullable
+    public String getNextHopInterface() {
+      return _nextHopInterface;
+    }
+
+    @Nullable
+    public Ip getNextHopIp() {
+      return _nextHopIp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof QualifiedNextHopKey)) {
+        return false;
+      }
+      QualifiedNextHopKey that = (QualifiedNextHopKey) o;
+      return Objects.equals(_nextHopIp, that._nextHopIp)
+          && Objects.equals(_nextHopInterface, that._nextHopInterface);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_nextHopIp, _nextHopInterface);
+    }
+  }
+
+  @Nullable private Integer _metric;
+  @Nullable private String _nextHopInterface;
+  @Nullable private Ip _nextHopIp;
+  @Nullable private Integer _preference;
+  @Nullable private Long _tag;
+
+  private QualifiedNextHop(@Nullable String nextHopInterface, @Nullable Ip nextHopIp) {
+    _nextHopIp = nextHopIp;
+    _nextHopInterface = nextHopInterface;
+  }
+
+  public QualifiedNextHop(@Nonnull QualifiedNextHopKey qualifiedNextHopKey) {
+    this(qualifiedNextHopKey._nextHopInterface, qualifiedNextHopKey._nextHopIp);
+  }
+
+  @Nullable
+  public Integer getMetric() {
+    return _metric;
+  }
+
+  public void setMetric(@Nullable Integer metric) {
+    _metric = metric;
+  }
+
+  @Nullable
+  public Integer getPreference() {
+    return _preference;
+  }
+
+  public void setPreference(@Nullable Integer preference) {
+    _preference = preference;
+  }
+
+  @Nullable
+  public Long getTag() {
+    return _tag;
+  }
+
+  public void setTag(@Nullable Long tag) {
+    _tag = tag;
+  }
+
+  @Nullable
+  public String getNextHopInterface() {
+    return _nextHopInterface;
+  }
+
+  @Nullable
+  public Ip getNextHopIp() {
+    return _nextHopIp;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/QualifiedNextHop.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/QualifiedNextHop.java
@@ -1,71 +1,18 @@
 package org.batfish.representation.juniper;
 
 import java.io.Serializable;
-import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.Ip;
 
 /** Represents a qualified next-hop configured for a {@link StaticRoute} */
 public class QualifiedNextHop implements Serializable {
-  /**
-   * {@link QualifiedNextHop} in a {@link StaticRoute} are keyed by either next hop IP or next hop
-   * interface
-   */
-  public static class QualifiedNextHopKey implements Serializable {
-    @Nullable private Ip _nextHopIp;
-    @Nullable private String _nextHopInterface;
-
-    public QualifiedNextHopKey(@Nonnull String nextHopInterface) {
-      _nextHopInterface = nextHopInterface;
-    }
-
-    public QualifiedNextHopKey(@Nonnull Ip nextHopIp) {
-      _nextHopIp = nextHopIp;
-    }
-
-    @Nullable
-    public String getNextHopInterface() {
-      return _nextHopInterface;
-    }
-
-    @Nullable
-    public Ip getNextHopIp() {
-      return _nextHopIp;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (!(o instanceof QualifiedNextHopKey)) {
-        return false;
-      }
-      QualifiedNextHopKey that = (QualifiedNextHopKey) o;
-      return Objects.equals(_nextHopIp, that._nextHopIp)
-          && Objects.equals(_nextHopInterface, that._nextHopInterface);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(_nextHopIp, _nextHopInterface);
-    }
-  }
-
   @Nullable private Integer _metric;
-  @Nullable private String _nextHopInterface;
-  @Nullable private Ip _nextHopIp;
+  @Nonnull private NextHop _nextHop;
   @Nullable private Integer _preference;
   @Nullable private Long _tag;
 
-  private QualifiedNextHop(@Nullable String nextHopInterface, @Nullable Ip nextHopIp) {
-    _nextHopIp = nextHopIp;
-    _nextHopInterface = nextHopInterface;
-  }
-
-  public QualifiedNextHop(@Nonnull QualifiedNextHopKey qualifiedNextHopKey) {
-    this(qualifiedNextHopKey._nextHopInterface, qualifiedNextHopKey._nextHopIp);
+  public QualifiedNextHop(@Nonnull NextHop nextHop) {
+    _nextHop = nextHop;
   }
 
   @Nullable
@@ -95,13 +42,8 @@ public class QualifiedNextHop implements Serializable {
     _tag = tag;
   }
 
-  @Nullable
-  public String getNextHopInterface() {
-    return _nextHopInterface;
-  }
-
-  @Nullable
-  public Ip getNextHopIp() {
-    return _nextHopIp;
+  @Nonnull
+  public NextHop getNextHop() {
+    return _nextHop;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
@@ -2,13 +2,16 @@ package org.batfish.representation.juniper;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.bgp.community.Community;
+import org.batfish.representation.juniper.QualifiedNextHop.QualifiedNextHopKey;
 
 public class StaticRoute implements Serializable {
 
@@ -31,6 +34,12 @@ public class StaticRoute implements Serializable {
 
   private Prefix _prefix;
 
+  /**
+   * Each qualified next hop will produce a separate static route using properties of the static
+   * route and overriding with properties of {@link QualifiedNextHop}
+   */
+  private Map<QualifiedNextHopKey, QualifiedNextHop> _qualifiedNextHops;
+
   private Long _tag;
 
   private Boolean _noInstall;
@@ -41,6 +50,7 @@ public class StaticRoute implements Serializable {
     _policies = new ArrayList<>();
     // default admin costs for static routes in Juniper
     _distance = DEFAULT_ADMIN_DISTANCE;
+    _qualifiedNextHops = new HashMap<>();
   }
 
   public Set<Community> getCommunities() {
@@ -78,6 +88,14 @@ public class StaticRoute implements Serializable {
 
   public Prefix getPrefix() {
     return _prefix;
+  }
+
+  public QualifiedNextHop getOrCreateQualifiedNextHop(QualifiedNextHopKey qualifiedNextHopKey) {
+    return _qualifiedNextHops.computeIfAbsent(qualifiedNextHopKey, QualifiedNextHop::new);
+  }
+
+  public Map<QualifiedNextHopKey, QualifiedNextHop> getQualifiedNextHops() {
+    return _qualifiedNextHops;
   }
 
   public Long getTag() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
@@ -11,7 +11,6 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.bgp.community.Community;
-import org.batfish.representation.juniper.QualifiedNextHop.QualifiedNextHopKey;
 
 public class StaticRoute implements Serializable {
 
@@ -38,7 +37,7 @@ public class StaticRoute implements Serializable {
    * Each qualified next hop will produce a separate static route using properties of the static
    * route and overriding with properties of {@link QualifiedNextHop}
    */
-  private Map<QualifiedNextHopKey, QualifiedNextHop> _qualifiedNextHops;
+  private Map<NextHop, QualifiedNextHop> _qualifiedNextHops;
 
   private Long _tag;
 
@@ -90,11 +89,11 @@ public class StaticRoute implements Serializable {
     return _prefix;
   }
 
-  public QualifiedNextHop getOrCreateQualifiedNextHop(QualifiedNextHopKey qualifiedNextHopKey) {
-    return _qualifiedNextHops.computeIfAbsent(qualifiedNextHopKey, QualifiedNextHop::new);
+  public QualifiedNextHop getOrCreateQualifiedNextHop(NextHop nextHop) {
+    return _qualifiedNextHops.computeIfAbsent(nextHop, QualifiedNextHop::new);
   }
 
-  public Map<QualifiedNextHopKey, QualifiedNextHop> getQualifiedNextHops() {
+  public Map<NextHop, QualifiedNextHop> getQualifiedNextHops() {
     return _qualifiedNextHops;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4505,6 +4505,32 @@ public final class FlatJuniperGrammarTest {
                             .setNextHopIp(Ip.parse("10.0.0.2"))
                             .setAdministrativeCost(5)
                             .build())))));
+
+    assertThat(
+        c,
+        hasVrf(
+            "ri3",
+            hasStaticRoutes(
+                containsInAnyOrder(
+                    // normal next-hop
+                    StaticRoute.builder()
+                        .setNetwork(Prefix.parse("5.5.5.0/24"))
+                        .setNextHopIp(Ip.parse("2.3.4.5"))
+                        .setAdministrativeCost(150)
+                        .build(),
+                    // inherits admin from the static route preference
+                    StaticRoute.builder()
+                        .setNetwork(Prefix.parse("5.5.5.0/24"))
+                        .setNextHopInterface("ge-0/0/0.0")
+                        .setAdministrativeCost(150)
+                        .build(),
+                    // qualified next-hop overrides admin and tag
+                    StaticRoute.builder()
+                        .setNetwork(Prefix.parse("5.5.5.0/24"))
+                        .setNextHopIp(Ip.parse("1.2.3.4"))
+                        .setAdministrativeCost(180)
+                        .setTag(12L)
+                        .build()))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-routes
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-routes
@@ -6,3 +6,8 @@ set routing-instances ri2 routing-options static route 2.0.0.0/8 next-hop 10.0.0
 set routing-options static route 3.0.0.0/8 no-install
 set routing-options static route 4.0.0.0/8 next-hop ge-0/0/0.0
 #
+set routing-instances ri3 routing-options static route 5.5.5.0/24 preference 150
+set routing-instances ri3 routing-options static route 5.5.5.0/24 next-hop 2.3.4.5
+set routing-instances ri3 routing-options static route 5.5.5.0/24 qualified-next-hop ge-0/0/0.0
+set routing-instances ri3 routing-options static route 5.5.5.0/24 qualified-next-hop 1.2.3.4 preference 180
+set routing-instances ri3 routing-options static route 5.5.5.0/24 qualified-next-hop 1.2.3.4 tag 12


### PR DESCRIPTION
[juniper doc](https://www.juniper.net/documentation/en_US/junos/topics/concept/routing-protocol-static-security-route-preference-and-qualified-next-hop-understanding.html)

Qualified next-hop let's a user define multiple next-hops with different properties for a single static route. 