### PR TITLE
Cisco: do not ignore vxlan commands

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ignored.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ignored.g4
@@ -255,7 +255,6 @@ null_block
       | VLAN_POLICY
       | VLT
       | VTY_POOL
-      | VXLAN
       | WISM
       | WRED_PROFILE
       | WSMA

--- a/tests/parsing-tests/networks/unit-tests/configs/vxlan
+++ b/tests/parsing-tests/networks/unit-tests/configs/vxlan
@@ -1,4 +1,0 @@
-!
-hostname vxlan
-!
-vxlan dummy-l2-tunnel-udp-port 1234

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -38465,26 +38465,6 @@
             ]
           }
         }
-      },
-      "vxlan" : {
-        "configurationFormat" : "CISCO_IOS",
-        "name" : "vxlan",
-        "defaultCrossZoneAction" : "PERMIT",
-        "defaultInboundAction" : "PERMIT",
-        "deviceType" : "SWITCH",
-        "vendorFamily" : {
-          "cisco" : {
-            "hostname" : "vxlan",
-            "logging" : {
-              "on" : true
-            }
-          }
-        },
-        "vrfs" : {
-          "default" : {
-            "name" : "default"
-          }
-        }
       }
     }
   }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -912,9 +912,6 @@
         ],
         "vmx4" : [
           "configs/gh-2658-juniper-vrf-import-export.cfg"
-        ],
-        "vxlan" : [
-          "configs/vxlan"
         ]
       },
       "parseStatus" : {
@@ -1219,7 +1216,6 @@
         "configs/variables" : "PASSED",
         "configs/variables_dos" : "PASSED",
         "configs/vlan_access_map2" : "PASSED",
-        "configs/vxlan" : "PASSED",
         "hosts/host1.json" : "PASSED",
         "hosts/host2.json" : "PASSED",
         "hosts/hostEmpty.json" : "EMPTY",
@@ -75634,25 +75630,6 @@
             "  EOF:<EOF>)"
           ]
         },
-        "configs/vxlan" : {
-          "sentences" : [
-            "(cisco_configuration",
-            "  (stanza",
-            "    (s_hostname",
-            "      HOSTNAME:'hostname'",
-            "      VXLAN:'vxlan'",
-            "      NEWLINE:'\\n'))",
-            "  (stanza",
-            "    (s_null",
-            "      (null_block",
-            "        VXLAN:'vxlan'",
-            "        (null_rest_of_line",
-            "          VARIABLE:'dummy-l2-tunnel-udp-port'",
-            "          DEC:'1234'",
-            "          NEWLINE:'\\n\\n'))))",
-            "  EOF:<EOF>)"
-          ]
-        },
         "iptables/host1.iptables" : {
           "sentences" : [
             "(iptables_configuration",
@@ -78070,8 +78047,7 @@
         "variables" : "PASSED",
         "variables_dos" : "PASSED",
         "vlan_access_map4" : "PASSED",
-        "vmx4" : "PASSED",
-        "vxlan" : "PASSED"
+        "vmx4" : "PASSED"
       },
       "definedStructures" : {
         "aws_configs" : { },
@@ -85972,7 +85948,6 @@
           }
         },
         "configs/vlan_access_map2" : { },
-        "configs/vxlan" : { },
         "hosts/host1.json" : { }
       },
       "fileMap" : {
@@ -86877,9 +86852,6 @@
         ],
         "configs/vlan_access_map2" : [
           "vlan_access_map4"
-        ],
-        "configs/vxlan" : [
-          "vxlan"
         ],
         "hosts/host1.json" : [
           "host1"
@@ -95465,7 +95437,6 @@
         "configs/variables" : "PASSED",
         "configs/variables_dos" : "PASSED",
         "configs/vlan_access_map2" : "PASSED",
-        "configs/vxlan" : "PASSED",
         "hosts/host1.json" : "PASSED",
         "hosts/host2.json" : "PASSED",
         "hosts/hostEmpty.json" : "EMPTY",


### PR DESCRIPTION
Goal: not have vxlan lines silently eaten (messes up initIssues for Arista in some cases)

Since we have recover, this should be fine.

Test removal: Doesn't seem like a valid command on cisco. Closes thing I found is this: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/cether/configuration/xe-16/ce-xe-16-book/vxlan-gpe-tunnel.html
For which we currently have no support anyway.

Thoughts?