### PR TITLE
Frr fix default originate

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -1004,7 +1004,10 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     } else {
       // Round up to the next multiple of 5
       // http://docs.frrouting.org/en/latest/filter.html#clicmd-ipprefix-listNAMEseqNUMBER(permit|deny)PREFIX[leLEN][geLEN]
-      Long lastNum = _currentIpPrefixList.getLines().lastKey();
+      Long lastNum =
+          _currentIpPrefixList.getLines().isEmpty()
+              ? 0L
+              : _currentIpPrefixList.getLines().lastKey();
       num = nextMultipleOfFive(lastNum);
     }
     LineAction action = ctx.action.permit != null ? LineAction.PERMIT : LineAction.DENY;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -1004,10 +1004,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     } else {
       // Round up to the next multiple of 5
       // http://docs.frrouting.org/en/latest/filter.html#clicmd-ipprefix-listNAMEseqNUMBER(permit|deny)PREFIX[leLEN][geLEN]
-      Long lastNum =
-          _currentIpPrefixList.getLines().isEmpty()
-              ? 0L
-              : _currentIpPrefixList.getLines().lastKey();
+      Long lastNum = _currentIpPrefixList.getLines().lastKey();
       num = nextMultipleOfFive(lastNum);
     }
     LineAction action = ctx.action.permit != null ? LineAction.PERMIT : LineAction.DENY;

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -534,6 +534,8 @@ public final class CumulusConversions {
             .setOwner(c)
             .setName(computeBgpPeerExportPolicyName(vrfName, neighbor.getName()));
 
+    // If default originate is set for a neighbor, we will send it a "fresh" default route is not
+    // subjected to the neighbor's outgoing route map. We will drop other default routes.
     if (bgpDefaultOriginate(neighbor)) {
       initBgpDefaultRouteExportPolicy(vrfName, neighbor.getName(), true, null, c);
       peerExportPolicy.addStatement(
@@ -543,10 +545,9 @@ public final class CumulusConversions {
                   computeBgpDefaultRouteExportPolicyName(true, vrfName, neighbor.getName())),
               singletonList(Statements.ReturnTrue.toStaticStatement()),
               ImmutableList.of()));
+
+      peerExportPolicy.addStatement(REJECT_DEFAULT_ROUTE);
     }
-    // FRR does not advertise default routes even if they are in the routing table:
-    // https://readthedocs.org/projects/frrouting/downloads/pdf/stable-5.0/
-    peerExportPolicy.addStatement(REJECT_DEFAULT_ROUTE);
 
     BooleanExpr peerExportConditions = computePeerExportConditions(neighbor, bgpVrf);
     List<Statement> acceptStmts = getAcceptStatements(neighbor, bgpVrf);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -43,7 +43,6 @@ import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.Warning;
 import org.batfish.common.Warnings;
 import org.batfish.config.Settings;
