### PR TITLE
Arista BGP: evpn AF allow-remote-as-out

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/AristaConversions.java
@@ -524,7 +524,7 @@ final class AristaConversions {
                   .setAdvertiseInactive(
                       firstNonNull(vrfConfig.getAdvertiseInactive(), Boolean.FALSE))
                   .setAllowLocalAsIn(Boolean.FALSE) // todo
-                  .setAllowRemoteAsOut(Boolean.FALSE) // todo
+                  .setAllowRemoteAsOut(true) // this is always true on Arista
                   .setSendCommunity(firstNonNull(neighbor.getSendCommunity(), Boolean.FALSE))
                   .setSendExtendedCommunity(
                       firstNonNull(neighbor.getSendCommunity(), Boolean.FALSE))

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -648,6 +648,8 @@ public class AristaGrammarTest {
       BgpActivePeerConfig neighbor =
           c.getDefaultVrf().getBgpProcess().getActiveNeighbors().get(ip.toPrefix());
       assertThat(neighbor.getEvpnAddressFamily(), notNullValue());
+      assertTrue(
+          neighbor.getEvpnAddressFamily().getAddressFamilyCapabilities().getAllowRemoteAsOut());
       assertThat(
           neighbor.getEvpnAddressFamily().getL2VNIs(),
           equalTo(


### PR DESCRIPTION
Should always be set to true, just like for IPv4 AF