### PR TITLE
Arista BGP: extraction for confederations

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Arista_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Arista_bgp.g4
@@ -6,6 +6,22 @@ options {
    tokenVocab = CiscoLexer;
 }
 
+eos_as_range
+:
+  lo = bgp_asn
+  (
+    DASH hi = bgp_asn
+  )?
+;
+
+eos_as_range_list
+:
+  aslist += eos_as_range
+  (
+    COMMA aslist += eos_as_range
+  )*
+;
+
 eos_bgp_community
 :
   EXTENDED
@@ -310,7 +326,7 @@ eos_rbi_bgp
     | eos_rbib_bestpath
 //    | eos_rbib_client_to_client
     | eos_rbib_cluster_id
-//    | eos_rbib_confederation
+    | eos_rbib_confederation
 //    | eos_rbib_control_plane_filter
     | eos_rbib_convergence
 //    | eos_rbib_default
@@ -358,6 +374,25 @@ eos_rbib_always_compare_med
 eos_rbib_asn
 :
   ASN NOTATION (ASDOT | ASPLAIN) NEWLINE
+;
+
+eos_rbib_confederation
+:
+  CONFEDERATION
+  (
+    eos_rbibconf_identifier
+    | eos_rbibconf_peers
+  )
+;
+
+eos_rbibconf_identifier
+:
+  IDENTIFIER asn = bgp_asn NEWLINE
+;
+
+eos_rbibconf_peers
+:
+  PEERS asns = eos_as_range_list NEWLINE
 ;
 
 eos_rbib_convergence

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/eos/AristaBgpVrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/eos/AristaBgpVrf.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Prefix6;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
@@ -21,6 +22,8 @@ public final class AristaBgpVrf implements Serializable {
   @Nullable private Boolean _bestpathAsPathMultipathRelax;
   @Nullable private AristaBgpBestpathTieBreaker _bestpathTieBreaker;
   @Nullable private Ip _clusterId;
+  @Nullable private Long _confederationIdentifier;
+  @Nullable private LongSpace _confederationPeers;
   @Nullable private Long _defaultMetric;
   @Nullable private Integer _ebgpAdminDistance;
   @Nullable private Boolean _enforceFirstAs;
@@ -121,6 +124,24 @@ public final class AristaBgpVrf implements Serializable {
 
   public void setClusterId(@Nullable Ip clusterId) {
     _clusterId = clusterId;
+  }
+
+  @Nullable
+  public Long getConfederationIdentifier() {
+    return _confederationIdentifier;
+  }
+
+  public void setConfederationIdentifier(@Nullable Long confederationIdentifier) {
+    _confederationIdentifier = confederationIdentifier;
+  }
+
+  @Nullable
+  public LongSpace getConfederationPeers() {
+    return _confederationPeers;
+  }
+
+  public void setConfederationPeers(@Nullable LongSpace confederationPeers) {
+    _confederationPeers = confederationPeers;
   }
 
   @Nullable

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Range;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
@@ -1122,6 +1123,27 @@ public class AristaGrammarTest {
       Builder builder = Bgpv4Route.builder();
       policy.processBgpRoute(originalRoute, builder, session, Direction.OUT);
       assertThat(builder.getNextHopIp(), equalTo(UNSET_ROUTE_NEXT_HOP_IP));
+    }
+  }
+
+  @Test
+  public void testConfederationExtraction() {
+    CiscoConfiguration config = parseVendorConfig("arista_bgp_confederations");
+    {
+      AristaBgpVrf vrf = config.getAristaBgp().getDefaultVrf();
+      assertThat(vrf.getConfederationIdentifier(), equalTo(1111L));
+      assertThat(vrf.getConfederationPeers(), equalTo(LongSpace.of(Range.closed(3L, 6L))));
+    }
+    {
+      AristaBgpVrf vrf = config.getAristaBgp().getVrfs().get("vrf2");
+      assertThat(vrf.getConfederationIdentifier(), equalTo((22L << 16) + 22));
+      assertThat(
+          vrf.getConfederationPeers(),
+          equalTo(
+              LongSpace.unionOf(
+                  Range.closed((1L << 16) + 1, (2L << 16) + 2),
+                  Range.singleton((3L << 16) + 3),
+                  Range.singleton(44L))));
     }
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_confederations
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_confederations
@@ -1,0 +1,12 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_bgp_confederations
+!
+vrf instance vrf2
+!
+router bgp 1
+  bgp confederation identifier 1111
+  bgp confederation peers 3,4,5-6
+  vrf vrf2
+    bgp confederation identifier 22.22
+    bgp confederation peers 1.1-2.2,3.3,44


### PR DESCRIPTION
Will do conversion separately; Need to tweak VI to have a space instead of enumerations of peer ASes.