### PR TITLE
bazel: add tag pmd_test to pmd tests

### DIFF
--- a/skylark/pmd_test.bzl
+++ b/skylark/pmd_test.bzl
@@ -56,7 +56,7 @@ def _impl(ctx):
     )
     return [DefaultInfo(executable = test_file, runfiles = runfiles)]
 
-pmd_test = rule(
+_pmd_test = rule(
     implementation = _impl,
     attrs = {
         "lib": attr.label(
@@ -76,3 +76,11 @@ pmd_test = rule(
     },
     test = True,
 )
+
+def pmd_test(name, **kwargs):
+    # Add the pmd_test tag so that pmd tests can be skipped with
+    # --test_tag_filters=-pmd-test"
+    if "tags" not in kwargs:
+        kwargs["tags"] = []
+    kwargs["tags"].append("pmd_test")
+    _pmd_test(name = name, **kwargs)

--- a/skylark/pmd_test.bzl
+++ b/skylark/pmd_test.bzl
@@ -79,8 +79,6 @@ _pmd_test = rule(
 
 def pmd_test(name, **kwargs):
     # Add the pmd_test tag so that pmd tests can be skipped with
-    # --test_tag_filters=-pmd-test"
-    if "tags" not in kwargs:
-        kwargs["tags"] = []
-    kwargs["tags"].append("pmd_test")
+    # --test_tag_filters=-pmd_test
+    kwargs["tags"] = kwargs.get("tags", []) + ["pmd_test"]
     _pmd_test(name = name, **kwargs)


### PR DESCRIPTION
They can now be skipped with --test_tag_filters=-pmd_test