### PR TITLE
Simplify AclTracer

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TraceElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TraceElement.java
@@ -21,8 +21,6 @@ import org.batfish.vendor.VendorStructureId;
 /** Metadata used to create human-readable traces. */
 @ParametersAreNonnullByDefault
 public final class TraceElement implements Serializable {
-  public static final TraceElement AUTO_GENERATE_LEGACY_TRACE = TraceElement.of("~AUTO~");
-
   private static final String PROP_FRAGMENTS = "fragments";
   private static final String PROP_TEXT = "text";
   private static final String PROP_VENDOR_STRUCTURE_ID = "vendorStructureId";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TraceElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/TraceElement.java
@@ -21,6 +21,8 @@ import org.batfish.vendor.VendorStructureId;
 /** Metadata used to create human-readable traces. */
 @ParametersAreNonnullByDefault
 public final class TraceElement implements Serializable {
+  public static final TraceElement AUTO_GENERATE_LEGACY_TRACE = TraceElement.of("~AUTO~");
+
   private static final String PROP_FRAGMENTS = "fragments";
   private static final String PROP_TEXT = "text";
   private static final String PROP_VENDOR_STRUCTURE_ID = "vendorStructureId";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTrace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTrace.java
@@ -23,9 +23,13 @@ public final class AclTrace implements Serializable {
     _events = events != null ? ImmutableList.copyOf(events) : ImmutableList.of();
   }
 
-  public AclTrace(TraceTree traceTree) {
+  public AclTrace(List<TraceTree> trace) {
     this(
-        Streams.stream(Traverser.forTree(TraceTree::getChildren).depthFirstPreOrder(traceTree))
+        trace.stream()
+            .flatMap(
+                traceTree ->
+                    Streams.stream(
+                        Traverser.forTree(TraceTree::getChildren).depthFirstPreOrder(traceTree)))
             .map(TraceTree::getTraceElement)
             .filter(Objects::nonNull)
             .map(TraceEvent::of)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -34,7 +34,7 @@ public final class AclTracer extends AclLineEvaluator {
 
   @VisibleForTesting static String SRC_IP_DESCRIPTION = "source IP";
 
-  public static TraceTree trace(
+  public static List<TraceTree> trace(
       @Nonnull IpAccessList ipAccessList,
       @Nonnull Flow flow,
       @Nullable String srcInterface,
@@ -66,7 +66,7 @@ public final class AclTracer extends AclLineEvaluator {
     return _flow;
   }
 
-  public @Nonnull TraceTree getTrace() {
+  public @Nonnull List<TraceTree> getTrace() {
     return _tracer.getTrace();
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TraceElements.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TraceElements.java
@@ -18,26 +18,24 @@ public final class TraceElements {
   private TraceElements() {}
 
   public static TraceElement permittedByAclLine(IpAccessList acl, int index) {
-    String type = firstNonNull(acl.getSourceType(), "filter");
-    String name = firstNonNull(acl.getSourceName(), acl.getName());
-    AclLine line = acl.getLines().get(index);
-    String lineDescription = firstNonNull(line.getName(), line.toString());
-    String description =
-        String.format(
-            "Flow permitted by %s named %s, index %d: %s", type, name, index, lineDescription);
-    return TraceElement.of(description);
+    return matchedByAclLine(acl, index, "permitted");
   }
 
   static TraceElement deniedByAclLine(IpAccessList acl, int index) {
+    return matchedByAclLine(acl,index,"denied");
+  }
+
+  private static TraceElement matchedByAclLine(IpAccessList acl, int index, String action) {
     String type = firstNonNull(acl.getSourceType(), "filter");
     String name = firstNonNull(acl.getSourceName(), acl.getName());
     AclLine line = acl.getLines().get(index);
-    String lineDescription = firstNonNull(line.getName(), line.toString());
+    String lineDescription = line.getName() == null ? "" : ": " + line.getName();
     String description =
         String.format(
-            "Flow denied by %s named %s, index %d: %s", type, name, index, lineDescription);
+            "Flow %s by %s named %s, index %d%s", action, type, name, index, lineDescription);
     return TraceElement.of(description);
   }
+
 
   public static TraceElement defaultDeniedByIpAccessList(IpAccessList ipAccessList) {
     String name = ipAccessList.getName();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TraceElements.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TraceElements.java
@@ -22,7 +22,7 @@ public final class TraceElements {
   }
 
   static TraceElement deniedByAclLine(IpAccessList acl, int index) {
-    return matchedByAclLine(acl,index,"denied");
+    return matchedByAclLine(acl, index, "denied");
   }
 
   private static TraceElement matchedByAclLine(IpAccessList acl, int index, String action) {
@@ -35,7 +35,6 @@ public final class TraceElements {
             "Flow %s by %s named %s, index %d%s", action, type, name, index, lineDescription);
     return TraceElement.of(description);
   }
-
 
   public static TraceElement defaultDeniedByIpAccessList(IpAccessList ipAccessList) {
     String name = ipAccessList.getName();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/trace/TraceTree.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/trace/TraceTree.java
@@ -1,11 +1,11 @@
 package org.batfish.datamodel.trace;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -19,30 +19,10 @@ public final class TraceTree {
   private static final String PROP_TRACE_ELEMENT = "traceElement";
   private static final String PROP_CHILDREN = "children";
 
-  /** Builder for {@link TraceTree}. */
-  public static class Builder {
-    private @Nullable TraceElement _traceElement;
-    private final List<TraceTree> _children = new ArrayList<>();
-
-    public Builder setTraceElement(TraceElement traceElement) {
-      _traceElement = traceElement;
-      return this;
-    }
-
-    public Builder addChild(TraceTree child) {
-      _children.add(child);
-      return this;
-    }
-
-    public TraceTree build() {
-      return new TraceTree(_traceElement, _children);
-    }
-  }
-
   private final @Nullable TraceElement _traceElement;
   private final @Nonnull List<TraceTree> _children;
 
-  TraceTree(@Nullable TraceElement traceElement, List<TraceTree> children) {
+  TraceTree(TraceElement traceElement, List<TraceTree> children) {
     _traceElement = traceElement;
     _children = ImmutableList.copyOf(children);
   }
@@ -51,11 +31,8 @@ public final class TraceTree {
   private static TraceTree jsonCreator(
       @Nullable @JsonProperty(PROP_TRACE_ELEMENT) TraceElement traceElement,
       @Nullable @JsonProperty(PROP_CHILDREN) List<TraceTree> children) {
+    checkNotNull(traceElement, "%s cannot be null", PROP_TRACE_ELEMENT);
     return new TraceTree(traceElement, firstNonNull(children, ImmutableList.of()));
-  }
-
-  public static Builder builder() {
-    return new Builder();
   }
 
   @JsonProperty(PROP_CHILDREN)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -12,11 +12,11 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.EmptyIpSpace;
@@ -51,12 +51,13 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        root, allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty())));
+        root,
+        contains(allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
     /* The ACL has no lines, so the only event should be a default deny */
@@ -84,12 +85,13 @@ public class AclTracerTest {
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of(ACL_IP_SPACE_NAME, aclIpSpace);
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata =
         ImmutableMap.of(ACL_IP_SPACE_NAME, new IpSpaceMetadata(ACL_IP_SPACE_NAME, TEST_ACL));
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        root, allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty())));
+        root,
+        contains(allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
@@ -116,19 +118,20 @@ public class AclTracerTest {
         ImmutableMap.of(ACL_NAME, acl, aclIndirectName, aclIndirect);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
         root,
-        allOf(
-            hasTraceElement(deniedByAclLine(acl, 0)),
-            hasChildren(
-                contains(
-                    allOf(
-                        hasTraceElement(permittedByAclLine(aclIndirect, 0)),
-                        hasChildren(empty()))))));
+        contains(
+            allOf(
+                hasTraceElement(deniedByAclLine(acl, 0)),
+                hasChildren(
+                    contains(
+                        allOf(
+                            hasTraceElement(permittedByAclLine(aclIndirect, 0)),
+                            hasChildren(empty())))))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(
@@ -149,11 +152,12 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(root, allOf(hasTraceElement(deniedByAclLine(acl, 0)), hasChildren(empty())));
+    assertThat(
+        root, contains(allOf(hasTraceElement(deniedByAclLine(acl, 0)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(deniedByAclLine(acl, 0)))));
@@ -181,12 +185,13 @@ public class AclTracerTest {
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of(ACL_IP_SPACE_NAME, aclIpSpace);
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata =
         ImmutableMap.of(ACL_IP_SPACE_NAME, new IpSpaceMetadata(ACL_IP_SPACE_NAME, TEST_ACL));
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        root, allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty())));
+        root,
+        contains(allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
@@ -211,12 +216,13 @@ public class AclTracerTest {
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata =
         ImmutableMap.of(ipSpaceName, new IpSpaceMetadata(ipSpaceName, TEST_ACL));
 
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        root, allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty())));
+        root,
+        contains(allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
@@ -241,12 +247,13 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        root, allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty())));
+        root,
+        contains(allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
@@ -266,12 +273,13 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        root, allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty())));
+        root,
+        contains(allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
@@ -287,11 +295,12 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(root, allOf(hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty())));
+    assertThat(
+        root, contains(allOf(hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(permittedByAclLine(acl, 0)))));
@@ -315,24 +324,25 @@ public class AclTracerTest {
     IpSpaceMetadata ipSpaceMetadata = new IpSpaceMetadata(ipSpaceName, TEST_ACL);
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata =
         ImmutableMap.of(ipSpaceName, ipSpaceMetadata);
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
         root,
-        allOf(
-            hasTraceElement(permittedByAclLine(acl, 0)),
-            hasChildren(
-                contains(
-                    allOf(
-                        hasTraceElement(
-                            permittedByNamedIpSpace(
-                                FLOW.getDstIp(),
-                                DEST_IP_DESCRIPTION,
-                                ipSpaceMetadata,
-                                ipSpaceName)),
-                        hasChildren(empty()))))));
+        contains(
+            allOf(
+                hasTraceElement(permittedByAclLine(acl, 0)),
+                hasChildren(
+                    contains(
+                        allOf(
+                            hasTraceElement(
+                                permittedByNamedIpSpace(
+                                    FLOW.getDstIp(),
+                                    DEST_IP_DESCRIPTION,
+                                    ipSpaceMetadata,
+                                    ipSpaceName)),
+                            hasChildren(empty())))))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(
@@ -364,11 +374,12 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(root, allOf(hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty())));
+    assertThat(
+        root, contains(allOf(hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(permittedByAclLine(acl, 0)))));
@@ -389,11 +400,12 @@ public class AclTracerTest {
     Map<String, IpAccessList> availableAcls = ImmutableMap.of(ACL_NAME, acl);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(root, allOf(hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty())));
+    assertThat(
+        root, contains(allOf(hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(permittedByAclLine(acl, 0)))));
@@ -434,30 +446,23 @@ public class AclTracerTest {
             ACL_NAME, acl, aclIndirectName1, aclIndirect1, aclIndirectName2, aclIndirect2);
     Map<String, IpSpace> namedIpSpaces = ImmutableMap.of();
     Map<String, IpSpaceMetadata> namedIpSpaceMetadata = ImmutableMap.of();
-    TraceTree root =
+    List<TraceTree> root =
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
         root,
-        allOf(
-            hasTraceElement(permittedByAclLine(acl, 0)),
-            hasChildren(
-                contains(
-                    allOf(
-                        hasTraceElement(nullValue()), // and conjunct
-                        hasChildren(
-                            contains(
-                                allOf(
-                                    hasTraceElement(permittedByAclLine(aclIndirect1, 0)),
-                                    hasChildren(empty()))))),
-                    allOf(
-                        hasTraceElement(nullValue()), // and conjunct
-                        hasChildren(
-                            contains(
-                                allOf(
-                                    hasTraceElement(permittedByAclLine(aclIndirect2, 0)),
-                                    hasChildren(empty())))))))));
+        contains(
+            allOf(
+                hasTraceElement(permittedByAclLine(acl, 0)),
+                hasChildren(
+                    contains(
+                        allOf(
+                            hasTraceElement(permittedByAclLine(aclIndirect1, 0)),
+                            hasChildren(empty())),
+                        allOf(
+                            hasTraceElement(permittedByAclLine(aclIndirect2, 0)),
+                            hasChildren(empty())))))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(


### PR DESCRIPTION
1. Don't toString lines ACL in traces
2. Make Tracer a bit smarter to ensure TraceTrees have a TraceElement at each node. When a subtree is missing a TraceElement, the root node is deleted. This means we can have multiple top-level trace trees.