### PR TITLE
Make EVPN Type 3 routes for L2 VNIs only

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -95,7 +95,6 @@ import org.batfish.datamodel.isis.IsisTopology;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.datamodel.vxlan.Layer3Vni;
-import org.batfish.datamodel.vxlan.Vni;
 import org.batfish.dataplane.protocols.BgpProtocolHelper;
 import org.batfish.dataplane.protocols.GeneratedRouteHelper;
 import org.batfish.dataplane.rib.AnnotatedRib;
@@ -2057,12 +2056,6 @@ public class VirtualRouter implements Serializable {
       _layer2Vnis =
           _layer2Vnis.stream()
               .map(vs -> updateVniFloodList(vs, route))
-              .map(Layer2Vni.class::cast)
-              .collect(ImmutableSet.toImmutableSet());
-      _layer3Vnis =
-          _layer3Vnis.stream()
-              .map(vs -> updateVniFloodList(vs, route))
-              .map(Layer3Vni.class::cast)
               .collect(ImmutableSet.toImmutableSet());
     }
   }
@@ -2073,7 +2066,7 @@ public class VirtualRouter implements Serializable {
    * and if the {@link Layer2Vni#getBumTransportMethod()} is unicast flood group (otherwise returns
    * the original {@code vs}).
    */
-  private static Vni updateVniFloodList(Vni vs, EvpnType3Route route) {
+  private static Layer2Vni updateVniFloodList(Layer2Vni vs, EvpnType3Route route) {
     if (vs.getBumTransportMethod() != BumTransportMethod.UNICAST_FLOOD_GROUP
         || route.getVniIp().equals(vs.getSourceAddress())) {
       // Only update settings if transport method is unicast.

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -41,6 +41,7 @@ import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.bgp.BgpTopology.EdgeId;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.bgp.Layer2VniConfig;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
 import org.batfish.datamodel.bgp.Layer3VniConfig.Builder;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
@@ -143,16 +144,15 @@ public class BgpRoutingProcessTest {
     Ip localIp = Ip.parse("2.2.2.2");
     int vni = 10001;
     int vni2 = 10002;
-    Builder vniConfigBuilder =
-        Layer3VniConfig.builder()
+    Layer2VniConfig.Builder vniConfigBuilder =
+        Layer2VniConfig.builder()
             .setVni(vni)
             .setVrf(DEFAULT_VRF_NAME)
             .setRouteDistinguisher(RouteDistinguisher.from(_bgpProcess.getRouterId(), 2))
             .setRouteTarget(ExtendedCommunity.target(65500, vni))
-            .setImportRouteTarget(VniConfig.importRtPatternForAnyAs(vni))
-            .setAdvertiseV4Unicast(false);
-    Layer3VniConfig vniConfig1 = vniConfigBuilder.build();
-    Layer3VniConfig vniConfig2 =
+            .setImportRouteTarget(VniConfig.importRtPatternForAnyAs(vni));
+    Layer2VniConfig vniConfig1 = vniConfigBuilder.build();
+    Layer2VniConfig vniConfig2 =
         vniConfigBuilder
             .setVni(vni2)
             .setVrf(_vrf2.getName())
@@ -166,8 +166,8 @@ public class BgpRoutingProcessTest {
             .setLocalAs(2L)
             .setEvpnAddressFamily(
                 EvpnAddressFamily.builder()
-                    .setL2Vnis(ImmutableSet.of())
-                    .setL3Vnis(ImmutableSet.of(vniConfig1, vniConfig2))
+                    .setL2Vnis(ImmutableSet.of(vniConfig1, vniConfig2))
+                    .setL3Vnis(ImmutableSet.of())
                     .setPropagateUnmatched(true)
                     .build())
             .build();
@@ -363,15 +363,14 @@ public class BgpRoutingProcessTest {
     Ip localIp = Ip.parse("2.2.2.2");
     Ip peerIp = Ip.parse("1.1.1.1");
     int vni = 10001;
-    Builder vniConfigBuilder =
-        Layer3VniConfig.builder()
+    Layer2VniConfig.Builder vniConfigBuilder =
+        Layer2VniConfig.builder()
             .setVni(vni)
             .setVrf(DEFAULT_VRF_NAME)
             .setRouteDistinguisher(RouteDistinguisher.from(_bgpProcess.getRouterId(), 2))
             .setRouteTarget(ExtendedCommunity.target(65500, vni))
-            .setImportRouteTarget(VniConfig.importRtPatternForAnyAs(vni))
-            .setAdvertiseV4Unicast(false);
-    Layer3VniConfig vniConfig1 = vniConfigBuilder.build();
+            .setImportRouteTarget(VniConfig.importRtPatternForAnyAs(vni));
+    Layer2VniConfig vniConfig1 = vniConfigBuilder.build();
     String policyName = "POL";
     BgpActivePeerConfig evpnPeer =
         BgpActivePeerConfig.builder()
@@ -381,8 +380,8 @@ public class BgpRoutingProcessTest {
             .setLocalAs(localAs)
             .setEvpnAddressFamily(
                 EvpnAddressFamily.builder()
-                    .setL2Vnis(ImmutableSet.of())
-                    .setL3Vnis(ImmutableSet.of(vniConfig1))
+                    .setL2Vnis(ImmutableSet.of(vniConfig1))
+                    .setL3Vnis(ImmutableSet.of())
                     .setPropagateUnmatched(true)
                     .setExportPolicy(policyName)
                     .build())

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
@@ -34,8 +34,8 @@ import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
-import org.batfish.datamodel.bgp.Layer3VniConfig;
-import org.batfish.datamodel.bgp.Layer3VniConfig.Builder;
+import org.batfish.datamodel.bgp.Layer2VniConfig;
+import org.batfish.datamodel.bgp.Layer2VniConfig.Builder;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
@@ -123,13 +123,13 @@ public class EvpnTest {
                 .build()));
 
     Builder vniConfigBuilder =
-        Layer3VniConfig.builder()
+        Layer2VniConfig.builder()
             .setVni(vni)
             .setVrf(DEFAULT_VRF_NAME)
             .setRouteDistinguisher(RouteDistinguisher.from(bgpProcess1.getRouterId(), 1))
             .setRouteTarget(ExtendedCommunity.target(65500, vni));
-    Layer3VniConfig vniConfig1 = vniConfigBuilder.build();
-    Layer3VniConfig vniConfig2 =
+    Layer2VniConfig vniConfig1 = vniConfigBuilder.build();
+    Layer2VniConfig vniConfig2 =
         vniConfigBuilder
             .setVni(vni)
             .setRouteDistinguisher(RouteDistinguisher.from(bgpProcess2.getRouterId(), 2))
@@ -142,8 +142,8 @@ public class EvpnTest {
         .setBgpProcess(bgpProcess1)
         .setEvpnAddressFamily(
             EvpnAddressFamily.builder()
-                .setL2Vnis(ImmutableSet.of())
-                .setL3Vnis(ImmutableSet.of(vniConfig1))
+                .setL2Vnis(ImmutableSet.of(vniConfig1))
+                .setL3Vnis(ImmutableSet.of())
                 .setPropagateUnmatched(true)
                 .setAddressFamilyCapabilities(
                     AddressFamilyCapabilities.builder()
@@ -163,8 +163,8 @@ public class EvpnTest {
         .setBgpProcess(bgpProcess2)
         .setEvpnAddressFamily(
             EvpnAddressFamily.builder()
-                .setL2Vnis(ImmutableSet.of())
-                .setL3Vnis(ImmutableSet.of(vniConfig2))
+                .setL2Vnis(ImmutableSet.of(vniConfig2))
+                .setL3Vnis(ImmutableSet.of())
                 .setPropagateUnmatched(true)
                 .setAddressFamilyCapabilities(
                     AddressFamilyCapabilities.builder()
@@ -236,14 +236,6 @@ public class EvpnTest {
                 allOf(
                     hasPrefix(leaf1VtepPrefix),
                     hasCommunities(
-                        equalTo(ImmutableSet.of(ExtendedCommunity.target(65000, 100333))))))));
-    assertThat(
-        exitgwRoutes,
-        hasItem(
-            isEvpnType3RouteThat(
-                allOf(
-                    hasPrefix(leaf1VtepPrefix),
-                    hasCommunities(
                         equalTo(ImmutableSet.of(ExtendedCommunity.target(65000, 10010))))))));
     assertThat(
         exitgwRoutes,
@@ -256,14 +248,6 @@ public class EvpnTest {
     assertThat(exitgwRoutes, not(hasItem(isEvpnType3RouteThat(hasPrefix(exitgwVtepPrefix)))));
 
     Set<AbstractRoute> leaf1Routes = routes.get(leaf1).get(vrf1);
-    assertThat(
-        leaf1Routes,
-        hasItem(
-            isEvpnType3RouteThat(
-                allOf(
-                    hasPrefix(exitgwVtepPrefix),
-                    hasCommunities(
-                        equalTo(ImmutableSet.of(ExtendedCommunity.target(65000, 100333))))))));
     assertThat(
         leaf1Routes,
         hasItem(


### PR DESCRIPTION
Fixes some issues uncovered by our validation.
Flood lists (and thus Type 3 routes) only apply to L2 VNIs.