### PR TITLE
IsisTest cleanup (no functional changes)

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -60,9 +60,36 @@ public class IsisTest {
   private static final Ip R2_LOOPBACK_IP = Ip.parse("10.2.2.2");
   private static final Ip R3_LOOPBACK_IP = Ip.parse("10.3.3.3");
   private static final Ip R4_LOOPBACK_IP = Ip.parse("10.4.4.4");
-  private static final Ip R1_INTERFACE_IP = Ip.parse("10.1.2.1");
-  private static final Ip R2_INTERFACE_IP = Ip.parse("10.1.2.2");
+  private static final Ip R5_LOOPBACK_IP = Ip.parse("10.5.5.5");
+
   private static final int INTERFACE_PREFIX_LENGTH = 24;
+
+  private static final Ip R1_TO_R2_IP = Ip.parse("10.1.2.1");
+  private static final Ip R2_TO_R1_IP = Ip.parse("10.1.2.2");
+  private static final Prefix R1_R2_PREFIX = Prefix.create(R1_TO_R2_IP, INTERFACE_PREFIX_LENGTH);
+
+  private static final Ip R1_TO_R3_IP = Ip.parse("10.1.3.1");
+  private static final Ip R3_TO_R1_IP = Ip.parse("10.1.3.3");
+  private static final Prefix R1_R3_PREFIX = Prefix.create(R1_TO_R3_IP, INTERFACE_PREFIX_LENGTH);
+
+  private static final Ip R2_TO_R3_IP = Ip.parse("10.2.3.2");
+  private static final Ip R3_TO_R2_IP = Ip.parse("10.2.3.3");
+  private static final Prefix R2_R3_PREFIX = Prefix.create(R2_TO_R3_IP, INTERFACE_PREFIX_LENGTH);
+
+  private static final Ip R2_TO_R4_IP = Ip.parse("10.2.4.2");
+  private static final Ip R4_TO_R2_IP = Ip.parse("10.2.4.4");
+
+  private static final Ip R3_TO_R4_IP = Ip.parse("10.3.4.3");
+  private static final Ip R4_TO_R3_IP = Ip.parse("10.3.4.4");
+  private static final Prefix R3_R4_PREFIX = Prefix.create(R3_TO_R4_IP, INTERFACE_PREFIX_LENGTH);
+
+  private static final Ip R3_TO_R5_IP = Ip.parse("10.3.5.3");
+  private static final Ip R5_TO_R3_IP = Ip.parse("10.3.5.5");
+  private static final Prefix R3_R5_PREFIX = Prefix.create(R3_TO_R5_IP, INTERFACE_PREFIX_LENGTH);
+
+  private static final Ip R4_TO_R5_IP = Ip.parse("10.4.5.4");
+  private static final Ip R5_TO_R4_IP = Ip.parse("10.4.5.5");
+  private static final Prefix R4_R5_PREFIX = Prefix.create(R4_TO_R5_IP, INTERFACE_PREFIX_LENGTH);
 
   private static void assertInterAreaRoute(
       SortedMap<String, SortedMap<String, Set<AbstractRoute>>> routesByNode,
@@ -116,7 +143,7 @@ public class IsisTest {
         .setIsis(iib.setLevel1(passiveIls).setLevel2(passiveIls).build())
         .build();
     // r1 interface to r2
-    ib.setAddress(ConcreteInterfaceAddress.create(R1_INTERFACE_IP, INTERFACE_PREFIX_LENGTH))
+    ib.setAddress(ConcreteInterfaceAddress.create(R1_TO_R2_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(
             iib.setLevel1(r1Level1Passive ? passiveIls : activeIls)
                 .setLevel2(r1Level2Passive ? passiveIls : activeIls)
@@ -133,7 +160,7 @@ public class IsisTest {
         .setIsis(iib.setLevel1(passiveIls).setLevel2(passiveIls).build())
         .build();
     // r2 interface to r1
-    ib.setAddress(ConcreteInterfaceAddress.create(R2_INTERFACE_IP, INTERFACE_PREFIX_LENGTH))
+    ib.setAddress(ConcreteInterfaceAddress.create(R2_TO_R1_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel1(activeIls).setLevel2(activeIls).build())
         .build();
 
@@ -159,7 +186,6 @@ public class IsisTest {
     IncrementalDataPlane dp = setUpPassiveIsis(true, false);
     Prefix r1LoopbackPrefix = R1_LOOPBACK_IP.toPrefix();
     Prefix r2LoopbackPrefix = R2_LOOPBACK_IP.toPrefix();
-    Prefix isisInterfacePrefix = Prefix.create(R1_INTERFACE_IP, INTERFACE_PREFIX_LENGTH);
 
     Set<IsisRoute> r1L1RibRoutes =
         dp.getNodes().get(R1).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
@@ -176,14 +202,14 @@ public class IsisTest {
         containsInAnyOrder(
             ImmutableList.of(
                 isisRouteWith(r1LoopbackPrefix, R1_LOOPBACK_IP, 0),
-                isisRouteWith(isisInterfacePrefix, R1_INTERFACE_IP, 0), // 0 because passive
+                isisRouteWith(R1_R2_PREFIX, R1_TO_R2_IP, 0), // 0 because passive
                 isisRouteWith(Prefix.ZERO, Route.UNSET_ROUTE_NEXT_HOP_IP, 0))));
     assertThat(
         r2L1RibRoutes,
         containsInAnyOrder(
             ImmutableList.of(
                 isisRouteWith(r2LoopbackPrefix, R2_LOOPBACK_IP, 0),
-                isisRouteWith(isisInterfacePrefix, R2_INTERFACE_IP, 10),
+                isisRouteWith(R1_R2_PREFIX, R2_TO_R1_IP, 10),
                 isisRouteWith(Prefix.ZERO, Route.UNSET_ROUTE_NEXT_HOP_IP, 0))));
 
     // L2 RIBs have the other's loopback
@@ -192,18 +218,18 @@ public class IsisTest {
         containsInAnyOrder(
             ImmutableList.of(
                 isisRouteWith(r1LoopbackPrefix, R1_LOOPBACK_IP, 0),
-                isisRouteWith(r2LoopbackPrefix, R2_INTERFACE_IP, 10),
-                isisRouteWith(isisInterfacePrefix, R1_INTERFACE_IP, 10))));
+                isisRouteWith(r2LoopbackPrefix, R2_TO_R1_IP, 10),
+                isisRouteWith(R1_R2_PREFIX, R1_TO_R2_IP, 10))));
     assertThat(
         r2L2RibRoutes,
         containsInAnyOrder(
             ImmutableList.of(
-                isisRouteWith(r1LoopbackPrefix, R1_INTERFACE_IP, 10),
+                isisRouteWith(r1LoopbackPrefix, R1_TO_R2_IP, 10),
                 isisRouteWith(r2LoopbackPrefix, R2_LOOPBACK_IP, 0),
-                isisRouteWith(isisInterfacePrefix, R2_INTERFACE_IP, 10),
+                isisRouteWith(R1_R2_PREFIX, R2_TO_R1_IP, 10),
                 // This route comes from r1's passive L1 interface level. It starts with cost 0,
                 // then gets upgraded to L2 and sent to r2 with cost 10 (same as previous route).
-                isisRouteWith(isisInterfacePrefix, R1_INTERFACE_IP, 10))));
+                isisRouteWith(R1_R2_PREFIX, R1_TO_R2_IP, 10))));
 
     // Both nodes have an L2 route to the other's loopback
     SortedMap<String, SortedMap<String, Set<AbstractRoute>>> routes =
@@ -219,7 +245,6 @@ public class IsisTest {
     IncrementalDataPlane dp = setUpPassiveIsis(false, true);
     Prefix r1LoopbackPrefix = R1_LOOPBACK_IP.toPrefix();
     Prefix r2LoopbackPrefix = R2_LOOPBACK_IP.toPrefix();
-    Prefix isisInterfacePrefix = Prefix.create(R1_INTERFACE_IP, INTERFACE_PREFIX_LENGTH);
 
     Set<IsisRoute> r1L1RibRoutes =
         dp.getNodes().get(R1).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
@@ -236,16 +261,16 @@ public class IsisTest {
         containsInAnyOrder(
             ImmutableList.of(
                 isisRouteWith(r1LoopbackPrefix, R1_LOOPBACK_IP, 0),
-                isisRouteWith(r2LoopbackPrefix, R2_INTERFACE_IP, 10),
-                isisRouteWith(isisInterfacePrefix, R1_INTERFACE_IP, 10),
+                isisRouteWith(r2LoopbackPrefix, R2_TO_R1_IP, 10),
+                isisRouteWith(R1_R2_PREFIX, R1_TO_R2_IP, 10),
                 isisRouteWith(Prefix.ZERO, Route.UNSET_ROUTE_NEXT_HOP_IP, 0))));
     assertThat(
         r2L1RibRoutes,
         containsInAnyOrder(
             ImmutableList.of(
-                isisRouteWith(r1LoopbackPrefix, R1_INTERFACE_IP, 10),
+                isisRouteWith(r1LoopbackPrefix, R1_TO_R2_IP, 10),
                 isisRouteWith(r2LoopbackPrefix, R2_LOOPBACK_IP, 0),
-                isisRouteWith(isisInterfacePrefix, R2_INTERFACE_IP, 10),
+                isisRouteWith(R1_R2_PREFIX, R2_TO_R1_IP, 10),
                 isisRouteWith(Prefix.ZERO, Route.UNSET_ROUTE_NEXT_HOP_IP, 0))));
 
     // L2 RIBs lack the other's loopback
@@ -254,13 +279,13 @@ public class IsisTest {
         containsInAnyOrder(
             ImmutableList.of(
                 isisRouteWith(r1LoopbackPrefix, R1_LOOPBACK_IP, 0),
-                isisRouteWith(isisInterfacePrefix, R1_INTERFACE_IP, 0)))); // 0 because passive
+                isisRouteWith(R1_R2_PREFIX, R1_TO_R2_IP, 0)))); // 0 because passive
     assertThat(
         r2L2RibRoutes,
         containsInAnyOrder(
             ImmutableList.of(
                 isisRouteWith(r2LoopbackPrefix, R2_LOOPBACK_IP, 0),
-                isisRouteWith(isisInterfacePrefix, R2_INTERFACE_IP, 10))));
+                isisRouteWith(R1_R2_PREFIX, R2_TO_R1_IP, 10))));
 
     // Both nodes have an L1 route to the other's loopback
     SortedMap<String, SortedMap<String, Set<AbstractRoute>>> routes =
