### PR TITLE
Batfish: delete unused warning suppression arguments

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -53,9 +53,7 @@ public class BfConsts {
   public static final String ARG_IGNORE_FILES_WITH_STRINGS = "ignorefileswithstrings";
   public static final String ARG_IGNORE_MANAGEMENT_INTERFACES = "ignoremanagementinterfaces";
   public static final String ARG_LOG_LEVEL = "loglevel";
-  public static final String ARG_PEDANTIC_SUPPRESS = "pedanticsuppress";
   public static final String ARG_QUESTION_NAME = "questionname";
-  public static final String ARG_RED_FLAG_SUPPRESS = "redflagsuppress";
   public static final String ARG_SNAPSHOT_NAME = "snapshotname";
   public static final String ARG_SSL_DISABLE = "ssldisable";
   public static final String ARG_SSL_KEYSTORE_FILE = "sslkeystorefile";
@@ -67,7 +65,6 @@ public class BfConsts {
   public static final String ARG_SYNTHESIZE_TOPOLOGY = "synthesizetopology";
   public static final String ARG_TASK_PLUGIN = "taskplugin";
   public static final String ARG_TESTRIG = "testrig";
-  public static final String ARG_UNIMPLEMENTED_SUPPRESS = "unimplementedsuppress";
   public static final String ARG_VERBOSE_PARSE = "verboseparse";
 
   public static final String COMMAND_ANALYZE = "analyze";

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -322,10 +322,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _config.getInt(ARG_MAX_RUNTIME_MS);
   }
 
-  public boolean getPedanticRecord() {
-    return !_config.getBoolean(BfConsts.ARG_PEDANTIC_SUPPRESS);
-  }
-
   @Override
   public boolean getPrintParseTree() {
     return _config.getBoolean(ARG_PRINT_PARSE_TREES);
@@ -339,10 +335,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
   public @Nullable QuestionId getQuestionName() {
     String name = _config.getString(BfConsts.ARG_QUESTION_NAME);
     return name != null ? new QuestionId(name) : null;
-  }
-
-  public boolean getRedFlagRecord() {
-    return !_config.getBoolean(BfConsts.ARG_RED_FLAG_SUPPRESS);
   }
 
   public RunMode getRunMode() {
@@ -462,10 +454,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _config.getBoolean(ARG_TRACING_ENABLE);
   }
 
-  public boolean getUnimplementedRecord() {
-    return !_config.getBoolean(BfConsts.ARG_UNIMPLEMENTED_SUPPRESS);
-  }
-
   @Override
   public boolean getUseAristaBgp() {
     return debugFlagEnabled(DEBUG_FLAG_USE_ARISTA_BGP);
@@ -539,13 +527,11 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(ARG_MAX_RUNTIME_MS, 0);
     setDefaultProperty(ARG_CHECK_BGP_REACHABILITY, true);
     setDefaultProperty(ARG_NO_SHUFFLE, false);
-    setDefaultProperty(BfConsts.ARG_PEDANTIC_SUPPRESS, false);
     setDefaultProperty(ARG_PARENT_PID, -1);
     setDefaultProperty(ARG_PARSE_REUSE, true);
     setDefaultProperty(ARG_PRINT_PARSE_TREES, false);
     setDefaultProperty(ARG_PRINT_PARSE_TREE_LINE_NUMS, false);
     setDefaultProperty(BfConsts.ARG_QUESTION_NAME, null);
-    setDefaultProperty(BfConsts.ARG_RED_FLAG_SUPPRESS, false);
     setDefaultProperty(ARG_RUN_MODE, RunMode.WORKER.toString());
     setDefaultProperty(ARG_SEQUENTIAL, false);
     setDefaultProperty(ARG_SERVICE_BIND_HOST, Ip.ZERO.toString());
@@ -567,7 +553,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(ARG_TRACING_AGENT_HOST, "localhost");
     setDefaultProperty(ARG_TRACING_AGENT_PORT, 5775);
     setDefaultProperty(ARG_TRACING_ENABLE, false);
-    setDefaultProperty(BfConsts.ARG_UNIMPLEMENTED_SUPPRESS, false);
     setDefaultProperty(BfConsts.ARG_VERBOSE_PARSE, false);
     setDefaultProperty(ARG_VERSION, false);
     setDefaultProperty(BfConsts.COMMAND_ANALYZE, false);
@@ -717,16 +702,12 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
     addBooleanOption(ARG_PARSE_REUSE, "reuse parse results when appropriate");
 
-    addBooleanOption(BfConsts.ARG_PEDANTIC_SUPPRESS, "suppresses pedantic warnings");
-
     addBooleanOption(ARG_PRINT_PARSE_TREES, "print parse trees");
 
     addBooleanOption(
         ARG_PRINT_PARSE_TREE_LINE_NUMS, "print line numbers when printing parse trees");
 
     addOption(BfConsts.ARG_QUESTION_NAME, "name of question", ARGNAME_NAME);
-
-    addBooleanOption(BfConsts.ARG_RED_FLAG_SUPPRESS, "suppresses red-flag warnings");
 
     addOption(
         ARG_RUN_MODE,
@@ -778,10 +759,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     addBooleanOption(ARG_TRACING_ENABLE, "enable tracing");
 
     addBooleanOption(
-        BfConsts.ARG_UNIMPLEMENTED_SUPPRESS,
-        "suppresses warnings about unimplemented configuration directives");
-
-    addBooleanOption(
         BfConsts.ARG_VERBOSE_PARSE,
         "(developer option) include parse/convert data in init-testrig answer");
 
@@ -817,8 +794,11 @@ public final class Settings extends BaseSettings implements GrammarSettings {
           "gsinputrole",
           "gsremoteas",
           "outputenv",
+          "pedanticsuppress",
           "ppa",
+          "redflagsuppress",
           "stext",
+          "unimplementedsuppress",
           "venv"
         }) {
       addOption(deprecatedStringArg, DEPRECATED_ARG_DESC, "ignored");
@@ -885,11 +865,9 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     getIntOptionValue(ARG_MAX_PARSE_TREE_PRINT_LENGTH);
     getIntOptionValue(ARG_MAX_RUNTIME_MS);
     getIntOptionValue(ARG_PARENT_PID);
-    getBooleanOptionValue(BfConsts.ARG_PEDANTIC_SUPPRESS);
     getBooleanOptionValue(ARG_PRINT_PARSE_TREES);
     getBooleanOptionValue(ARG_PRINT_PARSE_TREE_LINE_NUMS);
     getStringOptionValue(BfConsts.ARG_QUESTION_NAME);
-    getBooleanOptionValue(BfConsts.ARG_RED_FLAG_SUPPRESS);
     getStringOptionValue(ARG_RUN_MODE);
     getBooleanOptionValue(ARG_SEQUENTIAL);
     getBooleanOptionValue(BfConsts.COMMAND_PARSE_VENDOR_INDEPENDENT);
@@ -916,7 +894,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     getStringOptionValue(ARG_TRACING_AGENT_HOST);
     getIntegerOptionValue(ARG_TRACING_AGENT_PORT);
     getBooleanOptionValue(ARG_TRACING_ENABLE);
-    getBooleanOptionValue(BfConsts.ARG_UNIMPLEMENTED_SUPPRESS);
     getBooleanOptionValue(BfConsts.ARG_VERBOSE_PARSE);
     getIntegerOptionValue(ARG_Z3_TIMEOUT);
     getStringOptionValue(ARG_DATAPLANE_ENGINE_NAME);

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -730,10 +730,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   public static Warnings buildWarnings(Settings settings) {
     return new Warnings(
-        settings.getPedanticRecord() && settings.getLogger().isActive(BatfishLogger.LEVEL_PEDANTIC),
-        settings.getRedFlagRecord() && settings.getLogger().isActive(BatfishLogger.LEVEL_REDFLAG),
-        settings.getUnimplementedRecord()
-            && settings.getLogger().isActive(BatfishLogger.LEVEL_UNIMPLEMENTED));
+        settings.getLogger().isActive(BatfishLogger.LEVEL_PEDANTIC),
+        settings.getLogger().isActive(BatfishLogger.LEVEL_REDFLAG),
+        settings.getLogger().isActive(BatfishLogger.LEVEL_UNIMPLEMENTED));
   }
 
   @Override


### PR DESCRIPTION
Instead, we use log levels.