### PR TITLE
Internet modeling: Use /29 instead of /30 for internet interface

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
@@ -72,7 +72,8 @@ public final class IspModelingUtils {
   public static final String INTERNET_HOST_NAME = "internet";
   static final Ip INTERNET_OUT_ADDRESS = Ip.parse("240.254.254.1");
   static final String INTERNET_OUT_INTERFACE = "Internet_out_interface";
-  static final int INTERNET_OUT_SUBNET = 30;
+  // picking a value < 30 so that @enter(internet) is meaningful
+  static final int INTERNET_OUT_SUBNET = 29;
   private static final int ISP_INTERNET_SUBNET = 31;
 
   public static String getDefaultIspNodeName(Long asn) {

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -1101,12 +1101,12 @@
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
             "allPrefixes" : [
-              "240.254.254.1/30"
+              "240.254.254.1/29"
             ],
             "allowedVlans" : "",
             "autostate" : true,
             "mtu" : 1500,
-            "prefix" : "240.254.254.1/30",
+            "prefix" : "240.254.254.1/29",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,


### PR DESCRIPTION
This change allows users to use @enter(internet) as a valid specifier, which also helps other analysis that wants to analyze traffic coming from "outside". 