### PR TITLE
Remove interfaces from VRF as well as configuration

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -153,6 +153,7 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
                 "Interface %s has switchport %s but switchport mode %s",
                 name, i.getSwitchport(), i.getSwitchportMode()));
         c.getAllInterfaces().remove(name);
+        c.getVrfs().get(i.getVrfName()).getInterfaces().remove(name);
       }
     }
   }


### PR DESCRIPTION
This is a bit of a stop-gap. Working on removing two (or three, depending on how you count) sources of truth for interfaces in VRFs.