### PR TITLE
FRR: fix NPE because of missing interface names

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
@@ -262,7 +262,7 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
   void initVrfStaticRoutes(Configuration c) {
     // post-up routes from the interfaces file
     _interfacesConfiguration.getInterfaces().values().stream()
-        .filter(iface -> !iface.getName().equals(BRIDGE_NAME))
+        .filter(CumulusConcatenatedConfiguration::isValidVIInterface)
         .forEach(
             iface -> {
               if (!c.getAllInterfaces().get(iface.getName()).getActive()) {


### PR DESCRIPTION
ignore all interfaces that show up in cumulus interfaces configuration that should not interfaces in the VI model.