### PR TITLE
Clean up CompareFilters

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/IpAccessListToBdd.java
@@ -155,18 +155,19 @@ public abstract class IpAccessListToBdd {
   }
 
   /**
-   * Return the set matched by each line (and no earlier line). The last element is the set
-   * unmatched by any line.
+   * Return the {@link PermitAndDenyBdds} matched by each line (and no earlier line). The last
+   * element is a {@link PermitAndDenyBdds} representing default action: permits nothing, denies all
+   * unmatched packets.
    */
-  public List<BDD> reachAndMatchLines(IpAccessList acl) {
-    ImmutableList.Builder<BDD> bdds = ImmutableList.builder();
+  public List<PermitAndDenyBdds> reachAndMatchLines(IpAccessList acl) {
+    ImmutableList.Builder<PermitAndDenyBdds> bdds = ImmutableList.builder();
     BDD reach = _pkt.getFactory().one();
     for (AclLine line : acl.getLines()) {
-      BDD match = convert(line).getMatchBdd();
-      bdds.add(reach.and(match));
-      reach = reach.diff(match);
+      PermitAndDenyBdds match = convert(line);
+      bdds.add(match.and(reach));
+      reach = reach.diff(match.getMatchBdd());
     }
-    bdds.add(reach);
+    bdds.add(new PermitAndDenyBdds(_pkt.getFactory().zero(), reach));
     return bdds.build();
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/PermitAndDenyBdds.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/PermitAndDenyBdds.java
@@ -1,6 +1,8 @@
 package org.batfish.common.bdd;
 
+import java.util.Objects;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 import org.batfish.datamodel.AclLine;
@@ -19,6 +21,15 @@ public final class PermitAndDenyBdds {
   public PermitAndDenyBdds(BDD permit, BDD deny) {
     _permitBdd = permit;
     _denyBdd = deny;
+  }
+
+  /**
+   * Returns true if the lines represented by the given {@link PermitAndDenyBdds} can take different
+   * actions on the same packet
+   */
+  public static boolean takeDifferentActions(PermitAndDenyBdds bdds1, PermitAndDenyBdds bdds2) {
+    return bdds1.getPermitBdd().andSat(bdds2.getDenyBdd())
+        || bdds1.getDenyBdd().andSat(bdds2.getPermitBdd());
   }
 
   /** BDD of all flows explicitly matched and permitted */
@@ -43,14 +54,40 @@ public final class PermitAndDenyBdds {
   }
 
   /**
+   * Returns a new {@link PermitAndDenyBdds} with BDDs created by {@link BDD#and anding} {@code bdd}
+   * with this object's BDDs.
+   */
+  @Nonnull
+  public PermitAndDenyBdds and(BDD bdd) {
+    return new PermitAndDenyBdds(_permitBdd.and(bdd), _denyBdd.and(bdd));
+  }
+
+  /**
    * Returns a new {@link PermitAndDenyBdds} with BDDs created by subtracting {@code subtrahend}
    * from this object's BDDs.
    */
+  @Nonnull
   public PermitAndDenyBdds diff(BDD subtrahend) {
     return new PermitAndDenyBdds(_permitBdd.diff(subtrahend), _denyBdd.diff(subtrahend));
   }
 
   public boolean isZero() {
     return _permitBdd.isZero() && _denyBdd.isZero();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof PermitAndDenyBdds)) {
+      return false;
+    }
+    PermitAndDenyBdds o = (PermitAndDenyBdds) obj;
+    return _permitBdd.equals(o._permitBdd) && _denyBdd.equals(o._denyBdd);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_permitBdd, _denyBdd);
   }
 }

--- a/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/filterlinereachability/FilterLineReachabilityAnswerer.java
@@ -1,6 +1,7 @@
 package org.batfish.question.filterlinereachability;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.batfish.common.bdd.PermitAndDenyBdds.takeDifferentActions;
 import static org.batfish.question.filterlinereachability.FilterLineReachabilityRows.createMetadata;
 import static org.batfish.question.filterlinereachability.FilterLineReachabilityUtils.getReferencedAcls;
 import static org.batfish.question.filterlinereachability.FilterLineReachabilityUtils.getReferencedInterfaces;
@@ -566,15 +567,6 @@ public class FilterLineReachabilityAnswerer extends Answerer {
     }
 
     return new BlockingProperties(answerLines.build(), diffAction);
