### PR TITLE
PAN: handle multiline tokens better during flattening

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto_nested/PaloAltoNestedFlattener.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto_nested/PaloAltoNestedFlattener.java
@@ -110,12 +110,12 @@ public class PaloAltoNestedFlattener extends PaloAltoNestedParserBaseListener im
       for (WordContext wordCtx : line) {
         sb.append(" ");
         int orgLine = wordCtx.WORD().getSymbol().getLine();
-        // Assume that sb length corresponds to position in the current line, i.e. no multiline
-        // tokens before this / are always last token in a given line
+        // Assume that sb length corresponds to column in the current line, i.e. no multiline
+        // tokens before this (assume they're always last token on their line)
         _lineMap.setOriginalLine(_outputLineCount, sb.length(), orgLine);
 
         // Account for newlines inside of tokens, e.g. "something\nsomething" is two lines
-        // -1 since token's line is counted later and don't want to double count
+        // Subtract 1 since token's line is counted later and don't want to double count
         int tokenExtraLines = countLines(wordCtx.getText()) - 1;
         for (int i = 1; i <= tokenExtraLines; i++) {
           _lineMap.setOriginalLine(_outputLineCount + i, 0, orgLine);

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto_nested/PaloAltoNestedFlattener.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto_nested/PaloAltoNestedFlattener.java
@@ -110,7 +110,7 @@ public class PaloAltoNestedFlattener extends PaloAltoNestedParserBaseListener im
     for (List<WordContext> line : _stack) {
       for (WordContext wordCtx : line) {
         sb.append(" ");
-        int orgLine = wordCtx.WORD().getSymbol().getLine();
+        int orgLine = wordCtx.getStart().getLine();
         // Assume that sb length corresponds to column in the current line, i.e. no multiline
         // tokens before this (assume they're always last token on their line)
         _lineMap.setOriginalLine(_outputLineCount, sb.length(), orgLine);

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto_nested/PaloAltoNestedFlattener.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto_nested/PaloAltoNestedFlattener.java
@@ -20,11 +20,6 @@ public class PaloAltoNestedFlattener extends PaloAltoNestedParserBaseListener im
 
   /** An ordered list of all produced set statements, including those not to be retained */
   private List<String> _allSetStatements;
-  /**
-   * Number of lines in the output text, used for line mapping. This needs to be updated as the
-   * output set statement list is being populated.
-   */
-  private int _outputLineCount;
 
   private List<WordContext> _currentBracketedWords;
   private List<WordContext> _currentStatement;
@@ -33,6 +28,11 @@ public class PaloAltoNestedFlattener extends PaloAltoNestedParserBaseListener im
   private final String _header;
   private boolean _inBrackets;
   private FlattenerLineMap _lineMap;
+  /**
+   * Number of lines in the output text, used for line mapping. This needs to be updated as the
+   * output set statement list is being populated.
+   */
+  private int _outputLineCount;
   private SetStatementTree _root;
 
   @SuppressWarnings("PMD.LooseCoupling") // actually use linked-specific functions in the code

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto_nested/PaloAltoNestedFlattener.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto_nested/PaloAltoNestedFlattener.java
@@ -33,6 +33,7 @@ public class PaloAltoNestedFlattener extends PaloAltoNestedParserBaseListener im
    * output set statement list is being populated.
    */
   private int _outputLineCount;
+
   private SetStatementTree _root;
 
   @SuppressWarnings("PMD.LooseCoupling") // actually use linked-specific functions in the code

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1339,12 +1339,12 @@ public final class PaloAltoGrammarTest {
     /* Line number for a particular set line */
     int setLine = 10;
 
-    /* Array is 0 indexed, line numbers are 1 indexed */
+    /* lines array is 0 indexed, line numbers are 1 indexed */
     String setLineText = lines[setLine - 1];
     String startTokenText = lines[startTokenLine - 1];
     String midTokenText = lines[midTokenLine - 1];
     String endTokenText = lines[endTokenLine - 1];
-    /* Make sure flattening produces the line we expect, where we expect them */
+    /* Sanity check; make sure flattening produces the line we expect, where we expect them */
     assertThat(setLineText, equalTo("set config shared certificate cert-name algorithm RSA"));
     assertThat(startTokenText, containsString("BEGIN CERT"));
     assertThat(midTokenText, containsString("AAaaaaa"));

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1358,6 +1358,10 @@ public final class PaloAltoGrammarTest {
         map.getOriginalLine(startTokenLine, startTokenText.indexOf("BEGIN CERT")), equalTo(5));
     assertThat(map.getOriginalLine(midTokenLine, midTokenText.indexOf("AAaaaaa")), equalTo(5));
     assertThat(map.getOriginalLine(endTokenLine, endTokenText.indexOf("\"")), equalTo(5));
+
+    /* Line beyond end of config should not be mapped */
+    assertThat(
+        map.getOriginalLine(lines.length, 0), equalTo(FlattenerLineMap.UNMAPPED_LINE_NUMBER));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -77,6 +77,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
@@ -1314,6 +1315,49 @@ public final class PaloAltoGrammarTest {
 
     // Confirm extraction works for nested configs even in the presence of line comments
     assertThat(parseTextConfigs(hostname).keySet(), contains(hostname));
+  }
+
+  @Test
+  public void testLineMapMultilineToken() {
+    String hostname = "multiline-token";
+    Flattener flattener =
+        Batfish.flatten(
+            CommonUtil.readResource(TESTCONFIGS_PREFIX + hostname),
+            new BatfishLogger(BatfishLogger.LEVELSTR_OUTPUT, false),
+            new Settings(),
+            new Warnings(),
+            PALO_ALTO_NESTED,
+            BATFISH_FLATTENED_PALO_ALTO_HEADER);
+    FlattenerLineMap map = flattener.getOriginalLineMap();
+
+    String[] lines = flattener.getFlattenedConfigurationText().split("\n", -1);
+
+    /* Line numbers for a multiline token in output text */
+    int startTokenLine = 2;
+    int midTokenLine = 5;
+    int endTokenLine = 9;
+    /* Line number for a particular set line */
+    int setLine = 10;
+
+    /* Array is 0 indexed, line numbers are 1 indexed */
+    String setLineText = lines[setLine - 1];
+    String startTokenText = lines[startTokenLine - 1];
+    String midTokenText = lines[midTokenLine - 1];
+    String endTokenText = lines[endTokenLine - 1];
+    /* Make sure flattening produces the line we expect, where we expect them */
+    assertThat(setLineText, equalTo("set config shared certificate cert-name algorithm RSA"));
+    assertThat(startTokenText, containsString("BEGIN CERT"));
+    assertThat(midTokenText, containsString("AAaaaaa"));
+    assertThat(endTokenText, containsString("\""));
+
+    /* Confirm original line numbers are preserved thru map, note line number here starts from 1 */
+    assertThat(map.getOriginalLine(setLine, setLineText.indexOf("certificate")), equalTo(3));
+    assertThat(map.getOriginalLine(setLine, setLineText.indexOf("algorithm")), equalTo(13));
+    /* Start, middle, and end lines in a multiline token should be mapped to public key line */
+    assertThat(
+        map.getOriginalLine(startTokenLine, startTokenText.indexOf("BEGIN CERT")), equalTo(5));
+    assertThat(map.getOriginalLine(midTokenLine, midTokenText.indexOf("AAaaaaa")), equalTo(5));
+    assertThat(map.getOriginalLine(endTokenLine, endTokenText.indexOf("\"")), equalTo(5));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/multiline-token
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/multiline-token
@@ -1,0 +1,22 @@
+config {
+  shared {
+    certificate {
+      cert-name {
+        public-key "-----BEGIN CERTIFICATE-----
+AAAAAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaaaaaaaaAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaaaaaaaaAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaaaaaaaaAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaaaaaaaaAAAAAAAAAAAAAAAAAAAAAAA
+HHHHHHHHHHHHHHHHHhhhhhhhhhhhhhhhhhhhhhhhhHHHHHHHHHHHHHHHHHHHHHHH
+-----END CERTIFICATE-----
+";
+        algorithm RSA;
+      }
+    }
+  }
+}
+deviceconfig {
+  system {
+    hostname nested-config;
+  }
+}


### PR DESCRIPTION
During flattening, some tokens may span multiple lines (e.g. quoted strings: `"something\nsomething"`).  Currently, when the line map is being updated, these multiline tokens are not taken into account, so mapping for any line after a multiline token is shifted and incorrect.

-----

This PR takes into account multiline tokens when populating the line map.  After this PR, all lines in the output text corresponding to the multiline token are mapped back to the original config line containing the token start.
