### PR TITLE
Juniper: fix BGP aggregate export

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -757,6 +757,7 @@ public class VirtualRouter implements Serializable {
     }
     // first import aggregates
     switch (_c.getConfigurationFormat()) {
+      case FLAT_JUNIPER:
       case JUNIPER:
       case JUNIPER_SWITCH:
         return;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -331,6 +331,17 @@ public final class BgpProtocolHelper {
             originalRouteNhip.equals(UNSET_ROUTE_NEXT_HOP_IP) ? localIp : originalRouteNhip);
       }
     }
+
+    /*
+    Routes can be aggregate only when generated locally. When transiting across nodes they must be BGP or
+    IBGP.
+
+    This is a bit of a hack since we currently overload AGGREGATE to mean aggregate protocol (i.e., just
+    like on Juniper) AND to mean "locally generated". :(
+    */
+    if (routeBuilder.getProtocol() == RoutingProtocol.AGGREGATE) {
+      routeBuilder.setProtocol(isEbgp ? RoutingProtocol.BGP : RoutingProtocol.IBGP);
+    }
   }
 
   private BgpProtocolHelper() {}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
@@ -3,6 +3,7 @@ package org.batfish.dataplane.protocols;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasNextHopIp;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.convertGeneratedRouteToBgp;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.convertNonBgpRouteToBgpRoute;
+import static org.batfish.dataplane.protocols.BgpProtocolHelper.transformBgpRoutePostExport;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -21,6 +22,7 @@ import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.Bgpv4Route.Builder;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.GeneratedRoute;
@@ -165,7 +167,7 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
    * and the class variables representing the BGP session.
    */
   private void runTransformBgpRoutePostExport(Bgpv4Route.Builder routeBuilder) {
-    BgpProtocolHelper.transformBgpRoutePostExport(
+    transformBgpRoutePostExport(
         routeBuilder,
         _sessionProperties.isEbgp(),
         ConfedSessionType.NO_CONFED,
@@ -371,5 +373,14 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
                 RoutingProtocol.BGP)
             .getTag(),
         equalTo(tag));
+  }
+
+  @Test
+  public void testAggregateProtocolIsCleared() {
+    Builder routeBuilder = Bgpv4Route.builder().setProtocol(RoutingProtocol.AGGREGATE);
+    transformBgpRoutePostExport(
+        routeBuilder, true, ConfedSessionType.NO_CONFED, 1, Ip.MAX, Ip.ZERO);
+    assertThat(
+        "Protocol overriden to BGP", routeBuilder.getProtocol(), equalTo(RoutingProtocol.BGP));
   }
 }


### PR DESCRIPTION
1. Fix configuration format identification bug for juniper
2. Aggregate routes should become bgp when transiting nodes.

This is a stop-gap.