### PR TITLE
Include match criteria in MatchSessionStepDetail

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FirewallSessionTraceInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FirewallSessionTraceInfo.java
@@ -14,14 +14,14 @@ public final class FirewallSessionTraceInfo {
   private final @Nonnull String _hostname;
   private final @Nonnull Set<String> _incomingInterfaces;
   private final @Nonnull SessionAction _action;
-  private final @Nonnull AclLineMatchExpr _sessionFlows;
+  private final @Nonnull SessionMatchExpr _sessionFlows;
   private final @Nullable Transformation _transformation;
 
   public FirewallSessionTraceInfo(
       String hostname,
       SessionAction action,
       Set<String> incomingInterfaces,
-      AclLineMatchExpr sessionFlows,
+      SessionMatchExpr sessionFlows,
       @Nullable Transformation transformation) {
     _hostname = hostname;
     _action = action;
@@ -71,7 +71,7 @@ public final class FirewallSessionTraceInfo {
    * org.batfish.datamodel.acl.PermittedByAcl} or {@link org.batfish.datamodel.IpSpaceReference}.
    */
   public @Nonnull AclLineMatchExpr getSessionFlows() {
-    return _sessionFlows;
+    return _sessionFlows.toAclLineMatchExpr();
   }
 
   /** The (optional) transformation for session traffic. */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FirewallSessionTraceInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FirewallSessionTraceInfo.java
@@ -74,6 +74,7 @@ public final class FirewallSessionTraceInfo {
     return _sessionFlows.toAclLineMatchExpr();
   }
 
+  /** The match criteria of the ingress flow for the session. */
   public @Nonnull SessionMatchExpr getMatchCriteria() {
     return _sessionFlows;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FirewallSessionTraceInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FirewallSessionTraceInfo.java
@@ -74,6 +74,10 @@ public final class FirewallSessionTraceInfo {
     return _sessionFlows.toAclLineMatchExpr();
   }
 
+  public @Nonnull SessionMatchExpr getMatchCriteria() {
+    return _sessionFlows;
+  }
+
   /** The (optional) transformation for session traffic. */
   @Nullable
   public Transformation getTransformation() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
@@ -21,23 +21,30 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
   public static final class MatchSessionStepDetail {
     private static final String PROP_INCOMING_INTERFACES = "incomingInterfaces";
     private static final String PROP_SESSION_ACTION = "sessionAction";
+    private static final String PROP_MATCH_CRITERIA = "matchCriteria";
 
     @Nonnull private final Set<String> _incomingInterfaces;
     @Nonnull private final SessionAction _sessionAction;
+    @Nonnull private final SessionMatchExpr _matchCriteria;
 
     private MatchSessionStepDetail(
-        @Nonnull Set<String> incomingInterfaces, @Nonnull SessionAction sessionAction) {
+        @Nonnull Set<String> incomingInterfaces,
+        @Nonnull SessionAction sessionAction,
+        @Nonnull SessionMatchExpr matchCriteria) {
       _incomingInterfaces = ImmutableSet.copyOf(incomingInterfaces);
       _sessionAction = sessionAction;
+      _matchCriteria = matchCriteria;
     }
 
     @JsonCreator
     private static MatchSessionStepDetail jsonCreator(
         @JsonProperty(PROP_INCOMING_INTERFACES) Set<String> incomingInterfaces,
-        @JsonProperty(PROP_SESSION_ACTION) SessionAction sessionAction) {
+        @JsonProperty(PROP_SESSION_ACTION) SessionAction sessionAction,
+        @JsonProperty(PROP_MATCH_CRITERIA) SessionMatchExpr matchCriteria) {
       checkArgument(incomingInterfaces != null, "Missing %s", PROP_INCOMING_INTERFACES);
       checkArgument(sessionAction != null, "Missing %s", PROP_SESSION_ACTION);
-      return new MatchSessionStepDetail(incomingInterfaces, sessionAction);
+      checkArgument(matchCriteria != null, "Missing %s", PROP_MATCH_CRITERIA);
+      return new MatchSessionStepDetail(incomingInterfaces, sessionAction, matchCriteria);
     }
 
     @JsonProperty(PROP_INCOMING_INTERFACES)
@@ -52,6 +59,12 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
       return _sessionAction;
     }
 
+    @JsonProperty(PROP_MATCH_CRITERIA)
+    @Nonnull
+    public SessionMatchExpr getMatchCriteria() {
+      return _matchCriteria;
+    }
+
     public static Builder builder() {
       return new Builder();
     }
@@ -60,13 +73,17 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
     public static class Builder {
       private @Nullable Set<String> _incomingInterfaces;
       private @Nullable SessionAction _sessionAction;
+      private @Nullable SessionMatchExpr _matchCriteria;
 
       public MatchSessionStepDetail build() {
         checkNotNull(
             _sessionAction,
             "Cannot build MatchSessionStepDetail without specifying session action");
+        checkNotNull(
+            _matchCriteria,
+            "Cannot build MatchSessionStepDetail without specifying match criteria");
         return new MatchSessionStepDetail(
-            firstNonNull(_incomingInterfaces, ImmutableSet.of()), _sessionAction);
+            firstNonNull(_incomingInterfaces, ImmutableSet.of()), _sessionAction, _matchCriteria);
       }
 
       public Builder setIncomingInterfaces(Set<String> incomingInterfaces) {
@@ -76,6 +93,11 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
 
       public Builder setSessionAction(SessionAction sessionAction) {
         _sessionAction = sessionAction;
+        return this;
+      }
+
+      public Builder setMatchCriteria(SessionMatchExpr matchCriteria) {
+        _matchCriteria = matchCriteria;
         return this;
       }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
@@ -3,11 +3,16 @@ package org.batfish.datamodel.flow;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.ImmutableList;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
 
 @JsonTypeName("SessionMatchExpr")
 @ParametersAreNonnullByDefault
@@ -63,6 +68,21 @@ public class SessionMatchExpr {
   @Nullable
   public Integer getDstPort() {
     return _dstPort;
+  }
+
+  public AclLineMatchExpr toAclLineMatchExpr() {
+    HeaderSpace.Builder hb =
+        HeaderSpace.builder()
+            .setSrcIps(_srcIp.toIpSpace())
+            .setDstIps(_dstIp.toIpSpace())
+            .setIpProtocols(ImmutableList.of(_ipProtocol));
+
+    if (_srcPort != null) {
+      hb.setSrcPorts(ImmutableList.of(SubRange.singleton(_srcPort)))
+          .setDstPorts(ImmutableList.of(SubRange.singleton(_dstPort)));
+    }
+
+    return new MatchHeaderSpace(hb.build());
   }
 
   public boolean equals(@Nullable Object o) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
@@ -1,0 +1,86 @@
+package org.batfish.datamodel.flow;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
+
+@JsonTypeName("SessionMatchExpr")
+@ParametersAreNonnullByDefault
+public class SessionMatchExpr {
+  private static final String PROP_IP_PROTOCOL = "ipProtocol";
+  private static final String PROP_SRC_IP = "srcIp";
+  private static final String PROP_DST_IP = "dstIp";
+  private static final String PROP_SRC_PORT = "srcPort";
+  private static final String PROP_DST_PORT = "dstPort";
+
+  private final IpProtocol _ipProtocol;
+  private final Ip _srcIp;
+  private final Ip _dstIp;
+  @Nullable private final Integer _srcPort;
+  @Nullable private final Integer _dstPort;
+
+  @JsonCreator
+  public SessionMatchExpr(
+      @JsonProperty(PROP_IP_PROTOCOL) IpProtocol ipProtocol,
+      @JsonProperty(PROP_SRC_IP) Ip srcIp,
+      @JsonProperty(PROP_DST_IP) Ip dstIp,
+      @JsonProperty(PROP_SRC_PORT) @Nullable Integer srcPort,
+      @JsonProperty(PROP_DST_PORT) @Nullable Integer dstPort) {
+    _ipProtocol = ipProtocol;
+    _srcIp = srcIp;
+    _dstIp = dstIp;
+    _srcPort = srcPort;
+    _dstPort = dstPort;
+  }
+
+  @JsonProperty
+  public IpProtocol getIpProtocol() {
+    return _ipProtocol;
+  }
+
+  @JsonProperty
+  public Ip getSrcIp() {
+    return _srcIp;
+  }
+
+  @JsonProperty
+  public Ip getDstIp() {
+    return _dstIp;
+  }
+
+  @JsonProperty
+  @Nullable
+  public Integer getSrcPort() {
+    return _srcPort;
+  }
+
+  @JsonProperty
+  @Nullable
+  public Integer getDstPort() {
+    return _dstPort;
+  }
+
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SessionMatchExpr)) {
+      return false;
+    }
+    SessionMatchExpr rhs = (SessionMatchExpr) o;
+    return Objects.equals(_ipProtocol, rhs._ipProtocol)
+        && Objects.equals(_srcIp, rhs._srcIp)
+        && Objects.equals(_dstIp, rhs._dstIp)
+        && Objects.equals(_srcPort, rhs._srcPort)
+        && Objects.equals(_dstPort, rhs._dstPort);
+  }
+
+  public int hashCode() {
+    return Objects.hash(_ipProtocol, _srcIp, _dstIp, _srcPort, _dstPort);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
@@ -44,28 +44,28 @@ public class SessionMatchExpr {
     _dstPort = dstPort;
   }
 
-  @JsonProperty
+  @JsonProperty(PROP_IP_PROTOCOL)
   public IpProtocol getIpProtocol() {
     return _ipProtocol;
   }
 
-  @JsonProperty
+  @JsonProperty(PROP_SRC_IP)
   public Ip getSrcIp() {
     return _srcIp;
   }
 
-  @JsonProperty
+  @JsonProperty(PROP_DST_IP)
   public Ip getDstIp() {
     return _dstIp;
   }
 
-  @JsonProperty
+  @JsonProperty(PROP_SRC_PORT)
   @Nullable
   public Integer getSrcPort() {
     return _srcPort;
   }
 
-  @JsonProperty
+  @JsonProperty(PROP_DST_PORT)
   @Nullable
   public Integer getDstPort() {
     return _dstPort;
@@ -87,6 +87,7 @@ public class SessionMatchExpr {
     return new MatchHeaderSpace(hb.build());
   }
 
+  @Override
   public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
@@ -102,6 +103,7 @@ public class SessionMatchExpr {
         && Objects.equals(_dstPort, rhs._dstPort);
   }
 
+  @Override
   public int hashCode() {
     return Objects.hash(_ipProtocol, _srcIp, _dstIp, _srcPort, _dstPort);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
@@ -14,6 +14,7 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 
+/** Represents a match criteria for a {@link FirewallSessionTraceInfo} */
 @JsonTypeName("SessionMatchExpr")
 @ParametersAreNonnullByDefault
 public class SessionMatchExpr {
@@ -70,6 +71,7 @@ public class SessionMatchExpr {
     return _dstPort;
   }
 
+  /** Transforms into generic {@link AclLineMatchExpr} which allows usage with visitors */
   public AclLineMatchExpr toAclLineMatchExpr() {
     HeaderSpace.Builder hb =
         HeaderSpace.builder()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTraceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTraceTest.java
@@ -2,7 +2,6 @@ package org.batfish.datamodel.flow;
 
 import static org.batfish.datamodel.FlowDisposition.ACCEPTED;
 import static org.batfish.datamodel.FlowDisposition.DENIED_IN;
-import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -10,6 +9,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
 import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.flow.BidirectionalTrace.Key;
 import org.junit.Test;
 
@@ -19,8 +20,11 @@ public final class BidirectionalTraceTest {
   public void testKeyEquals() {
     Flow flow1 = Flow.builder().setIngressNode("ingressNode").setTag("tag1").build();
     Flow flow2 = Flow.builder().setIngressNode("ingressNode").setTag("tag2").build();
+    SessionMatchExpr dummySessionMatch =
+        new SessionMatchExpr(IpProtocol.TCP, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
     FirewallSessionTraceInfo session =
-        new FirewallSessionTraceInfo("hostname", Accept.INSTANCE, ImmutableSet.of(), TRUE, null);
+        new FirewallSessionTraceInfo(
+            "hostname", Accept.INSTANCE, ImmutableSet.of(), dummySessionMatch, null);
     new EqualsTester()
         .addEqualityGroup(
             new Key(flow1, ImmutableSet.of(), flow1), new Key(flow1, ImmutableSet.of(), flow1))
@@ -34,6 +38,8 @@ public final class BidirectionalTraceTest {
   public void testKey() {
     Flow flow1 = Flow.builder().setIngressNode("ingressNode").setTag("tag1").build();
     Flow flow2 = Flow.builder().setIngressNode("ingressNode").setTag("tag2").build();
+    SessionMatchExpr dummySessionMatch =
+        new SessionMatchExpr(IpProtocol.TCP, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
     Trace successTrace = new Trace(ACCEPTED, ImmutableList.of());
     assertThat(
         new BidirectionalTrace(flow1, successTrace, ImmutableSet.of(), flow2, successTrace)
@@ -44,7 +50,8 @@ public final class BidirectionalTraceTest {
             .getKey(),
         equalTo(new Key(flow2, ImmutableSet.of(), flow1)));
     FirewallSessionTraceInfo session =
-        new FirewallSessionTraceInfo("hostname", Accept.INSTANCE, ImmutableSet.of(), TRUE, null);
+        new FirewallSessionTraceInfo(
+            "hostname", Accept.INSTANCE, ImmutableSet.of(), dummySessionMatch, null);
     Trace failTrace = new Trace(DENIED_IN, ImmutableList.of());
     assertThat(
         new BidirectionalTrace(flow1, failTrace, ImmutableSet.of(session), null, null).getKey(),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/FirewallSessionTraceInfoTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/FirewallSessionTraceInfoTest.java
@@ -1,50 +1,54 @@
 package org.batfish.datamodel.flow;
 
-import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
-import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.transformation.Transformation.always;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.junit.Test;
 
 /** Tests for {@link FirewallSessionTraceInfo}. */
 public final class FirewallSessionTraceInfoTest {
+  private static final SessionMatchExpr FLOW1 =
+      new SessionMatchExpr(IpProtocol.TCP, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
+  private static final SessionMatchExpr FLOW2 =
+      new SessionMatchExpr(IpProtocol.TCP, Ip.parse("2.2.2.2"), Ip.parse("1.1.1.1"), null, null);
 
   @Test
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
             new FirewallSessionTraceInfo(
-                "A", new ForwardOutInterface("B", null), ImmutableSet.of(), TRUE, null),
+                "A", new ForwardOutInterface("B", null), ImmutableSet.of(), FLOW1, null),
             new FirewallSessionTraceInfo(
-                "A", new ForwardOutInterface("B", null), ImmutableSet.of(), TRUE, null))
+                "A", new ForwardOutInterface("B", null), ImmutableSet.of(), FLOW1, null))
         .addEqualityGroup(
             new FirewallSessionTraceInfo(
-                "A1", new ForwardOutInterface("B", null), ImmutableSet.of(), TRUE, null))
+                "A1", new ForwardOutInterface("B", null), ImmutableSet.of(), FLOW1, null))
         .addEqualityGroup(
             new FirewallSessionTraceInfo(
-                "A", new ForwardOutInterface("B1", null), ImmutableSet.of(), TRUE, null))
+                "A", new ForwardOutInterface("B1", null), ImmutableSet.of(), FLOW1, null))
         .addEqualityGroup(
             new FirewallSessionTraceInfo(
                 "A",
                 new ForwardOutInterface("B", NodeInterfacePair.of("", "")),
                 ImmutableSet.of(),
-                TRUE,
+                FLOW1,
                 null))
         .addEqualityGroup(
             new FirewallSessionTraceInfo(
-                "A", new ForwardOutInterface("B1", null), ImmutableSet.of(""), TRUE, null))
+                "A", new ForwardOutInterface("B1", null), ImmutableSet.of(""), FLOW1, null))
         .addEqualityGroup(
             new FirewallSessionTraceInfo(
-                "A", new ForwardOutInterface("B1", null), ImmutableSet.of(), FALSE, null))
+                "A", new ForwardOutInterface("B1", null), ImmutableSet.of(), FLOW2, null))
         .addEqualityGroup(
             new FirewallSessionTraceInfo(
                 "A",
                 new ForwardOutInterface("B1", null),
                 ImmutableSet.of(),
-                TRUE,
+                FLOW1,
                 always().build()))
         .testEquals();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
@@ -8,6 +8,8 @@ import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.Set;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.MatchSessionStep.MatchSessionStepDetail;
 import org.junit.Test;
@@ -17,15 +19,19 @@ public final class MatchSessionStepTest {
   @Test
   public void testConstructor() {
     Set<String> incomingInterfaces = ImmutableSet.of("a");
+    SessionMatchExpr matchCriteria =
+        new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
     MatchSessionStep step =
         new MatchSessionStep(
             MatchSessionStepDetail.builder()
                 .setIncomingInterfaces(incomingInterfaces)
                 .setSessionAction(Accept.INSTANCE)
+                .setMatchCriteria(matchCriteria)
                 .build());
     assertEquals(step.getAction(), StepAction.MATCHED_SESSION);
     assertEquals(step.getDetail().getIncomingInterfaces(), incomingInterfaces);
     assertEquals(step.getDetail().getSessionAction(), Accept.INSTANCE);
+    assertEquals(step.getDetail().getMatchCriteria(), matchCriteria);
   }
 
   @Test
@@ -33,11 +39,14 @@ public final class MatchSessionStepTest {
     Set<String> incomingInterfaces = ImmutableSet.of("b");
     ForwardOutInterface forwardAction =
         new ForwardOutInterface("a", NodeInterfacePair.of("a", "b"));
+    SessionMatchExpr matchCriteria =
+        new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
     MatchSessionStep step =
         new MatchSessionStep(
             MatchSessionStepDetail.builder()
                 .setIncomingInterfaces(incomingInterfaces)
                 .setSessionAction(forwardAction)
+                .setMatchCriteria(matchCriteria)
                 .build());
     MatchSessionStep clone = BatfishObjectMapper.clone(step, MatchSessionStep.class);
     assertEquals(step.getAction(), clone.getAction());
@@ -45,5 +54,6 @@ public final class MatchSessionStepTest {
         clone.getDetail().getIncomingInterfaces(),
         equalTo(step.getDetail().getIncomingInterfaces()));
     assertThat(clone.getDetail().getSessionAction(), equalTo(step.getDetail().getSessionAction()));
+    assertThat(clone.getDetail().getMatchCriteria(), equalTo(step.getDetail().getMatchCriteria()));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SessionMatchExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SessionMatchExprTest.java
@@ -1,0 +1,53 @@
+package org.batfish.datamodel.flow;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
+import org.junit.Test;
+
+public class SessionMatchExprTest {
+  @Test
+  public void testEquals() {
+    SessionMatchExpr expr =
+        new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), null, null);
+    new EqualsTester()
+        .addEqualityGroup(
+            expr,
+            expr,
+            new SessionMatchExpr(
+                IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), null, null))
+        .addEqualityGroup(
+            new SessionMatchExpr(
+                IpProtocol.TCP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), null, null))
+        .addEqualityGroup(
+            new SessionMatchExpr(
+                IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("2.2.2.2"), null, null))
+        .addEqualityGroup(
+            new SessionMatchExpr(
+                IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("2.2.2.2"), 4000, 5000),
+            new SessionMatchExpr(
+                IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("2.2.2.2"), 4000, 5000))
+        .addEqualityGroup(
+            new SessionMatchExpr(
+                IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("2.2.2.2"), 4040, 5050))
+        .testEquals();
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    SessionMatchExpr matcher =
+        new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), null, null);
+    SessionMatchExpr clone = BatfishObjectMapper.clone(matcher, SessionMatchExpr.class);
+    assertThat(matcher, equalTo(clone));
+
+    matcher =
+        new SessionMatchExpr(IpProtocol.TCP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), 5000, 8000);
+    clone = BatfishObjectMapper.clone(matcher, SessionMatchExpr.class);
+    assertThat(matcher, equalTo(clone));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SessionMatchExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SessionMatchExprTest.java
@@ -1,13 +1,19 @@
 package org.batfish.datamodel.flow;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpIpSpace;
 import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.junit.Test;
 
 public class SessionMatchExprTest {
@@ -49,5 +55,25 @@ public class SessionMatchExprTest {
         new SessionMatchExpr(IpProtocol.TCP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), 5000, 8000);
     clone = BatfishObjectMapper.clone(matcher, SessionMatchExpr.class);
     assertThat(matcher, equalTo(clone));
+  }
+
+  @Test
+  public void testToAclLineMatchExpr() {
+    SessionMatchExpr matcher =
+        new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), null, null);
+    MatchHeaderSpace aclExpr = (MatchHeaderSpace) matcher.toAclLineMatchExpr();
+    HeaderSpace hs = aclExpr.getHeaderspace();
+    assertThat(((IpIpSpace) hs.getSrcIps()).getIp(), equalTo(matcher.getSrcIp()));
+    assertThat(((IpIpSpace) hs.getDstIps()).getIp(), equalTo(matcher.getDstIp()));
+    assertThat(hs.getIpProtocols(), contains(IpProtocol.ICMP));
+    assertThat(hs.getSrcPorts(), hasSize(0));
+    assertThat(hs.getDstPorts(), hasSize(0));
+
+    matcher =
+        new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), 4000, 5000);
+    aclExpr = (MatchHeaderSpace) matcher.toAclLineMatchExpr();
+    hs = aclExpr.getHeaderspace();
+    assertThat(hs.getSrcPorts(), contains(SubRange.singleton(4000)));
+    assertThat(hs.getDstPorts(), contains(SubRange.singleton(5000)));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -55,17 +55,13 @@ import org.batfish.datamodel.FibNullRoute;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.Route;
-import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.Evaluator;
-import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Accept;
 import org.batfish.datamodel.flow.ExitOutputIfaceStep;
