### PR TITLE
handle the case where vsInterfaces do not exists

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -1108,6 +1108,11 @@ public final class CumulusConversions {
     viIfaces.forEach(
         (ifaceName, iface) -> {
           Interface vsIface = vsIfaces.get(iface.getName());
+          if (vsIface == null) {
+            // if this interface does not exist (e.g., it's a bond) we skip it for now
+            return;
+          }
+
           OspfInterface ospfInterface = vsIface.getOspf();
           if (ospfInterface == null || ospfInterface.getOspfArea() == null) {
             // no ospf running on this interface
@@ -1136,7 +1141,11 @@ public final class CumulusConversions {
     Map<Long, List<String>> areaInterfaces =
         vrfIfaceNames.stream()
             .map(vsIfaces::get)
-            .filter(vsIface -> vsIface.getOspf() != null && vsIface.getOspf().getOspfArea() != null)
+            .filter(
+                vsIface ->
+                    vsIface != null
+                        && vsIface.getOspf() != null
+                        && vsIface.getOspf().getOspfArea() != null)
             .collect(
                 groupingBy(
                     vsIface -> vsIface.getOspf().getOspfArea(),

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -1110,6 +1110,7 @@ public final class CumulusConversions {
           Interface vsIface = vsIfaces.get(iface.getName());
           if (vsIface == null) {
             // if this interface does not exist (e.g., it's a bond) we skip it for now
+            // TODO: need to handle other types of interfaces: bonds, vlans, bridge
             return;
           }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -1115,6 +1115,21 @@ public final class CumulusConversionsTest {
   }
 
   @Test
+  public void testAddOspfInterfaces_NoInterface() {
+    CumulusNcluConfiguration ncluConfiguration = new CumulusNcluConfiguration();
+
+    Vrf vrf = new Vrf(Configuration.DEFAULT_VRF_NAME);
+    org.batfish.datamodel.Interface viIface =
+        org.batfish.datamodel.Interface.builder().setName("iface").setVrf(vrf).build();
+
+    Map<String, org.batfish.datamodel.Interface> ifaceMap =
+        ImmutableMap.of(viIface.getName(), viIface);
+    addOspfInterfaces(ifaceMap, "1", ncluConfiguration.getInterfaces(), new Warnings());
+
+    assertNull(viIface.getOspfSettings());
+  }
+
+  @Test
   public void testComputeOspfProcess_HasArea() {
     CumulusNcluConfiguration ncluConfiguration = new CumulusNcluConfiguration();
     Interface vsIface = new Interface("iface", CumulusInterfaceType.PHYSICAL, null, null);
@@ -1136,6 +1151,15 @@ public final class CumulusConversionsTest {
     Interface vsIface = new Interface("iface", CumulusInterfaceType.PHYSICAL, null, null);
     ncluConfiguration.getInterfaces().put("iface", vsIface);
     vsIface.getOrCreateOspf();
+
+    SortedMap<Long, OspfArea> areas =
+        computeOspfAreas(ImmutableList.of("iface"), ncluConfiguration.getInterfaces());
+    assertThat(areas, equalTo(ImmutableSortedMap.of()));
+  }
+
+  @Test
+  public void testComputeOspfProcess_NoInterface() {
+    CumulusNcluConfiguration ncluConfiguration = new CumulusNcluConfiguration();
 
     SortedMap<Long, OspfArea> areas =
         computeOspfAreas(ImmutableList.of("iface"), ncluConfiguration.getInterfaces());


### PR DESCRIPTION
when converting ospf settings for interfaces in cumulus, we currently need to skip interfaces like bonds to avoid null pointer failures.