### PR TITLE
JNPR IS-IS: Only enable level if enabled on interface

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisInterfaceSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/isis/IsisInterfaceSettings.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.isis;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.Objects;
@@ -139,6 +140,13 @@ public class IsisInterfaceSettings implements Serializable {
   @JsonProperty(PROP_BFD_LIVENESS_DETECTION_MULTIPLIER)
   public @Nullable Integer getBfdLivenessDetectionMultiplier() {
     return _bfdLivenessDetectionMultiplier;
+  }
+
+  @JsonIgnore
+  public IsisLevel getEnabledLevels() {
+    IsisLevel l1 = _level1 == null ? null : IsisLevel.LEVEL_1;
+    IsisLevel l2 = _level2 == null ? null : IsisLevel.LEVEL_2;
+    return IsisLevel.union(l1, l2);
   }
 
   @JsonProperty(PROP_ISO_ADDRESS)

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -867,10 +867,10 @@ public final class JuniperConfiguration extends VendorConfiguration {
     // Process interface settings. Enabled levels in the IS-IS process should be limited to union of
     // enabled levels on non-loopback interfaces.
     IsisLevel allEnabledLevels = processIsisInterfaceSettings(routingInstance, level1, level2);
-    if (!allEnabledLevels.includes(IsisLevel.LEVEL_1)) {
+    if (allEnabledLevels == null || !allEnabledLevels.includes(IsisLevel.LEVEL_1)) {
       newProc.setLevel1(null);
     }
-    if (!allEnabledLevels.includes(IsisLevel.LEVEL_2)) {
+    if (allEnabledLevels == null || !allEnabledLevels.includes(IsisLevel.LEVEL_2)) {
       newProc.setLevel2(null);
     }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -3238,7 +3238,7 @@ public final class FlatJuniperGrammarTest {
 
   @Test
   public void testIsisMinimal() {
-    // This config only has a loopback with an ISO address and "set protocols isis interface lo0.0".
+    // This config has an IS-IS loopback and IS-IS interface.
     // Should contain an IS-IS process even though no level is explicitly configured.
     Configuration c = parseConfig("isis-minimal");
     assertThat(c, hasDefaultVrf(hasIsisProcess(notNullValue())));
@@ -3246,7 +3246,8 @@ public final class FlatJuniperGrammarTest {
 
   @Test
   public void testIsisL1Disabled() {
-    // This config has a loopback with an ISO address and "set protocols isis interface lo0.0".
+    // This config has a loopback with an ISO address and "set protocols isis interface lo0.0" and
+    // an interface ge-0/0/1.0 with both levels enabled.
     // Then in [protocols isis level 1] it sets "disable" and "wide-metrics-only".
     // Setting wide-metrics-only should not re-enable level 1.
     // None of the level 1 configuration should affect level 2 (which is enabled by default).

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-disabled-l1
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-disabled-l1
@@ -2,8 +2,11 @@
 set system host-name isis-disabled-l1
 #
 set interfaces lo0 unit 0 family inet address 1.1.1.1/32 
-set interfaces lo0 unit 0 family iso address 12.1234.1234.1234.1234.00 
+set interfaces lo0 unit 0 family iso address 12.1234.1234.1234.1234.00
+set interfaces ge-0/0/1 unit 0 family inet address 2.2.2.0/30 
+set interfaces ge-0/0/1 unit 0 family iso
 #
 set protocols isis interface lo0
+set protocols isis interface ge-0/0/1.0
 set protocols isis level 1 disable
 set protocols isis level 1 wide-metrics-only

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-minimal
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/isis-minimal
@@ -3,5 +3,8 @@ set system host-name isis-minimal
 #
 set interfaces lo0 unit 0 family inet address 1.1.1.1/32 
 set interfaces lo0 unit 0 family iso address 12.1234.1234.1234.1234.00 
+set interfaces ge-0/0/1 unit 0 family inet address 2.2.2.0/30 
+set interfaces ge-0/0/1 unit 0 family iso
 #
 set protocols isis interface lo0
+set protocols isis interface ge-0/0/1.0


### PR DESCRIPTION
IS-IS processes generally have both level 1 and level 2 enabled if neither is explicitly disabled in the config. However, if either level is disabled on all interfaces in the IS-IS process (not counting loopbacks), then the process should also have that level disabled. This can affect routing; for instance, L1 routers should install an IS-IS default route to L1/L2 neighbors, which won't happen if we incorrectly designate the L1 router as L1/L2.