### PR TITLE
Eclipse disable bcp xtext builder

### DIFF
--- a/projects/batfish-common-protocol/.externalToolBuilders/org.eclipse.xtext.ui.shared.xtextBuilder.launch
+++ b/projects/batfish-common-protocol/.externalToolBuilders/org.eclipse.xtext.ui.shared.xtextBuilder.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.ant.AntBuilderLaunchConfigurationType">
+    <booleanAttribute key="org.eclipse.ui.externaltools.ATTR_BUILDER_ENABLED" value="false"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_DISABLED_BUILDER" value="org.eclipse.xtext.ui.shared.xtextBuilder"/>
+    <mapAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS"/>
+    <booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
+</launchConfiguration>

--- a/projects/batfish-common-protocol/.project
+++ b/projects/batfish-common-protocol/.project
@@ -6,8 +6,13 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
+			<triggers>full,incremental,</triggers>
 			<arguments>
+				<dictionary>
+					<key>LaunchConfigHandle</key>
+					<value>&lt;project&gt;/.externalToolBuilders/org.eclipse.xtext.ui.shared.xtextBuilder.launch</value>
+				</dictionary>
 			</arguments>
 		</buildCommand>
 		<buildCommand>


### PR DESCRIPTION
- should always disable xtext builder
- xtext builder causes bug where clean triggers rebuild regardless of
build-after-clean setting