### PR TITLE
FibLookupOutgoingInterfaceIsOneOf: fix buggy Json deserialization

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/FibLookupOutgoingInterfaceIsOneOf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/FibLookupOutgoingInterfaceIsOneOf.java
@@ -4,6 +4,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
@@ -41,6 +42,7 @@ public class FibLookupOutgoingInterfaceIsOneOf implements BoolExpr {
   }
 
   @Nonnull
+  @JsonIgnore
   public Set<String> getInterfaceNames() {
     return _interfaceNames;
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FibLookupOutgoingInterfaceIsOneOfTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FibLookupOutgoingInterfaceIsOneOfTest.java
@@ -41,7 +41,8 @@ public class FibLookupOutgoingInterfaceIsOneOfTest {
   @Test
   public void testJsonSerialization() throws IOException {
     FibLookupOutgoingInterfaceIsOneOf expr =
-        new FibLookupOutgoingInterfaceIsOneOf(IngressInterfaceVrf.instance(), ImmutableSet.of());
+        new FibLookupOutgoingInterfaceIsOneOf(
+            IngressInterfaceVrf.instance(), ImmutableSet.of("iface"));
     assertThat(
         BatfishObjectMapper.clone(expr, FibLookupOutgoingInterfaceIsOneOf.class), equalTo(expr));
   }


### PR DESCRIPTION
Stops us from crashing viModel in networks where FLOIIOO is used