### PR TITLE
Stop storing interfaces in VRFs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -477,6 +477,30 @@ public final class Configuration implements Serializable {
     return _interfaces;
   }
 
+  /**
+   * Return all interfaces in a given VRF
+   *
+   * @param vrf the VRF name
+   */
+  @JsonIgnore
+  public Map<String, Interface> getAllInterfaces(@Nonnull String vrf) {
+    return _interfaces.entrySet().stream()
+        .filter(e -> e.getValue().getVrfName().equals(vrf))
+        .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+  }
+
+  /**
+   * Return all active interfaces in a given VRF
+   *
+   * @param vrf the VRF name
+   */
+  @JsonIgnore
+  public Map<String, Interface> getActiveInterfaces(@Nonnull String vrf) {
+    return _interfaces.entrySet().stream()
+        .filter(e -> e.getValue().getVrfName().equals(vrf) && e.getValue().getActive())
+        .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+  }
+
   @JsonIgnore
   public Map<String, Interface> getActiveInterfaces() {
     return _interfaces.entrySet().stream()

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -174,9 +174,6 @@ public final class Interface extends ComparableStructure<String> {
       iface.setVlan(_vlan);
 
       iface.setVrf(_vrf);
-      if (_vrf != null) {
-        _vrf.getInterfaces().put(name, iface);
-      }
       iface.setVrrpGroups(_vrrpGroups);
 
       iface.setOspfSettings(_ospfSettings);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
@@ -16,11 +16,9 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableMap;
 import java.util.NavigableSet;
 import java.util.SortedMap;
 import java.util.SortedSet;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -80,7 +78,6 @@ public class Vrf extends ComparableStructure<String> {
   private static final String PROP_GENERATED_ROUTES = "aggregateRoutes";
   private static final String PROP_CROSS_VRF_IMPORT_POLICY = "crossVrfImportPolicy";
   private static final String PROP_CROSS_VRF_IMPORT_VRFS = "crossVrfImportVrfs";
-  private static final String PROP_INTERFACES = "interfaces";
   private static final String PROP_ISIS_PROCESS = "isisProcess";
   private static final String PROP_EIGRP_PROCESSES = "eigrpProcesses";
   private static final String PROP_KERNEL_ROUTES = "kernelRoutes";
@@ -101,8 +98,6 @@ public class Vrf extends ComparableStructure<String> {
   private SortedMap<Long, EigrpProcess> _eigrpProcesses;
   @Nullable private String _crossVrfImportPolicy;
   @Nullable private List<String> _crossVrfImportVrfs;
-  private transient SortedSet<String> _interfaceNames;
-  private NavigableMap<String, Interface> _interfaces;
   private IsisProcess _isisProcess;
   private SortedSet<KernelRoute> _kernelRoutes;
   @Nonnull private SortedMap<String, OspfProcess> _ospfProcesses;
@@ -118,7 +113,6 @@ public class Vrf extends ComparableStructure<String> {
     _eigrpProcesses = ImmutableSortedMap.of();
     _generatedRoutes = new TreeSet<>();
     _generatedIpv6Routes = new TreeSet<>();
-    _interfaces = new TreeMap<>();
     _kernelRoutes = ImmutableSortedSet.of();
     _ospfProcesses = ImmutableSortedMap.of();
     _staticRoutes = new TreeSet<>();
@@ -188,26 +182,6 @@ public class Vrf extends ComparableStructure<String> {
   @JsonProperty(PROP_CROSS_VRF_IMPORT_VRFS)
   public List<String> getCrossVrfImportVrfs() {
     return _crossVrfImportVrfs;
-  }
-
-  /** Interfaces assigned to this VRF. */
-  @JsonProperty(PROP_INTERFACES)
-  public SortedSet<String> getInterfaceNames() {
-    if (_interfaces != null && !_interfaces.isEmpty()) {
-      return new TreeSet<>(_interfaces.keySet());
-    } else {
-      return firstNonNull(_interfaceNames, ImmutableSortedSet.of());
-    }
-  }
-
-  @JsonIgnore
-  public Map<String, Interface> getInterfaces() {
-    return _interfaces;
-  }
-
-  @JsonIgnore
-  public @Nonnull Stream<Interface> getActiveInterfaces() {
-    return _interfaces.values().stream().filter(Interface::getActive);
   }
 
   /** IS-IS routing process for this VRF. */
@@ -324,16 +298,6 @@ public class Vrf extends ComparableStructure<String> {
   @JsonProperty(PROP_CROSS_VRF_IMPORT_VRFS)
   public void setCrossVrfImportVrfs(@Nonnull List<String> crossVrfImportVrfs) {
     _crossVrfImportVrfs = ImmutableList.copyOf(crossVrfImportVrfs);
-  }
-
-  @JsonProperty(PROP_INTERFACES)
-  public void setInterfaceNames(SortedSet<String> interfaceNames) {
-    _interfaceNames = interfaceNames;
-  }
-
-  @JsonIgnore
-  public void setInterfaces(NavigableMap<String, Interface> interfaces) {
-    _interfaces = interfaces;
   }
 
   @JsonProperty(PROP_ISIS_PROCESS)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpTopologyUtils.java
@@ -125,7 +125,7 @@ public class EigrpTopologyUtils {
       for (Vrf vrf : config.getVrfs().values()) {
         for (EigrpProcess proc : vrf.getEigrpProcesses().values()) {
           ImmutableList.Builder<EigrpNeighborConfig> neighborsBuilder = ImmutableList.builder();
-          for (Interface iface : vrf.getInterfaces().values()) {
+          for (Interface iface : config.getAllInterfaces(vrf.getName()).values()) {
             // if the interface does not belong to the current EIGRP process, skip it
             if (iface.getConcreteAddress() == null
                 || iface.getEigrp() == null

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameInterfaceSpecifier.java
@@ -1,7 +1,6 @@
 package org.batfish.specifier;
 
 import com.google.common.collect.ImmutableSet;
-import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 import org.batfish.datamodel.collections.NodeInterfacePair;
@@ -37,12 +36,8 @@ public final class VrfNameInterfaceSpecifier implements InterfaceSpecifier {
   @Override
   public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     return nodes.stream()
-        .map(n -> ctxt.getConfigs().get(n).getVrfs().values())
-        .flatMap(Collection::stream)
-        // we have a stream of VRFs now
-        .filter(v -> v.getName().equalsIgnoreCase(_name))
-        .map(v -> v.getInterfaces().values())
-        .flatMap(Collection::stream)
+        .flatMap(n -> ctxt.getConfigs().get(n).getAllInterfaces().values().stream())
+        .filter(i -> _name.equalsIgnoreCase(i.getVrfName()))
         .map(NodeInterfacePair::of)
         .collect(ImmutableSet.toImmutableSet());
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameRegexInterfaceLinkLocationSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameRegexInterfaceLinkLocationSpecifier.java
@@ -2,7 +2,7 @@ package org.batfish.specifier;
 
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.Configuration;
 
 /**
  * A {@link LocationSpecifier} specifying links of interfaces that belong to VRFs with names
@@ -15,8 +15,8 @@ public final class VrfNameRegexInterfaceLinkLocationSpecifier
   }
 
   @Override
-  protected Stream<Location> getVrfLocations(Vrf vrf) {
-    return vrf.getInterfaces().values().stream()
+  protected Stream<Location> getVrfLocations(Configuration c, String vrfName) {
+    return c.getAllInterfaces(vrfName).values().stream()
         .map(iface -> new InterfaceLinkLocation(iface.getOwner().getHostname(), iface.getName()));
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameRegexInterfaceLocationSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameRegexInterfaceLocationSpecifier.java
@@ -2,7 +2,7 @@ package org.batfish.specifier;
 
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.Configuration;
 
 /**
  * A {@link LocationSpecifier} specifying interfaces that belong to VRFs with names matching the
@@ -14,8 +14,8 @@ public final class VrfNameRegexInterfaceLocationSpecifier extends VrfNameRegexLo
   }
 
   @Override
-  protected Stream<Location> getVrfLocations(Vrf vrf) {
-    return vrf.getInterfaces().values().stream()
+  protected Stream<Location> getVrfLocations(Configuration c, String vrfName) {
+    return c.getAllInterfaces(vrfName).values().stream()
         .map(iface -> new InterfaceLocation(iface.getOwner().getHostname(), iface.getName()));
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameRegexInterfaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameRegexInterfaceSpecifier.java
@@ -1,7 +1,6 @@
 package org.batfish.specifier;
 
 import com.google.common.collect.ImmutableSet;
-import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -38,12 +37,8 @@ public final class VrfNameRegexInterfaceSpecifier implements InterfaceSpecifier 
   @Override
   public Set<NodeInterfacePair> resolve(Set<String> nodes, SpecifierContext ctxt) {
     return nodes.stream()
-        .map(n -> ctxt.getConfigs().get(n).getVrfs().values())
-        .flatMap(Collection::stream)
-        // we have a stream of VRFs now
-        .filter(v -> _pattern.matcher(v.getName()).matches())
-        .map(v -> v.getInterfaces().values())
-        .flatMap(Collection::stream)
+        .flatMap(n -> ctxt.getConfigs().get(n).getAllInterfaces().values().stream())
+        .filter(i -> _pattern.matcher(i.getVrfName()).matches())
         .map(NodeInterfacePair::of)
         .collect(ImmutableSet.toImmutableSet());
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameRegexLocationSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/VrfNameRegexLocationSpecifier.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.Configuration;
 
 /**
  * An abstract {@link LocationSpecifier} specifying interfaces that belong to VRFs with names
@@ -35,14 +35,16 @@ public abstract class VrfNameRegexLocationSpecifier implements LocationSpecifier
     return Objects.hashCode(_pattern);
   }
 
-  protected abstract Stream<Location> getVrfLocations(Vrf vrf);
+  protected abstract Stream<Location> getVrfLocations(Configuration c, String vrfName);
 
   @Override
   public Set<Location> resolve(SpecifierContext ctxt) {
     return ctxt.getConfigs().values().stream()
-        .flatMap(node -> node.getVrfs().values().stream())
-        .filter(vrf -> _pattern.matcher(vrf.getName()).matches())
-        .flatMap(this::getVrfLocations)
+        .flatMap(
+            node ->
+                node.getVrfs().values().stream()
+                    .filter(vrf -> _pattern.matcher(vrf.getName()).matches())
+                    .flatMap(v -> this.getVrfLocations(node, v.getName())))
         .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/NetworkFactoryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/NetworkFactoryTest.java
@@ -72,9 +72,7 @@ public class NetworkFactoryTest {
     assertThat(c.getAllInterfaces(), not(hasKey(i2.getName())));
     assertThat(c.getAllInterfaces(), hasKey(i3.getName()));
     assertThat(i3.getOwner(), sameInstance(c));
-    assertThat(vrf.getInterfaces(), not(hasKey(i3.getName())));
     assertThat(c.getAllInterfaces(), hasKey(i4.getName()));
-    assertThat(vrf.getInterfaces(), hasKey(i4.getName()));
     assertThat(i4.getVrf(), sameInstance(vrf));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchers.java
@@ -16,7 +16,6 @@ import org.batfish.datamodel.eigrp.EigrpProcess;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasBgpProcess;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasEigrpProcesses;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasGeneratedRoutes;
-import org.batfish.datamodel.matchers.VrfMatchersImpl.HasInterfaces;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasKernelRoutes;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasName;
 import org.batfish.datamodel.matchers.VrfMatchersImpl.HasOspfProcesses;
@@ -53,14 +52,6 @@ public class VrfMatchers {
   public static HasGeneratedRoutes hasGeneratedRoutes(
       Matcher<? super SortedSet<GeneratedRoute>> subMatcher) {
     return new HasGeneratedRoutes(subMatcher);
-  }
-
-  /**
-   * Provides a matcher that matches if the provided {@code subMatcher} matches the VRF's
-   * interfaces.
-   */
-  public static Matcher<Vrf> hasInterfaces(Matcher<? super SortedSet<String>> subMatcher) {
-    return new HasInterfaces(subMatcher);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/VrfMatchersImpl.java
@@ -51,17 +51,6 @@ final class VrfMatchersImpl {
     }
   }
 
-  static final class HasInterfaces extends FeatureMatcher<Vrf, SortedSet<String>> {
-    HasInterfaces(@Nonnull Matcher<? super SortedSet<String>> subMatcher) {
-      super(subMatcher, "A VRF with interfaces:", "interfaces");
-    }
-
-    @Override
-    protected SortedSet<String> featureValueOf(Vrf actual) {
-      return actual.getInterfaceNames();
-    }
-  }
-
   static final class HasIsisProcess extends FeatureMatcher<Vrf, IsisProcess> {
     HasIsisProcess(@Nonnull Matcher<? super IsisProcess> subMatcher) {
       super(subMatcher, "A Vrf with isisProcess:", "isisProcess");

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/VrfNameInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/VrfNameInterfaceSpecifierTest.java
@@ -29,17 +29,12 @@ public class VrfNameInterfaceSpecifierTest {
 
     Interface iface11 =
         Interface.builder().setName("iface11").setOwner(node1).setVrf(vrf1node1).build();
-    Interface iface12 =
-        Interface.builder().setName("iface12").setOwner(node1).setVrf(vrf2node1).build();
+    Interface.builder().setName("iface12").setOwner(node1).setVrf(vrf2node1).build();
     Interface iface2 =
         Interface.builder().setName("iface2").setOwner(node2).setVrf(vrf1node2).build();
 
     node1.setVrfs(ImmutableSortedMap.of("vrf1", vrf1node1, "vrf2", vrf2node1));
-    vrf1node1.setInterfaces(ImmutableSortedMap.of("iface11", iface11));
-    vrf2node1.setInterfaces(ImmutableSortedMap.of("iface12", iface12));
-
     node2.setVrfs(ImmutableSortedMap.of("vrf1", vrf1node2));
-    vrf1node2.setInterfaces(ImmutableSortedMap.of("iface2", iface2));
 
     MockSpecifierContext ctxt =
         MockSpecifierContext.builder()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/VrfNameRegexInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/VrfNameRegexInterfaceSpecifierTest.java
@@ -27,15 +27,11 @@ public class VrfNameRegexInterfaceSpecifierTest {
     Vrf vrf3 = new Vrf("vrf2");
 
     Interface iface11 = Interface.builder().setName("iface11").setOwner(node1).setVrf(vrf1).build();
-    Interface iface12 = Interface.builder().setName("iface12").setOwner(node1).setVrf(vrf2).build();
-    Interface iface2 = Interface.builder().setName("iface2").setOwner(node2).setVrf(vrf3).build();
+    Interface.builder().setName("iface12").setOwner(node1).setVrf(vrf2).build();
+    Interface.builder().setName("iface2").setOwner(node2).setVrf(vrf3).build();
 
     node1.setVrfs(ImmutableSortedMap.of("vrf1", vrf1, "vrf2", vrf2));
-    vrf1.setInterfaces(ImmutableSortedMap.of("iface11", iface11));
-    vrf2.setInterfaces(ImmutableSortedMap.of("iface12", iface12));
-
     node2.setVrfs(ImmutableSortedMap.of("vrf3", vrf3));
-    vrf3.setInterfaces(ImmutableSortedMap.of("iface2", iface2));
 
     MockSpecifierContext ctxt =
         MockSpecifierContext.builder()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledInterfaceSpecifierTest.java
@@ -176,7 +176,6 @@ public class ParboiledInterfaceSpecifierTest {
     Vrf vrf1 = new Vrf("vrf1");
     _iface11B.setVrf(vrf1);
     build();
-    vrf1.setInterfaces(ImmutableSortedMap.of("iface11", _iface11));
     _node1.setVrfs(ImmutableMap.of("node1", vrf1));
     assertThat(
         new ParboiledInterfaceSpecifier(new VrfInterfaceAstNode("vrf1")).resolve(_nodes, _ctxt),

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -470,7 +470,8 @@ public final class BDDReachabilityAnalysisFactory {
                         IpsRoutedOutInterfaces ipsRoutedOutInterfaces =
                             ipsRoutedOutInterfacesFactory.getIpsRoutedOutInterfaces(
                                 configEntry.getKey(), vrf.getName());
-                        return vrf.getActiveInterfaces()
+                        return configEntry.getValue().getActiveInterfaces(vrf.getName()).values()
+                            .stream()
                             .filter(iface -> iface.getRoutingPolicyName() != null)
                             .map(
                                 iface ->
@@ -1036,9 +1037,8 @@ public final class BDDReachabilityAnalysisFactory {
                   .flatMap(
                       vrfEntry -> {
                         StateExpr postState = new NodeDropAclOut(node);
-                        return vrfEntry
-                            .getValue()
-                            .getActiveInterfaces()
+                        return nodeEntry.getValue().getActiveInterfaces(vrfEntry.getKey()).values()
+                            .stream()
                             .filter(iface -> iface.getOutgoingFilterName() != null)
                             .flatMap(
                                 iface -> {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -256,10 +256,10 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
    */
   private RibDelta<EigrpInternalRoute> initInternalRoutes(String vrfName, Configuration c) {
     Builder<EigrpInternalRoute> builder = RibDelta.builder();
-    for (String ifaceName : c.getVrfs().get(vrfName).getInterfaceNames()) {
+    for (String ifaceName : c.getActiveInterfaces(vrfName).keySet()) {
       Interface iface = c.getAllInterfaces().get(ifaceName);
-      if (!iface.getActive()
-          || iface.getEigrp() == null
+      assert iface.getActive();
+      if (iface.getEigrp() == null
           || iface.getEigrp().getAsn() != _asn
           || !iface.getEigrp().getEnabled()) {
         continue;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -718,7 +718,7 @@ public class VirtualRouter implements Serializable {
 
     // init internal routes from connected routes
     for (String ifaceName : _vrf.getRipProcess().getInterfaces()) {
-      Interface iface = _vrf.getInterfaces().get(ifaceName);
+      Interface iface = _c.getAllInterfaces(_vrf.getName()).get(ifaceName);
       if (iface.getActive()) {
         Set<Prefix> allNetworkPrefixes =
             iface.getAllConcreteAddresses().stream()
@@ -1332,7 +1332,8 @@ public class VirtualRouter implements Serializable {
 
       // Get interface
       String connectingInterfaceName = edge.getInt1();
-      Interface connectingInterface = _vrf.getInterfaces().get(connectingInterfaceName);
+      Interface connectingInterface =
+          _c.getAllInterfaces(_vrf.getName()).get(connectingInterfaceName);
       if (connectingInterface == null) {
         // wrong vrf, so skip
         continue;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -397,7 +397,7 @@ public class VirtualRouter implements Serializable {
       _isisIncomingRoutes = ImmutableSortedMap.of();
     } else {
       _isisIncomingRoutes =
-          _vrf.getInterfaceNames().stream()
+          _c.getAllInterfaces(_vrf.getName()).keySet().stream()
               .map(ifaceName -> new IsisNode(_c.getHostname(), ifaceName))
               .filter(network.nodes()::contains)
               .flatMap(n -> network.inEdges(n).stream())
@@ -787,7 +787,7 @@ public class VirtualRouter implements Serializable {
   @VisibleForTesting
   void initConnectedRib() {
     // Look at all interfaces in our VRF
-    _vrf.getActiveInterfaces()
+    _c.getActiveInterfaces(_name).values().stream()
         .flatMap(VirtualRouter::generateConnectedRoutes)
         .forEach(r -> _connectedRib.mergeRoute(annotateRoute(r)));
   }
@@ -839,7 +839,7 @@ public class VirtualRouter implements Serializable {
   @VisibleForTesting
   void initLocalRib() {
     // Look at all interfaces in our VRF
-    _vrf.getActiveInterfaces()
+    _c.getActiveInterfaces(_name).values().stream()
         .flatMap(VirtualRouter::generateLocalRoutes)
         .forEach(r -> _localRib.mergeRoute(annotateRoute(r)));
   }
@@ -916,7 +916,8 @@ public class VirtualRouter implements Serializable {
         new IsisRoute.Builder()
             .setArea(proc.getNetAddress().getAreaIdString())
             .setSystemId(proc.getNetAddress().getSystemIdString());
-    _vrf.getActiveInterfaces()
+    _c.getActiveInterfaces(_vrf.getName())
+        .values()
         .forEach(
             iface ->
                 generateAllIsisInterfaceRoutes(

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -153,7 +153,6 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
                 "Interface %s has switchport %s but switchport mode %s",
                 name, i.getSwitchport(), i.getSwitchportMode()));
         c.getAllInterfaces().remove(name);
-        c.getVrfs().get(i.getVrfName()).getInterfaces().remove(name);
       }
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1704,7 +1704,10 @@ public class Batfish extends PluginConsumer implements IBatfish {
             c ->
                 c.getVrfs()
                     .values()
-                    .forEach(v -> postProcessAggregatedInterfacesHelper(v.getInterfaces())));
+                    .forEach(
+                        v ->
+                            postProcessAggregatedInterfacesHelper(
+                                c.getAllInterfaces(v.getName()))));
   }
 
   private void postProcessAggregatedInterfacesHelper(Map<String, Interface> interfaces) {

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -35,7 +35,6 @@ import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.representation.aws.Instance.Status;
 
@@ -635,10 +634,8 @@ final class Region implements Serializable {
 
     // TODO: for now, set all interfaces to have the same bandwidth
     for (Configuration cfgNode : awsConfiguration.getConfigurationNodes().values()) {
-      for (Vrf vrf : cfgNode.getVrfs().values()) {
-        for (Interface iface : vrf.getInterfaces().values()) {
-          iface.setBandwidth(1E12d);
-        }
+      for (Interface iface : cfgNode.getAllInterfaces().values()) {
+        iface.setBandwidth(1E12d);
       }
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/AristaConversions.java
@@ -631,7 +631,7 @@ final class AristaConversions {
   @Nonnull
   static Optional<Vrf> getVrfForVlan(Configuration c, int vlan) {
     return c.getVrfs().values().stream()
-        .filter(vrf -> vrf.getInterfaceNames().contains(String.format("Vlan%d", vlan)))
+        .filter(vrf -> c.getAllInterfaces(vrf.getName()).containsKey(String.format("Vlan%d", vlan)))
         .findFirst();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/AristaConversions.java
@@ -80,20 +80,20 @@ import org.batfish.representation.cisco.eos.AristaEosVxlan;
 final class AristaConversions {
   /** Computes the router ID. */
   @Nonnull
-  static Ip getBgpRouterId(AristaBgpVrf vrfConfig, Vrf vrf, Warnings w) {
+  static Ip getBgpRouterId(
+      AristaBgpVrf vrfConfig, String vrfName, Map<String, Interface> vrfInterfaces, Warnings w) {
     // If Router ID is configured in the VRF-Specific BGP config, it always wins.
     if (vrfConfig.getRouterId() != null) {
       return vrfConfig.getRouterId();
     }
 
     String messageBase =
-        String.format(
-            "Router-id is not manually configured for BGP process in VRF %s", vrf.getName());
+        String.format("Router-id is not manually configured for BGP process in VRF %s", vrfName);
 
     // Otherwise, Router ID is defined based on the interfaces in the VRF that have IP addresses.
     // EOS does NOT use shutdown interfaces to configure router-id.
     Map<String, Interface> interfaceMap =
-        vrf.getInterfaces().entrySet().stream()
+        vrfInterfaces.entrySet().stream()
             .filter(e -> e.getValue().getActive())
             .filter(e -> e.getValue().getConcreteAddress() != null)
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
@@ -254,16 +254,21 @@ final class AristaConversions {
 
   @Nullable
   private static Ip computeUpdateSource(
-      Vrf vrf, Prefix prefix, AristaBgpNeighbor neighbor, boolean dynamic, Warnings warnings) {
+      String vrfName,
+      Map<String, Interface> vrfInterfaces,
+      Prefix prefix,
+      AristaBgpNeighbor neighbor,
+      boolean dynamic,
+      Warnings warnings) {
     String updateSourceInterface = neighbor.getUpdateSource();
     if (updateSourceInterface != null) {
-      Interface iface = vrf.getInterfaces().get(updateSourceInterface);
+      Interface iface = vrfInterfaces.get(updateSourceInterface);
       if (iface == null) {
         warnings.redFlag(
             String.format(
                 "BGP neighbor %s in vrf %s: configured update-source %s does not exist or "
                     + "is not associated with this vrf",
-                dynamic ? prefix : prefix.getStartIp(), vrf.getName(), updateSourceInterface));
+                dynamic ? prefix : prefix.getStartIp(), vrfName, updateSourceInterface));
         return null;
       }
       ConcreteInterfaceAddress address = iface.getConcreteAddress();
@@ -271,7 +276,7 @@ final class AristaConversions {
         warnings.redFlag(
             String.format(
                 "BGP neighbor %s in vrf %s: configured update-source %s has no IP address",
-                dynamic ? prefix : prefix.getStartIp(), vrf.getName(), updateSourceInterface));
+                dynamic ? prefix : prefix.getStartIp(), vrfName, updateSourceInterface));
         return null;
       }
       return address.getIp();
@@ -279,7 +284,7 @@ final class AristaConversions {
       return Ip.AUTO;
     }
     Optional<Ip> firstMatchingInterfaceAddress =
-        vrf.getInterfaces().values().stream()
+        vrfInterfaces.values().stream()
             .flatMap(i -> i.getAllConcreteAddresses().stream())
             .filter(ia -> ia != null && ia.getPrefix().containsIp(prefix.getStartIp()))
             .map(ConcreteInterfaceAddress::getIp)
@@ -292,7 +297,7 @@ final class AristaConversions {
     warnings.redFlag(
         String.format(
             "BGP neighbor %s in vrf %s: could not determine update source",
-            prefix.getStartIp(), vrf.getName()));
+            prefix.getStartIp(), vrfName));
     return null;
   }
 
@@ -351,7 +356,9 @@ final class AristaConversions {
       newNeighborBuilder.setLocalAs(bgpConfig.getAsn());
     }
 
-    newNeighborBuilder.setLocalIp(computeUpdateSource(vrf, prefix, neighbor, dynamic, warnings));
+    newNeighborBuilder.setLocalIp(
+        computeUpdateSource(
+            vrf.getName(), c.getAllInterfaces(vrf.getName()), prefix, neighbor, dynamic, warnings));
 
     @Nullable AristaBgpVrfIpv4UnicastAddressFamily af4 = vrfConfig.getV4UnicastAf();
     @Nullable AristaBgpNeighborAddressFamily naf4;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -703,8 +703,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
     }
     if (processRouterId == null) {
       processRouterId = Ip.ZERO;
-      org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
-      for (Entry<String, org.batfish.datamodel.Interface> e : vrf.getInterfaces().entrySet()) {
+      for (Entry<String, org.batfish.datamodel.Interface> e :
+          c.getAllInterfaces(vrfName).entrySet()) {
         String iname = e.getKey();
         org.batfish.datamodel.Interface iface = e.getValue();
         if (iname.startsWith("Loopback")) {
@@ -718,7 +718,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
         }
       }
       if (processRouterId.equals(Ip.ZERO)) {
-        for (org.batfish.datamodel.Interface currentInterface : vrf.getInterfaces().values()) {
+        for (org.batfish.datamodel.Interface currentInterface :
+            c.getAllInterfaces(vrfName).values()) {
           ConcreteInterfaceAddress address = currentInterface.getConcreteAddress();
           if (address != null) {
             Ip currentIp = address.getIp();
@@ -964,11 +965,10 @@ public final class CiscoConfiguration extends VendorConfiguration {
       String updateSourceInterface,
       boolean ipv4) {
     Ip updateSource = null;
-    org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
     if (ipv4) {
       if (updateSourceInterface != null) {
         org.batfish.datamodel.Interface sourceInterface =
-            vrf.getInterfaces().get(updateSourceInterface);
+            c.getAllInterfaces(vrfName).get(updateSourceInterface);
         if (sourceInterface != null) {
           ConcreteInterfaceAddress address = sourceInterface.getConcreteAddress();
           if (address != null) {
@@ -986,7 +986,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
           updateSource = Ip.AUTO;
         } else {
           Ip neighborAddress = lpg.getNeighborPrefix().getStartIp();
-          for (org.batfish.datamodel.Interface iface : vrf.getInterfaces().values()) {
+          for (org.batfish.datamodel.Interface iface : c.getAllInterfaces(vrfName).values()) {
             for (ConcreteInterfaceAddress interfaceAddress : iface.getAllConcreteAddresses()) {
               if (interfaceAddress.getPrefix().containsIp(neighborAddress)) {
                 Ip ifaceAddress = interfaceAddress.getIp();
@@ -1628,7 +1628,10 @@ public final class CiscoConfiguration extends VendorConfiguration {
             RoutingProtocol.IBGP.getDefaultAdministrativeCost(c.getConfigurationFormat()));
     org.batfish.datamodel.BgpProcess newBgpProcess =
         new org.batfish.datamodel.BgpProcess(
-            AristaConversions.getBgpRouterId(bgpVrf, v, _w), ebgpAdmin, ibgpAdmin);
+            AristaConversions.getBgpRouterId(
+                bgpVrf, v.getName(), c.getAllInterfaces(v.getName()), _w),
+            ebgpAdmin,
+            ibgpAdmin);
 
     boolean multipath = firstNonNull(bgpVrf.getMaxPaths(), 1) > 1;
     newBgpProcess.setMultipathEbgp(multipath);
@@ -2429,7 +2432,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
                 RoutingProtocol.OSPF_IA.getSummaryAdministrativeCost(c.getConfigurationFormat()))
             .setRouterId(routerId)
             .build();
-    org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
 
     if (proc.getMaxMetricRouterLsa()) {
       newProcess.setMaxMetricTransitLinks(OspfProcess.MAX_METRIC_ROUTER_LSA);
@@ -2447,7 +2449,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
     // Set RFC 1583 compatibility
     newProcess.setRfc1583Compatible(proc.getRfc1583Compatible());
 
-    for (Entry<String, org.batfish.datamodel.Interface> e : vrf.getInterfaces().entrySet()) {
+    for (Entry<String, org.batfish.datamodel.Interface> e :
+        c.getAllInterfaces(vrfName).entrySet()) {
       org.batfish.datamodel.Interface iface = e.getValue();
       /*
        * Filter out interfaces that do not belong to this process, however if the process name is missing,
@@ -2685,11 +2688,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
   private org.batfish.datamodel.RipProcess toRipProcess(
       RipProcess proc, String vrfName, Configuration c) {
     org.batfish.datamodel.RipProcess newProcess = new org.batfish.datamodel.RipProcess();
-    org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
 
     // establish areas and associated interfaces
     SortedSet<Prefix> networks = proc.getNetworks();
-    for (Entry<String, org.batfish.datamodel.Interface> e : vrf.getInterfaces().entrySet()) {
+    for (Entry<String, org.batfish.datamodel.Interface> e :
+        c.getAllInterfaces(vrfName).entrySet()) {
       String ifaceName = e.getKey();
       org.batfish.datamodel.Interface i = e.getValue();
       ConcreteInterfaceAddress interfaceAddress = i.getConcreteAddress();
@@ -3289,7 +3292,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
             throw new BatfishException("Missing vrf name for iface: '" + iface.getName() + "'");
           }
           c.getAllInterfaces().put(newIfaceName, newInterface);
-          c.getVrfs().get(vrfName).getInterfaces().put(newIfaceName, newInterface);
         });
     /*
      * Second pass over the interfaces to set dependency pointers correctly for portchannels

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -1378,7 +1378,7 @@ public class CiscoConversions {
         newOspfProcess.getAreas().values().stream()
             .flatMap(a -> a.getInterfaces().stream())
             .collect(Collectors.toList())) {
-      org.batfish.datamodel.Interface iface = c.getVrfs().get(vrf).getInterfaces().get(ifaceName);
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces(vrf).get(ifaceName);
       DistributeList ifaceDistributeList = interfaceDistributeLists.get(ifaceName);
       BooleanExpr ifaceCondition = null;
       if (ifaceDistributeList != null

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -566,8 +566,8 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
     }
     if (processRouterId == null) {
       processRouterId = Ip.ZERO;
-      org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
-      for (Entry<String, org.batfish.datamodel.Interface> e : vrf.getInterfaces().entrySet()) {
+      for (Entry<String, org.batfish.datamodel.Interface> e :
+          c.getAllInterfaces(vrfName).entrySet()) {
         String iname = e.getKey();
         org.batfish.datamodel.Interface iface = e.getValue();
         if (iname.startsWith("Loopback")) {
@@ -581,7 +581,8 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
         }
       }
       if (processRouterId.equals(Ip.ZERO)) {
-        for (org.batfish.datamodel.Interface currentInterface : vrf.getInterfaces().values()) {
+        for (org.batfish.datamodel.Interface currentInterface :
+            c.getAllInterfaces(vrfName).values()) {
           ConcreteInterfaceAddress address = currentInterface.getConcreteAddress();
           if (address != null) {
             Ip currentIp = address.getIp();
@@ -755,11 +756,10 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
       String updateSourceInterface,
       boolean ipv4) {
     Ip updateSource = null;
-    org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
     if (ipv4) {
       if (updateSourceInterface != null) {
         org.batfish.datamodel.Interface sourceInterface =
-            vrf.getInterfaces().get(updateSourceInterface);
+            c.getAllInterfaces(vrfName).get(updateSourceInterface);
         if (sourceInterface != null) {
           ConcreteInterfaceAddress address = sourceInterface.getConcreteAddress();
           if (address != null) {
@@ -777,7 +777,7 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
           updateSource = Ip.AUTO;
         } else {
           Ip neighborAddress = lpg.getNeighborPrefix().getStartIp();
-          for (org.batfish.datamodel.Interface iface : vrf.getInterfaces().values()) {
+          for (org.batfish.datamodel.Interface iface : c.getAllInterfaces(vrfName).values()) {
             for (ConcreteInterfaceAddress interfaceAddress : iface.getAllConcreteAddresses()) {
               if (interfaceAddress.getPrefix().containsIp(neighborAddress)) {
                 Ip ifaceAddress = interfaceAddress.getIp();
@@ -1622,7 +1622,6 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
                 RoutingProtocol.OSPF_IA.getSummaryAdministrativeCost(c.getConfigurationFormat()))
             .setRouterId(routerId)
             .build();
-    org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
 
     if (proc.getMaxMetricRouterLsa()) {
       newProcess.setMaxMetricTransitLinks(OspfProcess.MAX_METRIC_ROUTER_LSA);
@@ -1640,7 +1639,8 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
     // Set RFC 1583 compatibility
     newProcess.setRfc1583Compatible(proc.getRfc1583Compatible());
 
-    for (Entry<String, org.batfish.datamodel.Interface> e : vrf.getInterfaces().entrySet()) {
+    for (Entry<String, org.batfish.datamodel.Interface> e :
+        c.getAllInterfaces(vrfName).entrySet()) {
       org.batfish.datamodel.Interface iface = e.getValue();
       /*
        * Filter out interfaces that do not belong to this process, however if the process name is missing,
@@ -1857,11 +1857,11 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
   private org.batfish.datamodel.RipProcess toRipProcess(
       RipProcess proc, String vrfName, Configuration c) {
     org.batfish.datamodel.RipProcess newProcess = new org.batfish.datamodel.RipProcess();
-    org.batfish.datamodel.Vrf vrf = c.getVrfs().get(vrfName);
 
     // establish areas and associated interfaces
     SortedSet<Prefix> networks = proc.getNetworks();
-    for (Entry<String, org.batfish.datamodel.Interface> e : vrf.getInterfaces().entrySet()) {
+    for (Entry<String, org.batfish.datamodel.Interface> e :
+        c.getAllInterfaces(vrfName).entrySet()) {
       String ifaceName = e.getKey();
       org.batfish.datamodel.Interface i = e.getValue();
       ConcreteInterfaceAddress interfaceAddress = i.getConcreteAddress();
@@ -2206,7 +2206,6 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
             throw new BatfishException("Missing vrf name for iface: '" + ifaceName + "'");
           }
           c.getAllInterfaces().put(ifaceName, newInterface);
-          c.getVrfs().get(vrfName).getInterfaces().put(ifaceName, newInterface);
         });
     /*
      * Second pass over the interfaces to set dependency pointers correctly for portchannels

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
@@ -1688,7 +1688,7 @@ public class CiscoXrConversions {
         newOspfProcess.getAreas().values().stream()
             .flatMap(a -> a.getInterfaces().stream())
             .collect(Collectors.toList())) {
-      org.batfish.datamodel.Interface iface = c.getVrfs().get(vrf).getInterfaces().get(ifaceName);
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces(vrf).get(ifaceName);
       DistributeList ifaceDistributeList = interfaceDistributeLists.get(ifaceName);
       BooleanExpr ifaceCondition = null;
       if (ifaceDistributeList != null

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -789,7 +789,8 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
   }
 
   private void convertOspfVrf(OspfVrf ospfVrf, org.batfish.datamodel.Vrf vrf) {
-    org.batfish.datamodel.ospf.OspfProcess ospfProcess = toOspfProcess(ospfVrf, vrf);
+    org.batfish.datamodel.ospf.OspfProcess ospfProcess =
+        toOspfProcess(ospfVrf, _c.getAllInterfaces(vrf.getName()));
     vrf.addOspfProcess(ospfProcess);
   }
 
@@ -1256,7 +1257,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
 
   @VisibleForTesting
   org.batfish.datamodel.ospf.OspfProcess toOspfProcess(
-      OspfVrf ospfVrf, org.batfish.datamodel.Vrf vrf) {
+      OspfVrf ospfVrf, Map<String, org.batfish.datamodel.Interface> vrfInterfaces) {
     Ip routerId = ospfVrf.getRouterId();
     if (routerId == null) {
       routerId = inferRouterId();
@@ -1272,8 +1273,8 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
             .setReferenceBandwidth(OspfProcess.DEFAULT_REFERENCE_BANDWIDTH)
             .build();
 
-    addOspfInterfaces(_c.getAllInterfaces(vrf.getName()), proc.getProcessId());
-    proc.setAreas(computeOspfAreas(_c.getAllInterfaces(vrf.getName()).keySet()));
+    addOspfInterfaces(vrfInterfaces, proc.getProcessId());
+    proc.setAreas(computeOspfAreas(vrfInterfaces.keySet()));
     return proc;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -490,7 +490,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
     if (vrf == null) {
       return null;
     }
-    return vrf.getInterfaces().values().stream()
+    return c.getAllInterfaces(vrf.getName()).values().stream()
         .flatMap(
             i ->
                 i.getAllConcreteAddresses().stream()
@@ -684,7 +684,6 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
         .forEach(
             iface -> {
               iface.setVrf(vrf);
-              vrf.getInterfaces().put(iface.getName(), iface);
             });
   }
 
@@ -851,7 +850,6 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
             (ifaceName, iface) -> {
               if (iface.getVrf() == null) {
                 iface.setVrf(defaultVrf);
-                defaultVrf.getInterfaces().put(ifaceName, iface);
               }
             });
     _c.getVrfs().put(DEFAULT_VRF_NAME, defaultVrf);
@@ -1274,37 +1272,36 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
             .setReferenceBandwidth(OspfProcess.DEFAULT_REFERENCE_BANDWIDTH)
             .build();
 
-    addOspfInterfaces(vrf, proc.getProcessId());
+    addOspfInterfaces(_c.getAllInterfaces(vrf.getName()), proc.getProcessId());
     proc.setAreas(computeOspfAreas(vrf.getInterfaceNames()));
     return proc;
   }
 
   @VisibleForTesting
-  void addOspfInterfaces(org.batfish.datamodel.Vrf vrf, String processId) {
-    vrf.getInterfaces()
-        .forEach(
-            (ifaceName, iface) -> {
-              Interface vsIface = _interfaces.get(iface.getName());
-              OspfInterface ospfInterface = vsIface.getOspf();
-              if (ospfInterface == null || ospfInterface.getOspfArea() == null) {
-                // no ospf running on this interface
-                return;
-              }
+  void addOspfInterfaces(Map<String, org.batfish.datamodel.Interface> ifaces, String processId) {
+    ifaces.forEach(
+        (ifaceName, iface) -> {
+          Interface vsIface = _interfaces.get(iface.getName());
+          OspfInterface ospfInterface = vsIface.getOspf();
+          if (ospfInterface == null || ospfInterface.getOspfArea() == null) {
+            // no ospf running on this interface
+            return;
+          }
 
-              iface.setOspfSettings(
-                  OspfInterfaceSettings.builder()
-                      .setPassive(Optional.ofNullable(ospfInterface.getPassive()).orElse(false))
-                      .setAreaName(ospfInterface.getOspfArea())
-                      .setNetworkType(toOspfNetworkType(ospfInterface.getNetwork()))
-                      .setDeadInterval(
-                          Optional.ofNullable(ospfInterface.getDeadInterval())
-                              .orElse(DEFAULT_OSPF_DEAD_INTERVAL))
-                      .setHelloInterval(
-                          Optional.ofNullable(ospfInterface.getHelloInterval())
-                              .orElse(DEFAULT_OSPF_HELLO_INTERVAL))
-                      .setProcess(processId)
-                      .build());
-            });
+          iface.setOspfSettings(
+              OspfInterfaceSettings.builder()
+                  .setPassive(Optional.ofNullable(ospfInterface.getPassive()).orElse(false))
+                  .setAreaName(ospfInterface.getOspfArea())
+                  .setNetworkType(toOspfNetworkType(ospfInterface.getNetwork()))
+                  .setDeadInterval(
+                      Optional.ofNullable(ospfInterface.getDeadInterval())
+                          .orElse(DEFAULT_OSPF_DEAD_INTERVAL))
+                  .setHelloInterval(
+                      Optional.ofNullable(ospfInterface.getHelloInterval())
+                          .orElse(DEFAULT_OSPF_HELLO_INTERVAL))
+                  .setProcess(processId)
+                  .build());
+        });
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusNcluConfiguration.java
@@ -1273,7 +1273,7 @@ public class CumulusNcluConfiguration extends VendorConfiguration {
             .build();
 
     addOspfInterfaces(_c.getAllInterfaces(vrf.getName()), proc.getProcessId());
-    proc.setAreas(computeOspfAreas(vrf.getInterfaceNames()));
+    proc.setAreas(computeOspfAreas(_c.getAllInterfaces(vrf.getName()).keySet()));
     return proc;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/host/HostConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/host/HostConfiguration.java
@@ -220,7 +220,6 @@ public class HostConfiguration extends VendorConfiguration {
               String canonicalName = hostInterface.getCanonicalName();
               Interface newIface = hostInterface.toInterface(_c, _w);
               _c.getAllInterfaces().put(canonicalName, newIface);
-              _c.getDefaultVrf().getInterfaces().put(canonicalName, newIface);
             });
 
     // add iptables
@@ -230,7 +229,7 @@ public class HostConfiguration extends VendorConfiguration {
 
     // apply acls to interfaces
     if (simple()) {
-      for (Interface iface : _c.getDefaultVrf().getInterfaces().values()) {
+      for (Interface iface : _c.getAllInterfaces(Configuration.DEFAULT_VRF_NAME).values()) {
         iface.setIncomingFilter(_c.getIpAccessLists().get(FILTER_INPUT));
         iface.setOutgoingFilter(_c.getIpAccessLists().get(FILTER_OUTPUT));
       }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -316,7 +316,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
     initDefaultBgpExportPolicy();
     initDefaultBgpImportPolicy();
     String vrfName = routingInstance.getName();
-    Vrf vrf = _c.getVrfs().get(vrfName);
     Ip routerId = routingInstance.getRouterId();
     if (routerId == null) {
       routerId = _masterLogicalSystem.getDefaultRoutingInstance().getRouterId();
@@ -598,7 +597,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
         // assign the ip of the interface that is likely connected to this
         // peer
         outerloop:
-        for (org.batfish.datamodel.Interface iface : vrf.getInterfaces().values()) {
+        for (org.batfish.datamodel.Interface iface : _c.getAllInterfaces(vrfName).values()) {
           for (ConcreteInterfaceAddress address : iface.getAllConcreteAddresses()) {
             if (address.getPrefix().containsPrefix(prefix)) {
               localIp = address.getIp();
@@ -887,7 +886,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
   @VisibleForTesting
   IsisLevel processIsisInterfaceSettings(
       RoutingInstance routingInstance, boolean level1, boolean level2) {
-    return _c.getVrfs().get(routingInstance.getName()).getInterfaces().entrySet().stream()
+    return _c.getAllInterfaces(routingInstance.getName()).entrySet().stream()
         .map(
             e -> {
               String ifaceName = e.getKey();
@@ -1083,7 +1082,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
                     .forEach(
                         ifaceName -> {
                           org.batfish.datamodel.Interface iface =
-                              _c.getVrfs().get(vrfName).getInterfaces().get(ifaceName);
+                              _c.getAllInterfaces(vrfName).get(ifaceName);
                           Interface vsIface = routingInstance.getInterfaces().get(ifaceName);
                           finalizeOspfInterfaceSettings(
                               iface, vsIface, newProc, area.getAreaNumber());
@@ -1351,8 +1350,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       String interfaceName,
       Interface iface,
       String vrfName) {
-    Vrf vrf = _c.getVrfs().get(vrfName);
-    org.batfish.datamodel.Interface newIface = vrf.getInterfaces().get(interfaceName);
+    org.batfish.datamodel.Interface newIface = _c.getAllInterfaces(vrfName).get(interfaceName);
     Ip ospfArea = iface.getOspfArea();
     if (ospfArea == null) {
       return;
@@ -3589,7 +3587,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
       return;
     }
     _c.getAllInterfaces().put(ifaceName, viIface);
-    vrf.getInterfaces().put(ifaceName, viIface);
     if (viIface.getOwner() == null) {
       viIface.setOwner(_c);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
@@ -80,10 +80,8 @@ public class VyosConfiguration extends VendorConfiguration {
 
   private void convertInterfaces() {
     for (Entry<String, Interface> e : _interfaces.entrySet()) {
-      String name = e.getKey();
       Interface iface = e.getValue();
-      org.batfish.datamodel.Interface newIface = toInterface(iface);
-      _c.getDefaultVrf().getInterfaces().put(name, newIface);
+      toInterface(iface);
     }
   }
 
@@ -143,7 +141,7 @@ public class VyosConfiguration extends VendorConfiguration {
       // bind interface
       String bindInterfaceName = ipsecPeer.getBindInterface();
       org.batfish.datamodel.Interface newBindInterface =
-          _c.getDefaultVrf().getInterfaces().get(bindInterfaceName);
+          _c.getAllInterfaces().get(bindInterfaceName);
       if (newBindInterface != null) {
         ipsecPeerConfigBuilder.setTunnelInterface(newBindInterface.getName());
       } else {

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisArpFailureDispositionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisArpFailureDispositionsTest.java
@@ -109,8 +109,7 @@ public class BDDReachabilityAnalysisArpFailureDispositionsTest {
 
   private IpSpaceAssignment srcIpSpaceAssignment() {
     Set<Location> locations =
-        _configs.get(NODE1).getVrfs().get(Configuration.DEFAULT_VRF_NAME).getInterfaces().values()
-            .stream()
+        _configs.get(NODE1).getAllInterfaces(Configuration.DEFAULT_VRF_NAME).values().stream()
             .limit(1)
             .map(iface -> new InterfaceLocation(iface.getOwner().getHostname(), iface.getName()))
             .collect(ImmutableSet.toImmutableSet());

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -396,7 +396,7 @@ public class VirtualRouterTest {
 
     // Complete setup by adding a process
     RipProcess ripProcess = new RipProcess();
-    ripProcess.setInterfaces(vr._vrf.getInterfaceNames());
+    ripProcess.setInterfaces(ImmutableSortedSet.copyOf(exampleInterfaceAddresses.keySet()));
     vr._vrf.setRipProcess(ripProcess);
 
     vr.initBaseRipRoutes();

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -4614,8 +4614,7 @@ public final class CiscoGrammarTest {
     Configuration abr = configurations.get(abrName);
 
     // Sanity check: ensure the ABR does not have suppressType7 set for area 1
-    Long areaNum =
-        abr.getVrfs().get(DEFAULT_VRF_NAME).getInterfaces().get("Ethernet1").getOspfAreaName();
+    Long areaNum = abr.getAllInterfaces().get("Ethernet1").getOspfAreaName();
     OspfArea abrToArea1 =
         abr.getVrfs().get(DEFAULT_VRF_NAME).getOspfProcesses().get("1").getAreas().get(areaNum);
     assertThat(abrToArea1.getNssa(), hasSuppressType7(false));
@@ -4650,8 +4649,7 @@ public final class CiscoGrammarTest {
     abr = configurations.get(abrName);
 
     // This time the ABR should have suppressType7 set for area 1
-    areaNum =
-        abr.getVrfs().get(DEFAULT_VRF_NAME).getInterfaces().get("Ethernet1").getOspfAreaName();
+    areaNum = abr.getAllInterfaces().get("Ethernet1").getOspfAreaName();
     abrToArea1 =
         abr.getVrfs().get(DEFAULT_VRF_NAME).getOspfProcesses().get("1").getAreas().get(areaNum);
     assertThat(abrToArea1.getNssa(), hasSuppressType7(true));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -209,7 +209,6 @@ import org.batfish.datamodel.matchers.Route6FilterListMatchers;
 import org.batfish.datamodel.matchers.RouteFilterListMatchers;
 import org.batfish.datamodel.matchers.StubSettingsMatchers;
 import org.batfish.datamodel.matchers.VniSettingsMatchers;
-import org.batfish.datamodel.matchers.VrfMatchers;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.ospf.OspfNetworkType;
@@ -7117,17 +7116,16 @@ public final class CiscoNxosGrammarTest {
 
     assertThat(c.getVrfs(), hasKeys(DEFAULT_VRF_NAME, MANAGEMENT_VRF_NAME, "Vrf1", "vrf3"));
     {
-      org.batfish.datamodel.Vrf vrf = c.getVrfs().get(DEFAULT_VRF_NAME);
-      assertThat(vrf, VrfMatchers.hasInterfaces(contains("Ethernet1/2")));
+      Map<String, org.batfish.datamodel.Interface> vrfIfaces = c.getAllInterfaces(DEFAULT_VRF_NAME);
+      assertThat(vrfIfaces, hasKey("Ethernet1/2"));
     }
     {
-      org.batfish.datamodel.Vrf vrf = c.getVrfs().get("Vrf1");
-      assertThat(
-          vrf, VrfMatchers.hasInterfaces(contains("Ethernet1/1", "Ethernet1/3", "Ethernet1/4")));
+      Map<String, org.batfish.datamodel.Interface> vrfIfaces = c.getAllInterfaces("Vrf1");
+      assertThat(vrfIfaces, hasKeys("Ethernet1/1", "Ethernet1/3", "Ethernet1/4"));
     }
     {
-      org.batfish.datamodel.Vrf vrf = c.getVrfs().get("vrf3");
-      assertThat(vrf, VrfMatchers.hasInterfaces(contains("Ethernet1/5")));
+      Map<String, org.batfish.datamodel.Interface> vrfIfaces = c.getAllInterfaces("vrf3");
+      assertThat(vrfIfaces, hasKeys("Ethernet1/5"));
     }
 
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -44,7 +44,6 @@ import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasSourceAddres
 import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasUdpPort;
 import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasVni;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasBgpProcess;
-import static org.batfish.datamodel.matchers.VrfMatchers.hasInterfaces;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasStaticRoutes;
 import static org.batfish.main.BatfishTestUtils.TEST_SNAPSHOT;
 import static org.batfish.representation.cumulus.CumulusNcluConfiguration.CUMULUS_CLAG_DOMAIN_ID;
@@ -893,25 +892,23 @@ public final class CumulusNcluGrammarTest {
             "vrf1"));
 
     assertThat(
-        c,
-        hasDefaultVrf(
-            hasInterfaces(
-                containsInAnyOrder(
-                    "bond1",
-                    "bond2",
-                    "bond2.4094",
-                    "bond3",
-                    "bond3.4094",
-                    "eth0",
-                    "lo",
-                    "swp1",
-                    "swp2",
-                    "swp3",
-                    "swp4",
-                    "swp5",
-                    "swp6"))));
-    assertThat(c, hasVrf("mgmt", hasInterfaces(containsInAnyOrder("mgmt"))));
-    assertThat(c, hasVrf("vrf1", hasInterfaces(containsInAnyOrder("vrf1", "swp5.1"))));
+        c.getAllInterfaces(DEFAULT_VRF_NAME).keySet(),
+        containsInAnyOrder(
+            "bond1",
+            "bond2",
+            "bond2.4094",
+            "bond3",
+            "bond3.4094",
+            "eth0",
+            "lo",
+            "swp1",
+            "swp2",
+            "swp3",
+            "swp4",
+            "swp5",
+            "swp6"));
+    assertThat(c.getAllInterfaces("mgmt").keySet(), containsInAnyOrder("mgmt"));
+    assertThat(c.getAllInterfaces("vrf1").keySet(), containsInAnyOrder("vrf1", "swp5.1"));
 
     // encapsulation vlan
     assertThat(c, hasInterface("bond2.4094", hasEncapsulationVlan(4094)));
@@ -1121,7 +1118,7 @@ public final class CumulusNcluGrammarTest {
                     // this anycast IP is here until better place for it in the VI model is found
                     ConcreteInterfaceAddress.parse("192.0.2.1/32")))));
     assertThat(c, hasInterface("lo", hasVrfName(DEFAULT_VRF_NAME)));
-    assertThat(c, hasDefaultVrf(hasInterfaces(contains("lo"))));
+    assertThat(c.getAllInterfaces(DEFAULT_VRF_NAME).keySet(), contains("lo"));
   }
 
   @Test
@@ -1344,8 +1341,9 @@ public final class CumulusNcluGrammarTest {
 
     // vlan interfaces should be put in correct vrfs
     assertThat(
-        c, hasDefaultVrf(hasInterfaces(containsInAnyOrder("vlan3", "vlan4", "vlan5", "lo"))));
-    assertThat(c, hasVrf("vrf1", hasInterfaces(containsInAnyOrder("vrf1", "vlan2"))));
+        c.getAllInterfaces(DEFAULT_VRF_NAME).keySet(),
+        containsInAnyOrder("vlan3", "vlan4", "vlan5", "lo"));
+    assertThat(c.getAllInterfaces("vrf1").keySet(), containsInAnyOrder("vrf1", "vlan2"));
     assertThat(c, hasInterface("vlan2", hasVrfName("vrf1")));
     assertThat(c, hasInterface("vlan3", hasVrfName(DEFAULT_VRF_NAME)));
     assertThat(c, hasInterface("vlan4", hasVrfName(DEFAULT_VRF_NAME)));
@@ -1434,8 +1432,8 @@ public final class CumulusNcluGrammarTest {
     Configuration c = parseConfig("cumulus_nclu_vrf");
 
     // vrf presence and loopbacks
-    assertThat(c, hasVrf("vrf1", hasInterfaces(contains("vrf1"))));
-    assertThat(c, hasVrf("vrf2", hasInterfaces(contains("vrf2"))));
+    assertThat(c.getAllInterfaces("vrf1").keySet(), contains("vrf1"));
+    assertThat(c.getAllInterfaces("vrf2").keySet(), contains("vrf2"));
 
     // ip address
     assertThat(c, hasInterface("vrf1", hasAddress(ConcreteInterfaceAddress.parse("10.0.0.1/24"))));

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -42,7 +42,6 @@ import static org.batfish.datamodel.matchers.OspfProcessMatchers.hasArea;
 import static org.batfish.datamodel.matchers.StaticRouteMatchers.hasNextVrf;
 import static org.batfish.datamodel.matchers.StubSettingsMatchers.hasSuppressType3;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasBgpProcess;
-import static org.batfish.datamodel.matchers.VrfMatchers.hasInterfaces;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasName;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasStaticRoutes;
 import static org.batfish.grammar.VendorConfigurationFormatDetector.BATFISH_FLATTENED_PALO_ALTO_HEADER;
@@ -2173,9 +2172,9 @@ public final class PaloAltoGrammarTest {
     String hostname = "virtual-router-interfaces";
     Configuration c = parseConfig(hostname);
 
-    assertThat(c, hasVrf("default", hasInterfaces(hasItem("ethernet1/1"))));
-    assertThat(c, hasVrf("somename", hasInterfaces(hasItems("ethernet1/2", "ethernet1/3"))));
-    assertThat(c, hasVrf("some other name", hasInterfaces(emptyIterable())));
+    assertThat(c.getAllInterfaces("default").keySet(), hasItem("ethernet1/1"));
+    assertThat(c.getAllInterfaces("somename").keySet(), hasItems("ethernet1/2", "ethernet1/3"));
+    assertThat(c.getAllInterfaces("some other name").keySet(), empty());
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusNcluConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusNcluConfigurationTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.Warning;
@@ -560,7 +561,7 @@ public class CumulusNcluConfigurationTest {
     Vrf vrf = new Vrf(Configuration.DEFAULT_VRF_NAME);
 
     CumulusNcluConfiguration ncluConfiguration = new CumulusNcluConfiguration();
-    OspfProcess ospfProcess = ncluConfiguration.toOspfProcess(ospfVrf, vrf);
+    OspfProcess ospfProcess = ncluConfiguration.toOspfProcess(ospfVrf, ImmutableMap.of());
     assertThat(ospfProcess.getRouterId(), equalTo(Ip.parse("0.0.0.0")));
     assertThat(ospfProcess.getProcessId(), equalTo("default"));
     assertThat(
@@ -576,8 +577,7 @@ public class CumulusNcluConfigurationTest {
     Loopback lo = ncluConfiguration.getLoopback();
     lo.setConfigured(true);
     lo.getAddresses().add(ConcreteInterfaceAddress.parse("1.1.1.1/24"));
-    OspfProcess ospfProcess =
-        ncluConfiguration.toOspfProcess(ospfVrf, new Vrf(Configuration.DEFAULT_VRF_NAME));
+    OspfProcess ospfProcess = ncluConfiguration.toOspfProcess(ospfVrf, ImmutableMap.of());
     assertThat(ospfProcess.getRouterId(), equalTo(Ip.parse("1.1.1.1")));
     assertThat(ospfProcess.getProcessId(), equalTo("default"));
     assertThat(
@@ -592,8 +592,7 @@ public class CumulusNcluConfigurationTest {
 
     CumulusNcluConfiguration ncluConfiguration = new CumulusNcluConfiguration();
 
-    OspfProcess ospfProcess =
-        ncluConfiguration.toOspfProcess(ospfVrf, new Vrf(Configuration.DEFAULT_VRF_NAME));
+    OspfProcess ospfProcess = ncluConfiguration.toOspfProcess(ospfVrf, ImmutableMap.of());
     assertThat(ospfProcess.getRouterId(), equalTo(Ip.parse("1.2.3.4")));
     assertThat(ospfProcess.getProcessId(), equalTo("default"));
     assertThat(
@@ -649,7 +648,9 @@ public class CumulusNcluConfigurationTest {
     org.batfish.datamodel.Interface viIface =
         org.batfish.datamodel.Interface.builder().setName("iface").setVrf(vrf).build();
 
-    ncluConfiguration.addOspfInterfaces(vrf, "1");
+    Map<String, org.batfish.datamodel.Interface> ifaceMap =
+        ImmutableMap.of(viIface.getName(), viIface);
+    ncluConfiguration.addOspfInterfaces(ifaceMap, "1");
     assertThat(viIface.getOspfAreaName(), equalTo(1L));
   }
 
@@ -677,8 +678,10 @@ public class CumulusNcluConfigurationTest {
     Vrf vrf = new Vrf(Configuration.DEFAULT_VRF_NAME);
     org.batfish.datamodel.Interface viIface =
         org.batfish.datamodel.Interface.builder().setName("iface").setVrf(vrf).build();
+    Map<String, org.batfish.datamodel.Interface> ifaceMap =
+        ImmutableMap.of(viIface.getName(), viIface);
 
-    ncluConfiguration.addOspfInterfaces(vrf, "1");
+    ncluConfiguration.addOspfInterfaces(ifaceMap, "1");
     assertNull(viIface.getOspfNetworkType());
   }
 
@@ -692,8 +695,10 @@ public class CumulusNcluConfigurationTest {
     Vrf vrf = new Vrf(Configuration.DEFAULT_VRF_NAME);
     org.batfish.datamodel.Interface viIface =
         org.batfish.datamodel.Interface.builder().setName("iface").setVrf(vrf).build();
+    Map<String, org.batfish.datamodel.Interface> ifaceMap =
+        ImmutableMap.of(viIface.getName(), viIface);
 
-    ncluConfiguration.addOspfInterfaces(vrf, "1");
+    ncluConfiguration.addOspfInterfaces(ifaceMap, "1");
     assertFalse(viIface.getOspfPassive());
   }
 
@@ -709,8 +714,10 @@ public class CumulusNcluConfigurationTest {
     Vrf vrf = new Vrf(Configuration.DEFAULT_VRF_NAME);
     org.batfish.datamodel.Interface viIface =
         org.batfish.datamodel.Interface.builder().setName("iface").setVrf(vrf).build();
+    Map<String, org.batfish.datamodel.Interface> ifaceMap =
+        ImmutableMap.of(viIface.getName(), viIface);
 
-    ncluConfiguration.addOspfInterfaces(vrf, "1");
+    ncluConfiguration.addOspfInterfaces(ifaceMap, "1");
     assertTrue(viIface.getOspfPassive());
   }
 
@@ -725,8 +732,10 @@ public class CumulusNcluConfigurationTest {
     Vrf vrf = new Vrf(Configuration.DEFAULT_VRF_NAME);
     org.batfish.datamodel.Interface viIface =
         org.batfish.datamodel.Interface.builder().setName("iface").setVrf(vrf).build();
+    Map<String, org.batfish.datamodel.Interface> ifaceMap =
+        ImmutableMap.of(viIface.getName(), viIface);
 
-    ncluConfiguration.addOspfInterfaces(vrf, "1");
+    ncluConfiguration.addOspfInterfaces(ifaceMap, "1");
     assertThat(
         viIface.getOspfNetworkType(),
         equalTo(org.batfish.datamodel.ospf.OspfNetworkType.POINT_TO_POINT));
@@ -742,8 +751,10 @@ public class CumulusNcluConfigurationTest {
     Vrf vrf = new Vrf(Configuration.DEFAULT_VRF_NAME);
     org.batfish.datamodel.Interface viIface =
         org.batfish.datamodel.Interface.builder().setName("iface").setVrf(vrf).build();
+    Map<String, org.batfish.datamodel.Interface> ifaceMap =
+        ImmutableMap.of(viIface.getName(), viIface);
 
-    ncluConfiguration.addOspfInterfaces(vrf, "1");
+    ncluConfiguration.addOspfInterfaces(ifaceMap, "1");
 
     // default hello interval
     assertThat(
@@ -752,7 +763,7 @@ public class CumulusNcluConfigurationTest {
 
     // set hello interval
     vsIface.getOrCreateOspf().setHelloInterval(1);
-    ncluConfiguration.addOspfInterfaces(vrf, "1");
+    ncluConfiguration.addOspfInterfaces(ifaceMap, "1");
     assertThat(viIface.getOspfSettings().getHelloInterval(), equalTo(1));
   }
 
@@ -766,8 +777,10 @@ public class CumulusNcluConfigurationTest {
     Vrf vrf = new Vrf(Configuration.DEFAULT_VRF_NAME);
     org.batfish.datamodel.Interface viIface =
         org.batfish.datamodel.Interface.builder().setName("iface").setVrf(vrf).build();
+    Map<String, org.batfish.datamodel.Interface> ifaceMap =
+        ImmutableMap.of(viIface.getName(), viIface);
 
-    ncluConfiguration.addOspfInterfaces(vrf, "1");
+    ncluConfiguration.addOspfInterfaces(ifaceMap, "1");
 
     // default dead interval
     assertThat(
@@ -776,7 +789,7 @@ public class CumulusNcluConfigurationTest {
 
     // set dead interval
     vsIface.getOrCreateOspf().setDeadInterval(1);
-    ncluConfiguration.addOspfInterfaces(vrf, "1");
+    ncluConfiguration.addOspfInterfaces(ifaceMap, "1");
     assertThat(viIface.getOspfSettings().getDeadInterval(), equalTo(1));
   }
 
@@ -791,7 +804,9 @@ public class CumulusNcluConfigurationTest {
     org.batfish.datamodel.Interface viIface =
         org.batfish.datamodel.Interface.builder().setName("iface").setVrf(vrf).build();
 
-    ncluConfiguration.addOspfInterfaces(vrf, "1");
+    Map<String, org.batfish.datamodel.Interface> ifaceMap =
+        ImmutableMap.of(viIface.getName(), viIface);
+    ncluConfiguration.addOspfInterfaces(ifaceMap, "1");
 
     // default dead interval
     assertThat(viIface.getOspfSettings().getProcess(), equalTo("1"));

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusNcluConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusNcluConfigurationTest.java
@@ -558,7 +558,6 @@ public class CumulusNcluConfigurationTest {
   @Test
   public void testToOspfProcess_NoRouterId() {
     OspfVrf ospfVrf = new OspfVrf(Configuration.DEFAULT_VRF_NAME);
-    Vrf vrf = new Vrf(Configuration.DEFAULT_VRF_NAME);
 
     CumulusNcluConfiguration ncluConfiguration = new CumulusNcluConfiguration();
     OspfProcess ospfProcess = ncluConfiguration.toOspfProcess(ospfVrf, ImmutableMap.of());

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -134,10 +134,10 @@ public class JuniperConfigurationTest {
    * @return the created interface
    */
   private static org.batfish.datamodel.Interface createInterface(Configuration c) {
-    org.batfish.datamodel.Interface iface =
-        org.batfish.datamodel.Interface.builder().setName("iface").setOwner(c).build();
     Vrf vrf = new Vrf("vrf");
     c.setVrfs(ImmutableMap.of("vrf", vrf));
+    org.batfish.datamodel.Interface iface =
+        org.batfish.datamodel.Interface.builder().setName("iface").setOwner(c).setVrf(vrf).build();
     return iface;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import java.util.List;
 import java.util.Map;
@@ -136,9 +135,8 @@ public class JuniperConfigurationTest {
    */
   private static org.batfish.datamodel.Interface createInterface(Configuration c) {
     org.batfish.datamodel.Interface iface =
-        org.batfish.datamodel.Interface.builder().setName("iface").build();
+        org.batfish.datamodel.Interface.builder().setName("iface").setOwner(c).build();
     Vrf vrf = new Vrf("vrf");
-    vrf.setInterfaces(ImmutableSortedMap.of("iface", iface));
     c.setVrfs(ImmutableMap.of("vrf", vrf));
     return iface;
   }
@@ -180,18 +178,23 @@ public class JuniperConfigurationTest {
     String loopbackName = "lo0.0";
     String iface1Name = "iface1";
     String iface2Name = "iface2";
-    org.batfish.datamodel.Interface loopback =
-        org.batfish.datamodel.Interface.builder()
-            .setName(loopbackName)
-            .setType(InterfaceType.LOOPBACK)
-            .build();
-    org.batfish.datamodel.Interface iface1 =
-        org.batfish.datamodel.Interface.builder().setName(iface1Name).build();
-    org.batfish.datamodel.Interface iface2 =
-        org.batfish.datamodel.Interface.builder().setName(iface2Name).build();
     Vrf vrf = new Vrf("vrf");
-    vrf.setInterfaces(
-        ImmutableSortedMap.of(loopbackName, loopback, iface1Name, iface1, iface2Name, iface2));
+    org.batfish.datamodel.Interface.builder()
+        .setOwner(config._c)
+        .setName(loopbackName)
+        .setVrf(vrf)
+        .setType(InterfaceType.LOOPBACK)
+        .build();
+    org.batfish.datamodel.Interface.builder()
+        .setName(iface1Name)
+        .setOwner(config._c)
+        .setVrf(vrf)
+        .build();
+    org.batfish.datamodel.Interface.builder()
+        .setName(iface2Name)
+        .setOwner(config._c)
+        .setVrf(vrf)
+        .build();
     config._c.setVrfs(ImmutableMap.of("vrf", vrf));
 
     // Loopback has IS-IS enabled at both levels; other interfaces' IS-IS settings vary by test

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/abstraction/AbstractionBuilder.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/abstraction/AbstractionBuilder.java
@@ -516,15 +516,13 @@ class AbstractionBuilder {
       abstractVrf.setSnmpServer(vrf.getSnmpServer());
 
       NavigableMap<String, Interface> abstractVrfInterfaces = new TreeMap<>();
-      for (Entry<String, Interface> entry2 : vrf.getInterfaces().entrySet()) {
+      for (Entry<String, Interface> entry2 : conf.getAllInterfaces(name).entrySet()) {
         String iname = entry2.getKey();
         Interface iface = entry2.getValue();
         if (toRetain.contains(iface)) {
           abstractVrfInterfaces.put(iname, iface);
         }
       }
-      abstractVrf.setInterfaces(abstractVrfInterfaces);
-      abstractVrf.setInterfaceNames(new TreeSet<>(abstractVrfInterfaces.keySet()));
       abstractVrf.setOspfProcesses(
           vrf.getOspfProcesses().values().stream()
               .map(

--- a/projects/question/src/main/java/org/batfish/question/OspfStatusQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/OspfStatusQuestionPlugin.java
@@ -138,7 +138,7 @@ public class OspfStatusQuestionPlugin extends QuestionPlugin {
                 .getInterfaceSpecifier()
                 .resolve(ImmutableSet.of(hostname), _batfish.specifierContext(snapshot));
         for (Vrf vrf : c.getVrfs().values()) {
-          for (Entry<String, Interface> e2 : vrf.getInterfaces().entrySet()) {
+          for (Entry<String, Interface> e2 : c.getAllInterfaces(vrf.getName()).entrySet()) {
             String interfaceName = e2.getKey();
             Interface iface = e2.getValue();
             if (includeInterfaces.contains(NodeInterfacePair.of(iface))) {

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -235,13 +235,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "~Interface_0~",
-              "~Interface_1~",
-              "~Interface_2~",
-              "~Interface_4~"
-            ]
+            }
           }
         }
       },
@@ -375,10 +369,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "es-domain-subnet-1641fa70",
-              "es-domain-subnet-7044ff16"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -592,12 +582,6 @@
               },
               "tieBreaker" : "ARRIVAL_ORDER"
             },
-            "interfaces" : [
-              "backbone",
-              "subnet-1f315846",
-              "subnet-9c8adceb",
-              "subnet-d9cafabc"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -864,14 +848,6 @@
               },
               "tieBreaker" : "ARRIVAL_ORDER"
             },
-            "interfaces" : [
-              "backbone",
-              "subnet-073b8061",
-              "subnet-1641fa70",
-              "subnet-30398256",
-              "subnet-7044ff16",
-              "subnet-f73a8191"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -1090,11 +1066,6 @@
               },
               "tieBreaker" : "ARRIVAL_ORDER"
             },
-            "interfaces" : [
-              "backbone",
-              "subnet-62f14104",
-              "subnet-8d0cbdeb"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -1256,10 +1227,6 @@
               },
               "tieBreaker" : "ARRIVAL_ORDER"
             },
-            "interfaces" : [
-              "Internet_out_interface",
-              "~Interface_3~"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -2791,22 +2758,6 @@
               },
               "tieBreaker" : "ROUTER_ID"
             },
-            "interfaces" : [
-              "Ethernet0/0",
-              "Ethernet1/0",
-              "Ethernet1/1",
-              "Ethernet1/2",
-              "Ethernet1/3",
-              "Ethernet1/4",
-              "Ethernet1/5",
-              "Ethernet1/6",
-              "Ethernet1/7",
-              "GigabitEthernet0/0",
-              "GigabitEthernet2/0",
-              "Loopback0",
-              "Tunnel1",
-              "Tunnel2"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -2989,11 +2940,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "igw-9b93ddfc",
-              "subnet-073b8061",
-              "vpc-b390fad5"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -3167,11 +3113,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "igw-9b93ddfc",
-              "subnet-1641fa70",
-              "vpc-b390fad5"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -3357,11 +3298,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "igw-068fee63",
-              "subnet-1f315846",
-              "vpc-f8fad69d"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -3535,11 +3471,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "igw-9b93ddfc",
-              "subnet-30398256",
-              "vpc-b390fad5"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -3713,11 +3644,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "igw-fac5839d",
-              "subnet-62f14104",
-              "vpc-925131f4"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -3891,11 +3817,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "igw-9b93ddfc",
-              "subnet-7044ff16",
-              "vpc-b390fad5"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -4069,11 +3990,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "igw-fac5839d",
-              "subnet-8d0cbdeb",
-              "vpc-925131f4"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -4259,11 +4175,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "igw-068fee63",
-              "subnet-9c8adceb",
-              "vpc-f8fad69d"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -4449,11 +4360,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "igw-068fee63",
-              "subnet-d9cafabc",
-              "vpc-f8fad69d"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -4627,11 +4533,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "igw-9b93ddfc",
-              "subnet-f73a8191",
-              "vpc-b390fad5"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -4762,9 +4663,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "test-rds-subnet-1641fa70"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -5183,13 +5081,6 @@
               },
               "tieBreaker" : "ARRIVAL_ORDER"
             },
-            "interfaces" : [
-              "external-vpn-ba2e34a8-1",
-              "external-vpn-ba2e34a8-2",
-              "loopbackBgp",
-              "vpn-vpn-ba2e34a8-1",
-              "vpn-vpn-ba2e34a8-2"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -5296,10 +5187,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "subnet-62f14104",
-              "subnet-8d0cbdeb"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -5460,13 +5347,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "subnet-073b8061",
-              "subnet-1641fa70",
-              "subnet-30398256",
-              "subnet-7044ff16",
-              "subnet-f73a8191"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -5610,11 +5490,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "subnet-1f315846",
-              "subnet-9c8adceb",
-              "subnet-d9cafabc"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -2531,13 +2531,7 @@
               }
             },
             "tieBreaker" : "ARRIVAL_ORDER"
-          },
-          "interfaces" : [
-            "Ethernet0/0",
-            "GigabitEthernet0/0",
-            "GigabitEthernet1/0",
-            "Loopback0"
-          ]
+          }
         },
         "structType" : "Vrf"
       }

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -1226,13 +1226,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -2495,14 +2489,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "GigabitEthernet2/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -2930,13 +2917,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -4257,14 +4238,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "GigabitEthernet2/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -5527,14 +5501,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "GigabitEthernet2/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -6201,15 +6168,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "GigabitEthernet2/0",
-              "GigabitEthernet3/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -6821,15 +6780,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "GigabitEthernet2/0",
-              "GigabitEthernet3/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -7772,15 +7723,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "GigabitEthernet2/0",
-              "GigabitEthernet3/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -8578,14 +8521,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "GigabitEthernet2/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -9383,14 +9319,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "GigabitEthernet2/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -10530,13 +10459,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -11628,13 +11551,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -12243,15 +12160,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "GigabitEthernet0/0",
-              "GigabitEthernet1/0",
-              "GigabitEthernet2/0",
-              "GigabitEthernet3/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -12475,9 +12384,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "eth0"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -12710,9 +12616,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "eth0"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -845,11 +845,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Ethernet0",
-              "Ethernet1"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -914,10 +910,7 @@
             "name" : "default"
           },
           "mgmt" : {
-            "name" : "mgmt",
-            "interfaces" : [
-              "Vlan1"
-            ]
+            "name" : "mgmt"
           }
         }
       },
@@ -1123,10 +1116,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Ethernet1"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -1396,10 +1386,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "GigabitEthernet0/0/0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -2352,10 +2339,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "ifname"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -2665,10 +2649,7 @@
                 "routerId" : "192.168.1.0",
                 "summaryAdminCost" : 254
               }
-            },
-            "interfaces" : [
-              "blah"
-            ]
+            }
           }
         },
         "zones" : {
@@ -4904,39 +4885,16 @@
         },
         "vrfs" : {
           "bleepvrf" : {
-            "name" : "bleepvrf",
-            "interfaces" : [
-              "Ethernet6/0.48"
-            ]
+            "name" : "bleepvrf"
           },
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Ethernet6/0.0",
-              "Ethernet6/1",
-              "cable-downstream1/2",
-              "cable-downstream1/2/3",
-              "cable-downstream5/0/0",
-              "cable-mac1",
-              "cable-mac1.2",
-              "cable-mac2",
-              "cable-mac3",
-              "cable-upstream1/0/0",
-              "cable-upstream1/0/0.0",
-              "cable-upstream1/0/10"
-            ]
+            "name" : "default"
           },
           "foovrf" : {
-            "name" : "foovrf",
-            "interfaces" : [
-              "cable-mac1.1"
-            ]
+            "name" : "foovrf"
           },
           "management" : {
-            "name" : "management",
-            "interfaces" : [
-              "mgmt6/0"
-            ]
+            "name" : "management"
           }
         }
       },
@@ -7127,10 +7085,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Cable1/2/3"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -7905,10 +7860,7 @@
                 "exportPolicy" : "~EIGRP_EXPORT_POLICY:default:5~",
                 "routerId" : "100.1.1.1"
               }
-            },
-            "interfaces" : [
-              "Ethernet0"
-            ]
+            }
           }
         }
       },
@@ -7975,10 +7927,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "GigabitEthernet0/1"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -8044,10 +7993,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "TenGigabitEthernet0/0/2/2"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -8775,38 +8721,10 @@
         },
         "vrfs" : {
           "U_VRF" : {
-            "name" : "U_VRF",
-            "interfaces" : [
-              "Ethernet0"
-            ]
+            "name" : "U_VRF"
           },
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Async1",
-              "Cable1/2/3:4",
-              "Crypto-Engine1/2/3",
-              "Dot11Radio0",
-              "Ethernet1/11",
-              "Ethernet1/12",
-              "Loopback0",
-              "Modular-Cable1/2/3:4",
-              "Null0",
-              "Tunnel0",
-              "Vlan1",
-              "Vlan1005",
-              "Vlan1006",
-              "Vlan111",
-              "Vlan1234",
-              "Vlan2",
-              "Vlan3",
-              "Vlan4094",
-              "Wideband-Cable1/2/3:4",
-              "Wlan-GigabitEthernet0",
-              "Wlan-ap0",
-              "inside",
-              "tunnel-ip6"
-            ]
+            "name" : "default"
           }
         },
         "zones" : {
@@ -9622,14 +9540,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "GigabitEthernet0/0",
-              "GigabitEthernet0/0/1",
-              "GigabitEthernet0/1",
-              "HundredGigabitEthernet0/0/0/0.2302",
-              "Loopback0",
-              "Serial4/0"
-            ],
             "isisProcess" : {
               "level1" : {
                 "wideMetricsOnly" : false
@@ -10823,12 +10733,7 @@
                 "routerId" : "1.2.3.4",
                 "summaryAdminCost" : 254
               }
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "Ethernet1/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -10886,10 +10791,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Ethernet0/0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -11167,12 +11069,7 @@
                 "routerId" : "1.1.1.1",
                 "summaryAdminCost" : 254
               }
-            },
-            "interfaces" : [
-              "Ethernet0/0",
-              "Ethernet1/0",
-              "Loopback0"
-            ]
+            }
           }
         }
       },
@@ -11230,10 +11127,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Ethernet0/0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -12354,10 +12248,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Ethernet0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -15569,20 +15460,6 @@
               "multipathIbgp" : true,
               "tieBreaker" : "ARRIVAL_ORDER"
             },
-            "interfaces" : [
-              "bond1",
-              "bond1.4094",
-              "bond2",
-              "lo",
-              "swp1",
-              "swp2",
-              "swp3",
-              "swp4",
-              "swp5",
-              "swp6",
-              "swp7",
-              "swp8"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -15596,11 +15473,7 @@
             ]
           },
           "mgmt" : {
-            "name" : "mgmt",
-            "interfaces" : [
-              "eth0",
-              "mgmt"
-            ]
+            "name" : "mgmt"
           },
           "vrf1" : {
             "name" : "vrf1",
@@ -15613,10 +15486,6 @@
               "multipathIbgp" : true,
               "tieBreaker" : "ARRIVAL_ORDER"
             },
-            "interfaces" : [
-              "vlan4",
-              "vrf1"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -15829,10 +15698,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "lo"
-            ]
+            }
           },
           "vrf1" : {
             "name" : "vrf1",
@@ -15869,10 +15735,7 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "vrf1"
-            ]
+            }
           }
         }
       },
@@ -15952,10 +15815,7 @@
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
               "multipathIbgp" : true,
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "lo"
-            ]
+            }
           }
         }
       },
@@ -16081,10 +15941,7 @@
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
               "multipathIbgp" : true,
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "lo"
-            ]
+            }
           },
           "vrf1" : {
             "name" : "vrf1",
@@ -16096,10 +15953,7 @@
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
               "multipathIbgp" : true,
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "vrf1"
-            ]
+            }
           }
         }
       },
@@ -16183,10 +16037,7 @@
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
               "multipathIbgp" : true,
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "lo"
-            ]
+            }
           }
         }
       },
@@ -16266,10 +16117,7 @@
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
               "multipathIbgp" : true,
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "lo"
-            ]
+            }
           }
         }
       },