-  }
-
-  /**
-   * Returns true if the lines represented by the given {@link PermitAndDenyBdds} can take different
-   * actions on the same packet
-   */
-  private static boolean takeDifferentActions(PermitAndDenyBdds bdds1, PermitAndDenyBdds bdds2) {
-    return bdds1.getPermitBdd().andSat(bdds2.getDenyBdd())
-        || bdds1.getDenyBdd().andSat(bdds2.getPermitBdd());
   }
 
   private static void answerAclReachabilityLine(

--- a/projects/question/src/test/java/org/batfish/question/comparefilters/CompareFiltersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/comparefilters/CompareFiltersAnswererTest.java
@@ -37,7 +37,7 @@ public final class CompareFiltersAnswererTest {
 
   private static List<FilterDifference> compare(
       List<PermitAndDenyBdds> currentBdds, List<PermitAndDenyBdds> referenceBdds) {
-    return compareFilters(HOSTNAME, FILTER, currentBdds, referenceBdds)
+    return compareFilters(HOSTNAME, FILTER, currentBdds, referenceBdds, PKT)
         .collect(Collectors.toList());
   }
 

--- a/projects/question/src/test/java/org/batfish/question/comparefilters/CompareFiltersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/comparefilters/CompareFiltersAnswererTest.java
@@ -11,31 +11,33 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import net.sf.javabdd.BDD;
 import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.PermitAndDenyBdds;
 import org.batfish.datamodel.LineAction;
-import org.junit.Before;
 import org.junit.Test;
 
 public final class CompareFiltersAnswererTest {
   private static final String HOSTNAME = "hostname";
   private static final String FILTER = "filter";
-
-  private BDDPacket _pkt;
-
-  @Before
-  public void setup() {
-    _pkt = new BDDPacket();
-  }
+  private static final BDDPacket PKT = new BDDPacket();
+  private static final BDD ZERO = PKT.getFactory().zero();
 
   private static List<FilterDifference> compare(
       List<LineAction> currentActions,
       List<BDD> currentBdds,
       List<LineAction> referenceActions,
       List<BDD> referenceBdds) {
-    return compareFilters(
-            HOSTNAME, FILTER, currentActions, currentBdds, referenceActions, referenceBdds)
+    List<PermitAndDenyBdds> currentLineBdds = toPermitAndDenyBdds(currentActions, currentBdds);
+    List<PermitAndDenyBdds> refLineBdds = toPermitAndDenyBdds(referenceActions, referenceBdds);
+    return compare(currentLineBdds, refLineBdds);
+  }
+
+  private static List<FilterDifference> compare(
+      List<PermitAndDenyBdds> currentBdds, List<PermitAndDenyBdds> referenceBdds) {
+    return compareFilters(HOSTNAME, FILTER, currentBdds, referenceBdds)
         .collect(Collectors.toList());
   }
 
@@ -48,7 +50,7 @@ public final class CompareFiltersAnswererTest {
     checkArgument(lineBdds.length > 0);
 
     ImmutableList.Builder<BDD> aclBdds = ImmutableList.builder();
-    BDD reach = _pkt.getFactory().one();
+    BDD reach = PKT.getFactory().one();
     for (BDD lineBdd : lineBdds) {
       aclBdds.add(reach.and(lineBdd));
       reach = reach.and(lineBdd.not());
@@ -60,16 +62,16 @@ public final class CompareFiltersAnswererTest {
 
   @Test
   public void testCompareFilters() {
-    BDD dstIp0 = _pkt.getDstIp().value(0);
-    BDD dstIp1 = _pkt.getDstIp().value(1);
-    BDD srcIp0 = _pkt.getSrcIp().value(0);
-    BDD dstPort0 = _pkt.getDstPort().value(0);
-    BDD srcPort0 = _pkt.getSrcPort().value(0);
+    BDD dstIp0 = PKT.getDstIp().value(0);
+    BDD dstIp1 = PKT.getDstIp().value(1);
+    BDD srcIp0 = PKT.getSrcIp().value(0);
+    BDD dstPort0 = PKT.getDstPort().value(0);
+    BDD srcPort0 = PKT.getSrcPort().value(0);
 
     List<BDD> zeroBdds = aclBdds(dstIp0, srcIp0, dstPort0, srcPort0);
 
     // Representation of an empty Acl.
-    List<BDD> emptyAclBdds = ImmutableList.of(_pkt.getFactory().one());
+    List<BDD> emptyAclBdds = ImmutableList.of(PKT.getFactory().one());
     List<LineAction> emptyAclActions = ImmutableList.of();
 
     List<LineAction> pppp = ImmutableList.of(PERMIT, PERMIT, PERMIT, PERMIT);
@@ -111,5 +113,20 @@ public final class CompareFiltersAnswererTest {
           compare,
           contains(difference(0, 1), difference(0, 3), difference(1, 0), difference(3, 0)));
     }
+  }
+
+  private static List<PermitAndDenyBdds> toPermitAndDenyBdds(
+      List<LineAction> actions, List<BDD> bdds) {
+    // bdds should have one more element than actions, representing the default denied packets
+    assert bdds.size() == actions.size() + 1;
+    return IntStream.range(0, bdds.size())
+        .mapToObj(
+            i -> {
+              LineAction action = i == actions.size() ? DENY : actions.get(i);
+              return action == PERMIT
+                  ? new PermitAndDenyBdds(bdds.get(i), ZERO)
+                  : new PermitAndDenyBdds(ZERO, bdds.get(i));
+            })
+        .collect(ImmutableList.toImmutableList());
   }
 }


### PR DESCRIPTION
CompareFilters now uses the same metric for whether lines take different actions as FilterLineReachability.