@@ -269,6 +294,15 @@ public class IsisTest {
     assertRoute(routes, ISIS_L1, R2, r1LoopbackPrefix, 10L);
   }
 
+  /*
+  Setup:
+          R1 - R3 - R4
+           \  /  \  /
+            R2    R5
+
+   R1 and R2 are L2 only, R4 and R5 are L1 only. R3 interfaces to R1 and R2 are L2 only, to R4 and
+   R5 are L1 only.
+   */
   private IncrementalDataPlane computeDataPlane() {
     NetworkFactory nf = new NetworkFactory();
     Configuration.Builder cb =
@@ -294,15 +328,15 @@ public class IsisTest {
         .setLevel2(levelSettings)
         .build();
     // r1l
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.1.1/32"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R1_LOOPBACK_IP, 32))
         .setIsis(iib.setLevel2(passiveIls).build())
         .build();
     // r1r2
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.2.1/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R1_TO_R2_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel2(activeIls).build())
         .build();
     // r1r3
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.3.1/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R1_TO_R3_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel2(activeIls).build())
         .build();
 
@@ -317,15 +351,15 @@ public class IsisTest {
         .setLevel2(levelSettings)
         .build();
     // r2l
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.2.2.2/32"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R2_LOOPBACK_IP, 32))
         .setIsis(iib.setLevel2(passiveIls).build())
         .build();
     // r2r1
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.2.2/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R2_TO_R1_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel2(activeIls).build())
         .build();
     // r2r3
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.2.3.2/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R2_TO_R3_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel2(activeIls).build())
         .build();
 
