### PR TITLE
Include forwarding behaviour in MatchSessionStep

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Accept.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Accept.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.flow;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.visitors.SessionActionVisitor;
@@ -8,6 +9,7 @@ import org.batfish.datamodel.visitors.SessionActionVisitor;
  * A {@link SessionAction} whereby return traffic is be accepted by the node from which it
  * originated.
  */
+@JsonTypeName("Accept")
 @ParametersAreNonnullByDefault
 public final class Accept implements SessionAction {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FibLookup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FibLookup.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.flow;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.visitors.SessionActionVisitor;
@@ -8,6 +9,7 @@ import org.batfish.datamodel.visitors.SessionActionVisitor;
  * A {@link SessionAction} whereby return traffic is forwarded according to the result of a lookup
  * on the FIB of the interface on which the return traffic is received.
  */
+@JsonTypeName("FibLookup")
 @ParametersAreNonnullByDefault
 public final class FibLookup implements SessionAction {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/ForwardOutInterface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/ForwardOutInterface.java
@@ -26,7 +26,7 @@ public final class ForwardOutInterface implements SessionAction {
   private final @Nullable NodeInterfacePair _nextHop;
   private final @Nonnull String _outgoingInterface;
 
-  public ForwardOutInterface(String outgoingInterface, NodeInterfacePair nextHop) {
+  public ForwardOutInterface(String outgoingInterface, @Nullable NodeInterfacePair nextHop) {
     _outgoingInterface = outgoingInterface;
     _nextHop = nextHop;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/ForwardOutInterface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/ForwardOutInterface.java
@@ -1,5 +1,10 @@
 package org.batfish.datamodel.flow;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -11,8 +16,12 @@ import org.batfish.datamodel.visitors.SessionActionVisitor;
  * A {@link SessionAction} whereby a return flow is forwarded out a specified interface to a
  * specified next hop with neither FIB resolution nor ARP lookup.
  */
+@JsonTypeName("ForwardOutInterface")
 @ParametersAreNonnullByDefault
 public final class ForwardOutInterface implements SessionAction {
+
+  private static final String PROP_NEXT_HOP = "nextHop";
+  private static final String PROP_OUTGOING_INTERFACE = "outgoingInterface";
 
   private final @Nullable NodeInterfacePair _nextHop;
   private final @Nonnull String _outgoingInterface;
@@ -20,6 +29,15 @@ public final class ForwardOutInterface implements SessionAction {
   public ForwardOutInterface(String outgoingInterface, NodeInterfacePair nextHop) {
     _outgoingInterface = outgoingInterface;
     _nextHop = nextHop;
+  }
+
+  @JsonCreator
+  private static ForwardOutInterface jsonCreator(
+      @Nullable @JsonProperty(PROP_NEXT_HOP) NodeInterfacePair nextHop,
+      @Nullable @JsonProperty(PROP_OUTGOING_INTERFACE) String outgoingInterface) {
+    checkArgument(
+        outgoingInterface != null, "ForwardOutInterface missing %s", PROP_OUTGOING_INTERFACE);
+    return new ForwardOutInterface(outgoingInterface, nextHop);
   }
 
   @Override
@@ -31,12 +49,16 @@ public final class ForwardOutInterface implements SessionAction {
    * The next hop and ingress interface for session traffic. If null, then the traffic should be
    * delivered to the attached subnet of the outgoing interface, or else should exit the network.
    */
-  public @Nullable NodeInterfacePair getNextHop() {
+  @JsonProperty(PROP_NEXT_HOP)
+  @Nullable
+  public NodeInterfacePair getNextHop() {
     return _nextHop;
   }
 
   /** The interface out which return traffic should be sent. */
-  public @Nonnull String getOutgoingInterface() {
+  @JsonProperty(PROP_OUTGOING_INTERFACE)
+  @Nonnull
+  public String getOutgoingInterface() {
     return _outgoingInterface;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel.flow;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -19,24 +20,36 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
 
   public static final class MatchSessionStepDetail {
     private static final String PROP_INCOMING_INTERFACES = "incomingInterfaces";
+    private static final String PROP_SESSION_ACTION = "sessionAction";
 
     @Nonnull private final Set<String> _incomingInterfaces;
+    @Nonnull private final SessionAction _sessionAction;
 
-    private MatchSessionStepDetail(@Nonnull Set<String> incomingInterfaces) {
+    private MatchSessionStepDetail(
+        @Nonnull Set<String> incomingInterfaces, @Nonnull SessionAction sessionAction) {
       _incomingInterfaces = ImmutableSet.copyOf(incomingInterfaces);
+      _sessionAction = sessionAction;
     }
 
     @JsonCreator
     private static MatchSessionStepDetail jsonCreator(
-        @JsonProperty(PROP_INCOMING_INTERFACES) Set<String> incomingInterfaces) {
-      checkArgument(incomingInterfaces != null, "Missing %s", PROP_ACTION);
-      return new MatchSessionStepDetail(incomingInterfaces);
+        @JsonProperty(PROP_INCOMING_INTERFACES) Set<String> incomingInterfaces,
+        @JsonProperty(PROP_SESSION_ACTION) SessionAction sessionAction) {
+      checkArgument(incomingInterfaces != null, "Missing %s", PROP_INCOMING_INTERFACES);
+      checkArgument(sessionAction != null, "Missing %s", PROP_SESSION_ACTION);
+      return new MatchSessionStepDetail(incomingInterfaces, sessionAction);
     }
 
     @JsonProperty(PROP_INCOMING_INTERFACES)
     @Nonnull
     public Set<String> getIncomingInterfaces() {
       return _incomingInterfaces;
+    }
+
+    @JsonProperty(PROP_SESSION_ACTION)
+    @Nonnull
+    public SessionAction getSessionAction() {
+      return _sessionAction;
     }
 
     public static Builder builder() {
@@ -46,13 +59,23 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
     /** Chained builder to create a {@link MatchSessionStepDetail} object */
     public static class Builder {
       private @Nullable Set<String> _incomingInterfaces;
+      private @Nullable SessionAction _sessionAction;
 
       public MatchSessionStepDetail build() {
-        return new MatchSessionStepDetail(firstNonNull(_incomingInterfaces, ImmutableSet.of()));
+        checkNotNull(
+            _sessionAction,
+            "Cannot build MatchSessionStepDetail without specifying session action");
+        return new MatchSessionStepDetail(
+            firstNonNull(_incomingInterfaces, ImmutableSet.of()), _sessionAction);
       }
 
       public Builder setIncomingInterfaces(Set<String> incomingInterfaces) {
         _incomingInterfaces = incomingInterfaces;
+        return this;
+      }
+
+      public Builder setSessionAction(SessionAction sessionAction) {
+        _sessionAction = sessionAction;
         return this;
       }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionAction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionAction.java
@@ -1,8 +1,16 @@
 package org.batfish.datamodel.flow;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.batfish.datamodel.visitors.SessionActionVisitor;
 
 /** An action that a firewall session takes for return traffic matching the session */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = Accept.class, name = "Accept"),
+  @JsonSubTypes.Type(value = FibLookup.class, name = "FibLookup"),
+  @JsonSubTypes.Type(value = ForwardOutInterface.class, name = "ForwardOutInterface"),
+})
 public interface SessionAction {
   <T> T accept(SessionActionVisitor<T> visitor);
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/AcceptTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/AcceptTest.java
@@ -1,7 +1,6 @@
 package org.batfish.datamodel.flow;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
@@ -25,8 +24,6 @@ public final class AcceptTest {
   @Test
   public void testSerialization() throws IOException {
     SessionAction clone = BatfishObjectMapper.clone(Accept.INSTANCE, SessionAction.class);
-    assertThat(clone, instanceOf(SessionAction.class));
-    assertThat(clone, instanceOf(Accept.class));
     assertThat(clone, equalTo(Accept.INSTANCE));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/AcceptTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/AcceptTest.java
@@ -1,7 +1,13 @@
 package org.batfish.datamodel.flow;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
 import com.google.common.testing.EqualsTester;
+import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 /** Test of {@link Accept}. */
@@ -14,5 +20,13 @@ public final class AcceptTest {
         .addEqualityGroup(new Object())
         .addEqualityGroup(Accept.INSTANCE, Accept.INSTANCE)
         .testEquals();
+  }
+
+  @Test
+  public void testSerialization() throws IOException {
+    SessionAction clone = BatfishObjectMapper.clone(Accept.INSTANCE, SessionAction.class);
+    assertThat(clone, instanceOf(SessionAction.class));
+    assertThat(clone, instanceOf(Accept.class));
+    assertThat(clone, equalTo(Accept.INSTANCE));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/FibLookupTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/FibLookupTest.java
@@ -2,7 +2,6 @@ package org.batfish.datamodel.flow;
 
 import static org.batfish.datamodel.flow.FibLookup.INSTANCE;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
@@ -26,8 +25,6 @@ public final class FibLookupTest {
   @Test
   public void testSerialization() throws IOException {
     SessionAction clone = BatfishObjectMapper.clone(FibLookup.INSTANCE, SessionAction.class);
-    assertThat(clone, instanceOf(SessionAction.class));
-    assertThat(clone, instanceOf(FibLookup.class));
     assertThat(clone, equalTo(FibLookup.INSTANCE));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/FibLookupTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/FibLookupTest.java
@@ -1,9 +1,14 @@
 package org.batfish.datamodel.flow;
 
 import static org.batfish.datamodel.flow.FibLookup.INSTANCE;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
+import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 /** Test of {@link FibLookup}. */
@@ -16,5 +21,13 @@ public final class FibLookupTest {
         .addEqualityGroup(new Object())
         .addEqualityGroup(INSTANCE, INSTANCE)
         .testEquals();
+  }
+
+  @Test
+  public void testSerialization() throws IOException {
+    SessionAction clone = BatfishObjectMapper.clone(FibLookup.INSTANCE, SessionAction.class);
+    assertThat(clone, instanceOf(SessionAction.class));
+    assertThat(clone, instanceOf(FibLookup.class));
+    assertThat(clone, equalTo(FibLookup.INSTANCE));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/ForwardOutInterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/ForwardOutInterfaceTest.java
@@ -29,10 +29,7 @@ public final class ForwardOutInterfaceTest {
   @Test
   public void testSerialization() throws IOException {
     ForwardOutInterface f = new ForwardOutInterface("a", null);
-    SessionAction castedClone = BatfishObjectMapper.clone(f, SessionAction.class);
-    assertThat(castedClone, instanceOf(ForwardOutInterface.class));
-
-    ForwardOutInterface clone = (ForwardOutInterface) castedClone;
+    SessionAction clone = BatfishObjectMapper.clone(f, SessionAction.class);
     assertThat(clone, equalTo(f));
 
     f = new ForwardOutInterface("b", NodeInterfacePair.of("a", "b"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/ForwardOutInterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/ForwardOutInterfaceTest.java
@@ -1,7 +1,13 @@
 package org.batfish.datamodel.flow;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
 import com.google.common.testing.EqualsTester;
+import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.junit.Test;
 
@@ -18,5 +24,22 @@ public final class ForwardOutInterfaceTest {
         .addEqualityGroup(new ForwardOutInterface("b", null))
         .addEqualityGroup(new ForwardOutInterface("a", NodeInterfacePair.of("a", "a")))
         .testEquals();
+  }
+
+  @Test
+  public void testSerialization() throws IOException {
+    ForwardOutInterface f = new ForwardOutInterface("a", null);
+    SessionAction castedClone = BatfishObjectMapper.clone(f, SessionAction.class);
+    assertThat(castedClone, instanceOf(SessionAction.class));
+    assertThat(castedClone, instanceOf(ForwardOutInterface.class));
+
+    ForwardOutInterface clone = (ForwardOutInterface) castedClone;
+    assertThat(clone.getOutgoingInterface(), equalTo(f.getOutgoingInterface()));
+    assertThat(clone.getNextHop(), equalTo(f.getNextHop()));
+
+    f = new ForwardOutInterface("b", NodeInterfacePair.of("a", "b"));
+    clone = BatfishObjectMapper.clone(f, ForwardOutInterface.class);
+    assertThat(clone.getOutgoingInterface(), equalTo(f.getOutgoingInterface()));
+    assertThat(clone.getNextHop(), equalTo(f.getNextHop()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/ForwardOutInterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/ForwardOutInterfaceTest.java
@@ -1,7 +1,6 @@
 package org.batfish.datamodel.flow;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/ForwardOutInterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/ForwardOutInterfaceTest.java
@@ -30,16 +30,13 @@ public final class ForwardOutInterfaceTest {
   public void testSerialization() throws IOException {
     ForwardOutInterface f = new ForwardOutInterface("a", null);
     SessionAction castedClone = BatfishObjectMapper.clone(f, SessionAction.class);
-    assertThat(castedClone, instanceOf(SessionAction.class));
     assertThat(castedClone, instanceOf(ForwardOutInterface.class));
 
     ForwardOutInterface clone = (ForwardOutInterface) castedClone;
-    assertThat(clone.getOutgoingInterface(), equalTo(f.getOutgoingInterface()));
-    assertThat(clone.getNextHop(), equalTo(f.getNextHop()));
+    assertThat(clone, equalTo(f));
 
     f = new ForwardOutInterface("b", NodeInterfacePair.of("a", "b"));
     clone = BatfishObjectMapper.clone(f, ForwardOutInterface.class);
-    assertThat(clone.getOutgoingInterface(), equalTo(f.getOutgoingInterface()));
-    assertThat(clone.getNextHop(), equalTo(f.getNextHop()));
+    assertThat(clone, equalTo(f));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
@@ -1,11 +1,15 @@
 package org.batfish.datamodel.flow;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.Set;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.MatchSessionStep.MatchSessionStepDetail;
 import org.junit.Test;
 
@@ -16,24 +20,56 @@ public final class MatchSessionStepTest {
     Set<String> incomingInterfaces = ImmutableSet.of("a");
     MatchSessionStep step =
         new MatchSessionStep(
-            MatchSessionStepDetail.builder().setIncomingInterfaces(incomingInterfaces).build());
-
+            MatchSessionStepDetail.builder()
+                .setIncomingInterfaces(incomingInterfaces)
+                .setSessionAction(Accept.INSTANCE)
+                .build());
     assertEquals(step.getAction(), StepAction.MATCHED_SESSION);
     assertEquals(step.getDetail().getIncomingInterfaces(), incomingInterfaces);
+    assertEquals(step.getDetail().getSessionAction(), Accept.INSTANCE);
+
+    incomingInterfaces = ImmutableSet.of("b");
+    step =
+        new MatchSessionStep(
+            MatchSessionStepDetail.builder()
+                .setIncomingInterfaces(incomingInterfaces)
+                .setSessionAction(FibLookup.INSTANCE)
+                .build());
+    assertEquals(step.getAction(), StepAction.MATCHED_SESSION);
+    assertEquals(step.getDetail().getIncomingInterfaces(), incomingInterfaces);
+    assertEquals(step.getDetail().getSessionAction(), FibLookup.INSTANCE);
+
+    ForwardOutInterface forwardAction =
+        new ForwardOutInterface("a", NodeInterfacePair.of("a", "b"));
+    step =
+        new MatchSessionStep(
+            MatchSessionStepDetail.builder()
+                .setIncomingInterfaces(incomingInterfaces)
+                .setSessionAction(forwardAction)
+                .build());
+    assertEquals(step.getAction(), StepAction.MATCHED_SESSION);
+    assertEquals(step.getDetail().getIncomingInterfaces(), incomingInterfaces);
+    assertEquals(step.getDetail().getSessionAction(), forwardAction);
   }
 
   @Test
   public void testJsonSerialization() throws IOException {
     Set<String> incomingInterfaces = ImmutableSet.of("b");
+    ForwardOutInterface forwardAction =
+        new ForwardOutInterface("a", NodeInterfacePair.of("a", "b"));
     MatchSessionStep step =
         new MatchSessionStep(
-            MatchSessionStep.MatchSessionStepDetail.builder()
+            MatchSessionStepDetail.builder()
                 .setIncomingInterfaces(incomingInterfaces)
+                .setSessionAction(forwardAction)
                 .build());
     MatchSessionStep clone = BatfishObjectMapper.clone(step, MatchSessionStep.class);
     assertEquals(step.getAction(), clone.getAction());
-    assertEquals(
-        step.getDetail().getIncomingInterfaces(), clone.getDetail().getIncomingInterfaces());
-    assertEquals(clone.getDetail().getIncomingInterfaces(), incomingInterfaces);
+    assertThat(
+        clone.getDetail().getIncomingInterfaces(),
+        allOf(equalTo(step.getDetail().getIncomingInterfaces()), equalTo(incomingInterfaces)));
+    assertThat(
+        clone.getDetail().getSessionAction(),
+        allOf(equalTo(step.getDetail().getSessionAction()), equalTo(forwardAction)));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
@@ -1,6 +1,5 @@
 package org.batfish.datamodel.flow;
 
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -27,29 +26,6 @@ public final class MatchSessionStepTest {
     assertEquals(step.getAction(), StepAction.MATCHED_SESSION);
     assertEquals(step.getDetail().getIncomingInterfaces(), incomingInterfaces);
     assertEquals(step.getDetail().getSessionAction(), Accept.INSTANCE);
-
-    incomingInterfaces = ImmutableSet.of("b");
-    step =
-        new MatchSessionStep(
-            MatchSessionStepDetail.builder()
-                .setIncomingInterfaces(incomingInterfaces)
-                .setSessionAction(FibLookup.INSTANCE)
-                .build());
-    assertEquals(step.getAction(), StepAction.MATCHED_SESSION);
-    assertEquals(step.getDetail().getIncomingInterfaces(), incomingInterfaces);
-    assertEquals(step.getDetail().getSessionAction(), FibLookup.INSTANCE);
-
-    ForwardOutInterface forwardAction =
-        new ForwardOutInterface("a", NodeInterfacePair.of("a", "b"));
-    step =
-        new MatchSessionStep(
-            MatchSessionStepDetail.builder()
-                .setIncomingInterfaces(incomingInterfaces)
-                .setSessionAction(forwardAction)
-                .build());
-    assertEquals(step.getAction(), StepAction.MATCHED_SESSION);
-    assertEquals(step.getDetail().getIncomingInterfaces(), incomingInterfaces);
-    assertEquals(step.getDetail().getSessionAction(), forwardAction);
   }
 
   @Test
@@ -67,9 +43,7 @@ public final class MatchSessionStepTest {
     assertEquals(step.getAction(), clone.getAction());
     assertThat(
         clone.getDetail().getIncomingInterfaces(),
-        allOf(equalTo(step.getDetail().getIncomingInterfaces()), equalTo(incomingInterfaces)));
-    assertThat(
-        clone.getDetail().getSessionAction(),
-        allOf(equalTo(step.getDetail().getSessionAction()), equalTo(forwardAction)));
+        equalTo(step.getDetail().getIncomingInterfaces()));
+    assertThat(clone.getDetail().getSessionAction(), equalTo(step.getDetail().getSessionAction()));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -785,6 +785,7 @@ class FlowTracer {
         new MatchSessionStep(
             MatchSessionStepDetail.builder()
                 .setIncomingInterfaces(session.getIncomingInterfaces())
+                .setSessionAction(session.getAction())
                 .build()));
 
     Configuration config = _tracerouteContext.getConfigurations().get(currentNodeName);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -1970,7 +1970,9 @@ public class TracerouteEngineImplTest {
                   instanceOf(MatchSessionStep.class),
                   hasProperty(
                       "detail",
-                      hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name)))))));
+                      allOf(
+                          hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
+                          hasProperty("sessionAction", equalTo(Accept.INSTANCE)))))));
       assertThat(
           results,
           contains(
@@ -2001,7 +2003,9 @@ public class TracerouteEngineImplTest {
                   instanceOf(MatchSessionStep.class),
                   hasProperty(
                       "detail",
-                      hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name)))))));
+                      allOf(
+                          hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
+                          hasProperty("sessionAction", equalTo(session.getAction())))))));
       /* Disposition is always exits network -- see:
        * TracerouteEngineImplContext#buildSessionArpFailureTrace(String, TransmissionContext, List).
        */
@@ -2035,7 +2039,9 @@ public class TracerouteEngineImplTest {
                   instanceOf(MatchSessionStep.class),
                   hasProperty(
                       "detail",
-                      hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name)))))));
+                      allOf(
+                          hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
+                          hasProperty("sessionAction", equalTo(session.getAction())))))));
       // flow reaches c2.
       assertThat(
           results,
@@ -2068,7 +2074,9 @@ public class TracerouteEngineImplTest {
                   instanceOf(MatchSessionStep.class),
                   hasProperty(
                       "detail",
-                      hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name)))))));
+                      allOf(
+                          hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
+                          hasProperty("sessionAction", equalTo(session.getAction())))))));
       assertThat(results, contains(hasTrace(hasDisposition(DENIED_IN))));
     }
 
@@ -2093,7 +2101,9 @@ public class TracerouteEngineImplTest {
                   instanceOf(MatchSessionStep.class),
                   hasProperty(
                       "detail",
-                      hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name)))))));
+                      allOf(
+                          hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
+                          hasProperty("sessionAction", equalTo(session.getAction())))))));
       assertThat(results, contains(hasTrace(hasDisposition(DENIED_OUT))));
     }
 


### PR DESCRIPTION
- Make `SessionAction` JSON serialisable
    - e.g. `{"type": "Accept"}`, `{"type": "FibLookup"}`
    - e.g. `{"type": "ForwardOutInterface", "nextHop": {"hostname": "a", "interface": "b"}, "outgoingInterface": "a"}`
- Add `sessionAction` field in `MatchSessionStepDetail`
- Include session action when constructing `MatchSessionStep` in `FlowTracer`
- Test JSON serialisation for all `SessionAction`s
- Test construction and JSON serialisation of `MatchSessionStep`
- Test match session in traceroute implementation