### PR TITLE
maven: update license mergers and document BDD licenses

### DIFF
--- a/projects/bdd/pom.xml
+++ b/projects/bdd/pom.xml
@@ -11,6 +11,21 @@
 
   <artifactId>bdd</artifactId>
 
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <distribution>manual</distribution>
+      <comments>John Whaley gave permission to use this project under MIT license. See LICENSE.email.</comments>
+    </license>
+    <license>
+      <name>LGPL-2.0</name>
+      <url>https://www.gnu.org/licenses/old-licenses/lgpl-2.0.html</url>
+      <distribution>manual</distribution>
+      <comments>Original project license on sourceforge.net.</comments>
+    </license>
+  </licenses>
+
   <packaging>jar</packaging>
   <build>
     <plugins>

--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -408,10 +408,9 @@
           <version>${maven-license-plugin.version}</version>
           <configuration>
             <licenseMerges>
-              <licenseMerge>The Apache Software License, Version 2.0|Apache License, Version
-                2.0|Apache 2.0|Apache License 2.0
+              <licenseMerge>Apache-2.0|The Apache Software License, Version 2.0|Apache License, Version 2.0|Apache 2.0|Apache License 2.0|Apache 2|Apache License, 2.0
               </licenseMerge>
-              <licenseMerge>MIT License|MIT|MIT license</licenseMerge>
+              <licenseMerge>MIT|MIT License|MIT license|The MIT License</licenseMerge>
             </licenseMerges>
           </configuration>
         </plugin>


### PR DESCRIPTION
1. Improve name normalization
2. Document the BDD license as separate from project license.