### PR TITLE
Update role inference to the new roles format

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/role/InferRoles.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/role/InferRoles.java
@@ -141,7 +141,7 @@ public final class InferRoles {
         case ALPHA_PLUS_DIGIT_PLUS:
           return plus(ALPHABETIC_REGEX) + plus(DIGIT_REGEX);
         case ALNUM_PLUS:
-          return plus(ALPHABETIC_REGEX) + (ALPHANUMERIC_REGEX);
+          return plus(ALPHANUMERIC_REGEX);
         case DELIMITER:
           return Pattern.quote(s);
         case DIGIT_PLUS:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/role/InferRoles.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/role/InferRoles.java
@@ -387,8 +387,11 @@ public final class InferRoles {
     for (int i = 0; i < _tokens.size(); i++) {
       switch (_tokens.get(i).getToken()) {
         case ALNUM_PLUS:
+          _regex.set(i, group(plus(ALPHABETIC_REGEX)) + star(ALPHANUMERIC_REGEX));
+          groups++;
+          break;
         case ALPHA_PLUS_DIGIT_PLUS:
-          _regex.set(i, group(_regex.get(i)));
+          _regex.set(i, group(plus(ALPHABETIC_REGEX)) + plus(DIGIT_REGEX));
           groups++;
           break;
         default:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/role/NodeRole.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/role/NodeRole.java
@@ -17,7 +17,6 @@ import org.batfish.datamodel.Names.Type;
 public class NodeRole implements Comparable<NodeRole> {
   private static final String PROP_NAME = "name";
   private static final String PROP_REGEX = "regex";
-  private static final String PROP_CASE_SENSITIVE = "caseSensitive";
 
   @Nonnull private final transient Pattern _compiledPattern;
 
@@ -25,33 +24,24 @@ public class NodeRole implements Comparable<NodeRole> {
 
   @Nonnull private final String _regex;
 
-  private final boolean _caseSensitive;
-
   @JsonCreator
   private static NodeRole create(
-      @JsonProperty(PROP_NAME) String name,
-      @JsonProperty(PROP_REGEX) String regex,
-      @JsonProperty(PROP_CASE_SENSITIVE) boolean caseSensitive) {
+      @JsonProperty(PROP_NAME) String name, @JsonProperty(PROP_REGEX) String regex) {
     if (name == null) {
       throw new IllegalArgumentException("Node role name cannot be null");
     }
     if (regex == null) {
       throw new IllegalArgumentException("Node role regex cannot be null");
     }
-    return new NodeRole(name, regex, caseSensitive);
+    return new NodeRole(name, regex);
   }
 
   public NodeRole(String name, String regex) {
-    this(name, regex, false);
-  }
-
-  public NodeRole(String name, String regex, boolean caseSensitive) {
     Names.checkName(name, "role", Type.REFERENCE_OBJECT);
     _name = name;
     _regex = regex;
-    _caseSensitive = caseSensitive;
     try {
-      _compiledPattern = Pattern.compile(regex, caseSensitive ? 0 : Pattern.CASE_INSENSITIVE);
+      _compiledPattern = Pattern.compile(regex);
     } catch (PatternSyntaxException e) {
       throw new IllegalArgumentException("Bad regex: " + e.getMessage());
     }
@@ -61,7 +51,6 @@ public class NodeRole implements Comparable<NodeRole> {
   public int compareTo(NodeRole o) {
     return Comparator.comparing(NodeRole::getName)
         .thenComparing(NodeRole::getRegex)
-        .thenComparing(NodeRole::getCaseSensitive)
         .compare(this, o);
   }
 
@@ -71,8 +60,7 @@ public class NodeRole implements Comparable<NodeRole> {
       return false;
     }
     return Objects.equals(_name, ((NodeRole) o)._name)
-        && Objects.equals(_regex, ((NodeRole) o)._regex)
-        && _caseSensitive == ((NodeRole) o)._caseSensitive;
+        && Objects.equals(_regex, ((NodeRole) o)._regex);
   }
 
   @JsonProperty(PROP_NAME)
@@ -83,11 +71,6 @@ public class NodeRole implements Comparable<NodeRole> {
   @JsonProperty(PROP_REGEX)
   public String getRegex() {
     return _regex;
-  }
-
-  @JsonProperty(PROP_CASE_SENSITIVE)
-  public boolean getCaseSensitive() {
-    return _caseSensitive;
   }
 
   @Override
@@ -110,7 +93,6 @@ public class NodeRole implements Comparable<NodeRole> {
     return MoreObjects.toStringHelper(getClass())
         .add("name", _name)
         .add("regex", _regex)
-        .add("caseSensitive", _caseSensitive)
         .toString();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/role/NodeRoleDimension.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/role/NodeRoleDimension.java
@@ -220,8 +220,7 @@ public final class NodeRoleDimension implements Comparable<NodeRoleDimension> {
               null,
               rdMap.getRegex(),
               ImmutableMap.of(_name, rdMap.getGroups()),
-              ImmutableMap.of(_name, rdMap.getCanonicalRoleNames()),
-              rdMap.getCaseSensitive()));
+              ImmutableMap.of(_name, rdMap.getCanonicalRoleNames())));
     }
     return copyOf(mappings);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/role/NodeRolesData.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/role/NodeRolesData.java
@@ -210,10 +210,7 @@ public class NodeRolesData {
         List<Integer> groups = entry.getValue();
         RoleDimensionMapping rdmap =
             new RoleDimensionMapping(
-                regex,
-                groups,
-                canonicalRoleNames.getOrDefault(dim, ImmutableMap.of()),
-                rmap.getCaseSensitive());
+                regex, groups, canonicalRoleNames.getOrDefault(dim, ImmutableMap.of()));
         List<RoleDimensionMapping> dimMaps = rdMaps.computeIfAbsent(dim, k -> new LinkedList<>());
         dimMaps.add(rdmap);
       }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/role/RoleMapping.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/role/RoleMapping.java
@@ -28,7 +28,6 @@ public class RoleMapping {
   private static final String PROP_REGEX = "regex";
   private static final String PROP_ROLE_DIMENSION_GROUPS = "roleDimensionGroups";
   private static final String PROP_CANONICAL_ROLE_NAMES = "canonicalRoleNames";
-  private static final String PROP_CASE_SENSITIVE = "caseSensitive";
 
   // a name for this mapping
   @Nullable private String _name;
@@ -41,23 +40,20 @@ public class RoleMapping {
   obtained from the node name to a canonical role name */
   @Nonnull private Map<String, Map<String, String>> _canonicalRoleNames;
 
-  private boolean _caseSensitive;
-
   @JsonCreator
   public RoleMapping(
       @JsonProperty(PROP_NAME) String name,
       @JsonProperty(PROP_REGEX) String regex,
       @JsonProperty(PROP_ROLE_DIMENSION_GROUPS) Map<String, List<Integer>> roleDimensionGroups,
-      @JsonProperty(PROP_CANONICAL_ROLE_NAMES) Map<String, Map<String, String>> canonicalRoleNames,
-      @JsonProperty(PROP_CASE_SENSITIVE) boolean caseSensitive) {
+      @JsonProperty(PROP_CANONICAL_ROLE_NAMES)
+          Map<String, Map<String, String>> canonicalRoleNames) {
     _name = name;
     checkArgument(regex != null, "The regex cannot be null");
     _regex = regex;
     _roleDimensionGroups = firstNonNull(roleDimensionGroups, ImmutableMap.of());
     _canonicalRoleNames = firstNonNull(canonicalRoleNames, ImmutableMap.of());
-    _caseSensitive = caseSensitive;
     try {
-      Pattern.compile(regex, caseSensitive ? 0 : Pattern.CASE_INSENSITIVE);
+      Pattern.compile(regex);
     } catch (PatternSyntaxException e) {
       throw new BatfishException("Supplied regex is not a valid Java regex: \"" + regex + "\"", e);
     }
@@ -87,11 +83,6 @@ public class RoleMapping {
     return _regex;
   }
 
-  @JsonProperty(PROP_CASE_SENSITIVE)
-  public boolean getCaseSensitive() {
-    return _caseSensitive;
-  }
-
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof RoleMapping)) {
@@ -100,12 +91,11 @@ public class RoleMapping {
     return Objects.equals(_name, ((RoleMapping) o)._name)
         && Objects.equals(_regex, ((RoleMapping) o)._regex)
         && Objects.equals(_roleDimensionGroups, ((RoleMapping) o)._roleDimensionGroups)
-        && Objects.equals(_canonicalRoleNames, ((RoleMapping) o)._canonicalRoleNames)
-        && Objects.equals(_caseSensitive, ((RoleMapping) o)._caseSensitive);
+        && Objects.equals(_canonicalRoleNames, ((RoleMapping) o)._canonicalRoleNames);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_name, _regex, _roleDimensionGroups, _canonicalRoleNames, _caseSensitive);
+    return Objects.hash(_name, _regex, _roleDimensionGroups, _canonicalRoleNames);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AutoCompleteUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AutoCompleteUtilsTest.java
@@ -1101,8 +1101,7 @@ public class AutoCompleteUtilsTest {
                         "(.*)",
                         ImmutableMap.of(
                             "someDimension", ImmutableList.of(1), "blah", ImmutableList.of(1)),
-                        null,
-                        false)))
+                        null)))
             .build();
 
     assertThat(
@@ -1134,17 +1133,14 @@ public class AutoCompleteUtilsTest {
                         .setRoleDimensionMappings(
                             ImmutableList.of(
                                 new RoleDimensionMapping(
-                                    "(.*)",
-                                    null,
-                                    ImmutableMap.of("node1", "r1", "node2", "s1"),
-                                    false)))
+                                    "(.*)", null, ImmutableMap.of("node1", "r1", "node2", "s1"))))
                         .build(),
                     NodeRoleDimension.builder()
                         .setName("someOtherDimension")
                         .setRoleDimensionMappings(
                             ImmutableList.of(
                                 new RoleDimensionMapping(
-                                    "(.*)", null, ImmutableMap.of("node3", "r2"), false)))
+                                    "(.*)", null, ImmutableMap.of("node3", "r2"))))
                         .build()))
             .build();
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/NodesSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/NodesSpecifierTest.java
@@ -198,8 +198,7 @@ public class NodesSpecifierTest {
                         "(.+-.+)-.+",
                         null,
                         ImmutableMap.of(
-                            "lhr-border", "match1", "svr-border", "match2", "lhr-core", "dumb0"),
-                        false)))
+                            "lhr-border", "match1", "svr-border", "match2", "lhr-core", "dumb0"))))
             .build();
 
     Set<String> matchingNodes = specifier.getMatchingNodesByRole(roleDimension, nodes);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesTest.java
