### PR TITLE
Fix VXLAN edge establishment

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Layer3Vni.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Layer3Vni.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.BumTransportMethod;
+import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Ip;
 
 /** Configuration for an L3 VXLAN VNI */
@@ -19,18 +20,21 @@ public final class Layer3Vni implements Vni {
   @Nullable private final Ip _sourceAddress;
   @Nonnull private final Integer _udpPort;
   private final int _vni;
+  @Nonnull private final String _srcVrf;
 
   private Layer3Vni(
       Set<Ip> bumTransportIps,
       BumTransportMethod bumTransportMethod,
       @Nullable Ip sourceAddress,
       Integer udpPort,
-      int vni) {
+      int vni,
+      String srcVrf) {
     _bumTransportIps = ImmutableSet.copyOf(bumTransportIps);
     _bumTransportMethod = bumTransportMethod;
     _sourceAddress = sourceAddress;
     _udpPort = udpPort;
     _vni = vni;
+    _srcVrf = srcVrf;
   }
 
   @Override
@@ -71,6 +75,12 @@ public final class Layer3Vni implements Vni {
   }
 
   @Override
+  @Nonnull
+  public String getSrcVrf() {
+    return _srcVrf;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -105,6 +115,10 @@ public final class Layer3Vni implements Vni {
         .setBumTransportIps(_bumTransportIps);
   }
 
+  public static Builder testBuilder() {
+    return builder().setSrcVrf(Configuration.DEFAULT_VRF_NAME);
+  }
+
   /** Builder for {@link Layer3Vni} */
   public static final class Builder {
     @Nonnull private Set<Ip> _bumTransportIps = ImmutableSet.of();
@@ -112,6 +126,7 @@ public final class Layer3Vni implements Vni {
     @Nullable private Ip _sourceAddress;
     @Nullable private Integer _udpPort = Vni.DEFAULT_UDP_PORT;
     @Nullable private Integer _vni;
+    @Nullable private String _srcVrf;
 
     private Builder() {}
 
@@ -146,18 +161,26 @@ public final class Layer3Vni implements Vni {
     }
 
     @Nonnull
+    public Builder setSrcVrf(String srcVrf) {
+      _srcVrf = srcVrf;
+      return this;
+    }
+
+    @Nonnull
     public Layer3Vni build() {
       checkArgument(_vni != null, "VNI must not be null.");
       checkArgument(_bumTransportMethod != null, "BumTransportMethod must not be null.");
       checkArgument(
           _bumTransportMethod != BumTransportMethod.MULTICAST_GROUP || _bumTransportIps.size() <= 1,
           "Cannot specify more than one multicast group.");
+      checkArgument(_srcVrf != null, "Source VRF for VNI cannot be null");
       return new Layer3Vni(
           _bumTransportIps,
           _bumTransportMethod,
           _sourceAddress,
           firstNonNull(_udpPort, DEFAULT_UDP_PORT),
-          _vni);
+          _vni,
+          _srcVrf);
     }
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Vni.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/Vni.java
@@ -21,11 +21,16 @@ public interface Vni extends Serializable {
   @Nonnull
   BumTransportMethod getBumTransportMethod();
 
+  /** IP address with which the encapsulated packets would be sourced */
   @Nullable
   Ip getSourceAddress();
 
   @Nonnull
   Integer getUdpPort();
 
+  /** VNI number */
   int getVni();
+
+  /** Name of the VRF from which the encapsulated packets would be sourced */
+  String getSrcVrf();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanTopologyUtils.java
@@ -13,7 +13,6 @@ import io.opentracing.util.GlobalTracer;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import org.batfish.common.plugin.TracerouteEngine;
@@ -102,12 +101,8 @@ public final class VxlanTopologyUtils {
   }
 
   @VisibleForTesting
-  static @Nonnull String getVniVrf(NetworkConfigurations nc, String host, Layer2Vni vniSettings) {
-    return nc.get(host).get().getVrfs().entrySet().stream()
-        .filter(vrfEntry -> vrfEntry.getValue().getLayer2Vnis().containsKey(vniSettings.getVni()))
-        .map(Entry::getKey)
-        .findAny()
-        .get();
+  static @Nonnull String getVniSrcVrf(Layer2Vni vniSettings) {
+    return vniSettings.getSrcVrf();
   }
 
   /**
@@ -210,8 +205,8 @@ public final class VxlanTopologyUtils {
       return false;
     }
     Layer2Vni vniSettingsV = nc.getVniSettings(hostV, vni).get();
-    String vrfU = getVniVrf(nc, hostU, vniSettingsU);
-    String vrfV = getVniVrf(nc, hostV, vniSettingsV);
+    String vrfU = getVniSrcVrf(vniSettingsU);
+    String vrfV = getVniSrcVrf(vniSettingsV);
     Ip srcIpU = vniSettingsU.getSourceAddress();
     Ip srcIpV = vniSettingsV.getSourceAddress();
     int udpPort = vniSettingsU.getUdpPort();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -18,7 +18,7 @@ import static org.batfish.datamodel.matchers.EdgeMatchers.hasHead;
 import static org.batfish.datamodel.matchers.EdgeMatchers.hasNode1;
 import static org.batfish.datamodel.matchers.EdgeMatchers.hasNode2;
 import static org.batfish.datamodel.matchers.EdgeMatchers.hasTail;
-import static org.batfish.datamodel.vxlan.Layer2Vni.builder;
+import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -240,7 +240,7 @@ public final class TopologyUtilTest {
 
     // VNIs
     Layer2Vni.Builder vnb =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(Ip.FIRST_MULTICAST_IP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setVlan(vlanId)
@@ -273,7 +273,7 @@ public final class TopologyUtilTest {
     Vrf v1 = _vb.setOwner(s1).setName(vrfName).build();
     Vrf v2 = _vb.setOwner(s2).setName(vrfName).build();
     Layer2Vni.Builder vnb =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(Ip.FIRST_MULTICAST_IP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setVlan(vlanId)
@@ -607,7 +607,7 @@ public final class TopologyUtilTest {
 
     String vniName = TopologyUtil.computeVniName(vni);
     v1.addLayer2Vni(
-        builder()
+        testBuilder()
             .setBumTransportMethod(UNICAST_FLOOD_GROUP)
             .setBumTransportIps(of(FIRST_CLASS_B_PRIVATE_IP))
             .setVni(vni)
@@ -647,7 +647,7 @@ public final class TopologyUtilTest {
 
     String vniName = TopologyUtil.computeVniName(vni);
     v1.addLayer2Vni(
-        builder()
+        testBuilder()
             .setBumTransportMethod(UNICAST_FLOOD_GROUP)
             .setBumTransportIps(of(FIRST_CLASS_B_PRIVATE_IP))
             .setVni(vni)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Layer2VniTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Layer2VniTest.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel;
 
+import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
@@ -21,7 +22,7 @@ public class Layer2VniTest {
   public void testAllAttrs() {
     SortedSet<Ip> bumTransportIps = ImmutableSortedSet.of(Ip.parse("2.2.2.2"), Ip.parse("2.2.2.3"));
     Layer2Vni vs =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(bumTransportIps)
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(Ip.parse("1.2.3.4"))
@@ -42,7 +43,7 @@ public class Layer2VniTest {
   public void testJavaSerialization() {
     SortedSet<Ip> bumTransportIps = ImmutableSortedSet.of(Ip.parse("2.2.2.2"), Ip.parse("2.2.2.3"));
     Layer2Vni vs =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(bumTransportIps)
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(Ip.parse("1.2.3.4"))
@@ -56,7 +57,7 @@ public class Layer2VniTest {
   @Test
   public void testEquals() {
     Layer2Vni.Builder builder =
-        Layer2Vni.builder().setVni(1).setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP);
+        testBuilder().setVni(1).setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP);
 
     new EqualsTester()
         .addEqualityGroup(new Object())
@@ -76,7 +77,7 @@ public class Layer2VniTest {
   public void testToBuilder() {
     SortedSet<Ip> bumTransportIps = ImmutableSortedSet.of(Ip.parse("2.2.2.2"), Ip.parse("2.2.2.3"));
     Layer2Vni vs =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(bumTransportIps)
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(Ip.parse("1.2.3.4"))
@@ -91,7 +92,7 @@ public class Layer2VniTest {
   public void testAddToFloodList() {
     Ip ip = Ip.parse("2.2.2.2");
     Layer2Vni vs =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(ip))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(Ip.parse("1.2.3.4"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.vxlan;
 
 import static com.google.common.collect.ImmutableSortedSet.of;
+import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
 import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addVniEdge;
 import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.addVniEdges;
 import static org.batfish.datamodel.vxlan.VxlanTopologyUtils.buildVxlanNode;
@@ -134,7 +135,7 @@ public final class VxlanTopologyUtilsTest {
     ib.setAddresses(ConcreteInterfaceAddress.create(SRC_IP1, 31)).setOwner(_c1).setVrf(_v1).build();
     ib.setAddresses(ConcreteInterfaceAddress.create(SRC_IP2, 31)).setOwner(_c2).setVrf(_v2).build();
     Layer2Vni.Builder vsb =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setUdpPort(UDP_PORT)
             .setVlan(VLAN1)
@@ -160,7 +161,7 @@ public final class VxlanTopologyUtilsTest {
   public void testAddVniEdge() {
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
     Layer2Vni.Builder vniSettingsBuilder =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setUdpPort(UDP_PORT)
@@ -192,7 +193,7 @@ public final class VxlanTopologyUtilsTest {
   public void testAddVniEdgeIncompatible() {
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
     Layer2Vni.Builder vniSettingsBuilder =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setUdpPort(UDP_PORT)
@@ -217,7 +218,7 @@ public final class VxlanTopologyUtilsTest {
     Map<String, Configuration> configurations = ImmutableMap.of(NODE1, _c1, NODE2, _c2);
     MutableGraph<VxlanNode> graph = GraphBuilder.undirected().allowsSelfLoops(false).build();
     Layer2Vni.Builder vniSettingsBuilder =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setUdpPort(UDP_PORT)
@@ -243,7 +244,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testBuildVxlanNode() {
     Layer2Vni vniSettings =
-        Layer2Vni.builder()
+        testBuilder()
             .setSourceAddress(SRC_IP1)
             .setVlan(VLAN1)
             .setVni(VNI)
@@ -257,7 +258,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testCompatibleVniSettingsMismatchBumTransportHeadFloodGroup() {
     Layer2Vni vniSettingsTail =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP2))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -266,7 +267,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP2))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -281,7 +282,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testCompatibleVniSettingsMismatchBumTransportMethod() {
     Layer2Vni vniSettingsTail =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -290,7 +291,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -305,7 +306,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testCompatibleVniSettingsMismatchBumTransportMulticastGroup() {
     Layer2Vni vniSettingsTail =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -314,7 +315,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(Ip.parse("224.0.0.5")))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -329,7 +330,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testCompatibleVniSettingsMismatchBumTransportMulticastGroupUnicast() {
     Layer2Vni vniSettingsTail =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP2))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -338,7 +339,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP1))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -353,7 +354,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testCompatibleVniSettingsMismatchBumTransportTailFloodGroup() {
     Layer2Vni vniSettingsTail =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP1))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -362,7 +363,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP1))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -377,7 +378,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testCompatibleVniSettingsMismatchDifferentUdpPort() {
     Layer2Vni vniSettingsTail =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -386,7 +387,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -401,7 +402,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testCompatibleVniSettingsMismatchNullHeadSourceAddress() {
     Layer2Vni vniSettingsTail =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -410,7 +411,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(null)
@@ -425,7 +426,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testCompatibleVniSettingsMismatchNullTailSourceAddress() {
     Layer2Vni vniSettingsTail =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(null)
@@ -434,7 +435,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -449,7 +450,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testCompatibleVniSettingsMismatchSameSourceAddress() {
     Layer2Vni vniSettingsTail =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -458,7 +459,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -473,7 +474,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testCompatibleVniSettingsMulticast() {
     Layer2Vni vniSettingsTail =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -482,7 +483,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -497,7 +498,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testCompatibleVniSettingsUnicast() {
     Layer2Vni vniSettingsTail =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP2))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP1)
@@ -506,7 +507,7 @@ public final class VxlanTopologyUtilsTest {
             .setVni(VNI)
             .build();
     Layer2Vni vniSettingsHead =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(SRC_IP1))
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setSourceAddress(SRC_IP2)
@@ -522,7 +523,7 @@ public final class VxlanTopologyUtilsTest {
   public void testInitialVxlanTopology() {
     Map<String, Configuration> configurations = ImmutableMap.of(NODE1, _c1, NODE2, _c2);
     Layer2Vni.Builder vniSettingsBuilder =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setUdpPort(UDP_PORT)
@@ -543,7 +544,7 @@ public final class VxlanTopologyUtilsTest {
   @Test
   public void testInitialVxlanTopologyFromTable() {
     Layer2Vni.Builder vniSettingsBuilder =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setUdpPort(UDP_PORT)

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3966,6 +3966,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
         .setUdpPort(firstNonNull(vxlan.getUdpPort(), AristaEosVxlan.DEFAULT_UDP_PORT))
         .setVlan(vlan)
         .setVni(vni)
+        .setSrcVrf(Configuration.DEFAULT_VRF_NAME)
         .build();
   }
 
@@ -3994,6 +3995,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
         .setSourceAddress(sourceAddress)
         .setUdpPort(firstNonNull(vxlan.getUdpPort(), AristaEosVxlan.DEFAULT_UDP_PORT))
         .setVni(vni)
+        .setSrcVrf(Configuration.DEFAULT_VRF_NAME)
         .build();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1159,6 +1159,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                       : null)
               .setUdpPort(Layer2Vni.DEFAULT_UDP_PORT)
               .setVni(nveVni.getVni())
+              .setSrcVrf(DEFAULT_VRF_NAME)
               .build();
       _c.getVrfs().get(vsTenantVrfForL3Vni.getName()).addLayer3Vni(vniSettings);
     } else {
@@ -1174,6 +1175,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
               .setUdpPort(Layer2Vni.DEFAULT_UDP_PORT)
               .setVni(nveVni.getVni())
               .setVlan(vlan)
+              .setSrcVrf(DEFAULT_VRF_NAME)
               .build();
       if (viTenantVrfForL2Vni == null) {
         return;

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -6,6 +6,7 @@ import static java.util.Comparator.naturalOrder;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static org.batfish.common.util.CollectionUtil.toImmutableSortedMap;
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENGTH;
 import static org.batfish.datamodel.bgp.VniConfig.importRtPatternForAnyAs;
@@ -570,7 +571,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
               // Grab the BgpVrf for the innerVrf, if it exists
               @Nullable
               BgpVrf innerBgpVrf =
-                  (innerVrfName.equals(Configuration.DEFAULT_VRF_NAME)
+                  (innerVrfName.equals(DEFAULT_VRF_NAME)
                       ? _bgpProcess.getDefaultVrf()
                       : _bgpProcess.getVrfs().get(innerVrfName));
               l3Vnis.add(
@@ -707,8 +708,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
       return;
     }
     // First pass: only core processes
-    _c.getDefaultVrf()
-        .setBgpProcess(toBgpProcess(Configuration.DEFAULT_VRF_NAME, _bgpProcess.getDefaultVrf()));
+    _c.getDefaultVrf().setBgpProcess(toBgpProcess(DEFAULT_VRF_NAME, _bgpProcess.getDefaultVrf()));
     // We make one VI process per VRF because our current datamodel requires it
     _bgpProcess
         .getVrfs()
@@ -839,8 +839,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
   }
 
   private void convertDefaultVrf() {
-    org.batfish.datamodel.Vrf defaultVrf =
-        new org.batfish.datamodel.Vrf(Configuration.DEFAULT_VRF_NAME);
+    org.batfish.datamodel.Vrf defaultVrf = new org.batfish.datamodel.Vrf(DEFAULT_VRF_NAME);
     defaultVrf.setStaticRoutes(
         _staticRoutes.stream()
             .map(StaticRoute::convert)
@@ -854,7 +853,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
                 defaultVrf.getInterfaces().put(ifaceName, iface);
               }
             });
-    _c.getVrfs().put(Configuration.DEFAULT_VRF_NAME, defaultVrf);
+    _c.getVrfs().put(DEFAULT_VRF_NAME, defaultVrf);
   }
 
   private void convertDnsServers() {
@@ -1000,7 +999,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
                 return;
               }
               // TODO: this logic is wrong, fix it later.
-              String vrfName = vniToVrf.getOrDefault(vxlan.getId(), Configuration.DEFAULT_VRF_NAME);
+              String vrfName = vniToVrf.getOrDefault(vxlan.getId(), DEFAULT_VRF_NAME);
               vrfToVniSettings
                   .computeIfAbsent(vrfName, k -> new HashSet<>())
                   .add(
@@ -1012,6 +1011,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
                                   _loopback.getClagVxlanAnycastIp(), vxlan.getLocalTunnelip()))
                           .setUdpPort(NamedPort.VXLAN.number())
                           .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
+                          .setSrcVrf(DEFAULT_VRF_NAME)
                           .build());
             });
     vrfToVniSettings.forEach((vrfName, vnis) -> _c.getVrfs().get(vrfName).setLayer2Vnis(vnis));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -2,7 +2,7 @@ package org.batfish.dataplane.ibdp;
 
 import static org.batfish.datamodel.BumTransportMethod.UNICAST_FLOOD_GROUP;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
-import static org.batfish.datamodel.vxlan.Layer2Vni.builder;
+import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
 import static org.batfish.dataplane.ibdp.BgpRoutingProcess.initEvpnType3Route;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -113,7 +113,7 @@ public class BgpRoutingProcessTest {
     EvpnType3Route route =
         initEvpnType3Route(
             admin,
-            Layer2Vni.builder()
+            Layer2Vni.testBuilder()
                 .setVlan(1)
                 .setVni(10001)
                 .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
@@ -173,14 +173,14 @@ public class BgpRoutingProcessTest {
             .build();
     _bgpProcess.getActiveNeighbors().put(localIp.toPrefix(), evpnPeer);
     _vrf.addLayer2Vni(
-        builder()
+        testBuilder()
             .setVni(vni)
             .setVlan(1)
             .setBumTransportMethod(UNICAST_FLOOD_GROUP)
             .setSourceAddress(localIp)
             .build());
     _vrf2.addLayer2Vni(
-        builder()
+        testBuilder()
             .setVni(vni2)
             .setVlan(2)
             .setBumTransportMethod(UNICAST_FLOOD_GROUP)
@@ -393,14 +393,14 @@ public class BgpRoutingProcessTest {
         .build();
     _bgpProcess.getActiveNeighbors().put(peerIp.toPrefix(), evpnPeer);
     _vrf.addLayer2Vni(
-        builder()
+        testBuilder()
             .setVni(vni)
             .setVlan(1)
             .setBumTransportMethod(UNICAST_FLOOD_GROUP)
             .setSourceAddress(localIp)
             .build());
     _vrf2.addLayer2Vni(
-        builder()
+        testBuilder()
             .setVni(vni)
             .setVlan(2)
             .setBumTransportMethod(UNICAST_FLOOD_GROUP)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EvpnTest.java
@@ -107,7 +107,7 @@ public class EvpnTest {
     Ip vniIp2 = Ip.parse("2.222.222.222");
     vrf1.setLayer2Vnis(
         ImmutableSet.of(
-            Layer2Vni.builder()
+            Layer2Vni.testBuilder()
                 .setVni(vni)
                 .setVlan(1)
                 .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
@@ -115,7 +115,7 @@ public class EvpnTest {
                 .build()));
     vrf2.setLayer2Vnis(
         ImmutableSet.of(
-            Layer2Vni.builder()
+            Layer2Vni.testBuilder()
                 .setVni(vni)
                 .setVlan(1)
                 .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/FixedPointTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/FixedPointTopologyTest.java
@@ -128,8 +128,10 @@ public final class FixedPointTopologyTest {
     Vrf.Builder vb = nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME);
     Vrf h1Vrf = vb.setOwner(_h1).build();
     Vrf h2Vrf = vb.setOwner(_h2).build();
-    Vrf s1Vrf = vb.setOwner(_s1).build();
-    Vrf s2Vrf = vb.setOwner(_s2).build();
+    Vrf s1Vrf = vb.setOwner(_s1).setName(Configuration.DEFAULT_VRF_NAME).build();
+    Vrf s1VniVrf = vb.setOwner(_s1).setName("vrf1").build();
+    Vrf s2Vrf = vb.setOwner(_s2).setName(Configuration.DEFAULT_VRF_NAME).build();
+    Vrf s2VniVrf = vb.setOwner(_s2).setName("vrf1").build();
     Interface.Builder l3Builder =
         Interface.builder().setType(InterfaceType.PHYSICAL).setActive(true);
     l3Builder.setName(E1_NAME).setAddresses(H1_ADDRESS).setOwner(_h1).setVrf(h1Vrf).build();
@@ -147,16 +149,16 @@ public final class FixedPointTopologyTest {
     l2Builder.setName(SWP2_NAME).setOwner(_s2).setVrf(s2Vrf).build();
 
     Layer2Vni.Builder vsb =
-        Layer2Vni.builder()
+        Layer2Vni.testBuilder()
             .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
             .setUdpPort(UDP_PORT)
             .setVlan(VLAN)
             .setVni(VNI);
-    s1Vrf.addLayer2Vni(
+    s1VniVrf.addLayer2Vni(
         vsb.setBumTransportIps(of(S2_ADDRESS.getIp()))
             .setSourceAddress(S1_ADDRESS.getIp())
             .build());
-    s2Vrf.addLayer2Vni(
+    s2VniVrf.addLayer2Vni(
         vsb.setBumTransportIps(of(S1_ADDRESS.getIp()))
             .setSourceAddress(S2_ADDRESS.getIp())
             .build());

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -1,6 +1,7 @@
 package org.batfish.question.edges;
 
 import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
+import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
 import static org.batfish.question.edges.EdgesAnswerer.COL_AS_NUMBER;
 import static org.batfish.question.edges.EdgesAnswerer.COL_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_IP;
@@ -133,7 +134,7 @@ public class EdgesAnswererTest {
     Vrf v2 = vb.setOwner(c2).build();
     Map<String, Configuration> configurations = ImmutableMap.of(VXLAN_NODE1, c1, VXLAN_NODE2, c2);
     Layer2Vni.Builder vniSettingsBuilder =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(VXLAN_MULTICAST_GROUP))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setUdpPort(VXLAN_UDP_PORT)

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesTest.java
@@ -1,5 +1,6 @@
 package org.batfish.question.edges;
 
+import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
 import static org.batfish.question.edges.EdgesAnswerer.COL_INTERFACE;
 import static org.batfish.question.edges.EdgesAnswerer.COL_MULTICAST_GROUP;
 import static org.batfish.question.edges.EdgesAnswerer.COL_NODE;
@@ -168,7 +169,7 @@ public final class EdgesTest {
     Vrf v2 = _vb.setOwner(c2).build();
     SortedMap<String, Configuration> configurations = ImmutableSortedMap.of(node1, c1, node2, c2);
     Layer2Vni.Builder vniSettingsBuilder =
-        Layer2Vni.builder()
+        testBuilder()
             .setBumTransportIps(ImmutableSortedSet.of(multicastGroup))
             .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
             .setUdpPort(udpPort)

--- a/projects/question/src/test/java/org/batfish/question/switchedvlanproperties/SwitchedVlanPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/switchedvlanproperties/SwitchedVlanPropertiesAnswererTest.java
@@ -1,5 +1,6 @@
 package org.batfish.question.switchedvlanproperties;
 
+import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
 import static org.batfish.question.switchedvlanproperties.SwitchedVlanPropertiesAnswerer.COL_INTERFACES;
 import static org.batfish.question.switchedvlanproperties.SwitchedVlanPropertiesAnswerer.COL_NODE;
 import static org.batfish.question.switchedvlanproperties.SwitchedVlanPropertiesAnswerer.COL_VLAN_ID;
@@ -71,7 +72,7 @@ public final class SwitchedVlanPropertiesAnswererTest {
     Vrf v = nf.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME).setOwner(c).build();
     _ib = nf.interfaceBuilder().setOwner(c).setVrf(v).setName(INTERFACE).setActive(true);
     _configurations = ImmutableMap.of(c.getHostname(), c);
-    _vnb = Layer2Vni.builder().setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP);
+    _vnb = testBuilder().setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP);
     _specifierContext =
         new TestSpecifierContext() {
           @Override

--- a/projects/question/src/test/java/org/batfish/question/vxlanproperties/VxlanVniPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/vxlanproperties/VxlanVniPropertiesAnswererTest.java
@@ -6,6 +6,7 @@ import static org.batfish.datamodel.questions.VxlanVniPropertySpecifier.MULTICAS
 import static org.batfish.datamodel.questions.VxlanVniPropertySpecifier.VLAN;
 import static org.batfish.datamodel.questions.VxlanVniPropertySpecifier.VTEP_FLOOD_LIST;
 import static org.batfish.datamodel.questions.VxlanVniPropertySpecifier.VXLAN_PORT;
+import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
 import static org.batfish.question.vxlanproperties.VxlanVniPropertiesAnswerer.COL_NODE;
 import static org.batfish.question.vxlanproperties.VxlanVniPropertiesAnswerer.COL_VNI;
 import static org.batfish.question.vxlanproperties.VxlanVniPropertiesAnswerer.COL_VRF;
@@ -164,7 +165,7 @@ public final class VxlanVniPropertiesAnswererTest {
           "hostname",
           DEFAULT_VRF_NAME,
           ImmutableSet.of(
-              Layer2Vni.builder()
+              testBuilder()
                   .setVni(10001)
                   .setVlan(1)
                   .setSourceAddress(Ip.parse("1.2.3.4"))
@@ -173,7 +174,7 @@ public final class VxlanVniPropertiesAnswererTest {
                   .setBumTransportIps(
                       ImmutableSortedSet.of(Ip.parse("2.3.4.5"), Ip.parse("2.3.4.6")))
                   .build(),
-              Layer2Vni.builder()
+              testBuilder()
                   .setVni(10002)
                   .setVlan(2)
                   .setSourceAddress(Ip.parse("1.2.3.4"))
@@ -185,7 +186,7 @@ public final class VxlanVniPropertiesAnswererTest {
           "minimal",
           DEFAULT_VRF_NAME,
           ImmutableSet.of(
-              Layer2Vni.builder()
+              testBuilder()
                   .setVni(10001)
                   .setVlan(1)
                   .setUdpPort(1234)


### PR DESCRIPTION
Tunnels are established in default VRF on most vendors, while VNIs are placed in tenant VRFs in batfish.
To have traceroutes succeed, add a srcVrf field to correctly source "tunnel" packets for traceroute