### PR TITLE
Arista BGP: correct parse tree for network statements

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Arista_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Arista_bgp.g4
@@ -59,7 +59,7 @@ eos_rb_af_ipv4_unicast
 //    | eos_rbafipv4u_graceful_restart
     | eos_rbafipv4u_neighbor
     | eos_rbafipv4_no
-//    | eos_rbafipv4u_network
+    | eos_rbafipv4u_network
 //    | eos_rbafipv4u_redistribute
   )*
 ;
@@ -135,6 +135,15 @@ eos_rbafipv4_no_neighbor
     | pg = variable
   )
   eos_rb_af_no_neighbor_common
+;
+
+eos_rbafipv4u_network
+:
+  NETWORK
+  (
+    eos_rbi_network4
+    | eos_rbi_network6
+  )
 ;
 
 eos_rb_af_ipv6

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -566,10 +566,14 @@ public class AristaGrammarTest {
     }
     {
       Prefix prefix = Prefix.parse("1.1.3.0/24");
-      AristaBgpNetworkConfiguration network =
-          config.getAristaBgp().getDefaultVrf().getV4UnicastAf().getNetworks().get(prefix);
+      AristaBgpVrf vrf = config.getAristaBgp().getDefaultVrf();
+      AristaBgpVrfIpv4UnicastAddressFamily v4UnicastAf = vrf.getV4UnicastAf();
+      AristaBgpNetworkConfiguration network = v4UnicastAf.getNetworks().get(prefix);
       assertThat(network, notNullValue());
       assertThat(network.getRouteMap(), equalTo("RM"));
+      // Ensure parser didn't go into "router bgp" context and stayed in "address family ipv4"
+      assertNull(vrf.getNextHopUnchanged());
+      assertTrue(v4UnicastAf.getNextHopUnchanged());
     }
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_network
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_network
@@ -9,3 +9,6 @@ router bgp 65104
   network 1.1.2.0 255.255.255.0
   address-family ipv4
     network 1.1.3.0/24 route-map RM
+    !! the next-hop-unchanged command is here to verify that
+    !! we haven't left the "address-family ipv4" parser context
+    bgp next-hop-unchanged


### PR DESCRIPTION
Stay within ipv4 address family context