@@ -2,8 +2,6 @@ package org.batfish.role;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -119,6 +117,5 @@ public class InferRolesTest {
     }
 
     assertTrue(roleMapping.getCanonicalRoleNames().isEmpty());
-    assertFalse(roleMapping.getCaseSensitive());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesTest.java
@@ -101,7 +101,7 @@ public class InferRolesTest {
 
     RoleMapping roleMapping = roleMappingOpt.get();
 
-    assertThat(roleMapping.getRegex(), equalTo("\\p{Alpha}+\\p{Digit}+(\\p{Alpha}+)\\p{Digit}+"));
+    assertThat(roleMapping.getRegex(), equalTo("(\\p{Alpha}+)\\p{Digit}+(\\p{Alpha}+)\\p{Digit}+"));
 
     assertThat(roleMapping.getRoleDimensionsGroups().entrySet(), hasSize(2));
 
@@ -118,7 +118,7 @@ public class InferRolesTest {
       }
     }
 
-    assertNull(roleMapping.getCanonicalRoleNames());
+    assertTrue(roleMapping.getCanonicalRoleNames().isEmpty());
     assertFalse(roleMapping.getCaseSensitive());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/role/NodeRoleDimensionTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/role/NodeRoleDimensionTest.java
@@ -49,11 +49,10 @@ public class NodeRoleDimensionTest {
 
   @Test
   public void testNodeRoles() {
-    NodeRole nodeRole = new NodeRole("roleName", "x(.+)y.*", true);
+    NodeRole nodeRole = new NodeRole("roleName", "x(.+)y.*");
     RoleDimensionMapping rdMap = new RoleDimensionMapping(nodeRole);
 
     assertThat(rdMap.getRegex(), equalTo("(x(.+)y.*)"));
-    assertThat(rdMap.getCaseSensitive(), equalTo(true));
 
     NodeRoleDimension nrDim =
         NodeRoleDimension.builder()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/role/RoleDimensionMappingTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/role/RoleDimensionMappingTest.java
@@ -38,7 +38,7 @@ public class RoleDimensionMappingTest {
   @Test
   public void testGroups() {
     RoleDimensionMapping rdMap =
-        new RoleDimensionMapping("x(b.*d)(.+)y.*", ImmutableList.of(2, 1), null, false);
+        new RoleDimensionMapping("x(b.*d)(.+)y.*", ImmutableList.of(2, 1), null);
     Set<String> nodes = ImmutableSet.of("xbordery", "core", "xbordery2", "xcorey");
     SortedMap<String, String> nodeRolesMap = rdMap.createNodeRolesMap(nodes);
     assertThat(
@@ -49,7 +49,7 @@ public class RoleDimensionMappingTest {
   @Test
   public void testCanonicalNameMap() {
     RoleDimensionMapping rdMap =
-        new RoleDimensionMapping("x(.+)y.*", null, ImmutableMap.of("border", "something"), false);
+        new RoleDimensionMapping("x(.+)y.*", null, ImmutableMap.of("border", "something"));
     Set<String> nodes = ImmutableSet.of("xbordery", "core", "xbordery2", "xcorey");
     SortedMap<String, String> nodeRolesMap = rdMap.createNodeRolesMap(nodes);
     assertThat(
@@ -57,25 +57,5 @@ public class RoleDimensionMappingTest {
         equalTo(
             ImmutableSortedMap.of(
                 "xbordery", "something", "xbordery2", "something", "xcorey", "core")));
-  }
-
-  @Test
-  public void testCaseInsensitive() {
-    RoleDimensionMapping rdMap = new RoleDimensionMapping("x(.+)y.*");
-    Set<String> nodes = ImmutableSet.of("xBorDery", "core", "xboRderY2", "xcorey");
-    SortedMap<String, String> nodeRolesMap = rdMap.createNodeRolesMap(nodes);
-    assertThat(
-        nodeRolesMap,
-        equalTo(
-            ImmutableSortedMap.of("xBorDery", "border", "xboRderY2", "border", "xcorey", "core")));
-  }
-
-  @Test
-  public void testCaseSensitive() {
-    RoleDimensionMapping rdMap = new RoleDimensionMapping("x(.+)y.*", null, null, true);
-    Set<String> nodes = ImmutableSet.of("xBorDery", "core", "xboRderY2", "xcorey");
-    SortedMap<String, String> nodeRolesMap = rdMap.createNodeRolesMap(nodes);
-    assertThat(
-        nodeRolesMap, equalTo(ImmutableSortedMap.of("xBorDery", "BorDer", "xcorey", "core")));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/RoleNameNodeSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/RoleNameNodeSpecifierTest.java
@@ -36,8 +36,7 @@ public class RoleNameNodeSpecifierTest {
                               new RoleDimensionMapping(
                                   "(.*)",
                                   null,
-                                  ImmutableMap.of("node1", "role1", "node2", "role2"),
-                                  false)))
+                                  ImmutableMap.of("node1", "role1", "node2", "role2"))))
                       .build(),
                   NodeRoleDimension.builder()
                       .setName("dim2")
@@ -46,8 +45,7 @@ public class RoleNameNodeSpecifierTest {
                               new RoleDimensionMapping(
                                   "\\(.*\\)",
                                   null,
-                                  ImmutableMap.of("node1", "role1", "node2", "role1"),
-                                  false)))
+                                  ImmutableMap.of("node1", "role1", "node2", "role1"))))
                       .build()))
           .build();
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledNodeSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledNodeSpecifierTest.java
@@ -55,7 +55,7 @@ public class ParboiledNodeSpecifierTest {
                 .setRoleDimensionMappings(
                     ImmutableList.of(
                         new RoleDimensionMapping(
-                            "(node1.*)", null, ImmutableMap.of("node1", roleName), false)))
+                            "(node1.*)", null, ImmutableMap.of("node1", roleName))))
                 .build()));
     assertThat(
         new ParboiledNodeSpecifier(new RoleNodeAstNode(dimensionName, roleName))
@@ -75,7 +75,7 @@ public class ParboiledNodeSpecifierTest {
                 .setRoleDimensionMappings(
                     ImmutableList.of(
                         new RoleDimensionMapping(
-                            "(node1.*)", null, ImmutableMap.of("node1", roleName), false)))
+                            "(node1.*)", null, ImmutableMap.of("node1", roleName))))
                 .build()));
     assertThat(
         new ParboiledNodeSpecifier(new RoleNodeAstNode(roleName, dimensionName))

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -212,6 +212,8 @@ import org.batfish.representation.iptables.IptablesVendorConfiguration;
 import org.batfish.role.InferRoles;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
+import org.batfish.role.NodeRolesData.Type;
+import org.batfish.role.RoleMapping;
 import org.batfish.specifier.AllInterfaceLinksLocationSpecifier;
 import org.batfish.specifier.AllInterfacesLocationSpecifier;
 import org.batfish.specifier.InferFromLocationIpSpaceSpecifier;
@@ -2471,12 +2473,13 @@ public class Batfish extends PluginConsumer implements IBatfish {
     NodeRolesId snapshotNodeRolesId = _idResolver.getSnapshotNodeRolesId(networkId, snapshotId);
     Set<String> nodeNames = loadConfigurations().keySet();
     Topology rawLayer3Topology = _topologyProvider.getRawLayer3Topology(getNetworkSnapshot());
-    List<NodeRoleDimension> autoRoles = new InferRoles(nodeNames, rawLayer3Topology).inferRoles();
+    Optional<RoleMapping> autoRoles = new InferRoles(nodeNames, rawLayer3Topology).inferRoles();
     NodeRolesData.Builder snapshotNodeRoles = NodeRolesData.builder();
     try {
-      if (!autoRoles.isEmpty()) {
-        snapshotNodeRoles.setDefaultDimension(autoRoles.get(0).getName());
-        snapshotNodeRoles.setRoleDimensions(autoRoles);
+      if (autoRoles.isPresent()) {
+        snapshotNodeRoles.setDefaultDimension(NodeRoleDimension.AUTO_DIMENSION_PRIMARY);
+        snapshotNodeRoles.setRoleMappings(ImmutableList.of(autoRoles.get()));
+        snapshotNodeRoles.setType(Type.AUTO);
       }
       _storage.storeNodeRoles(snapshotNodeRoles.build(), snapshotNodeRolesId);
     } catch (IOException e) {

--- a/projects/batfish/src/test/java/org/batfish/specifier/LocationSpecifierTest.java
+++ b/projects/batfish/src/test/java/org/batfish/specifier/LocationSpecifierTest.java
@@ -84,8 +84,7 @@ public class LocationSpecifierTest {
                                 new RoleDimensionMapping(
                                     "(" + n1.getHostname() + ")",
                                     null,
-                                    ImmutableMap.of(n1.getHostname(), roleName),
-                                    true)))
+                                    ImmutableMap.of(n1.getHostname(), roleName))))
                         .build()))
             .build();
   }

