### PR TITLE
AclTracer: return trace trees

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTrace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTrace.java
@@ -4,10 +4,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import com.google.common.graph.Traverser;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.trace.TraceNode;
 
 public final class AclTrace implements Serializable {
   private static final String PROP_EVENTS = "events";
@@ -17,6 +21,15 @@ public final class AclTrace implements Serializable {
   @JsonCreator
   public AclTrace(@JsonProperty(PROP_EVENTS) @Nullable Iterable<TraceEvent> events) {
     _events = events != null ? ImmutableList.copyOf(events) : ImmutableList.of();
+  }
+
+  public AclTrace(TraceNode traceTree) {
+    this(
+        Streams.stream(Traverser.forTree(TraceNode::getChildren).depthFirstPreOrder(traceTree))
+            .map(TraceNode::getTraceElement)
+            .filter(Objects::nonNull)
+            .map(TraceEvent::of)
+            .collect(ImmutableList.toImmutableList()));
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -5,12 +5,9 @@ import static org.batfish.datamodel.acl.TraceElements.deniedByAclLine;
 import static org.batfish.datamodel.acl.TraceElements.permittedByAclLine;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
-import com.google.common.graph.Traverser;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.AclLine;
@@ -37,7 +34,7 @@ public final class AclTracer extends AclLineEvaluator {
 
   @VisibleForTesting static String SRC_IP_DESCRIPTION = "source IP";
 
-  public static AclTrace trace(
+  public static TraceNode trace(
       @Nonnull IpAccessList ipAccessList,
       @Nonnull Flow flow,
       @Nullable String srcInterface,
@@ -69,15 +66,8 @@ public final class AclTracer extends AclLineEvaluator {
     return _flow;
   }
 
-  public @Nonnull AclTrace getTrace() {
-    TraceNode root = _tracer.getTrace();
-    return new AclTrace(
-        ImmutableList.copyOf(Traverser.forTree(TraceNode::getChildren).depthFirstPreOrder(root))
-            .stream()
-            .map(TraceNode::getTraceElement)
-            .filter(Objects::nonNull)
-            .map(TraceEvent::of)
-            .collect(ImmutableList.toImmutableList()));
+  public @Nonnull TraceNode getTrace() {
+    return _tracer.getTrace();
   }
 
   public void recordAction(@Nonnull IpAccessList ipAccessList, int index, LineAction action) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/trace/TraceNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/trace/TraceNode.java
@@ -48,7 +48,7 @@ public final class TraceNode {
     return _children;
   }
 
-  @Nonnull
+  @Nullable
   public TraceElement getTraceElement() {
     return _traceElement;
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -5,9 +5,14 @@ import static org.batfish.datamodel.acl.TraceElements.defaultDeniedByIpAccessLis
 import static org.batfish.datamodel.acl.TraceElements.deniedByAclLine;
 import static org.batfish.datamodel.acl.TraceElements.permittedByAclLine;
 import static org.batfish.datamodel.acl.TraceElements.permittedByNamedIpSpace;
+import static org.batfish.datamodel.acl.TraceNodeMatchers.hasChildren;
+import static org.batfish.datamodel.acl.TraceNodeMatchers.hasTraceElement;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasEvents;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -25,6 +30,7 @@ import org.batfish.datamodel.IpSpaceMetadata;
 import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.datamodel.trace.TraceNode;
 import org.junit.Test;
 
 public class AclTracerTest {
@@ -45,10 +51,14 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(
+        root, allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty())));
+
+    AclTrace trace = new AclTrace(root);
     /* The ACL has no lines, so the only event should be a default deny */
     assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
   }
@@ -74,10 +84,14 @@ public class AclTracerTest {
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of(ACL_IP_SPACE_NAME, aclIpSpace);
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata =
         ImmutableMap.of(ACL_IP_SPACE_NAME, new IpSpaceMetadata(ACL_IP_SPACE_NAME, TEST_ACL));
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(
+        root, allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty())));
+
+    AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
   }
 
@@ -102,10 +116,21 @@ public class AclTracerTest {
         ImmutableMap.of(ACL_NAME, acl, aclIndirectName, aclIndirect);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(
+        root,
+        allOf(
+            hasTraceElement(deniedByAclLine(acl, 0)),
+            hasChildren(
+                contains(
+                    allOf(
+                        hasTraceElement(permittedByAclLine(aclIndirect, 0)),
+                        hasChildren(empty()))))));
+
+    AclTrace trace = new AclTrace(root);
     assertThat(
         trace,
         hasEvents(
@@ -124,10 +149,13 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(root, allOf(hasTraceElement(deniedByAclLine(acl, 0)), hasChildren(empty())));
+
+    AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(deniedByAclLine(acl, 0)))));
   }
 
@@ -153,10 +181,14 @@ public class AclTracerTest {
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of(ACL_IP_SPACE_NAME, aclIpSpace);
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata =
         ImmutableMap.of(ACL_IP_SPACE_NAME, new IpSpaceMetadata(ACL_IP_SPACE_NAME, TEST_ACL));
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(
+        root, allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty())));
+
+    AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
   }
 
@@ -179,10 +211,14 @@ public class AclTracerTest {
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata =
         ImmutableMap.of(ipSpaceName, new IpSpaceMetadata(ipSpaceName, TEST_ACL));
 
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(
+        root, allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty())));
+
+    AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
   }
 
@@ -205,10 +241,14 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(
+        root, allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty())));
+
+    AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
   }
 
@@ -226,10 +266,14 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(
+        root, allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty())));
+
+    AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
   }
 
@@ -243,10 +287,13 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(root, allOf(hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty())));
+
+    AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(permittedByAclLine(acl, 0)))));
   }
 
