### PR TITLE
FRR: export networks at VRF level

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpVrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpVrf.java
@@ -16,10 +16,7 @@ public class BgpVrf implements Serializable {
   private @Nullable Long _autonomousSystem;
   private @Nullable Boolean _asPathMultipathRelax;
   private final @Nonnull Map<String, BgpNeighbor> _neighbors;
-
-  // TODO: this needs to move to VI after testing behavior
   private @Nonnull Map<Prefix, BgpNetwork> _networks;
-
   private @Nullable BgpIpv4UnicastAddressFamily _ipv4Unicast;
   private @Nullable BgpL2vpnEvpnAddressFamily _l2VpnEvpn;
   private @Nullable Ip _routerId;
@@ -32,6 +29,10 @@ public class BgpVrf implements Serializable {
     _vrfName = vrfName;
     _neighbors = new HashMap<>();
     _networks = ImmutableMap.of();
+  }
+
+  public boolean isIpv4UnicastActive() {
+    return _defaultIpv4Unicast || (_ipv4Unicast != null);
   }
 
   public boolean getDefaultIpv4Unicast() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpVrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpVrf.java
@@ -31,10 +31,6 @@ public class BgpVrf implements Serializable {
     _networks = ImmutableMap.of();
   }
 
-  public boolean isIpv4UnicastActive() {
-    return _defaultIpv4Unicast || (_ipv4Unicast != null);
-  }
-
   public boolean getDefaultIpv4Unicast() {
     return _defaultIpv4Unicast;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpVrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpVrf.java
@@ -31,6 +31,10 @@ public class BgpVrf implements Serializable {
     _networks = ImmutableMap.of();
   }
 
+  public boolean isIpv4UnicastActive() {
+    return _defaultIpv4Unicast || (_ipv4Unicast != null);
+  }
+
   public boolean getDefaultIpv4Unicast() {
     return _defaultIpv4Unicast;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -388,15 +388,17 @@ public final class CumulusConversions {
       newProc.setConfederation(new BgpConfederation(confederationId, ImmutableSet.of(asn)));
     }
 
-    BgpIpv4UnicastAddressFamily ipv4Unicast =
-        firstNonNull(bgpVrf.getIpv4Unicast(), new BgpIpv4UnicastAddressFamily());
+    if (bgpVrf.isIpv4UnicastActive()) {
+      BgpIpv4UnicastAddressFamily ipv4Unicast =
+          firstNonNull(bgpVrf.getIpv4Unicast(), new BgpIpv4UnicastAddressFamily());
 
-    // Add networks from network statements to new process's origination space
-    Sets.union(bgpVrf.getNetworks().keySet(), ipv4Unicast.getNetworks().keySet())
-        .forEach(newProc::addToOriginationSpace);
+      // Add networks from network statements to new process's origination space
+      Sets.union(bgpVrf.getNetworks().keySet(), ipv4Unicast.getNetworks().keySet())
+          .forEach(newProc::addToOriginationSpace);
 
-    // Generate aggregate routes
-    generateGeneratedRoutes(c, c.getVrfs().get(vrfName), ipv4Unicast.getAggregateNetworks());
+      // Generate aggregate routes
+      generateGeneratedRoutes(c, c.getVrfs().get(vrfName), ipv4Unicast.getAggregateNetworks());
+    }
 
     generateBgpCommonExportPolicy(c, vrfName, bgpVrf, vsConfig.getRouteMaps());
 
@@ -816,8 +818,8 @@ public final class CumulusConversions {
     exportConditions.add(new MatchProtocol(RoutingProtocol.BGP, RoutingProtocol.IBGP));
 
     // we don't need to process redist policies and network statements (inside v4 address family or
-    // bgp-vrf-level) if v4 address family is not turned on
-    if (!bgpVrf.getDefaultIpv4Unicast() && bgpVrf.getIpv4Unicast() == null) {
+    // bgp-vrf-level) if v4 address family is not active
+    if (!bgpVrf.isIpv4UnicastActive()) {
       return exportConditions;
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -815,7 +815,12 @@ public final class CumulusConversions {
     // Always export BGP and iBGP routes
     exportConditions.add(new MatchProtocol(RoutingProtocol.BGP, RoutingProtocol.IBGP));
 
-    // Use an empty BgpIpv4UnicastAddressFamily object to simplify the subsequent code
+    // we don't need to process redist policies and network statements (inside v4 address family or
+    // bgp-vrf-level) if v4 address family is not turned on
+    if (!bgpVrf.getDefaultIpv4Unicast() && bgpVrf.getIpv4Unicast() == null) {
+      return exportConditions;
+    }
+
     BgpIpv4UnicastAddressFamily bgpIpv4UnicastAddressFamily =
         firstNonNull(bgpVrf.getIpv4Unicast(), new BgpIpv4UnicastAddressFamily());
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -815,10 +815,7 @@ public final class CumulusConversions {
     // Always export BGP and iBGP routes
     exportConditions.add(new MatchProtocol(RoutingProtocol.BGP, RoutingProtocol.IBGP));
 
-    if (!bgpVrf.isIpv4UnicastActive()) {
-      return exportConditions;
-    }
-
+    // Use an empty BgpIpv4UnicastAddressFamily object to simplify the subsequent code
     BgpIpv4UnicastAddressFamily bgpIpv4UnicastAddressFamily =
         firstNonNull(bgpVrf.getIpv4Unicast(), new BgpIpv4UnicastAddressFamily());
 


### PR DESCRIPTION
Add VI conversion for BGP VRF level network statements (not inside v4 address family stanza). If the address family is active, the prefixes in these statements are advertised like those inside the v4 address family. They are ignored if the v4 address family is not active.