-import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
@@ -382,11 +381,22 @@ public class CumulusFrrGrammarTest {
   @Test
   public void testBgpAddressFamilyNeighborDefaultOriginate_behavior() throws IOException {
     /*
-    The implemented behavior with default-originate is that the default route will be advertised unconditionally.
-    TODO: Check if this behavior is actually correct.
+     There are four nodes in the topology arranged in a line.
+       - frr-originator -- frr-reoriginator -- frr-propagator -- ios-listener
+
+     frr-originator has default-originate.
+
+     frr-reoriginator also has default-originate. it should generate a fresh route not propagate
+        the one it got from frr-originator. it also has a route map toward frr-propagator that
+        drops default (but shouldn't interfere with default-originate)
+
+     frr-propagator does not default-originate. it should propagate the default it got from
+         frr-reoriginator to ios-listener
     */
+
     String snapshotName = "default-originate";
-    List<String> configurationNames = ImmutableList.of("frr-originator", "ios-listener");
+    List<String> configurationNames =
+        ImmutableList.of("frr-originator", "frr-reoriginator", "frr-propagator", "ios-listener");
     Batfish batfish =
         BatfishTestUtils.getBatfishFromTestrigText(
             TestrigText.builder()
@@ -397,23 +407,60 @@ public class CumulusFrrGrammarTest {
     NetworkSnapshot snapshot = batfish.getSnapshot();
     batfish.computeDataPlane(snapshot);
     DataPlane dp = batfish.loadDataPlane(snapshot);
-    Set<AbstractRoute> listenerRoutes =
-        dp.getRibs().get("ios-listener").get(DEFAULT_VRF_NAME).getRoutes();
 
-    Bgpv4Route expectedDefaultRoute =
-        Bgpv4Route.builder()
-            .setNetwork(Prefix.ZERO)
-            .setNextHopIp(Ip.parse("10.1.1.1"))
-            .setReceivedFromIp(Ip.parse("10.1.1.1"))
-            .setOriginatorIp(Ip.parse("1.1.1.1"))
-            .setOriginType(OriginType.INCOMPLETE)
-            .setProtocol(RoutingProtocol.BGP)
-            .setSrcProtocol(RoutingProtocol.BGP)
-            .setAsPath(AsPath.ofSingletonAsSets(1L))
-            .setAdmin(20)
-            .setLocalPreference(100)
-            .build();
-    assertThat(listenerRoutes, hasItem(equalTo(expectedDefaultRoute)));
+    // frr-reoriginator should get a default route from frr-originator
+    assertThat(
+        dp.getRibs().get("frr-reoriginator").get(DEFAULT_VRF_NAME).getRoutes(),
+        hasItem(
+            equalTo(
+                Bgpv4Route.builder()
+                    .setNetwork(Prefix.ZERO)
+                    .setNextHopIp(Ip.parse("10.1.1.1"))
+                    .setReceivedFromIp(Ip.parse("10.1.1.1"))
+                    .setOriginatorIp(Ip.parse("1.1.1.1"))
+                    .setOriginType(OriginType.INCOMPLETE)
+                    .setProtocol(RoutingProtocol.BGP)
+                    .setSrcProtocol(RoutingProtocol.BGP)
+                    .setAsPath(AsPath.ofSingletonAsSets(1L))
+                    .setAdmin(20)
+                    .setLocalPreference(100)
+                    .build())));
+
+    // frr-propagator should get a fresh default route from frr-originator
+    assertThat(
+        dp.getRibs().get("frr-propagator").get(DEFAULT_VRF_NAME).getRoutes(),
+        hasItem(
+            equalTo(
+                Bgpv4Route.builder()
+                    .setNetwork(Prefix.ZERO)
+                    .setNextHopIp(Ip.parse("20.1.1.2"))
+                    .setReceivedFromIp(Ip.parse("20.1.1.2"))
+                    .setOriginatorIp(Ip.parse("2.2.2.2"))
+                    .setOriginType(OriginType.INCOMPLETE)
+                    .setProtocol(RoutingProtocol.BGP)
+                    .setSrcProtocol(RoutingProtocol.BGP)
+                    .setAsPath(AsPath.ofSingletonAsSets(2L)) // fresh route with only one AS
+                    .setAdmin(20)
+                    .setLocalPreference(100)
+                    .build())));
+
+    // ios-listener should get a propagated route from frr-propagator
+    assertThat(
+        dp.getRibs().get("ios-listener").get(DEFAULT_VRF_NAME).getRoutes(),
+        hasItem(
+            equalTo(
+                Bgpv4Route.builder()
+                    .setNetwork(Prefix.ZERO)
+                    .setNextHopIp(Ip.parse("30.1.1.3"))
+                    .setReceivedFromIp(Ip.parse("30.1.1.3"))
+                    .setOriginatorIp(Ip.parse("3.3.3.3"))
+                    .setOriginType(OriginType.INCOMPLETE)
+                    .setProtocol(RoutingProtocol.BGP)
+                    .setSrcProtocol(RoutingProtocol.BGP)
+                    .setAsPath(AsPath.ofSingletonAsSets(3L, 2L)) // propagated route
+                    .setAdmin(20)
+                    .setLocalPreference(100)
+                    .build())));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -539,16 +539,6 @@ public final class CumulusConversionsTest {
         BgpActivePeerConfig.builder().setPeerAddress(peerIp);
     generateBgpCommonPeerConfig(
         viConfig, vsConfig, neighbor, 10000L, new BgpVrf("vrf"), newProc, peerConfigBuilder);
-
-    // We test exact match with the constant REJECT_DEFAULT_ROUTE here. The constant is
-    // tested in testRejectDefaultRoute()
-    assertThat(
-        viConfig
-            .getRoutingPolicies()
-            .get(computeBgpPeerExportPolicyName("vrf", neighbor.getName()))
-            .getStatements()
-            .get(0),
-        equalTo(REJECT_DEFAULT_ROUTE));
   }
 
   @Test
@@ -646,6 +636,16 @@ public final class CumulusConversionsTest {
     assertThat(
         newProc.getActiveNeighbors().get(peerIp.toPrefix()).getGeneratedRoutes(),
         equalTo(ImmutableSet.of(GENERATED_DEFAULT_ROUTE)));
+
+    // We test exact match with the constant REJECT_DEFAULT_ROUTE here. The constant is
+    // tested in testRejectDefaultRoute()
+    assertThat(
+        viConfig
+            .getRoutingPolicies()
+            .get(computeBgpPeerExportPolicyName("vrf", neighbor.getName()))
+            .getStatements()
+            .get(1),
+        equalTo(REJECT_DEFAULT_ROUTE));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_frr/snapshots/default-originate/configs/frr-originator
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_frr/snapshots/default-originate/configs/frr-originator
@@ -24,8 +24,5 @@ router bgp 1
   neighbor 10.1.1.2 default-originate
  exit-address-family
 !
-route-map LOOPBACKS permit 10
-  match interface lo
-!
 end
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_frr/snapshots/default-originate/configs/frr-propagator
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_frr/snapshots/default-originate/configs/frr-propagator
@@ -1,0 +1,31 @@
+frr-propagator
+# This file describes the network interfaces
+auto lo
+iface lo inet loopback
+
+auto swp1
+iface swp1
+
+auto swp2
+iface swp2
+
+# ports.conf --
+frr version
+frr defaults datacenter
+!
+interface lo
+ ip address 3.3.3.3/32
+!
+interface swp1
+ ip address 20.1.1.3/24
+!
+interface swp1
+ ip address 30.1.1.3/24
+!
+router bgp 3
+ bgp router-id 3.3.3.3
+ neighbor 20.1.1.2 remote-as 2
+ neighbor 30.1.1.4 remote-as 4
+!
+end
+

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_frr/snapshots/default-originate/configs/frr-reoriginator
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_frr/snapshots/default-originate/configs/frr-reoriginator
@@ -1,0 +1,41 @@
+frr-reoriginator
+# This file describes the network interfaces
+auto lo
+iface lo inet loopback
+
+auto swp1
+iface swp1
+
+auto swp2
+iface swp2
+
+# ports.conf --
+frr version
+frr defaults datacenter
+!
+interface lo
+ ip address 2.2.2.2/32
+!
+interface swp1
+ ip address 10.1.1.2/24
+!
+interface swp1
+ ip address 20.1.1.2/24
+!
+router bgp 2
+ bgp router-id 2.2.2.2
+ neighbor 10.1.1.1 remote-as 1
+ neighbor 20.1.1.3 remote-as 3
+ !
+ address-family ipv4 unicast
+  neighbor 20.1.1.3 default-originate
+  neighbor 20.1.1.3 route-map RM_TEST out
+ exit-address-family
+!
+ip prefix-list PL_DEFAULT seq 5 permit 0.0.0.0/0
+!
+route-map RM_TEST deny 10
+ match ip address prefix-list PL_DEFAULT
+!
+end
+

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_frr/snapshots/default-originate/configs/ios-listener
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_frr/snapshots/default-originate/configs/ios-listener
@@ -2,12 +2,12 @@
 hostname ios-listener
 !
 interface Loopback0
- ip address 2.2.2.2 255.255.255.255
+ ip address 4.4.4.4 255.255.255.255
 !
 interface FastEthernet0/0
-  ip address 10.1.1.2 255.255.255.0
+  ip address 30.1.1.4 255.255.255.0
 !
-router bgp 2
-  bgp router-id 2.2.2.2
-  neighbor 10.1.1.1 remote-as 1
+router bgp 4
+  bgp router-id 4.4.4.4
+  neighbor 30.1.1.3 remote-as 3
 !

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -15193,28 +15193,6 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                  "comment" : "match default route",
-                  "prefix" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                  },
-                  "prefixSet" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                    "prefixSpace" : [
-                      "0.0.0.0/0"
-                    ]
-                  }
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnFalse"
-                  }
-                ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
                 "falseStatements" : [
                   {
@@ -15240,28 +15218,6 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                  "comment" : "match default route",
-                  "prefix" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                  },
-                  "prefixSet" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                    "prefixSpace" : [
-                      "0.0.0.0/0"
-                    ]
-                  }
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnFalse"
-                  }
-                ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
                 "falseStatements" : [
                   {
@@ -15285,28 +15241,6 @@
           "~BGP_PEER_EXPORT_POLICY:default:swp3~" : {
             "name" : "~BGP_PEER_EXPORT_POLICY:default:swp3~",
             "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                  "comment" : "match default route",
-                  "prefix" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                  },
-                  "prefixSet" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                    "prefixSpace" : [
-                      "0.0.0.0/0"
-                    ]
-                  }
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnFalse"
-                  }
-                ]
-              },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
@@ -15681,28 +15615,6 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                  "comment" : "match default route",
-                  "prefix" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                  },
-                  "prefixSet" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                    "prefixSpace" : [
-                      "0.0.0.0/0"
-                    ]
-                  }
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnFalse"
-                  }
-                ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",
                 "falseStatements" : [
                   {
@@ -15726,28 +15638,6 @@
           "~BGP_PEER_EXPORT_POLICY:vrf1:1.1.1.2~" : {
             "name" : "~BGP_PEER_EXPORT_POLICY:vrf1:1.1.1.2~",
             "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                  "comment" : "match default route",
-                  "prefix" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                  },
-                  "prefixSet" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                    "prefixSpace" : [
-                      "0.0.0.0/0"
-                    ]
-                  }
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnFalse"
-                  }
-                ]
-              },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "comment" : "peer-export policy main conditional: exitAccept if true / exitReject if false",


### PR DESCRIPTION
Vagrant tests showed the following about FRR semantics
  - if `default-originate` is present, a new default to sent toward the neighbor, irrespective of whether there is another default route in the RIB. (That is, other defaults are ignored.)
  - default-originated routes do not go through the neighbor-level route map. (there can be a separate route map attached to default-originate command, but we don't support that yet.)
  - without the default-originate, default is treated like any other route (i.e., propagated per policy). 