@@ -268,10 +315,26 @@ public class AclTracerTest {
     IpSpaceMetadata ipSpaceMetadata = new IpSpaceMetadata(ipSpaceName, TEST_ACL);
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata =
         ImmutableMap.of(ipSpaceName, ipSpaceMetadata);
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(
+        root,
+        allOf(
+            hasTraceElement(permittedByAclLine(acl, 0)),
+            hasChildren(
+                contains(
+                    allOf(
+                        hasTraceElement(
+                            permittedByNamedIpSpace(
+                                FLOW.getDstIp(),
+                                DEST_IP_DESCRIPTION,
+                                ipSpaceMetadata,
+                                ipSpaceName)),
+                        hasChildren(empty()))))));
+
+    AclTrace trace = new AclTrace(root);
     assertThat(
         trace,
         hasEvents(
@@ -301,10 +364,13 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(root, allOf(hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty())));
+
+    AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(permittedByAclLine(acl, 0)))));
   }
 
@@ -323,10 +389,13 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(root, allOf(hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty())));
+
+    AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(permittedByAclLine(acl, 0)))));
   }
 
@@ -365,10 +434,32 @@ public class AclTracerTest {
             ACL_NAME, acl, aclIndirectName1, aclIndirect1, aclIndirectName2, aclIndirect2);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    AclTrace trace =
+    TraceNode root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
+    assertThat(
+        root,
+        allOf(
+            hasTraceElement(permittedByAclLine(acl, 0)),
+            hasChildren(
+                contains(
+                    allOf(
+                        hasTraceElement(nullValue()), // and conjunct
+                        hasChildren(
+                            contains(
+                                allOf(
+                                    hasTraceElement(permittedByAclLine(aclIndirect2, 0)),
+                                    hasChildren(empty()))))),
+                    allOf(
+                        hasTraceElement(nullValue()), // and conjunct
+                        hasChildren(
+                            contains(
+                                allOf(
+                                    hasTraceElement(permittedByAclLine(aclIndirect1, 0)),
+                                    hasChildren(empty())))))))));
+
+    AclTrace trace = new AclTrace(root);
     assertThat(
         trace,
         hasEvents(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/TraceNodeMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/TraceNodeMatchers.java
@@ -1,0 +1,29 @@
+package org.batfish.datamodel.acl;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.List;
+import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.acl.TraceNodeMatchersImpl.HasChildren;
+import org.batfish.datamodel.acl.TraceNodeMatchersImpl.HasTraceElement;
+import org.batfish.datamodel.trace.TraceNode;
+import org.hamcrest.Matcher;
+
+public final class TraceNodeMatchers {
+  private TraceNodeMatchers() {}
+
+  /** A {@link TraceNode} matcher on {@link TraceNode#getTraceElement()}. */
+  public static Matcher<TraceNode> hasTraceElement(Matcher<? super TraceElement> subMatcher) {
+    return new HasTraceElement(subMatcher);
+  }
+
+  /** A {@link TraceNode} matcher on {@link TraceNode#getTraceElement()}. */
+  public static Matcher<TraceNode> hasTraceElement(TraceElement traceElement) {
+    return new HasTraceElement(equalTo(traceElement));
+  }
+
+  /** A {@link TraceNode} matcher on {@link TraceNode#getChildren()}. */
+  public static Matcher<TraceNode> hasChildren(Matcher<? super List<TraceNode>> subMatcher) {
+    return new HasChildren(subMatcher);
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/TraceNodeMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/TraceNodeMatchersImpl.java
@@ -1,0 +1,33 @@
+package org.batfish.datamodel.acl;
+
+import java.util.List;
+import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.trace.TraceNode;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+public final class TraceNodeMatchersImpl {
+  private TraceNodeMatchersImpl() {}
+
+  public static final class HasChildren extends FeatureMatcher<TraceNode, List<TraceNode>> {
+    public HasChildren(Matcher<? super List<TraceNode>> subMatcher) {
+      super(subMatcher, "a TraceNode with children: ", "children");
+    }
+
+    @Override
+    protected List<TraceNode> featureValueOf(TraceNode traceNode) {
+      return traceNode.getChildren();
+    }
+  }
+
+  public static final class HasTraceElement extends FeatureMatcher<TraceNode, TraceElement> {
+    public HasTraceElement(Matcher<? super TraceElement> subMatcher) {
+      super(subMatcher, "a TraceNode with traceElement: ", "traceElement");
+    }
+
+    @Override
+    protected TraceElement featureValueOf(TraceNode traceNode) {
+      return traceNode.getTraceElement();
+    }
+  }
+}

--- a/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersAnswerer.java
@@ -201,13 +201,14 @@ public class TestFiltersAnswerer extends Answerer {
    */
   public static Row getRow(IpAccessList filter, Flow flow, Configuration c) {
     AclTrace trace =
-        AclTracer.trace(
-            filter,
-            flow,
-            flow.getIngressInterface(),
-            c.getIpAccessLists(),
-            c.getIpSpaces(),
-            c.getIpSpaceMetadata());
+        new AclTrace(
+            AclTracer.trace(
+                filter,
+                flow,
+                flow.getIngressInterface(),
+                c.getIpAccessLists(),
+                c.getIpSpaces(),
+                c.getIpSpaceMetadata()));
     FilterResult result =
         filter.filter(flow, flow.getIngressInterface(), c.getIpAccessLists(), c.getIpSpaces());
     Integer matchLine = result.getMatchLine();


### PR DESCRIPTION
No user-visible changes, but is another step toward returning the trace trees produced by AclTracer to the user. In particular, it allows us to test the trace trees directly.