@@ -339,23 +373,23 @@ public class IsisTest {
         .setLevel2(levelSettings)
         .build();
     // r3l
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.3.3.3/32"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R3_LOOPBACK_IP, 32))
         .setIsis(iib.setLevel1(passiveIls).setLevel2(passiveIls).build())
         .build();
     // r3r1
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.3.3/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R3_TO_R1_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel1(null).setLevel2(activeIls).build())
         .build();
     // r3r2
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.2.3.3/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R3_TO_R2_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel1(null).setLevel2(activeIls).build())
         .build();
     // r3r4
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.3.4.3/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R3_TO_R4_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel1(activeIls).setLevel2(null).build())
         .build();
     // r3r5
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.3.5.3/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R3_TO_R5_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel1(activeIls).setLevel2(null).build())
         .build();
 
@@ -370,15 +404,15 @@ public class IsisTest {
         .setLevel2(null)
         .build();
     // r4l
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.4.4.4/32"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R4_LOOPBACK_IP, 32))
         .setIsis(iib.setLevel1(passiveIls).build())
         .build();
     // r4r3
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.3.4.4/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R4_TO_R3_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel1(activeIls).build())
         .build();
     // r4r5
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.4.5.4/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R4_TO_R5_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel1(activeIls).build())
         .build();
 
