### PR TITLE
Make EVPN type-3 routes non-routing

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -677,6 +677,11 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
       if (!acceptIncoming) {
         continue;
       }
+      if (clazz.equals(EvpnType3Route.class)) {
+        // Type 3 routes are special: they don't go into main RIB, they only update L2 VNI's flood
+        // list
+        transformedBuilder.setNonRouting(true);
+      }
       R transformedRoute = transformedBuilder.build();
       Set<ExtendedCommunity> routeTargets = transformedRoute.getRouteTargets();
       if (routeTargets.isEmpty()) {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnCumulusTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnCumulusTest.java
@@ -7,12 +7,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Table;
 import java.io.IOException;
-import java.util.SortedMap;
-import org.batfish.datamodel.AbstractRoute;
-import org.batfish.datamodel.AnnotatedRoute;
+import java.util.Set;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.EvpnRoute;
 import org.batfish.datamodel.Prefix;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
@@ -21,6 +20,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+/** End-to-end-ish test of EVPN Type 3 routes on cumulus devices */
 public class EvpnCumulusTest {
   private static final String SNAPSHOT_FOLDER = "org/batfish/dataplane/testrigs/evpn-l2-vnis";
 
@@ -41,14 +41,13 @@ public class EvpnCumulusTest {
     batfish.computeDataPlane(batfish.getSnapshot());
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
 
-    SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> ribs =
-        dp.getRibs();
+    Table<String, String, Set<EvpnRoute<?, ?>>> ribs = dp.getEvpnRoutes();
 
     assertThat(
-        ribs.get(leaf1).get(DEFAULT_VRF_NAME).getRoutes(),
+        ribs.get(leaf1, DEFAULT_VRF_NAME),
         hasItem(isEvpnType3RouteThat(hasPrefix(Prefix.parse("3.3.3.3/32")))));
     assertThat(
-        ribs.get(leaf2).get(DEFAULT_VRF_NAME).getRoutes(),
+        ribs.get(leaf2, DEFAULT_VRF_NAME),
         hasItem(isEvpnType3RouteThat(hasPrefix(Prefix.parse("1.1.1.1/32")))));
   }
 }


### PR DESCRIPTION
Type 3 routes should not be merged into main RIBs. They are only used to
update L2 VNI's flood lists.