@@ -87,6 +83,7 @@ import org.batfish.datamodel.flow.RoutingStep;
 import org.batfish.datamodel.flow.RoutingStep.Builder;
 import org.batfish.datamodel.flow.RoutingStep.RoutingStepDetail;
 import org.batfish.datamodel.flow.SessionAction;
+import org.batfish.datamodel.flow.SessionMatchExpr;
 import org.batfish.datamodel.flow.SetupSessionStep;
 import org.batfish.datamodel.flow.Step;
 import org.batfish.datamodel.flow.StepAction;
@@ -1001,24 +998,18 @@ class FlowTracer {
   }
 
   @VisibleForTesting
-  static AclLineMatchExpr matchSessionReturnFlow(Flow forwardFlow) {
+  static SessionMatchExpr matchSessionReturnFlow(Flow forwardFlow) {
     IpProtocol ipProtocol = forwardFlow.getIpProtocol();
     checkArgument(
         IpProtocol.IP_PROTOCOLS_WITH_SESSIONS.contains(ipProtocol),
         "cannot match session return flow with IP protocol %s",
         ipProtocol);
-    HeaderSpace.Builder hb =
-        HeaderSpace.builder()
-            .setSrcIps(forwardFlow.getDstIp().toIpSpace())
-            .setDstIps(forwardFlow.getSrcIp().toIpSpace())
-            .setIpProtocols(ImmutableList.of(ipProtocol));
-
-    if (forwardFlow.getSrcPort() != null) {
-      hb.setSrcPorts(ImmutableList.of(SubRange.singleton(forwardFlow.getDstPort())))
-          .setDstPorts(ImmutableList.of(SubRange.singleton(forwardFlow.getSrcPort())));
-    }
-
-    return new MatchHeaderSpace(hb.build());
+    return new SessionMatchExpr(
+        ipProtocol,
+        forwardFlow.getDstIp(),
+        forwardFlow.getSrcIp(),
+        forwardFlow.getDstPort(),
+        forwardFlow.getSrcPort());
   }
 
   private void buildAcceptTrace() {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -734,6 +734,7 @@ class FlowTracer {
             MatchSessionStepDetail.builder()
                 .setIncomingInterfaces(session.getIncomingInterfaces())
                 .setSessionAction(session.getAction())
+                .setMatchCriteria(session.getMatchCriteria())
                 .build()));
 
     Configuration config = _tracerouteContext.getConfigurations().get(currentNodeName);

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -4,7 +4,6 @@ import static org.batfish.datamodel.FlowDisposition.DELIVERED_TO_SUBNET;
 import static org.batfish.datamodel.FlowDisposition.DENIED_IN;
 import static org.batfish.datamodel.FlowDisposition.LOOP;
 import static org.batfish.datamodel.FlowDisposition.NULL_ROUTED;
-import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.matchers.TraceAndReverseFlowMatchers.hasNewFirewallSessions;
 import static org.batfish.datamodel.matchers.TraceAndReverseFlowMatchers.hasTrace;
@@ -73,6 +72,7 @@ import org.batfish.datamodel.flow.Hop;
 import org.batfish.datamodel.flow.RouteInfo;
 import org.batfish.datamodel.flow.RoutingStep;
 import org.batfish.datamodel.flow.RoutingStep.RoutingStepDetail;
+import org.batfish.datamodel.flow.SessionMatchExpr;
 import org.batfish.datamodel.flow.Step;
 import org.batfish.datamodel.flow.StepAction;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
@@ -130,8 +130,11 @@ public final class FlowTracerTest {
             .build();
     List<TraceAndReverseFlow> traces = new ArrayList<>();
 
+    SessionMatchExpr dummySessionFlow =
+        new SessionMatchExpr(IpProtocol.TCP, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
     FirewallSessionTraceInfo sessionInfo =
-        new FirewallSessionTraceInfo("hostname", Accept.INSTANCE, ImmutableSet.of(), TRUE, null);
+        new FirewallSessionTraceInfo(
+            "hostname", Accept.INSTANCE, ImmutableSet.of(), dummySessionFlow, null);
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
             MockDataPlane.builder().setConfigs(ImmutableMap.of(c.getHostname(), c)).build(),
@@ -629,7 +632,7 @@ public final class FlowTracerTest {
     // TCP
     {
       Flow flow = fb.setIpProtocol(IpProtocol.TCP).setDstPort(100).setSrcPort(20).build();
-      BDD returnFlowBdd = toBdd.toBdd(matchSessionReturnFlow(flow));
+      BDD returnFlowBdd = toBdd.toBdd(matchSessionReturnFlow(flow).toAclLineMatchExpr());
       assertEquals(
           returnFlowBdd,
           BDDOps.andNull(
@@ -643,7 +646,7 @@ public final class FlowTracerTest {
     // UDP
     {
       Flow flow = fb.setIpProtocol(IpProtocol.UDP).setDstPort(100).setSrcPort(20).build();
-      BDD returnFlowBdd = toBdd.toBdd(matchSessionReturnFlow(flow));
+      BDD returnFlowBdd = toBdd.toBdd(matchSessionReturnFlow(flow).toAclLineMatchExpr());
       assertEquals(
           returnFlowBdd,
           BDDOps.andNull(
@@ -657,7 +660,7 @@ public final class FlowTracerTest {
     // ICMP
     {
       Flow flow = fb.setIpProtocol(IpProtocol.ICMP).setIcmpType(100).setIcmpCode(20).build();
-      BDD returnFlowBdd = toBdd.toBdd(matchSessionReturnFlow(flow));
+      BDD returnFlowBdd = toBdd.toBdd(matchSessionReturnFlow(flow).toAclLineMatchExpr());
       assertEquals(
           returnFlowBdd,
           BDDOps.andNull(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -15,7 +15,6 @@ import static org.batfish.datamodel.FlowDisposition.INSUFFICIENT_INFO;
 import static org.batfish.datamodel.FlowDisposition.LOOP;
 import static org.batfish.datamodel.FlowDisposition.NEIGHBOR_UNREACHABLE;
 import static org.batfish.datamodel.FlowDisposition.NO_ROUTE;
-import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcPort;
@@ -109,6 +108,7 @@ import org.batfish.datamodel.flow.MatchSessionStep;
 import org.batfish.datamodel.flow.OriginateStep;
 import org.batfish.datamodel.flow.RouteInfo;
 import org.batfish.datamodel.flow.RoutingStep;
+import org.batfish.datamodel.flow.SessionMatchExpr;
 import org.batfish.datamodel.flow.Step;
 import org.batfish.datamodel.flow.StepAction;
 import org.batfish.datamodel.flow.Trace;
@@ -1955,9 +1955,11 @@ public class TracerouteEngineImplTest {
     // Session exists with no outgoingInterface. Accepted at that node.
     {
       Flow flow = protoFlow;
+      SessionMatchExpr matchCriteria =
+          new SessionMatchExpr(IpProtocol.HOPOPT, ip11, ip10, null, null);
       FirewallSessionTraceInfo session =
           new FirewallSessionTraceInfo(
-              c1.getHostname(), Accept.INSTANCE, ImmutableSet.of(c1i1Name), TRUE, null);
+              c1.getHostname(), Accept.INSTANCE, ImmutableSet.of(c1i1Name), matchCriteria, null);
       List<TraceAndReverseFlow> results =
           tracerouteEngine
               .computeTracesAndReverseFlows(ImmutableSet.of(flow), ImmutableSet.of(session), false)
@@ -1990,7 +1992,7 @@ public class TracerouteEngineImplTest {
               c1.getHostname(),
               new ForwardOutInterface(c1i2Name, null),
               ImmutableSet.of(c1i1Name),
-              TRUE,
+              new SessionMatchExpr(IpProtocol.HOPOPT, ip11, ip10, null, null),
               null);
       List<TraceAndReverseFlow> results =
           tracerouteEngine
@@ -2026,7 +2028,7 @@ public class TracerouteEngineImplTest {
               c1.getHostname(),
               new ForwardOutInterface(c1i2Name, NodeInterfacePair.of(c2.getHostname(), c2i1Name)),
               ImmutableSet.of(c1i1Name),
-              TRUE,
+              new SessionMatchExpr(IpProtocol.HOPOPT, ip11, ip10, null, null),
               null);
       List<TraceAndReverseFlow> results =
           tracerouteEngine
@@ -2061,7 +2063,7 @@ public class TracerouteEngineImplTest {
               c1.getHostname(),
               new ForwardOutInterface(c1i2Name, NodeInterfacePair.of(c2.getHostname(), c2i1Name)),
               ImmutableSet.of(c1i1Name),
-              TRUE,
+              new SessionMatchExpr(IpProtocol.HOPOPT, ingressDenySrcIp, ip10, null, null),
               null);
       List<TraceAndReverseFlow> results =
           tracerouteEngine
@@ -2088,7 +2090,7 @@ public class TracerouteEngineImplTest {
               c1.getHostname(),
               new ForwardOutInterface(c1i2Name, NodeInterfacePair.of(c2.getHostname(), c2i1Name)),
               ImmutableSet.of(c1i1Name),
-              TRUE,
+              new SessionMatchExpr(IpProtocol.HOPOPT, egressDenySrcIp, ip10, null, null),
               null);
       List<TraceAndReverseFlow> results =
           tracerouteEngine
@@ -2117,7 +2119,7 @@ public class TracerouteEngineImplTest {
               c1.getHostname(),
               new ForwardOutInterface(c1i2Name, NodeInterfacePair.of(c2.getHostname(), c2i1Name)),
               ImmutableSet.of(c1i1Name),
-              TRUE,
+              new SessionMatchExpr(IpProtocol.HOPOPT, egressDenySrcIp, ip10, null, null),
               always().apply(assignSourceIp(ip11, ip11)).build());
       List<TraceAndReverseFlow> results =
           tracerouteEngine
@@ -2144,7 +2146,7 @@ public class TracerouteEngineImplTest {
               c1.getHostname(),
               new ForwardOutInterface(c1i2Name, NodeInterfacePair.of(c2.getHostname(), c2i1Name)),
               ImmutableSet.of(c1i1Name),
-              TRUE,
+              new SessionMatchExpr(IpProtocol.HOPOPT, ingressDenySrcIp, ip10, null, null),
               always().apply(assignSourceIp(ip11, ip11)).build());
       List<TraceAndReverseFlow> results =
           tracerouteEngine
@@ -2160,7 +2162,7 @@ public class TracerouteEngineImplTest {
               c1.getHostname(),
               new ForwardOutInterface(c1i2Name, NodeInterfacePair.of(c2.getHostname(), c2i1Name)),
               ImmutableSet.of(c1i1Name),
-              TRUE,
+              new SessionMatchExpr(IpProtocol.HOPOPT, ingressDenySrcIp, ip10, null, null),
               always().apply(assignSourceIp(ip11, ip11)).build());
       Flow flow = protoFlow.toBuilder().setSrcIp(ingressDenySrcIp).build();
       List<TraceAndReverseFlow> results =
@@ -2178,6 +2180,13 @@ public class TracerouteEngineImplTest {
                               hasNodeName(c1.getHostname()), hasNodeName(c2.getHostname())))))));
 
       flow = protoFlow.toBuilder().setSrcIp(egressDenySrcIp).build();
+      session =
+          new FirewallSessionTraceInfo(
+              c1.getHostname(),
+              new ForwardOutInterface(c1i2Name, NodeInterfacePair.of(c2.getHostname(), c2i1Name)),
+              ImmutableSet.of(c1i1Name),
+              new SessionMatchExpr(IpProtocol.HOPOPT, egressDenySrcIp, ip10, null, null),
+              always().apply(assignSourceIp(ip11, ip11)).build());
       results =
           tracerouteEngine
               .computeTracesAndReverseFlows(ImmutableSet.of(flow), ImmutableSet.of(session), true)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -1974,7 +1974,8 @@ public class TracerouteEngineImplTest {
                       "detail",
                       allOf(
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
-                          hasProperty("sessionAction", equalTo(Accept.INSTANCE)))))));
+                          hasProperty("sessionAction", equalTo(Accept.INSTANCE)),
+                          hasProperty("matchCriteria", equalTo(matchCriteria)))))));
       assertThat(
           results,
           contains(
@@ -2007,7 +2008,8 @@ public class TracerouteEngineImplTest {
                       "detail",
                       allOf(
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
-                          hasProperty("sessionAction", equalTo(session.getAction())))))));
+                          hasProperty("sessionAction", equalTo(session.getAction())),
+                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())))))));
       /* Disposition is always exits network -- see:
        * TracerouteEngineImplContext#buildSessionArpFailureTrace(String, TransmissionContext, List).
        */
