### PR TITLE
Referred interfaces in JNPR: Don't create interfaces if not defined

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2330,6 +2330,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       _currentInterfaceOrRange.setParent(_currentMasterInterface);
       units.put(unitFullName, _currentInterfaceOrRange);
     }
+    _currentInterfaceOrRange.setDefined(true);
     _configuration.defineFlattenedStructure(INTERFACE, unitFullName, ctx, _parser);
     _configuration.referenceStructure(
         INTERFACE, unitFullName, INTERFACE_SELF_REFERENCE, getLine(ctx.num));
@@ -2392,6 +2393,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
           _currentLogicalSystem.getDefaultRoutingInstance().getName());
       currentInterfaceRange.setParent(_currentLogicalSystem.getGlobalMasterInterface());
     }
+    currentInterfaceRange.setDefined(true);
     _currentInterfaceOrRange = currentInterfaceRange;
   }
 
@@ -2427,6 +2429,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
         currentInterface.setParent(_currentLogicalSystem.getGlobalMasterInterface());
         interfaces.put(fullIfaceName, currentInterface);
       }
+      currentInterface.setDefined(true);
       _configuration.defineFlattenedStructure(INTERFACE, currentInterface.getName(), ctx, _parser);
       _configuration.referenceStructure(
           INTERFACE, currentInterface.getName(), INTERFACE_SELF_REFERENCE, getLine(ctx.getStart()));
