### PR TITLE
Arista BGP: fix address family rule inside VRF

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Arista_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Arista_bgp.g4
@@ -1031,9 +1031,12 @@ eos_rb_vlan_tail
 
 eos_rbv_address_family
 :
-  eos_rb_af_ipv4
+  ADDRESS_FAMILY
+  (
+    eos_rb_af_ipv4
 //  | eos_rb_af_ipv4_multicast
-  | eos_rb_af_ipv6
+    | eos_rb_af_ipv6
+  )
 ;
 
 eos_rbv_local_as

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -537,6 +537,14 @@ public class AristaGrammarTest {
       assertThat(v6, notNullValue());
       assertThat(v6.getActivate(), equalTo(Boolean.TRUE));
     }
+    {
+      Ip neighbor = Ip.parse("3.3.3.3");
+      assertThat(vrf.getV4neighbors(), not(hasKey(neighbor)));
+      AristaBgpVrf vrf1 = config.getAristaBgp().getVrfs().get("vrf1");
+      assertThat(vrf1.getV4neighbors(), hasKey(neighbor));
+      assertTrue(vrf1.getV4UnicastAf().getNeighbor(neighbor).getActivate());
+      assertThat(vrf1.getV4UnicastAf().getNeighbor(neighbor).getRouteMapOut(), equalTo("RM1"));
+    }
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_af
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_af
@@ -16,3 +16,10 @@ router bgp 65104
   address-family evpn
     neighbor 1.1.1.1 activate
     neighbor PG activate
+
+  vrf vrf1
+    neighbor 3.3.3.3 remote-as 3
+    address-family ipv4
+      neighbor 3.3.3.3 activate
+      neighbor 3.3.3.3 route-map RM1 out
+


### PR DESCRIPTION
Was missing a token and therefore was kicking us up to parent context/default vrf