### PR TITLE
Introduce PermitAndDenyBdds

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBddImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBddImpl.java
@@ -27,7 +27,7 @@ public final class IpAccessListToBddImpl extends IpAccessListToBdd {
   }
 
   @Override
-  public BDD toBdd(AclLine line) {
+  public PermitAndDenyBdds toPermitAndDenyBdds(AclLine line) {
     return convert(line);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MemoizedIpAccessListToBdd.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MemoizedIpAccessListToBdd.java
@@ -15,7 +15,7 @@ import org.batfish.datamodel.acl.AclLineMatchExpr;
  * {@link IdentityHashMap}.
  */
 public final class MemoizedIpAccessListToBdd extends IpAccessListToBdd {
-  private Map<AclLine, BDD> _lineCache = new IdentityHashMap<>();
+  private Map<AclLine, PermitAndDenyBdds> _lineCache = new IdentityHashMap<>();
   private Map<AclLineMatchExpr, BDD> _exprCache = new IdentityHashMap<>();
 
   public MemoizedIpAccessListToBdd(
@@ -27,7 +27,7 @@ public final class MemoizedIpAccessListToBdd extends IpAccessListToBdd {
   }
 
   @Override
-  public BDD toBdd(AclLine line) {
+  public PermitAndDenyBdds toPermitAndDenyBdds(AclLine line) {
     return _lineCache.computeIfAbsent(line, this::convert);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/PermitAndDenyBdds.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/PermitAndDenyBdds.java
@@ -1,0 +1,44 @@
+package org.batfish.common.bdd;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.sf.javabdd.BDD;
+import org.batfish.datamodel.AclLine;
+import org.batfish.datamodel.IpAccessList;
+
+/**
+ * Represents flows explicitly permitted and denied by some ACL-like object (e.g. {@link AclLine} or
+ * {@link IpAccessList})
+ */
+@ParametersAreNonnullByDefault
+public final class PermitAndDenyBdds {
+  @Nonnull private final BDD _permitBdd;
+  @Nonnull private final BDD _denyBdd;
+  private BDD _matchBdd;
+
+  public PermitAndDenyBdds(BDD permit, BDD deny) {
+    _permitBdd = permit;
+    _denyBdd = deny;
+  }
+
+  /** BDD of all flows explicitly matched and permitted */
+  @Nonnull
+  public BDD getPermitBdd() {
+    return _permitBdd;
+  }
+
+  /** BDD of all flows explicitly matched and denied */
+  @Nonnull
+  public BDD getDenyBdd() {
+    return _denyBdd;
+  }
+
+  /** BDD of all explicitly matched flows, whether permitted or denied */
+  @Nonnull
+  public BDD getMatchBdd() {
+    if (_matchBdd == null) {
+      _matchBdd = _permitBdd.or(_denyBdd);
+    }
+    return _matchBdd;
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/datamodel/BddTestbed.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/BddTestbed.java
@@ -15,7 +15,7 @@ import org.batfish.datamodel.acl.AclLineMatchExpr;
 public final class BddTestbed {
 
   public @Nonnull BDD toBDD(AclLine aclLine) {
-    return _aclToBdd.toBdd(aclLine);
+    return _aclToBdd.toPermitAndDenyBdds(aclLine).getMatchBdd();
   }
 
   public @Nonnull BDD toBDD(AclLineMatchExpr aclLineMatchExpr) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -379,7 +379,7 @@ public final class CiscoNxosGrammarTest {
     return ACL_TO_BDD.toBdd(aclLineMatchExpr);
   }
 
-  private static @Nonnull BDD toBDD(AclLine aclLine) {
+  private static @Nonnull BDD toMatchBDD(AclLine aclLine) {
     return ACL_TO_BDD.toPermitAndDenyBdds(aclLine).getMatchBdd();
   }
 
@@ -394,7 +394,7 @@ public final class CiscoNxosGrammarTest {
   }
 
   private static @Nonnull BDD toIfBDD(AclLine aclLine) {
-    return toBDD(aclLine).and(toBDD(matchFragmentOffset(0)));
+    return toMatchBDD(aclLine).and(toBDD(matchFragmentOffset(0)));
   }
 
   private static @Nonnull BDD toNonIfBDD(AclLineMatchExpr aclLineMatchExpr) {
@@ -404,7 +404,8 @@ public final class CiscoNxosGrammarTest {
   }
 
   private static @Nonnull BDD toNonIfBDD(AclLine aclLine) {
-    return toBDD(aclLine).and(toBDD(matchFragmentOffset(IntegerSpace.of(Range.closed(1, 8191)))));
+    return toMatchBDD(aclLine)
+        .and(toBDD(matchFragmentOffset(IntegerSpace.of(Range.closed(1, 8191)))));
   }
 
   private static @Nonnull BDD toTcpIfBDD(AclLineMatchExpr aclLineMatchExpr) {
@@ -2478,7 +2479,7 @@ public final class CiscoNxosGrammarTest {
       org.batfish.datamodel.IpAccessList acl = c.getIpAccessLists().get("acl_indices");
       assertThat(
           acl.getLines().stream()
-              .map(CiscoNxosGrammarTest::toBDD)
+              .map(CiscoNxosGrammarTest::toMatchBDD)
               .collect(ImmutableList.toImmutableList()),
           contains(
               toBDD(matchIpProtocol(1)),
@@ -2490,7 +2491,7 @@ public final class CiscoNxosGrammarTest {
       org.batfish.datamodel.IpAccessList acl = c.getIpAccessLists().get("acl_simple_protocols");
       assertThat(
           acl.getLines().stream()
-              .map(CiscoNxosGrammarTest::toBDD)
+              .map(CiscoNxosGrammarTest::toMatchBDD)
               .collect(ImmutableList.toImmutableList()),
           contains(
               toBDD(matchIpProtocol(IpProtocol.AHP)),
@@ -2535,7 +2536,7 @@ public final class CiscoNxosGrammarTest {
           c.getIpAccessLists().get("acl_common_ip_options_dscp");
       assertThat(
           acl.getLines().stream()
-              .map(CiscoNxosGrammarTest::toBDD)
+              .map(CiscoNxosGrammarTest::toMatchBDD)
               .collect(ImmutableList.toImmutableList()),
           contains(
               toBDD(matchDscp(1)),
@@ -2567,7 +2568,7 @@ public final class CiscoNxosGrammarTest {
           c.getIpAccessLists().get("acl_common_ip_options_packet_length");
       assertThat(
           acl.getLines().stream()
-              .map(CiscoNxosGrammarTest::toBDD)
+              .map(CiscoNxosGrammarTest::toMatchBDD)
               .collect(ImmutableList.toImmutableList()),
           contains(
               toBDD(matchPacketLength(100)),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -380,7 +380,7 @@ public final class CiscoNxosGrammarTest {
   }
 
   private static @Nonnull BDD toBDD(AclLine aclLine) {
-    return ACL_TO_BDD.toBdd(aclLine);
+    return ACL_TO_BDD.toPermitAndDenyBdds(aclLine).getMatchBdd();
   }
 
   private static @Nonnull BDD toIcmpIfBDD(AclLineMatchExpr aclLineMatchExpr) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredGrammarTest.java
@@ -335,7 +335,7 @@ public final class F5BigipStructuredGrammarTest {
     if (matchLine == null) {
       return false;
     }
-    return !toBDD().toBdd(acl.getLines().get(matchLine)).isOne();
+    return !toBDD().toPermitAndDenyBdds(acl.getLines().get(matchLine)).getMatchBdd().isOne();
   }
 
   private @Nonnull F5BigipConfiguration parseVendorConfig(String filename) {

--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
@@ -32,6 +32,7 @@ import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.IpAccessListToBdd;
 import org.batfish.common.bdd.IpAccessListToBddImpl;
+import org.batfish.common.bdd.PermitAndDenyBdds;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.util.CollectionUtil;
 import org.batfish.datamodel.AclLine;
@@ -553,7 +554,10 @@ public class FilterLineReachabilityAnswerer extends Answerer {
 
     /* Convert every line to a BDD. */
     List<BDD> ipLineToBDDMap =
-        lines.stream().map(ipAccessListToBdd::toBdd).collect(Collectors.toList());
+        lines.stream()
+            .map(ipAccessListToBdd::toPermitAndDenyBdds)
+            .map(PermitAndDenyBdds::getMatchBdd)
+            .collect(Collectors.toList());
 
     /* Pass over BDDs to classify each as unmatchable, unreachable, or (implicitly) reachable. */
     BDD unmatchedPackets = bddFactory.one(); // The packets that are not yet matched by the ACL.

--- a/projects/question/src/main/java/org/batfish/question/findmatchingfilterlines/FindMatchingFilterLinesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/findmatchingfilterlines/FindMatchingFilterLinesAnswerer.java
@@ -205,7 +205,7 @@ public final class FindMatchingFilterLinesAnswerer extends Answerer {
         return false;
       }
       // If there is any overlap between the header space BDD and this line, include it
-      BDD lineBdd = _ipAccessListToBdd.toBdd(exprAclLine);
+      BDD lineBdd = _ipAccessListToBdd.toBdd(exprAclLine.getMatchCondition());
       return _headerSpaceBdd.andSat(lineBdd);
     }
   }


### PR DESCRIPTION
Introduces new class `PermitAndDenyBdds`, containing two BDDs representing an explicitly matched set of flows and an explicitly denied set of flows respectively. This paves the way for simplifications in `IpAccessListToBdd` that also make it flexible to types of ACL line with no concrete action.