### PR TITLE
Remove defaultAccept field from PermittedByAcl

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
@@ -244,12 +244,7 @@ public abstract class IpAccessListToBdd {
       checkArgument(
           _permitAndDenyBdds.containsKey(name), "Undefined PermittedByAcl reference: %s", name);
       try {
-        if (permittedByAcl.getDefaultAccept()) {
-          // Return the BDD of packets not explicitly rejected by the referenced ACL
-          return _permitAndDenyBdds.get(name).get().getDenyBdd().not();
-        } else {
-          return _permitAndDenyBdds.get(name).get().getPermitBdd();
-        }
+        return _permitAndDenyBdds.get(name).get().getPermitBdd();
       } catch (NonRecursiveSupplierException e) {
         throw new BatfishException("Circular PermittedByAcl reference: " + name);
       }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
@@ -138,15 +138,6 @@ public class IpAccessList implements Serializable {
       String srcInterface,
       Map<String, IpAccessList> availableAcls,
       Map<String, IpSpace> namedIpSpaces) {
-    return filter(flow, srcInterface, availableAcls, namedIpSpaces, LineAction.DENY);
-  }
-
-  public FilterResult filter(
-      Flow flow,
-      String srcInterface,
-      Map<String, IpAccessList> availableAcls,
-      Map<String, IpSpace> namedIpSpaces,
-      LineAction defaultAction) {
     AclLineEvaluator lineEvaluator =
         new AclLineEvaluator(flow, srcInterface, availableAcls, namedIpSpaces);
     for (int i = 0; i < _lines.size(); i++) {
@@ -155,7 +146,7 @@ public class IpAccessList implements Serializable {
         return new FilterResult(i, action);
       }
     }
-    return new FilterResult(null, defaultAction);
+    return new FilterResult(null, LineAction.DENY);
   }
 
   @JsonProperty(PROP_NAME)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/Evaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/Evaluator.java
@@ -75,7 +75,7 @@ public class Evaluator implements GenericAclLineMatchExprVisitor<Boolean> {
   public Boolean visitPermittedByAcl(PermittedByAcl permittedByAcl) {
     return _availableAcls
             .get(permittedByAcl.getAclName())
-            .filter(_flow, _srcInterface, _availableAcls, _namedIpSpaces, LineAction.DENY)
+            .filter(_flow, _srcInterface, _availableAcls, _namedIpSpaces)
             .getAction()
         == LineAction.PERMIT;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/Evaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/Evaluator.java
@@ -75,12 +75,7 @@ public class Evaluator implements GenericAclLineMatchExprVisitor<Boolean> {
   public Boolean visitPermittedByAcl(PermittedByAcl permittedByAcl) {
     return _availableAcls
             .get(permittedByAcl.getAclName())
-            .filter(
-                _flow,
-                _srcInterface,
-                _availableAcls,
-                _namedIpSpaces,
-                permittedByAcl.getDefaultAccept() ? LineAction.PERMIT : LineAction.DENY)
+            .filter(_flow, _srcInterface, _availableAcls, _namedIpSpaces, LineAction.DENY)
             .getAction()
         == LineAction.PERMIT;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/IpAccessListRenamer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/IpAccessListRenamer.java
@@ -114,9 +114,7 @@ public class IpAccessListRenamer implements Function<IpAccessList, IpAccessList>
     public AclLineMatchExpr visitPermittedByAcl(PermittedByAcl permittedByAcl) {
       PermittedByAcl newPermittedByAcl =
           new PermittedByAcl(
-              _aclRenamer.apply(permittedByAcl.getAclName()),
-              permittedByAcl.getDefaultAccept(),
-              permittedByAcl.getDescription());
+              _aclRenamer.apply(permittedByAcl.getAclName()), permittedByAcl.getDescription());
       _literalsMap.put(permittedByAcl, newPermittedByAcl);
       return newPermittedByAcl;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/PermittedByAcl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/PermittedByAcl.java
@@ -3,36 +3,23 @@ package org.batfish.datamodel.acl;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import java.util.Objects;
 import javax.annotation.Nullable;
 
 public class PermittedByAcl extends AclLineMatchExpr {
   private static final String PROP_ACL_NAME = "aclName";
-  private static final String PROP_DEFAULT_ACCEPT = "defaultAccept";
 
   private final String _aclName;
-  private final boolean _defaultAccept;
-
-  public PermittedByAcl(String aclName, boolean defaultAccept) {
-    this(aclName, defaultAccept, null);
-  }
 
   public PermittedByAcl(String aclName) {
-    this(aclName, false, null);
-  }
-
-  public PermittedByAcl(String aclName, String description) {
-    this(aclName, false, description);
+    this(aclName, null);
   }
 
   @JsonCreator
   public PermittedByAcl(
       @JsonProperty(PROP_ACL_NAME) String aclName,
-      @JsonProperty(PROP_DEFAULT_ACCEPT) boolean defaultAccept,
       @JsonProperty(PROP_DESCRIPTION) @Nullable String description) {
     super(description);
     _aclName = aclName;
-    _defaultAccept = defaultAccept;
   }
 
   @Override
@@ -47,8 +34,7 @@ public class PermittedByAcl extends AclLineMatchExpr {
 
   @Override
   protected boolean exprEquals(Object o) {
-    return _aclName.equals(((PermittedByAcl) o)._aclName)
-        && _defaultAccept == ((PermittedByAcl) o)._defaultAccept;
+    return _aclName.equals(((PermittedByAcl) o)._aclName);
   }
 
   @JsonProperty(PROP_ACL_NAME)
@@ -56,21 +42,13 @@ public class PermittedByAcl extends AclLineMatchExpr {
     return _aclName;
   }
 
-  @JsonProperty(PROP_DEFAULT_ACCEPT)
-  public boolean getDefaultAccept() {
-    return _defaultAccept;
-  }
-
   @Override
   public int hashCode() {
-    return Objects.hash(_aclName, _defaultAccept);
+    return _aclName.hashCode();
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(getClass())
-        .add(PROP_ACL_NAME, _aclName)
-        .add(PROP_DEFAULT_ACCEPT, _defaultAccept)
-        .toString();
+    return MoreObjects.toStringHelper(getClass()).add(PROP_ACL_NAME, _aclName).toString();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/IpAccessListToBddTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/IpAccessListToBddTest.java
@@ -4,7 +4,6 @@ import static org.batfish.datamodel.ExprAclLine.rejecting;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
@@ -81,35 +80,6 @@ public class IpAccessListToBddTest {
             ImmutableMap.of(),
             BDDSourceManager.empty(_pkt));
     assertThat(bdd, equalTo(fooIpBDD));
-  }
-
-  @Test
-  public void testPermittedByAclDefaultAccept() {
-    Ip fooIp = Ip.parse("1.1.1.1");
-    IpAccessList acceptsFooIp =
-        aclWithLines(accepting(HeaderSpace.builder().setDstIps(fooIp.toIpSpace()).build()));
-    IpAccessList mainAcl = aclWithLines(accepting(new PermittedByAcl("foo", true)));
-    Map<String, IpAccessList> namedAcls = ImmutableMap.of("foo", acceptsFooIp, "acl", mainAcl);
-
-    // ACL acl should accept everything since the PermittedByAcl has defaultAccept true
-    BDD bdd =
-        IpAccessListToBdd.toBDD(
-            _pkt, mainAcl, namedAcls, ImmutableMap.of(), BDDSourceManager.empty(_pkt));
-    assertTrue(bdd.isOne());
-  }
-
-  @Test
-  public void testPermittedByAclDefaultAccept2() {
-    Ip fooIp = Ip.parse("1.1.1.1");
-    IpAccessList rejectsFooIp = aclWithLines(rejectingDst(fooIp.toPrefix()));
-    IpAccessList mainAcl = aclWithLines(accepting(new PermittedByAcl("foo", true)));
-    Map<String, IpAccessList> namedAcls = ImmutableMap.of("foo", rejectsFooIp, "acl", mainAcl);
-
-    // ACL acl should accept everything except packets destined for fooIp
-    BDD bdd =
-        IpAccessListToBdd.toBDD(
-            _pkt, mainAcl, namedAcls, ImmutableMap.of(), BDDSourceManager.empty(_pkt));
-    assertThat(bdd, equalTo(_pkt.getDstIp().value(fooIp.asLong()).not()));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/PermittedByAclTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/PermittedByAclTest.java
@@ -64,7 +64,7 @@ public class PermittedByAclTest {
 
     Map<String, IpAccessList> acceptAcl = createAclMap("acl1", "1.2.3.4/32", LineAction.PERMIT);
     Map<String, IpAccessList> rejectAcl = createAclMap("acl1", "1.2.3.4/32", LineAction.DENY);
-    PermittedByAcl exprMatch = new PermittedByAcl("acl1", false);
+    PermittedByAcl exprMatch = new PermittedByAcl("acl1");
 
     // Confirm a flow matching the ACL is correctly identified as accepted
     assertThat(exprMatch, matches(createFlow("1.2.3.4"), "", acceptAcl));

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1940,7 +1940,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
                   IpAccessList screenAcl =
                       _c.getIpAccessLists()
                           .computeIfAbsent(screenAclName, x -> buildScreen(screen, screenAclName));
-                  return screenAcl != null ? new PermittedByAcl(screenAcl.getName(), false) : null;
+                  return screenAcl != null ? new PermittedByAcl(screenAcl.getName()) : null;
                 })
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
@@ -1989,11 +1989,10 @@ public final class JuniperConfiguration extends VendorConfiguration {
     if (screenAcl == null) {
       return inAcl;
     } else if (inAcl == null) {
-      aclConjunctList = ImmutableSet.of(new PermittedByAcl(screenAcl.getName(), false));
+      aclConjunctList = ImmutableSet.of(new PermittedByAcl(screenAcl.getName()));
     } else {
       aclConjunctList =
-          ImmutableSet.of(
-              new PermittedByAcl(screenAcl.getName(), false), new PermittedByAcl(inAclName, false));
+          ImmutableSet.of(new PermittedByAcl(screenAcl.getName()), new PermittedByAcl(inAclName));
     }
 
     String combinedAclName = ACL_NAME_COMBINED_INCOMING + iface.getName();
@@ -2091,7 +2090,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
     zoneAclLines.add(
         new ExprAclLine(
             LineAction.PERMIT,
-            new PermittedByAcl(ACL_NAME_EXISTING_CONNECTION, false),
+            new PermittedByAcl(ACL_NAME_EXISTING_CONNECTION),
             "EXISTING_CONNECTION"));
 
     /* Default policy allows traffic originating from the device to be accepted */

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -4988,8 +4988,7 @@ public final class FlatJuniperGrammarTest {
                     ImmutableList.of(
                         ExprAclLine.accepting(
                             new AndMatchExpr(
-                                ImmutableList.of(
-                                    new PermittedByAcl("~SCREEN~IDS_OPTION_NAME", false))))))
+                                ImmutableList.of(new PermittedByAcl("~SCREEN~IDS_OPTION_NAME"))))))
                 .build()));
 
     assertThat(
@@ -4999,7 +4998,7 @@ public final class FlatJuniperGrammarTest {
                 .setName("~SCREEN_INTERFACE~ge-0/0/0.0")
                 .setLines(
                     ImmutableList.of(
-                        ExprAclLine.accepting(new PermittedByAcl("~SCREEN_ZONE~untrust", false))))
+                        ExprAclLine.accepting(new PermittedByAcl("~SCREEN_ZONE~untrust"))))
                 .build()));
 
     assertThat(
@@ -5012,8 +5011,8 @@ public final class FlatJuniperGrammarTest {
                         ExprAclLine.accepting(
                             new AndMatchExpr(
                                 ImmutableList.of(
-                                    new PermittedByAcl("~SCREEN_INTERFACE~ge-0/0/0.0", false),
-                                    new PermittedByAcl("FILTER1", false))))))
+                                    new PermittedByAcl("~SCREEN_INTERFACE~ge-0/0/0.0"),
+                                    new PermittedByAcl("FILTER1"))))))
                 .build()));
 
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -473,7 +473,7 @@ public class JuniperConfigurationTest {
                     ImmutableList.of(
                         ExprAclLine.accepting(
                             new AndMatchExpr(
-                                ImmutableList.of(new PermittedByAcl("~SCREEN~screen1", false))))))
+                                ImmutableList.of(new PermittedByAcl("~SCREEN~screen1"))))))
                 .build()));
     assertThat(config._c.getIpAccessLists().get("~SCREEN~screen1"), notNullValue());
     assertThat(config._c.getIpAccessLists().get("~SCREEN~screen2"), nullValue());

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -1049,8 +1049,7 @@
             "outgoingTransformation" : {
               "guard" : {
                 "class" : "org.batfish.datamodel.acl.PermittedByAcl",
-                "aclName" : "acl1",
-                "defaultAccept" : false
+                "aclName" : "acl1"
               },
               "transformationSteps" : [
                 {
@@ -2578,8 +2577,7 @@
                     },
                     {
                       "class" : "org.batfish.datamodel.acl.PermittedByAcl",
-                      "aclName" : "~ZONE_OUTGOING_ACL~SECURITY_LEVEL_0~",
-                      "defaultAccept" : false
+                      "aclName" : "~ZONE_OUTGOING_ACL~SECURITY_LEVEL_0~"
                     }
                   ]
                 }
