### PR TITLE
Stop Json-serializing VNI settings

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
@@ -12,6 +12,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -83,7 +84,6 @@ public class Vrf extends ComparableStructure<String> {
   private static final String PROP_OSPF_PROCESSES = "ospfProcesses";
   private static final String PROP_RIP_PROCESS = "ripProcess";
   private static final String PROP_STATIC_ROUTES = "staticRoutes";
-  private static final String PROP_VNI_SETTINGS = "vniSettings";
 
   public static @Nonnull Builder builder() {
     return new Builder(null);
@@ -105,7 +105,7 @@ public class Vrf extends ComparableStructure<String> {
   private RipProcess _ripProcess;
   private SnmpServer _snmpServer;
   private SortedSet<StaticRoute> _staticRoutes;
-  private NavigableMap<Integer, VniSettings> _vniSettings;
+  private Map<Integer, VniSettings> _vniSettings;
 
   public Vrf(@Nonnull String name) {
     super(name);
@@ -117,7 +117,7 @@ public class Vrf extends ComparableStructure<String> {
     _kernelRoutes = ImmutableSortedSet.of();
     _ospfProcesses = ImmutableSortedMap.of();
     _staticRoutes = new TreeSet<>();
-    _vniSettings = new TreeMap<>();
+    _vniSettings = new HashMap<>();
   }
 
   @JsonCreator
@@ -237,8 +237,8 @@ public class Vrf extends ComparableStructure<String> {
     return _staticRoutes;
   }
 
-  @JsonProperty(PROP_VNI_SETTINGS)
-  public NavigableMap<Integer, VniSettings> getVniSettings() {
+  @JsonIgnore
+  public Map<Integer, VniSettings> getVniSettings() {
     return _vniSettings;
   }
 
@@ -358,8 +358,7 @@ public class Vrf extends ComparableStructure<String> {
     _staticRoutes = staticRoutes;
   }
 
-  @JsonProperty(PROP_VNI_SETTINGS)
-  public void setVniSettings(NavigableMap<Integer, VniSettings> vniSetting) {
-    _vniSettings = vniSetting;
+  public void setVniSettings(Map<Integer, VniSettings> vniSettings) {
+    _vniSettings = ImmutableMap.copyOf(vniSettings);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VniSettingsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VniSettingsTest.java
@@ -6,10 +6,8 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.SortedSet;
 import org.apache.commons.lang3.SerializationUtils;
-import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -52,21 +50,6 @@ public class VniSettingsTest {
             .setVni(10007)
             .build();
     assertThat(SerializationUtils.clone(vs), equalTo(vs));
-  }
-
-  @Test
-  public void testJsonSerialization() throws IOException {
-    SortedSet<Ip> bumTransportIps = ImmutableSortedSet.of(Ip.parse("2.2.2.2"), Ip.parse("2.2.2.3"));
-    VniSettings vs =
-        VniSettings.builder()
-            .setBumTransportIps(bumTransportIps)
-            .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
-            .setSourceAddress(Ip.parse("1.2.3.4"))
-            .setUdpPort(2345)
-            .setVlan(7)
-            .setVni(10007)
-            .build();
-    assertThat(BatfishObjectMapper.clone(vs, VniSettings.class), equalTo(vs));
   }
 
   @Test

--- a/projects/question/src/main/java/org/batfish/question/vxlanproperties/VxlanVniPropertiesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/vxlanproperties/VxlanVniPropertiesAnswerer.java
@@ -2,12 +2,12 @@ package org.batfish.question.vxlanproperties;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Table;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.stream.Collectors;
 import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
@@ -128,14 +128,18 @@ public final class VxlanVniPropertiesAnswerer extends Answerer {
           RowBuilder row = Row.builder(columns).put(COL_NODE, nodeName).put(COL_VNI, vni);
           boolean unicast =
               vniSettings.getBumTransportMethod() == BumTransportMethod.UNICAST_FLOOD_GROUP;
-          SortedSet<Ip> bumTransportIps = vniSettings.getBumTransportIps();
+          Set<Ip> bumTransportIps = vniSettings.getBumTransportIps();
           VxlanVniPropertiesRow vxlanVniProperties =
               new VxlanVniPropertiesRow(
                   nodeName,
                   vni,
                   vniSettings.getVlan(),
                   vniSettings.getSourceAddress(),
-                  unicast ? null : bumTransportIps.isEmpty() ? null : bumTransportIps.first(),
+                  unicast
+                      ? null
+                      : bumTransportIps.isEmpty()
+                          ? null
+                          : Iterables.getOnlyElement(bumTransportIps),
                   unicast ? bumTransportIps : null,
                   vniSettings.getUdpPort());
 

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -8731,20 +8731,7 @@
               "Wlan-ap0",
               "inside",
               "tunnel-ip6"
-            ],
-            "vniSettings" : {
-              "456" : {
-                "bumTransportIps" : [
-                  "1.0.0.1",
-                  "2.0.0.1",
-                  "3.0.0.1"
-                ],
-                "bumTransportMethod" : "UNICAST_FLOOD_GROUP",
-                "udpPort" : 1234,
-                "vlan" : 123,
-                "vni" : 456
-              }
-            }
+            ]
           }
         },
         "zones" : {


### PR DESCRIPTION
Working towards splitting L2 VNI settings from L3 VNI settings, don't really want the JSON/comparable overhead here.