### PR TITLE
Arista BGP: fix routing policy for default-originate

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/AristaConversions.java
@@ -452,13 +452,14 @@ final class AristaConversions {
       trueStatementsForGeneratedDefaultRoute.add(Statements.ReturnTrue.toStaticStatement());
       exportStatements.add(
           new If(
-              new Conjunction(
-                  ImmutableList.of(
-                      Common.matchDefaultRoute(),
-                      // AGGREGATE means we generated it in this context
-                      new MatchProtocol(RoutingProtocol.AGGREGATE))),
-              trueStatementsForGeneratedDefaultRoute.build(),
-              ImmutableList.of(Statements.ReturnFalse.toStaticStatement())));
+              Common.matchDefaultRoute(), // we are exporting some default route
+              ImmutableList.of(
+                  new If(
+                      new MatchProtocol(RoutingProtocol.AGGREGATE),
+                      // default-originate (we generated it): call the routemap, etc.
+                      trueStatementsForGeneratedDefaultRoute.build(),
+                      // not default-originate: deny.
+                      ImmutableList.of(Statements.ReturnFalse.toStaticStatement())))));
     }
     if (firstNonNull(neighbor.getNextHopSelf(), Boolean.FALSE)) {
       exportStatements.add(new SetNextHop(SelfNextHop.getInstance()));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -824,6 +824,8 @@ public final class CiscoGrammarTest {
             .setLocalPreference(100)
             .build();
     assertThat(listenerRoutes, hasItem(equalTo(expectedDefaultRoute)));
+    // Ensure 10.10.10.0/24 doesn't get blocked
+    assertThat(listenerRoutes, hasItem(hasPrefix(Prefix.parse("10.10.10.0/24"))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-bgp-default-originate/configs/arista-originator
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/arista-bgp-default-originate/configs/arista-originator
@@ -12,7 +12,10 @@ router bgp 1
  router-id 1.1.1.1
  neighbor 10.1.1.2 remote-as 2
  neighbor 10.1.1.2 default-originate route-map ROUTE_MAP
+ network 10.10.10.0/24
 !
 route-map ROUTE_MAP permit 10
  set community 111:222 additive
  set community 333:444 additive
+!
+ip route 10.10.10.0/24 Null0


### PR DESCRIPTION
Fix a bug where all non-default routes would be blocked due to a bad routing policy If statement