### PR TITLE
Flow: use ordinal in hashCode

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Flow.java
@@ -751,7 +751,7 @@ public final class Flow implements Comparable<Flow>, Serializable {
         _ingressInterface,
         _ingressNode,
         _ingressVrf,
-        _ipProtocol,
+        _ipProtocol.ordinal(),
         _packetLength,
         _srcIp,
         _srcPort,


### PR DESCRIPTION
Didn't seem to matter, but it's practice.