### PR TITLE
PAN: Support quoted values containing quotes

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/BUILD
@@ -9,6 +9,7 @@ java_library(
         ":PaloAltoParserListener.java",
     ],
     deps = [
+        "//projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/parsing:cisco_nxos_base",
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",
     ],

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/BUILD
@@ -9,7 +9,7 @@ java_library(
         ":PaloAltoParserListener.java",
     ],
     deps = [
-        "//projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/parsing:cisco_nxos_base",
+        "//projects/batfish/src/main/java/org/batfish/grammar/palo_alto/parsing:palo_alto_base",
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",
     ],

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -1,7 +1,7 @@
 lexer grammar PaloAltoLexer;
 
 options {
-  superClass = 'org.batfish.grammar.BatfishLexer';
+  superClass = 'org.batfish.grammar.palo_alto.parsing.PaloAltoBaseLexer';
 }
 
 tokens {
@@ -13,10 +13,6 @@ tokens {
 
 @members {
 // Java code to end up in PaloAltoLexer.java goes here
-  public boolean followedByNewline() {
-    char followedBy = (char) _input.LA(1);
-    return followedBy == '\n' || followedBy == '\r';
-  }
 }
 
 // Keywords

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -11,10 +11,6 @@ tokens {
   WORD
 }
 
-@members {
-// Java code to end up in PaloAltoLexer.java goes here
-}
-
 // Keywords
 
 TWO_BYTE

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -14,8 +14,8 @@ tokens {
 @members {
 // Java code to end up in PaloAltoLexer.java goes here
   public boolean followedByNewline() {
-    String followedBy = lookAheadString(1);
-    return followedBy.equals("\n") || followedBy.equals("\r");
+    char followedBy = (char) _input.LA(1);
+    return followedBy == '\n' || followedBy == '\r';
   }
 }
 
@@ -1726,6 +1726,11 @@ M_Value_BODY
 M_Value_DOUBLE_QUOTE
 :
   '"' -> type(DOUBLE_QUOTE), mode(M_ValueDoubleQuoted)
+;
+
+M_Value_NEWLINE
+:
+  F_Newline+ -> type(NEWLINE), popMode
 ;
 
 M_Value_SINGLE_QUOTE

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -1708,7 +1708,8 @@ F_NotWhitespaceNewlineOrQuote
 
 // Modes
 
-// PaloAlto devices can produce output where quotes enclose unescaped quotes.
+// PaloAlto devices can produce set-line output where quotes enclose unescaped quotes.
+//
 // Terminate quoted values when encountering the expected closing quote followed by a newline
 // to avoid accidentally consuming following lines.
 mode M_Value;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_address.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_address.g4
@@ -25,7 +25,7 @@ s_address_definition
 
 sa_description
 :
-    DESCRIPTION description = variable
+    DESCRIPTION description = value
 ;
 
 sa_fqdn

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_address_group.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_address_group.g4
@@ -24,7 +24,7 @@ s_address_group_definition
 
 sag_description
 :
-    DESCRIPTION description = variable
+    DESCRIPTION description = value
 ;
 
 sag_dynamic

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_application.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_application.g4
@@ -21,7 +21,7 @@ s_application_definition
 
 sapp_description
 :
-    DESCRIPTION description = variable
+    DESCRIPTION description = value
 ;
 
 s_application_group

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
@@ -110,7 +110,7 @@ value
 :
     DOUBLE_QUOTE body = BODY DOUBLE_QUOTE
     | SINGLE_QUOTE body = BODY SINGLE_QUOTE
-    | body = BODY
+    | body = BODY?
 ;
 
 variable_port_list

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
@@ -108,8 +108,8 @@ uint32
 
 value
 :
-    DOUBLE_QUOTE body = BODY DOUBLE_QUOTE
-    | SINGLE_QUOTE body = BODY SINGLE_QUOTE
+    DOUBLE_QUOTE body = BODY? DOUBLE_QUOTE
+    | SINGLE_QUOTE body = BODY? SINGLE_QUOTE
     | body = BODY?
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
@@ -106,6 +106,13 @@ uint32
     | UINT32
 ;
 
+value
+:
+    DOUBLE_QUOTE body = BODY DOUBLE_QUOTE
+    | SINGLE_QUOTE body = BODY SINGLE_QUOTE
+    | body = BODY
+;
+
 variable_port_list
 :
     port_or_range

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_policy_rule.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_policy_rule.g4
@@ -91,7 +91,7 @@ praau_extended_community
 
 praau_med
 :
-    MED value = bgp_med
+    MED val = bgp_med
 ;
 
 praau_origin

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_rulebase.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_rulebase.g4
@@ -76,7 +76,7 @@ srs_category
 
 srs_description
 :
-    DESCRIPTION description = variable
+    DESCRIPTION description = value
 ;
 
 srs_destination

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_service.g4
@@ -24,7 +24,7 @@ s_service_definition
 
 sserv_description
 :
-    DESCRIPTION description = variable
+    DESCRIPTION description = value
 ;
 
 sserv_port

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/BUILD
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/BUILD
@@ -5,7 +5,7 @@ load("@batfish//skylark:pmd_test.bzl", "pmd_test")
 java_library(
     name = "palo_alto",
     srcs = glob(
-        ["*.java"],
+        ["**/*.java"],
         exclude = ["BUILD"],
     ),
     deps = [

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -701,7 +701,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void exitPraau_med(Praau_medContext ctx) {
-    _currentPolicyRule.setUpdateMetric(new PolicyRuleUpdateMetric(toLong(ctx.value.uint32())));
+    _currentPolicyRule.setUpdateMetric(new PolicyRuleUpdateMetric(toLong(ctx.val.uint32())));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -280,6 +280,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Translated_address_list_item
 import org.batfish.grammar.palo_alto.PaloAltoParser.Uint16Context;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Uint32Context;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Uint8Context;
+import org.batfish.grammar.palo_alto.PaloAltoParser.ValueContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.VariableContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Variable_listContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Variable_list_itemContext;
@@ -467,6 +468,11 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   /** Return token text with enclosing quotes removed, if applicable */
   private String getText(Token t) {
     return unquote(t.getText());
+  }
+
+  /** Return text corresponding to value context with enclosing quotes removed, if applicable */
+  private String getText(ValueContext ctx) {
+    return unquote(ctx.getText());
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/parsing/BUILD
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/parsing/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "palo_alto_base",
+    srcs = [
+        ":PaloAltoBaseLexer.java",
+    ],
+    deps = [
+        "//projects/batfish-common-protocol:parser_common",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:org_antlr_antlr4_runtime",
+    ],
+)

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/parsing/PaloAltoBaseLexer.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/parsing/PaloAltoBaseLexer.java
@@ -1,0 +1,21 @@
+package org.batfish.grammar.palo_alto.parsing;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.antlr.v4.runtime.CharStream;
+import org.batfish.grammar.BatfishLexer;
+
+/**
+ * Cisco NX-OS lexer base class providing additional functionality on top of {@link BatfishLexer}.
+ */
+@ParametersAreNonnullByDefault
+public abstract class PaloAltoBaseLexer extends BatfishLexer {
+
+  public PaloAltoBaseLexer(CharStream input) {
+    super(input);
+  }
+
+  public boolean followedByNewline() {
+    char followedBy = (char) _input.LA(1);
+    return followedBy == '\n' || followedBy == '\r';
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/parsing/PaloAltoBaseLexer.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/parsing/PaloAltoBaseLexer.java
@@ -4,9 +4,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.antlr.v4.runtime.CharStream;
 import org.batfish.grammar.BatfishLexer;
 
-/**
- * Cisco NX-OS lexer base class providing additional functionality on top of {@link BatfishLexer}.
- */
+/** Palo Alto lexer base class providing additional functionality on top of {@link BatfishLexer}. */
 @ParametersAreNonnullByDefault
 public abstract class PaloAltoBaseLexer extends BatfishLexer {
 
@@ -15,7 +13,7 @@ public abstract class PaloAltoBaseLexer extends BatfishLexer {
   }
 
   public boolean followedByNewline() {
-    char followedBy = (char) _input.LA(1);
+    int followedBy = _input.LA(1);
     return followedBy == '\n' || followedBy == '\r';
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2333,7 +2333,8 @@ public final class PaloAltoGrammarTest {
             hasKey("addr3"),
             hasKey("addr4"),
             hasKey("addr5"),
-            hasKey("addr6")));
+            hasKey("addr6"),
+            hasKey("addr7")));
 
     String descr0 = addrs.get("addr0").getDescription();
     String descr1 = addrs.get("addr1").getDescription();
@@ -2342,6 +2343,7 @@ public final class PaloAltoGrammarTest {
     String descr4 = addrs.get("addr4").getDescription();
     String descr5 = addrs.get("addr5").getDescription();
     String descr6 = addrs.get("addr6").getDescription();
+    String descr7 = addrs.get("addr7").getDescription();
 
     // Quoted values containing quotes should be extracted
     assertThat(descr0, equalTo("quoted description with a '"));
@@ -2352,7 +2354,8 @@ public final class PaloAltoGrammarTest {
     // Quoted and non-quoted values should be extracted correctly
     assertThat(descr4, equalTo("shortdescription"));
     assertThat(descr5, equalTo("quoted description"));
-    // Missing value should be interpreted as empty string
+    // Missing value and empty quotes should be interpreted as empty string
     assertThat(descr6, equalTo(""));
+    assertThat(descr7, equalTo(""));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2332,7 +2332,8 @@ public final class PaloAltoGrammarTest {
             hasKey("addr2"),
             hasKey("addr3"),
             hasKey("addr4"),
-            hasKey("addr5")));
+            hasKey("addr5"),
+            hasKey("addr6")));
 
     String descr0 = addrs.get("addr0").getDescription();
     String descr1 = addrs.get("addr1").getDescription();
@@ -2340,6 +2341,7 @@ public final class PaloAltoGrammarTest {
     String descr3 = addrs.get("addr3").getDescription();
     String descr4 = addrs.get("addr4").getDescription();
     String descr5 = addrs.get("addr5").getDescription();
+    String descr6 = addrs.get("addr6").getDescription();
 
     // Quoted values containing quotes should be extracted
     assertThat(descr0, equalTo("quoted description with a '"));
@@ -2350,5 +2352,7 @@ public final class PaloAltoGrammarTest {
     // Quoted and non-quoted values should be extracted correctly
     assertThat(descr4, equalTo("shortdescription"));
     assertThat(descr5, equalTo("quoted description"));
+    // Missing value should be interpreted as empty string
+    assertThat(descr6, equalTo(""));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2324,7 +2324,15 @@ public final class PaloAltoGrammarTest {
 
     PaloAltoConfiguration c = parsePaloAltoConfig(hostname);
     SortedMap<String, AddressObject> addrs = c.getVirtualSystems().get("vsys1").getAddressObjects();
-    assertThat(addrs, allOf(hasKey("addr0"), hasKey("addr1"), hasKey("addr2"), hasKey("addr3")));
+    assertThat(
+        addrs,
+        allOf(
+            hasKey("addr0"),
+            hasKey("addr1"),
+            hasKey("addr2"),
+            hasKey("addr3"),
+            hasKey("addr4"),
+            hasKey("addr5")));
 
     String descr0 = addrs.get("addr0").getDescription();
     String descr1 = addrs.get("addr1").getDescription();

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2319,7 +2319,7 @@ public final class PaloAltoGrammarTest {
   }
 
   @Test
-  public void testQuotedValues() throws IOException {
+  public void testQuotedValues() {
     String hostname = "quoted-values";
 
     PaloAltoConfiguration c = parsePaloAltoConfig(hostname);
@@ -2331,14 +2331,16 @@ public final class PaloAltoGrammarTest {
     String descr2 = addrs.get("addr2").getDescription();
     String descr3 = addrs.get("addr3").getDescription();
     String descr4 = addrs.get("addr4").getDescription();
+    String descr5 = addrs.get("addr5").getDescription();
 
     // Quoted values containing quotes should be extracted
     assertThat(descr0, equalTo("quoted description with a '"));
     assertThat(descr1, equalTo("quoted description with a \""));
     assertThat(descr2, equalTo("quoted description with a \" and '"));
+    assertThat(descr3, equalTo("multiline description with \" inside'\nand other stuff"));
 
     // Quoted and non-quoted values should be extracted correctly
-    assertThat(descr3, equalTo("shortdescription"));
-    assertThat(descr4, equalTo("quoted description"));
+    assertThat(descr4, equalTo("shortdescription"));
+    assertThat(descr5, equalTo("quoted description"));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2317,4 +2317,28 @@ public final class PaloAltoGrammarTest {
     assertThat(c, hasInterface("ethernet1/2", hasZoneName(equalTo("zone 1"))));
     assertThat(c, hasInterface("ethernet1/3", hasZoneName(is(nullValue()))));
   }
+
+  @Test
+  public void testQuotedValues() throws IOException {
+    String hostname = "quoted-values";
+
+    PaloAltoConfiguration c = parsePaloAltoConfig(hostname);
+    SortedMap<String, AddressObject> addrs = c.getVirtualSystems().get("vsys1").getAddressObjects();
+    assertThat(addrs, allOf(hasKey("addr0"), hasKey("addr1"), hasKey("addr2"), hasKey("addr3")));
+
+    String descr0 = addrs.get("addr0").getDescription();
+    String descr1 = addrs.get("addr1").getDescription();
+    String descr2 = addrs.get("addr2").getDescription();
+    String descr3 = addrs.get("addr3").getDescription();
+    String descr4 = addrs.get("addr4").getDescription();
+
+    // Quoted values containing quotes should be extracted
+    assertThat(descr0, equalTo("quoted description with a '"));
+    assertThat(descr1, equalTo("quoted description with a \""));
+    assertThat(descr2, equalTo("quoted description with a \" and '"));
+
+    // Quoted and non-quoted values should be extracted correctly
+    assertThat(descr3, equalTo("shortdescription"));
+    assertThat(descr4, equalTo("quoted description"));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/quoted-values
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/quoted-values
@@ -7,3 +7,5 @@ set address "addr3" description "multiline description with " inside'
 and other stuff"
 set address "addr4" description shortdescription
 set address addr5 description "quoted description"
+# Show output after entering `set address addr6 description ""`:
+set address addr6 description

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/quoted-values
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/quoted-values
@@ -9,3 +9,4 @@ set address "addr4" description shortdescription
 set address addr5 description "quoted description"
 # Show output after entering `set address addr6 description ""`:
 set address addr6 description
+set address addr7 description ""

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/quoted-values
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/quoted-values
@@ -3,5 +3,7 @@ set address "addr0" description "quoted description with a '"
 # Wrapping " with " is syntactically ambiguous, but can exist in device's show output
 set address "addr1" description "quoted description with a ""
 set address "addr2" description "quoted description with a " and '"
-set address "addr3" description shortdescription
-set address addr4 description "quoted description"
+set address "addr3" description "multiline description with " inside'
+and other stuff"
+set address "addr4" description shortdescription
+set address addr5 description "quoted description"

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/quoted-values
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/quoted-values
@@ -1,0 +1,7 @@
+set deviceconfig system hostname quoted-values
+set address "addr0" description "quoted description with a '"
+# Wrapping " with " is syntactically ambiguous, but can exist in device's show output
+set address "addr1" description "quoted description with a ""
+set address "addr2" description "quoted description with a " and '"
+set address "addr3" description shortdescription
+set address addr4 description "quoted description"


### PR DESCRIPTION
Palo Alto item values containing special characters (including quotes) are enclosed in quotes in `show` output, e.g. consider a named structure `named struct`, whose description is `foo "inner ' text' ". Newline:\nSecond line.`:
```
  "named struct" {
    description "foo "inner ' text' ". Newline:
Second line.";
  }
```
or
```
set "named struct" description "foo "inner ' text' ". Newline:
Second line."
```
Note the ambiguous syntax since inner quotes are unescaped.

This was causing issues where structures like this would end up consuming following config lines due to "unterminated" quotes.

-----

This PR updates lexing logic for PAN to terminate quoted strings when encountering the first appropriate end-quote character immediately followed by a newline.