--- a/projects/batfish/src/test/java/org/batfish/specifier/NodeSpecifierTest.java
+++ b/projects/batfish/src/test/java/org/batfish/specifier/NodeSpecifierTest.java
@@ -51,8 +51,7 @@ public class NodeSpecifierTest {
                                 new RoleDimensionMapping(
                                     "(" + n1.getHostname() + ")",
                                     null,
-                                    ImmutableMap.of(n1.getHostname(), roleName),
-                                    true)))
+                                    ImmutableMap.of(n1.getHostname(), roleName))))
                         .build()))
             .build();
   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/NetworkNodeRoleDimensionResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/NetworkNodeRoleDimensionResource.java
@@ -77,8 +77,7 @@ public final class NetworkNodeRoleDimensionResource {
             m.getName().orElse(null),
             m.getRegex(),
             delDimensionFromMap(dimension, m.getRoleDimensionsGroups()),
-            delDimensionFromMap(dimension, m.getCanonicalRoleNames()),
-            m.getCaseSensitive());
+            delDimensionFromMap(dimension, m.getCanonicalRoleNames()));
     if (result.getRoleDimensionsGroups().isEmpty()) {
       // this role mapping is useless so let's delete it entirely
       return null;

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/RoleDimensionMappingBean.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/RoleDimensionMappingBean.java
@@ -11,7 +11,6 @@ public class RoleDimensionMappingBean {
   public String regex;
   public List<Integer> groups;
   public Map<String, String> canonicalRoleNames;
-  public boolean caseSensitive;
 
   @JsonCreator
   private RoleDimensionMappingBean() {}
@@ -21,7 +20,6 @@ public class RoleDimensionMappingBean {
     regex = rdMapping.getRegex();
     groups = rdMapping.getGroups();
     canonicalRoleNames = rdMapping.getCanonicalRoleNames();
-    caseSensitive = rdMapping.getCaseSensitive();
   }
 
   @Override
@@ -33,8 +31,7 @@ public class RoleDimensionMappingBean {
             regex, ((org.batfish.coordinator.resources.RoleDimensionMappingBean) o).regex)
         && Objects.equals(
             groups, ((org.batfish.coordinator.resources.RoleDimensionMappingBean) o).groups)
-        && Objects.equals(canonicalRoleNames, ((RoleDimensionMappingBean) o).canonicalRoleNames)
-        && caseSensitive == ((RoleDimensionMappingBean) o).caseSensitive;
+        && Objects.equals(canonicalRoleNames, ((RoleDimensionMappingBean) o).canonicalRoleNames);
   }
 
   @Override
@@ -44,6 +41,6 @@ public class RoleDimensionMappingBean {
 
   /** Gets a {@link RoleDimensionMapping} object from this bean. */
   public RoleDimensionMapping toRoleDimensionMapping() {
-    return new RoleDimensionMapping(regex, groups, canonicalRoleNames, caseSensitive);
+    return new RoleDimensionMapping(regex, groups, canonicalRoleNames);
   }
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/RoleMappingBean.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/RoleMappingBean.java
@@ -12,7 +12,6 @@ public class RoleMappingBean {
   public String regex;
   public Map<String, List<Integer>> roleDimensionGroups;
   public Map<String, Map<String, String>> canonicalRoleNames;
-  public boolean caseSensitive;
 
   @JsonCreator
   private RoleMappingBean() {}
@@ -23,7 +22,6 @@ public class RoleMappingBean {
     regex = roleMapping.getRegex();
     roleDimensionGroups = roleMapping.getRoleDimensionsGroups();
     canonicalRoleNames = roleMapping.getCanonicalRoleNames();
-    caseSensitive = roleMapping.getCaseSensitive();
   }
 
   @Override
@@ -34,17 +32,16 @@ public class RoleMappingBean {
     return Objects.equals(name, ((RoleMappingBean) o).name)
         && Objects.equals(regex, ((RoleMappingBean) o).regex)
         && Objects.equals(roleDimensionGroups, ((RoleMappingBean) o).roleDimensionGroups)
-        && Objects.equals(canonicalRoleNames, ((RoleMappingBean) o).canonicalRoleNames)
-        && caseSensitive == ((RoleMappingBean) o).caseSensitive;
+        && Objects.equals(canonicalRoleNames, ((RoleMappingBean) o).canonicalRoleNames);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, regex, roleDimensionGroups, canonicalRoleNames, caseSensitive);
+    return Objects.hash(name, regex, roleDimensionGroups, canonicalRoleNames);
   }
 
   /** Gets a {@link RoleMapping} object from this bean. */
   public RoleMapping toRoleMapping() {
-    return new RoleMapping(name, regex, roleDimensionGroups, canonicalRoleNames, caseSensitive);
+    return new RoleMapping(name, regex, roleDimensionGroups, canonicalRoleNames);
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -3077,7 +3077,7 @@ public final class WorkMgrTest {
                         .setRoleDimensionMappings(
                             ImmutableList.of(
                                 new RoleDimensionMapping(
-                                    "(" + node + ")", null, ImmutableMap.of(node, "role1"), false)))
+                                    "(" + node + ")", null, ImmutableMap.of(node, "role1"))))
                         .build()))
             .build();
     _manager.getStorage().storeNodeRoles(networkNodeRoles, networkNodeRolesId);

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkNodeRolesResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkNodeRolesResourceTest.java
@@ -115,8 +115,8 @@ public final class NetworkNodeRolesResourceTest extends WorkMgrServiceV2TestBase
             NodeRolesData.builder()
                 .setRoleMappings(
                     ImmutableList.of(
-                        new RoleMapping(name, "", null, null, false),
-                        new RoleMapping(name, "", null, null, false)))
+                        new RoleMapping(name, "", null, null),
+                        new RoleMapping(name, "", null, null)))
                 .build(),
             null);
 
