### PR TITLE
FilterLineReachability: Better diffAction metric

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/PermitAndDenyBdds.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/PermitAndDenyBdds.java
@@ -41,4 +41,16 @@ public final class PermitAndDenyBdds {
     }
     return _matchBdd;
   }
+
+  /**
+   * Returns a new {@link PermitAndDenyBdds} with BDDs created by subtracting {@code subtrahend}
+   * from this object's BDDs.
+   */
+  public PermitAndDenyBdds diff(BDD subtrahend) {
+    return new PermitAndDenyBdds(_permitBdd.diff(subtrahend), _denyBdd.diff(subtrahend));
+  }
+
+  public boolean isZero() {
+    return _permitBdd.isZero() && _denyBdd.isZero();
+  }
 }

--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
@@ -22,7 +22,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
@@ -481,11 +481,38 @@ public class FilterLineReachabilityAnswerer extends Answerer {
             .thenComparing(LineAndWeight::getLine);
   }
 
+  /**
+   * Info about how some ACL line is blocked: which lines block it and whether any of them treat any
+   * packet differently than the blocked line would
+   */
+  static class BlockingProperties {
+    @Nonnull private final SortedSet<Integer> _blockingLineNums;
+    private final boolean _diffAction;
+
+    BlockingProperties(@Nonnull SortedSet<Integer> blockingLineNums, boolean diffAction) {
+      _blockingLineNums = blockingLineNums;
+      _diffAction = diffAction;
+    }
+
+    @Nonnull
+    SortedSet<Integer> getBlockingLineNums() {
+      return _blockingLineNums;
+    }
+
+    /**
+     * If true, indicates that some packet that matches the blocked line would be treated
+     * differently by some blocking line. (Does not require that the packet be able to reach that
+     * blocking line.)
+     */
+    boolean getDiffAction() {
+      return _diffAction;
+    }
+  }
+
   @VisibleForTesting