@@ -16597,23 +16445,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "AGG",
-              "lo",
-              "otherbond",
-              "swp1",
-              "swp10",
-              "swp2",
-              "swp3",
-              "swp3s0",
-              "swp4",
-              "swp5",
-              "swp6",
-              "swp7",
-              "swp8",
-              "swp9"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -16695,12 +16527,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "lo",
-              "swp1",
-              "swp1s2"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -16761,16 +16588,10 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "lo"
-            ]
+            "name" : "default"
           },
           "vrf1" : {
-            "name" : "vrf1",
-            "interfaces" : [
-              "vrf1"
-            ]
+            "name" : "vrf1"
           }
         }
       },
@@ -16851,17 +16672,10 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "bond1",
-              "lo"
-            ]
+            "name" : "default"
           },
           "vrf1" : {
-            "name" : "vrf1",
-            "interfaces" : [
-              "vrf1"
-            ]
+            "name" : "vrf1"
           }
         }
       },
@@ -16947,12 +16761,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "bond1",
-              "lo",
-              "swp1"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -17057,18 +16866,10 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "bond1",
-              "lo",
-              "swp0"
-            ]
+            "name" : "default"
           },
           "vrf1" : {
-            "name" : "vrf1",
-            "interfaces" : [
-              "vrf1"
-            ]
+            "name" : "vrf1"
           }
         }
       },
