### PR TITLE
referencedSources method for multiple ACLs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDSourceManager.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -171,13 +170,11 @@ public final class BDDSourceManager {
                 return active;
               }
 
-              Set<String> sources = new HashSet<>();
-              for (IpAccessList acl : config.getIpAccessLists().values()) {
-                referencedSources(config.getIpAccessLists(), acl).stream()
-                    .filter(active::contains)
-                    .forEach(sources::add);
-              }
-              return sources;
+              return referencedSources(
+                      config.getIpAccessLists(), config.getIpAccessLists().keySet())
+                  .stream()
+                  .filter(active::contains)
+                  .collect(ImmutableSet.toImmutableSet());
             });
 
     Map<String, Set<String>> activeAndReferenced =

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedByIpAccessLists.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/SourcesReferencedByIpAccessLists.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.acl;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 
 import com.google.common.collect.ImmutableSet;
@@ -129,6 +130,14 @@ public final class SourcesReferencedByIpAccessLists {
       Map<String, IpAccessList> namedAcls, IpAccessList acl) {
     ReferenceSourcesVisitor visitor = new ReferenceSourcesVisitor(namedAcls);
     visitor.visit(acl);
+    return visitor.referencedInterfaces();
+  }
+
+  public static Set<String> referencedSources(
+      Map<String, IpAccessList> namedAcls, Set<String> acls) {
+    checkArgument(namedAcls.keySet().containsAll(acls));
+    ReferenceSourcesVisitor visitor = new ReferenceSourcesVisitor(namedAcls);
+    acls.forEach(acl -> visitor.visit(namedAcls.get(acl)));
     return visitor.referencedInterfaces();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 
 /** Tests for {@link BDDReverseTransformationRangesImpl}. */
 public class BDDReverseTransformationRangesImplTest {
-  private static final String HOSTNAME = "HOSTNAME";
+  private static final String HOSTNAME = "hostname";
 
   private BDDPacket _bddPacket;
   private Map<String, Configuration> _configs;


### PR DESCRIPTION
Also some cleanup in the test class. The new method is not particularly needed at the moment, but will be useful in some forthcoming work.