-  static SortedSet<Integer> findBlockingLinesForLine(
-      int blockedLineNum, List<LineAction> actions, List<BDD> bdds) {
-    BDD blockedLine = bdds.get(blockedLineNum);
-    @Nullable LineAction blockedLineAction = actions.get(blockedLineNum);
+  static BlockingProperties findBlockingPropsForLine(
+      int blockedLineNum, List<PermitAndDenyBdds> bdds) {
+    PermitAndDenyBdds blockedLine = bdds.get(blockedLineNum);
 
     ImmutableSortedSet.Builder<LineAndWeight> linesByWeight =
         ImmutableSortedSet.orderedBy(LineAndWeight.COMPARATOR);
@@ -497,19 +524,19 @@ public class FilterLineReachabilityAnswerer extends Answerer {
     // and weight each blocking line by that overlap.
     //
     // Finally, we record whether any of these lines has a different action than the blocked line.
-    BDD restOfLine = blockedLine;
+    PermitAndDenyBdds restOfLine = blockedLine;
     boolean diffAction = false; // true if some partially-blocking line has a different action.
     for (int prevLineNum = 0; prevLineNum < blockedLineNum && !restOfLine.isZero(); prevLineNum++) {
-      BDD prevLine = bdds.get(prevLineNum);
+      PermitAndDenyBdds prevLine = bdds.get(prevLineNum);
 
-      if (!prevLine.andSat(restOfLine)) {
+      if (!prevLine.getMatchBdd().andSat(restOfLine.getMatchBdd())) {
         continue;
       }
 
-      BDD blockedLineOverlap = prevLine.and(blockedLine);
+      BDD blockedLineOverlap = prevLine.getMatchBdd().and(blockedLine.getMatchBdd());
       linesByWeight.add(new LineAndWeight(prevLineNum, blockedLineOverlap.satCount()));
-      restOfLine = restOfLine.diff(prevLine);
-      diffAction = diffAction || actions.get(prevLineNum) != blockedLineAction;
+      diffAction = diffAction || takeDifferentActions(prevLine, restOfLine);
+      restOfLine = restOfLine.diff(prevLine.getMatchBdd());
     }
 
     // In this second loop, we compute the answer:
@@ -522,11 +549,12 @@ public class FilterLineReachabilityAnswerer extends Answerer {
     boolean needDiffAction = diffAction;
     for (LineAndWeight line : linesByWeight.build()) {
       int curLineNum = line.getLine();
-      boolean curDiff = actions.get(curLineNum) != blockedLineAction;
+      PermitAndDenyBdds curLine = bdds.get(curLineNum);
+      boolean curDiff = takeDifferentActions(curLine, blockedLine);
 
       // The original line is still not blocked, or this is the first line with a different action.
       if (!restOfLine.isZero() || needDiffAction && curDiff) {
-        restOfLine = restOfLine.diff(bdds.get(curLineNum));
+        restOfLine = restOfLine.diff(curLine.getMatchBdd());
         answerLines.add(curLineNum);
         needDiffAction = needDiffAction && !curDiff;
       }
@@ -537,7 +565,16 @@ public class FilterLineReachabilityAnswerer extends Answerer {
       }
     }
 
-    return answerLines.build();
+    return new BlockingProperties(answerLines.build(), diffAction);
+  }
+
+  /**
+   * Returns true if the lines represented by the given {@link PermitAndDenyBdds} can take different
+   * actions on the same packet
+   */
+  private static boolean takeDifferentActions(PermitAndDenyBdds bdds1, PermitAndDenyBdds bdds2) {
+    return bdds1.getPermitBdd().andSat(bdds2.getDenyBdd())
+        || bdds1.getDenyBdd().andSat(bdds2.getPermitBdd());
   }
 
   private static void answerAclReachabilityLine(
@@ -552,32 +589,25 @@ public class FilterLineReachabilityAnswerer extends Answerer {
     IpAccessList ipAcl = aclSpec.acl.getSanitizedAcl();
     List<AclLine> lines = ipAcl.getLines();
 
-    /* Convert every line to a BDD. */
-    List<BDD> ipLineToBDDMap =
-        lines.stream()
-            .map(ipAccessListToBdd::toPermitAndDenyBdds)
-            .map(PermitAndDenyBdds::getMatchBdd)
-            .collect(Collectors.toList());
+    /* Convert every line to permit and deny BDDs. */
+    List<PermitAndDenyBdds> ipLineToBDDMap =
+        lines.stream().map(ipAccessListToBdd::toPermitAndDenyBdds).collect(Collectors.toList());
 
     /* Pass over BDDs to classify each as unmatchable, unreachable, or (implicitly) reachable. */
     BDD unmatchedPackets = bddFactory.one(); // The packets that are not yet matched by the ACL.
-    ListIterator<BDD> lineIt = ipLineToBDDMap.listIterator();
-    ActionGetter actionGetter = new ActionGetter(false);
+    ListIterator<PermitAndDenyBdds> lineIt = ipLineToBDDMap.listIterator();
     while (lineIt.hasNext()) {
       int lineNum = lineIt.nextIndex();
-      BDD lineBDD = lineIt.next();
-      if (lineBDD.isZero()) {
+      PermitAndDenyBdds lineBDDs = lineIt.next();
+      if (lineBDDs.isZero()) {
         // This line is unmatchable
-        answerRows.addUnreachableLine(aclSpec, lineNum, true, ImmutableSortedSet.of());
-      } else if (unmatchedPackets.isZero() || !lineBDD.andSat(unmatchedPackets)) {
+        answerRows.addUnmatchableLine(aclSpec, lineNum);
+      } else if (unmatchedPackets.isZero() || !lineBDDs.getMatchBdd().andSat(unmatchedPackets)) {
         // No unmatched packets in the ACL match this line, so this line is unreachable.
-        List<LineAction> actions =
-            lines.stream().map(actionGetter::visit).collect(Collectors.toList());
-        SortedSet<Integer> blockingLines =
-            findBlockingLinesForLine(lineNum, actions, ipLineToBDDMap);
-        answerRows.addUnreachableLine(aclSpec, lineNum, false, blockingLines);
+        BlockingProperties blockingProps = findBlockingPropsForLine(lineNum, ipLineToBDDMap);
+        answerRows.addBlockedLine(aclSpec, lineNum, blockingProps);
       }
-      unmatchedPackets = unmatchedPackets.diff(lineBDD);
+      unmatchedPackets = unmatchedPackets.diff(lineBDDs.getMatchBdd());
     }
   }
 

--- a/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswererTest.java
@@ -650,14 +650,14 @@ public class FilterLineReachabilityAnswererTest {
 
     // last line (#4) is really blocked by (#3). Also report #0 as first line with diff action.
     List<LineAction> actions = ImmutableList.of(DENY, DENY, DENY, PERMIT, PERMIT);
-    List<PermitAndDenyBdds> permitAndDenyBdds = toPermitAndDenyBdds(bdds, actions, ZERO);
+    List<PermitAndDenyBdds> permitAndDenyBdds = toPermitAndDenyBdds(bdds, actions);
     BlockingProperties blockingProperties = findBlockingPropsForLine(4, permitAndDenyBdds);
     assertThat(blockingProperties.getBlockingLineNums(), contains(0, 3));
     assertTrue(blockingProperties.getDiffAction());
 
     // if there are no lines with different actions, only report #3.
     List<LineAction> sameActions = ImmutableList.of(PERMIT, PERMIT, PERMIT, PERMIT, PERMIT);
-    permitAndDenyBdds = toPermitAndDenyBdds(bdds, sameActions, ZERO);
+    permitAndDenyBdds = toPermitAndDenyBdds(bdds, sameActions);
     blockingProperties = findBlockingPropsForLine(4, permitAndDenyBdds);
     assertThat(blockingProperties.getBlockingLineNums(), contains(3));
     assertFalse(blockingProperties.getDiffAction());
@@ -678,14 +678,14 @@ public class FilterLineReachabilityAnswererTest {
     List<LineAction> actions = ImmutableList.of(PERMIT, DENY, PERMIT);
 
     // last line (#2) is blocked by both first two lines.
-    List<PermitAndDenyBdds> permitAndDenyBdds = toPermitAndDenyBdds(bdds, actions, ZERO);
+    List<PermitAndDenyBdds> permitAndDenyBdds = toPermitAndDenyBdds(bdds, actions);
     BlockingProperties blockingProperties = findBlockingPropsForLine(2, permitAndDenyBdds);
     assertThat(blockingProperties.getBlockingLineNums(), contains(0, 1));
     assertTrue(blockingProperties.getDiffAction());
 
     //  Action should not matter.
     List<LineAction> sameActions = ImmutableList.of(PERMIT, PERMIT, PERMIT);
-    permitAndDenyBdds = toPermitAndDenyBdds(bdds, sameActions, ZERO);
+    permitAndDenyBdds = toPermitAndDenyBdds(bdds, sameActions);
     blockingProperties = findBlockingPropsForLine(2, permitAndDenyBdds);
     assertThat(blockingProperties.getBlockingLineNums(), contains(0, 1));
     assertFalse(blockingProperties.getDiffAction());
@@ -706,7 +706,7 @@ public class FilterLineReachabilityAnswererTest {
     List<LineAction> actions = ImmutableList.of(PERMIT, DENY, PERMIT);
 
     // last line (#2) is blocked only by #0. #1 is ignored since it terminates no flows.
-    List<PermitAndDenyBdds> permitAndDenyBdds = toPermitAndDenyBdds(bdds, actions, ZERO);
+    List<PermitAndDenyBdds> permitAndDenyBdds = toPermitAndDenyBdds(bdds, actions);
     BlockingProperties blockingProperties = findBlockingPropsForLine(2, permitAndDenyBdds);
     assertThat(blockingProperties.getBlockingLineNums(), contains(0));
     assertFalse(blockingProperties.getDiffAction());
@@ -728,21 +728,21 @@ public class FilterLineReachabilityAnswererTest {
 
     // last line (#2) is blocked entirely by #1. But #0 is included since it matches with different
     // action.
-    List<PermitAndDenyBdds> permitAndDenyBdds = toPermitAndDenyBdds(bdds, actions, ZERO);
+    List<PermitAndDenyBdds> permitAndDenyBdds = toPermitAndDenyBdds(bdds, actions);
     BlockingProperties blockingProperties = findBlockingPropsForLine(2, permitAndDenyBdds);
     assertThat(blockingProperties.getBlockingLineNums(), contains(0, 1));
     assertTrue(blockingProperties.getDiffAction());
 
     // #0 is not included when all lines have same action.
     List<LineAction> sameActions = ImmutableList.of(PERMIT, PERMIT, PERMIT);
-    permitAndDenyBdds = toPermitAndDenyBdds(bdds, sameActions, ZERO);
+    permitAndDenyBdds = toPermitAndDenyBdds(bdds, sameActions);
     blockingProperties = findBlockingPropsForLine(2, permitAndDenyBdds);
     assertThat(blockingProperties.getBlockingLineNums(), contains(1));
     assertFalse(blockingProperties.getDiffAction());
 
     // #0 is not included despite different action when #1 already has different action.
     List<LineAction> actionsAndCover = ImmutableList.of(DENY, DENY, PERMIT);
-    permitAndDenyBdds = toPermitAndDenyBdds(bdds, actionsAndCover, ZERO);
+    permitAndDenyBdds = toPermitAndDenyBdds(bdds, actionsAndCover);
     blockingProperties = findBlockingPropsForLine(2, permitAndDenyBdds);
     assertThat(blockingProperties.getBlockingLineNums(), contains(1));
     assertTrue(blockingProperties.getDiffAction());
@@ -768,13 +768,13 @@ public class FilterLineReachabilityAnswererTest {
     // last line (#2) is blocked entirely by #1. Since #1 has a different action, and even though #0
     // matches many packets, we will not include #0 independent of action of #0.
     List<LineAction> actions = ImmutableList.of(PERMIT, DENY, PERMIT);
-    List<PermitAndDenyBdds> permitAndDenyBdds = toPermitAndDenyBdds(bdds, actions, ZERO);
+    List<PermitAndDenyBdds> permitAndDenyBdds = toPermitAndDenyBdds(bdds, actions);
     BlockingProperties blockingProperties = findBlockingPropsForLine(2, permitAndDenyBdds);
     assertThat(blockingProperties.getBlockingLineNums(), contains(1));
     assertTrue(blockingProperties.getDiffAction());
 
     List<LineAction> sameActions = ImmutableList.of(DENY, DENY, PERMIT);
-    permitAndDenyBdds = toPermitAndDenyBdds(bdds, sameActions, ZERO);
+    permitAndDenyBdds = toPermitAndDenyBdds(bdds, sameActions);
     blockingProperties = findBlockingPropsForLine(2, permitAndDenyBdds);
     assertThat(blockingProperties.getBlockingLineNums(), contains(1));
     assertTrue(blockingProperties.getDiffAction());
@@ -850,7 +850,7 @@ public class FilterLineReachabilityAnswererTest {
   }
 
   private static List<PermitAndDenyBdds> toPermitAndDenyBdds(
-      List<BDD> bdds, List<LineAction> actions, BDD ZERO) {
+      List<BDD> bdds, List<LineAction> actions) {
     assert bdds.size() == actions.size();
     return IntStream.range(0, bdds.size())
         .mapToObj(


### PR DESCRIPTION
Previously, we were conservatively setting `diffAction` to `true` if the blocked line or any blocking line was an `AclAclLine`. This PR updates the answerer to more carefully examine blocking lines' `PermitAndDenyBdds`. Now `diffAction` is only true if there is a packet permitted by the blocked line that would be denied by one of its blocking lines or vice versa.