### PR TITLE
Arista BGP: flip bit to new bgp parser

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -1,6 +1,6 @@
 package org.batfish.config;
 
-import static org.batfish.grammar.cisco.CiscoCombinedParser.DEBUG_FLAG_USE_ARISTA_BGP;
+import static org.batfish.grammar.cisco.CiscoCombinedParser.DEBUG_FLAG_NO_USE_ARISTA_BGP;
 
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
@@ -450,7 +450,7 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   @Override
   public boolean getUseAristaBgp() {
-    return debugFlagEnabled(DEBUG_FLAG_USE_ARISTA_BGP);
+    return !debugFlagEnabled(DEBUG_FLAG_NO_USE_ARISTA_BGP);
   }
 
   public boolean getVerboseParse() {

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoCombinedParser.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoCombinedParser.java
@@ -13,7 +13,7 @@ public class CiscoCombinedParser extends BatfishCombinedParser<CiscoParser, Cisc
   private static final BatfishANTLRErrorStrategyFactory NEWLINE_BASED_RECOVERY =
       new BatfishANTLRErrorStrategy.BatfishANTLRErrorStrategyFactory(CiscoLexer.NEWLINE, "\n");
 
-  public static final String DEBUG_FLAG_USE_ARISTA_BGP = "aristabgp";
+  public static final String DEBUG_FLAG_NO_USE_ARISTA_BGP = "noaristabgp";
 
   public CiscoCombinedParser(String input, GrammarSettings settings, ConfigurationFormat format) {
     super(

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -13,7 +13,6 @@ import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVrf;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasBgpProcess;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasName;
-import static org.batfish.grammar.cisco.CiscoCombinedParser.DEBUG_FLAG_USE_ARISTA_BGP;
 import static org.batfish.main.BatfishTestUtils.TEST_SNAPSHOT;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
 import static org.batfish.representation.cisco.eos.AristaBgpProcess.DEFAULT_VRF;
@@ -38,7 +37,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Range;
@@ -124,7 +122,6 @@ public class AristaGrammarTest {
     String src = CommonUtil.readResource(TESTCONFIGS_PREFIX + hostname);
     Settings settings = new Settings();
     configureBatfishTestSettings(settings);
-    settings.setDebugFlags(ImmutableList.of(DEBUG_FLAG_USE_ARISTA_BGP));
     CiscoCombinedParser ciscoParser =
         new CiscoCombinedParser(src, settings, ConfigurationFormat.ARISTA);
     CiscoControlPlaneExtractor extractor =
@@ -145,9 +142,7 @@ public class AristaGrammarTest {
       throws IOException {
     String[] names =
         Arrays.stream(configurationNames).map(s -> TESTCONFIGS_PREFIX + s).toArray(String[]::new);
-    Batfish batfish = BatfishTestUtils.getBatfishForTextConfigs(_folder, names);
-    batfish.getSettings().setDebugFlags(ImmutableList.of(DEBUG_FLAG_USE_ARISTA_BGP));
-    return batfish;
+    return BatfishTestUtils.getBatfishForTextConfigs(_folder, names);
   }
 
   private @Nonnull Configuration parseConfig(String hostname) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaRouterIdTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaRouterIdTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
@@ -17,7 +16,6 @@ import org.batfish.common.plugin.IBatfish;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
-import org.batfish.grammar.cisco.CiscoCombinedParser;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.junit.Rule;
@@ -34,9 +32,6 @@ public class AristaRouterIdTest {
     String[] names =
         Arrays.stream(configurationNames).map(s -> TESTCONFIGS_PREFIX + s).toArray(String[]::new);
     Batfish batfish = BatfishTestUtils.getBatfishForTextConfigs(_folder, names);
-    batfish
-        .getSettings()
-        .setDebugFlags(ImmutableList.of(CiscoCombinedParser.DEBUG_FLAG_USE_ARISTA_BGP));
     return batfish;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -4176,7 +4176,8 @@ public final class CiscoGrammarTest {
             hostname,
             containsString(
                 String.format(
-                    "No remote-as set for peer: %s", neighborWithoutRemoteAs.getStartIp()))));
+                    "No remote-as configured for BGP neighbor %s in vrf default",
+                    neighborWithoutRemoteAs.getStartIp()))));
 
     /*
      * Also ensure that default value of allowRemoteAsOut is true.

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as1
@@ -18,7 +18,7 @@ route-map permit-all permit 10
 !
 !
 router bgp 1
- bgp router-id 10.1.1.1
+ router-id 10.1.1.1
  neighbor 10.0.12.2 remote-as 2
  neighbor 10.0.12.2 activate
  neighbor 10.0.12.2 route-map deny-all in

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as1
@@ -20,7 +20,6 @@ route-map permit-all permit 10
 router bgp 1
  router-id 10.1.1.1
  neighbor 10.0.12.2 remote-as 2
- neighbor 10.0.12.2 activate
  neighbor 10.0.12.2 route-map deny-all in
  neighbor 10.0.12.2 route-map permit-all out
  network 0.0.0.0 mask 0.0.0.0

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as2-advertise-inactive
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as2-advertise-inactive
@@ -21,7 +21,7 @@ route-map deny-all deny 10
 route-map permit-all permit 10
 !
 router bgp 2
- bgp router-id 10.2.2.2
+ router-id 10.2.2.2
  bgp advertise-inactive
  neighbor 10.0.12.1 remote-as 1
  neighbor 10.0.12.1 activate

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as2-advertise-inactive
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as2-advertise-inactive
@@ -24,11 +24,9 @@ router bgp 2
  router-id 10.2.2.2
  bgp advertise-inactive
  neighbor 10.0.12.1 remote-as 1
- neighbor 10.0.12.1 activate
  neighbor 10.0.12.1 route-map permit-all in
  neighbor 10.0.12.1 route-map deny-all out
  neighbor 10.0.23.3 remote-as 3
- neighbor 10.0.23.3 activate
  neighbor 10.0.23.3 route-map deny-all in
  neighbor 10.0.23.3 route-map permit-all out
 !

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as2-no-advertise-inactive
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as2-no-advertise-inactive
@@ -23,11 +23,9 @@ route-map permit-all permit 10
 router bgp 2
  router-id 10.2.2.2
  neighbor 10.0.12.1 remote-as 1
- neighbor 10.0.12.1 activate
  neighbor 10.0.12.1 route-map permit-all in
  neighbor 10.0.12.1 route-map deny-all out
  neighbor 10.0.23.3 remote-as 3
- neighbor 10.0.23.3 activate
  neighbor 10.0.23.3 route-map deny-all in
  neighbor 10.0.23.3 route-map permit-all out
 !

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as2-no-advertise-inactive
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as2-no-advertise-inactive
@@ -21,7 +21,7 @@ route-map deny-all deny 10
 route-map permit-all permit 10
 !
 router bgp 2
- bgp router-id 10.2.2.2
+ router-id 10.2.2.2
  neighbor 10.0.12.1 remote-as 1
  neighbor 10.0.12.1 activate
  neighbor 10.0.12.1 route-map permit-all in

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as3
@@ -15,7 +15,7 @@ route-map deny-all deny 10
 route-map permit-all permit 10
 !
 router bgp 3
- bgp router-id 10.3.3.3
+ router-id 10.3.3.3
  neighbor 10.0.23.2 remote-as 2
  neighbor 10.0.23.2 activate
  neighbor 10.0.23.2 route-map permit-all in

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/ibdp/bgp-filter-inactive/configs/as3
@@ -17,7 +17,6 @@ route-map permit-all permit 10
 router bgp 3
  router-id 10.3.3.3
  neighbor 10.0.23.2 remote-as 2
- neighbor 10.0.23.2 activate
  neighbor 10.0.23.2 route-map permit-all in
  neighbor 10.0.23.2 route-map deny-all out
 !

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-misconfigured/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-misconfigured/configs/r2
@@ -31,7 +31,6 @@ router bgp 2
  neighbor r3r4group peer-group
  bgp listen range 9.9.9.0/24 peer-group r3r4group
  neighbor r3r4group remote-as 3
- neighbor r3r4group activate
  neighbor r3r4group update-source Loopback0
 !
 ip route 9.9.9.3 255.255.255.255 FastEthernet1/0

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r1
@@ -12,6 +12,6 @@ interface Loopback0
  ip address 1.1.1.1 255.255.255.255
 !
 router bgp 1
- bgp router-id 1.1.1.1
+ router-id 1.1.1.1
  neighbor 1.2.0.2 remote-as 2
 !

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r2
@@ -29,7 +29,7 @@ interface Loopback0
  ip address 2.2.2.2 255.255.255.255
 !
 router bgp 2
- bgp router-id 2.2.2.2
+ router-id 2.2.2.2
  neighbor 1.2.0.1 remote-as 1
  ! dynamic session here, should get connections from r3, r4
  neighbor r3r4group peer-group

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r2
@@ -33,7 +33,5 @@ router bgp 2
  neighbor 1.2.0.1 remote-as 1
  ! dynamic session here, should get connections from r3, r4
  neighbor r3r4group peer-group
- bgp listen range 2.0.0.0/26 peer-group r3r4group
- neighbor r3r4group remote-as 3
- neighbor r3r4group activate
+ bgp listen range 2.0.0.0/26 peer-group r3r4group remote-as 3
 !

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r3
@@ -16,7 +16,7 @@ interface Loopback0
  ip address 3.3.3.3 255.255.255.255
 !
 router bgp 3
- bgp router-id 3.3.3.3
+ router-id 3.3.3.3
  no auto-summary
  neighbor 2.0.0.1 remote-as 2
  network 3.3.3.3 mask 255.255.255.255

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r3
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r3
@@ -17,7 +17,6 @@ interface Loopback0
 !
 router bgp 3
  router-id 3.3.3.3
- no auto-summary
  neighbor 2.0.0.1 remote-as 2
  network 3.3.3.3 mask 255.255.255.255
 !

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r4
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r4
@@ -16,7 +16,6 @@ interface Loopback0
 !
 router bgp 3
  router-id 4.4.4.4
- no auto-summary
  neighbor 2.0.0.9 remote-as 2
  network 4.4.4.4 mask 255.255.255.255
 !

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r4
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session-no-update-source/configs/r4
@@ -15,7 +15,7 @@ interface Loopback0
  ip address 4.4.4.4 255.255.255.255
 !
 router bgp 3
- bgp router-id 4.4.4.4
+ router-id 4.4.4.4
  no auto-summary
  neighbor 2.0.0.9 remote-as 2
  network 4.4.4.4 mask 255.255.255.255

--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/bgp-dynamic-session/configs/r2
@@ -31,7 +31,6 @@ router bgp 2
  neighbor r3r4group peer-group
  bgp listen range 9.9.9.0/24 peer-group r3r4group
  neighbor r3r4group remote-as 3
- neighbor r3r4group activate
  neighbor r3r4group update-source Loopback0
 !
 ip route 9.9.9.3 255.255.255.255 FastEthernet1/0

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-bgp-default-originate/configs/arista-originator
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-bgp-default-originate/configs/arista-originator
@@ -10,7 +10,6 @@ interface Eth0
 !
 router bgp 1
  router-id 1.1.1.1
- neighbor 10.1.1.2 activate
  neighbor 10.1.1.2 remote-as 2
  neighbor 10.1.1.2 default-originate route-map ROUTE_MAP
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-bgp-default-originate/configs/arista-originator-undefined-rm
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-bgp-default-originate/configs/arista-originator-undefined-rm
@@ -10,6 +10,5 @@ interface Eth0
 !
 router bgp 1
  router-id 1.1.1.1
- neighbor 10.1.1.2 activate
  neighbor 10.1.1.2 remote-as 2
  neighbor 10.1.1.2 default-originate route-map ROUTE_MAP

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -44,18 +44,6 @@
     "rows" : [
       {
         "File_Name" : "configs/arista_bgp",
-        "Struct_Type" : "bgp peer-group",
-        "Ref_Name" : "UNDEFINED_PEER_GROUP",
-        "Context" : "bgp neighbor statement",
-        "Lines" : {
-          "filename" : "configs/arista_bgp",
-          "lines" : [
-            11
-          ]
-        }
-      },
-      {
-        "File_Name" : "configs/arista_bgp",
         "Struct_Type" : "route-map",
         "Ref_Name" : "UNDEFINED_MAP",
         "Context" : "bgp redistribute ospfv3 route-map",
@@ -4180,10 +4168,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 339 results",
+      "notes" : "Found 338 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 339
+      "numResults" : 338
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -44,6 +44,18 @@
     "rows" : [
       {
         "File_Name" : "configs/arista_bgp",
+        "Struct_Type" : "bgp peer-group",
+        "Ref_Name" : "UNDEFINED_PEER_GROUP",
+        "Context" : "bgp neighbor peer-group",
+        "Lines" : {
+          "filename" : "configs/arista_bgp",
+          "lines" : [
+            11
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/arista_bgp",
         "Struct_Type" : "route-map",
         "Ref_Name" : "UNDEFINED_MAP",
         "Context" : "bgp redistribute ospfv3 route-map",
@@ -4168,10 +4180,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 338 results",
+      "notes" : "Found 339 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 338
+      "numResults" : 339
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -770,7 +770,7 @@
               "multipathEbgp" : false,
               "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
               "multipathIbgp" : false,
-              "tieBreaker" : "ARRIVAL_ORDER"
+              "tieBreaker" : "ROUTER_ID"
             }
           }
         }

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -43,6 +43,20 @@
     },
     "rows" : [
       {
+        "Filename" : "configs/arista_bgp",
+        "Line" : 12,
+        "Text" : "ospf3 match internal route-map ROUTE_MAP",
+        "Parser_Context" : "[eos_rbir_ospf3 eos_rbi_redistribute eos_rb_inner eos_router_bgp_tail router_bgp_stanza stanza cisco_configuration]",
+        "Comment" : "This feature is not currently supported"
+      },
+      {
+        "Filename" : "configs/arista_bgp",
+        "Line" : 13,
+        "Text" : "ospf3 match external route-map UNDEFINED_MAP",
+        "Parser_Context" : "[eos_rbir_ospf3 eos_rbi_redistribute eos_rb_inner eos_router_bgp_tail router_bgp_stanza stanza cisco_configuration]",
+        "Comment" : "This feature is not currently supported"
+      },
+      {
         "Filename" : "configs/arista_nat",
         "Line" : 9,
         "Text" : "ip nat pool pool2 1.1.1.1 1.1.1.2 netmask 255.255.255.255",
@@ -1465,10 +1479,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 203 results",
+      "notes" : "Found 205 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 203
+      "numResults" : 205
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -1563,65 +1563,70 @@
             "      procnum = (bgp_asn",
             "        asn = DEC:'1')",
             "      NEWLINE:'\\n'",
-            "      (router_bgp_stanza_tail",
-            "        (as_path_multipath_relax_rb_stanza",
-            "          NO:'no'",
-            "          BGP:'bgp'",
-            "          BESTPATH:'bestpath'",
-            "          AS_PATH:'as-path'",
-            "          MULTIPATH_RELAX:'multipath-relax'  <== mode:M_AsPath",
-            "          NEWLINE:'\\n'))",
-            "      (router_bgp_stanza_tail",
-            "        (bgp_tail",
-            "          (null_bgp_tail",
+            "      (eos_router_bgp_tail",
+            "        (eos_rb_inner",
+            "          (eos_rbi_no",
+            "            NO:'no'",
+            "            (eos_rbino_bgp",
+            "              BGP:'bgp'",
+            "              (eos_rbino_bgp_bestpath",
+            "                BESTPATH:'bestpath'",
+            "                (eos_rbino_bgp_bp_as_path",
+            "                  AS_PATH:'as-path'",
+            "                  (eos_rbino_bgp_bpa_multipath_relax",
+            "                    MULTIPATH_RELAX:'multipath-relax'  <== mode:M_AsPath",
+            "                    NEWLINE:'\\n')))))))",
+            "      (eos_router_bgp_tail",
+            "        (eos_rb_inner",
+            "          (eos_rbi_update",
             "            UPDATE:'update'",
-            "            (null_rest_of_line",
-            "              WAIT_FOR_CONVERGENCE:'wait-for-convergence'",
-            "              NEWLINE:'\\n'))))",
-            "      (router_bgp_stanza_tail",
-            "        (bgp_tail",
-            "          (null_bgp_tail",
+            "            WAIT_FOR_CONVERGENCE:'wait-for-convergence'",
+            "            NEWLINE:'\\n')))",
+            "      (eos_router_bgp_tail",
+            "        (eos_rb_inner",
+            "          (eos_rbi_update",
             "            UPDATE:'update'",
-            "            (null_rest_of_line",
-            "              WAIT_INSTALL:'wait-install'",
-            "              NEWLINE:'\\n'))))",
-            "      (router_bgp_stanza_tail",
-            "        (address_family_rb_stanza",
-            "          (address_family_header",
-            "            ADDRESS_FAMILY:'address-family'",
-            "            af = (bgp_address_family",
-            "              IPV4:'ipv4')",
-            "            NEWLINE:'\\n')",
-            "          (neighbor_flat_rb_stanza",
-            "            NEIGHBOR:'neighbor'",
-            "            peergroup = VARIABLE:'UNDEFINED_PEER_GROUP'  <== mode:M_NEIGHBOR",
-            "            (bgp_tail",
-            "              (activate_bgp_tail",
-            "                ACTIVATE:'activate'",
-            "                NEWLINE:'\\n')))",
-            "          (bgp_tail",
-            "            (redistribute_ospfv3_bgp_tail",
-            "              REDISTRIBUTE:'redistribute'",
+            "            WAIT_INSTALL:'wait-install'",
+            "            NEWLINE:'\\n')))",
+            "      (eos_router_bgp_tail",
+            "        (eos_rb_address_family",
+            "          ADDRESS_FAMILY:'address-family'",
+            "          (eos_rb_af_ipv4",
+            "            IPV4:'ipv4'",
+            "            (eos_rb_af_ipv4_unicast",
+            "              NEWLINE:'\\n'",
+            "              (eos_rbafipv4u_neighbor",
+            "                NEIGHBOR:'neighbor'",
+            "                pg = (variable",
+            "                  VARIABLE:'UNDEFINED_PEER_GROUP'  <== mode:M_NEIGHBOR)",
+            "                (eos_rb_af_neighbor_common",
+            "                  (eos_rbafnc_activate",
+            "                    ACTIVATE:'activate'",
+            "                    NEWLINE:'\\n')))))))",
+            "      (eos_router_bgp_tail",
+            "        (eos_rb_inner",
+            "          (eos_rbi_redistribute",
+            "            REDISTRIBUTE:'redistribute'",
+            "            (eos_rbir_ospf3",
             "              OSPF3:'ospf3'",
             "              MATCH:'match'",
-            "              (ospf_route_type",
-            "                INTERNAL:'internal')",
+            "              INTERNAL:'internal'",
             "              ROUTE_MAP:'route-map'",
-            "              map = (variable",
+            "              rm = (variable",
             "                VARIABLE:'ROUTE_MAP'  <== mode:M_RouteMap)",
-            "              NEWLINE:'\\n'))",
-            "          (bgp_tail",
-            "            (redistribute_ospfv3_bgp_tail",
-            "              REDISTRIBUTE:'redistribute'",
+            "              NEWLINE:'\\n'))))",
+            "      (eos_router_bgp_tail",
+            "        (eos_rb_inner",
+            "          (eos_rbi_redistribute",
+            "            REDISTRIBUTE:'redistribute'",
+            "            (eos_rbir_ospf3",
             "              OSPF3:'ospf3'",
             "              MATCH:'match'",
-            "              (ospf_route_type",
-            "                EXTERNAL:'external')",
+            "              EXTERNAL:'external'",
             "              ROUTE_MAP:'route-map'",
-            "              map = (variable",
+            "              rm = (variable",
             "                VARIABLE:'UNDEFINED_MAP'  <== mode:M_RouteMap)",
-            "              NEWLINE:'\\n'))",
-            "          (address_family_footer)))))",
+            "              NEWLINE:'\\n'))))))",
             "  (stanza",
             "    (route_map_stanza",
             "      ROUTE_MAP:'route-map'",
@@ -75962,6 +75967,22 @@
       },
       "version" : "0.36.0",
       "warnings" : {
+        "configs/arista_bgp" : {
+          "Parse warnings" : [
+            {
+              "Comment" : "This feature is not currently supported",
+              "Line" : 12,
+              "Parser_Context" : "[eos_rbir_ospf3 eos_rbi_redistribute eos_rb_inner eos_router_bgp_tail router_bgp_stanza stanza cisco_configuration]",
+              "Text" : "ospf3 match internal route-map ROUTE_MAP"
+            },
+            {
+              "Comment" : "This feature is not currently supported",
+              "Line" : 13,
+              "Parser_Context" : "[eos_rbir_ospf3 eos_rbi_redistribute eos_rb_inner eos_router_bgp_tail router_bgp_stanza stanza cisco_configuration]",
+              "Text" : "ospf3 match external route-map UNDEFINED_MAP"
+            }
+          ]
+        },
         "configs/arista_nat" : {
           "Parse warnings" : [
             {
@@ -77755,7 +77776,7 @@
         "aggaddress" : "PASSED",
         "arista-event-handler" : "PASSED",
         "arista_acl" : "PASSED",
-        "arista_bgp" : "PASSED",
+        "arista_bgp" : "WARNINGS",
         "arista_dhcp_relay" : "PASSED",
         "arista_interface" : "PASSED",
         "arista_ip_route" : "PASSED",
@@ -86859,13 +86880,6 @@
       },
       "referencedStructures" : {
         "configs/arista_bgp" : {
-          "bgp peer-group" : {
-            "UNDEFINED_PEER_GROUP" : {
-              "bgp neighbor statement" : [
-                11
-              ]
-            }
-          },
           "route-map" : {
             "ROUTE_MAP" : {
               "bgp redistribute ospfv3 route-map" : [
@@ -92428,13 +92442,6 @@
       },
       "undefinedReferences" : {
         "configs/arista_bgp" : {
-          "bgp peer-group" : {
-            "UNDEFINED_PEER_GROUP" : {
-              "bgp neighbor statement" : [
-                11
-              ]
-            }
-          },
           "route-map" : {
             "UNDEFINED_MAP" : {
               "bgp redistribute ospfv3 route-map" : [
@@ -94660,6 +94667,26 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "Could not determine update source for BGP neighbor: '1.2.3.4'"
+            }
+          ]
+        },
+        "arista_bgp" : {
+          "Red flags" : [
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Router-id is not manually configured for BGP process in VRF default. Unable to infer default router-id as no interfaces have IP addresses"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Redistribution of OSPF_NSSA_EXTERNAL routes is not yet supported"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Redistribution of OSPF_NSSA_EXTERNAL_TYPE_1 routes is not yet supported"
+            },
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Redistribution of OSPF_NSSA_EXTERNAL_TYPE_2 routes is not yet supported"
             }
           ]
         },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -86880,6 +86880,13 @@
       },
       "referencedStructures" : {
         "configs/arista_bgp" : {
+          "bgp peer-group" : {
+            "UNDEFINED_PEER_GROUP" : {
+              "bgp neighbor peer-group" : [
+                11
+              ]
+            }
+          },
           "route-map" : {
             "ROUTE_MAP" : {
               "bgp redistribute ospfv3 route-map" : [
@@ -92442,6 +92449,13 @@
       },
       "undefinedReferences" : {
         "configs/arista_bgp" : {
+          "bgp peer-group" : {
+            "UNDEFINED_PEER_GROUP" : {
+              "bgp neighbor peer-group" : [
+                11
+              ]
+            }
+          },
           "route-map" : {
             "UNDEFINED_MAP" : {
               "bgp redistribute ospfv3 route-map" : [


### PR DESCRIPTION
* `aristabgp` debug flag is now a noop
* `noaristabgp` debug flag now allows reverting to the old hybrid parser
* Fix up syntax in some of our older tests that use EOS configs