### PR TITLE
DataPlane settings: remove unused settings/code

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlaneSettings.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlaneSettings.java
@@ -18,8 +18,6 @@ public class IncrementalDataPlaneSettings {
 
   public static final String PROP_COLORING = "coloring";
   public static final String PROP_SCHEDULE = "schedule";
-  public static final String PROP_LOG_ROUTES = "logiterationroutes";
-  public static final String PROP_CHECK_BGP_REACHABILITY = "checkbgpsessionreachability";
 
   /**
    * Return the underlying configuration (it will be mutable).
@@ -51,27 +49,11 @@ public class IncrementalDataPlaneSettings {
   private void initDefaults() {
     _config.setProperty(PROP_COLORING, SATURATION.toString());
     _config.setProperty(PROP_SCHEDULE, NODE_COLORED.toString());
-    _config.setProperty(PROP_LOG_ROUTES, true);
-    _config.setProperty(PROP_CHECK_BGP_REACHABILITY, true);
   }
 
   /** Return the dataplane computation {@link Schedule} */
   public Schedule getScheduleName() {
     return Schedule.valueOf(_config.getString(PROP_SCHEDULE));
-  }
-
-  /** Whether to perform reachability checks to ensure BGP sessions can be properly established */
-  public boolean getCheckBgpSessionReachability() {
-    return _config.getBoolean(PROP_CHECK_BGP_REACHABILITY);
-  }
-
-  /**
-   * Set the dataplane computation {@link Schedule}
-   *
-   * @param schedule the new schedule
-   */
-  public void setScheduleName(Schedule schedule) {
-    _config.setProperty(PROP_SCHEDULE, schedule.toString());
   }
 
   /**


### PR DESCRIPTION
The two settings removed effectively are (and should be) always true.