@@ -17110,10 +16911,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "lo"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -17199,12 +16997,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "bond1",
-              "lo",
-              "swp1"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -17284,11 +17077,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Port-Channel1",
-              "Port-Channel2"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -17331,10 +17120,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Port-Channel1"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -17706,13 +17492,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "/Common/MYVLAN",
-              "1.0",
-              "2.0",
-              "3.0",
-              "trunk1"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -18605,10 +18384,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Ethernet1/15"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -18941,9 +18717,6 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
-            "interfaces" : [
-              "eth0"
-            ],
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -19153,11 +18926,7 @@
                 "routerId" : "2.130.0.1",
                 "summaryAdminCost" : 254
               }
-            },
-            "interfaces" : [
-              "Ethernet0",
-              "Ethernet1"
-            ]
+            }
           }
         }
       },
@@ -19658,15 +19427,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "ge-0/0/0",
-              "ge-0/0/0.0",
-              "ge-0/0/1",
-              "ge-0/0/1.0",
-              "reth0",
-              "reth0.3"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -19748,11 +19509,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Vlan303",
-              "Vlan803"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -19861,13 +19618,7 @@
         "vendorFamily" : { },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "FastEthernet12/13",
-              "HundredGigabitEthernet0/6/0/8",
-              "Port-Channel1",
-              "Vlan100"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -19917,10 +19668,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Loopback0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -20119,12 +19867,7 @@
                 "routerId" : "10.1.2.3",
                 "summaryAdminCost" : 10
               }
