### PR TITLE
Include incoming interfaces in MatchSessionStepDetail

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
@@ -2,10 +2,12 @@ package org.batfish.datamodel.flow;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
@@ -21,10 +23,15 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
 
     @Nonnull private final Set<String> _incomingInterfaces;
 
+    private MatchSessionStepDetail(@Nonnull Set<String> incomingInterfaces) {
+      _incomingInterfaces = ImmutableSet.copyOf(incomingInterfaces);
+    }
+
     @JsonCreator
-    private MatchSessionStepDetail(
-        @JsonProperty(PROP_INCOMING_INTERFACES) @Nonnull Set<String> incomingInterfaces) {
-      _incomingInterfaces = incomingInterfaces;
+    private static MatchSessionStepDetail jsonCreator(
+        @JsonProperty(PROP_INCOMING_INTERFACES) Set<String> incomingInterfaces) {
+      checkArgument(incomingInterfaces != null, "Missing %s", PROP_ACTION);
+      return new MatchSessionStepDetail(incomingInterfaces);
     }
 
     @JsonProperty(PROP_INCOMING_INTERFACES)
@@ -42,7 +49,7 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
       private @Nullable Set<String> _incomingInterfaces;
 
       public MatchSessionStepDetail build() {
-        return new MatchSessionStepDetail(_incomingInterfaces);
+        return new MatchSessionStepDetail(firstNonNull(_incomingInterfaces, ImmutableSet.of()));
       }
 
       public Builder setIncomingInterfaces(Set<String> incomingInterfaces) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
@@ -71,29 +71,7 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
     return new MatchSessionStep(detail);
   }
 
