### PR TITLE
Add SessionMatchExpr as a simpler structure to represent session match criteria

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
@@ -1,0 +1,110 @@
+package org.batfish.datamodel.flow;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.ImmutableList;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+
+/** Represents a match criteria for a {@link FirewallSessionTraceInfo} */
+@JsonTypeName("SessionMatchExpr")
+@ParametersAreNonnullByDefault
+public class SessionMatchExpr {
+  private static final String PROP_IP_PROTOCOL = "ipProtocol";
+  private static final String PROP_SRC_IP = "srcIp";
+  private static final String PROP_DST_IP = "dstIp";
+  private static final String PROP_SRC_PORT = "srcPort";
+  private static final String PROP_DST_PORT = "dstPort";
+
+  private final IpProtocol _ipProtocol;
+  private final Ip _srcIp;
+  private final Ip _dstIp;
+  @Nullable private final Integer _srcPort;
+  @Nullable private final Integer _dstPort;
+
+  @JsonCreator
+  public SessionMatchExpr(
+      @JsonProperty(PROP_IP_PROTOCOL) IpProtocol ipProtocol,
+      @JsonProperty(PROP_SRC_IP) Ip srcIp,
+      @JsonProperty(PROP_DST_IP) Ip dstIp,
+      @JsonProperty(PROP_SRC_PORT) @Nullable Integer srcPort,
+      @JsonProperty(PROP_DST_PORT) @Nullable Integer dstPort) {
+    _ipProtocol = ipProtocol;
+    _srcIp = srcIp;
+    _dstIp = dstIp;
+    _srcPort = srcPort;
+    _dstPort = dstPort;
+  }
+
+  @JsonProperty(PROP_IP_PROTOCOL)
+  public IpProtocol getIpProtocol() {
+    return _ipProtocol;
+  }
+
+  @JsonProperty(PROP_SRC_IP)
+  public Ip getSrcIp() {
+    return _srcIp;
+  }
+
+  @JsonProperty(PROP_DST_IP)
+  public Ip getDstIp() {
+    return _dstIp;
+  }
+
+  @JsonProperty(PROP_SRC_PORT)
+  @Nullable
+  public Integer getSrcPort() {
+    return _srcPort;
+  }
+
+  @JsonProperty(PROP_DST_PORT)
+  @Nullable
+  public Integer getDstPort() {
+    return _dstPort;
+  }
+
+  /** Transforms into generic {@link AclLineMatchExpr} which allows usage with visitors */
+  public AclLineMatchExpr toAclLineMatchExpr() {
+    HeaderSpace.Builder hb =
+        HeaderSpace.builder()
+            .setSrcIps(_srcIp.toIpSpace())
+            .setDstIps(_dstIp.toIpSpace())
+            .setIpProtocols(ImmutableList.of(_ipProtocol));
+
+    if (_srcPort != null) {
+      hb.setSrcPorts(ImmutableList.of(SubRange.singleton(_srcPort)))
+          .setDstPorts(ImmutableList.of(SubRange.singleton(_dstPort)));
+    }
+
+    return new MatchHeaderSpace(hb.build());
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SessionMatchExpr)) {
+      return false;
+    }
+    SessionMatchExpr rhs = (SessionMatchExpr) o;
+    return Objects.equals(_ipProtocol, rhs._ipProtocol)
+        && Objects.equals(_srcIp, rhs._srcIp)
+        && Objects.equals(_dstIp, rhs._dstIp)
+        && Objects.equals(_srcPort, rhs._srcPort)
+        && Objects.equals(_dstPort, rhs._dstPort);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_ipProtocol, _srcIp, _dstIp, _srcPort, _dstPort);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.flow;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -30,18 +32,38 @@ public class SessionMatchExpr {
   @Nullable private final Integer _srcPort;
   @Nullable private final Integer _dstPort;
 
-  @JsonCreator
   public SessionMatchExpr(
-      @JsonProperty(PROP_IP_PROTOCOL) IpProtocol ipProtocol,
-      @JsonProperty(PROP_SRC_IP) Ip srcIp,
-      @JsonProperty(PROP_DST_IP) Ip dstIp,
-      @JsonProperty(PROP_SRC_PORT) @Nullable Integer srcPort,
-      @JsonProperty(PROP_DST_PORT) @Nullable Integer dstPort) {
+      IpProtocol ipProtocol,
+      Ip srcIp,
+      Ip dstIp,
+      @Nullable Integer srcPort,
+      @Nullable Integer dstPort) {
+    checkArgument(
+        (srcPort == null && dstPort == null) || (srcPort != null && dstPort != null),
+        "srcPort and dstPort should be both null or both non-null");
     _ipProtocol = ipProtocol;
     _srcIp = srcIp;
     _dstIp = dstIp;
     _srcPort = srcPort;
     _dstPort = dstPort;
+  }
+
+  @JsonCreator
+  private static SessionMatchExpr jsonCreator(
+      @JsonProperty(PROP_IP_PROTOCOL) @Nullable IpProtocol ipProtocol,
+      @JsonProperty(PROP_SRC_IP) @Nullable Ip srcIp,
+      @JsonProperty(PROP_DST_IP) @Nullable Ip dstIp,
+      @JsonProperty(PROP_SRC_PORT) @Nullable Integer srcPort,
+      @JsonProperty(PROP_DST_PORT) @Nullable Integer dstPort) {
+    checkArgument(ipProtocol != null, "Missing %s", PROP_IP_PROTOCOL);
+    checkArgument(srcIp != null, "Missing %s", PROP_SRC_IP);
+    checkArgument(dstIp != null, "Missing %s", PROP_DST_IP);
+    checkArgument(
+        (srcPort == null && dstPort == null) || (srcPort != null && dstPort != null),
+        "%s and %s should be both null or both non-null",
+        PROP_SRC_PORT,
+        PROP_DST_PORT);
+    return new SessionMatchExpr(ipProtocol, srcIp, dstIp, srcPort, dstPort);
   }
 
   @JsonProperty(PROP_IP_PROTOCOL)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionMatchExpr.java
@@ -58,11 +58,6 @@ public class SessionMatchExpr {
     checkArgument(ipProtocol != null, "Missing %s", PROP_IP_PROTOCOL);
     checkArgument(srcIp != null, "Missing %s", PROP_SRC_IP);
     checkArgument(dstIp != null, "Missing %s", PROP_DST_IP);
-    checkArgument(
-        (srcPort == null && dstPort == null) || (srcPort != null && dstPort != null),
-        "%s and %s should be both null or both non-null",
-        PROP_SRC_PORT,
-        PROP_DST_PORT);
     return new SessionMatchExpr(ipProtocol, srcIp, dstIp, srcPort, dstPort);
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SessionMatchExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SessionMatchExprTest.java
@@ -36,15 +36,15 @@ public class SessionMatchExprTest {
                 IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("1.1.2.2"), null, null))
         .addEqualityGroup(
             new SessionMatchExpr(
-                IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("2.2.2.2"), 4000, 5000),
+                IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), 4000, 5000),
             new SessionMatchExpr(
-                IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("2.2.2.2"), 4000, 5000))
+                IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), 4000, 5000))
         .addEqualityGroup(
             new SessionMatchExpr(
-                IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("2.2.2.2"), 4040, 5000))
+                IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), 4040, 5000))
         .addEqualityGroup(
             new SessionMatchExpr(
-                IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("2.2.2.2"), 4000, 5050))
+                IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), 4000, 5050))
         .testEquals();
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SessionMatchExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SessionMatchExprTest.java
@@ -1,0 +1,79 @@
+package org.batfish.datamodel.flow;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpIpSpace;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.junit.Test;
+
+public class SessionMatchExprTest {
+  @Test
+  public void testEquals() {
+    SessionMatchExpr expr =
+        new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), null, null);
+    new EqualsTester()
+        .addEqualityGroup(
+            expr,
+            expr,
+            new SessionMatchExpr(
+                IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), null, null))
+        .addEqualityGroup(
+            new SessionMatchExpr(
+                IpProtocol.TCP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), null, null))
+        .addEqualityGroup(
+            new SessionMatchExpr(
+                IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("2.2.2.2"), null, null))
+        .addEqualityGroup(
+            new SessionMatchExpr(
+                IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("2.2.2.2"), 4000, 5000),
+            new SessionMatchExpr(
+                IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("2.2.2.2"), 4000, 5000))
+        .addEqualityGroup(
+            new SessionMatchExpr(
+                IpProtocol.ICMP, Ip.parse("1.1.2.2"), Ip.parse("2.2.2.2"), 4040, 5050))
+        .testEquals();
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    SessionMatchExpr matcher =
+        new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), null, null);
+    SessionMatchExpr clone = BatfishObjectMapper.clone(matcher, SessionMatchExpr.class);
+    assertThat(matcher, equalTo(clone));
+
+    matcher =
+        new SessionMatchExpr(IpProtocol.TCP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), 5000, 8000);
+    clone = BatfishObjectMapper.clone(matcher, SessionMatchExpr.class);
+    assertThat(matcher, equalTo(clone));
+  }
+
+  @Test
+  public void testToAclLineMatchExpr() {
+    SessionMatchExpr matcher =
+        new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), null, null);
+    MatchHeaderSpace aclExpr = (MatchHeaderSpace) matcher.toAclLineMatchExpr();
+    HeaderSpace hs = aclExpr.getHeaderspace();
+    assertThat(((IpIpSpace) hs.getSrcIps()).getIp(), equalTo(matcher.getSrcIp()));
+    assertThat(((IpIpSpace) hs.getDstIps()).getIp(), equalTo(matcher.getDstIp()));
+    assertThat(hs.getIpProtocols(), contains(IpProtocol.ICMP));
+    assertThat(hs.getSrcPorts(), hasSize(0));
+    assertThat(hs.getDstPorts(), hasSize(0));
+
+    matcher =
+        new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), 4000, 5000);
+    aclExpr = (MatchHeaderSpace) matcher.toAclLineMatchExpr();
+    hs = aclExpr.getHeaderspace();
+    assertThat(hs.getSrcPorts(), contains(SubRange.singleton(4000)));
+    assertThat(hs.getDstPorts(), contains(SubRange.singleton(5000)));
+  }
+}


### PR DESCRIPTION
This will be replacing the type of `sessionFlows` in `FirewallSessionTraceInfo` from `AclLineMatchExpr`.