### PR TITLE
Don't add exit output interface step for null routed trace

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -902,15 +902,6 @@ class FlowTracer {
   }
 
   private void buildNullRoutedTrace() {
-    _steps.add(
-        ExitOutputIfaceStep.builder()
-            .setDetail(
-                ExitOutputIfaceStepDetail.builder()
-                    .setOutputInterface(
-                        NodeInterfacePair.of(_currentNode.getName(), Interface.NULL_INTERFACE_NAME))
-                    .build())
-            .setAction(StepAction.NULL_ROUTED)
-            .build());
     _hops.add(new Hop(_currentNode, _steps));
     Trace trace = new Trace(FlowDisposition.NULL_ROUTED, _hops);
     _flowTraces.accept(new TraceAndReverseFlow(trace, null, _newSessions));

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -902,6 +903,12 @@ class FlowTracer {
   }
 
   private void buildNullRoutedTrace() {
+    checkState(
+        Iterables.getLast(_steps) instanceof RoutingStep,
+        "RoutingStep should be the last step while creating a null routed trace");
+    checkState(
+        Iterables.getLast(_steps).getAction() == NULL_ROUTED,
+        "The last routing step should should have the action as NULL_ROUTED");
     _hops.add(new Hop(_currentNode, _steps));
     Trace trace = new Trace(FlowDisposition.NULL_ROUTED, _hops);
     _flowTraces.accept(new TraceAndReverseFlow(trace, null, _newSessions));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -70,7 +69,6 @@ import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Accept;
 import org.batfish.datamodel.flow.ArpErrorStep;
 import org.batfish.datamodel.flow.DeliveredStep;
-import org.batfish.datamodel.flow.ExitOutputIfaceStep;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
 import org.batfish.datamodel.flow.Hop;
 import org.batfish.datamodel.flow.RouteInfo;
@@ -294,12 +292,7 @@ public final class FlowTracerTest {
     // - null-route should occur in the second step
     // - third step should have null-route action
 
-    assertThat(
-        steps,
-        contains(
-            instanceOf(RoutingStep.class),
-            instanceOf(RoutingStep.class),
-            instanceOf(ExitOutputIfaceStep.class)));
+    assertThat(steps, contains(instanceOf(RoutingStep.class), instanceOf(RoutingStep.class)));
     assertThat(
         ((RoutingStep) steps.get(0)).getDetail().getRoutes().get(0).getNextVrf(),
         equalTo(nextVrfName));
@@ -308,7 +301,6 @@ public final class FlowTracerTest {
         ((RoutingStep) steps.get(1)).getDetail().getRoutes().get(0).getNextHopIp(),
         equalTo(Ip.AUTO));
     assertThat((steps.get(1)).getAction(), equalTo(StepAction.NULL_ROUTED));
-    assertThat(((ExitOutputIfaceStep) steps.get(2)).getAction(), is(StepAction.NULL_ROUTED));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -227,11 +227,10 @@ public class TracerouteEngineImplTest {
     assertThat(hops, hasSize(1));
 
     List<Step<?>> steps = hops.get(0).getSteps();
-    assertThat(steps, hasSize(3));
+    assertThat(steps, hasSize(2));
 
     assertTrue(OriginateStep.class.isInstance(steps.get(0)));
     assertTrue(RoutingStep.class.isInstance(steps.get(1)));
-    assertTrue(ExitOutputIfaceStep.class.isInstance(steps.get(2)));
   }
 
   @Test


### PR DESCRIPTION
- it does not serve any purpose to have an exit output Interface step like
`NULL_ROUTED(null_interface)`
as Routing step already has enough information.