-  private MatchSessionStep(MatchSessionStepDetail detail) {
+  public MatchSessionStep(MatchSessionStepDetail detail) {
     super(detail, StepAction.MATCHED_SESSION);
-  }
-
-  public static Builder builder() {
-    return new Builder();
-  }
-
-  /** Chained builder to create a {@link MatchSessionStep} object */
-  public static final class Builder {
-    private @Nullable MatchSessionStepDetail _detail;
-
-    public MatchSessionStep build() {
-      checkState(_detail != null, "Must call setDetail before building");
-      return new MatchSessionStep(_detail);
-    }
-
-    public Builder setDetail(MatchSessionStepDetail detail) {
-      _detail = detail;
-      return this;
-    }
-
-    /** Only for use by {@link MatchSessionStep#builder()}. */
-    private Builder() {}
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
@@ -1,16 +1,15 @@
 package org.batfish.datamodel.flow;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
-import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.flow.MatchSessionStep.MatchSessionStepDetail;
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
@@ -74,7 +74,7 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
 
   /** Chained builder to create a {@link MatchSessionStep} object */
   public static final class Builder {
-    private @Nullable MatchSessionStepDetail  _detail;
+    private @Nullable MatchSessionStepDetail _detail;
 
     public MatchSessionStep build() {
       checkState(_detail != null, "Must call setDetail before building");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
@@ -19,7 +19,7 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
   public static final class MatchSessionStepDetail {
     private static final String PROP_INCOMING_INTERFACES = "incomingInterfaces";
 
-    @Nonnull private Set<String> _incomingInterfaces;
+    @Nonnull private final Set<String> _incomingInterfaces;
 
     @JsonCreator
     private MatchSessionStepDetail(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
@@ -1,29 +1,92 @@
 package org.batfish.datamodel.flow;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.util.Set;
 import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.flow.MatchSessionStep.MatchSessionStepDetail;
 
 /** A {@link Step} for when a {@link Flow} matches a session. */
 @JsonTypeName("MatchSession")
 public class MatchSessionStep extends Step<MatchSessionStepDetail> {
-  public MatchSessionStep() {
-    super(DETAIL, StepAction.MATCHED_SESSION);
+
+  public static final class MatchSessionStepDetail {
+    private static final String PROP_INCOMING_INTERFACES = "incomingInterfaces";
+
+    @Nonnull private Set<String> _incomingInterfaces;
+
+    @JsonCreator
+    private MatchSessionStepDetail(
+        @JsonProperty(PROP_INCOMING_INTERFACES) @Nonnull Set<String> incomingInterfaces) {
+      _incomingInterfaces = incomingInterfaces;
+    }
+
+    @JsonProperty(PROP_INCOMING_INTERFACES)
+    @Nonnull
+    public Set<String> getIncomingInterfaces() {
+      return _incomingInterfaces;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    /** Chained builder to create a {@link MatchSessionStepDetail} object */
+    public static class Builder {
+      private @Nullable Set<String> _incomingInterfaces;
+
+      public MatchSessionStepDetail build() {
+        return new MatchSessionStepDetail(_incomingInterfaces);
+      }
+
+      public Builder setIncomingInterfaces(Set<String> incomingInterfaces) {
+        _incomingInterfaces = incomingInterfaces;
+        return this;
+      }
+
+      /** Only for use by {@link MatchSessionStepDetail#builder()}. */
+      private Builder() {}
+    }
   }
-
-  static final class MatchSessionStepDetail {}
-
-  private static final MatchSessionStepDetail DETAIL = new MatchSessionStepDetail();
 
   @JsonCreator
   private static MatchSessionStep jsonCreator(
+      @Nullable @JsonProperty(PROP_DETAIL) MatchSessionStepDetail detail,
       @Nullable @JsonProperty(PROP_ACTION) StepAction action) {
     checkArgument(action != null, "Missing %s", PROP_ACTION);
-    return new MatchSessionStep();
+    checkArgument(detail != null, "Missing %s", PROP_DETAIL);
+    return new MatchSessionStep(detail);
+  }
+
+  private MatchSessionStep(MatchSessionStepDetail detail) {
+    super(detail, StepAction.MATCHED_SESSION);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Chained builder to create a {@link MatchSessionStep} object */
+  public static final class Builder {
+    private @Nullable MatchSessionStepDetail  _detail;
+
+    public MatchSessionStep build() {
+      checkState(_detail != null, "Must call setDetail before building");
+      return new MatchSessionStep(_detail);
+    }
+
+    public Builder setDetail(MatchSessionStepDetail detail) {
+      _detail = detail;
+      return this;
+    }
+
+    /** Only for use by {@link MatchSessionStep#builder()}. */
+    private Builder() {}
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
@@ -15,9 +15,11 @@ public final class MatchSessionStepTest {
   public void testBuilder() {
     Set<String> incomingInterfaces = new HashSet<String>();
     incomingInterfaces.add("a");
-    MatchSessionStep step = MatchSessionStep.builder().setDetail(
-        MatchSessionStepDetail.builder().setIncomingInterfaces(incomingInterfaces).build()
-    ).build();
+    MatchSessionStep step =
+        MatchSessionStep.builder()
+            .setDetail(
+                MatchSessionStepDetail.builder().setIncomingInterfaces(incomingInterfaces).build())
+            .build();
 
     assertEquals(step.getAction(), StepAction.MATCHED_SESSION);
 
@@ -30,14 +32,16 @@ public final class MatchSessionStepTest {
   public void testJsonSerialization() throws IOException {
     Set<String> incomingInterfaces = new HashSet<String>();
     incomingInterfaces.add("b");
-    MatchSessionStep step = MatchSessionStep.builder().setDetail(
-      MatchSessionStep.MatchSessionStepDetail
-          .builder().setIncomingInterfaces(incomingInterfaces).build()
-    ).build();
+    MatchSessionStep step =
+        MatchSessionStep.builder()
+            .setDetail(
+                MatchSessionStep.MatchSessionStepDetail.builder()
+                    .setIncomingInterfaces(incomingInterfaces)
+                    .build())
+            .build();
     MatchSessionStep clone = BatfishObjectMapper.clone(step, MatchSessionStep.class);
     assertEquals(step.getAction(), clone.getAction());
     assertEquals(
-        step.getDetail().getIncomingInterfaces(),
-        clone.getDetail().getIncomingInterfaces());
+        step.getDetail().getIncomingInterfaces(), clone.getDetail().getIncomingInterfaces());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
@@ -2,17 +2,42 @@ package org.batfish.datamodel.flow;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Set;
+import java.util.HashSet;
 import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.flow.MatchSessionStep.MatchSessionStepDetail;
 import org.junit.Test;
 
 /** Test for {@link MatchSessionStep}. */
 public final class MatchSessionStepTest {
   @Test
+  public void testBuilder() {
+    Set<String> incomingInterfaces = new HashSet<String>();
+    incomingInterfaces.add("a");
+    MatchSessionStep step = MatchSessionStep.builder().setDetail(
+        MatchSessionStepDetail.builder().setIncomingInterfaces(incomingInterfaces).build()
+    ).build();
+
+    assertEquals(step.getAction(), StepAction.MATCHED_SESSION);
+
+    Set<String> testInterfaces = new HashSet<String>();
+    testInterfaces.add("a");
+    assertEquals(step.getDetail().getIncomingInterfaces(), testInterfaces);
+  }
+
+  @Test
   public void testJsonSerialization() throws IOException {
-    MatchSessionStep step = new MatchSessionStep();
+    Set<String> incomingInterfaces = new HashSet<String>();
+    incomingInterfaces.add("b");
+    MatchSessionStep step = MatchSessionStep.builder().setDetail(
+      MatchSessionStep.MatchSessionStepDetail
+          .builder().setIncomingInterfaces(incomingInterfaces).build()
+    ).build();
     MatchSessionStep clone = BatfishObjectMapper.clone(step, MatchSessionStep.class);
     assertEquals(step.getAction(), clone.getAction());
-    assertEquals(step.getDetail(), clone.getDetail());
+    assertEquals(
+        step.getDetail().getIncomingInterfaces(),
+        clone.getDetail().getIncomingInterfaces());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
-import java.util.HashSet;
 import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.flow.MatchSessionStep.MatchSessionStepDetail;
@@ -13,33 +12,28 @@ import org.junit.Test;
 /** Test for {@link MatchSessionStep}. */
 public final class MatchSessionStepTest {
   @Test
-  public void testBuilder() {
+  public void testConstructor() {
     Set<String> incomingInterfaces = ImmutableSet.of("a");
     MatchSessionStep step =
-        MatchSessionStep.builder()
-            .setDetail(
-                MatchSessionStepDetail.builder().setIncomingInterfaces(incomingInterfaces).build())
-            .build();
+        new MatchSessionStep(
+            MatchSessionStepDetail.builder().setIncomingInterfaces(incomingInterfaces).build());
 
     assertEquals(step.getAction(), StepAction.MATCHED_SESSION);
-
     assertEquals(step.getDetail().getIncomingInterfaces(), incomingInterfaces);
   }
 
   @Test
   public void testJsonSerialization() throws IOException {
-    Set<String> incomingInterfaces = new HashSet<String>();
-    incomingInterfaces.add("b");
+    Set<String> incomingInterfaces = ImmutableSet.of("b");
     MatchSessionStep step =
-        MatchSessionStep.builder()
-            .setDetail(
-                MatchSessionStep.MatchSessionStepDetail.builder()
-                    .setIncomingInterfaces(incomingInterfaces)
-                    .build())
-            .build();
+        new MatchSessionStep(
+            MatchSessionStep.MatchSessionStepDetail.builder()
+                .setIncomingInterfaces(incomingInterfaces)
+                .build());
     MatchSessionStep clone = BatfishObjectMapper.clone(step, MatchSessionStep.class);
     assertEquals(step.getAction(), clone.getAction());
     assertEquals(
         step.getDetail().getIncomingInterfaces(), clone.getDetail().getIncomingInterfaces());
+    assertEquals(clone.getDetail().getIncomingInterfaces(), incomingInterfaces);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
@@ -3,8 +3,8 @@ package org.batfish.datamodel.flow;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
-import java.util.Set;
 import java.io.IOException;
+import java.util.Set;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.flow.MatchSessionStep.MatchSessionStepDetail;
 import org.junit.Test;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel.flow;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import java.util.HashSet;
 import java.io.IOException;
@@ -13,8 +14,7 @@ import org.junit.Test;
 public final class MatchSessionStepTest {
   @Test
   public void testBuilder() {
-    Set<String> incomingInterfaces = new HashSet<String>();
-    incomingInterfaces.add("a");
+    Set<String> incomingInterfaces = ImmutableSet.of("a");
     MatchSessionStep step =
         MatchSessionStep.builder()
             .setDetail(
@@ -23,9 +23,7 @@ public final class MatchSessionStepTest {
 
     assertEquals(step.getAction(), StepAction.MATCHED_SESSION);
 
-    Set<String> testInterfaces = new HashSet<String>();
-    testInterfaces.add("a");
-    assertEquals(step.getDetail().getIncomingInterfaces(), testInterfaces);
+    assertEquals(step.getDetail().getIncomingInterfaces(), incomingInterfaces);
   }
 
   @Test

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -781,10 +781,13 @@ class FlowTracer {
     }
     FirewallSessionTraceInfo session = matchingSessions.get(0);
 
-    MatchSessionStep matchSessionStep = MatchSessionStep.builder().setDetail(
-        MatchSessionStepDetail.builder()
-            .setIncomingInterfaces(session.getIncomingInterfaces()).build()
-    ).build();
+    MatchSessionStep matchSessionStep =
+        MatchSessionStep.builder()
+            .setDetail(
+                MatchSessionStepDetail.builder()
+                    .setIncomingInterfaces(session.getIncomingInterfaces())
+                    .build())
+            .build();
     _steps.add(matchSessionStep);
 
     Configuration config = _tracerouteContext.getConfigurations().get(currentNodeName);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -77,6 +77,7 @@ import org.batfish.datamodel.flow.Hop;
 import org.batfish.datamodel.flow.InboundStep;
 import org.batfish.datamodel.flow.InboundStep.InboundStepDetail;
 import org.batfish.datamodel.flow.MatchSessionStep;
+import org.batfish.datamodel.flow.MatchSessionStep.MatchSessionStepDetail;
 import org.batfish.datamodel.flow.OriginateStep;
 import org.batfish.datamodel.flow.OriginateStep.OriginateStepDetail;
 import org.batfish.datamodel.flow.PolicyStep;
@@ -780,7 +781,11 @@ class FlowTracer {
     }
     FirewallSessionTraceInfo session = matchingSessions.get(0);
 
-    _steps.add(new MatchSessionStep());
+    MatchSessionStep matchSessionStep = MatchSessionStep.builder().setDetail(
+        MatchSessionStepDetail.builder()
+            .setIncomingInterfaces(session.getIncomingInterfaces()).build()
+    ).build();
+    _steps.add(matchSessionStep);
 
     Configuration config = _tracerouteContext.getConfigurations().get(currentNodeName);
     Map<String, IpAccessList> ipAccessLists = config.getIpAccessLists();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -781,14 +781,11 @@ class FlowTracer {
     }
     FirewallSessionTraceInfo session = matchingSessions.get(0);
 
-    MatchSessionStep matchSessionStep =
-        MatchSessionStep.builder()
-            .setDetail(
-                MatchSessionStepDetail.builder()
-                    .setIncomingInterfaces(session.getIncomingInterfaces())
-                    .build())
-            .build();
-    _steps.add(matchSessionStep);
+    _steps.add(
+        new MatchSessionStep(
+            MatchSessionStepDetail.builder()
+                .setIncomingInterfaces(session.getIncomingInterfaces())
+                .build()));
 
     Configuration config = _tracerouteContext.getConfigurations().get(currentNodeName);
     Map<String, IpAccessList> ipAccessLists = config.getIpAccessLists();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -48,8 +48,11 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
@@ -102,6 +105,7 @@ import org.batfish.datamodel.flow.FilterStep.FilterType;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
 import org.batfish.datamodel.flow.ForwardOutInterface;
 import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.MatchSessionStep;
 import org.batfish.datamodel.flow.OriginateStep;
 import org.batfish.datamodel.flow.RouteInfo;
 import org.batfish.datamodel.flow.RoutingStep;
@@ -1941,6 +1945,10 @@ public class TracerouteEngineImplTest {
           tracerouteEngine
               .computeTracesAndReverseFlows(ImmutableSet.of(flow), ImmutableSet.of(), false)
               .get(flow);
+      // MatchSessionStep is not captured in trace
+      assertThat(
+          results.get(0).getTrace().getHops().get(0).getSteps(),
+          not(hasItem(instanceOf(MatchSessionStep.class))));
       assertThat(results, contains(hasTrace(hasDisposition(NO_ROUTE))));
     }
 
@@ -1954,6 +1962,15 @@ public class TracerouteEngineImplTest {
           tracerouteEngine
               .computeTracesAndReverseFlows(ImmutableSet.of(flow), ImmutableSet.of(session), false)
               .get(flow);
+      // MatchSessionStep is captured in trace
+      assertThat(
+          results.get(0).getTrace().getHops().get(0).getSteps(),
+          hasItem(
+              allOf(
+                  instanceOf(MatchSessionStep.class),
+                  hasProperty(
+                      "detail",
+                      hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name)))))));
       assertThat(
           results,
           contains(
@@ -1977,6 +1994,14 @@ public class TracerouteEngineImplTest {
           tracerouteEngine
               .computeTracesAndReverseFlows(ImmutableSet.of(flow), ImmutableSet.of(session), false)
               .get(flow);
+      assertThat(
+          results.get(0).getTrace().getHops().get(0).getSteps(),
+          hasItem(
+              allOf(
+                  instanceOf(MatchSessionStep.class),
+                  hasProperty(
+                      "detail",
+                      hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name)))))));
       /* Disposition is always exits network -- see:
        * TracerouteEngineImplContext#buildSessionArpFailureTrace(String, TransmissionContext, List).
        */
@@ -2003,6 +2028,14 @@ public class TracerouteEngineImplTest {
           tracerouteEngine
               .computeTracesAndReverseFlows(ImmutableSet.of(flow), ImmutableSet.of(session), false)
               .get(flow);
+      assertThat(
+          results.get(0).getTrace().getHops().get(0).getSteps(),
+          hasItem(
+              allOf(
+                  instanceOf(MatchSessionStep.class),
+                  hasProperty(
+                      "detail",
+                      hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name)))))));
       // flow reaches c2.
       assertThat(
           results,
@@ -2028,6 +2061,14 @@ public class TracerouteEngineImplTest {
           tracerouteEngine
               .computeTracesAndReverseFlows(ImmutableSet.of(flow), ImmutableSet.of(session), false)
               .get(flow);
+      assertThat(
+          results.get(0).getTrace().getHops().get(0).getSteps(),
+          hasItem(
+              allOf(
+                  instanceOf(MatchSessionStep.class),
+                  hasProperty(
+                      "detail",
+                      hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name)))))));
       assertThat(results, contains(hasTrace(hasDisposition(DENIED_IN))));
     }
 
@@ -2045,6 +2086,14 @@ public class TracerouteEngineImplTest {
           tracerouteEngine
               .computeTracesAndReverseFlows(ImmutableSet.of(flow), ImmutableSet.of(session), false)
               .get(flow);
+      assertThat(
+          results.get(0).getTrace().getHops().get(0).getSteps(),
+          hasItem(
+              allOf(
+                  instanceOf(MatchSessionStep.class),
+                  hasProperty(
+                      "detail",
+                      hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name)))))));
       assertThat(results, contains(hasTrace(hasDisposition(DENIED_OUT))));
     }
 


### PR DESCRIPTION
- Rewrite `MatchSessionStep` and `MatchSessionStepDetail`
    - New field in `MatchSessionStepDetail`: `incomingInterfaces`
    - Use new `MatchSessionStep` and its detail class in `FlowTracer`
- Tests:
    - JSON serialization of `MatchSessionStep`
    - Adapt `MatchSessionStep` in `TracerouteEngineImplTest`, make assertions for existence of `MatchSessionStep` in traces