### PR TITLE
Include transformation behaviour in MatchSessionStepDetail

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.FlowDiff;
 import org.batfish.datamodel.flow.MatchSessionStep.MatchSessionStepDetail;
 
 /** A {@link Step} for when a {@link Flow} matches a session. */
@@ -22,29 +23,39 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
     private static final String PROP_INCOMING_INTERFACES = "incomingInterfaces";
     private static final String PROP_SESSION_ACTION = "sessionAction";
     private static final String PROP_MATCH_CRITERIA = "matchCriteria";
+    private static final String PROP_TRANSFORMATION = "transformation";
 
     @Nonnull private final Set<String> _incomingInterfaces;
     @Nonnull private final SessionAction _sessionAction;
     @Nonnull private final SessionMatchExpr _matchCriteria;
+    private final Set<FlowDiff> _transformation;
 
     private MatchSessionStepDetail(
         @Nonnull Set<String> incomingInterfaces,
         @Nonnull SessionAction sessionAction,
-        @Nonnull SessionMatchExpr matchCriteria) {
+        @Nonnull SessionMatchExpr matchCriteria,
+        Set<FlowDiff> transformation) {
       _incomingInterfaces = ImmutableSet.copyOf(incomingInterfaces);
       _sessionAction = sessionAction;
       _matchCriteria = matchCriteria;
+      if (transformation != null) {
+        _transformation = ImmutableSet.copyOf(transformation);
+      } else {
+        _transformation = null;
+      }
     }
 
     @JsonCreator
     private static MatchSessionStepDetail jsonCreator(
         @JsonProperty(PROP_INCOMING_INTERFACES) Set<String> incomingInterfaces,
         @JsonProperty(PROP_SESSION_ACTION) SessionAction sessionAction,
-        @JsonProperty(PROP_MATCH_CRITERIA) SessionMatchExpr matchCriteria) {
+        @JsonProperty(PROP_MATCH_CRITERIA) SessionMatchExpr matchCriteria,
+        @JsonProperty(PROP_TRANSFORMATION) Set<FlowDiff> transformation) {
       checkArgument(incomingInterfaces != null, "Missing %s", PROP_INCOMING_INTERFACES);
       checkArgument(sessionAction != null, "Missing %s", PROP_SESSION_ACTION);
       checkArgument(matchCriteria != null, "Missing %s", PROP_MATCH_CRITERIA);
-      return new MatchSessionStepDetail(incomingInterfaces, sessionAction, matchCriteria);
+      return new MatchSessionStepDetail(
+          incomingInterfaces, sessionAction, matchCriteria, transformation);
     }
 
     @JsonProperty(PROP_INCOMING_INTERFACES)
@@ -65,6 +76,11 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
       return _matchCriteria;
     }
 
+    @JsonProperty(PROP_TRANSFORMATION)
+    public Set<FlowDiff> getTransformation() {
+      return _transformation;
+    }
+
     public static Builder builder() {
       return new Builder();
     }
@@ -74,6 +90,7 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
       private @Nullable Set<String> _incomingInterfaces;
       private @Nullable SessionAction _sessionAction;
       private @Nullable SessionMatchExpr _matchCriteria;
+      private @Nullable Set<FlowDiff> _transformation;
 
       public MatchSessionStepDetail build() {
         checkNotNull(
@@ -83,7 +100,10 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
             _matchCriteria,
             "Cannot build MatchSessionStepDetail without specifying match criteria");
         return new MatchSessionStepDetail(
-            firstNonNull(_incomingInterfaces, ImmutableSet.of()), _sessionAction, _matchCriteria);
+            firstNonNull(_incomingInterfaces, ImmutableSet.of()),
+            _sessionAction,
+            _matchCriteria,
+            _transformation);
       }
 
       public Builder setIncomingInterfaces(Set<String> incomingInterfaces) {
@@ -98,6 +118,11 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
 
       public Builder setMatchCriteria(SessionMatchExpr matchCriteria) {
         _matchCriteria = matchCriteria;
+        return this;
+      }
+
+      public Builder setTransformation(Set<FlowDiff> transformation) {
+        _transformation = transformation;
         return this;
       }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/MatchSessionStep.java
@@ -34,15 +34,11 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
         @Nonnull Set<String> incomingInterfaces,
         @Nonnull SessionAction sessionAction,
         @Nonnull SessionMatchExpr matchCriteria,
-        Set<FlowDiff> transformation) {
+        @Nonnull Set<FlowDiff> transformation) {
       _incomingInterfaces = ImmutableSet.copyOf(incomingInterfaces);
       _sessionAction = sessionAction;
       _matchCriteria = matchCriteria;
-      if (transformation != null) {
-        _transformation = ImmutableSet.copyOf(transformation);
-      } else {
-        _transformation = null;
-      }
+      _transformation = ImmutableSet.copyOf(transformation);
     }
 
     @JsonCreator
