### PR TITLE
Arista BGP: prefix-lists as method of filtering on neighbors

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Arista_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Arista_bgp.g4
@@ -487,7 +487,7 @@ eos_rbi_neighbor_common
     | eos_rbinc_next_hop_unchanged
 //    | eos_rbinc_out_delay
     | eos_rbinc_password
-//    | eos_rbinc_prefix_list
+    | eos_rbinc_prefix_list
     | eos_rbinc_remote_as
     | eos_rbinc_remove_private_as
     | eos_rbafnc_route_map
@@ -596,6 +596,11 @@ eos_rbinc_next_hop_unchanged
 eos_rbinc_password
 :
   PASSWORD (encrypt_level = DEC)? variable NEWLINE
+;
+
+eos_rbinc_prefix_list
+:
+  PREFIX_LIST name = variable (IN | OUT) NEWLINE
 ;
 
 eos_rbinc_remote_as

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -602,6 +602,7 @@ import org.batfish.grammar.cisco.CiscoParser.Eos_rbinc_maximum_accepted_routesCo
 import org.batfish.grammar.cisco.CiscoParser.Eos_rbinc_maximum_routesContext;
 import org.batfish.grammar.cisco.CiscoParser.Eos_rbinc_next_hop_selfContext;
 import org.batfish.grammar.cisco.CiscoParser.Eos_rbinc_next_hop_unchangedContext;
+import org.batfish.grammar.cisco.CiscoParser.Eos_rbinc_prefix_listContext;
 import org.batfish.grammar.cisco.CiscoParser.Eos_rbinc_remote_asContext;
 import org.batfish.grammar.cisco.CiscoParser.Eos_rbinc_remove_private_asContext;
 import org.batfish.grammar.cisco.CiscoParser.Eos_rbinc_route_reflector_clientContext;
@@ -2670,6 +2671,17 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitEos_rbinc_next_hop_unchanged(Eos_rbinc_next_hop_unchangedContext ctx) {
     _currentAristaBgpNeighbor.setNextHopUnchanged(true);
+  }
+
+  @Override
+  public void exitEos_rbinc_prefix_list(Eos_rbinc_prefix_listContext ctx) {
+    if (ctx.IN() != null) {
+      _currentAristaBgpNeighbor.getGenericAddressFamily().setPrefixListIn(ctx.name.getText());
+    } else if (ctx.OUT() != null) {
+      _currentAristaBgpNeighbor.getGenericAddressFamily().setPrefixListOut(ctx.name.getText());
+    } else {
+      _w.addWarning(ctx, ctx.getText(), _parser, "Unknown prefix list direction");
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -2676,12 +2676,14 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitEos_rbinc_prefix_list(Eos_rbinc_prefix_listContext ctx) {
     String name = ctx.name.getText();
-    _configuration.referenceStructure(
-        PREFIX_LIST, name, BGP_OUTBOUND_PREFIX_LIST, ctx.getStart().getLine());
     if (ctx.IN() != null) {
       _currentAristaBgpNeighbor.getGenericAddressFamily().setPrefixListIn(name);
+      _configuration.referenceStructure(
+          PREFIX_LIST, name, BGP_INBOUND_PREFIX_LIST, ctx.getStart().getLine());
     } else if (ctx.OUT() != null) {
       _currentAristaBgpNeighbor.getGenericAddressFamily().setPrefixListOut(name);
+      _configuration.referenceStructure(
+          PREFIX_LIST, name, BGP_OUTBOUND_PREFIX_LIST, ctx.getStart().getLine());
     } else {
       _w.addWarning(ctx, ctx.getText(), _parser, "Unknown prefix list direction");
     }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -2675,10 +2675,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitEos_rbinc_prefix_list(Eos_rbinc_prefix_listContext ctx) {
+    String name = ctx.name.getText();
+    _configuration.referenceStructure(
+        PREFIX_LIST, name, BGP_OUTBOUND_PREFIX_LIST, ctx.getStart().getLine());
     if (ctx.IN() != null) {
-      _currentAristaBgpNeighbor.getGenericAddressFamily().setPrefixListIn(ctx.name.getText());
+      _currentAristaBgpNeighbor.getGenericAddressFamily().setPrefixListIn(name);
     } else if (ctx.OUT() != null) {
-      _currentAristaBgpNeighbor.getGenericAddressFamily().setPrefixListOut(ctx.name.getText());
+      _currentAristaBgpNeighbor.getGenericAddressFamily().setPrefixListOut(name);
     } else {
       _w.addWarning(ctx, ctx.getText(), _parser, "Unknown prefix list direction");
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/AristaConversions.java
@@ -389,10 +389,8 @@ final class AristaConversions {
           && c.getRouteFilterLists().containsKey(inboundPrefixList)) {
         warnings.redFlag(
             String.format(
-                "Inbound prefix list {} + route map {} not supported for neighbor {}. Preferring route map.",
-                inboundPrefixList,
-                inboundMap,
-                peerStrRepr));
+                "Inbound prefix list %s + route map %s not supported for neighbor %s. Preferring route map.",
+                inboundPrefixList, inboundMap, peerStrRepr));
         policy = inboundMap;
       } else if (inboundMap != null && c.getRoutingPolicies().containsKey(inboundMap)) {
         policy = inboundMap;
@@ -465,10 +463,8 @@ final class AristaConversions {
           && c.getRouteFilterLists().containsKey(outboundPrefixList)) {
         warnings.redFlag(
             String.format(
-                "Outbound prefix list {} + route map {} not supported for neighbor {}. Preferring route map.",
-                outboundPrefixList,
-                outboundMap,
-                peerStrRepr));
+                "Outbound prefix list %s + route map %s not supported for neighbor %s. Preferring route map.",
+                outboundPrefixList, outboundMap, peerStrRepr));
         peerExportConditions.add(new CallExpr(outboundMap));
       } else if (outboundMap != null && c.getRoutingPolicies().containsKey(outboundMap)) {
         peerExportConditions.add(new CallExpr(outboundMap));

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/eos/AristaBgpNeighborAddressFamily.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/eos/AristaBgpNeighborAddressFamily.java
@@ -107,6 +107,12 @@ public class AristaBgpNeighborAddressFamily implements Serializable {
     if (_nextHopUnchanged == null) {
       _nextHopUnchanged = other._nextHopUnchanged;
     }
+    if (_prefixListIn == null) {
+      _prefixListIn = other._prefixListIn;
+    }
+    if (_prefixListOut == null) {
+      _prefixListOut = other._prefixListOut;
+    }
     if (_routeMapIn == null) {
       _routeMapIn = other._routeMapIn;
     }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_neighbor_prefix_list
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_neighbor_prefix_list
@@ -1,0 +1,14 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_bgp_neighbor_prefix_list
+!
+ip prefix-list PREFIX_LIST_IN
+  seq 10 permit 10.1.2.0/24
+ip prefix-list PREFIX_LIST_OUT
+  seq 10 permit 10.7.8.0/24
+!
+router bgp 1
+  router-id 1.2.3.4
+  neighbor 1.1.1.1 remote-as 2
+  neighbor 1.1.1.1 prefix-list PREFIX_LIST_IN in
+  neighbor 1.1.1.1 prefix-list PREFIX_LIST_OUT out


### PR DESCRIPTION
Support prefix lists in both directions.
Currently continuing to perpetuate the behavior where route map + prefix list defined at the same time is not supported.