-            },
-            "interfaces" : [
-              "xe-0/0/0",
-              "xe-0/0/0:0",
-              "xe-0/0/0:0.0"
-            ]
+            }
           }
         }
       },
@@ -20294,10 +20037,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "GigabitEthernet1/0/1"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -20343,10 +20083,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Ethernet0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -20392,10 +20129,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Ethernet0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -20441,10 +20175,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Ethernet0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -20508,10 +20239,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Vlan1000"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -21092,10 +20820,7 @@
         "vendorFamily" : { },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "GigabitEthernet0/2/1/6"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -21629,18 +21354,7 @@
                 "routerId" : "169.232.1.4",
                 "summaryAdminCost" : 254
               }
-            },
-            "interfaces" : [
-              "Bundle-Ethernet101",
-              "Bundle-Ethernet103",
-              "Bundle-Ethernet201",
-              "HundredGigabitEthernet0/2/0/0.292",
-              "HundredGigabitEthernet0/2/0/3",
-              "Loopback0",
-              "TenGigabitEthernet0/0/0/2",
-              "TenGigabitEthernet0/0/0/4",
-              "TenGigabitEthernet0/0/0/5"
-            ]
+            }
           }
         }
       },
@@ -24298,31 +24012,7 @@
             "name" : "SOME_INSTANCE"
           },
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "ae0",
-              "ae0.0",
-              "fab0",
-              "ge-0/0/0",
-              "ge-1/0/0",
-              "ge-2/0/0",
-              "ge-2/0/0.0",
-              "ge-2/0/0.1",
-              "ge-3/0/0",
-              "ge-3/0/0.0",
-              "ge-4/0/0",
-              "ge-4/0/0.0",
-              "ge-5/0/0",
-              "ge-5/0/0.0",
-              "irb.5",
-              "vme",
-              "vme.0",
-              "xe-0/0/0:0",
-              "xe-0/0/0:0.0",
-              "xe-0/0/5:0",
-              "xe-0/0/5:0.0",
-              "xe-0/0/6"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -24415,11 +24105,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "ge-0/0/0",
-              "ge-0/0/0.0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -24799,11 +24485,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "ge-0/0/0",
-              "ge-0/0/0.0"
-            ]
+            "name" : "default"
           }
         },
         "zones" : {
@@ -26732,11 +26414,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "ge-0/0/0",
-              "ge-0/0/0.0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -27914,11 +27592,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "xe-0/0/0",
-              "xe-0/0/0.0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -28136,13 +27810,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Ethernet1",
-              "Ethernet2",
-              "Management1",
-              "ap1"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -28724,10 +28392,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "GigabitEthernet1"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -29393,11 +29058,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Ethernet0/0",
-              "Ethernet0/1"
-            ]
+            "name" : "default"
           },
           "management" : {
             "name" : "management"
@@ -29553,10 +29214,7 @@
                 "routerId" : "5.6.7.8",
                 "summaryAdminCost" : 254
               }
