### PR TITLE
use ALL_LOCATIONS by default for startLocation 

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/specifiers/PathConstraintsUtil.java
+++ b/projects/question/src/main/java/org/batfish/question/specifiers/PathConstraintsUtil.java
@@ -1,8 +1,8 @@
 package org.batfish.question.specifiers;
 
 import org.batfish.datamodel.PathConstraints;
-import org.batfish.specifier.AllInterfacesLocationSpecifier;
 import org.batfish.specifier.AllNodesNodeSpecifier;
+import org.batfish.specifier.LocationSpecifier;
 import org.batfish.specifier.NoNodesNodeSpecifier;
 import org.batfish.specifier.NodeSpecifier;
 import org.batfish.specifier.SpecifierFactories;
@@ -29,7 +29,7 @@ public final class PathConstraintsUtil {
     return PathConstraints.builder()
         .withStartLocation(
             SpecifierFactories.getLocationSpecifierOrDefault(
-                input.getStartLocation(), AllInterfacesLocationSpecifier.INSTANCE))
+                input.getStartLocation(), LocationSpecifier.ALL_LOCATIONS))
         .withEndLocation(
             SpecifierFactories.getNodeSpecifierOrDefault(
                 input.getEndLocation(), AllNodesNodeSpecifier.INSTANCE))

--- a/projects/question/src/test/java/org/batfish/question/differentialreachability/DifferentialReachabilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/differentialreachability/DifferentialReachabilityAnswererTest.java
@@ -27,6 +27,7 @@ import org.batfish.identifiers.NetworkId;
 import org.batfish.identifiers.SnapshotId;
 import org.batfish.referencelibrary.ReferenceBook;
 import org.batfish.role.NodeRoleDimension;
+import org.batfish.specifier.InterfaceLinkLocation;
 import org.batfish.specifier.InterfaceLocation;
 import org.batfish.specifier.IpSpaceAssignment;
 import org.batfish.specifier.Location;
@@ -98,7 +99,9 @@ public final class DifferentialReachabilityAnswererTest {
             .flatMap(Collection::stream)
             .collect(ImmutableSet.toImmutableSet());
 
-    Set<Location> expected = ImmutableSet.of(new InterfaceLocation(hostname, i1Name));
+    Set<Location> expected =
+        ImmutableSet.of(
+            new InterfaceLocation(hostname, i1Name), new InterfaceLinkLocation(hostname, i1Name));
     assertEquals(expected, startLocations);
   }
 

--- a/projects/question/src/test/java/org/batfish/question/specifiers/PathConstraintsUtilTest.java
+++ b/projects/question/src/test/java/org/batfish/question/specifiers/PathConstraintsUtilTest.java
@@ -1,0 +1,23 @@
+package org.batfish.question.specifiers;
+
+import static org.junit.Assert.assertEquals;
+
+import org.batfish.datamodel.PathConstraints;
+import org.batfish.specifier.AllNodesNodeSpecifier;
+import org.batfish.specifier.LocationSpecifier;
+import org.batfish.specifier.NoNodesNodeSpecifier;
+import org.junit.Test;
+
+/** Test for {@link PathConstraintsUtil}. */
+public final class PathConstraintsUtilTest {
+  @Test
+  public void testUnconstrained() {
+    PathConstraints pathConstraints =
+        PathConstraintsUtil.createPathConstraints(PathConstraintsInput.unconstrained());
+
+    assertEquals(LocationSpecifier.ALL_LOCATIONS, pathConstraints.getStartLocation());
+    assertEquals(NoNodesNodeSpecifier.INSTANCE, pathConstraints.getForbiddenLocations());
+    assertEquals(NoNodesNodeSpecifier.INSTANCE, pathConstraints.getTransitLocations());
+    assertEquals(AllNodesNodeSpecifier.INSTANCE, pathConstraints.getEndLocation());
+  }
+}


### PR DESCRIPTION
For reachability, this means that the results for any constrained
startLocation will be a subset of the results for unconstrained.