### PR TITLE
JNPR: Loopbacks running IS-IS always passive

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3046,40 +3046,50 @@ public final class FlatJuniperGrammarTest {
         hasDefaultVrf(
             hasIsisProcess(IsisProcessMatchers.hasReferenceBandwidth(expectedReferenceBandwidth))));
 
-    Interface loopback = c.getActiveInterfaces().get("lo0.0");
-    assertThat(loopback, hasIsis(hasIsoAddress(new IsoAddress("12.1234.1234.1234.1234.00"))));
-    assertThat(loopback, hasIsis(hasLevel1(nullValue())));
-    // Loopbacks are always passive for IS-IS regardless of configuration
-    assertThat(loopback, hasIsis(hasLevel2(hasMode(IsisInterfaceMode.PASSIVE))));
+    {
+      Interface loopback = c.getActiveInterfaces().get("lo0.0");
+      assertThat(loopback, hasIsis(hasIsoAddress(new IsoAddress("12.1234.1234.1234.1234.00"))));
+      assertThat(loopback, hasIsis(hasLevel1(nullValue())));
+      // Loopbacks are always passive for IS-IS regardless of configuration
+      assertThat(loopback, hasIsis(hasLevel2(hasMode(IsisInterfaceMode.PASSIVE))));
 
-    // Loopback did not set an IS-IS metric, so its cost should be based on the reference bandwidth.
-    // First confirm the expected cost isn't coincidentally equal to the Juniper default cost of 10.
-    // No need to worry about getBandwidth() returning null for Juniper interfaces.
-    long expectedCost = Math.max((long) (expectedReferenceBandwidth / loopback.getBandwidth()), 1L);
-    assertThat(expectedCost, not(equalTo(10L)));
-    assertThat(loopback, hasIsis(hasLevel2(hasCost(expectedCost))));
+      // Loopback did not set an IS-IS metric, so its cost should be based on the reference
+      // bandwidth.
+      // First confirm the expected cost isn't coincidentally equal to the Juniper default cost of
+      // 10.
+      // No need to worry about getBandwidth() returning null for Juniper interfaces.
+      long expectedCost =
+          Math.max((long) (expectedReferenceBandwidth / loopback.getBandwidth()), 1L);
+      assertThat(expectedCost, not(equalTo(10L)));
+      assertThat(loopback, hasIsis(hasLevel2(hasCost(expectedCost))));
+    }
 
-    Interface physical = c.getActiveInterfaces().get("ge-0/0/0.0");
-    assertThat(physical, hasIsis(hasIsoAddress(new IsoAddress("12.1234.1234.1234.1234.01"))));
-    assertThat(physical, hasIsis(hasBfdLivenessDetectionMinimumInterval(250)));
-    assertThat(physical, hasIsis(hasBfdLivenessDetectionMultiplier(3)));
-    assertThat(physical, hasIsis(IsisInterfaceSettingsMatchers.hasPointToPoint()));
-    assertThat(physical, hasIsis(hasLevel1(nullValue())));
-    assertThat(physical, hasIsis(hasLevel2(hasCost(5L))));
-    // Explicitly configured passive
-    assertThat(physical, hasIsis(hasLevel2(hasMode(IsisInterfaceMode.ACTIVE))));
-    assertThat(
-        physical, hasIsis(hasLevel2(hasHelloAuthenticationType(IsisHelloAuthenticationType.MD5))));
-    assertThat(
-        physical, hasIsis(hasLevel2(IsisInterfaceLevelSettingsMatchers.hasHelloInterval(1))));
-    assertThat(physical, hasIsis(hasLevel2(hasHoldTime(3))));
+    {
+      Interface physical = c.getActiveInterfaces().get("ge-0/0/0.0");
+      assertThat(physical, hasIsis(hasIsoAddress(new IsoAddress("12.1234.1234.1234.1234.01"))));
+      assertThat(physical, hasIsis(hasBfdLivenessDetectionMinimumInterval(250)));
+      assertThat(physical, hasIsis(hasBfdLivenessDetectionMultiplier(3)));
+      assertThat(physical, hasIsis(IsisInterfaceSettingsMatchers.hasPointToPoint()));
+      assertThat(physical, hasIsis(hasLevel1(nullValue())));
+      assertThat(physical, hasIsis(hasLevel2(hasCost(5L))));
+      // Explicitly configured passive
+      assertThat(physical, hasIsis(hasLevel2(hasMode(IsisInterfaceMode.ACTIVE))));
+      assertThat(
+          physical,
+          hasIsis(hasLevel2(hasHelloAuthenticationType(IsisHelloAuthenticationType.MD5))));
+      assertThat(
+          physical, hasIsis(hasLevel2(IsisInterfaceLevelSettingsMatchers.hasHelloInterval(1))));
+      assertThat(physical, hasIsis(hasLevel2(hasHoldTime(3))));
+    }
 
-    // Assert non-ISIS interface has no ISIS, but has IP address
-    Interface nonIsis = c.getActiveInterfaces().get("ge-1/0/0.0");
-    assertThat(nonIsis, hasIsis(nullValue()));
-    assertThat(
-        nonIsis,
-        hasAllAddresses(contains(ConcreteInterfaceAddress.create(Ip.parse("10.1.1.1"), 24))));
+    {
+      // Assert non-ISIS interface has no ISIS, but has IP address
+      Interface nonIsis = c.getActiveInterfaces().get("ge-1/0/0.0");
+      assertThat(nonIsis, hasIsis(nullValue()));
+      assertThat(
+          nonIsis,
+          hasAllAddresses(contains(ConcreteInterfaceAddress.create(Ip.parse("10.1.1.1"), 24))));
+    }
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis
@@ -17,7 +17,7 @@ set protocols isis interface ge-0/0/0.0 level 2 hold-time 3
 set protocols isis interface ge-0/0/0.0 level 2 metric 5
 set protocols isis interface ge-0/0/0.0 point-to-point
 #
-set protocols isis interface lo0.0 passive
+set protocols isis interface lo0.0
 #
 set protocols isis level 1 disable
 set protocols isis level 2 wide-metrics-only

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis-passive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-isis-passive
@@ -1,13 +1,16 @@
 #
-set system host-name juniper-isis-passive-level
+set system host-name juniper-isis-passive
 #
 set interfaces ge-1/2/0 unit 0 family inet address 10.0.0.1/30
 set interfaces ge-1/2/0 unit 0 family iso
+set interfaces ge-1/2/0 unit 1 family inet address 10.0.0.10/30
+set interfaces ge-1/2/0 unit 1 family iso
 #
 set interfaces lo0 unit 0 family inet address 192.168.0.1/32
 set interfaces lo0 unit 0 family iso address 49.0002.1921.6800.0001.00
 #
 set protocols isis interface ge-1/2/0.0 level 1 passive
-set protocols isis interface lo0.0 passive
+set protocols isis interface ge-1/2/0.1 passive
+set protocols isis interface lo0.0
 set protocols isis level 1 wide-metrics-only
 set protocols isis level 2 wide-metrics-only


### PR DESCRIPTION
As per the note in documentation [here](https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/passive-edit-protocols-isis.html):
> Configuring IS-IS on a loopback interface automatically renders it as a passive interface, irrespective of whether the passive statement was used in the configuration of the interface.