### PR TITLE
Cisco: a little more defensive programming on BGP peers

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpProcess.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.BgpTieBreaker;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
@@ -124,28 +125,31 @@ public class BgpProcess implements Serializable {
     return pg;
   }
 
-  public void addIpPeerGroup(Ip ip) {
+  public IpBgpPeerGroup addIpPeerGroup(Ip ip) {
     IpBgpPeerGroup pg = new IpBgpPeerGroup(ip);
     if (_defaultIpv4Activate) {
       pg.setActive(true);
     }
     _ipPeerGroups.put(ip, pg);
     _allPeerGroups.add(pg);
+    return pg;
   }
 
-  public void addIpv6PeerGroup(Ip6 ip6) {
+  public @Nonnull Ipv6BgpPeerGroup addIpv6PeerGroup(Ip6 ip6) {
     Ipv6BgpPeerGroup pg = new Ipv6BgpPeerGroup(ip6);
     if (_defaultIpv6Activate) {
       pg.setActive(true);
     }
     _ipv6PeerGroups.put(ip6, pg);
     _allPeerGroups.add(pg);
+    return pg;
   }
 
-  public void addNamedPeerGroup(String name) {
+  public @Nonnull NamedBgpPeerGroup addNamedPeerGroup(String name) {
     NamedBgpPeerGroup pg = new NamedBgpPeerGroup(name);
     _namedPeerGroups.put(name, pg);
     _allPeerGroups.add(pg);
+    return pg;
   }
 
   public void addPeerSession(String name) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpProcess.java
@@ -105,7 +105,7 @@ public class BgpProcess implements Serializable {
     _masterBgpPeerGroup.setDefaultMetric(DEFAULT_BGP_DEFAULT_METRIC);
   }
 
-  public DynamicIpBgpPeerGroup addDynamicIpPeerGroup(Prefix prefix) {
+  public @Nonnull DynamicIpBgpPeerGroup addDynamicIpPeerGroup(Prefix prefix) {
     DynamicIpBgpPeerGroup pg = new DynamicIpBgpPeerGroup(prefix);
     if (_defaultIpv4Activate) {
       pg.setActive(true);
@@ -115,7 +115,7 @@ public class BgpProcess implements Serializable {
     return pg;
   }
 
-  public DynamicIpv6BgpPeerGroup addDynamicIpv6PeerGroup(Prefix6 prefix6) {
+  public @Nonnull DynamicIpv6BgpPeerGroup addDynamicIpv6PeerGroup(Prefix6 prefix6) {
     DynamicIpv6BgpPeerGroup pg = new DynamicIpv6BgpPeerGroup(prefix6);
     if (_defaultIpv6Activate) {
       pg.setActive(true);
@@ -125,7 +125,7 @@ public class BgpProcess implements Serializable {
     return pg;
   }
 
-  public IpBgpPeerGroup addIpPeerGroup(Ip ip) {
+  public @Nonnull IpBgpPeerGroup addIpPeerGroup(Ip ip) {
     IpBgpPeerGroup pg = new IpBgpPeerGroup(ip);
     if (_defaultIpv4Activate) {
       pg.setActive(true);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -3617,6 +3617,18 @@ public final class CiscoGrammarTest {
   }
 
   @Test
+  public void testBgpMultipleRouters() throws IOException {
+    parseConfig("ios-bgp-multiple-routers");
+    // Don't crash.
+  }
+
+  @Test
+  public void testBgpUndeclaredPeer() throws IOException {
+    parseConfig("ios-bgp-undeclared-peer");
+    // Don't crash.
+  }
+
+  @Test
   public void testBgpOriginationSpace() throws IOException {
     Configuration c = parseConfig("ios-bgp-origination-space");
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-multiple-routers
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-multiple-routers
@@ -1,0 +1,7 @@
+!
+hostname ios-bgp-multiple-routers
+!
+router bgp 3
+!
+router bgp 2
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-undeclared-peer
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-undeclared-peer
@@ -1,0 +1,6 @@
+!
+hostname ios-bgp-undeclared-peer
+!
+router bgp 3
+  neighbor PG ebgp-multihop 2
+!


### PR DESCRIPTION
Diagnostics have reported some BGP extractor crashes in the old parser (we need to kill it off).

As a stopgap, I looked through for places invariants seemed violated, fixed them, and added some tests. Also rewrote the addFooGroup pattern to one that's more obviously correct.