@@ -55,7 +51,10 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
       checkArgument(sessionAction != null, "Missing %s", PROP_SESSION_ACTION);
       checkArgument(matchCriteria != null, "Missing %s", PROP_MATCH_CRITERIA);
       return new MatchSessionStepDetail(
-          incomingInterfaces, sessionAction, matchCriteria, transformation);
+          incomingInterfaces,
+          sessionAction,
+          matchCriteria,
+          firstNonNull(transformation, ImmutableSet.of()));
     }
 
     @JsonProperty(PROP_INCOMING_INTERFACES)
@@ -103,7 +102,7 @@ public class MatchSessionStep extends Step<MatchSessionStepDetail> {
             firstNonNull(_incomingInterfaces, ImmutableSet.of()),
             _sessionAction,
             _matchCriteria,
-            _transformation);
+            firstNonNull(_transformation, ImmutableSet.of()));
       }
 
       public Builder setIncomingInterfaces(Set<String> incomingInterfaces) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.flow;
 
+import static org.batfish.datamodel.FlowDiff.flowDiff;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -8,10 +9,12 @@ import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.Set;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.FlowDiff;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.MatchSessionStep.MatchSessionStepDetail;
+import org.batfish.datamodel.transformation.IpField;
 import org.junit.Test;
 
 /** Test for {@link MatchSessionStep}. */
@@ -21,17 +24,21 @@ public final class MatchSessionStepTest {
     Set<String> incomingInterfaces = ImmutableSet.of("a");
     SessionMatchExpr matchCriteria =
         new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
+    Set<FlowDiff> transformation =
+        ImmutableSet.of(flowDiff(IpField.SOURCE, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2")));
     MatchSessionStep step =
         new MatchSessionStep(
             MatchSessionStepDetail.builder()
                 .setIncomingInterfaces(incomingInterfaces)
                 .setSessionAction(Accept.INSTANCE)
                 .setMatchCriteria(matchCriteria)
+                .setTransformation(transformation)
                 .build());
     assertEquals(step.getAction(), StepAction.MATCHED_SESSION);
     assertEquals(step.getDetail().getIncomingInterfaces(), incomingInterfaces);
     assertEquals(step.getDetail().getSessionAction(), Accept.INSTANCE);
     assertEquals(step.getDetail().getMatchCriteria(), matchCriteria);
+    assertEquals(step.getDetail().getTransformation(), transformation);
   }
 
   @Test
@@ -41,12 +48,15 @@ public final class MatchSessionStepTest {
         new ForwardOutInterface("a", NodeInterfacePair.of("a", "b"));
     SessionMatchExpr matchCriteria =
         new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
+    Set<FlowDiff> transformation =
+        ImmutableSet.of(flowDiff(IpField.SOURCE, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2")));
     MatchSessionStep step =
         new MatchSessionStep(
             MatchSessionStepDetail.builder()
                 .setIncomingInterfaces(incomingInterfaces)
                 .setSessionAction(forwardAction)
                 .setMatchCriteria(matchCriteria)
+                .setTransformation(transformation)
                 .build());
     MatchSessionStep clone = BatfishObjectMapper.clone(step, MatchSessionStep.class);
     assertEquals(step.getAction(), clone.getAction());
@@ -55,5 +65,7 @@ public final class MatchSessionStepTest {
         equalTo(step.getDetail().getIncomingInterfaces()));
     assertThat(clone.getDetail().getSessionAction(), equalTo(step.getDetail().getSessionAction()));
     assertThat(clone.getDetail().getMatchCriteria(), equalTo(step.getDetail().getMatchCriteria()));
+    assertThat(
+        clone.getDetail().getTransformation(), equalTo(step.getDetail().getTransformation()));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -120,6 +120,7 @@ import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
 import org.batfish.datamodel.flow.TransformationStep;
 import org.batfish.datamodel.flow.TransformationStep.TransformationStepDetail;
+import org.batfish.datamodel.transformation.IpField;
 import org.batfish.datamodel.transformation.PortField;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.dataplane.TracerouteEngineImpl;
@@ -1957,7 +1958,8 @@ public class TracerouteEngineImplTest {
                       allOf(
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
                           hasProperty("sessionAction", equalTo(Accept.INSTANCE)),
-                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())))))));
+                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())),
+                          hasProperty("transformation", equalTo(null)))))));
       assertThat(
           results,
           contains(
@@ -1991,7 +1993,8 @@ public class TracerouteEngineImplTest {
                       allOf(
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
                           hasProperty("sessionAction", equalTo(session.getAction())),
-                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())))))));
+                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())),
+                          hasProperty("transformation", equalTo(null)))))));
       /* Disposition is always exits network -- see:
        * TracerouteEngineImplContext#buildSessionArpFailureTrace(String, TransmissionContext, List).
        */
