### PR TITLE
BatfishLogger: minor cleanup and simplification

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -771,7 +771,7 @@ public class Client extends AbstractClient implements IClient {
               Settings.ARG_COMMAND_FILE, Settings.ARG_RUN_MODE);
           System.exit(1);
         }
-        _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile(), false);
+        _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile());
         break;
       case genquestions:
         if (_settings.getQuestionsDir() == null) {
@@ -780,7 +780,7 @@ public class Client extends AbstractClient implements IClient {
           System.err.printf("Use '-%s <cmdfile>'\n", Settings.ARG_QUESTIONS_DIR);
           System.exit(1);
         }
-        _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile(), false);
+        _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile());
         break;
       case interactive:
         System.err.println(

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -771,8 +771,7 @@ public class Client extends AbstractClient implements IClient {
               Settings.ARG_COMMAND_FILE, Settings.ARG_RUN_MODE);
           System.exit(1);
         }
-        _logger =
-            new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile(), false, false);
+        _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile(), false);
         break;
       case genquestions:
         if (_settings.getQuestionsDir() == null) {
@@ -781,8 +780,7 @@ public class Client extends AbstractClient implements IClient {
           System.err.printf("Use '-%s <cmdfile>'\n", Settings.ARG_QUESTIONS_DIR);
           System.exit(1);
         }
-        _logger =
-            new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile(), false, false);
+        _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile(), false);
         break;
       case interactive:
         System.err.println(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishLogger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishLogger.java
@@ -171,8 +171,7 @@ public final class BatfishLogger {
     _ps = stream;
   }
 
-  public BatfishLogger(
-      String logLevel, boolean timestamp, @Nullable String logFile, boolean logTee) {
+  public BatfishLogger(String logLevel, boolean timestamp, @Nullable String logFile) {
     _history = null;
     _timestamp = timestamp;
     String levelStr = logLevel;
@@ -196,11 +195,7 @@ public final class BatfishLogger {
       } catch (FileNotFoundException | UnsupportedEncodingException e) {
         throw new BatfishException("Could not create logfile", e);
       }
-      if (logTee) {
-        _ps = new CompositePrintStream(System.out, filePrintStream);
-      } else {
-        _ps = filePrintStream;
-      }
+      _ps = filePrintStream;
 
     } else {
       _ps = System.out;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishLogger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BatfishLogger.java
@@ -145,16 +145,11 @@ public final class BatfishLogger {
     return LOG_LEVELS.containsKey(levelStr);
   }
 
-  private final BatfishLoggerHistory _history;
-
+  @Nullable private final BatfishLoggerHistory _history;
   private int _level;
-
-  private String _logFile;
-
-  private PrintStream _ps;
-
+  @Nullable private String _logFile;
+  @Nullable private PrintStream _ps;
   private long _timerCount;
-
   private boolean _timestamp;
 
   public BatfishLogger(String logLevel, boolean timestamp) {

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -58,8 +58,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   private static final String ARG_JOBS = "jobs";
 
-  private static final String ARG_LOG_TEE = "logtee";
-
   private static final String ARG_MAX_PARSER_CONTEXT_LINES = "maxparsercontextlines";
 
   private static final String ARG_MAX_PARSER_CONTEXT_TOKENS = "maxparsercontexttokens";
@@ -289,10 +287,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   public String getLogLevel() {
     return _config.getString(BfConsts.ARG_LOG_LEVEL);
-  }
-
-  public boolean getLogTee() {
-    return _config.getBoolean(ARG_LOG_TEE);
   }
 
   public int getParentPid() {
@@ -531,7 +525,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(ARG_IGNORE_UNSUPPORTED, true);
     setDefaultProperty(ARG_IGNORE_UNKNOWN, true);
     setDefaultProperty(ARG_JOBS, Integer.MAX_VALUE);
-    setDefaultProperty(ARG_LOG_TEE, false);
     setDefaultProperty(BfConsts.ARG_LOG_LEVEL, "debug");
     setDefaultProperty(ARG_MAX_PARSER_CONTEXT_LINES, 10);
     setDefaultProperty(ARG_MAX_PARSER_CONTEXT_TOKENS, 10);
@@ -691,8 +684,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
     addBooleanOption(ARG_HISTOGRAM, "build histogram of unimplemented features");
 
-    addBooleanOption(ARG_LOG_TEE, "print output to both logfile and standard out");
-
     addOption(
         ARG_MAX_PARSER_CONTEXT_LINES,
         "max number of surrounding lines to print on parser error",
@@ -816,6 +807,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
           "gsidregex",
           "gsinputrole",
           "gsremoteas",
+          "logtee",
           "outputenv",
           "ppa",
           "stext",
@@ -879,7 +871,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     getBooleanOptionValue(ARG_IGNORE_UNSUPPORTED);
     getBooleanOptionValue(BfConsts.COMMAND_INIT_INFO);
     getIntOptionValue(ARG_JOBS);
-    getBooleanOptionValue(ARG_LOG_TEE);
     getIntOptionValue(ARG_MAX_PARSER_CONTEXT_LINES);
     getIntOptionValue(ARG_MAX_PARSER_CONTEXT_TOKENS);
     getIntOptionValue(ARG_MAX_PARSE_TREE_PRINT_LENGTH);

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -270,10 +270,7 @@ public class Driver {
     mainInit(args);
     _mainLogger =
         new BatfishLogger(
-            _mainSettings.getLogLevel(),
-            _mainSettings.getTimestamp(),
-            _mainSettings.getLogFile(),
-            _mainSettings.getLogTee());
+            _mainSettings.getLogLevel(), _mainSettings.getTimestamp(), _mainSettings.getLogFile());
     mainRun();
   }
 
@@ -652,11 +649,7 @@ public class Driver {
     try {
 
       final BatfishLogger jobLogger =
-          new BatfishLogger(
-              settings.getLogLevel(),
-              settings.getTimestamp(),
-              settings.getLogFile(),
-              settings.getLogTee());
+          new BatfishLogger(settings.getLogLevel(), settings.getTimestamp(), settings.getLogFile());
       settings.setLogger(jobLogger);
 
       final Task task = new Task(args);

--- a/projects/batfish/src/main/java/org/batfish/main/Driver.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Driver.java
@@ -273,8 +273,7 @@ public class Driver {
             _mainSettings.getLogLevel(),
             _mainSettings.getTimestamp(),
             _mainSettings.getLogFile(),
-            _mainSettings.getLogTee(),
-            true);
+            _mainSettings.getLogTee());
     mainRun();
   }
 
@@ -657,8 +656,7 @@ public class Driver {
               settings.getLogLevel(),
               settings.getTimestamp(),
               settings.getLogFile(),
-              settings.getLogTee(),
-              false);
+              settings.getLogTee());
       settings.setLogger(jobLogger);
 
       final Task task = new Task(args);

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -356,8 +356,7 @@ public class Main {
 
   public static void main(String[] args) {
     mainInit(args);
-    _logger =
-        new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile(), false, true);
+    _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile(), false);
     mainRun(new BindPortFutures());
   }
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -356,7 +356,7 @@ public class Main {
 
   public static void main(String[] args) {
     mainInit(args);
-    _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile(), false);
+    _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile());
     mainRun(new BindPortFutures());
   }
 


### PR DESCRIPTION
Remove a bunch of unused functionality in the logger for a clearer migration path forward to a real logger.

1. Remove log rotation
2. Remove `tee` flag, as far as I can tell no client is actually using it