-            },
-            "interfaces" : [
-              "Ethernet0/0"
-            ]
+            }
           },
           "default" : {
             "name" : "default",
@@ -31672,11 +31330,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "ge-0/0/0",
-              "ge-0/0/0.0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -32096,18 +31750,7 @@
         "vendorFamily" : { },
         "vrfs" : {
           "~NULL_VRF~" : {
-            "name" : "~NULL_VRF~",
-            "interfaces" : [
-              "ethernet1/1",
-              "ethernet1/1.4",
-              "ethernet1/1.5",
-              "loopback",
-              "loopback.1",
-              "tunnel",
-              "tunnel.3",
-              "vlan",
-              "vlan.1"
-            ]
+            "name" : "~NULL_VRF~"
           }
         }
       },
@@ -32328,13 +31971,7 @@
         "vendorFamily" : { },
         "vrfs" : {
           "~NULL_VRF~" : {
-            "name" : "~NULL_VRF~",
-            "interfaces" : [
-              "ethernet1/1",
-              "ethernet1/2",
-              "ethernet1/3",
-              "ethernet1/4"
-            ]
+            "name" : "~NULL_VRF~"
           }
         },
         "zones" : {
@@ -32412,10 +32049,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "Loopback1"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -36315,10 +35949,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "FastEthernet0/1"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -36857,10 +36488,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "FastEthernet0/0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -36906,10 +36534,7 @@
         },
         "vrfs" : {
           "default" : {
-            "name" : "default",
-            "interfaces" : [
-              "FastEthernet0/0"
-            ]
+            "name" : "default"
           }
         }
       },
@@ -38609,29 +38234,13 @@
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "interfaces" : [
-              "fxp0",
-              "fxp0.0",
-              "irb.100",
-              "lo0",
-              "lo0.0",
-              "xe-0/0/2",
-              "xe-0/0/2.0",
-              "xe-0/0/3",
-              "xe-0/0/3.0",
-              "xe-0/0/4",
-              "xe-0/0/4.0"
-            ]
+            }
           },
           "fabric" : {
             "name" : "fabric"
           },
           "vr" : {
-            "name" : "vr",
-            "interfaces" : [
-              "lo0.1"
-            ]
+            "name" : "vr"
           }
         }
       }


### PR DESCRIPTION
Several reasons for doing this:

1. Multiple sources of truth were causing bugs where interfaces in configuration were removed from configuration but not vrfs. (see #5308 -- that was a temp fix)
2. This simplifies some conversion code a bit
3. Looking into the future, this relaxes the assumption (a tiny bit) that interface must be in a VRF, which is a good thing