@@ -2028,7 +2031,8 @@ public class TracerouteEngineImplTest {
                       allOf(
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
                           hasProperty("sessionAction", equalTo(session.getAction())),
-                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())))))));
+                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())),
+                          hasProperty("transformation", equalTo(null)))))));
       // flow reaches c2.
       assertThat(
           results,
@@ -2064,7 +2068,8 @@ public class TracerouteEngineImplTest {
                       allOf(
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
                           hasProperty("sessionAction", equalTo(session.getAction())),
-                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())))))));
+                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())),
+                          hasProperty("transformation", equalTo(null)))))));
       assertThat(results, contains(hasTrace(hasDisposition(DENIED_IN))));
     }
 
@@ -2092,7 +2097,8 @@ public class TracerouteEngineImplTest {
                       allOf(
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
                           hasProperty("sessionAction", equalTo(session.getAction())),
-                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())))))));
+                          hasProperty("matchCriteria", equalTo(session.getMatchCriteria())),
+                          hasProperty("transformation", equalTo(null)))))));
       assertThat(results, contains(hasTrace(hasDisposition(DENIED_OUT))));
     }
 
@@ -2112,6 +2118,16 @@ public class TracerouteEngineImplTest {
           tracerouteEngine
               .computeTracesAndReverseFlows(ImmutableSet.of(flow), ImmutableSet.of(session), false)
               .get(flow);
+      assertThat(
+          results.get(0).getTrace().getHops().get(0).getSteps(),
+          hasItem(
+              allOf(
+                  instanceOf(MatchSessionStep.class),
+                  hasProperty(
+                      "detail",
+                      hasProperty(
+                          "transformation",
+                          contains(flowDiff(IpField.SOURCE, egressDenySrcIp, ip11)))))));
       // flow reaches c2.
       assertThat(
           results,
@@ -2139,6 +2155,16 @@ public class TracerouteEngineImplTest {
           tracerouteEngine
               .computeTracesAndReverseFlows(ImmutableSet.of(flow), ImmutableSet.of(session), false)
               .get(flow);
+      assertThat(
+          results.get(0).getTrace().getHops().get(0).getSteps(),
+          hasItem(
+              allOf(
+                  instanceOf(MatchSessionStep.class),
+                  hasProperty(
+                      "detail",
+                      hasProperty(
+                          "transformation",
+                          contains(flowDiff(IpField.SOURCE, ingressDenySrcIp, ip11)))))));
       assertThat(results, contains(hasTrace(hasDisposition(DENIED_IN))));
     }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -1959,7 +1959,7 @@ public class TracerouteEngineImplTest {
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
                           hasProperty("sessionAction", equalTo(Accept.INSTANCE)),
                           hasProperty("matchCriteria", equalTo(session.getMatchCriteria())),
-                          hasProperty("transformation", equalTo(null)))))));
+                          hasProperty("transformation", hasSize(0)))))));
       assertThat(
           results,
           contains(
@@ -1994,7 +1994,7 @@ public class TracerouteEngineImplTest {
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
                           hasProperty("sessionAction", equalTo(session.getAction())),
                           hasProperty("matchCriteria", equalTo(session.getMatchCriteria())),
-                          hasProperty("transformation", equalTo(null)))))));
+                          hasProperty("transformation", hasSize(0)))))));
       /* Disposition is always exits network -- see:
        * TracerouteEngineImplContext#buildSessionArpFailureTrace(String, TransmissionContext, List).
        */
@@ -2032,7 +2032,7 @@ public class TracerouteEngineImplTest {
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
                           hasProperty("sessionAction", equalTo(session.getAction())),
                           hasProperty("matchCriteria", equalTo(session.getMatchCriteria())),
-                          hasProperty("transformation", equalTo(null)))))));
+                          hasProperty("transformation", hasSize(0)))))));
       // flow reaches c2.
       assertThat(
           results,
@@ -2069,7 +2069,7 @@ public class TracerouteEngineImplTest {
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
                           hasProperty("sessionAction", equalTo(session.getAction())),
                           hasProperty("matchCriteria", equalTo(session.getMatchCriteria())),
-                          hasProperty("transformation", equalTo(null)))))));
+                          hasProperty("transformation", hasSize(0)))))));
       assertThat(results, contains(hasTrace(hasDisposition(DENIED_IN))));
     }
 
@@ -2098,7 +2098,7 @@ public class TracerouteEngineImplTest {
                           hasProperty("incomingInterfaces", equalTo(ImmutableSet.of(c1i1Name))),
                           hasProperty("sessionAction", equalTo(session.getAction())),
                           hasProperty("matchCriteria", equalTo(session.getMatchCriteria())),
-                          hasProperty("transformation", equalTo(null)))))));
+                          hasProperty("transformation", hasSize(0)))))));
       assertThat(results, contains(hasTrace(hasDisposition(DENIED_OUT))));
     }
 


### PR DESCRIPTION
- Added new nullable field `transformation` in `MatchSessionStepDetail` as a set of `FlowDiff`s
- Rearranged transformation part of `processSessions` in `FlowTracer` in order to capture transformation behaviour before it's applied and before incoming ACL is applied.