@@ -393,15 +427,15 @@ public class IsisTest {
         .setLevel2(null)
         .build();
     // r5l
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.5.5.5/32"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R5_LOOPBACK_IP, 32))
         .setIsis(iib.setLevel1(passiveIls).build())
         .build();
     // r5r3
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.3.5.5/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R5_TO_R3_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel1(activeIls).build())
         .build();
     // r5r4
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.4.5.5/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R5_TO_R4_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(iib.setLevel1(activeIls).build())
         .build();
 
@@ -438,48 +472,48 @@ public class IsisTest {
     SortedMap<String, SortedMap<String, Set<AbstractRoute>>> routes =
         IncrementalBdpEngine.getRoutes(dp);
 
-    // r1
+    // R1 is directly connected to R2 and R3, can reach R4 and R5 through R3
     assertNoRoute(routes, R1, Prefix.ZERO);
-    assertRoute(routes, ISIS_L2, R1, Prefix.parse("10.2.2.2/32"), 10L);
-    assertRoute(routes, ISIS_L2, R1, Prefix.parse("10.2.3.0/24"), 20L);
-    assertRoute(routes, ISIS_L2, R1, Prefix.parse("10.3.3.3/32"), 10L);
-    assertRoute(routes, ISIS_L2, R1, Prefix.parse("10.3.4.0/24"), 20L);
-    assertRoute(routes, ISIS_L2, R1, Prefix.parse("10.3.5.0/24"), 20L);
-    assertRoute(routes, ISIS_L2, R1, Prefix.parse("10.4.4.4/32"), 20L);
-    assertRoute(routes, ISIS_L2, R1, Prefix.parse("10.4.5.0/24"), 30L);
-    assertRoute(routes, ISIS_L2, R1, Prefix.parse("10.5.5.5/32"), 20L);
+    assertRoute(routes, ISIS_L2, R1, R2_LOOPBACK_IP.toPrefix(), 10L);
+    assertRoute(routes, ISIS_L2, R1, R2_R3_PREFIX, 20L);
+    assertRoute(routes, ISIS_L2, R1, R3_LOOPBACK_IP.toPrefix(), 10L);
+    assertRoute(routes, ISIS_L2, R1, R3_R4_PREFIX, 20L);
+    assertRoute(routes, ISIS_L2, R1, R3_R5_PREFIX, 20L);
+    assertRoute(routes, ISIS_L2, R1, R4_LOOPBACK_IP.toPrefix(), 20L);
+    assertRoute(routes, ISIS_L2, R1, R4_R5_PREFIX, 30L);
+    assertRoute(routes, ISIS_L2, R1, R5_LOOPBACK_IP.toPrefix(), 20L);
 
-    // r2
+    // R2 is directly connected to R1 and R3, can reach R4 and R5 through R3
     assertNoRoute(routes, R2, Prefix.ZERO);
-    assertRoute(routes, ISIS_L2, R2, Prefix.parse("10.1.1.1/32"), 10L);
-    assertRoute(routes, ISIS_L2, R2, Prefix.parse("10.1.3.0/24"), 20L);
-    assertRoute(routes, ISIS_L2, R2, Prefix.parse("10.3.3.3/32"), 10L);
-    assertRoute(routes, ISIS_L2, R2, Prefix.parse("10.3.4.0/24"), 20L);
-    assertRoute(routes, ISIS_L2, R2, Prefix.parse("10.3.5.0/24"), 20L);
-    assertRoute(routes, ISIS_L2, R2, Prefix.parse("10.4.4.4/32"), 20L);
-    assertRoute(routes, ISIS_L2, R2, Prefix.parse("10.4.5.0/24"), 30L);
-    assertRoute(routes, ISIS_L2, R2, Prefix.parse("10.5.5.5/32"), 20L);
+    assertRoute(routes, ISIS_L2, R2, R1_LOOPBACK_IP.toPrefix(), 10L);
+    assertRoute(routes, ISIS_L2, R2, R1_R3_PREFIX, 20L);
+    assertRoute(routes, ISIS_L2, R2, R3_LOOPBACK_IP.toPrefix(), 10L);
+    assertRoute(routes, ISIS_L2, R2, R3_R4_PREFIX, 20L);
+    assertRoute(routes, ISIS_L2, R2, R3_R5_PREFIX, 20L);
+    assertRoute(routes, ISIS_L2, R2, R4_LOOPBACK_IP.toPrefix(), 20L);
+    assertRoute(routes, ISIS_L2, R2, R4_R5_PREFIX, 30L);
+    assertRoute(routes, ISIS_L2, R2, R5_LOOPBACK_IP.toPrefix(), 20L);
 
-    // r3
+    // R3 is directly connected to all other nodes
     assertNoRoute(routes, R3, Prefix.ZERO);
-    assertRoute(routes, ISIS_L2, R3, Prefix.parse("10.1.1.1/32"), 10L);
-    assertRoute(routes, ISIS_L2, R3, Prefix.parse("10.1.2.0/24"), 20L);
-    assertRoute(routes, ISIS_L2, R3, Prefix.parse("10.2.2.2/32"), 10L);
-    assertRoute(routes, ISIS_L1, R3, Prefix.parse("10.4.4.4/32"), 10L);
-    assertRoute(routes, ISIS_L1, R3, Prefix.parse("10.4.5.0/24"), 20L);
-    assertRoute(routes, ISIS_L1, R3, Prefix.parse("10.5.5.5/32"), 10L);
+    assertRoute(routes, ISIS_L2, R3, R1_LOOPBACK_IP.toPrefix(), 10L);
+    assertRoute(routes, ISIS_L2, R3, R1_R2_PREFIX, 20L);
+    assertRoute(routes, ISIS_L2, R3, R2_LOOPBACK_IP.toPrefix(), 10L);
+    assertRoute(routes, ISIS_L1, R3, R4_LOOPBACK_IP.toPrefix(), 10L);
+    assertRoute(routes, ISIS_L1, R3, R4_R5_PREFIX, 20L);
+    assertRoute(routes, ISIS_L1, R3, R5_LOOPBACK_IP.toPrefix(), 10L);
 
-    // r4
+    // R4 is directly connected to R3 and R5; no R1/R2 routes because those are L2 and R4 is L1 only
     assertRoute(routes, ISIS_L1, R4, Prefix.ZERO, 10L);
-    assertRoute(routes, ISIS_L1, R4, Prefix.parse("10.3.3.3/32"), 10L);
-    assertRoute(routes, ISIS_L1, R4, Prefix.parse("10.3.5.0/24"), 20L);
-    assertRoute(routes, ISIS_L1, R4, Prefix.parse("10.5.5.5/32"), 10L);
+    assertRoute(routes, ISIS_L1, R4, R3_LOOPBACK_IP.toPrefix(), 10L);
+    assertRoute(routes, ISIS_L1, R4, R3_R5_PREFIX, 20L);
+    assertRoute(routes, ISIS_L1, R4, R5_LOOPBACK_IP.toPrefix(), 10L);
 
-    // r5
+    // R5 is directly connected to R3 and R4; no R1/R2 routes because those are L2 and R5 is L1 only
     assertRoute(routes, ISIS_L1, R5, Prefix.ZERO, 10L);
-    assertRoute(routes, ISIS_L1, R5, Prefix.parse("10.3.3.3/32"), 10L);
-    assertRoute(routes, ISIS_L1, R5, Prefix.parse("10.3.4.0/24"), 20L);
-    assertRoute(routes, ISIS_L1, R5, Prefix.parse("10.4.4.4/32"), 10L);
+    assertRoute(routes, ISIS_L1, R5, R3_LOOPBACK_IP.toPrefix(), 10L);
+    assertRoute(routes, ISIS_L1, R5, R3_R4_PREFIX, 20L);
+    assertRoute(routes, ISIS_L1, R5, R4_LOOPBACK_IP.toPrefix(), 10L);
 
     // Assert r1/r2 have empty l1 rib
     assertThat(
@@ -527,15 +561,15 @@ public class IsisTest {
     ib.setOwner(r1).setVrf(v1);
     ipb.setVrf(v1).setNetAddress(new IsoAddress("49.0001.0100.0100.1001.00")).build();
     // r1l
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.1.1/32"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R1_LOOPBACK_IP, 32))
         .setIsis(loopbackIfaceSettings)
         .build();
     // r1r2
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.2.1/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R1_TO_R2_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(nonLoopbackIfaceSettings)
         .build();
     // r1r3
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.3.1/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R1_TO_R3_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(nonLoopbackIfaceSettings)
         .build();
 
@@ -551,15 +585,15 @@ public class IsisTest {
         .setOverload(true)
         .build();
     // r2l
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.2.2.2/32"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R2_LOOPBACK_IP, 32))
         .setIsis(loopbackIfaceSettings)
         .build();
     // r2r1
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.2.2/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R2_TO_R1_IP, 24))
         .setIsis(nonLoopbackIfaceSettings)
         .build();
     // r2r4
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.4.2/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R2_TO_R4_IP, 24))
         .setIsis(nonLoopbackIfaceSettings)
         .build();
 