@@ -132,8 +132,8 @@ public final class NetworkNodeRolesResourceTest extends WorkMgrServiceV2TestBase
             NodeRolesData.builder()
                 .setRoleMappings(
                     ImmutableList.of(
-                        new RoleMapping(name1, "", null, null, false),
-                        new RoleMapping(name2, "", null, null, false)))
+                        new RoleMapping(name1, "", null, null),
+                        new RoleMapping(name2, "", null, null)))
                 .build(),
             null);
 
@@ -149,8 +149,8 @@ public final class NetworkNodeRolesResourceTest extends WorkMgrServiceV2TestBase
             NodeRolesData.builder()
                 .setRoleMappings(
                     ImmutableList.of(
-                        new RoleMapping(name1, "", null, null, false),
-                        new RoleMapping(name2, "", null, null, false)))
+                        new RoleMapping(name1, "", null, null),
+                        new RoleMapping(name2, "", null, null)))
                 .build(),
             null);
 
@@ -167,8 +167,8 @@ public final class NetworkNodeRolesResourceTest extends WorkMgrServiceV2TestBase
             NodeRolesData.builder()
                 .setRoleMappings(
                     ImmutableList.of(
-                        new RoleMapping(name, "", null, null, false),
-                        new RoleMapping(name, "", null, null, false)))
+                        new RoleMapping(name, "", null, null),
+                        new RoleMapping(name, "", null, null)))
                 .build(),
             null);
     Response response =

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRolesDataBeanTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRolesDataBeanTest.java
@@ -16,7 +16,7 @@ public class NodeRolesDataBeanTest extends WorkMgrServiceV2TestBase {
   public void testProperties() {
     String snapshot = "snapshot1";
     String dimension = "someDimension";
-    RoleMapping rMapping = new RoleMapping("mymap", "\\(.*\\)", null, null, false);
+    RoleMapping rMapping = new RoleMapping("mymap", "\\(.*\\)", null, null);
     NodeRolesData data =
         NodeRolesData.builder()
             .setRoleMappings(ImmutableList.of(rMapping))

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/RoleDimensionMappingBeanTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/RoleDimensionMappingBeanTest.java
@@ -18,14 +18,12 @@ public class RoleDimensionMappingBeanTest {
     List<Integer> groups = ImmutableList.of(3, 4, 1);
     Map<String, String> canonicalRoleNames = ImmutableMap.of("baz", "bar", "bar", "foo");
     boolean caseSensitive = true;
-    RoleDimensionMapping rdMap =
-        new RoleDimensionMapping(regex, groups, canonicalRoleNames, caseSensitive);
+    RoleDimensionMapping rdMap = new RoleDimensionMapping(regex, groups, canonicalRoleNames);
     RoleDimensionMappingBean bean = new RoleDimensionMappingBean(rdMap);
 
     assertThat(bean.regex, equalTo(regex));
     assertThat(bean.groups, equalTo(groups));
     assertThat(bean.canonicalRoleNames, equalTo(canonicalRoleNames));
-    assertThat(bean.caseSensitive, equalTo(caseSensitive));
   }
 
   @Test
@@ -34,8 +32,7 @@ public class RoleDimensionMappingBeanTest {
     List<Integer> groups = ImmutableList.of(3, 4, 1);
     Map<String, String> canonicalRoleNames = ImmutableMap.of("baz", "bar", "bar", "foo");
     boolean caseSensitive = true;
-    RoleDimensionMapping rdMap =
-        new RoleDimensionMapping(regex, groups, canonicalRoleNames, caseSensitive);
+    RoleDimensionMapping rdMap = new RoleDimensionMapping(regex, groups, canonicalRoleNames);
     RoleDimensionMappingBean bean = new RoleDimensionMappingBean(rdMap);
 
     assertThat(bean.toRoleDimensionMapping(), equalTo(rdMap));

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/RoleDimensionMappingBeanTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/RoleDimensionMappingBeanTest.java
@@ -17,7 +17,6 @@ public class RoleDimensionMappingBeanTest {
     String regex = "(.*)";
     List<Integer> groups = ImmutableList.of(3, 4, 1);
     Map<String, String> canonicalRoleNames = ImmutableMap.of("baz", "bar", "bar", "foo");
-    boolean caseSensitive = true;
     RoleDimensionMapping rdMap = new RoleDimensionMapping(regex, groups, canonicalRoleNames);
     RoleDimensionMappingBean bean = new RoleDimensionMappingBean(rdMap);
 
@@ -31,7 +30,6 @@ public class RoleDimensionMappingBeanTest {
     String regex = "(.*)";
     List<Integer> groups = ImmutableList.of(3, 4, 1);
     Map<String, String> canonicalRoleNames = ImmutableMap.of("baz", "bar", "bar", "foo");
-    boolean caseSensitive = true;
     RoleDimensionMapping rdMap = new RoleDimensionMapping(regex, groups, canonicalRoleNames);
     RoleDimensionMappingBean bean = new RoleDimensionMappingBean(rdMap);
 

--- a/projects/question/src/main/java/org/batfish/question/InferRolesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/InferRolesQuestionPlugin.java
@@ -54,8 +54,7 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
                   nodes,
                   _batfish
                       .getTopologyProvider()
-                      .getInitialLayer3Topology(_batfish.getNetworkSnapshot()),
-                  question.getCaseSensitive())
+                      .getInitialLayer3Topology(_batfish.getNetworkSnapshot()))
               .inferRoles();
       return new InferRolesAnswerElement(roleMapping);
     }
@@ -68,15 +67,11 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
    */
   public static final class InferRolesQuestion extends Question {
     private static final String PROP_NODE_REGEX = "nodeRegex";
-    private static final String PROP_CASE_SENSITIVE = "caseSensitive";
 
     private NodesSpecifier _nodeRegex;
 
-    private boolean _caseSensitive;
-
     public InferRolesQuestion() {
       _nodeRegex = NodesSpecifier.ALL;
-      _caseSensitive = false;
     }
 
     @Override
@@ -97,16 +92,6 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
     @JsonProperty(PROP_NODE_REGEX)
     public void setNodeRegex(NodesSpecifier regex) {
       _nodeRegex = regex;
-    }
-
-    @JsonProperty(PROP_CASE_SENSITIVE)
-    public boolean getCaseSensitive() {
-      return _caseSensitive;
-    }
-
-    @JsonProperty(PROP_CASE_SENSITIVE)
-    public void setCaseSensitive(boolean caseSensitive) {
-      _caseSensitive = caseSensitive;
     }
   }
 

--- a/projects/question/src/main/java/org/batfish/question/InferRolesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/InferRolesQuestionPlugin.java
@@ -3,12 +3,8 @@ package org.batfish.question;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.service.AutoService;
-import java.util.List;
+import java.util.Optional;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.SortedSet;
-import java.util.TreeMap;
-import java.util.TreeSet;
 import javax.annotation.Nonnull;
 import org.batfish.common.Answerer;
 import org.batfish.common.plugin.IBatfish;
@@ -17,35 +13,25 @@ import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.questions.NodesSpecifier;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.role.InferRoles;
-import org.batfish.role.NodeRoleDimension;
+import org.batfish.role.RoleMapping;
 
 @AutoService(Plugin.class)
 public class InferRolesQuestionPlugin extends QuestionPlugin {
 
   public static class InferRolesAnswerElement extends AnswerElement {
-    private static final String PROP_ROLE_DIMENSIONS = "roleDimensions";
-    private static final String PROP_MATCHING_NODES_COUNT = "matchingNodesCount";
+    private static final String PROP_ROLE_MAPPING = "roleMapping";
 
-    @Nonnull private final SortedSet<NodeRoleDimension> _roleDimensions;
-
-    @Nonnull private final SortedMap<String, Integer> _matchingNodesCount;
+    @Nonnull private final Optional<RoleMapping> _roleMapping;
 
     @JsonCreator
     public InferRolesAnswerElement(
-        @JsonProperty(PROP_ROLE_DIMENSIONS) SortedSet<NodeRoleDimension> roleDimensions,
-        @JsonProperty(PROP_MATCHING_NODES_COUNT) SortedMap<String, Integer> matchingNodesCount) {
-      _roleDimensions = roleDimensions == null ? new TreeSet<>() : roleDimensions;
-      _matchingNodesCount = matchingNodesCount == null ? new TreeMap<>() : matchingNodesCount;
+        @JsonProperty(PROP_ROLE_MAPPING) Optional<RoleMapping> roleMapping) {
+      _roleMapping = roleMapping;
     }
 
-    @JsonProperty(PROP_MATCHING_NODES_COUNT)
-    public SortedMap<String, Integer> getMatchingNodesCount() {
-      return _matchingNodesCount;
-    }
-
-    @JsonProperty(PROP_ROLE_DIMENSIONS)
-    public SortedSet<NodeRoleDimension> getRoleDimensions() {
-      return _roleDimensions;
+    @JsonProperty(PROP_ROLE_MAPPING)
+    public Optional<RoleMapping> getRoleDimensions() {
+      return _roleMapping;
     }
   }
 
@@ -59,12 +45,11 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
     public InferRolesAnswerElement answer() {
 
       InferRolesQuestion question = (InferRolesQuestion) _question;
-      InferRolesAnswerElement answerElement = new InferRolesAnswerElement(null, null);
 
       // collect relevant nodes in a list.
       Set<String> nodes = question.getNodeRegex().getMatchingNodes(_batfish);
 
-      List<NodeRoleDimension> roleDimensions =
+      Optional<RoleMapping> roleMapping =
           new InferRoles(
                   nodes,
                   _batfish
@@ -72,18 +57,7 @@ public class InferRolesQuestionPlugin extends QuestionPlugin {
                       .getInitialLayer3Topology(_batfish.getNetworkSnapshot()),
                   question.getCaseSensitive())
               .inferRoles();
-      answerElement.getRoleDimensions().addAll(roleDimensions);
-
-      for (NodeRoleDimension dimension : roleDimensions) {
-        SortedMap<String, SortedSet<String>> roleNodesMap = dimension.createRoleNodesMap(nodes);
-        SortedSet<String> matchingNodes = new TreeSet<>();
-        for (SortedSet<String> nodeSet : roleNodesMap.values()) {
-          matchingNodes.addAll(nodeSet);
-        }
-
-        answerElement.getMatchingNodesCount().put(dimension.getName(), matchingNodes.size());
-      }
-      return answerElement;
+      return new InferRolesAnswerElement(roleMapping);
     }
   }
 

--- a/tests/roles/inferRoles.ref
+++ b/tests/roles/inferRoles.ref
@@ -1,35 +1,16 @@
 [
   {
     "class" : "org.batfish.question.InferRolesQuestionPlugin$InferRolesAnswerElement",
-    "matchingNodesCount" : {
-      "auto0" : 13,
-      "auto1" : 13
-    },
-    "roleDimensions" : [
-      {
-        "name" : "auto0",
-        "roleDimensionMappings" : [
-          {
-            "caseSensitive" : false,
-            "groups" : [
-              1
-            ],
-            "regex" : "\\p{Alpha}+\\p{Digit}+(\\p{Alpha}+)\\p{Digit}+"
-          }
-        ]
-      },
-      {
-        "name" : "auto1",
-        "roleDimensionMappings" : [
-          {
-            "caseSensitive" : false,
-            "groups" : [
-              1
-            ],
-            "regex" : "(\\p{Alpha}+)\\p{Digit}+\\p{Alpha}+\\p{Digit}+"
-          }
+    "roleMapping" : {
+      "regex" : "(\\p{Alpha}+)\\p{Digit}+(\\p{Alpha}+)\\p{Digit}+",
+      "roleDimensionGroups" : {
+        "auto0" : [
+          2
+        ],
+        "auto1" : [
+          1
         ]
       }
-    ]
+    }
   }
 ]

--- a/tests/roles/roles.ref
+++ b/tests/roles/roles.ref
@@ -5,14 +5,12 @@
       "name" : "default",
       "roleDimensionMappings" : [
         {
-          "caseSensitive" : false,
           "groups" : [
             1
           ],
           "regex" : "as.(.*).+"
         },
         {
-          "caseSensitive" : false,
           "groups" : [
             1
           ],


### PR DESCRIPTION
Updates role inference to the new roles format.

Also simplifies roles inference -- it no longer tries to automatically combine parts of a node name to identify the "one true role" but instead simply records each of the different parts as distinct role dimensions.

Also removed the case-sensitive flag from role specifications and questions, since it is not applicable to role names that are derived from node names (as those are always case-insensitive).