### PR TITLE
Cumulus FRR: allow-remote-as-out is always true

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -560,6 +560,7 @@ public final class CumulusConversions {
                 .setAllowLocalAsIn(
                     (ipv4UnicastAddressFamily != null
                         && (firstNonNull(ipv4UnicastAddressFamily.getAllowAsIn(), 0) > 0)))
+                .setAllowRemoteAsOut(true) // this is always true
                 .build())
         .setExportPolicy(exportRoutingPolicy.getName())
         .setImportPolicy(importRoutingPolicy == null ? null : importRoutingPolicy.getName())
@@ -1070,6 +1071,7 @@ public final class CumulusConversions {
             AddressFamilyCapabilities.builder()
                 .setSendCommunity(true)
                 .setSendExtendedCommunity(true)
+                .setAllowRemoteAsOut(true) // this is always true
                 .build())
         .setRouteReflectorClient(
             firstNonNull(

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -82,6 +82,7 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.routing_policy.Common;
@@ -835,29 +836,32 @@ public final class CumulusConversionsTest {
 
     {
       // address family is null
-      assertFalse(
-          convertIpv4UnicastAddressFamily(null, true, policy, null)
-              .getAddressFamilyCapabilities()
-              .getAllowLocalAsIn());
+      AddressFamilyCapabilities capabilities =
+          convertIpv4UnicastAddressFamily(null, true, policy, null).getAddressFamilyCapabilities();
+      assertFalse(capabilities.getAllowLocalAsIn());
+      // Counter-part to allow-as-in. Always true
+      assertTrue(capabilities.getAllowRemoteAsOut());
     }
 
     {
       // address family is non-null but allowasin is not set
       BgpNeighborIpv4UnicastAddressFamily af = new BgpNeighborIpv4UnicastAddressFamily();
-      assertFalse(
-          convertIpv4UnicastAddressFamily(af, true, policy, null)
-              .getAddressFamilyCapabilities()
-              .getAllowLocalAsIn());
+      AddressFamilyCapabilities capabilities =
+          convertIpv4UnicastAddressFamily(af, true, policy, null).getAddressFamilyCapabilities();
+      assertFalse(capabilities.getAllowLocalAsIn());
+      // Counter-part to allow-as-in. Always true
+      assertTrue(capabilities.getAllowRemoteAsOut());
     }
 
     {
       // address family is non-null and allowasin is  set
       BgpNeighborIpv4UnicastAddressFamily af = new BgpNeighborIpv4UnicastAddressFamily();
       af.setAllowAsIn(5);
-      assertTrue(
-          convertIpv4UnicastAddressFamily(af, true, policy, null)
-              .getAddressFamilyCapabilities()
-              .getAllowLocalAsIn());
+      AddressFamilyCapabilities capabilities =
+          convertIpv4UnicastAddressFamily(af, true, policy, null).getAddressFamilyCapabilities();
+      assertTrue(capabilities.getAllowLocalAsIn());
+      // Counter-part to allow-as-in. Always true
+      assertTrue(capabilities.getAllowRemoteAsOut());
     }
   }
 

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -15280,7 +15280,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : true,
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -15309,7 +15309,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : true,
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -15337,7 +15337,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : true,
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -15366,7 +15366,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : true,
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -15394,7 +15394,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : true,
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -15424,7 +15424,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : true,
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -15670,7 +15670,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : true,
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -15708,7 +15708,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : true,
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },


### PR DESCRIPTION
No knob to turn it off. Behavior confirmed with GNS3