### PR TITLE
NetworkFactory: remove almost all uses in production code

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpProcess.java
@@ -19,13 +19,12 @@ import java.util.TreeMap;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
 import org.batfish.datamodel.bgp.BgpConfederation;
 
 /** Represents a bgp process on a router */
 public class BgpProcess implements Serializable {
 
-  public static class Builder extends NetworkFactoryBuilder<BgpProcess> {
+  public static class Builder {
 
     @Nullable private BgpConfederation _confederation;
     @Nullable private Integer _ebgpAdminCost;
@@ -33,11 +32,6 @@ public class BgpProcess implements Serializable {
     @Nullable private Ip _routerId;
     @Nullable private Vrf _vrf;
 
-    private Builder(@Nullable NetworkFactory networkFactory) {
-      super(networkFactory, BgpProcess.class);
-    }
-
-    @Override
     public BgpProcess build() {
       checkArgument(_routerId != null, "Missing %s", PROP_ROUTER_ID);
       checkArgument(_ebgpAdminCost != null, "Missing %s", PROP_EBGP_ADMIN_COST);
@@ -197,11 +191,7 @@ public class BgpProcess implements Serializable {
   }
 
   public static Builder builder() {
-    return new Builder(null);
-  }
-
-  static Builder builder(@Nullable NetworkFactory nf) {
-    return new Builder(nf);
+    return new Builder();
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
@@ -11,34 +11,31 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
 import org.batfish.datamodel.acl.AclLineEvaluator;
 
 /** An access-list used to filter IPV4 packets */
 public class IpAccessList implements Serializable {
 
-  public static class Builder extends NetworkFactoryBuilder<IpAccessList> {
+  public static class Builder {
 
     private List<AclLine> _lines;
-
-    private String _name;
-
+    private @Nullable String _name;
+    private @Nullable Supplier<String> _nameGenerator;
     private Configuration _owner;
-
     private String _sourceName;
-
     private String _sourceType;
 
-    Builder(NetworkFactory networkFactory) {
-      super(networkFactory, IpAccessList.class);
+    private Builder(@Nullable Supplier<String> nameGenerator) {
       _lines = ImmutableList.of();
+      _nameGenerator = nameGenerator;
     }
 
-    @Override
     public IpAccessList build() {
-      String name = _name != null ? _name : generateName();
+      checkArgument(_name != null || _nameGenerator != null, "Must set name before building");
+      String name = _name != null ? _name : _nameGenerator.get();
       IpAccessList ipAccessList = new IpAccessList(name, _lines, _sourceName, _sourceType);
       if (_owner != null) {
         _owner.getIpAccessLists().put(name, ipAccessList);
@@ -94,6 +91,10 @@ public class IpAccessList implements Serializable {
 
   public static Builder builder() {
     return new Builder(null);
+  }
+
+  public static Builder builder(@Nullable Supplier<String> nameGenerator) {
+    return new Builder(nameGenerator);
   }
 
   @Nonnull private final List<AclLine> _lines;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkFactory.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/NetworkFactory.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -33,11 +34,6 @@ public class NetworkFactory {
 
     public abstract T build();
 
-    protected long generateLong() {
-      checkState(_networkFactory != null, "Cannot generate a long value without a network factory");
-      return _networkFactory.generateLong(_outputClass);
-    }
-
     protected String generateName() {
       checkState(_networkFactory != null, "Cannot generate a name without a network factory");
       return _networkFactory.generateName(_outputClass);
@@ -54,7 +50,7 @@ public class NetworkFactory {
   }
 
   public IpAccessList.Builder aclBuilder() {
-    return new IpAccessList.Builder(this);
+    return IpAccessList.builder(() -> generateName(IpAccessList.class));
   }
 
   public BgpActivePeerConfig.Builder bgpNeighborBuilder() {
@@ -68,11 +64,11 @@ public class NetworkFactory {
   }
 
   public BgpProcess.Builder bgpProcessBuilder() {
-    return BgpProcess.builder(this);
+    return BgpProcess.builder();
   }
 
   public Configuration.Builder configurationBuilder() {
-    return new Configuration.Builder(this);
+    return Configuration.builder(() -> generateName(Configuration.class));
   }
 
   private long generateLong(Class<?> forClass) {
@@ -89,27 +85,28 @@ public class NetworkFactory {
   }
 
   public Interface.Builder interfaceBuilder() {
-    return new Interface.Builder(this);
+    return Interface.builder(() -> generateName(Interface.class));
   }
 
   public OspfArea.Builder ospfAreaBuilder() {
-    return OspfArea.builder(this);
+    return OspfArea.builder(() -> generateLong(OspfArea.class));
   }
 
   /** Return an OSPF builder. Pre-defines required fields (e.g., reference bandwidth) */
   public OspfProcess.Builder ospfProcessBuilder() {
-    return OspfProcess.builder(this).setReferenceBandwidth(1e8);
+    return OspfProcess.builder(() -> generateName(OspfProcess.class)).setReferenceBandwidth(1e8);
   }
 
   public RipProcess.Builder ripProcessBuilder() {
-    return new RipProcess.Builder(this);
+    return RipProcess.builder();
   }
 
+  @VisibleForTesting
   public RoutingPolicy.Builder routingPolicyBuilder() {
-    return new RoutingPolicy.Builder(this);
+    return RoutingPolicy.builder(() -> generateName(RoutingPolicy.class));
   }
 
   public Vrf.Builder vrfBuilder() {
-    return new Vrf.Builder(this);
+    return Vrf.builder(() -> generateName(Vrf.class));
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RipProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RipProcess.java
@@ -7,19 +7,17 @@ import com.google.common.collect.Table;
 import java.io.Serializable;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import org.batfish.datamodel.NetworkFactory.NetworkFactoryBuilder;
 
 public class RipProcess implements Serializable {
 
-  public static class Builder extends NetworkFactoryBuilder<RipProcess> {
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
 
     private Vrf _vrf;
 
-    Builder(NetworkFactory networkFactory) {
-      super(networkFactory, RipProcess.class);
-    }
-
-    @Override
     public RipProcess build() {
       RipProcess ripProcess = new RipProcess();
       if (_vrf != null) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
@@ -385,7 +385,7 @@ public class IspModelingUtilsTest {
 
   @Test
   public void testCreateInternetNode() {
-    Configuration internet = IspModelingUtils.createInternetNode(new NetworkFactory());
+    Configuration internet = IspModelingUtils.createInternetNode();
     InterfaceAddress interfaceAddress =
         ConcreteInterfaceAddress.create(
             IspModelingUtils.INTERNET_OUT_ADDRESS, IspModelingUtils.INTERNET_OUT_SUBNET);
@@ -583,8 +583,7 @@ public class IspModelingUtilsTest {
         IspModelingUtils.installRoutingPolicyAdvertiseStatic(
             IspModelingUtils.EXPORT_POLICY_ON_INTERNET,
             internet,
-            new PrefixSpace(PrefixRange.fromPrefix(Prefix.ZERO)),
-            nf);
+            new PrefixSpace(PrefixRange.fromPrefix(Prefix.ZERO)));
 
     PrefixSpace prefixSpace = new PrefixSpace();
     prefixSpace.addPrefix(Prefix.ZERO);
@@ -616,7 +615,7 @@ public class IspModelingUtilsTest {
             .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
             .setHostname("fakeIsp")
             .build();
-    RoutingPolicy ispRoutingPolicy = IspModelingUtils.getRoutingPolicyForIsp(isp, nf);
+    RoutingPolicy ispRoutingPolicy = IspModelingUtils.getRoutingPolicyForIsp(isp);
 
     RoutingPolicy expectedRoutingPolicy =
         nf.routingPolicyBuilder()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfProcessTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfProcessTest.java
@@ -116,26 +116,23 @@ public class OspfProcessTest {
 
   @Test
   public void setAreasMismatchedNumbers() {
-    final NetworkFactory networkFactory = new NetworkFactory();
     OspfProcess proc =
-        OspfProcess.builder(networkFactory)
+        OspfProcess.builder()
             .setProcessId("1")
             .setRouterId(Ip.ZERO)
             .setReferenceBandwidth(10e8)
             .build();
     _thrown.expect(IllegalArgumentException.class);
-    proc.setAreas(
-        ImmutableSortedMap.of(1L, OspfArea.builder(networkFactory).setNumber(2L).build()));
+    proc.setAreas(ImmutableSortedMap.of(1L, OspfArea.builder().setNumber(2L).build()));
   }
 
   @Test
   public void setAreasMismatchedNumbersOnBuild() {
-    final NetworkFactory networkFactory = new NetworkFactory();
     _thrown.expect(IllegalArgumentException.class);
-    OspfProcess.builder(networkFactory)
+    OspfProcess.builder()
         .setProcessId("1")
         .setReferenceBandwidth(10e8)
-        .setAreas(ImmutableSortedMap.of(1L, OspfArea.builder(networkFactory).setNumber(2L).build()))
+        .setAreas(ImmutableSortedMap.of(1L, OspfArea.builder().setNumber(2L).build()))
         .build();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/InternetGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/InternetGateway.java
@@ -26,7 +26,6 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.acl.AclLineMatchExprs;
@@ -153,8 +152,7 @@ final class InternetGateway implements AwsVpcEntity, Serializable {
               addStaticRoute(cfgNode, toStaticRoute(publicIp.toPrefix(), NULL_INTERFACE_NAME));
             });
 
-    installRoutingPolicyAdvertiseStatic(
-        BACKBONE_EXPORT_POLICY_NAME, cfgNode, publicPrefixSpace, new NetworkFactory());
+    installRoutingPolicyAdvertiseStatic(BACKBONE_EXPORT_POLICY_NAME, cfgNode, publicPrefixSpace);
 
     BgpActivePeerConfig.builder()
         .setPeerAddress(bbInterfaceSubnet.getEndIp())

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -19,7 +19,6 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LinkLocalAddress;
-import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
@@ -36,8 +35,6 @@ import org.w3c.dom.NodeList;
 /** A collection for utilities for AWS vendor model */
 @ParametersAreNonnullByDefault
 final class Utils {
-
-  private static final NetworkFactory FACTORY = new NetworkFactory();
 
   static final Statement ACCEPT_ALL_BGP =
       new If(
@@ -61,15 +58,14 @@ final class Utils {
 
   static Configuration newAwsConfiguration(String name, String domainName) {
     Configuration c =
-        FACTORY
-            .configurationBuilder()
+        Configuration.builder()
             .setHostname(name)
             .setDomainName(domainName)
             .setConfigurationFormat(ConfigurationFormat.AWS)
             .setDefaultInboundAction(LineAction.PERMIT)
             .setDefaultCrossZoneAction(LineAction.PERMIT)
             .build();
-    FACTORY.vrfBuilder().setName(Configuration.DEFAULT_VRF_NAME).setOwner(c).build();
+    Vrf.builder().setName(Configuration.DEFAULT_VRF_NAME).setOwner(c).build();
     c.getVendorFamily().setAws(new AwsFamily());
     return c;
   }
@@ -92,8 +88,7 @@ final class Utils {
       String description) {
     checkArgument(
         c.getVrfs().containsKey(vrfName), "VRF %s does not exist on %s", vrfName, c.getHostname());
-    return FACTORY
-        .interfaceBuilder()
+    return Interface.builder()
         .setName(name)
         .setOwner(c)
         .setVrf(c.getVrfs().get(vrfName))

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnGateway.java
@@ -25,7 +25,6 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.LinkLocalAddress;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
-import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 
@@ -131,8 +130,7 @@ final class VpnGateway implements AwsVpcEntity, Serializable {
                 addStaticRoute(cfgNode, toStaticRoute(pfx, NULL_INTERFACE_NAME));
               });
 
-      installRoutingPolicyAdvertiseStatic(
-          VGW_EXPORT_POLICY_NAME, cfgNode, originationSpace, new NetworkFactory());
+      installRoutingPolicyAdvertiseStatic(VGW_EXPORT_POLICY_NAME, cfgNode, originationSpace);
 
       RoutingPolicy.builder()
           .setName(VGW_IMPORT_POLICY_NAME)

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Conversions.java
@@ -13,7 +13,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.PrefixRange;
 import org.batfish.datamodel.PrefixSpace;
@@ -76,8 +75,7 @@ final class Conversions {
   /** Creates and stores a routing policy from the given statement in configuration object */
   static void statementToRoutingPolicy(
       Statement statement, Configuration c, String routingPolicyName) {
-    new NetworkFactory()
-        .routingPolicyBuilder()
+    RoutingPolicy.builder()
         .setOwner(c)
         .setName(routingPolicyName)
         .setStatements(ImmutableList.of(statement))
@@ -250,8 +248,7 @@ final class Conversions {
     // Conjunction)
     String policyRulesRpNameForPeer =
         getRoutingPolicyNameForExportPolicyRulesForPeer(vr.getName(), peer.getName());
-    new NetworkFactory()
-        .routingPolicyBuilder()
+    RoutingPolicy.builder()
         .setOwner(c)
         .setName(policyRulesRpNameForPeer)
         .setStatements(statementsForExportPolicyRules)
@@ -265,8 +262,7 @@ final class Conversions {
                 new CallExpr(generatedBgpCommonExportPolicyName(vr.getName())),
                 new CallExpr(policyRulesRpNameForPeer)));
 
-    return new NetworkFactory()
-        .routingPolicyBuilder()
+    return RoutingPolicy.builder()
         .setOwner(c)
         .setName(generatedBgpPeerExportPolicyName(vr.getName(), peer.getName()))
         .setStatements(
@@ -298,8 +294,7 @@ final class Conversions {
                 Stream.of(Statements.ReturnFalse.toStaticStatement()))
             .collect(ImmutableList.toImmutableList());
 
-    return new NetworkFactory()
-        .routingPolicyBuilder()
+    return RoutingPolicy.builder()
         .setOwner(c)
         .setName(generatedBgpPeerImportPolicyName(vr.getName(), peer.getName()))
         .setStatements(statementsForImportPolicyRules)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -175,7 +175,7 @@ public class OspfRoutingProcessTest {
                     .build())
             .build();
     AREA0_CONFIG =
-        OspfArea.builder(nf)
+        OspfArea.builder()
             .setNumber(0)
             .setInterfaces(
                 ImmutableSet.of(
@@ -1162,7 +1162,7 @@ public class OspfRoutingProcessTest {
             .build();
 
     AREA0_CONFIG =
-        OspfArea.builder(nf)
+        OspfArea.builder()
             .setNumber(0)
             .setInterfaces(ImmutableSet.of(activeIface.getName()))
             .build();

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -29,7 +29,6 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.bgp.BgpTopologyUtils.ConfedSessionType;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
-import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.expr.LiteralCommunity;
 import org.batfish.datamodel.routing_policy.statement.SetCommunity;
 import org.batfish.datamodel.routing_policy.statement.Statements;
@@ -309,7 +308,7 @@ public class BgpProtocolHelperTest {
     Bgpv4Route result =
         convertGeneratedRouteToBgp(
             GeneratedRoute.builder().setNetwork(Prefix.ZERO).setDiscard(true).build(),
-            RoutingPolicy.builder(nf)
+            nf.routingPolicyBuilder()
                 .setOwner(c)
                 .setStatements(
                     ImmutableList.of(

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -118,7 +118,7 @@ public final class CumulusConversionsTest {
 
   private Environment finalEnvironment(Statement statement, String network) {
     RoutingPolicy policy =
-        RoutingPolicy.builder(_nf).setOwner(_c).setStatements(ImmutableList.of(statement)).build();
+        _nf.routingPolicyBuilder().setOwner(_c).setStatements(ImmutableList.of(statement)).build();
     Environment env =
         Environment.builder(_c)
             .setOriginalRoute(
@@ -137,7 +137,7 @@ public final class CumulusConversionsTest {
 
   private boolean value(BooleanExpr expr, Environment env) {
     RoutingPolicy policy =
-        RoutingPolicy.builder(_nf)
+        _nf.routingPolicyBuilder()
             .setOwner(_c)
             .setStatements(
                 ImmutableList.of(

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -381,12 +381,12 @@ public class EdgesAnswererTest {
   public void testGetOspfEdges() {
     NetworkFactory nf = new NetworkFactory();
     OspfProcess ospf1 =
-        OspfProcess.builder(nf).setRouterId(Ip.parse("1.1.1.1")).setReferenceBandwidth(1e8).build();
+        nf.ospfProcessBuilder().setRouterId(Ip.parse("1.1.1.1")).setReferenceBandwidth(1e8).build();
     OspfProcess ospf2 =
-        OspfProcess.builder(nf).setRouterId(Ip.parse("2.2.2.2")).setReferenceBandwidth(1e8).build();
+        nf.ospfProcessBuilder().setRouterId(Ip.parse("2.2.2.2")).setReferenceBandwidth(1e8).build();
 
-    OspfArea.builder(nf).setNumber(1L).setOspfProcess(ospf1).addInterface("int1").build();
-    OspfArea.builder(nf).setNumber(1L).setOspfProcess(ospf2).addInterface("int2").build();
+    OspfArea.builder().setNumber(1L).setOspfProcess(ospf1).addInterface("int1").build();
+    OspfArea.builder().setNumber(1L).setOspfProcess(ospf2).addInterface("int2").build();
 
     Vrf vrf1 = new Vrf("vrf1");
     vrf1.setOspfProcesses(Stream.of(ospf1));


### PR DESCRIPTION
Only remaining use is in `IspModelingUtils`, but deferring to when it can be analyzed on its own.