### PR TITLE
Arista BGP: handle parsing of IPV6 neighbors

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -568,6 +568,7 @@ import org.batfish.grammar.cisco.CiscoParser.Eos_rbi_default_metricContext;
 import org.batfish.grammar.cisco.CiscoParser.Eos_rbi_distanceContext;
 import org.batfish.grammar.cisco.CiscoParser.Eos_rbi_maximum_pathsContext;
 import org.batfish.grammar.cisco.CiscoParser.Eos_rbi_neighbor4Context;
+import org.batfish.grammar.cisco.CiscoParser.Eos_rbi_neighbor6Context;
 import org.batfish.grammar.cisco.CiscoParser.Eos_rbi_network4Context;
 import org.batfish.grammar.cisco.CiscoParser.Eos_rbi_network6Context;
 import org.batfish.grammar.cisco.CiscoParser.Eos_rbi_peer_groupContext;
@@ -2494,6 +2495,19 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitEos_rbi_neighbor4(Eos_rbi_neighbor4Context ctx) {
+    _currentAristaBgpNeighbor = null;
+    _currentAristaBgpNeighborAddressFamily = null;
+  }
+
+  @Override
+  public void enterEos_rbi_neighbor6(Eos_rbi_neighbor6Context ctx) {
+    // Create a dummy v4 neighbor instead
+    _currentAristaBgpNeighbor = new AristaBgpV4Neighbor(Ip.ZERO);
+    _currentAristaBgpNeighborAddressFamily = _currentAristaBgpNeighbor.getGenericAddressFamily();
+  }
+
+  @Override
+  public void exitEos_rbi_neighbor6(Eos_rbi_neighbor6Context ctx) {
     _currentAristaBgpNeighbor = null;
     _currentAristaBgpNeighborAddressFamily = null;
   }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_neighbors
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_neighbors
@@ -55,6 +55,8 @@ router bgp 1
   neighbor PARSE_ONLY password YzQ2ZTRlYTNhYzVhZTc0MDE2MTc2ZGEzODhkZmMyMmM=
   neighbor PARSE_ONLY timers 3 9
   neighbor PARSE_ONLY local-v6-addr 2001:db8:0:0:0:ff00:42:8329
+  !
+  neighbor 2001:db8:0:0:0:ff00:42:1111 peer-group PEER_G
 !
   neighbor DYNAMIC peer-group
   neighbor DYNAMIC send-community


### PR DESCRIPTION
Only parsing, no extraction. Prevents NPEs in the extractor if a peer group is assigned to a IPv6 neighbor.