### PR TITLE
FRR: assume zero for first unsequenced line

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -1004,7 +1004,10 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     } else {
       // Round up to the next multiple of 5
       // http://docs.frrouting.org/en/latest/filter.html#clicmd-ipprefix-listNAMEseqNUMBER(permit|deny)PREFIX[leLEN][geLEN]
-      Long lastNum = _currentIpPrefixList.getLines().lastKey();
+      Long lastNum =
+          _currentIpPrefixList.getLines().isEmpty()
+              ? 0L
+              : _currentIpPrefixList.getLines().lastKey();
       num = nextMultipleOfFive(lastNum);
     }
     LineAction action = ctx.action.permit != null ? LineAction.PERMIT : LineAction.DENY;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -974,7 +974,21 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
-  public void testCumulusFrrIpPrefixListNoSeq() {
+  public void testCumulusFrrIpPrefixListNoSeqOnFirstEntry() {
+    String name = "NAME";
+    String prefix1 = "10.0.0.1/24";
+    parse(String.format("ip prefix-list %s permit %s\n", name, prefix1));
+    assertThat(_frr.getIpPrefixLists().keySet(), equalTo(ImmutableSet.of(name)));
+    IpPrefixList prefixList = _frr.getIpPrefixLists().get(name);
+    IpPrefixListLine line1 = prefixList.getLines().get(5L);
+    assertThat(line1.getLine(), equalTo(5L));
+    assertThat(line1.getAction(), equalTo(LineAction.PERMIT));
+    assertThat(line1.getLengthRange(), equalTo(SubRange.singleton(24)));
+    assertThat(line1.getPrefix(), equalTo(Prefix.parse("10.0.0.1/24")));
+  }
+
+  @Test
+  public void testCumulusFrrIpPrefixListNoSeqOnLaterEntry() {
     String name = "NAME";
     String prefix1 = "10.0.0.1/24";
     String prefix2 = "10.0.1.2/24";


### PR DESCRIPTION
Fixes parser crash when we have to infer the sequence number for a route map for which no sequence numbers currently exist. 