### PR TITLE
Refactor SearchFilters to use BDDs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/DenyQuery.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/DenyQuery.java
@@ -1,0 +1,26 @@
+package org.batfish.question.searchfilters;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.IpAccessListToBdd;
+import org.batfish.datamodel.IpAccessList;
+
+/** {@link SearchFiltersQuery} for finding denied flows */
+@ParametersAreNonnullByDefault
+public class DenyQuery implements SearchFiltersQuery {
+  public static final DenyQuery INSTANCE = new DenyQuery();
+
+  private DenyQuery() {}
+
+  @Override
+  public boolean canQuery(IpAccessList acl) {
+    return true;
+  }
+
+  @Override
+  @Nonnull
+  public BDD getMatchingBdd(IpAccessList acl, IpAccessListToBdd ipAccessListToBdd) {
+    return ipAccessListToBdd.toBdd(acl).not();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/DenyQuery.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/DenyQuery.java
@@ -3,6 +3,7 @@ package org.batfish.question.searchfilters;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.IpAccessListToBdd;
 import org.batfish.datamodel.IpAccessList;
 
@@ -20,7 +21,7 @@ public class DenyQuery implements SearchFiltersQuery {
 
   @Override
   @Nonnull
-  public BDD getMatchingBdd(IpAccessList acl, IpAccessListToBdd ipAccessListToBdd) {
+  public BDD getMatchingBdd(IpAccessList acl, IpAccessListToBdd ipAccessListToBdd, BDDPacket pkt) {
     return ipAccessListToBdd.toBdd(acl).not();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/MatchLineQuery.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/MatchLineQuery.java
@@ -1,0 +1,42 @@
+package org.batfish.question.searchfilters;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import javax.annotation.Nonnull;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.IpAccessListToBdd;
+import org.batfish.datamodel.IpAccessList;
+
+/** {@link SearchFiltersQuery} for finding flows that match a particular line */
+public class MatchLineQuery implements SearchFiltersQuery {
+  private final int _lineNum;
+
+  MatchLineQuery(int lineNum) {
+    _lineNum = lineNum;
+  }
+
+  public int getLineNum() {
+    return _lineNum;
+  }
+
+  @Override
+  public boolean canQuery(IpAccessList acl) {
+    return acl.getLines().size() > _lineNum;
+  }
+
+  @Override
+  @Nonnull
+  public BDD getMatchingBdd(IpAccessList acl, IpAccessListToBdd ipAccessListToBdd) {
+    checkArgument(canQuery(acl), "ACL %s is too short to apply match line query", acl.getName());
+
+    // Generate BDD matching all flows that would match the target line, then subtract out the BDDs
+    // of flows matched by each previous line
+    BDD matchingTargetLine =
+        ipAccessListToBdd.toPermitAndDenyBdds(acl.getLines().get(_lineNum)).getMatchBdd();
+    for (int i = 0; i < _lineNum && !matchingTargetLine.isZero(); i++) {
+      BDD lineBdd = ipAccessListToBdd.toPermitAndDenyBdds(acl.getLines().get(i)).getMatchBdd();
+      matchingTargetLine = matchingTargetLine.diff(lineBdd);
+    }
+    return matchingTargetLine;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/PermitQuery.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/PermitQuery.java
@@ -3,6 +3,7 @@ package org.batfish.question.searchfilters;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.IpAccessListToBdd;
 import org.batfish.datamodel.IpAccessList;
 
@@ -20,7 +21,7 @@ public class PermitQuery implements SearchFiltersQuery {
 
   @Override
   @Nonnull
-  public BDD getMatchingBdd(IpAccessList acl, IpAccessListToBdd ipAccessListToBdd) {
+  public BDD getMatchingBdd(IpAccessList acl, IpAccessListToBdd ipAccessListToBdd, BDDPacket pkt) {
     return ipAccessListToBdd.toBdd(acl);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/PermitQuery.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/PermitQuery.java
@@ -1,0 +1,26 @@
+package org.batfish.question.searchfilters;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.IpAccessListToBdd;
+import org.batfish.datamodel.IpAccessList;
+
+/** {@link SearchFiltersQuery} for finding permitted flows */
+@ParametersAreNonnullByDefault
+public class PermitQuery implements SearchFiltersQuery {
+  public static final PermitQuery INSTANCE = new PermitQuery();
+
+  private PermitQuery() {}
+
+  @Override
+  public boolean canQuery(IpAccessList acl) {
+    return true;
+  }
+
+  @Override
+  @Nonnull
+  public BDD getMatchingBdd(IpAccessList acl, IpAccessListToBdd ipAccessListToBdd) {
+    return ipAccessListToBdd.toBdd(acl);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/SearchFiltersQuery.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/SearchFiltersQuery.java
@@ -1,0 +1,20 @@
+package org.batfish.question.searchfilters;
+
+import javax.annotation.Nonnull;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.IpAccessListToBdd;
+import org.batfish.datamodel.IpAccessList;
+
+/** Query indicating which flows to search for (permitted, denied, or matching a certain line) */
+public interface SearchFiltersQuery {
+
+  /** Whether this query can be applied to the provided {@link IpAccessList} */
+  boolean canQuery(IpAccessList acl);
+
+  /**
+   * Returns BDD representing the space of flows matching the given ACL for this query. Assumes this
+   * query is applicable to the ACL as per {@link SearchFiltersQuery#canQuery(IpAccessList)}.
+   */
+  @Nonnull
+  BDD getMatchingBdd(IpAccessList acl, IpAccessListToBdd ipAccessListToBdd);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/SearchFiltersQuery.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/question/searchfilters/SearchFiltersQuery.java
@@ -2,6 +2,7 @@ package org.batfish.question.searchfilters;
 
 import javax.annotation.Nonnull;
 import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.IpAccessListToBdd;
 import org.batfish.datamodel.IpAccessList;
 
@@ -16,5 +17,5 @@ public interface SearchFiltersQuery {
    * query is applicable to the ACL as per {@link SearchFiltersQuery#canQuery(IpAccessList)}.
    */
   @Nonnull
-  BDD getMatchingBdd(IpAccessList acl, IpAccessListToBdd ipAccessListToBdd);
+  BDD getMatchingBdd(IpAccessList acl, IpAccessListToBdd ipAccessListToBdd, BDDPacket pkt);
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/question/searchfilters/MatchLineQueryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/question/searchfilters/MatchLineQueryTest.java
@@ -1,11 +1,25 @@
 package org.batfish.question.searchfilters;
 
+import static org.batfish.datamodel.ExprAclLine.acceptingHeaderSpace;
+import static org.batfish.datamodel.ExprAclLine.rejectingHeaderSpace;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.common.bdd.HeaderSpaceToBDD;
+import org.batfish.common.bdd.IpAccessListToBdd;
+import org.batfish.common.bdd.IpAccessListToBddImpl;
 import org.batfish.datamodel.ExprAclLine;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.Prefix;
 import org.junit.Test;
 
 /** Tests of {@link MatchLineQuery} */
@@ -23,5 +37,48 @@ public class MatchLineQueryTest {
     MatchLineQuery matchLine1 = new MatchLineQuery(1);
     assertTrue(matchLine0.canQuery(acl));
     assertFalse(matchLine1.canQuery(acl));
+  }
+
+  @Test
+  public void testGetMatchingBdd() {
+    BDDPacket pkt = new BDDPacket();
+    IpAccessListToBdd ipAccessListToBdd =
+        new IpAccessListToBddImpl(
+            pkt, BDDSourceManager.empty(pkt), ImmutableMap.of(), ImmutableMap.of());
+
+    // ACL accepts ip1, rejects ip2, accepts prefix that contains both
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("1.1.1.2");
+    Prefix prefix = Prefix.parse("1.1.1.0/24");
+    HeaderSpace ip1HeaderSpace = HeaderSpace.builder().setDstIps(ip1.toIpSpace()).build();
+    HeaderSpace ip2HeaderSpace = HeaderSpace.builder().setDstIps(ip2.toIpSpace()).build();
+    HeaderSpace prefixHeaderSpace = HeaderSpace.builder().setDstIps(prefix.toIpSpace()).build();
+    IpAccessList acl =
+        IpAccessList.builder()
+            .setName("acl")
+            .setLines(
+                ImmutableList.of(
+                    acceptingHeaderSpace(ip1HeaderSpace),
+                    rejectingHeaderSpace(ip2HeaderSpace),
+                    acceptingHeaderSpace(prefixHeaderSpace)))
+            .build();
+
+    HeaderSpaceToBDD headerSpaceToBDD = new HeaderSpaceToBDD(pkt, ImmutableMap.of());
+    BDD ip1Bdd = headerSpaceToBDD.toBDD(ip1HeaderSpace);
+    BDD ip2Bdd = headerSpaceToBDD.toBDD(ip2HeaderSpace);
+    BDD prefixBdd = headerSpaceToBDD.toBDD(prefixHeaderSpace);
+
+    // Match line 0: Matching BDD should only include dst IP ip1
+    MatchLineQuery matchLine0 = new MatchLineQuery(0);
+    assertThat(matchLine0.getMatchingBdd(acl, ipAccessListToBdd, pkt), equalTo(ip1Bdd));
+
+    // Match line 1: Matching BDD should only include dst IP ip2
+    MatchLineQuery matchLine1 = new MatchLineQuery(1);
+    assertThat(matchLine1.getMatchingBdd(acl, ipAccessListToBdd, pkt), equalTo(ip2Bdd));
+
+    // Match line 2: Matching BDD should be the prefix except ip1 and ip2
+    MatchLineQuery matchLine2 = new MatchLineQuery(2);
+    BDD expectedBdd = prefixBdd.diff(ip1Bdd.or(ip2Bdd));
+    assertThat(matchLine2.getMatchingBdd(acl, ipAccessListToBdd, pkt), equalTo(expectedBdd));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/question/searchfilters/MatchLineQueryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/question/searchfilters/MatchLineQueryTest.java
@@ -1,0 +1,27 @@
+package org.batfish.question.searchfilters;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import org.batfish.datamodel.ExprAclLine;
+import org.batfish.datamodel.IpAccessList;
+import org.junit.Test;
+
+/** Tests of {@link MatchLineQuery} */
+public class MatchLineQueryTest {
+  @Test
+  public void testCanQuery() {
+    IpAccessList acl =
+        IpAccessList.builder()
+            .setName("acl")
+            .setLines(ImmutableList.of(ExprAclLine.ACCEPT_ALL))
+            .build();
+
+    // Match line queries should work only if the line number is within range for the ACL
+    MatchLineQuery matchLine0 = new MatchLineQuery(0);
+    MatchLineQuery matchLine1 = new MatchLineQuery(1);
+    assertTrue(matchLine0.canQuery(acl));
+    assertFalse(matchLine1.canQuery(acl));
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersAnswerer.java
@@ -1,9 +1,9 @@
 package org.batfish.question.searchfilters;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.referencedSources;
 import static org.batfish.question.FilterQuestionUtils.differentialBDDSourceManager;
-import static org.batfish.question.FilterQuestionUtils.getFlow;
 import static org.batfish.question.FilterQuestionUtils.resolveSources;
 import static org.batfish.question.testfilters.TestFiltersAnswerer.COLUMN_METADATA;
 import static org.batfish.question.testfilters.TestFiltersAnswerer.COL_FILTER_NAME;
@@ -11,25 +11,19 @@ import static org.batfish.question.testfilters.TestFiltersAnswerer.COL_NODE;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultiset;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
-import com.google.common.collect.Streams;
-import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import net.sf.javabdd.BDD;
-import org.apache.commons.lang3.tuple.ImmutableTriple;
-import org.apache.commons.lang3.tuple.Triple;
 import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
 import org.batfish.common.NetworkSnapshot;
@@ -37,37 +31,27 @@ import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.HeaderSpaceToBDD;
 import org.batfish.common.bdd.IpAccessListToBdd;
+import org.batfish.common.bdd.MemoizedIpAccessListToBdd;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.acl.GenericAclLineVisitor;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.questions.Question;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.datamodel.table.TableDiff;
 import org.batfish.datamodel.table.TableMetadata;
+import org.batfish.question.FilterQuestionUtils;
 import org.batfish.question.SearchFiltersParameters;
+import org.batfish.question.searchfilters.SearchFiltersQuestion.Type;
 import org.batfish.question.testfilters.TestFiltersAnswerer;
 import org.batfish.specifier.FilterSpecifier;
 import org.batfish.specifier.SpecifierContext;
 
 /** Answerer for SearchFiltersQuestion */
 public final class SearchFiltersAnswerer extends Answerer {
-
-  @VisibleForTesting
-  public static final Function<String, String> NEGATED_RENAMER =
-      name -> String.format("~~ Negated ACL: %s ~~", name);
-
-  @VisibleForTesting
-  public static final BiFunction<Integer, String, String> MATCH_LINE_RENAMER =
-      (line, name) -> String.format("~~ Match-Line %d ACL: %s ~~", line, name);
-
   private TableAnswerElement _tableAnswerElement;
 
   public SearchFiltersAnswerer(Question question, IBatfish batfish) {
@@ -92,230 +76,188 @@ public final class SearchFiltersAnswerer extends Answerer {
     SearchFiltersParameters parameters = question.toSearchFiltersParameters();
 
     TableAnswerElement baseTable = new TableAnswerElement(new TableMetadata(COLUMN_METADATA));
-    TableAnswerElement deltaTable = new TableAnswerElement(new TableMetadata(COLUMN_METADATA));
+    TableAnswerElement refTable = new TableAnswerElement(new TableMetadata(COLUMN_METADATA));
 
-    Multimap<String, String> baseAcls = getSpecifiedAcls(snapshot, question);
-    Multimap<String, String> deltaAcls = getSpecifiedAcls(reference, question);
-    Map<String, Configuration> baseConfigs = _batfish.loadConfigurations(snapshot);
-    Map<String, Configuration> deltaConfigs = _batfish.loadConfigurations(reference);
+    Map<String, Map<String, IpAccessList>> acls = getSpecifiedAcls(snapshot, question);
+    Map<String, Map<String, IpAccessList>> refAcls = getSpecifiedAcls(reference, question);
+    Map<String, DiffConfigContext> configContexts =
+        getDiffConfigContexts(acls, refAcls, snapshot, reference, parameters);
 
-    Set<String> commonNodes = Sets.intersection(baseAcls.keySet(), deltaAcls.keySet());
-    for (String node : commonNodes) {
-      Configuration baseConfig = baseConfigs.get(node);
-      Configuration deltaConfig = deltaConfigs.get(node);
+    for (Entry<String, DiffConfigContext> e : configContexts.entrySet()) {
+      String hostname = e.getKey();
+      DiffConfigContext configContext = e.getValue();
+      Map<String, IpAccessList> aclsForNode = acls.get(hostname);
+      Map<String, IpAccessList> refAclsForNode = refAcls.get(hostname);
 
-      Set<String> commonAcls =
-          Sets.intersection(
-              ImmutableSet.copyOf(baseAcls.get(node)), ImmutableSet.copyOf(deltaAcls.get(node)));
-
+      Set<String> commonAcls = Sets.union(aclsForNode.keySet(), refAclsForNode.keySet());
       for (String aclName : commonAcls) {
-        Optional<IpAccessList> baseAcl = makeQueryAcl(baseConfig.getIpAccessLists().get(aclName));
-        Optional<IpAccessList> deltaAcl = makeQueryAcl(deltaConfig.getIpAccessLists().get(aclName));
-        if (!baseAcl.isPresent() && !deltaAcl.isPresent()) {
-          continue;
-        }
-        if (baseAcl.isPresent() && !deltaAcl.isPresent() && question.getIncludeOneTableKeys()) {
-          baseTable.addRow(
-              Row.builder(baseTable.getMetadata().toColumnMap())
-                  .put(COL_NODE, node)
-                  .put(COL_FILTER_NAME, aclName)
-                  .build());
-          continue;
-        }
-        if (!baseAcl.isPresent() && question.getIncludeOneTableKeys()) {
-          deltaTable.addRow(
-              Row.builder(deltaTable.getMetadata().toColumnMap())
-                  .put(COL_NODE, node)
-                  .put(COL_FILTER_NAME, aclName)
-                  .build());
+        IpAccessList acl = aclsForNode.get(aclName);
+        IpAccessList refAcl = refAclsForNode.get(aclName);
+
+        // If either ACL can't be queried, can't compare them; fill in row in the other table if
+        // necessary and continue
+        boolean canQueryAcl = canQuery(acl, question);
+        boolean canQueryRefAcl = canQuery(refAcl, question);
+        if (!canQueryAcl || !canQueryRefAcl) {
+          if (question.getIncludeOneTableKeys() && (canQueryAcl || canQueryRefAcl)) {
+            // One of them is not null and question specifies to include rows in this case
+            TableAnswerElement table = canQueryAcl ? baseTable : refTable;
+            table.addRow(
+                Row.builder(table.getMetadata().toColumnMap())
+                    .put(COL_NODE, hostname)
+                    .put(COL_FILTER_NAME, aclName)
+                    .build());
+          }
           continue;
         }
 
         // present in both snapshot
         DifferentialSearchFiltersResult result =
-            differentialReachFilter(
-                snapshot,
-                _batfish,
-                baseConfig,
-                baseAcl.get(),
-                deltaConfig,
-                deltaAcl.get(),
-                parameters);
+            getDiffResult(acl, refAcl, configContext, question);
 
         Stream.of(result.getDecreasedFlow(), result.getIncreasedFlow())
             .filter(Optional::isPresent)
             .map(Optional::get)
             .forEach(
                 flow -> {
-                  baseTable.addRow(testFiltersRow(snapshot, node, aclName, flow));
-                  deltaTable.addRow(testFiltersRow(reference, node, aclName, flow));
+                  baseTable.addRow(testFiltersRow(snapshot, hostname, aclName, flow));
+                  refTable.addRow(testFiltersRow(reference, hostname, aclName, flow));
                 });
       }
     }
 
     // take care of nodes that are present in only one snapshot
     if (question.getIncludeOneTableKeys()) {
-      addOneSnapshotNodes(Sets.difference(baseAcls.keySet(), deltaAcls.keySet()), baseTable);
-      addOneSnapshotNodes(Sets.difference(deltaAcls.keySet(), baseAcls.keySet()), deltaTable);
+      addOneSnapshotNodes(Sets.difference(acls.keySet(), refAcls.keySet()), baseTable);
+      addOneSnapshotNodes(Sets.difference(refAcls.keySet(), acls.keySet()), refTable);
     }
 
     TableAnswerElement diffTable =
-        TableDiff.diffTables(baseTable, deltaTable, question.getIncludeOneTableKeys());
+        TableDiff.diffTables(baseTable, refTable, question.getIncludeOneTableKeys());
 
     _tableAnswerElement = new TableAnswerElement(diffTable.getMetadata());
     _tableAnswerElement.postProcessAnswer(question, diffTable.getRows().getData());
   }
 
+  /**
+   * Returns true if the given ACL can be queried using the given question. Currently only returns
+   * false if the question specifies a match line for a line number too big for the ACL.
+   */
+  @VisibleForTesting
+  static boolean canQuery(IpAccessList acl, SearchFiltersQuestion question) {
+    if (question.getType() != Type.MATCH_LINE) {
+      return true;
+    }
+    Integer lineNumber = question.getLineNumber();
+    checkState(lineNumber != null, "Line number must be defined for MATCH_LINE query");
+    return acl.getLines().size() > question.getLineNumber();
+  }
+
   private void nonDifferentialAnswer(NetworkSnapshot snapshot, SearchFiltersQuestion question) {
-    List<Triple<String, String, IpAccessList>> acls =
-        getQueryAcls(_batfish.getSnapshot(), question);
-    if (acls.isEmpty()) {
+    Map<String, Map<String, IpAccessList>> specifiedAcls = getSpecifiedAcls(snapshot, question);
+    if (specifiedAcls.values().stream().allMatch(Map::isEmpty)) {
       throw new BatfishException("No matching filters");
     }
 
     Multiset<Row> rows = HashMultiset.create();
-    /*
-     * For each query ACL, try to get a flow. If one exists, run traceFilter on that flow.
-     * Concatenate the answers for all flows into one big table.
-     */
-    Map<String, Configuration> configurations = _batfish.loadConfigurations(snapshot);
-    for (Triple<String, String, IpAccessList> triple : acls) {
-      String hostname = triple.getLeft();
-      String aclname = triple.getMiddle();
-      Configuration node = configurations.get(hostname);
-      IpAccessList acl = triple.getRight();
-      Optional<Flow> optionalResultFlow =
-          reachFilter(snapshot, _batfish, node, acl, question.toSearchFiltersParameters());
-      optionalResultFlow.ifPresent(
-          flow -> rows.add(testFiltersRow(snapshot, hostname, aclname, flow)));
-    }
 
-    _tableAnswerElement = new TableAnswerElement(new TableMetadata(COLUMN_METADATA));
-    _tableAnswerElement.postProcessAnswer(question, rows);
+    /*
+     * For each ACL, try to get a flow matching the query. If one exists, run traceFilter on that
+     * flow. Concatenate the answers for all flows into one big table.
+     */
+    SearchFiltersParameters parameters = question.toSearchFiltersParameters();
+    for (Entry<String, NonDiffConfigContext> e :
+        getConfigContexts(specifiedAcls, snapshot, parameters).entrySet()) {
+      String hostname = e.getKey();
+      NonDiffConfigContext configContext = e.getValue();
+      for (IpAccessList acl : specifiedAcls.get(hostname).values()) {
+        // Ensure that query is applicable to acl
+        if (!canQuery(acl, question)) {
+          continue;
+        }
+
+        // Generate representative flow for ACL, if one exists
+        Flow flow = configContext.getFlow(configContext.getReachBdd(acl, question));
+        if (flow == null) {
+          continue;
+        }
+
+        // Add result to table
+        rows.add(testFiltersRow(snapshot, hostname, acl.getName(), flow));
+      }
+
+      _tableAnswerElement = new TableAnswerElement(new TableMetadata(COLUMN_METADATA));
+      _tableAnswerElement.postProcessAnswer(question, rows);
+    }
   }
 
-  private Multimap<String, String> getSpecifiedAcls(
+  /**
+   * Given all specified ACLs on all configs of the given snapshot, returns a {@link
+   * NonDiffConfigContext} for each config.
+   */
+  private Map<String, NonDiffConfigContext> getConfigContexts(
+      Map<String, Map<String, IpAccessList>> specifiedAcls,
+      NetworkSnapshot snapshot,
+      SearchFiltersParameters parameters) {
+    Map<String, Configuration> configs = _batfish.loadConfigurations(snapshot);
+    return specifiedAcls.entrySet().stream()
+        .collect(
+            ImmutableMap.toImmutableMap(
+                Entry::getKey,
+                e -> {
+                  Configuration c = configs.get(e.getKey());
+                  Set<String> aclNames = e.getValue().keySet();
+                  return new NonDiffConfigContext(c, aclNames, snapshot, _batfish, parameters);
+                }));
+  }
+
+  /**
+   * Given all specified ACLs in two snapshots, returns a {@link DiffConfigContext} for each config
+   * in common between the two snapshots.
+   */
+  private Map<String, DiffConfigContext> getDiffConfigContexts(
+      Map<String, Map<String, IpAccessList>> baseAcls,
+      Map<String, Map<String, IpAccessList>> refAcls,
+      NetworkSnapshot snapshot,
+      NetworkSnapshot reference,
+      SearchFiltersParameters parameters) {
+    Map<String, Configuration> baseConfigs = _batfish.loadConfigurations(snapshot);
+    Map<String, Configuration> refConfigs = _batfish.loadConfigurations(reference);
+
+    Set<String> commonNodes = Sets.intersection(baseAcls.keySet(), refAcls.keySet());
+    ImmutableMap.Builder<String, DiffConfigContext> configContexts = ImmutableMap.builder();
+    for (String hostname : commonNodes) {
+      Configuration c = baseConfigs.get(hostname);
+      Configuration refC = refConfigs.get(hostname);
+      Set<String> commonAcls =
+          Sets.intersection(baseAcls.get(hostname).keySet(), refAcls.get(hostname).keySet());
+      configContexts.put(
+          hostname,
+          new DiffConfigContext(c, refC, commonAcls, snapshot, reference, _batfish, parameters));
+    }
+    return configContexts.build();
+  }
+
+  /**
+   * Creates a map of hostname to ACL name to {@link IpAccessList} specifying all ACLs to query.
+   * Keys include all hostnames matching the query, even if they contain no ACLs matching the query
+   * (might matter in differential context where the other snapshot's version of the node does have
+   * matching ACLs).
+   */
+  @VisibleForTesting
+  Map<String, Map<String, IpAccessList>> getSpecifiedAcls(
       NetworkSnapshot snapshot, SearchFiltersQuestion question) {
-    SortedMap<String, Configuration> configs = _batfish.loadConfigurations(snapshot);
     FilterSpecifier filterSpecifier = question.getFilterSpecifier();
     SpecifierContext specifierContext = _batfish.specifierContext(snapshot);
-    ImmutableMultimap.Builder<String, String> acls = ImmutableMultimap.builder();
-    question.getNodesSpecifier().resolve(specifierContext).stream()
-        .map(configs::get)
-        .forEach(
-            config ->
-                filterSpecifier
-                    .resolve(config.getHostname(), specifierContext)
-                    .forEach(acl -> acls.put(config.getHostname(), acl.getName())));
-    return acls.build();
-  }
-
-  private Optional<IpAccessList> makeQueryAcl(IpAccessList originalAcl) {
-    SearchFiltersQuestion question = (SearchFiltersQuestion) _question;
-    switch (question.getType()) {
-      case PERMIT:
-        return Optional.of(originalAcl);
-      case DENY:
-        return Optional.of(toDenyAcl(originalAcl));
-      case MATCH_LINE:
-        // for each ACL, construct a new ACL that accepts if and only if the specified line matches
-        Integer lineNumber = question.getLineNumber();
-        checkState(lineNumber != null, "Cannot perform a match line query without a line number");
-        return originalAcl.getLines().size() > lineNumber
-            ? Optional.of(toMatchLineAcl(lineNumber, originalAcl))
-            : Optional.empty();
-      default:
-        throw new BatfishException("Unexpected query Type: " + question.getType());
-    }
-  }
-
-  // Each triple in the result is a node name, ACL name, and the ACL itself.  The ACL itself
-  // may rename the ACL, so we explicitly keep track of the original name for later use.
-  @VisibleForTesting
-  List<Triple<String, String, IpAccessList>> getQueryAcls(
-      NetworkSnapshot snapshot, SearchFiltersQuestion question) {
-    Map<String, Configuration> configs = _batfish.loadConfigurations(snapshot);
-    return getSpecifiedAcls(snapshot, question).entries().stream()
-        .map(
-            entry -> {
-              String hostName = entry.getKey();
-              String aclName = entry.getValue();
-              Optional<IpAccessList> queryAcl =
-                  makeQueryAcl(configs.get(hostName).getIpAccessLists().get(aclName));
-              return queryAcl.map(acl -> ImmutableTriple.of(hostName, aclName, acl));
-            })
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .collect(ImmutableList.toImmutableList());
-  }
-
-  @VisibleForTesting
-  static IpAccessList toMatchLineAcl(Integer lineNumber, IpAccessList acl) {
-    CopierWithAction permittingCopier = new CopierWithAction(LineAction.PERMIT);
-    CopierWithAction denyingCopier = new CopierWithAction(LineAction.DENY);
-    List<AclLine> lines =
-        Streams.concat(
-                // Deny everything that matches any previous line
-                acl.getLines().subList(0, lineNumber).stream().map(denyingCopier::visit),
-                // Permit everything that matches selected line
-                Stream.of(permittingCopier.visit(acl.getLines().get(lineNumber))))
-            .collect(ImmutableList.toImmutableList());
-    return IpAccessList.builder()
-        .setName(MATCH_LINE_RENAMER.apply(lineNumber, acl.getName()))
-        .setLines(lines)
-        .build();
-  }
-
-  @VisibleForTesting
-  static IpAccessList toDenyAcl(IpAccessList acl) {
-    List<AclLine> lines =
-        Streams.concat(
-                acl.getLines().stream().map(ComplementaryCopier::copy),
-                // accept if we reach the end of the ACL
-                Stream.of(ExprAclLine.ACCEPT_ALL))
-            .collect(ImmutableList.toImmutableList());
-    return IpAccessList.builder()
-        .setName(NEGATED_RENAMER.apply(acl.getName()))
-        .setLines(lines)
-        .build();
-  }
-
-  /**
-   * Creates a copy of the visited {@link AclLine} that matches the same flows but always takes the
-   * provided action.
-   */
-  private static final class CopierWithAction implements GenericAclLineVisitor<AclLine> {
-    private final LineAction _action;
-
-    CopierWithAction(LineAction action) {
-      _action = action;
-    }
-
-    @Override
-    public AclLine visitExprAclLine(ExprAclLine exprAclLine) {
-      return exprAclLine.toBuilder().setAction(_action).build();
-    }
-  }
-
-  /**
-   * Creates a copy of the visited {@link AclLine} that matches all the same flows as the original
-   * line, but permits the flows the original denies and vice versa.
-   */
-  private static final class ComplementaryCopier implements GenericAclLineVisitor<AclLine> {
-    private static final ComplementaryCopier INSTANCE = new ComplementaryCopier();
-
-    private ComplementaryCopier() {}
-
-    static AclLine copy(AclLine line) {
-      return INSTANCE.visit(line);
-    }
-
-    @Override
-    public AclLine visitExprAclLine(ExprAclLine exprAclLine) {
-      LineAction newAction =
-          exprAclLine.getAction() == LineAction.PERMIT ? LineAction.DENY : LineAction.PERMIT;
-      return exprAclLine.toBuilder().setAction(newAction).build();
-    }
+    return question.getNodesSpecifier().resolve(specifierContext).stream()
+        .collect(
+            ImmutableMap.toImmutableMap(
+                Function.identity(),
+                hostname ->
+                    filterSpecifier.resolve(hostname, specifierContext).stream()
+                        .collect(
+                            ImmutableMap.toImmutableMap(
+                                IpAccessList::getName, Function.identity()))));
   }
 
   private Row testFiltersRow(NetworkSnapshot snapshot, String hostname, String aclName, Flow flow) {
@@ -331,85 +273,185 @@ public final class SearchFiltersAnswerer extends Answerer {
     }
   }
 
-  @VisibleForTesting
-  static Optional<Flow> reachFilter(
-      NetworkSnapshot snapshot,
-      IBatfish batfish,
-      Configuration node,
-      IpAccessList acl,
-      SearchFiltersParameters parameters) {
-    BDDPacket bddPacket = new BDDPacket();
+  /**
+   * Returns BDD representing the space of flows matching the given ACL for the given question.
+   * Assumes the question is applicable to the ACL (see {@link
+   * SearchFiltersAnswerer#canQuery(IpAccessList, SearchFiltersQuestion)}).
+   */
+  @Nonnull
+  private static BDD getQueryBdd(
+      IpAccessList acl, IpAccessListToBdd ipAccessListToBdd, SearchFiltersQuestion question) {
+    checkArgument(canQuery(acl, question), "Unable to apply query to ACL %s", acl.getName());
+    switch (question.getType()) {
+      case PERMIT:
+        // BDD of everything permitted by the acl
+        return ipAccessListToBdd.toBdd(acl);
+      case DENY:
+        // BDD of everything not permitted by the acl
+        return ipAccessListToBdd.toBdd(acl).not();
+      case MATCH_LINE:
+        Integer lineNumber = question.getLineNumber();
+        assert lineNumber != null; // ensured by canQuery() check
 
-    SpecifierContext specifierContext = batfish.specifierContext(snapshot);
+        // Generate BDD matching all flows that would match the target line, then
+        // subtract out the BDDs of flows matched by each previous line
+        BDD matchingTargetLine =
+            ipAccessListToBdd.toPermitAndDenyBdds(acl.getLines().get(lineNumber)).getMatchBdd();
+        for (int i = 0; i < lineNumber && !matchingTargetLine.isZero(); i++) {
+          BDD lineBdd = ipAccessListToBdd.toPermitAndDenyBdds(acl.getLines().get(i)).getMatchBdd();
+          matchingTargetLine = matchingTargetLine.diff(lineBdd);
+        }
+        return matchingTargetLine;
+      default:
+        throw new IllegalStateException(
+            String.format("Unrecognized Search Filters question type %s", question.getType()));
+    }
+  }
 
+  private static Set<String> getActiveSources(
+      Configuration c, SpecifierContext specifierContext, SearchFiltersParameters parameters) {
     Set<String> inactiveIfaces =
-        Sets.difference(node.getAllInterfaces().keySet(), node.activeInterfaceNames());
-    Set<String> activeSources =
-        Sets.difference(
-            resolveSources(
-                specifierContext, parameters.getStartLocationSpecifier(), node.getHostname()),
-            inactiveIfaces);
-    Set<String> referencedSources = referencedSources(node.getIpAccessLists(), acl);
-
-    BDDSourceManager mgr = BDDSourceManager.forSources(bddPacket, activeSources, referencedSources);
-
-    HeaderSpace headerSpace = parameters.resolveHeaderspace(specifierContext);
-    BDD headerSpaceBDD = new HeaderSpaceToBDD(bddPacket, node.getIpSpaces()).toBDD(headerSpace);
-    BDD bdd =
-        IpAccessListToBdd.toBDD(bddPacket, acl, node.getIpAccessLists(), node.getIpSpaces(), mgr)
-            .and(headerSpaceBDD)
-            .and(mgr.isValidValue());
-
-    return getFlow(bddPacket, mgr, node.getHostname(), bdd);
+        Sets.difference(c.getAllInterfaces().keySet(), c.activeInterfaceNames());
+    return Sets.difference(
+        resolveSources(specifierContext, parameters.getStartLocationSpecifier(), c.getHostname()),
+        inactiveIfaces);
   }
 
   /** Performs a difference reachFilters analysis (both increased and decreased reachability). */
   @VisibleForTesting
-  static DifferentialSearchFiltersResult differentialReachFilter(
-      NetworkSnapshot snapshot,
-      IBatfish batfish,
-      Configuration baseConfig,
-      IpAccessList baseAcl,
-      Configuration deltaConfig,
-      IpAccessList deltaAcl,
-      SearchFiltersParameters searchFiltersParameters) {
-    BDDPacket bddPacket = new BDDPacket();
+  static DifferentialSearchFiltersResult getDiffResult(
+      IpAccessList acl,
+      IpAccessList refAcl,
+      DiffConfigContext configContext,
+      SearchFiltersQuestion question) {
+    BDD bdd = configContext.getReachBdd(acl, question, false);
+    BDD refBdd = configContext.getReachBdd(refAcl, question, true);
 
-    HeaderSpace headerSpace =
-        searchFiltersParameters.resolveHeaderspace(batfish.specifierContext(snapshot));
-    BDD headerSpaceBDD =
-        new HeaderSpaceToBDD(bddPacket, baseConfig.getIpSpaces()).toBDD(headerSpace);
+    // Find example increased and decreased flows, if they exist
+    BDD increasedBDD = bdd.diff(refBdd);
+    BDD decreasedBDD = refBdd.diff(bdd);
+    Flow increasedFlow = configContext.getFlow(increasedBDD);
+    Flow decreasedFlow = configContext.getFlow(decreasedBDD);
 
-    BDDSourceManager mgr =
-        differentialBDDSourceManager(
-            bddPacket,
-            batfish,
-            baseConfig,
-            deltaConfig,
-            baseAcl,
-            deltaAcl,
-            searchFiltersParameters.getStartLocationSpecifier());
+    return new DifferentialSearchFiltersResult(increasedFlow, decreasedFlow);
+  }
 
-    BDD baseAclBDD =
-        IpAccessListToBdd.toBDD(
-                bddPacket, baseAcl, baseConfig.getIpAccessLists(), baseConfig.getIpSpaces(), mgr)
-            .and(headerSpaceBDD)
-            .and(mgr.isValidValue());
-    BDD deltaAclBDD =
-        IpAccessListToBdd.toBDD(
-                bddPacket, deltaAcl, deltaConfig.getIpAccessLists(), deltaConfig.getIpSpaces(), mgr)
-            .and(headerSpaceBDD)
-            .and(mgr.isValidValue());
+  /** Holds BDD state for one configuration */
+  @VisibleForTesting
+  static final class NonDiffConfigContext {
+    private final String _hostname;
+    private final IpAccessListToBdd _ipAccessListToBdd;
 
-    String hostname = baseConfig.getHostname();
+    private final BDDPacket _pkt;
+    private final BDDSourceManager _mgr;
+    private final BDD _prerequisiteBdd;
 
-    BDD increasedBDD = deltaAclBDD.diff(baseAclBDD);
-    Optional<Flow> increasedFlow = getFlow(bddPacket, mgr, hostname, increasedBDD);
+    NonDiffConfigContext(
+        Configuration config,
+        Set<String> specifiedAcls,
+        NetworkSnapshot snapshot,
+        IBatfish batfish,
+        SearchFiltersParameters parameters) {
+      _hostname = config.getHostname();
+      _pkt = new BDDPacket();
 
-    BDD decreasedBDD = baseAclBDD.diff(deltaAclBDD);
-    Optional<Flow> decreasedFlow = getFlow(bddPacket, mgr, hostname, decreasedBDD);
+      // Build source manager, including sources from ref snapshot if necessary
+      SpecifierContext specifierContext = batfish.specifierContext(snapshot);
+      Set<String> activeSources = getActiveSources(config, specifierContext, parameters);
+      Set<String> referencedSources = referencedSources(config.getIpAccessLists(), specifiedAcls);
+      _mgr = BDDSourceManager.forSources(_pkt, activeSources, referencedSources);
+      HeaderSpace headerSpace = parameters.resolveHeaderspace(specifierContext);
+      BDD headerSpaceBdd = new HeaderSpaceToBDD(_pkt, config.getIpSpaces()).toBDD(headerSpace);
+      _prerequisiteBdd = headerSpaceBdd.and(_mgr.isValidValue());
 
-    return new DifferentialSearchFiltersResult(
-        increasedFlow.orElse(null), decreasedFlow.orElse(null));
+      _ipAccessListToBdd =
+          new MemoizedIpAccessListToBdd(
+              _pkt, _mgr, config.getIpAccessLists(), config.getIpSpaces());
+    }
+
+    /**
+     * Returns the BDD representing all flows that will match the query for the given ACL. Assumes
+     * the question is applicable to the ACL (see {@link
+     * SearchFiltersAnswerer#canQuery(IpAccessList, SearchFiltersQuestion)}).
+     */
+    @Nonnull
+    BDD getReachBdd(IpAccessList acl, SearchFiltersQuestion question) {
+      return getQueryBdd(acl, _ipAccessListToBdd, question).and(_prerequisiteBdd);
+    }
+
+    /** Returns a concrete flow satisfying the input {@link BDD}, if one exists. */
+    @Nullable
+    Flow getFlow(BDD reachBdd) {
+      return FilterQuestionUtils.getFlow(_pkt, _mgr, _hostname, reachBdd).orElse(null);
+    }
+  }
+
+  @VisibleForTesting
+  /** Holds BDD state for two snapshots' versions of one configuration */
+  static final class DiffConfigContext {
+    private final String _hostname;
+    private final IpAccessListToBdd _ipAccessListToBdd;
+    private final IpAccessListToBdd _refIpAccessListToBdd;
+
+    private final BDDPacket _pkt;
+    private final BDDSourceManager _mgr;
+    private final BDD _prerequisiteBdd;
+
+    DiffConfigContext(
+        Configuration config,
+        Configuration refConfig,
+        Set<String> specifiedAcls,
+        NetworkSnapshot snapshot,
+        NetworkSnapshot refSnapshot,
+        IBatfish batfish,
+        SearchFiltersParameters parameters) {
+      // Both configs should share the same hostname
+      _hostname = config.getHostname();
+      _pkt = new BDDPacket();
+
+      // Build source manager, including sources from ref snapshot if necessary
+      SpecifierContext specifierContext = batfish.specifierContext(snapshot);
+      SpecifierContext refSpecifierContext = batfish.specifierContext(refSnapshot);
+      _mgr =
+          differentialBDDSourceManager(
+              _pkt,
+              specifierContext,
+              refSpecifierContext,
+              config,
+              refConfig,
+              specifiedAcls,
+              parameters.getStartLocationSpecifier());
+
+      // TODO: How to adjust _headerSpace in differential context?
+      HeaderSpace headerSpace = parameters.resolveHeaderspace(specifierContext);
+      BDD headerSpaceBdd = new HeaderSpaceToBDD(_pkt, config.getIpSpaces()).toBDD(headerSpace);
+      _prerequisiteBdd = headerSpaceBdd.and(_mgr.isValidValue());
+
+      _ipAccessListToBdd =
+          new MemoizedIpAccessListToBdd(
+              _pkt, _mgr, config.getIpAccessLists(), config.getIpSpaces());
+      _refIpAccessListToBdd =
+          new MemoizedIpAccessListToBdd(
+              _pkt, _mgr, refConfig.getIpAccessLists(), refConfig.getIpSpaces());
+    }
+
+    /**
+     * Returns the BDD representing all flows that will match the query for the given ACL. Assumes
+     * the question is applicable to the ACL (see {@link
+     * SearchFiltersAnswerer#canQuery(IpAccessList, SearchFiltersQuestion)}).
+     *
+     * @param reference Whether the provided ACL is from the reference snapshot
+     */
+    @Nonnull
+    BDD getReachBdd(IpAccessList acl, SearchFiltersQuestion question, boolean reference) {
+      IpAccessListToBdd ipAccessListToBdd = reference ? _refIpAccessListToBdd : _ipAccessListToBdd;
+      return getQueryBdd(acl, ipAccessListToBdd, question).and(_prerequisiteBdd);
+    }
+
+    /** Returns a concrete flow satisfying the input {@link BDD}, if one exists. */
+    @Nullable
+    Flow getFlow(BDD reachBdd) {
+      return FilterQuestionUtils.getFlow(_pkt, _mgr, _hostname, reachBdd).orElse(null);
+    }
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersAnswerer.java
@@ -86,7 +86,7 @@ public final class SearchFiltersAnswerer extends Answerer {
       Map<String, IpAccessList> aclsForNode = acls.get(hostname);
       Map<String, IpAccessList> refAclsForNode = refAcls.get(hostname);
 
-      Set<String> commonAcls = Sets.union(aclsForNode.keySet(), refAclsForNode.keySet());
+      Set<String> commonAcls = Sets.intersection(aclsForNode.keySet(), refAclsForNode.keySet());
       for (String aclName : commonAcls) {
         IpAccessList acl = aclsForNode.get(aclName);
         IpAccessList refAcl = refAclsForNode.get(aclName);

--- a/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/searchfilters/SearchFiltersAnswerer.java
@@ -110,8 +110,7 @@ public final class SearchFiltersAnswerer extends Answerer {
         }
 
         // present in both snapshot
-        DifferentialSearchFiltersResult result =
-            getDiffResult(acl, refAcl, configContext, question);
+        DifferentialSearchFiltersResult result = getDiffResult(acl, refAcl, configContext, query);
 
         Stream.of(result.getDecreasedFlow(), result.getIncreasedFlow())
             .filter(Optional::isPresent)
@@ -273,8 +272,7 @@ public final class SearchFiltersAnswerer extends Answerer {
       IpAccessList acl,
       IpAccessList refAcl,
       DiffConfigContext configContext,
-      SearchFiltersQuestion question) {
-    SearchFiltersQuery query = question.getQuery();
+      SearchFiltersQuery query) {
     BDD bdd = configContext.getReachBdd(acl, query, false);
     BDD refBdd = configContext.getReachBdd(refAcl, query, true);
 

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererDifferentialTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererDifferentialTest.java
@@ -23,6 +23,7 @@ import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.question.SearchFiltersParameters;
 import org.batfish.question.searchfilters.SearchFiltersAnswerer.DiffConfigContext;
+import org.batfish.specifier.LocationSpecifier;
 import org.batfish.specifier.NameRegexInterfaceLinkLocationSpecifier;
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,13 +38,13 @@ public class SearchFiltersAnswererDifferentialTest {
   private static final String IFACE1 = "iface1";
   private static final String IFACE2 = "iface2";
   private static final Ip IP = Ip.parse("1.2.3.4");
+  private static final SearchFiltersQuery PERMIT_QUERY = PermitQuery.INSTANCE;
 
   private NetworkFactory _nf;
   private Configuration.Builder _cb;
   private Interface.Builder _ib;
   private IpAccessList.Builder _ab;
   private SearchFiltersParameters _params;
-  private SearchFiltersQuestion _question;
 
   @Before
   public void setup() {
@@ -54,8 +55,12 @@ public class SearchFiltersAnswererDifferentialTest {
             .setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     _ib = _nf.interfaceBuilder();
     _ab = _nf.aclBuilder();
-    _question = new SearchFiltersQuestion();
-    _params = _question.toSearchFiltersParameters();
+    _params =
+        new SearchFiltersQuestion()
+            .toSearchFiltersParameters()
+            .toBuilder()
+            .setStartLocationSpecifier(LocationSpecifier.ALL_LOCATIONS)
+            .build();
   }
 
   private static IBatfish getBatfish(Configuration baseConfig, Configuration deltaConfig) {
@@ -85,7 +90,8 @@ public class SearchFiltersAnswererDifferentialTest {
     DiffConfigContext configContext =
         new DiffConfigContext(
             config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, _params);
-    DifferentialSearchFiltersResult result = getDiffResult(acl, refAcl, configContext, _question);
+    DifferentialSearchFiltersResult result =
+        getDiffResult(acl, refAcl, configContext, PERMIT_QUERY);
     assertTrue("Expected no decreased result", !result.getDecreasedFlow().isPresent());
     assertTrue("Expected increased result", result.getIncreasedFlow().isPresent());
     assertThat(result.getIncreasedFlow().get(), allOf(hasIngressInterface(IFACE1), hasDstIp(IP)));
@@ -100,7 +106,7 @@ public class SearchFiltersAnswererDifferentialTest {
             snapshot,
             getBatfish(refConfig, config),
             _params);
-    result = getDiffResult(refAcl, acl, configContext, _question);
+    result = getDiffResult(refAcl, acl, configContext, PERMIT_QUERY);
     assertTrue("Expected no increased result", !result.getIncreasedFlow().isPresent());
     assertTrue("Expected decreased result", result.getDecreasedFlow().isPresent());
     assertThat(result.getDecreasedFlow().get(), allOf(hasIngressInterface(IFACE1), hasDstIp(IP)));
@@ -123,7 +129,8 @@ public class SearchFiltersAnswererDifferentialTest {
     DiffConfigContext configContext =
         new DiffConfigContext(
             config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, _params);
-    DifferentialSearchFiltersResult result = getDiffResult(acl, refAcl, configContext, _question);
+    DifferentialSearchFiltersResult result =
+        getDiffResult(acl, refAcl, configContext, PERMIT_QUERY);
     assertTrue("Expected no decreased result", !result.getDecreasedFlow().isPresent());
     assertTrue("Expected increased result", result.getIncreasedFlow().isPresent());
     assertThat(result.getIncreasedFlow().get(), hasDstIp(IP));
@@ -138,7 +145,7 @@ public class SearchFiltersAnswererDifferentialTest {
             snapshot,
             getBatfish(refConfig, config),
             _params);
-    result = getDiffResult(refAcl, acl, configContext, _question);
+    result = getDiffResult(refAcl, acl, configContext, PERMIT_QUERY);
     assertTrue("Expected no increased result", !result.getIncreasedFlow().isPresent());
     assertTrue("Expected decreased result", result.getDecreasedFlow().isPresent());
     assertThat(result.getDecreasedFlow().get(), hasDstIp(IP));
@@ -176,7 +183,8 @@ public class SearchFiltersAnswererDifferentialTest {
     DiffConfigContext configContext =
         new DiffConfigContext(
             config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, params);
-    DifferentialSearchFiltersResult result = getDiffResult(acl, refAcl, configContext, _question);
+    DifferentialSearchFiltersResult result =
+        getDiffResult(acl, refAcl, configContext, PERMIT_QUERY);
     assertTrue("Expected no decreased result", !result.getDecreasedFlow().isPresent());
     assertTrue("Expected increased result", result.getIncreasedFlow().isPresent());
     assertThat(result.getIncreasedFlow().get(), allOf(hasIngressInterface(IFACE1), hasDstIp(IP)));
@@ -191,7 +199,7 @@ public class SearchFiltersAnswererDifferentialTest {
     configContext =
         new DiffConfigContext(
             config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, params);
-    result = getDiffResult(acl, refAcl, configContext, _question);
+    result = getDiffResult(acl, refAcl, configContext, PERMIT_QUERY);
     assertTrue("Expected no decreased result", !result.getDecreasedFlow().isPresent());
     assertTrue("Expected no increased result", !result.getIncreasedFlow().isPresent());
   }

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererDifferentialTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererDifferentialTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.batfish.common.NetworkSnapshot;
+import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -34,6 +35,7 @@ import org.junit.rules.TemporaryFolder;
 public class SearchFiltersAnswererDifferentialTest {
   @Rule public TemporaryFolder _tmp = new TemporaryFolder();
 
+  private static final BDDPacket PKT = new BDDPacket();
   private static final String HOSTNAME = "hostname";
   private static final String IFACE1 = "iface1";
   private static final String IFACE2 = "iface2";
@@ -89,7 +91,14 @@ public class SearchFiltersAnswererDifferentialTest {
 
     DiffConfigContext configContext =
         new DiffConfigContext(
-            config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, _params);
+            config,
+            refConfig,
+            ImmutableSet.of(aclName),
+            snapshot,
+            reference,
+            batfish,
+            _params,
+            PKT);
     DifferentialSearchFiltersResult result =
         getDiffResult(acl, refAcl, configContext, PERMIT_QUERY);
     assertTrue("Expected no decreased result", !result.getDecreasedFlow().isPresent());
@@ -105,7 +114,8 @@ public class SearchFiltersAnswererDifferentialTest {
             reference,
             snapshot,
             getBatfish(refConfig, config),
-            _params);
+            _params,
+            PKT);
     result = getDiffResult(refAcl, acl, configContext, PERMIT_QUERY);
     assertTrue("Expected no increased result", !result.getIncreasedFlow().isPresent());
     assertTrue("Expected decreased result", result.getDecreasedFlow().isPresent());
@@ -128,7 +138,14 @@ public class SearchFiltersAnswererDifferentialTest {
 
     DiffConfigContext configContext =
         new DiffConfigContext(
-            config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, _params);
+            config,
+            refConfig,
+            ImmutableSet.of(aclName),
+            snapshot,
+            reference,
+            batfish,
+            _params,
+            PKT);
     DifferentialSearchFiltersResult result =
         getDiffResult(acl, refAcl, configContext, PERMIT_QUERY);
     assertTrue("Expected no decreased result", !result.getDecreasedFlow().isPresent());
@@ -144,7 +161,8 @@ public class SearchFiltersAnswererDifferentialTest {
             reference,
             snapshot,
             getBatfish(refConfig, config),
-            _params);
+            _params,
+            PKT);
     result = getDiffResult(refAcl, acl, configContext, PERMIT_QUERY);
     assertTrue("Expected no increased result", !result.getIncreasedFlow().isPresent());
     assertTrue("Expected decreased result", result.getDecreasedFlow().isPresent());
@@ -182,7 +200,7 @@ public class SearchFiltersAnswererDifferentialTest {
     // can match line 1 because IFACE1 is specified
     DiffConfigContext configContext =
         new DiffConfigContext(
-            config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, params);
+            config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, params, PKT);
     DifferentialSearchFiltersResult result =
         getDiffResult(acl, refAcl, configContext, PERMIT_QUERY);
     assertTrue("Expected no decreased result", !result.getDecreasedFlow().isPresent());
@@ -198,7 +216,7 @@ public class SearchFiltersAnswererDifferentialTest {
     // can't match line 1 because IFACE2 is specified
     configContext =
         new DiffConfigContext(
-            config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, params);
+            config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, params, PKT);
     result = getDiffResult(acl, refAcl, configContext, PERMIT_QUERY);
     assertTrue("Expected no decreased result", !result.getDecreasedFlow().isPresent());
     assertTrue("Expected no increased result", !result.getIncreasedFlow().isPresent());

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererDifferentialTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererDifferentialTest.java
@@ -85,13 +85,10 @@ public class SearchFiltersAnswererDifferentialTest {
     DiffConfigContext configContext =
         new DiffConfigContext(
             config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, _params);
-    DifferentialSearchFiltersResult result =
-        getDiffResult(acl, refAcl, configContext, _question);
+    DifferentialSearchFiltersResult result = getDiffResult(acl, refAcl, configContext, _question);
     assertTrue("Expected no decreased result", !result.getDecreasedFlow().isPresent());
     assertTrue("Expected increased result", result.getIncreasedFlow().isPresent());
-    assertThat(
-        result.getIncreasedFlow().get(),
-        allOf(hasIngressInterface(IFACE1), hasDstIp(IP)));
+    assertThat(result.getIncreasedFlow().get(), allOf(hasIngressInterface(IFACE1), hasDstIp(IP)));
 
     // flip base and delta
     configContext =
@@ -106,9 +103,7 @@ public class SearchFiltersAnswererDifferentialTest {
     result = getDiffResult(refAcl, acl, configContext, _question);
     assertTrue("Expected no increased result", !result.getIncreasedFlow().isPresent());
     assertTrue("Expected decreased result", result.getDecreasedFlow().isPresent());
-    assertThat(
-        result.getDecreasedFlow().get(),
-        allOf(hasIngressInterface(IFACE1), hasDstIp(IP)));
+    assertThat(result.getDecreasedFlow().get(), allOf(hasIngressInterface(IFACE1), hasDstIp(IP)));
   }
 
   @Test
@@ -128,8 +123,7 @@ public class SearchFiltersAnswererDifferentialTest {
     DiffConfigContext configContext =
         new DiffConfigContext(
             config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, _params);
-    DifferentialSearchFiltersResult result =
-        getDiffResult(acl, refAcl, configContext, _question);
+    DifferentialSearchFiltersResult result = getDiffResult(acl, refAcl, configContext, _question);
     assertTrue("Expected no decreased result", !result.getDecreasedFlow().isPresent());
     assertTrue("Expected increased result", result.getIncreasedFlow().isPresent());
     assertThat(result.getIncreasedFlow().get(), hasDstIp(IP));
@@ -182,13 +176,10 @@ public class SearchFiltersAnswererDifferentialTest {
     DiffConfigContext configContext =
         new DiffConfigContext(
             config, refConfig, ImmutableSet.of(aclName), snapshot, reference, batfish, params);
-    DifferentialSearchFiltersResult result =
-        getDiffResult(acl, refAcl, configContext, _question);
+    DifferentialSearchFiltersResult result = getDiffResult(acl, refAcl, configContext, _question);
     assertTrue("Expected no decreased result", !result.getDecreasedFlow().isPresent());
     assertTrue("Expected increased result", result.getIncreasedFlow().isPresent());
-    assertThat(
-        result.getIncreasedFlow().get(),
-        allOf(hasIngressInterface(IFACE1), hasDstIp(IP)));
+    assertThat(result.getIncreasedFlow().get(), allOf(hasIngressInterface(IFACE1), hasDstIp(IP)));
 
     params =
         _params

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererTest.java
@@ -1,12 +1,9 @@
 package org.batfish.question.searchfilters;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstIp;
-import static org.batfish.question.searchfilters.SearchFiltersAnswerer.canQuery;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -34,24 +31,6 @@ public class SearchFiltersAnswererTest {
               ImmutableList.of(
                   ExprAclLine.accepting().setMatchCondition(matchDstIp("2.2.2.2")).build()))
           .build();
-
-  @Test
-  public void testCanQuery() {
-    // Permit or deny queries should work
-    SearchFiltersQuestion permit = SearchFiltersQuestion.builder().setAction("permit").build();
-    SearchFiltersQuestion deny = SearchFiltersQuestion.builder().setAction("deny").build();
-    assertTrue(canQuery(ACL1, permit));
-    assertTrue(canQuery(ACL1, deny));
-
-    // Match line queries should work only if the line number is within range for the ACL
-    int numLines = ACL1.getLines().size();
-    SearchFiltersQuestion matchLastLine =
-        SearchFiltersQuestion.builder().setAction("matchLine " + (numLines - 1)).build();
-    SearchFiltersQuestion matchLineOutOfRange =
-        SearchFiltersQuestion.builder().setAction("matchLine " + numLines).build();
-    assertTrue(canQuery(ACL1, matchLastLine));
-    assertFalse(canQuery(ACL1, matchLineOutOfRange));
-  }
 
   @Test
   public void testGetSpecifiedAcls_includeAll() {

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersAnswererTest.java
@@ -1,69 +1,113 @@
 package org.batfish.question.searchfilters;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstIp;
-import static org.batfish.question.searchfilters.SearchFiltersAnswerer.MATCH_LINE_RENAMER;
-import static org.batfish.question.searchfilters.SearchFiltersAnswerer.NEGATED_RENAMER;
-import static org.batfish.question.searchfilters.SearchFiltersAnswerer.toMatchLineAcl;
+import static org.batfish.question.searchfilters.SearchFiltersAnswerer.canQuery;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.NetworkFactory;
 import org.junit.Test;
 
 /** Tests of {@link SearchFiltersAnswerer}. */
 public class SearchFiltersAnswererTest {
-  private final IpAccessList _acl =
+  private static final IpAccessList ACL1 =
       IpAccessList.builder()
-          .setName("foo")
+          .setName("acl1")
           .setLines(
               ImmutableList.of(
-                  ExprAclLine.accepting().setMatchCondition(matchDstIp("1.1.1.1")).build(),
-                  ExprAclLine.rejecting().setMatchCondition(matchDstIp("1.1.1.2")).build(),
-                  ExprAclLine.rejecting().setMatchCondition(matchDstIp("1.1.1.3")).build(),
-                  ExprAclLine.accepting().setMatchCondition(matchDstIp("1.1.1.4")).build()))
+                  ExprAclLine.accepting().setMatchCondition(matchDstIp("1.1.1.1")).build()))
+          .build();
+  private static final IpAccessList ACL2 =
+      IpAccessList.builder()
+          .setName("acl2")
+          .setLines(
+              ImmutableList.of(
+                  ExprAclLine.accepting().setMatchCondition(matchDstIp("2.2.2.2")).build()))
           .build();
 
   @Test
-  public void testToMatchLineAcl_0() {
-    IpAccessList matchLine0Acl =
-        IpAccessList.builder()
-            .setName(MATCH_LINE_RENAMER.apply(0, _acl.getName()))
-            .setLines(
-                ImmutableList.of(
-                    ExprAclLine.accepting().setMatchCondition(matchDstIp("1.1.1.1")).build()))
-            .build();
-    assertThat(toMatchLineAcl(0, _acl), equalTo(matchLine0Acl));
+  public void testCanQuery() {
+    // Permit or deny queries should work
+    SearchFiltersQuestion permit = SearchFiltersQuestion.builder().setAction("permit").build();
+    SearchFiltersQuestion deny = SearchFiltersQuestion.builder().setAction("deny").build();
+    assertTrue(canQuery(ACL1, permit));
+    assertTrue(canQuery(ACL1, deny));
+
+    // Match line queries should work only if the line number is within range for the ACL
+    int numLines = ACL1.getLines().size();
+    SearchFiltersQuestion matchLastLine =
+        SearchFiltersQuestion.builder().setAction("matchLine " + (numLines - 1)).build();
+    SearchFiltersQuestion matchLineOutOfRange =
+        SearchFiltersQuestion.builder().setAction("matchLine " + numLines).build();
+    assertTrue(canQuery(ACL1, matchLastLine));
+    assertFalse(canQuery(ACL1, matchLineOutOfRange));
   }
 
   @Test
-  public void testToMatchLineAcl_2() {
-    IpAccessList matchLine2Acl =
-        IpAccessList.builder()
-            .setName(MATCH_LINE_RENAMER.apply(2, _acl.getName()))
-            .setLines(
-                ImmutableList.of(
-                    ExprAclLine.rejecting().setMatchCondition(matchDstIp("1.1.1.1")).build(),
-                    ExprAclLine.rejecting().setMatchCondition(matchDstIp("1.1.1.2")).build(),
-                    ExprAclLine.accepting().setMatchCondition(matchDstIp("1.1.1.3")).build()))
-            .build();
-    assertThat(toMatchLineAcl(2, _acl), equalTo(matchLine2Acl));
+  public void testGetSpecifiedAcls_includeAll() {
+    Configuration c = createConfigWithAcls(ACL1, ACL2);
+    IBatfish bf = new MockBatfish(c);
+    SearchFiltersQuestion question = SearchFiltersQuestion.builder().build();
+    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, bf);
+    assertThat(
+        answerer.getSpecifiedAcls(bf.getSnapshot(), question),
+        equalTo(ImmutableMap.of(c.getHostname(), c.getIpAccessLists())));
   }
 
   @Test
-  public void testToDenyAcl() {
-    IpAccessList denyAcl =
-        IpAccessList.builder()
-            .setName(NEGATED_RENAMER.apply(_acl.getName()))
-            .setLines(
-                ImmutableList.of(
-                    ExprAclLine.rejecting().setMatchCondition(matchDstIp("1.1.1.1")).build(),
-                    ExprAclLine.accepting().setMatchCondition(matchDstIp("1.1.1.2")).build(),
-                    ExprAclLine.accepting().setMatchCondition(matchDstIp("1.1.1.3")).build(),
-                    ExprAclLine.rejecting().setMatchCondition(matchDstIp("1.1.1.4")).build(),
-                    ExprAclLine.ACCEPT_ALL))
+  public void testGetSpecifiedAcls_onlyAcl1() {
+    Configuration c = createConfigWithAcls(ACL1, ACL2);
+    IBatfish bf = new MockBatfish(c);
+    SearchFiltersQuestion question =
+        SearchFiltersQuestion.builder()
+            .setNodeSpecifier(c.getHostname())
+            .setFilterSpecifier(ACL1.getName())
             .build();
-    assertThat(SearchFiltersAnswerer.toDenyAcl(_acl), equalTo(denyAcl));
+    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, bf);
+    assertThat(
+        answerer.getSpecifiedAcls(bf.getSnapshot(), question),
+        equalTo(ImmutableMap.of(c.getHostname(), ImmutableMap.of(ACL1.getName(), ACL1))));
+  }
+
+  @Test
+  public void testGetSpecifiedAcls_noHostnameMatch() {
+    Configuration c = createConfigWithAcls(ACL1);
+    IBatfish bf = new MockBatfish(c);
+    SearchFiltersQuestion question =
+        SearchFiltersQuestion.builder().setNodeSpecifier("unknown_hostname").build();
+    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, bf);
+    assertThat(answerer.getSpecifiedAcls(bf.getSnapshot(), question), anEmptyMap());
+  }
+
+  @Test
+  public void testGetSpecifiedAcls_noFilterMatch() {
+    Configuration c = createConfigWithAcls(ACL1);
+    IBatfish bf = new MockBatfish(c);
+    SearchFiltersQuestion question =
+        SearchFiltersQuestion.builder().setFilterSpecifier("unknown_filter").build();
+    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, bf);
+    assertThat(
+        answerer.getSpecifiedAcls(bf.getSnapshot(), question),
+        equalTo(ImmutableMap.of(c.getHostname(), ImmutableMap.of())));
+  }
+
+  private static Configuration createConfigWithAcls(IpAccessList... acls) {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    for (IpAccessList acl : acls) {
+      c.getIpAccessLists().put(acl.getName(), acl);
+    }
+    return c;
   }
 }

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersTest.java
@@ -171,63 +171,6 @@ public final class SearchFiltersTest {
         _config, _config.getIpAccessLists().keySet(), _batfish.getSnapshot(), _batfish, params);
   }
 
-  //  @Test
-  //  public void testGetQueryAcls_permit() {
-  //    SearchFiltersQuestion question =
-  //        SearchFiltersQuestion.builder()
-  //            .setFilterSpecifier(ACL.getName())
-  //            .setAction("permit")
-  //            .build();
-  //    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, _batfish);
-  //    List<Triple<String, String, IpAccessList>> queryAcls =
-  //        answerer.getQueryAcls(_batfish.getSnapshot(), question);
-  //    assertThat(queryAcls, hasSize(1));
-  //    String queryConfig = queryAcls.get(0).getLeft();
-  //    String queryAclName = queryAcls.get(0).getMiddle();
-  //    IpAccessList queryAcl = queryAcls.get(0).getRight();
-  //    assertThat(queryConfig, equalTo(_config.getHostname()));
-  //    assertThat(queryAclName, equalTo(ACL.getName()));
-  //    assertThat(queryAcl, is(ACL));
-  //  }
-  //
-  //  @Test
-  //  public void testGetQueryAcls_deny() {
-  //    SearchFiltersQuestion question =
-  //
-  // SearchFiltersQuestion.builder().setFilterSpecifier(ACL.getName()).setAction("deny").build();
-  //    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, _batfish);
-  //    List<Triple<String, String, IpAccessList>> queryAcls =
-  //        answerer.getQueryAcls(_batfish.getSnapshot(), question);
-  //    assertThat(queryAcls, hasSize(1));
-  //    String queryConfig = queryAcls.get(0).getLeft();
-  //    String queryAclName = queryAcls.get(0).getMiddle();
-  //    IpAccessList queryAcl = queryAcls.get(0).getRight();
-  //    assertThat(queryConfig, equalTo(_config.getHostname()));
-  //    assertThat(queryAclName, equalTo(ACL.getName()));
-  //    assertThat(queryAcl.getName(), equalTo(NEGATED_RENAMER.apply(ACL.getName())));
-  //    assertThat(queryAcl.getLines(), equalTo(DENY_ACL.getLines()));
-  //  }
-  //
-  //  @Test
-  //  public void testGetQueryAcls_matchLine2() {
-  //    SearchFiltersQuestion question =
-  //        SearchFiltersQuestion.builder()
-  //            .setFilterSpecifier(ACL.getName())
-  //            .setAction("matchLine 2")
-  //            .build();
-  //    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, _batfish);
-  //    List<Triple<String, String, IpAccessList>> queryAcls =
-  //        answerer.getQueryAcls(_batfish.getSnapshot(), question);
-  //    assertThat(queryAcls, hasSize(1));
-  //    String queryConfig = queryAcls.get(0).getLeft();
-  //    String queryAclName = queryAcls.get(0).getMiddle();
-  //    IpAccessList queryAcl = queryAcls.get(0).getRight();
-  //    assertThat(queryConfig, equalTo(_config.getHostname()));
-  //    assertThat(queryAclName, equalTo(ACL.getName()));
-  //    assertThat(queryAcl.getName(), equalTo(MATCH_LINE_RENAMER.apply(2, ACL.getName())));
-  //    assertThat(queryAcl.getLines(), equalTo(MATCH_LINE2_ACL.getLines()));
-  //  }
-
   @Test
   public void testPermittedFlows_ACCEPT_ALL() {
     SearchFiltersQuestion q = new SearchFiltersQuestion();

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersTest.java
@@ -14,11 +14,6 @@ import static org.batfish.datamodel.matchers.FlowMatchers.hasSrcIp;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasSrcPort;
 import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
 import static org.batfish.datamodel.matchers.TableAnswerElementMatchers.hasRows;
-import static org.batfish.question.searchfilters.SearchFiltersAnswerer.MATCH_LINE_RENAMER;
-import static org.batfish.question.searchfilters.SearchFiltersAnswerer.NEGATED_RENAMER;
-import static org.batfish.question.searchfilters.SearchFiltersAnswerer.reachFilter;
-import static org.batfish.question.searchfilters.SearchFiltersAnswerer.toDenyAcl;
-import static org.batfish.question.searchfilters.SearchFiltersAnswerer.toMatchLineAcl;
 import static org.batfish.question.testfilters.TestFiltersAnswerer.COL_ACTION;
 import static org.batfish.question.testfilters.TestFiltersAnswerer.COL_FILTER_NAME;
 import static org.hamcrest.Matchers.allOf;
@@ -26,20 +21,19 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.oneOf;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.List;
-import java.util.Optional;
+import com.google.common.collect.ImmutableSet;
 import java.util.Set;
-import org.apache.commons.lang3.tuple.Triple;
+import net.sf.javabdd.BDD;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -57,6 +51,7 @@ import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.question.SearchFiltersParameters;
+import org.batfish.question.searchfilters.SearchFiltersAnswerer.NonDiffConfigContext;
 import org.batfish.question.testfilters.TestFiltersAnswerer;
 import org.batfish.specifier.ConstantIpSpaceSpecifier;
 import org.batfish.specifier.LocationSpecifier;
@@ -69,15 +64,11 @@ import org.junit.rules.TemporaryFolder;
 /** End-to-end tests of {@link org.batfish.question.searchfilters}. */
 public final class SearchFiltersTest {
   private static final String IFACE1 = "iface1";
-
   private static final String IFACE2 = "iface2";
 
   private static final Ip IP0 = Ip.parse("1.1.1.0");
-
   private static final Ip IP1 = Ip.parse("1.1.1.1");
-
   private static final Ip IP2 = Ip.parse("1.1.1.2");
-
   private static final Ip IP3 = Ip.parse("1.1.1.3");
 
   private static final IpAccessList ACL =
@@ -86,8 +77,8 @@ public final class SearchFiltersTest {
           .setLines(
               ImmutableList.of(
                   accepting().setMatchCondition(matchDst(IP0)).build(),
-                  ExprAclLine.rejecting().setMatchCondition(matchDst(IP1)).build(),
-                  ExprAclLine.rejecting().setMatchCondition(matchDst(IP2)).build(),
+                  rejecting().setMatchCondition(matchDst(IP1)).build(),
+                  rejecting().setMatchCondition(matchDst(IP2)).build(),
                   accepting().setMatchCondition(matchDst(IP3)).build()))
           .build();
 
@@ -100,30 +91,8 @@ public final class SearchFiltersTest {
           .setLines(
               ImmutableList.of(
                   accepting().setMatchCondition(matchDst(IP0)).build(),
-                  ExprAclLine.rejecting().setMatchCondition(matchDst(IP1)).build(),
+                  rejecting().setMatchCondition(matchDst(IP1)).build(),
                   accepting().setMatchCondition(matchDst(Prefix.parse("1.1.1.0/31"))).build()))
-          .build();
-
-  private static final IpAccessList DENY_ACL =
-      IpAccessList.builder()
-          .setName("denyAcl")
-          .setLines(
-              ImmutableList.of(
-                  ExprAclLine.rejecting().setMatchCondition(matchDst(IP0)).build(),
-                  accepting().setMatchCondition(matchDst(IP1)).build(),
-                  accepting().setMatchCondition(matchDst(IP2)).build(),
-                  ExprAclLine.rejecting().setMatchCondition(matchDst(IP3)).build(),
-                  ACCEPT_ALL))
-          .build();
-
-  private static final IpAccessList MATCH_LINE2_ACL =
-      IpAccessList.builder()
-          .setName("matchLine2Acl")
-          .setLines(
-              ImmutableList.of(
-                  ExprAclLine.rejecting().setMatchCondition(matchDst(IP0)).build(),
-                  ExprAclLine.rejecting().setMatchCondition(matchDst(IP1)).build(),
-                  accepting().setMatchCondition(matchDst(IP2)).build()))
           .build();
 
   private static final IpAccessList SRC_ACL =
@@ -157,9 +126,7 @@ public final class SearchFiltersTest {
   @ClassRule public static TemporaryFolder _tmp = new TemporaryFolder();
 
   private static IBatfish _batfish;
-
   private static Configuration _config;
-
   private static SearchFiltersParameters _allLocationsParams;
 
   @BeforeClass
@@ -179,7 +146,11 @@ public final class SearchFiltersTest {
                 BLOCKED_LINE_ACL.getName(),
                 BLOCKED_LINE_ACL,
                 SRC_ACL.getName(),
-                SRC_ACL));
+                SRC_ACL,
+                ACCEPT_ALL_ACL.getName(),
+                ACCEPT_ALL_ACL,
+                REJECT_ALL_ACL.getName(),
+                REJECT_ALL_ACL));
 
     Builder ib = nf.interfaceBuilder().setActive(true).setOwner(_config);
     ib.setName(IFACE1).build();
@@ -195,110 +166,116 @@ public final class SearchFiltersTest {
             .build();
   }
 
+  private static NonDiffConfigContext getConfigContextWithParams(SearchFiltersParameters params) {
+    return new NonDiffConfigContext(
+        _config, _config.getIpAccessLists().keySet(), _batfish.getSnapshot(), _batfish, params);
+  }
+
+  //  @Test
+  //  public void testGetQueryAcls_permit() {
+  //    SearchFiltersQuestion question =
+  //        SearchFiltersQuestion.builder()
+  //            .setFilterSpecifier(ACL.getName())
+  //            .setAction("permit")
+  //            .build();
+  //    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, _batfish);
+  //    List<Triple<String, String, IpAccessList>> queryAcls =
+  //        answerer.getQueryAcls(_batfish.getSnapshot(), question);
+  //    assertThat(queryAcls, hasSize(1));
+  //    String queryConfig = queryAcls.get(0).getLeft();
+  //    String queryAclName = queryAcls.get(0).getMiddle();
+  //    IpAccessList queryAcl = queryAcls.get(0).getRight();
+  //    assertThat(queryConfig, equalTo(_config.getHostname()));
+  //    assertThat(queryAclName, equalTo(ACL.getName()));
+  //    assertThat(queryAcl, is(ACL));
+  //  }
+  //
+  //  @Test
+  //  public void testGetQueryAcls_deny() {
+  //    SearchFiltersQuestion question =
+  //
+  // SearchFiltersQuestion.builder().setFilterSpecifier(ACL.getName()).setAction("deny").build();
+  //    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, _batfish);
+  //    List<Triple<String, String, IpAccessList>> queryAcls =
+  //        answerer.getQueryAcls(_batfish.getSnapshot(), question);
+  //    assertThat(queryAcls, hasSize(1));
+  //    String queryConfig = queryAcls.get(0).getLeft();
+  //    String queryAclName = queryAcls.get(0).getMiddle();
+  //    IpAccessList queryAcl = queryAcls.get(0).getRight();
+  //    assertThat(queryConfig, equalTo(_config.getHostname()));
+  //    assertThat(queryAclName, equalTo(ACL.getName()));
+  //    assertThat(queryAcl.getName(), equalTo(NEGATED_RENAMER.apply(ACL.getName())));
+  //    assertThat(queryAcl.getLines(), equalTo(DENY_ACL.getLines()));
+  //  }
+  //
+  //  @Test
+  //  public void testGetQueryAcls_matchLine2() {
+  //    SearchFiltersQuestion question =
+  //        SearchFiltersQuestion.builder()
+  //            .setFilterSpecifier(ACL.getName())
+  //            .setAction("matchLine 2")
+  //            .build();
+  //    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, _batfish);
+  //    List<Triple<String, String, IpAccessList>> queryAcls =
+  //        answerer.getQueryAcls(_batfish.getSnapshot(), question);
+  //    assertThat(queryAcls, hasSize(1));
+  //    String queryConfig = queryAcls.get(0).getLeft();
+  //    String queryAclName = queryAcls.get(0).getMiddle();
+  //    IpAccessList queryAcl = queryAcls.get(0).getRight();
+  //    assertThat(queryConfig, equalTo(_config.getHostname()));
+  //    assertThat(queryAclName, equalTo(ACL.getName()));
+  //    assertThat(queryAcl.getName(), equalTo(MATCH_LINE_RENAMER.apply(2, ACL.getName())));
+  //    assertThat(queryAcl.getLines(), equalTo(MATCH_LINE2_ACL.getLines()));
+  //  }
+
   @Test
-  public void testGetQueryAcls_permit() {
-    SearchFiltersQuestion question =
-        SearchFiltersQuestion.builder()
-            .setFilterSpecifier(ACL.getName())
-            .setAction("permit")
-            .build();
-    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, _batfish);
-    List<Triple<String, String, IpAccessList>> queryAcls =
-        answerer.getQueryAcls(_batfish.getSnapshot(), question);
-    assertThat(queryAcls, hasSize(1));
-    String queryConfig = queryAcls.get(0).getLeft();
-    String queryAclName = queryAcls.get(0).getMiddle();
-    IpAccessList queryAcl = queryAcls.get(0).getRight();
-    assertThat(queryConfig, equalTo(_config.getHostname()));
-    assertThat(queryAclName, equalTo(ACL.getName()));
-    assertThat(queryAcl, is(ACL));
+  public void testPermittedFlows_ACCEPT_ALL() {
+    SearchFiltersQuestion q = new SearchFiltersQuestion();
+    NonDiffConfigContext configContext = getConfigContextWithParams(q.toSearchFiltersParameters());
+    Flow flow = configContext.getFlow(configContext.getReachBdd(ACCEPT_ALL_ACL, q));
+    assertNotNull("Should find permitted flow", flow);
   }
 
   @Test
-  public void testGetQueryAcls_deny() {
-    SearchFiltersQuestion question =
-        SearchFiltersQuestion.builder().setFilterSpecifier(ACL.getName()).setAction("deny").build();
-    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, _batfish);
-    List<Triple<String, String, IpAccessList>> queryAcls =
-        answerer.getQueryAcls(_batfish.getSnapshot(), question);
-    assertThat(queryAcls, hasSize(1));
-    String queryConfig = queryAcls.get(0).getLeft();
-    String queryAclName = queryAcls.get(0).getMiddle();
-    IpAccessList queryAcl = queryAcls.get(0).getRight();
-    assertThat(queryConfig, equalTo(_config.getHostname()));
-    assertThat(queryAclName, equalTo(ACL.getName()));
-    assertThat(queryAcl.getName(), equalTo(NEGATED_RENAMER.apply(ACL.getName())));
-    assertThat(queryAcl.getLines(), equalTo(DENY_ACL.getLines()));
+  public void testPermittedFlows_REJECT_ALL() {
+    SearchFiltersQuestion q = new SearchFiltersQuestion();
+    NonDiffConfigContext configContext = getConfigContextWithParams(q.toSearchFiltersParameters());
+    BDD reachBdd = configContext.getReachBdd(REJECT_ALL_ACL, q);
+    assertTrue("Reach BDD should be empty", reachBdd.isZero());
+    Flow flow = configContext.getFlow(reachBdd);
+    assertNull("Should not find permitted flow", flow);
   }
 
   @Test
-  public void testGetQueryAcls_matchLine2() {
-    SearchFiltersQuestion question =
-        SearchFiltersQuestion.builder()
-            .setFilterSpecifier(ACL.getName())
-            .setAction("matchLine 2")
-            .build();
-    SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, _batfish);
-    List<Triple<String, String, IpAccessList>> queryAcls =
-        answerer.getQueryAcls(_batfish.getSnapshot(), question);
-    assertThat(queryAcls, hasSize(1));
-    String queryConfig = queryAcls.get(0).getLeft();
-    String queryAclName = queryAcls.get(0).getMiddle();
-    IpAccessList queryAcl = queryAcls.get(0).getRight();
-    assertThat(queryConfig, equalTo(_config.getHostname()));
-    assertThat(queryAclName, equalTo(ACL.getName()));
-    assertThat(queryAcl.getName(), equalTo(MATCH_LINE_RENAMER.apply(2, ACL.getName())));
-    assertThat(queryAcl.getLines(), equalTo(MATCH_LINE2_ACL.getLines()));
+  public void testDeniedFlows_ACCEPT_ALL() {
+    SearchFiltersQuestion q = SearchFiltersQuestion.builder().setAction("deny").build();
+    NonDiffConfigContext configContext = getConfigContextWithParams(q.toSearchFiltersParameters());
+    BDD reachBdd = configContext.getReachBdd(ACCEPT_ALL_ACL, q);
+    assertTrue("Reach BDD should be empty", reachBdd.isZero());
+    Flow flow = configContext.getFlow(reachBdd);
+    assertNull("Should not find denied flow", flow);
   }
 
   @Test
-  public void testReachFilter_deny_ACCEPT_ALL() {
-    Optional<Flow> result =
-        reachFilter(
-            _batfish.getSnapshot(),
-            _batfish,
-            _config,
-            toDenyAcl(ACCEPT_ALL_ACL),
-            _allLocationsParams);
-    assertTrue("Should not find permitted flow", !result.isPresent());
+  public void testDeniedFlows_REJECT_ALL() {
+    SearchFiltersQuestion q = SearchFiltersQuestion.builder().setAction("deny").build();
+    NonDiffConfigContext configContext = getConfigContextWithParams(q.toSearchFiltersParameters());
+    BDD reachBdd = configContext.getReachBdd(REJECT_ALL_ACL, q);
+    Flow flow = configContext.getFlow(reachBdd);
+    assertNotNull("Should find denied flow", flow);
   }
 
   @Test
-  public void testReachFilter_deny_REJECT_ALL() {
-    Optional<Flow> result =
-        reachFilter(
-            _batfish.getSnapshot(),
-            _batfish,
-            _config,
-            toDenyAcl(REJECT_ALL_ACL),
-            _allLocationsParams);
-    assertTrue("Should find permitted flow", result.isPresent());
+  public void testPermittedFlows_ACL() {
+    SearchFiltersQuestion q = new SearchFiltersQuestion();
+    NonDiffConfigContext configContext = getConfigContextWithParams(q.toSearchFiltersParameters());
+    Flow flow = configContext.getFlow(configContext.getReachBdd(ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, hasDstIp(oneOf(IP0, IP3)));
   }
 
   @Test
-  public void testReachFilter_permit_ACCEPT_ALL() {
-    Optional<Flow> result =
-        reachFilter(_batfish.getSnapshot(), _batfish, _config, ACCEPT_ALL_ACL, _allLocationsParams);
-    assertTrue("Should find permitted flow", result.isPresent());
-  }
-
-  @Test
-  public void testReachFilter_permit_REJECT_ALL() {
-    Optional<Flow> result =
-        reachFilter(_batfish.getSnapshot(), _batfish, _config, REJECT_ALL_ACL, _allLocationsParams);
-    assertThat(result, equalTo(Optional.empty()));
-  }
-
-  @Test
-  public void testReachFilter_permit() {
-    Optional<Flow> result =
-        reachFilter(_batfish.getSnapshot(), _batfish, _config, ACL, _allLocationsParams);
-    assertTrue("Should find permitted flow", result.isPresent());
-    assertThat(result.get(), hasDstIp(oneOf(IP0, IP3)));
-  }
-
-  @Test
-  public void testReachFilter_permit_headerSpace() {
+  public void testPermittedFlows_headerSpace() {
     SearchFiltersParameters.Builder paramsBuilder =
         _allLocationsParams
             .toBuilder()
@@ -307,61 +284,60 @@ public final class SearchFiltersTest {
             .setHeaderSpace(HeaderSpace.builder().build());
 
     SearchFiltersParameters params = paramsBuilder.build();
-    Optional<Flow> result = reachFilter(_batfish.getSnapshot(), _batfish, _config, ACL, params);
-    assertTrue("Should find result", result.isPresent());
-    assertThat(result.get(), hasDstIp(IP0));
+    NonDiffConfigContext configContext = getConfigContextWithParams(params);
+    Flow flow = configContext.getFlow(configContext.getReachBdd(ACL, new SearchFiltersQuestion()));
+    assertNotNull("Should find permitted flow for IP0", flow);
+    assertThat(flow, hasDstIp(IP0));
 
     params = paramsBuilder.setHeaderSpace(HeaderSpace.builder().setNegate(true).build()).build();
-    result = reachFilter(_batfish.getSnapshot(), _batfish, _config, ACL, params);
-    assertTrue("Should find result", result.isPresent());
-    assertThat(result.get(), hasDstIp(IP3));
+    configContext = getConfigContextWithParams(params);
+    flow = configContext.getFlow(configContext.getReachBdd(ACL, new SearchFiltersQuestion()));
+    assertNotNull("Should find permitted flow for IP3 since IP0 is now excluded", flow);
+    assertThat(flow, hasDstIp(IP3));
   }
 
   @Test
-  public void testReachFilter_deny() {
-    Optional<Flow> permitResult =
-        reachFilter(_batfish.getSnapshot(), _batfish, _config, toDenyAcl(ACL), _allLocationsParams);
-    assertTrue("Should find permitted flow", permitResult.isPresent());
-    assertThat(permitResult.get(), hasDstIp(not(oneOf(IP0, IP3))));
+  public void testDeniedFlows_ACL() {
+    SearchFiltersQuestion q = SearchFiltersQuestion.builder().setAction("deny").build();
+    NonDiffConfigContext configContext = getConfigContextWithParams(q.toSearchFiltersParameters());
+    Flow flow = configContext.getFlow(configContext.getReachBdd(ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, hasDstIp(not(oneOf(IP0, IP3))));
   }
 
   @Test
-  public void testReachFilter_matchLine() {
-    Optional<Flow> permitResult =
-        reachFilter(
-            _batfish.getSnapshot(), _batfish, _config, toMatchLineAcl(0, ACL), _allLocationsParams);
-    assertTrue("Should find permitted flow", permitResult.isPresent());
-    assertThat(permitResult.get(), hasDstIp(IP0));
+  public void testMatchLine_ACL() {
+    SearchFiltersQuestion q = SearchFiltersQuestion.builder().setAction("matchLine 0").build();
+    NonDiffConfigContext configContext = getConfigContextWithParams(q.toSearchFiltersParameters());
+    Flow flow = configContext.getFlow(configContext.getReachBdd(ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, hasDstIp(IP0));
 
-    permitResult =
-        reachFilter(
-            _batfish.getSnapshot(), _batfish, _config, toMatchLineAcl(1, ACL), _allLocationsParams);
-    assertTrue("Should find permitted flow", permitResult.isPresent());
-    assertThat(permitResult.get(), hasDstIp(IP1));
+    q = SearchFiltersQuestion.builder().setAction("matchLine 1").build();
+    configContext = getConfigContextWithParams(q.toSearchFiltersParameters());
+    flow = configContext.getFlow(configContext.getReachBdd(ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, hasDstIp(IP1));
 
-    permitResult =
-        reachFilter(
-            _batfish.getSnapshot(), _batfish, _config, toMatchLineAcl(2, ACL), _allLocationsParams);
-    assertTrue("Should find permitted flow", permitResult.isPresent());
-    assertThat(permitResult.get(), hasDstIp(IP2));
+    q = SearchFiltersQuestion.builder().setAction("matchLine 2").build();
+    configContext = getConfigContextWithParams(q.toSearchFiltersParameters());
+    flow = configContext.getFlow(configContext.getReachBdd(ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, hasDstIp(IP2));
 
-    permitResult =
-        reachFilter(
-            _batfish.getSnapshot(), _batfish, _config, toMatchLineAcl(3, ACL), _allLocationsParams);
-    assertTrue("Should find permitted flow", permitResult.isPresent());
-    assertThat(permitResult.get(), hasDstIp(IP3));
+    q = SearchFiltersQuestion.builder().setAction("matchLine 3").build();
+    configContext = getConfigContextWithParams(q.toSearchFiltersParameters());
+    flow = configContext.getFlow(configContext.getReachBdd(ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, hasDstIp(IP3));
   }
 
   @Test
-  public void testReachFilter_matchLine_blocked() {
-    Optional<Flow> permitResult =
-        reachFilter(
-            _batfish.getSnapshot(),
-            _batfish,
-            _config,
-            toMatchLineAcl(2, BLOCKED_LINE_ACL),
-            _allLocationsParams);
-    assertTrue("Should not find permitted flow", !permitResult.isPresent());
+  public void testMatchLine_BLOCKED_LINE_ACL() {
+    SearchFiltersQuestion q = SearchFiltersQuestion.builder().setAction("matchLine 2").build();
+    NonDiffConfigContext configContext = getConfigContextWithParams(q.toSearchFiltersParameters());
+    Flow flow = configContext.getFlow(configContext.getReachBdd(BLOCKED_LINE_ACL, q));
+    assertNull("Should not find permitted flow", flow);
   }
 
   @Test
@@ -376,10 +352,12 @@ public final class SearchFiltersTest {
   }
 
   @Test
-  public void testAnswer() {
+  public void testPermitAnswer() {
     SearchFiltersQuestion question = new SearchFiltersQuestion();
     SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, _batfish);
     TableAnswerElement ae = (TableAnswerElement) answerer.answer(_batfish.getSnapshot());
+
+    // Should see results for all but ACCEPT_ALL_ACL (since that ACL denies no flows)
     assertThat(
         ae,
         hasRows(
@@ -394,14 +372,20 @@ public final class SearchFiltersTest {
                             COL_FILTER_NAME, equalTo(BLOCKED_LINE_ACL.getName()), Schema.STRING)),
                     allOf(
                         hasColumn(COL_ACTION, equalTo("PERMIT"), Schema.STRING),
-                        hasColumn(COL_FILTER_NAME, equalTo(SRC_ACL.getName()), Schema.STRING))))));
+                        hasColumn(COL_FILTER_NAME, equalTo(SRC_ACL.getName()), Schema.STRING)),
+                    allOf(
+                        hasColumn(COL_ACTION, equalTo("PERMIT"), Schema.STRING),
+                        hasColumn(
+                            COL_FILTER_NAME, equalTo(ACCEPT_ALL_ACL.getName()), Schema.STRING))))));
   }
 
   @Test
-  public void testAnswerWithRenaming() {
+  public void testDenyAnswer() {
     SearchFiltersQuestion question = SearchFiltersQuestion.builder().setAction("deny").build();
     SearchFiltersAnswerer answerer = new SearchFiltersAnswerer(question, _batfish);
     TableAnswerElement ae = (TableAnswerElement) answerer.answer(_batfish.getSnapshot());
+
+    // Should see results for all but ACCEPT_ALL_ACL (since that ACL denies no flows)
     assertThat(
         ae,
         hasRows(
@@ -416,62 +400,53 @@ public final class SearchFiltersTest {
                             COL_FILTER_NAME, equalTo(BLOCKED_LINE_ACL.getName()), Schema.STRING)),
                     allOf(
                         hasColumn(COL_ACTION, equalTo("DENY"), Schema.STRING),
-                        hasColumn(COL_FILTER_NAME, equalTo(SRC_ACL.getName()), Schema.STRING))))));
+                        hasColumn(COL_FILTER_NAME, equalTo(SRC_ACL.getName()), Schema.STRING)),
+                    allOf(
+                        hasColumn(COL_ACTION, equalTo("DENY"), Schema.STRING),
+                        hasColumn(
+                            COL_FILTER_NAME, equalTo(REJECT_ALL_ACL.getName()), Schema.STRING))))));
   }
 
   @Test
   public void testMatchSrcInterface() {
-    Optional<Flow> result =
-        reachFilter(
-            _batfish.getSnapshot(),
-            _batfish,
-            _config,
-            toMatchLineAcl(0, SRC_ACL),
-            _allLocationsParams);
-    assertThat(result.get(), allOf(hasIngressInterface(nullValue()), hasDstIp(IP0)));
+    SearchFiltersQuestion q = SearchFiltersQuestion.builder().setAction("matchLine 0").build();
+    NonDiffConfigContext configContext = getConfigContextWithParams(_allLocationsParams);
+    Flow flow = configContext.getFlow(configContext.getReachBdd(SRC_ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, allOf(hasIngressInterface(nullValue()), hasDstIp(IP0)));
 
-    result =
-        reachFilter(
-            _batfish.getSnapshot(),
-            _batfish,
-            _config,
-            toMatchLineAcl(1, SRC_ACL),
-            _allLocationsParams);
-    assertThat(result.get(), allOf(hasIngressInterface(IFACE1), hasDstIp(IP1)));
+    q = SearchFiltersQuestion.builder().setAction("matchLine 1").build();
+    configContext = getConfigContextWithParams(_allLocationsParams);
+    flow = configContext.getFlow(configContext.getReachBdd(SRC_ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, allOf(hasIngressInterface(IFACE1), hasDstIp(IP1)));
 
-    result =
-        reachFilter(
-            _batfish.getSnapshot(),
-            _batfish,
-            _config,
-            toMatchLineAcl(2, SRC_ACL),
-            _allLocationsParams);
-    assertThat(result.get(), allOf(hasIngressInterface(IFACE2), hasDstIp(IP2)));
+    q = SearchFiltersQuestion.builder().setAction("matchLine 2").build();
+    configContext = getConfigContextWithParams(_allLocationsParams);
+    flow = configContext.getFlow(configContext.getReachBdd(SRC_ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, allOf(hasIngressInterface(IFACE2), hasDstIp(IP2)));
 
     // cannot have two different source interfaces
-    result =
-        reachFilter(
-            _batfish.getSnapshot(),
-            _batfish,
-            _config,
-            toMatchLineAcl(3, SRC_ACL),
-            _allLocationsParams);
-    assertThat(result, equalTo(Optional.empty()));
+    q = SearchFiltersQuestion.builder().setAction("matchLine 3").build();
+    configContext = getConfigContextWithParams(_allLocationsParams);
+    BDD reachBdd = configContext.getReachBdd(SRC_ACL, q);
+    assertTrue(reachBdd.isZero());
+    flow = configContext.getFlow(reachBdd);
+    assertNull("Should not find permitted flow", flow);
 
     // cannot have originate from device and have a source interface
-    result =
-        reachFilter(
-            _batfish.getSnapshot(),
-            _batfish,
-            _config,
-            toMatchLineAcl(4, SRC_ACL),
-            _allLocationsParams);
-    assertThat(result, equalTo(Optional.empty()));
+    q = SearchFiltersQuestion.builder().setAction("matchLine 4").build();
+    configContext = getConfigContextWithParams(_allLocationsParams);
+    reachBdd = configContext.getReachBdd(SRC_ACL, q);
+    assertTrue(reachBdd.isZero());
+    flow = configContext.getFlow(reachBdd);
+    assertNull("Should not find permitted flow", flow);
   }
 
   @Test
   public void testSane() {
-    // an ACL that can only match with an insane interface
+    // An ACL that rejects flows originating from all possible sources should not be matchable.
     IpAccessList denyAllSourcesAcl =
         IpAccessList.builder()
             .setName("srcAcl")
@@ -482,16 +457,34 @@ public final class SearchFiltersTest {
                     rejecting().setMatchCondition(matchSrcInterface(IFACE2)).build(),
                     ACCEPT_ALL))
             .build();
-    Optional<Flow> flow =
-        reachFilter(
-            _batfish.getSnapshot(), _batfish, _config, denyAllSourcesAcl, _allLocationsParams);
-    assertThat(flow, equalTo(Optional.empty()));
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    c.getIpAccessLists().put(denyAllSourcesAcl.getName(), denyAllSourcesAcl);
+
+    Builder ib = nf.interfaceBuilder().setActive(true).setOwner(c);
+    ib.setName(IFACE1).build();
+    ib.setName(IFACE2).build();
+    // Inactive interfaces should not be considered possible sources
+    ib.setName("inactiveIface").setActive(false).build();
+
+    IBatfish bf = new MockBatfish(c);
+    SearchFiltersQuestion q = new SearchFiltersQuestion();
+    NonDiffConfigContext configContext =
+        new NonDiffConfigContext(
+            c,
+            ImmutableSet.of(denyAllSourcesAcl.getName()),
+            bf.getSnapshot(),
+            bf,
+            _allLocationsParams);
+    Flow flow = configContext.getFlow(configContext.getReachBdd(denyAllSourcesAcl, q));
+    assertNull("Should not find permitted flow", flow);
   }
 
   @Test
   public void testSane2() {
     // An ACL that can only match with ingress interface IFACE2.
-    IpAccessList denyAllSourcesAcl =
+    IpAccessList denyAllButIface2 =
         IpAccessList.builder()
             .setName("srcAcl")
             .setLines(
@@ -500,11 +493,28 @@ public final class SearchFiltersTest {
                     rejecting().setMatchCondition(matchSrcInterface(IFACE1)).build(),
                     ACCEPT_ALL))
             .build();
-    Optional<Flow> flow =
-        reachFilter(
-            _batfish.getSnapshot(), _batfish, _config, denyAllSourcesAcl, _allLocationsParams);
-    assertTrue("Should find a result", flow.isPresent());
-    assertThat(flow.get(), hasIngressInterface(IFACE2));
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS).build();
+    c.getIpAccessLists().put(denyAllButIface2.getName(), denyAllButIface2);
+
+    Builder ib = nf.interfaceBuilder().setActive(true).setOwner(c);
+    ib.setName(IFACE1).build();
+    ib.setName(IFACE2).build();
+    ib.setName("inactiveIface").setActive(false).build();
+
+    IBatfish bf = new MockBatfish(c);
+    SearchFiltersQuestion q = new SearchFiltersQuestion();
+    NonDiffConfigContext configContext =
+        new NonDiffConfigContext(
+            c,
+            ImmutableSet.of(denyAllButIface2.getName()),
+            bf.getSnapshot(),
+            bf,
+            _allLocationsParams);
+    Flow flow = configContext.getFlow(configContext.getReachBdd(denyAllButIface2, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, hasIngressInterface(IFACE2));
   }
 
   @Test
@@ -516,18 +526,20 @@ public final class SearchFiltersTest {
             .build();
 
     // can match line 1 because IFACE1 is specified
-    Optional<Flow> result =
-        reachFilter(_batfish.getSnapshot(), _batfish, _config, toMatchLineAcl(1, SRC_ACL), params);
-    assertThat(result.get(), allOf(hasIngressInterface(IFACE1), hasDstIp(IP1)));
+    SearchFiltersQuestion q = SearchFiltersQuestion.builder().setAction("matchLine 1").build();
+    NonDiffConfigContext configContext = getConfigContextWithParams(params);
+    Flow flow = configContext.getFlow(configContext.getReachBdd(SRC_ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, allOf(hasIngressInterface(IFACE1), hasDstIp(IP1)));
 
     // cannot match line 2 because IFACE2 is not specified
-    result =
-        reachFilter(_batfish.getSnapshot(), _batfish, _config, toMatchLineAcl(2, SRC_ACL), params);
-    assertTrue("Should not find a result", !result.isPresent());
+    q = SearchFiltersQuestion.builder().setAction("matchLine 2").build();
+    flow = configContext.getFlow(configContext.getReachBdd(SRC_ACL, q));
+    assertNull("Should not find permitted flow", flow);
   }
 
   @Test
-  public void testReachFilter_ACCEPT_ALL_dstIpConstraint() {
+  public void testDstIpConstraint_ACCEPT_ALL() {
     Ip constraintIp = Ip.parse("21.21.21.21");
     SearchFiltersParameters params =
         _allLocationsParams
@@ -536,13 +548,17 @@ public final class SearchFiltersTest {
             .setSourceIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
             .setHeaderSpace(new HeaderSpace())
             .build();
-    Optional<Flow> result =
-        reachFilter(_batfish.getSnapshot(), _batfish, _config, ACCEPT_ALL_ACL, params);
-    assertThat(result.get(), hasDstIp(constraintIp));
+
+    // TODO: Separate out query part of question so it's clear q's params are ignored in getReachBdd
+    SearchFiltersQuestion q = new SearchFiltersQuestion();
+    NonDiffConfigContext configContext = getConfigContextWithParams(params);
+    Flow flow = configContext.getFlow(configContext.getReachBdd(ACCEPT_ALL_ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, hasDstIp(constraintIp));
   }
 
   @Test
-  public void testReachFilter_ACCEPT_ALL_srcIpConstraint() {
+  public void testSrcIpConstraint_ACCEPT_ALL() {
     Ip constraintIp = Ip.parse("21.21.21.21");
     SearchFiltersParameters params =
         _allLocationsParams
@@ -551,13 +567,17 @@ public final class SearchFiltersTest {
             .setSourceIpSpaceSpecifier(new ConstantIpSpaceSpecifier(constraintIp.toIpSpace()))
             .setHeaderSpace(new HeaderSpace())
             .build();
-    Optional<Flow> result =
-        reachFilter(_batfish.getSnapshot(), _batfish, _config, ACCEPT_ALL_ACL, params);
-    assertThat(result.get(), hasSrcIp(constraintIp));
+
+    // TODO: Separate out query part of question so it's clear q's params are ignored in getReachBdd
+    SearchFiltersQuestion q = new SearchFiltersQuestion();
+    NonDiffConfigContext configContext = getConfigContextWithParams(params);
+    Flow flow = configContext.getFlow(configContext.getReachBdd(ACCEPT_ALL_ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, hasSrcIp(constraintIp));
   }
 
   @Test
-  public void testReachFilter_DENY_ALL_portConstraints() {
+  public void testPortConstraints_ACCEPT_ALL() {
     HeaderSpace hs = new HeaderSpace();
     hs.setSrcPorts(ImmutableList.of(SubRange.singleton(1111)));
     hs.setDstPorts(ImmutableList.of(SubRange.singleton(2222)));
@@ -569,9 +589,13 @@ public final class SearchFiltersTest {
             .setSourceIpSpaceSpecifier(new ConstantIpSpaceSpecifier(UniverseIpSpace.INSTANCE))
             .setHeaderSpace(hs)
             .build();
-    Optional<Flow> result =
-        reachFilter(_batfish.getSnapshot(), _batfish, _config, ACCEPT_ALL_ACL, params);
-    assertThat(result.get(), allOf(hasSrcPort(1111), hasDstPort(2222)));
+
+    // TODO: Separate out query part of question so it's clear q's params are ignored in getReachBdd
+    SearchFiltersQuestion q = new SearchFiltersQuestion();
+    NonDiffConfigContext configContext = getConfigContextWithParams(params);
+    Flow flow = configContext.getFlow(configContext.getReachBdd(ACCEPT_ALL_ACL, q));
+    assertNotNull("Should find permitted flow", flow);
+    assertThat(flow, allOf(hasSrcPort(1111), hasDstPort(2222)));
   }
 
   @Test

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersTest.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -63,6 +64,7 @@ import org.junit.rules.TemporaryFolder;
 
 /** End-to-end tests of {@link org.batfish.question.searchfilters}. */
 public final class SearchFiltersTest {
+  private static final BDDPacket PKT = new BDDPacket();
   private static final String IFACE1 = "iface1";
   private static final String IFACE2 = "iface2";
 
@@ -171,7 +173,12 @@ public final class SearchFiltersTest {
 
   private static NonDiffConfigContext getConfigContextWithParams(SearchFiltersParameters params) {
     return new NonDiffConfigContext(
-        _config, _config.getIpAccessLists().keySet(), _batfish.getSnapshot(), _batfish, params);
+        _config,
+        _config.getIpAccessLists().keySet(),
+        _batfish.getSnapshot(),
+        _batfish,
+        params,
+        PKT);
   }
 
   @Test
@@ -417,7 +424,8 @@ public final class SearchFiltersTest {
             ImmutableSet.of(denyAllSourcesAcl.getName()),
             bf.getSnapshot(),
             bf,
-            _allLocationsParams);
+            _allLocationsParams,
+            PKT);
     Flow flow = configContext.getFlow(configContext.getReachBdd(denyAllSourcesAcl, PERMIT_QUERY));
     assertNull("Should not find permitted flow", flow);
   }
@@ -451,7 +459,8 @@ public final class SearchFiltersTest {
             ImmutableSet.of(denyAllButIface2.getName()),
             bf.getSnapshot(),
             bf,
-            _allLocationsParams);
+            _allLocationsParams,
+            PKT);
     Flow flow = configContext.getFlow(configContext.getReachBdd(denyAllButIface2, PERMIT_QUERY));
     assertNotNull("Should find permitted flow", flow);
     assertThat(flow, hasIngressInterface(IFACE2));

--- a/tests/questions/experimental/searchfilters.ref
+++ b/tests/questions/experimental/searchfilters.ref
@@ -1,5 +1,6 @@
 {
   "class" : "org.batfish.question.searchfilters.SearchFiltersQuestion",
+  "action" : "matchLine 0",
   "filters" : ".*",
   "headers" : {
     "dstIps" : "2.2.2.2",


### PR DESCRIPTION
Previously, SearchFiltersAnswerer processed ACLs of interest into modified intermediate ACLs, converted those to single AclLineMatchExprs, and from there converted to BDDs to find matching flows. This was only necessary in order to derive ACL explanations. As of #5334, ACL explanations are gone and we can now convert the original ACLs directly to BDDs without losing required information.

Recommend reviewing commit by commit. Second commit is a dummy to hopefully get the diffs to work better, but the third commit is a relatively independent refactoring of SearchFiltersQuestion to use a new class (SearchFiltersQuery) to represent its action (permit/deny/matchLine). Included it in this PR to avoid really sketchy tests where there were two conflicting sources of truth for SearchFiltersParameters.