### PR TITLE
FRR: merge loopback parsing with other interfaces

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesParser.g4
@@ -37,7 +37,7 @@ si_inet
 :
   INET
   (
-    LOOPBACK NEWLINE l_property*
+    LOOPBACK NEWLINE i_property*
     | DHCP NEWLINE i_property*
     | MANUAL NEWLINE i_property*
     | STATIC NEWLINE i_property*
@@ -49,30 +49,6 @@ si_no_inet
     NEWLINE i_property*
 ;
 
-// loopback interface properties
-l_property
-:
-    l_address
-  | l_alias
-  | l_clagd_vxlan_anycast_ip
-;
-
-l_address
-:
-  ADDRESS prefix NEWLINE
-;
-
-l_alias
-:
-   ALIAS TEXT NEWLINE
-;
-
-l_clagd_vxlan_anycast_ip
-:
-  CLAGD_VXLAN_ANYCAST_IP IP_ADDRESS NEWLINE
-;
-
-// regular (non-loopback) interface properties
 i_property
 :
     i_address
@@ -98,6 +74,7 @@ i_property
   | i_clagd_peer_ip
   | i_clagd_priority
   | i_clagd_sys_mac
+  | i_clagd_vxlan_anycast_ip
   | i_gateway
   | i_hwaddress
   | i_link_speed
@@ -232,6 +209,11 @@ i_clagd_priority
 i_clagd_sys_mac
 :
   CLAGD_SYS_MAC MAC_ADDRESS NEWLINE
+;
+
+i_clagd_vxlan_anycast_ip
+:
+  CLAGD_VXLAN_ANYCAST_IP IP_ADDRESS NEWLINE
 ;
 
 i_gateway

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesConfigurationBuilder.java
@@ -296,8 +296,7 @@ public final class CumulusInterfacesConfigurationBuilder
 
   @Override
   public void exitI_clagd_vxlan_anycast_ip(I_clagd_vxlan_anycast_ipContext ctx) {
-    InterfaceClagSettings clag = _currentIface.createOrGetClagSettings();
-    clag.setVxlanAnycastIp(Ip.parse(ctx.IP_ADDRESS().getText()));
+    _currentIface.setClagVxlanAnycastIp(Ip.parse(ctx.IP_ADDRESS().getText()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
@@ -192,10 +192,8 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
         _interfacesConfiguration.getInterfaces().get(LOOPBACK_INTERFACE_NAME);
     @Nullable
     Ip loopbackClagVxlanAnycastIp =
-        vsLoopback != null
-                && vsLoopback.getClagSettings() != null
-                && vsLoopback.getClagSettings().getVxlanAnycastIp() != null
-            ? vsLoopback.getClagSettings().getVxlanAnycastIp()
+        vsLoopback != null && vsLoopback.getClagVxlanAnycastIp() != null
+            ? vsLoopback.getClagVxlanAnycastIp()
             : null;
 
     // Put all valid VXLAN VNIs into appropriate VRF
@@ -378,16 +376,14 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
   @VisibleForTesting
   static void populateLoopbackProperties(
       @Nullable InterfacesInterface vsLoopback, org.batfish.datamodel.Interface viLoopback) {
-    if (vsLoopback != null
-        && vsLoopback.getClagSettings() != null
-        && vsLoopback.getClagSettings().getVxlanAnycastIp() != null) {
+    if (vsLoopback != null && vsLoopback.getClagVxlanAnycastIp() != null) {
       // Just assume CLAG is correctly configured and comes up
       viLoopback.setAllAddresses(
           ImmutableSet.<InterfaceAddress>builder()
               .addAll(viLoopback.getAllAddresses())
               .add(
                   ConcreteInterfaceAddress.create(
-                      vsLoopback.getClagSettings().getVxlanAnycastIp(), Prefix.MAX_PREFIX_LENGTH))
+                      vsLoopback.getClagVxlanAnycastIp(), Prefix.MAX_PREFIX_LENGTH))
               .build());
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
@@ -49,6 +49,7 @@ import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.InterfaceType;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.MacAddress;
 import org.batfish.datamodel.NamedPort;
@@ -186,6 +187,17 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
             .filter(vrf -> vrf.getVni() != null)
             .collect(ImmutableMap.toImmutableMap(Vrf::getVni, Vrf::getName));
 
+    @Nullable
+    InterfacesInterface vsLoopback =
+        _interfacesConfiguration.getInterfaces().get(LOOPBACK_INTERFACE_NAME);
+    @Nullable
+    Ip loopbackClagVxlanAnycastIp =
+        vsLoopback != null
+                && vsLoopback.getClagSettings() != null
+                && vsLoopback.getClagSettings().getVxlanAnycastIp() != null
+            ? vsLoopback.getClagSettings().getVxlanAnycastIp()
+            : null;
+
     // Put all valid VXLAN VNIs into appropriate VRF
     _interfacesConfiguration.getInterfaces().values().stream()
         .filter(InterfaceConverter::isVxlan)
@@ -209,9 +221,7 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
                                     .setVni(vxlan.getVxlanId())
                                     .setSourceAddress(
                                         firstNonNull(
-                                            _interfacesConfiguration
-                                                .getLoopback()
-                                                .getClagVxlanAnycastIp(),
+                                            loopbackClagVxlanAnycastIp,
                                             vxlan.getVxlanLocalTunnelIp()))
                                     .setUdpPort(NamedPort.VXLAN.number())
                                     .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
@@ -233,9 +243,7 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
                                     .setVlan(vxlan.getBridgeSettings().getAccess())
                                     .setSourceAddress(
                                         firstNonNull(
-                                            _interfacesConfiguration
-                                                .getLoopback()
-                                                .getClagVxlanAnycastIp(),
+                                            loopbackClagVxlanAnycastIp,
                                             vxlan.getVxlanLocalTunnelIp()))
                                     .setUdpPort(NamedPort.VXLAN.number())
                                     .setBumTransportMethod(BumTransportMethod.UNICAST_FLOOD_GROUP)
@@ -316,7 +324,9 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
     _interfacesConfiguration.getInterfaces().values().stream()
         .filter(CumulusConcatenatedConfiguration::isValidVIInterface)
         .forEach(iface -> populateInterfaceProperties(c, iface));
-    populateLoopbackProperties(c.getAllInterfaces().get(LOOPBACK_INTERFACE_NAME));
+    populateLoopbackProperties(
+        _interfacesConfiguration.getInterfaces().get(LOOPBACK_INTERFACE_NAME),
+        c.getAllInterfaces().get(LOOPBACK_INTERFACE_NAME));
   }
 
   @VisibleForTesting
@@ -366,34 +376,20 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
   }
 
   @VisibleForTesting
-  void populateLoopbackProperties(org.batfish.datamodel.Interface viLoopback) {
-    Loopback vsLoopback = _interfacesConfiguration.getLoopback();
-
-    viLoopback.setDescription(vsLoopback.getAlias());
-
-    // addresses in interface configuration, if present, have been transferred via
-    // populateCommonProperties. we need to take care of other sources of addresses.
-
-    List<InterfaceAddress> addresses = new LinkedList<>(vsLoopback.getAddresses());
-
-    if (viLoopback.getAddress() == null && !addresses.isEmpty()) {
-      viLoopback.setAddress(addresses.get(0));
-    }
-
-    if (vsLoopback.getClagVxlanAnycastIp() != null) {
+  static void populateLoopbackProperties(
+      @Nullable InterfacesInterface vsLoopback, org.batfish.datamodel.Interface viLoopback) {
+    if (vsLoopback != null
+        && vsLoopback.getClagSettings() != null
+        && vsLoopback.getClagSettings().getVxlanAnycastIp() != null) {
       // Just assume CLAG is correctly configured and comes up
-      addresses.add(
-          ConcreteInterfaceAddress.create(
-              vsLoopback.getClagVxlanAnycastIp(), Prefix.MAX_PREFIX_LENGTH));
+      viLoopback.setAllAddresses(
+          ImmutableSet.<InterfaceAddress>builder()
+              .addAll(viLoopback.getAllAddresses())
+              .add(
+                  ConcreteInterfaceAddress.create(
+                      vsLoopback.getClagSettings().getVxlanAnycastIp(), Prefix.MAX_PREFIX_LENGTH))
+              .build());
     }
-    viLoopback.setAllAddresses(
-        ImmutableSet.<InterfaceAddress>builder()
-            .addAll(viLoopback.getAllAddresses())
-            .addAll(addresses)
-            .build());
-
-    // set bandwidth
-    viLoopback.setBandwidth(firstNonNull(vsLoopback.getBandwidth(), DEFAULT_LOOPBACK_BANDWIDTH));
   }
 
   private static void populateVlanInterfaceProperties(Configuration c, InterfacesInterface iface) {
@@ -462,7 +458,7 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
   }
 
   @VisibleForTesting
-  void populateCommonInterfaceProperties(
+  static void populateCommonInterfaceProperties(
       InterfacesInterface vsIface, org.batfish.datamodel.Interface viIface) {
     // addresses
     if (vsIface.getAddresses() != null && !vsIface.getAddresses().isEmpty()) {
@@ -485,7 +481,10 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
       viIface.setSpeed(speed);
       viIface.setBandwidth(speed);
     } else {
-      viIface.setBandwidth(DEFAULT_PORT_BANDWIDTH);
+      viIface.setBandwidth(
+          viIface.getName().equals(LOOPBACK_INTERFACE_NAME)
+              ? DEFAULT_LOOPBACK_BANDWIDTH
+              : DEFAULT_PORT_BANDWIDTH);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusInterfacesConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusInterfacesConfiguration.java
@@ -15,12 +15,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public final class CumulusInterfacesConfiguration implements Serializable {
   @Nonnull private final Set<String> _autoIfaces;
   @Nonnull private final Map<String, InterfacesInterface> _interfaces;
-  @Nonnull private final Loopback _loopback;
 
   public CumulusInterfacesConfiguration() {
     _autoIfaces = new HashSet<>();
     _interfaces = new HashMap<>();
-    _loopback = new Loopback();
   }
 
   /** Register an interface as being enabled on boot. */
@@ -42,11 +40,6 @@ public final class CumulusInterfacesConfiguration implements Serializable {
   public boolean hasVrf(String vrfName) {
     return _interfaces.values().stream()
         .anyMatch(iface -> iface.getName().equals(vrfName) && isVrf(iface));
-  }
-
-  @Nonnull
-  public Loopback getLoopback() {
-    return _loopback;
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/InterfaceClagSettings.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/InterfaceClagSettings.java
@@ -15,6 +15,7 @@ public final class InterfaceClagSettings implements Serializable {
   private boolean _peerIpLinkLocal;
   private @Nullable Integer _priority;
   private @Nullable MacAddress _sysMac;
+  private @Nullable Ip _vxlanAnycastIp;
 
   public @Nullable Ip getBackupIp() {
     return _backupIp;
@@ -73,5 +74,14 @@ public final class InterfaceClagSettings implements Serializable {
         .setPriority(_priority)
         .setSysMac(_sysMac)
         .build();
+  }
+
+  @Nullable
+  public Ip getVxlanAnycastIp() {
+    return _vxlanAnycastIp;
+  }
+
+  public void setVxlanAnycastIp(@Nullable Ip vxlanAnycastIp) {
+    _vxlanAnycastIp = vxlanAnycastIp;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/InterfaceClagSettings.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/InterfaceClagSettings.java
@@ -15,7 +15,6 @@ public final class InterfaceClagSettings implements Serializable {
   private boolean _peerIpLinkLocal;
   private @Nullable Integer _priority;
   private @Nullable MacAddress _sysMac;
-  private @Nullable Ip _vxlanAnycastIp;
 
   public @Nullable Ip getBackupIp() {
     return _backupIp;
@@ -74,14 +73,5 @@ public final class InterfaceClagSettings implements Serializable {
         .setPriority(_priority)
         .setSysMac(_sysMac)
         .build();
-  }
-
-  @Nullable
-  public Ip getVxlanAnycastIp() {
-    return _vxlanAnycastIp;
-  }
-
-  public void setVxlanAnycastIp(@Nullable Ip vxlanAnycastIp) {
-    _vxlanAnycastIp = vxlanAnycastIp;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/InterfacesInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/InterfacesInterface.java
@@ -43,6 +43,7 @@ public final class InterfacesInterface implements Serializable {
   private @Nullable InterfaceBridgeSettings _bridgeSettings;
   private @Nullable InterfaceClagSettings _clagSettings;
   private @Nullable Integer _clagId;
+  private @Nullable Ip _clagVxlanAnycastIp;
   private @Nullable String _description;
   private @Nullable String _vrfTable;
   private @Nullable Integer _linkSpeed;
@@ -264,5 +265,14 @@ public final class InterfacesInterface implements Serializable {
 
   public void addPostUpIpRoute(StaticRoute sr) {
     _postUpIpRoutes = ImmutableList.<StaticRoute>builder().addAll(_postUpIpRoutes).add(sr).build();
+  }
+
+  @Nullable
+  public Ip getClagVxlanAnycastIp() {
+    return _clagVxlanAnycastIp;
+  }
+
+  public void setClagVxlanAnycastIp(@Nullable Ip clagVxlanAnycastIp) {
+    _clagVxlanAnycastIp = clagVxlanAnycastIp;
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
@@ -508,9 +508,7 @@ public class CumulusInterfacesGrammarTest {
   @Test
   public void testLoopbackClagdVxlanAnycastIp() {
     parse("iface lo inet loopback\n clagd-vxlan-anycast-ip 1.2.3.4\n");
-    assertThat(
-        _ic.getInterfaces().get("lo").getClagSettings().getVxlanAnycastIp(),
-        equalTo(Ip.parse("1.2.3.4")));
+    assertThat(_ic.getInterfaces().get("lo").getClagVxlanAnycastIp(), equalTo(Ip.parse("1.2.3.4")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
@@ -488,34 +488,29 @@ public class CumulusInterfacesGrammarTest {
   @Test
   public void testLoopback() {
     parse("iface lo inet loopback\n");
-    assertTrue(_ic.getLoopback().getConfigured());
-    assertThat(
-        getDefinedStructureInfo(CumulusStructureType.LOOPBACK, "lo").getDefinitionLines(),
-        contains(1));
-    assertThat(
-        getStructureReferences(
-            CumulusStructureType.LOOPBACK, "lo", CumulusStructureUsage.LOOPBACK_SELF_REFERENCE),
-        contains(1));
+    assertTrue(_ic.getInterfaces().containsKey("lo"));
   }
 
   @Test
   public void testLoopbackAddress() {
     parse("iface lo inet loopback\n address 1.2.3.4/24\n");
     assertThat(
-        _ic.getLoopback().getAddresses(), contains(ConcreteInterfaceAddress.parse("1.2.3.4/24")));
+        _ic.getInterfaces().get("lo").getAddresses(),
+        contains(ConcreteInterfaceAddress.parse("1.2.3.4/24")));
   }
 
   @Test
   public void testLoopbackAlias() {
     parse("iface lo inet loopback\n alias my aliases\n");
-    assertThat(
-        _config.getInterfacesConfiguration().getLoopback().getAlias(), equalTo("my aliases"));
+    assertThat(_ic.getInterfaces().get("lo").getDescription(), equalTo("my aliases"));
   }
 
   @Test
   public void testLoopbackClagdVxlanAnycastIp() {
     parse("iface lo inet loopback\n clagd-vxlan-anycast-ip 1.2.3.4\n");
-    assertThat(_ic.getLoopback().getClagVxlanAnycastIp(), equalTo(Ip.parse("1.2.3.4")));
+    assertThat(
+        _ic.getInterfaces().get("lo").getClagSettings().getVxlanAnycastIp(),
+        equalTo(Ip.parse("1.2.3.4")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConcatenatedConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConcatenatedConfigurationTest.java
@@ -279,7 +279,7 @@ public class CumulusConcatenatedConfigurationTest {
 
     Ip clagIp = Ip.parse("1.1.1.1");
     InterfacesInterface vsLoopback = new InterfacesInterface("lo");
-    vsLoopback.createOrGetClagSettings().setVxlanAnycastIp(clagIp);
+    vsLoopback.setClagVxlanAnycastIp(clagIp);
 
     populateLoopbackProperties(vsLoopback, viLoopback);
 


### PR DESCRIPTION
NCLU heritage meant that parsing and post-processing of loopback ("lo") being special-cased. We keep seeing more properties that are shared and the separation does not make sense. No functional change in this PR.