### PR TITLE
Fix NX-OS default switchport inference

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosPreprocessor.java
@@ -328,11 +328,14 @@ public final class CiscoNxosPreprocessor extends CiscoNxosParserBaseListener {
   @SuppressWarnings("unused")
   private final @Nonnull Warnings _w;
 
-  /** {@code true} if current interfaces appears to have L3 configuration. */
+  /**
+   * {@code true} if current interface appears to have L3 configuration. {@code false} if current
+   * interface appears to have L2 configuration. {@code null} if unknown.
+   */
   private Boolean _currentInterfaceLayer3;
 
   /**
-   * {@code true} if current interfaces has explicit 'shutdown'; {@code false} if current interface
+   * {@code true} if current interface has explicit 'shutdown'; {@code false} if current interface
    * has explicit 'no shutdown'; or else {@code null}.
    */
   private Boolean _currentInterfaceShutdown;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -483,6 +483,38 @@ public final class CiscoNxosGrammarTest {
   }
 
   @Test
+  public void testImplicitShutdownSwitchportInference() throws IOException {
+    for (String hostname :
+        ImmutableList.of(
+            "shutdown-switchport-inference-defaultl2", "shutdown-switchport-inference-defaultl3")) {
+      Configuration c = parseConfig(hostname);
+      assertThat(
+          c,
+          hasInterface(
+              "Ethernet1/1",
+              allOf(isActive(), hasSwitchPortMode(org.batfish.datamodel.SwitchportMode.NONE))));
+      assertThat(
+          c,
+          hasInterface(
+              "Ethernet1/2",
+              allOf(
+                  isActive(false), hasSwitchPortMode(org.batfish.datamodel.SwitchportMode.NONE))));
+      assertThat(
+          c,
+          hasInterface(
+              "Ethernet1/3",
+              allOf(isActive(), hasSwitchPortMode(org.batfish.datamodel.SwitchportMode.ACCESS))));
+      assertThat(
+          c,
+          hasInterface(
+              "Ethernet1/4",
+              allOf(
+                  isActive(false),
+                  hasSwitchPortMode(org.batfish.datamodel.SwitchportMode.ACCESS))));
+    }
+  }
+
+  @Test
   public void testAaaParsing() {
     // TODO: make into extraction test
     assertThat(parseVendorConfig("nxos_aaa"), notNullValue());

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/shutdown-switchport-inference-defaultl2
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/shutdown-switchport-inference-defaultl2
@@ -1,0 +1,24 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+
+hostname shutdown-switchport-inference-defaultl2
+
+version 9.2(3) Bios:version
+
+! l3, on
+interface Ethernet1/1
+  no switchport
+  no shutdown
+
+! l3, off
+interface Ethernet1/2
+  no switchport
+
+! l2, on
+interface Ethernet1/3
+
+! l2, off
+interface Ethernet1/4
+  shutdown
+
+boot nxos bootflash:/nxos.9.2.3.bin

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/shutdown-switchport-inference-defaultl3
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/shutdown-switchport-inference-defaultl3
@@ -1,0 +1,24 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+
+hostname shutdown-switchport-inference-defaultl3
+
+version 9.2(3) Bios:version
+
+! l3, on
+interface Ethernet1/1
+  no shutdown
+
+! l3, off
+interface Ethernet1/2
+
+! l2, on
+interface Ethernet1/3
+  switchport
+
+! l2, off
+interface Ethernet1/4
+  switchport
+  shutdown
+
+boot nxos bootflash:/nxos.9.2.3.bin


### PR DESCRIPTION
- consider occurrences of 'switchport' and 'no switchport' as evidence
the first time they appear in an interface definition
- actually track whether interface has been explicitly shut down