@@ -576,15 +610,15 @@ public class IsisTest {
             .setLevel1(cost20LevelSettings)
             .build();
     // r3l
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.3.3.3/32"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R3_LOOPBACK_IP, 32))
         .setIsis(loopbackIfaceSettings)
         .build();
     // r3r1
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.3.3/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R3_TO_R1_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(cost20InterfaceSettings)
         .build();
     // r3r4
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.5.3/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R3_TO_R4_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(cost20InterfaceSettings)
         .build();
 
@@ -594,15 +628,15 @@ public class IsisTest {
     ib.setOwner(r4).setVrf(v4);
     ipb.setVrf(v4).setNetAddress(new IsoAddress("49.0001.0100.0400.4004.00")).build();
     // r4l
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.4.4.4/32"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R4_LOOPBACK_IP, 32))
         .setIsis(loopbackIfaceSettings)
         .build();
     // r4r2
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.4.4/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R4_TO_R2_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(nonLoopbackIfaceSettings)
         .build();
     // r4r3
-    ib.setAddress(ConcreteInterfaceAddress.parse("10.1.5.4/24"))
+    ib.setAddress(ConcreteInterfaceAddress.create(R4_TO_R3_IP, INTERFACE_PREFIX_LENGTH))
         .setIsis(nonLoopbackIfaceSettings)
         .build();
 
@@ -650,29 +684,19 @@ public class IsisTest {
 
     // r2 is overloaded. Other three routers should all have routes to each other's loopbacks that
     // don't traverse r2.
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R1, r3LoopbackPrefix, 10, Ip.parse("10.1.3.3"), false);
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R1, r4LoopbackPrefix, 30, Ip.parse("10.1.3.3"), false);
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R3, r1LoopbackPrefix, 20, Ip.parse("10.1.3.1"), false);
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R3, r4LoopbackPrefix, 20, Ip.parse("10.1.5.4"), false);
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R4, r1LoopbackPrefix, 30, Ip.parse("10.1.5.3"), false);
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R4, r3LoopbackPrefix, 10, Ip.parse("10.1.5.3"), false);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R1, r3LoopbackPrefix, 10, R3_TO_R1_IP, false);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R1, r4LoopbackPrefix, 30, R3_TO_R1_IP, false);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R3, r1LoopbackPrefix, 20, R1_TO_R3_IP, false);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R3, r4LoopbackPrefix, 20, R4_TO_R3_IP, false);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R4, r1LoopbackPrefix, 30, R3_TO_R4_IP, false);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R4, r3LoopbackPrefix, 10, R3_TO_R4_IP, false);
 
     // r1, r3, and r4 should all have an overloaded route to r2's loopback. r3 should have routes
     // through both r1 and r4.
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R1, r2LoopbackPrefix, 10, Ip.parse("10.1.2.2"), true);
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R3, r2LoopbackPrefix, 30, Ip.parse("10.1.3.1"), true);
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R3, r2LoopbackPrefix, 30, Ip.parse("10.1.5.4"), true);
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R4, r2LoopbackPrefix, 10, Ip.parse("10.1.4.2"), true);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R1, r2LoopbackPrefix, 10, R2_TO_R1_IP, true);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R3, r2LoopbackPrefix, 30, R1_TO_R3_IP, true);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R3, r2LoopbackPrefix, 30, R4_TO_R3_IP, true);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R4, r2LoopbackPrefix, 10, R2_TO_R4_IP, true);
 
     // r2 is a Level 1-2 router, but it should not have advertised a default route due to overload.
     assertNoRoute(routes, R1, Prefix.ZERO);