@@ -6187,6 +6190,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     String unitFullName = name + "." + unit;
     Interface iface = interfaces.get(name);
     if (iface == null) {
+      // TODO: this is not ideal, interface should not be created here as we are not sure if the
+      // interface was defined
       iface = new Interface(name);
       iface.setRoutingInstance(_currentLogicalSystem.getDefaultRoutingInstance().getName());
       interfaces.put(name, iface);
@@ -6195,6 +6200,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       Map<String, Interface> units = iface.getUnits();
       iface = units.get(unitFullName);
       if (iface == null) {
+        // TODO: this is not ideal, interface should not be created here as we are not sure if the
+        // interface was defined
         iface = new Interface(unitFullName);
         iface.setRoutingInstance(_currentLogicalSystem.getDefaultRoutingInstance().getName());
         units.put(unitFullName, iface);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -68,6 +68,7 @@ public class Interface implements Serializable {
   private final List<String> _allowedVlanNames;
   private double _bandwidth;
   private String _description;
+  private boolean _defined;
   private @Nullable String _incomingFilter;
   private @Nullable List<String> _incomingFilterList;
   private transient boolean _inherited;
@@ -104,6 +105,7 @@ public class Interface implements Serializable {
     _allAddresses = new LinkedHashSet<>();
     _allAddressIps = new LinkedHashSet<>();
     _bandwidth = getDefaultBandwidthByName(name);
+    _defined = false;
     _name = name;
     _ospfInterfaceType = OspfInterfaceType.BROADCAST;
     _ospfNeighbors = new HashSet<>();
@@ -322,6 +324,16 @@ public class Interface implements Serializable {
     }
   }
 
+  /**
+   * Returns true if the interface was defined in the config. Needed to check if interface was
+   * referred but not defined
+   *
+   * @return true if interface was defined.
+   */
+  public boolean isDefined() {
+    return _defined;
+  }
+
   public void set8023adInterface(String interfaceName) {
     _agg8023adInterface = interfaceName;
   }
@@ -340,6 +352,10 @@ public class Interface implements Serializable {
 
   public void setBandwidth(double bandwidth) {
     _bandwidth = bandwidth;
+  }
+
+  public void setDefined(boolean defined) {
+    _defined = defined;
   }
 
   public void setDescription(String description) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
@@ -141,6 +141,7 @@ public class LogicalSystem implements Serializable {
             iname -> {
               Interface iface = _interfaces.computeIfAbsent(iname, Interface::new);
               iface.inheritUnsetPhysicalFields(interfaceRange);
+              iface.setDefined(interfaceRange.isDefined());
               iface.setRoutingInstance(interfaceRange.getRoutingInstance());
               iface.setParent(interfaceRange.getParent());
             });

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4217,6 +4217,7 @@ public final class FlatJuniperGrammarTest {
     /* Properly configured interfaces should be present in respective areas. */
     assertThat(c, hasInterface("xe-0/0/0.0", hasOspfAreaName(0L)));
     assertThat(c, hasInterface("xe-0/0/0.0", isOspfPassive(equalTo(false))));
+    assertThat(c.getAllInterfaces(), not(hasKey("ge-0/0/0.1")));
     assertThat(
         c,
         hasDefaultVrf(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospfInterfaceAreaAssignment
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospfInterfaceAreaAssignment
@@ -14,4 +14,4 @@ set protocols ospf area 0.0.0.0 interface xe-0/0/0.2
 #
 set protocols ospf area 0.0.0.1 interface xe-0/0/0.3 passive
 #
-
+set protocols ospf area 0.0.0.1 interface ge-0/0/0.1 passive

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -21946,192 +21946,6 @@
         "defaultCrossZoneAction" : "PERMIT",
         "defaultInboundAction" : "PERMIT",
         "deviceType" : "ROUTER",
-        "interfaces" : {
-          "ae16" : {
-            "name" : "ae16",
-            "active" : false,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 0.0,
-            "declaredNames" : [
-              "ae16"
-            ],
-            "mtu" : 1500,
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "AGGREGATED",
-            "vrf" : "default"
-          },
-          "ae16.0" : {
-            "name" : "ae16.0",
-            "active" : false,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 0.0,
-            "declaredNames" : [
-              "ae16.0"
-            ],
-            "mtu" : 1500,
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "AGGREGATE_CHILD",
-            "vrf" : "default"
-          },
-          "xe-0/0/1" : {
-            "name" : "xe-0/0/1",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E10,
-            "declaredNames" : [
-              "xe-0/0/1"
-            ],
-            "mtu" : 1500,
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "xe-0/0/1.0" : {
-            "name" : "xe-0/0/1.0",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E10,
-            "declaredNames" : [
-              "xe-0/0/1.0"
-            ],
-            "mtu" : 1500,
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "LOGICAL",
-            "vrf" : "default"
-          },
-          "xe-0/0/20:0" : {
-            "name" : "xe-0/0/20:0",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E10,
-            "declaredNames" : [
-              "xe-0/0/20:0"
-            ],
-            "mtu" : 1500,
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "xe-0/0/20:0.0" : {
-            "name" : "xe-0/0/20:0.0",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E10,
-            "declaredNames" : [
-              "xe-0/0/20:0.0"
-            ],
-            "mtu" : 1500,
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "LOGICAL",
-            "vrf" : "default"
-          },
-          "xe-0/0/21:0" : {
-            "name" : "xe-0/0/21:0",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E10,
-            "declaredNames" : [
-              "xe-0/0/21:0"
-            ],
-            "mtu" : 1500,
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "xe-0/0/21:0.0" : {
-            "name" : "xe-0/0/21:0.0",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E10,
-            "declaredNames" : [
-              "xe-0/0/21:0.0"
-            ],
-            "mtu" : 1500,
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "LOGICAL",
-            "vrf" : "default"
-          }
-        },
         "routeFilterLists" : {
           "~OSPF_SUMMARY_FILTER:default:66051~" : {
             "lines" : [
@@ -22302,16 +22116,6 @@
                 "nextHopIp" : "AUTO/NONE(-1l)",
                 "tag" : -1
               }
-            ],
-            "interfaces" : [
-              "ae16",
-              "ae16.0",
-              "xe-0/0/1",
-              "xe-0/0/1.0",
-              "xe-0/0/20:0",
-              "xe-0/0/20:0.0",
-              "xe-0/0/21:0",
-              "xe-0/0/21:0.0"
             ]
           }
         }
@@ -24100,29 +23904,6 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "ge-0/0/1" : {
-            "name" : "ge-0/0/1",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E9,
-            "declaredNames" : [
-              "ge-0/0/1"
-            ],
-            "mtu" : 1500,
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "SOME_INSTANCE"
-          },
           "ge-1/0/0" : {
             "name" : "ge-1/0/0",
             "active" : true,
@@ -24591,10 +24372,7 @@
         },
         "vrfs" : {
           "SOME_INSTANCE" : {
-            "name" : "SOME_INSTANCE",
-            "interfaces" : [
-              "ge-0/0/1"
-            ]
+            "name" : "SOME_INSTANCE"
           },
           "default" : {
             "name" : "default",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -78008,7 +78008,7 @@
         "ip_prefix_list_single_line" : "PASSED",
         "isr_crypto_gdoi" : "PASSED",
         "isr_voip" : "PASSED",
-        "juniper-ospf" : "WARNINGS",
+        "juniper-ospf" : "PASSED",
         "juniper-tcpflags" : "WARNINGS",
         "juniper_application" : "PASSED",
         "juniper_apply_macro" : "PASSED",
@@ -94928,26 +94928,6 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Cannot create IS-IS process without specifying net-address"
-            }
-          ]
-        },
-        "juniper-ospf" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Cannot assign interface ae16.0 to area 0.1.2.3 because it has no IP address."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Cannot assign interface xe-0/0/1.0 to area 0.1.2.3 because it has no IP address."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Cannot assign interface xe-0/0/20:0.0 to area 0.1.2.3 because it has no IP address."
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Cannot assign interface xe-0/0/21:0.0 to area 0.1.2.3 because it has no IP address."
             }
           ]
         },


### PR DESCRIPTION
This PR is a stopgap solution to stop creating false interfaces in VI model when they are just referred in a configuration but not actually defined anywhere. 
It also gets rid of false warning `Cannot assign interface %s to area %s because it has no IP address.`
