### PR TITLE
Introduce TraceElement

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TraceElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TraceElement.java
@@ -175,5 +175,4 @@ public final class TraceElement implements Serializable {
   public String toString() {
     return _fragments.stream().map(Fragment::getText).collect(Collectors.joining());
   }
-
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TraceElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TraceElement.java
@@ -1,0 +1,179 @@
+package org.batfish.datamodel;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.vendor.VendorStructureId;
+
+/** Metadata used to create human-readable traces. */
+@ParametersAreNonnullByDefault
+public final class TraceElement implements Serializable {
+  private static final String PROP_FRAGMENTS = "fragments";
+  private static final String PROP_TEXT = "text";
+  private static final String PROP_VENDOR_STRUCTURE_ID = "vendorStructureId";
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
+  public interface Fragment {
+    String getText();
+  }
+
+  /** A plain text {@link Fragment}. */
+  public static final class TextFragment implements Fragment {
+    private final String _text;
+
+    TextFragment(String text) {
+      _text = text;
+    }
+
+    @JsonCreator
+    private static TextFragment jsonCreator(@Nullable @JsonProperty(PROP_TEXT) String text) {
+      checkNotNull(text, "%s cannot be null", PROP_TEXT);
+      return new TextFragment(text);
+    }
+
+    @Override
+    @JsonProperty(PROP_TEXT)
+    public String getText() {
+      return _text;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof TextFragment)) {
+        return false;
+      }
+      TextFragment other = (TextFragment) o;
+      return _text.equals(other._text);
+    }
+
+    @Override
+    public int hashCode() {
+      return _text.hashCode();
+    }
+  }
+
+  /** A {@link Fragment} that is linked to a vendor structure. */
+  public static final class LinkFragment implements Fragment {
+    private final String _text;
+    private final VendorStructureId _vendorStructureId;
+
+    LinkFragment(String text, VendorStructureId vendorStructureId) {
+      _text = text;
+      _vendorStructureId = vendorStructureId;
+    }
+
+    @JsonCreator
+    public static LinkFragment jsonCreator(
+        @Nullable @JsonProperty(PROP_TEXT) String text,
+        @Nullable @JsonProperty(PROP_VENDOR_STRUCTURE_ID) VendorStructureId vendorStructureId) {
+      checkNotNull(text, "%s cannot be null", PROP_TEXT);
+      checkNotNull(vendorStructureId, "%s cannot be null", PROP_VENDOR_STRUCTURE_ID);
+      return new LinkFragment(text, vendorStructureId);
+    }
+
+    @Override
+    @JsonProperty(PROP_TEXT)
+    public String getText() {
+      return _text;
+    }
+
+    @JsonProperty(PROP_VENDOR_STRUCTURE_ID)
+    public VendorStructureId getVendorStructureId() {
+      return _vendorStructureId;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof LinkFragment)) {
+        return false;
+      }
+      LinkFragment other = (LinkFragment) o;
+      return _text.equals(other._text) && _vendorStructureId.equals(other._vendorStructureId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_text, _vendorStructureId);
+    }
+  }
+
+  /** A {@link TraceElement} builder. */
+  public static final class Builder {
+    private List<Fragment> _fragments = new ArrayList<>();
+
+    Builder add(String text) {
+      _fragments.add(new TextFragment(text));
+      return this;
+    }
+
+    Builder add(String text, VendorStructureId vendorStructureId) {
+      _fragments.add(new LinkFragment(text, vendorStructureId));
+      return this;
+    }
+
+    TraceElement build() {
+      return new TraceElement(_fragments);
+    }
+  }
+
+  private final List<Fragment> _fragments;
+
+  TraceElement(List<Fragment> fragments) {
+    _fragments = ImmutableList.copyOf(fragments);
+  }
+
+  @JsonCreator
+  public static TraceElement jsonCreator(
+      @Nullable @JsonProperty(PROP_FRAGMENTS) List<Fragment> fragments) {
+    return new TraceElement(firstNonNull(fragments, ImmutableList.of()));
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @JsonProperty(PROP_FRAGMENTS)
+  public List<Fragment> getFragments() {
+    return _fragments;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TraceElement)) {
+      return false;
+    }
+    TraceElement other = (TraceElement) o;
+    return this._fragments.equals(other._fragments);
+  }
+
+  @Override
+  public int hashCode() {
+    return _fragments.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return _fragments.stream().map(Fragment::getText).collect(Collectors.joining());
+  }
+
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TraceElementTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TraceElementTest.java
@@ -1,0 +1,79 @@
+package org.batfish.datamodel;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import java.io.IOException;
+import java.util.List;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.TraceElement.Fragment;
+import org.batfish.datamodel.TraceElement.LinkFragment;
+import org.batfish.datamodel.TraceElement.TextFragment;
+import org.batfish.vendor.VendorStructureId;
+import org.junit.Test;
+
+/** Test for {@link TraceElement}. */
+public final class TraceElementTest {
+  @Test
+  public void testTextFragment_equals() {
+    new EqualsTester()
+        .addEqualityGroup(new TextFragment(""), new TextFragment(""))
+        .addEqualityGroup(new TextFragment("x"))
+        .testEquals();
+  }
+
+  @Test
+  public void testTextFragment_JsonSerialization() throws IOException {
+    TextFragment fragment = new TextFragment("asdf");
+    TextFragment clone = (TextFragment) BatfishObjectMapper.clone(fragment, Fragment.class);
+    assertEquals(fragment, clone);
+  }
+
+  @Test
+  public void testLinkFragment_equals() {
+    String text1 = "a";
+    String text2 = "b";
+    VendorStructureId vendorStructureId1 = new VendorStructureId("f1", "t1", "n1");
+    VendorStructureId vendorStructureId2 = new VendorStructureId("f2", "t2", "n2");
+    new EqualsTester()
+        .addEqualityGroup(
+            new LinkFragment(text1, vendorStructureId1),
+            new LinkFragment(text1, vendorStructureId1))
+        .addEqualityGroup(new LinkFragment(text2, vendorStructureId1))
+        .addEqualityGroup(new LinkFragment(text1, vendorStructureId2))
+        .testEquals();
+  }
+
+  @Test
+  public void testLinkFragment_JsonSerialization() throws IOException {
+    LinkFragment fragment = new LinkFragment("asdf", new VendorStructureId("f", "t", "n"));
+    LinkFragment clone = (LinkFragment) BatfishObjectMapper.clone(fragment, Fragment.class);
+    assertEquals(fragment, clone);
+  }
+
+  @Test
+  public void testTraceElement_equals() {
+    List<Fragment> fragments1 = ImmutableList.of();
+    List<Fragment> fragments2 = ImmutableList.of(new TextFragment(""));
+    new EqualsTester()
+        .addEqualityGroup(new TraceElement(fragments1), new TraceElement(fragments1))
+        .addEqualityGroup(new TraceElement(fragments2))
+        .testEquals();
+  }
+
+  @Test
+  public void testTraceElement_JsonSerialization() throws IOException {
+    TraceElement traceElement = new TraceElement(ImmutableList.of(new TextFragment("a")));
+    TraceElement clone = BatfishObjectMapper.clone(traceElement, TraceElement.class);
+    assertEquals(traceElement, clone);
+  }
+
+  @Test
+  public void testToString() {
+    VendorStructureId vendorStructureId = new VendorStructureId("f", "t", "n");
+    String actual =
+        TraceElement.builder().add("text ").add("link", vendorStructureId).build().toString();
+    assertEquals("text link", actual);
+  }
+}


### PR DESCRIPTION
TraceElements are strings where substrings can be annotated with vendor
structure ids. They will be used for generating better filter traces.
They support two operations: serialization to JSON (preserving
annotations), and conversion to a string (discarding annotations).