@@ -2043,7 +2045,8 @@ public class TracerouteEngineImplTest {
                       "detail",
                       allOf(
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
-                          hasProperty("sessionAction", equalTo(session.getAction())))))));
+                          hasProperty("sessionAction", equalTo(session.getAction())),
+                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())))))));
       // flow reaches c2.
       assertThat(
           results,
@@ -2078,7 +2081,8 @@ public class TracerouteEngineImplTest {
                       "detail",
                       allOf(
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
-                          hasProperty("sessionAction", equalTo(session.getAction())))))));
+                          hasProperty("sessionAction", equalTo(session.getAction())),
+                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())))))));
       assertThat(results, contains(hasTrace(hasDisposition(DENIED_IN))));
     }
 
@@ -2105,7 +2109,8 @@ public class TracerouteEngineImplTest {
                       "detail",
                       allOf(
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
-                          hasProperty("sessionAction", equalTo(session.getAction())))))));
+                          hasProperty("sessionAction", equalTo(session.getAction())),
+                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())))))));
       assertThat(results, contains(hasTrace(hasDisposition(DENIED_OUT))));
     }
 

--- a/projects/question/src/test/java/org/batfish/question/traceroute/BidirectionalTracerouteAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/traceroute/BidirectionalTracerouteAnswererTest.java
@@ -7,7 +7,6 @@ import static org.batfish.datamodel.FlowDisposition.DENIED_OUT;
 import static org.batfish.datamodel.FlowDisposition.EXITS_NETWORK;
 import static org.batfish.datamodel.FlowDisposition.NEIGHBOR_UNREACHABLE;
 import static org.batfish.datamodel.FlowDisposition.NO_ROUTE;
