### PR TITLE
aws: separate out bazel

### DIFF
--- a/projects/batfish/BUILD
+++ b/projects/batfish/BUILD
@@ -44,6 +44,7 @@ java_library(
         "//projects/batfish/src/main/java/org/batfish/grammar/flatjuniper",
         "//projects/batfish/src/main/java/org/batfish/grammar/juniper",
         "//projects/batfish/src/main/java/org/batfish/grammar/palo_alto",
+        "//projects/batfish/src/main/java/org/batfish/representation/aws",
         "//projects/bdd",
         "//projects/symbolic",
         "@maven//:com_fasterxml_jackson_core_jackson_annotations",

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/BUILD
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/BUILD
@@ -1,0 +1,23 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@batfish//skylark:pmd_test.bzl", "pmd_test")
+
+java_library(
+    name = "aws",
+    srcs = glob(
+        ["**/*.java"],
+        exclude = ["BUILD"],
+    ),
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "@maven//:com_fasterxml_jackson_core_jackson_annotations",
+        "@maven//:com_fasterxml_jackson_core_jackson_databind",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+    ],
+)
+
+pmd_test(
+    name = "pmd",
+    lib = ":aws",
+)

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/BUILD
@@ -1,0 +1,27 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "**/*Test.java",
+    ]),
+    resources = ["//projects/batfish/src/test/resources/org/batfish/representation/aws"],
+    deps = [
+        "//projects/batfish",
+        "//projects/batfish:batfish_testlib",
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:common_testlib",
+        "//projects/batfish/src/main/java/org/batfish/representation/aws",
+        "//projects/batfish/src/test/java/org/batfish/representation/aws/matchers",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
+        "@maven//:com_fasterxml_jackson_core_jackson_databind",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/matchers/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/matchers/BUILD
@@ -1,0 +1,18 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+java_library(
+    name = "matchers",
+    srcs = glob([
+        "*.java",
+    ]),
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish/src/main/java/org/batfish/representation/aws",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/BUILD
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/BUILD
@@ -1,0 +1,12 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "aws",
+    srcs = glob(
+        ["**"],
+        exclude = ["BUILD"],
+    ),
+)


### PR DESCRIPTION
Enabled testing AWS in isolation:

```
bazel test //projects/batfish/src/test/java/org/batfish/representation/aws/...
```

Can also add `//tests/aws/...` if you like.