### PR TITLE
Add interfaces, forwarding behaviour and match criteria to SetupSessionStep detail

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SetupSessionStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SetupSessionStep.java
@@ -27,7 +27,7 @@ public final class SetupSessionStep extends Step<SetupSessionStepDetail> {
     @Nonnull private final Set<String> _incomingInterfaces;
     @Nonnull private final SessionAction _sessionAction;
     @Nonnull private final SessionMatchExpr _matchCriteria;
-    private final Set<FlowDiff> _transformation;
+    @Nonnull private final Set<FlowDiff> _transformation;
 
     private SetupSessionStepDetail(
         @Nonnull Set<String> incomingInterfaces,
@@ -75,6 +75,7 @@ public final class SetupSessionStep extends Step<SetupSessionStepDetail> {
     }
 
     @JsonProperty(PROP_TRANSFORMATION)
+    @Nonnull
     public Set<FlowDiff> getTransformation() {
       return _transformation;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SetupSessionStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SetupSessionStep.java
@@ -1,26 +1,133 @@
 package org.batfish.datamodel.flow;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.batfish.datamodel.flow.StepAction.SETUP_SESSION;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.FlowDiff;
 import org.batfish.datamodel.flow.SetupSessionStep.SetupSessionStepDetail;
 
 /** A {@link Step} for when a new session is created. */
 @JsonTypeName("SetupSession")
 public final class SetupSessionStep extends Step<SetupSessionStepDetail> {
-  public SetupSessionStep() {
-    super(DETAIL, SETUP_SESSION);
+
+  public static final class SetupSessionStepDetail {
+    private static final String PROP_INCOMING_INTERFACES = "incomingInterfaces";
+    private static final String PROP_SESSION_ACTION = "sessionAction";
+    private static final String PROP_MATCH_CRITERIA = "matchCriteria";
+    private static final String PROP_TRANSFORMATION = "transformation";
+
+    @Nonnull private final Set<String> _incomingInterfaces;
+    @Nonnull private final SessionAction _sessionAction;
+    @Nonnull private final SessionMatchExpr _matchCriteria;
+    private final Set<FlowDiff> _transformation;
+
+    private SetupSessionStepDetail(
+        @Nonnull Set<String> incomingInterfaces,
+        @Nonnull SessionAction sessionAction,
+        @Nonnull SessionMatchExpr matchCriteria,
+        @Nonnull Set<FlowDiff> transformation) {
+      _incomingInterfaces = ImmutableSet.copyOf(incomingInterfaces);
+      _sessionAction = sessionAction;
+      _matchCriteria = matchCriteria;
+      _transformation = ImmutableSet.copyOf(transformation);
+    }
+
+    @JsonCreator
+    private static SetupSessionStepDetail jsonCreator(
+        @JsonProperty(PROP_INCOMING_INTERFACES) Set<String> incomingInterfaces,
+        @JsonProperty(PROP_SESSION_ACTION) SessionAction sessionAction,
+        @JsonProperty(PROP_MATCH_CRITERIA) SessionMatchExpr matchCriteria,
+        @JsonProperty(PROP_TRANSFORMATION) Set<FlowDiff> transformation) {
+      checkArgument(incomingInterfaces != null, "Missing %s", PROP_INCOMING_INTERFACES);
+      checkArgument(sessionAction != null, "Missing %s", PROP_SESSION_ACTION);
+      checkArgument(matchCriteria != null, "Missing %s", PROP_MATCH_CRITERIA);
+      return new SetupSessionStepDetail(
+          incomingInterfaces,
+          sessionAction,
+          matchCriteria,
+          firstNonNull(transformation, ImmutableSet.of()));
+    }
+
+    @JsonProperty(PROP_INCOMING_INTERFACES)
+    @Nonnull
+    public Set<String> getIncomingInterfaces() {
+      return _incomingInterfaces;
+    }
+
+    @JsonProperty(PROP_SESSION_ACTION)
+    @Nonnull
+    public SessionAction getSessionAction() {
+      return _sessionAction;
+    }
+
+    @JsonProperty(PROP_MATCH_CRITERIA)
+    @Nonnull
+    public SessionMatchExpr getMatchCriteria() {
+      return _matchCriteria;
+    }
+
+    @JsonProperty(PROP_TRANSFORMATION)
+    public Set<FlowDiff> getTransformation() {
+      return _transformation;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    /** Chained builder to create a {@link SetupSessionStepDetail} object */
+    public static class Builder {
+      private @Nullable Set<String> _incomingInterfaces;
+      private @Nullable SessionAction _sessionAction;
+      private @Nullable SessionMatchExpr _matchCriteria;
+      private @Nullable Set<FlowDiff> _transformation;
+
+      public SetupSessionStepDetail build() {
+        checkNotNull(
+            _sessionAction,
+            "Cannot build SetupSessionStepDetail without specifying session action");
+        checkNotNull(
+            _matchCriteria,
+            "Cannot build SetupSessionStepDetail without specifying match criteria");
+        return new SetupSessionStepDetail(
+            firstNonNull(_incomingInterfaces, ImmutableSet.of()),
+            _sessionAction,
+            _matchCriteria,
+            firstNonNull(_transformation, ImmutableSet.of()));
+      }
+
+      public Builder setIncomingInterfaces(Set<String> incomingInterfaces) {
+        _incomingInterfaces = incomingInterfaces;
+        return this;
+      }
+
+      public Builder setSessionAction(SessionAction sessionAction) {
+        _sessionAction = sessionAction;
+        return this;
+      }
+
+      public Builder setMatchCriteria(SessionMatchExpr matchCriteria) {
+        _matchCriteria = matchCriteria;
+        return this;
+      }
+
+      public Builder setTransformation(Set<FlowDiff> transformation) {
+        _transformation = transformation;
+        return this;
+      }
+
+      /** Only for use by {@link SetupSessionStepDetail#builder()}. */
+      private Builder() {}
+    }
   }
-
-  @JsonInclude // if not present, empty object will be omitted
-  static final class SetupSessionStepDetail {}
-
-  private static final SetupSessionStepDetail DETAIL = new SetupSessionStepDetail();
 
   @JsonCreator
   private static SetupSessionStep jsonCreator(
@@ -28,6 +135,10 @@ public final class SetupSessionStep extends Step<SetupSessionStepDetail> {
       @Nullable @JsonProperty(PROP_ACTION) StepAction action) {
     checkArgument(action != null, "Missing %s", PROP_ACTION);
     checkArgument(detail != null, "Missing %s", PROP_DETAIL);
-    return new SetupSessionStep();
+    return new SetupSessionStep(detail);
+  }
+
+  public SetupSessionStep(SetupSessionStepDetail detail) {
+    super(detail, StepAction.SETUP_SESSION);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SetupSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SetupSessionStepTest.java
@@ -1,24 +1,67 @@
 package org.batfish.datamodel.flow;
 
-import static org.batfish.datamodel.flow.StepAction.SETUP_SESSION;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.batfish.datamodel.FlowDiff.flowDiff;
+import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
+import java.util.Set;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.FlowDiff;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.SetupSessionStep.SetupSessionStepDetail;
+import org.batfish.datamodel.transformation.IpField;
 import org.junit.Test;
 
-/** Tests of {@link SetupSessionStep}. */
-public class SetupSessionStepTest {
+/** Test for {@link SetupSessionStep}. */
+public final class SetupSessionStepTest {
   @Test
-  public void testSerialization() throws IOException {
-    SetupSessionStep step = new SetupSessionStep();
-    Step<?> cloned = BatfishObjectMapper.clone(step, Step.class);
-    assertThat(cloned, instanceOf(SetupSessionStep.class));
-    SetupSessionStep clonedStep = (SetupSessionStep) cloned;
-    assertThat(clonedStep.getAction(), equalTo(SETUP_SESSION));
-    assertThat(clonedStep.getDetail(), instanceOf(SetupSessionStepDetail.class));
+  public void testConstructor() {
+    Set<String> incomingInterfaces = ImmutableSet.of("a");
+    SessionMatchExpr matchCriteria =
+        new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
+    Set<FlowDiff> transformation =
+        ImmutableSet.of(flowDiff(IpField.SOURCE, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2")));
+    SetupSessionStep step =
+        new SetupSessionStep(
+            SetupSessionStepDetail.builder()
+                .setIncomingInterfaces(incomingInterfaces)
+                .setSessionAction(Accept.INSTANCE)
+                .setMatchCriteria(matchCriteria)
+                .setTransformation(transformation)
+                .build());
+    assertEquals(step.getAction(), StepAction.SETUP_SESSION);
+    assertEquals(step.getDetail().getIncomingInterfaces(), incomingInterfaces);
+    assertEquals(step.getDetail().getSessionAction(), Accept.INSTANCE);
+    assertEquals(step.getDetail().getMatchCriteria(), matchCriteria);
+    assertEquals(step.getDetail().getTransformation(), transformation);
+  }
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    Set<String> incomingInterfaces = ImmutableSet.of("b");
+    ForwardOutInterface forwardAction =
+        new ForwardOutInterface("a", NodeInterfacePair.of("a", "b"));
+    SessionMatchExpr matchCriteria =
+        new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"), null, null);
+    Set<FlowDiff> transformation =
+        ImmutableSet.of(flowDiff(IpField.SOURCE, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2")));
+    SetupSessionStep step =
+        new SetupSessionStep(
+            SetupSessionStepDetail.builder()
+                .setIncomingInterfaces(incomingInterfaces)
+                .setSessionAction(forwardAction)
+                .setMatchCriteria(matchCriteria)
+                .setTransformation(transformation)
+                .build());
+    SetupSessionStep clone = BatfishObjectMapper.clone(step, SetupSessionStep.class);
+    assertEquals(step.getAction(), clone.getAction());
+    assertEquals(
+        clone.getDetail().getIncomingInterfaces(), step.getDetail().getIncomingInterfaces());
+    assertEquals(clone.getDetail().getSessionAction(), step.getDetail().getSessionAction());
+    assertEquals(clone.getDetail().getMatchCriteria(), step.getDetail().getMatchCriteria());
+    assertEquals(clone.getDetail().getTransformation(), step.getDetail().getTransformation());
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -92,6 +92,7 @@ import org.batfish.datamodel.flow.RoutingStep.RoutingStepDetail;
 import org.batfish.datamodel.flow.SessionAction;
 import org.batfish.datamodel.flow.SessionMatchExpr;
 import org.batfish.datamodel.flow.SetupSessionStep;
+import org.batfish.datamodel.flow.SetupSessionStep.SetupSessionStepDetail;
 import org.batfish.datamodel.flow.Step;
 import org.batfish.datamodel.flow.StepAction;
 import org.batfish.datamodel.flow.Trace;
@@ -971,7 +972,13 @@ class FlowTracer {
           buildFirewallSessionTraceInfo(firewallSessionInterfaceInfo);
       if (session != null) {
         _newSessions.add(session);
-        _steps.add(new SetupSessionStep());
+        _steps.add(
+            new SetupSessionStep(
+                SetupSessionStepDetail.builder()
+                    .setIncomingInterfaces(session.getIncomingInterfaces())
+                    .setMatchCriteria(session.getMatchCriteria())
+                    .setSessionAction(session.getAction())
+                    .build()));
       }
     }
 


### PR DESCRIPTION
- `SetupSessionStep` / `SetupSessionStepDetail` - Exactly the same as `MatchSessionStep` / `MatchSessionStepDetail`
- `FlowTracer` - Construct `SetupSessionStepDetail` with the session's incoming interfaces, forwarding behaviour and match criteria (not including transformation behaviour)
- Tests
    - `SetupSessionStep`: constructor and JSON serialisation
    - `TracerouteEngineImplTest`
        - Add assertions in `testNewSessionsSingleHop` and `testNewSessionsMultiHop` that traceroute captures `SetupSessionStep` with correct details