### PR TITLE
Arista BGP: fix grammar for legacy network specification

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Arista_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Arista_bgp.g4
@@ -803,7 +803,7 @@ eos_rbi_network
 eos_rbi_network4
 :
   (
-    ip = IP_ADDRESS mask = IP_ADDRESS
+    ip = IP_ADDRESS MASK mask = IP_ADDRESS
     | prefix = IP_PREFIX
   )
   (ROUTE_MAP rm = variable)?

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_network
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_network
@@ -6,7 +6,7 @@ router bgp 65104
   !! All network commands are valid at the top level and address-family ipv4
   !! They will show up under address-family in "show run"
   network 1.1.1.0/24
-  network 1.1.2.0 255.255.255.0
+  network 1.1.2.0 mask 255.255.255.0
   address-family ipv4
     network 1.1.3.0/24 route-map RM
     !! the next-hop-unchanged command is here to verify that


### PR DESCRIPTION
Missed the 'mask' keyword originally.
It won't appear in this format in show run, but you can type it (for
backwards compatibility, presumably).