### PR TITLE
Convert IpSpace::containsIp to a visitor

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractIpSpaceContainsIp.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractIpSpaceContainsIp.java
@@ -1,0 +1,61 @@
+package org.batfish.datamodel;
+
+import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
+
+/**
+ * An {@link GenericIpSpaceVisitor IpSpace visitor} that tests if the {@link IpSpace} contains an
+ * {@link Ip}. Implementation of {@link IpSpaceReference} is left abstract.
+ */
+public abstract class AbstractIpSpaceContainsIp implements GenericIpSpaceVisitor<Boolean> {
+  private final Ip _ip;
+
+  public AbstractIpSpaceContainsIp(Ip ip) {
+    _ip = ip;
+  }
+
+  @Override
+  public final Boolean castToGenericIpSpaceVisitorReturnType(Object o) {
+    return (Boolean) o;
+  }
+
+  @Override
+  public final Boolean visitAclIpSpace(AclIpSpace aclIpSpace) {
+    return aclIpSpace.getLines().stream()
+        .filter(line -> line.getIpSpace().accept(this))
+        .map(AclIpSpaceLine::getAction)
+        .findFirst()
+        .map(action -> action == LineAction.PERMIT)
+        .orElse(false);
+  }
+
+  @Override
+  public final Boolean visitEmptyIpSpace(EmptyIpSpace emptyIpSpace) {
+    return false;
+  }
+
+  @Override
+  public final Boolean visitIpIpSpace(IpIpSpace ipIpSpace) {
+    return _ip.equals(ipIpSpace.getIp());
+  }
+
+  @Override
+  public final Boolean visitIpWildcardIpSpace(IpWildcardIpSpace ipWildcardIpSpace) {
+    return ipWildcardIpSpace.getIpWildcard().containsIp(_ip);
+  }
+
+  @Override
+  public final Boolean visitIpWildcardSetIpSpace(IpWildcardSetIpSpace ipWildcardSetIpSpace) {
+    return ipWildcardSetIpSpace.getBlacklist().stream().noneMatch(w -> w.containsIp(_ip))
+        && ipWildcardSetIpSpace.getWhitelist().stream().anyMatch(w -> w.containsIp(_ip));
+  }
+
+  @Override
+  public final Boolean visitPrefixIpSpace(PrefixIpSpace prefixIpSpace) {
+    return prefixIpSpace.getPrefix().containsIp(_ip);
+  }
+
+  @Override
+  public final Boolean visitUniverseIpSpace(UniverseIpSpace universeIpSpace) {
+    return true;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpace.java
@@ -12,7 +12,6 @@ import com.google.common.collect.Ordering;
 import com.google.common.collect.Streams;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Spliterator;
 import java.util.stream.Stream;
@@ -279,23 +278,10 @@ public class AclIpSpace extends IpSpace {
     return ipSpaceVisitor.visitAclIpSpace(this);
   }
 
-  private LineAction action(Ip ip, Map<String, IpSpace> namedIpSpaces) {
-    return _lines.stream()
-        .filter(line -> line.getIpSpace().containsIp(ip, namedIpSpaces))
-        .map(AclIpSpaceLine::getAction)
-        .findFirst()
-        .orElse(LineAction.DENY);
-  }
-
   @Override
   protected int compareSameClass(IpSpace o) {
     return Comparators.lexicographical(Ordering.<AclIpSpaceLine>natural())
         .compare(_lines, ((AclIpSpace) o)._lines);
-  }
-
-  @Override
-  public boolean containsIp(@Nonnull Ip ip, @Nonnull Map<String, IpSpace> namedIpSpaces) {
-    return action(ip, namedIpSpaces) == LineAction.PERMIT;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EmptyIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EmptyIpSpace.java
@@ -1,6 +1,5 @@
 package org.batfish.datamodel;
 
-import java.util.Map;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
 public class EmptyIpSpace extends IpSpace {
@@ -17,11 +16,6 @@ public class EmptyIpSpace extends IpSpace {
   @Override
   protected int compareSameClass(IpSpace o) {
     return 0;
-  }
-
-  @Override
-  public boolean containsIp(Ip ip, Map<String, IpSpace> namedIpSpaces) {
-    return false;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EmptyIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EmptyIpSpace.java
@@ -4,7 +4,7 @@ import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
 public class EmptyIpSpace extends IpSpace {
 
-  public static final IpSpace INSTANCE = new EmptyIpSpace();
+  public static final EmptyIpSpace INSTANCE = new EmptyIpSpace();
 
   private EmptyIpSpace() {}
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpIpSpace.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import java.util.Map;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
 public class IpIpSpace extends IpSpace {
@@ -24,11 +23,6 @@ public class IpIpSpace extends IpSpace {
   @Override
   protected int compareSameClass(IpSpace o) {
     return _ip.compareTo(((IpIpSpace) o)._ip);
-  }
-
-  @Override
-  public boolean containsIp(Ip ip, Map<String, IpSpace> namedIpSpaces) {
-    return _ip.equals(ip);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpSpace.java
@@ -11,7 +11,9 @@ public abstract class IpSpace implements Comparable<IpSpace>, Serializable {
 
   public abstract <R> R accept(GenericIpSpaceVisitor<R> visitor);
 
-  public abstract boolean containsIp(@Nonnull Ip ip, @Nonnull Map<String, IpSpace> namedIpSpaces);
+  public final boolean containsIp(@Nonnull Ip ip, @Nonnull Map<String, IpSpace> namedIpSpaces) {
+    return accept(new IpSpaceContainsIp(ip, namedIpSpaces));
+  }
 
   /** Return the {@link IpSpace} of all IPs not in {@code this}. */
   public final IpSpace complement() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpSpaceContainsIp.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpSpaceContainsIp.java
@@ -2,44 +2,14 @@ package org.batfish.datamodel;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
-/**
- * An {@link GenericIpSpaceVisitor IpSpace visitor} that tests if the {@link IpSpace} contains an
- * {@link Ip}.
- */
-public class IpSpaceContainsIp implements GenericIpSpaceVisitor<Boolean> {
+/** Implementation of {@link AbstractIpSpaceContainsIp}. */
+public final class IpSpaceContainsIp extends AbstractIpSpaceContainsIp {
   private final Map<String, IpSpace> _namedIpSpaces;
-  private final Ip _ip;
 
   public IpSpaceContainsIp(Ip ip, Map<String, IpSpace> namedIpSpaces) {
-    _ip = ip;
+    super(ip);
     _namedIpSpaces = ImmutableMap.copyOf(namedIpSpaces);
-  }
-
-  @Override
-  public Boolean castToGenericIpSpaceVisitorReturnType(Object o) {
-    return (Boolean) o;
-  }
-
-  @Override
-  public Boolean visitAclIpSpace(AclIpSpace aclIpSpace) {
-    return aclIpSpace.getLines().stream()
-        .filter(line -> line.getIpSpace().accept(this))
-        .map(AclIpSpaceLine::getAction)
-        .findFirst()
-        .map(action -> action == LineAction.PERMIT)
-        .orElse(false);
-  }
-
-  @Override
-  public Boolean visitEmptyIpSpace(EmptyIpSpace emptyIpSpace) {
-    return false;
-  }
-
-  @Override
-  public Boolean visitIpIpSpace(IpIpSpace ipIpSpace) {
-    return _ip.equals(ipIpSpace.getIp());
   }
 
   @Override
@@ -49,26 +19,5 @@ public class IpSpaceContainsIp implements GenericIpSpaceVisitor<Boolean> {
       return false;
     }
     return ipSpace.accept(this);
-  }
-
-  @Override
-  public Boolean visitIpWildcardIpSpace(IpWildcardIpSpace ipWildcardIpSpace) {
-    return ipWildcardIpSpace.getIpWildcard().containsIp(_ip);
-  }
-
-  @Override
-  public Boolean visitIpWildcardSetIpSpace(IpWildcardSetIpSpace ipWildcardSetIpSpace) {
-    return ipWildcardSetIpSpace.getBlacklist().stream().noneMatch(w -> w.containsIp(_ip))
-        && ipWildcardSetIpSpace.getWhitelist().stream().anyMatch(w -> w.containsIp(_ip));
-  }
-
-  @Override
-  public Boolean visitPrefixIpSpace(PrefixIpSpace prefixIpSpace) {
-    return prefixIpSpace.getPrefix().containsIp(_ip);
-  }
-
-  @Override
-  public Boolean visitUniverseIpSpace(UniverseIpSpace universeIpSpace) {
-    return true;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpSpaceContainsIp.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpSpaceContainsIp.java
@@ -1,0 +1,74 @@
+package org.batfish.datamodel;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
+
+/**
+ * An {@link GenericIpSpaceVisitor IpSpace visitor} that tests if the {@link IpSpace} contains an
+ * {@link Ip}.
+ */
+public class IpSpaceContainsIp implements GenericIpSpaceVisitor<Boolean> {
+  private final Map<String, IpSpace> _namedIpSpaces;
+  private final Ip _ip;
+
+  public IpSpaceContainsIp(Ip ip, Map<String, IpSpace> namedIpSpaces) {
+    _ip = ip;
+    _namedIpSpaces = ImmutableMap.copyOf(namedIpSpaces);
+  }
+
+  @Override
+  public Boolean castToGenericIpSpaceVisitorReturnType(Object o) {
+    return (Boolean) o;
+  }
+
+  @Override
+  public Boolean visitAclIpSpace(AclIpSpace aclIpSpace) {
+    return aclIpSpace.getLines().stream()
+        .filter(line -> line.getIpSpace().accept(this))
+        .map(AclIpSpaceLine::getAction)
+        .findFirst()
+        .map(action -> action == LineAction.PERMIT)
+        .orElse(false);
+  }
+
+  @Override
+  public Boolean visitEmptyIpSpace(EmptyIpSpace emptyIpSpace) {
+    return false;
+  }
+
+  @Override
+  public Boolean visitIpIpSpace(IpIpSpace ipIpSpace) {
+    return _ip.equals(ipIpSpace.getIp());
+  }
+
+  @Override
+  public Boolean visitIpSpaceReference(IpSpaceReference ipSpaceReference) {
+    IpSpace ipSpace = _namedIpSpaces.get(ipSpaceReference.getName());
+    if (ipSpace == null) {
+      return false;
+    }
+    return ipSpace.accept(this);
+  }
+
+  @Override
+  public Boolean visitIpWildcardIpSpace(IpWildcardIpSpace ipWildcardIpSpace) {
+    return ipWildcardIpSpace.getIpWildcard().containsIp(_ip);
+  }
+
+  @Override
+  public Boolean visitIpWildcardSetIpSpace(IpWildcardSetIpSpace ipWildcardSetIpSpace) {
+    return ipWildcardSetIpSpace.getBlacklist().stream().noneMatch(w -> w.containsIp(_ip))
+        && ipWildcardSetIpSpace.getWhitelist().stream().anyMatch(w -> w.containsIp(_ip));
+  }
+
+  @Override
+  public Boolean visitPrefixIpSpace(PrefixIpSpace prefixIpSpace) {
+    return prefixIpSpace.getPrefix().containsIp(_ip);
+  }
+
+  @Override
+  public Boolean visitUniverseIpSpace(UniverseIpSpace universeIpSpace) {
+    return true;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpSpaceReference.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpSpaceReference.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -38,12 +37,6 @@ public class IpSpaceReference extends IpSpace {
   @Override
   protected int compareSameClass(IpSpace o) {
     return _name.compareTo(((IpSpaceReference) o)._name);
-  }
-
-  @Override
-  public boolean containsIp(@Nonnull Ip ip, @Nonnull Map<String, IpSpace> namedIpSpaces) {
-    return namedIpSpaces.containsKey(_name)
-        && namedIpSpaces.get(_name).containsIp(ip, namedIpSpaces);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcardIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcardIpSpace.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import java.util.Map;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
 public class IpWildcardIpSpace extends IpSpace {
@@ -24,11 +23,6 @@ public class IpWildcardIpSpace extends IpSpace {
   @Override
   protected int compareSameClass(IpSpace o) {
     return _ipWildcard.compareTo(((IpWildcardIpSpace) o)._ipWildcard);
-  }
-
-  @Override
-  public boolean containsIp(Ip ip, Map<String, IpSpace> namedIpSpaces) {
-    return _ipWildcard.containsIp(ip);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcardSetIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpWildcardSetIpSpace.java
@@ -8,7 +8,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
@@ -97,12 +96,6 @@ public final class IpWildcardSetIpSpace extends IpSpace {
         .thenComparing(
             IpWildcardSetIpSpace::getWhitelist, Comparators.lexicographical(Ordering.natural()))
         .compare(this, (IpWildcardSetIpSpace) o);
-  }
-
-  @Override
-  public boolean containsIp(Ip ip, Map<String, IpSpace> namedIpSpaces) {
-    return _blacklist.stream().noneMatch(w -> w.containsIp(ip))
-        && _whitelist.stream().anyMatch(w -> w.containsIp(ip));
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixIpSpace.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import java.util.Map;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
@@ -26,11 +25,6 @@ public final class PrefixIpSpace extends IpSpace {
   @Override
   protected int compareSameClass(IpSpace o) {
     return _prefix.compareTo(((PrefixIpSpace) o)._prefix);
-  }
-
-  @Override
-  public boolean containsIp(Ip ip, Map<String, IpSpace> namedIpSpaces) {
-    return _prefix.containsIp(ip);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/UniverseIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/UniverseIpSpace.java
@@ -1,6 +1,5 @@
 package org.batfish.datamodel;
 
-import java.util.Map;
 import org.batfish.datamodel.visitors.GenericIpSpaceVisitor;
 
 public class UniverseIpSpace extends IpSpace {
@@ -17,11 +16,6 @@ public class UniverseIpSpace extends IpSpace {
   @Override
   protected int compareSameClass(IpSpace o) {
     return 0;
-  }
-
-  @Override
-  public boolean containsIp(Ip ip, Map<String, IpSpace> namedIpSpaces) {
-    return true;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AbstractIpSpaceContainsIpTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AbstractIpSpaceContainsIpTest.java
@@ -1,0 +1,70 @@
+package org.batfish.datamodel;
+
+import static org.batfish.datamodel.AclIpSpace.rejecting;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+/** Test for {@link AbstractIpSpaceContainsIp}. */
+public class AbstractIpSpaceContainsIpTest {
+  private static final Ip IP1 = Ip.parse("1.1.1.1");
+  private static final Ip IP2 = Ip.parse("2.2.2.2");
+
+  private static AbstractIpSpaceContainsIp containsIp(Ip ip) {
+    return new AbstractIpSpaceContainsIp(ip) {
+      @Override
+      public Boolean visitIpSpaceReference(IpSpaceReference ipSpaceReference) {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  @Test
+  public void testVisitAclIpSpace() {
+    AclIpSpace ipSpace =
+        (AclIpSpace) rejecting(IP2.toIpSpace()).thenPermitting(UniverseIpSpace.INSTANCE).build();
+    assertTrue(containsIp(IP1).visitAclIpSpace(ipSpace));
+    assertFalse(containsIp(IP2).visitAclIpSpace(ipSpace));
+  }
+
+  @Test
+  public void testVisitEmptyIpSpace() {
+    assertFalse(containsIp(IP1).visitEmptyIpSpace(EmptyIpSpace.INSTANCE));
+  }
+
+  @Test
+  public void testVisitIpIpSpace() {
+    assertTrue(containsIp(IP1).visitIpIpSpace(IP1.toIpSpace()));
+    assertFalse(containsIp(IP2).visitIpIpSpace(IP1.toIpSpace()));
+  }
+
+  @Test
+  public void testVisitIpWildcardIpSpace() {
+    IpWildcardIpSpace ipSpace = IpWildcard.create(IP1).toIpSpace();
+    assertTrue(containsIp(IP1).visitIpWildcardIpSpace(ipSpace));
+    assertFalse(containsIp(IP2).visitIpWildcardIpSpace(ipSpace));
+  }
+
+  @Test
+  public void testVisitIpWildcardSetIpSpace() {
+    IpWildcardSetIpSpace ipSpace =
+        new IpWildcardSetIpSpace(
+            ImmutableSet.of(IpWildcard.create(IP2)), ImmutableSet.of(IpWildcard.create(IP1)));
+    assertTrue(containsIp(IP1).visitIpWildcardSetIpSpace(ipSpace));
+    assertFalse(containsIp(IP2).visitIpWildcardSetIpSpace(ipSpace));
+  }
+
+  @Test
+  public void testVisitPrefixIpSpace() {
+    PrefixIpSpace ipSpace = (PrefixIpSpace) Prefix.create(IP1, 31).toIpSpace();
+    assertTrue(containsIp(IP1).visitPrefixIpSpace(ipSpace));
+    assertFalse(containsIp(IP2).visitPrefixIpSpace(ipSpace));
+  }
+
+  @Test
+  public void visitUniverseIpSpace() {
+    assertTrue(containsIp(IP1).visitUniverseIpSpace(UniverseIpSpace.INSTANCE));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ForwardingAnalysisImplTest.java
@@ -1604,11 +1604,6 @@ public class ForwardingAnalysisImplTest {
     }
 
     @Override
-    public boolean containsIp(Ip ip, Map<String, IpSpace> namedIpSpaces) {
-      throw new UnsupportedOperationException("no implementation for generated method");
-    }
-
-    @Override
     protected boolean exprEquals(Object o) {
       return _num == ((MockIpSpace) o)._num;
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpSpaceContainsIpTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpSpaceContainsIpTest.java
@@ -1,0 +1,28 @@
+package org.batfish.datamodel;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.Test;
+
+/** Test for {@link IpSpaceContainsIp}. */
+public class IpSpaceContainsIpTest {
+  private static final String IP_SPACE_NAME = "ipSpace";
+  private static final Map<String, IpSpace> NAMED_IP_SPACES =
+      ImmutableMap.of(IP_SPACE_NAME, Prefix.parse("1.0.0.0/8").toIpSpace());
+
+  private static IpSpaceContainsIp containsIp(Ip ip) {
+    return new IpSpaceContainsIp(ip, NAMED_IP_SPACES);
+  }
+
+  @Test
+  public void testVisitIpSpaceReference_true() {
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("2.2.2.2");
+    assertTrue(containsIp(ip1).visitIpSpaceReference(new IpSpaceReference(IP_SPACE_NAME)));
+    assertFalse(containsIp(ip2).visitIpSpaceReference(new IpSpaceReference(IP_SPACE_NAME)));
+    assertFalse(containsIp(ip1).visitIpSpaceReference(new IpSpaceReference("missing ipSpace")));
+  }
+}


### PR DESCRIPTION
This is to prepare for an IpSpace tracer implemented by extending the
visitor.