@@ -8145,8 +8143,7 @@
             "outgoingTransformation" : {
               "guard" : {
                 "class" : "org.batfish.datamodel.acl.PermittedByAcl",
-                "aclName" : "def",
-                "defaultAccept" : false
+                "aclName" : "def"
               },
               "transformationSteps" : [
                 {
@@ -8686,8 +8683,7 @@
                     },
                     {
                       "class" : "org.batfish.datamodel.acl.PermittedByAcl",
-                      "aclName" : "~ZONE_OUTGOING_ACL~SECURITY_LEVEL_100~",
-                      "defaultAccept" : false
+                      "aclName" : "~ZONE_OUTGOING_ACL~SECURITY_LEVEL_100~"
                     }
                   ]
                 }
@@ -24547,8 +24543,7 @@
                 "action" : "PERMIT",
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.PermittedByAcl",
-                  "aclName" : "~EXISTING_CONNECTION~",
-                  "defaultAccept" : false
+                  "aclName" : "~EXISTING_CONNECTION~"
                 },
                 "name" : "EXISTING_CONNECTION"
               },
@@ -32052,8 +32047,7 @@
                     },
                     {
                       "class" : "org.batfish.datamodel.acl.PermittedByAcl",
-                      "aclName" : "zone~zl3~vsys10~to~zone~zl3~vsys10",
-                      "defaultAccept" : false
+                      "aclName" : "zone~zl3~vsys10~to~zone~zl3~vsys10"
                     }
                   ]
                 }


### PR DESCRIPTION
Now that #5355 is in, `defaultAccept` is never true. Also removed the IpAccessList `filter()` method that accepts a custom default action, as that argument was always `DENY` after removing `defaultAccept`.