@@ -680,14 +704,10 @@ public class IsisTest {
     assertNoRoute(routes, R4, Prefix.ZERO);
 
     // r2's own routes shouldn't be overloaded.
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R2, r1LoopbackPrefix, 10, Ip.parse("10.1.2.1"), false);
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R2, r3LoopbackPrefix, 20, Ip.parse("10.1.2.1"), false);
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R2, r3LoopbackPrefix, 20, Ip.parse("10.1.4.4"), false);
-    assertIsisRoute(
-        routes, RoutingProtocol.ISIS_L1, R2, r4LoopbackPrefix, 10, Ip.parse("10.1.4.4"), false);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R2, r1LoopbackPrefix, 10, R1_TO_R2_IP, false);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R2, r3LoopbackPrefix, 20, R1_TO_R2_IP, false);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R2, r3LoopbackPrefix, 20, R4_TO_R2_IP, false);
+    assertIsisRoute(routes, RoutingProtocol.ISIS_L1, R2, r4LoopbackPrefix, 10, R4_TO_R2_IP, false);
   }
 
   @Ignore("https://github.com/batfish/batfish/issues/1703")
@@ -697,17 +717,17 @@ public class IsisTest {
     SortedMap<String, SortedMap<String, Set<AbstractRoute>>> routes =
         IncrementalBdpEngine.getRoutes(dp);
 
-    assertInterAreaRoute(routes, R4, Prefix.parse("10.1.1.1/32"), 148L);
-    assertInterAreaRoute(routes, R4, Prefix.parse("10.1.2.0/24"), 158L);
-    assertInterAreaRoute(routes, R4, Prefix.parse("10.1.3.0/24"), 148L);
-    assertInterAreaRoute(routes, R4, Prefix.parse("10.2.2.2/32"), 148L);
-    assertInterAreaRoute(routes, R4, Prefix.parse("10.2.3.0/24"), 148L);
+    assertInterAreaRoute(routes, R4, R1_LOOPBACK_IP.toPrefix(), 148L);
+    assertInterAreaRoute(routes, R4, R1_R2_PREFIX, 158L);
+    assertInterAreaRoute(routes, R4, R1_R3_PREFIX, 148L);
+    assertInterAreaRoute(routes, R4, R2_LOOPBACK_IP.toPrefix(), 148L);
+    assertInterAreaRoute(routes, R4, R2_R3_PREFIX, 148L);
 
-    assertInterAreaRoute(routes, R5, Prefix.parse("10.1.1.1/32"), 148L);
-    assertInterAreaRoute(routes, R5, Prefix.parse("10.1.2.0/24"), 158L);
-    assertInterAreaRoute(routes, R5, Prefix.parse("10.1.3.0/24"), 148L);
-    assertInterAreaRoute(routes, R5, Prefix.parse("10.2.2.2/32"), 148L);
-    assertInterAreaRoute(routes, R5, Prefix.parse("10.2.3.0/24"), 148L);
+    assertInterAreaRoute(routes, R5, R1_LOOPBACK_IP.toPrefix(), 148L);
+    assertInterAreaRoute(routes, R5, R1_R2_PREFIX, 158L);
+    assertInterAreaRoute(routes, R5, R1_R3_PREFIX, 148L);
+    assertInterAreaRoute(routes, R5, R2_LOOPBACK_IP.toPrefix(), 148L);
+    assertInterAreaRoute(routes, R5, R2_R3_PREFIX, 148L);
   }
 
   @Ignore("https://github.com/batfish/batfish/issues/1703")


### PR DESCRIPTION
Still running all the same tests, but now more of the IPs and prefixes exist as named static variables and there are additional comments covering setup and expectations, so it's easier to tell what is being tested.