-import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
 import static org.batfish.question.traceroute.BidirectionalTracerouteAnswerer.COL_FORWARD_FLOW;
 import static org.batfish.question.traceroute.BidirectionalTracerouteAnswerer.COL_FORWARD_TRACES;
@@ -37,10 +36,12 @@ import java.util.Set;
 import org.batfish.common.plugin.TracerouteEngine;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.flow.Accept;
 import org.batfish.datamodel.flow.BidirectionalTrace;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
+import org.batfish.datamodel.flow.SessionMatchExpr;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
 import org.batfish.datamodel.table.Row;
@@ -63,6 +64,9 @@ public final class BidirectionalTracerouteAnswererTest {
           .setIngressNode("reverseIngressNode")
           .setIngressInterface("reverseIngressInterface")
           .build();
+
+  private static final SessionMatchExpr DUMMY_SESSION_FLOW =
+      new SessionMatchExpr(IpProtocol.HOPOPT, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
 
   @Test
   public void testNoReverseFlow() {
@@ -157,7 +161,8 @@ public final class BidirectionalTracerouteAnswererTest {
     Trace forwardTrace = new Trace(ACCEPTED, ImmutableList.of());
     Trace reverseTrace = new Trace(NEIGHBOR_UNREACHABLE, ImmutableList.of());
     FirewallSessionTraceInfo session =
-        new FirewallSessionTraceInfo("session", Accept.INSTANCE, ImmutableSet.of(), TRUE, null);
+        new FirewallSessionTraceInfo(
+            "session", Accept.INSTANCE, ImmutableSet.of(), DUMMY_SESSION_FLOW, null);
     TraceAndReverseFlow forwardTarf =
         new TraceAndReverseFlow(forwardTrace, REVERSE_FLOW, ImmutableList.of(session));
     TraceAndReverseFlow reverseTarf =
@@ -184,7 +189,8 @@ public final class BidirectionalTracerouteAnswererTest {
     Trace sessionForwardTrace = new Trace(ACCEPTED, ImmutableList.of());
     Trace noSessionForwardTrace = new Trace(DELIVERED_TO_SUBNET, ImmutableList.of());
     FirewallSessionTraceInfo session =
-        new FirewallSessionTraceInfo("session", Accept.INSTANCE, ImmutableSet.of(), TRUE, null);
+        new FirewallSessionTraceInfo(
+            "session", Accept.INSTANCE, ImmutableSet.of(), DUMMY_SESSION_FLOW, null);
     TraceAndReverseFlow sessionForwardTarf =
         new TraceAndReverseFlow(sessionForwardTrace, REVERSE_FLOW, ImmutableList.of(session));
     TraceAndReverseFlow noSessionForwardTarf =
@@ -233,9 +239,11 @@ public final class BidirectionalTracerouteAnswererTest {
     Trace t4 = new Trace(DENIED_IN, ImmutableList.of());
 
     FirewallSessionTraceInfo session1 =
-        new FirewallSessionTraceInfo("session1", Accept.INSTANCE, ImmutableSet.of(), TRUE, null);
+        new FirewallSessionTraceInfo(
+            "session1", Accept.INSTANCE, ImmutableSet.of(), DUMMY_SESSION_FLOW, null);
     FirewallSessionTraceInfo session2 =
-        new FirewallSessionTraceInfo("session2", Accept.INSTANCE, ImmutableSet.of(), TRUE, null);
+        new FirewallSessionTraceInfo(
+            "session2", Accept.INSTANCE, ImmutableSet.of(), DUMMY_SESSION_FLOW, null);
 
     {
       // All BidirectionalTraces have the same key, so are in the same group.
@@ -375,9 +383,11 @@ public final class BidirectionalTracerouteAnswererTest {
     {
       // Sessions in the key
       FirewallSessionTraceInfo session1 =
-          new FirewallSessionTraceInfo("session1", Accept.INSTANCE, ImmutableSet.of(), TRUE, null);
+          new FirewallSessionTraceInfo(
+              "session1", Accept.INSTANCE, ImmutableSet.of(), DUMMY_SESSION_FLOW, null);
       FirewallSessionTraceInfo session2 =
-          new FirewallSessionTraceInfo("session2", Accept.INSTANCE, ImmutableSet.of(), TRUE, null);
+          new FirewallSessionTraceInfo(
+              "session2", Accept.INSTANCE, ImmutableSet.of(), DUMMY_SESSION_FLOW, null);
       Set<FirewallSessionTraceInfo> sessions = ImmutableSet.of(session1, session2);
 
       BidirectionalTrace bt = new BidirectionalTrace(FORWARD_FLOW, t1, sessions, REVERSE_FLOW, t1);


### PR DESCRIPTION
- New data type:
    - `SessionMatchExpr`
        - Contains all the information needed to match a session, but simpler and more specific than `AclLineMatchExpr`
- Changes in `FirewallSessionTraceInfo`
    - Use `SessionMatchExpr` for `_sessionFlows`
    - Keep the getter `getSessionFlows` returning `AclLineMatchExpr` to not break all the usages of `FirewallSessionTraceInfo`
    - Add `getMatchCriteria` that returns `_sessionFlows` as is, which is used in `MatchSessionStepDetail`
- Changes in `FlowTracer`
    - `matchSessionReturnFlow` now returns a `SessionMatchExpr` instead of `AclLineMatchExpr`
- Changes in `MatchSessionStepDetail`
    - Added `matchCriteria` field of type `SessionMatchExpr`
- Tests
    - Created tests for `SessionMatchExpr` on equality and JSON serialisation
    - Tested `matchCriteria` field in `TracerouteEngineImplTest`
    - Fixed tests that broke because of the new data type
        - Replacing `AclLineMatchExprs.TRUE` with an arbitrary dummy `SessionMatchExpr` if the match criteria is meaningless in the test
        - Replacing `AclLineMatchExprs.TRUE` with a `SessionMatchExpr` that matches the tested flow if the match criteria is expected to pass