### PR TITLE
BGP: honor no-export community

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpSessionProperties.java
@@ -152,6 +152,11 @@ public final class BgpSessionProperties {
       _sessionType = sessionType;
       return this;
     }
+
+    public Builder setConfedSessionType(ConfedSessionType confedSessionType) {
+      _confedSessionType = confedSessionType;
+      return this;
+    }
   }
 
   public static @Nonnull Builder builder() {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -103,6 +103,12 @@ public final class BgpProtocolHelper {
             && !af.getAddressFamilyCapabilities().getAllowRemoteAsOut())) {
       return null;
     }
+    // Also do not export if route has NO_EXPORT community and this is a true ebgp session
+    if (route.getCommunities().contains(StandardCommunity.of(WellKnownCommunity.NO_EXPORT))
+        && sessionProperties.isEbgp()
+        && sessionProperties.getConfedSessionType() != ConfedSessionType.WITHIN_CONFED) {
+      return null;
+    }
 
     // Set transformed route's communities
     builder.setCommunities(ImmutableSet.of());

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
@@ -7,6 +7,7 @@ import static org.batfish.dataplane.protocols.BgpProtocolHelper.transformBgpRout
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
@@ -254,6 +255,62 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
 
       assertThat(transformedAggregateRoute, nullValue());
       assertThat(transformedBgpRoute, nullValue());
+    }
+  }
+
+  /**
+   * Test that transformBgpRouteOnExport returns {@code null} (meaning do not export the route) if
+   * it has the {@value org.batfish.common.WellKnownCommunity#NO_EXPORT} community and the session
+   * is EBGP.
+   */
+  @Test
+  public void testRoutesWithNoExportSetNotExported() {
+    Set<Community> noExportCommunitySet =
+        ImmutableSortedSet.of(StandardCommunity.of(WellKnownCommunity.NO_EXPORT));
+
+    {
+      // iBGP
+      setUpPeers(true);
+      Bgpv4Route.Builder transformedAggregateRoute =
+          runTransformBgpRoutePreExport(
+              _baseAggRouteBuilder.setCommunities(noExportCommunitySet).build());
+      Bgpv4Route.Builder transformedBgpRoute =
+          runTransformBgpRoutePreExport(
+              _baseBgpRouteBuilder.setCommunities(noExportCommunitySet).build());
+      assertThat(transformedAggregateRoute, notNullValue());
+      assertThat(transformedBgpRoute, notNullValue());
+    }
+
+    {
+      // eBGP
+      setUpPeers(false);
+      Bgpv4Route.Builder transformedAggregateRoute =
+          runTransformBgpRoutePreExport(
+              _baseAggRouteBuilder.setCommunities(noExportCommunitySet).build());
+      Bgpv4Route.Builder transformedBgpRoute =
+          runTransformBgpRoutePreExport(
+              _baseBgpRouteBuilder.setCommunities(noExportCommunitySet).build());
+      assertThat(transformedAggregateRoute, nullValue());
+      assertThat(transformedBgpRoute, nullValue());
+    }
+    {
+      // eBGP within confederation
+      _sessionProperties =
+          BgpSessionProperties.builder()
+              .setTailIp(_tailNeighbor.getLocalIp())
+              .setTailAs(_tailNeighbor.getLocalAs())
+              .setHeadAs(_headNeighbor.getLocalAs())
+              .setHeadIp(_headNeighbor.getLocalIp())
+              .setConfedSessionType(ConfedSessionType.WITHIN_CONFED)
+              .build();
+      Bgpv4Route.Builder transformedAggregateRoute =
+          runTransformBgpRoutePreExport(
+              _baseAggRouteBuilder.setCommunities(noExportCommunitySet).build());
+      Bgpv4Route.Builder transformedBgpRoute =
+          runTransformBgpRoutePreExport(
+              _baseBgpRouteBuilder.setCommunities(noExportCommunitySet).build());
+      assertThat(transformedAggregateRoute, notNullValue());
+      assertThat(transformedBgpRoute, notNullValue());
     }
   }
 


### PR DESCRIPTION
In BDP code, do not export routes with no-export community to external peers
https://tools.ietf.org/html/rfc1997