### PR TITLE
AclTracer: don't trace default deny

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -1,7 +1,6 @@
 package org.batfish.datamodel.acl;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.batfish.datamodel.acl.TraceElements.defaultDeniedByIpAccessList;
 import static org.batfish.datamodel.acl.TraceElements.deniedByAclLine;
 import static org.batfish.datamodel.acl.TraceElements.permittedByAclLine;
 
@@ -46,7 +45,9 @@ public final class AclTracer extends AclLineEvaluator {
       @Nonnull Map<String, IpSpaceMetadata> namedIpSpaceMetadata) {
     AclTracer tracer =
         new AclTracer(flow, srcInterface, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
-    tracer.traceWithDefaultDeny(ipAccessList);
+    tracer._tracer.newSubTrace();
+    tracer.trace(ipAccessList);
+    tracer._tracer.endSubTrace();
     return tracer.getTrace();
   }
 
@@ -89,10 +90,6 @@ public final class AclTracer extends AclLineEvaluator {
     } else {
       _tracer.setTraceElement(deniedByAclLine(ipAccessList, index));
     }
-  }
-
-  public void recordDefaultDeny(@Nonnull IpAccessList ipAccessList) {
-    _tracer.setTraceElement(defaultDeniedByIpAccessList(ipAccessList));
   }
 
   private static boolean rangesContain(Collection<SubRange> ranges, @Nullable Integer num) {
@@ -276,14 +273,6 @@ public final class AclTracer extends AclLineEvaluator {
       return false;
     }
     return true;
-  }
-
-  private void traceWithDefaultDeny(@Nonnull IpAccessList ipAccessList) {
-    if (trace(ipAccessList) == null) {
-      _tracer.newSubTrace();
-      recordDefaultDeny(ipAccessList);
-      _tracer.endSubTrace();
-    }
   }
 
   private LineAction trace(@Nonnull IpAccessList ipAccessList) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TraceElements.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TraceElements.java
@@ -36,17 +36,6 @@ public final class TraceElements {
     return TraceElement.of(description);
   }
 
-  public static TraceElement defaultDeniedByIpAccessList(IpAccessList ipAccessList) {
-    String name = ipAccessList.getName();
-    @Nullable String sourceName = ipAccessList.getSourceName();
-    @Nullable String sourceType = ipAccessList.getSourceType();
-    String description =
-        sourceName != null
-            ? String.format("Flow did not match '%s' named '%s'", sourceType, sourceName)
-            : String.format("Flow did not match ACL named '%s'", name);
-    return TraceElement.of(description);
-  }
-
   public static TraceElement permittedByNamedIpSpace(
       Ip ip,
       String ipDescription,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/trace/Tracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/trace/Tracer.java
@@ -84,7 +84,7 @@ public final class Tracer {
       }
     } else {
       if (context.getTraceElement() == null) {
-        _trace = context.getChildren();
+        _trace = ImmutableList.copyOf(context.getChildren());
       } else {
         _trace = ImmutableList.of(new TraceTree(context.getTraceElement(), context.getChildren()));
       }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -2,7 +2,6 @@ package org.batfish.datamodel.acl;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.acl.AclTracer.DEST_IP_DESCRIPTION;
-import static org.batfish.datamodel.acl.TraceElements.defaultDeniedByIpAccessList;
 import static org.batfish.datamodel.acl.TraceElements.deniedByAclLine;
 import static org.batfish.datamodel.acl.TraceElements.permittedByAclLine;
 import static org.batfish.datamodel.acl.TraceElements.permittedByNamedIpSpace;
@@ -58,13 +57,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(
-        root,
-        contains(allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty()))));
-
-    AclTrace trace = new AclTrace(root);
-    /* The ACL has no lines, so the only event should be a default deny */
-    assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
+    assertThat(root, empty());
   }
 
   @Test
@@ -92,12 +85,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(
-        root,
-        contains(allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty()))));
-
-    AclTrace trace = new AclTrace(root);
-    assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
+    assertThat(root, empty());
   }
 
   @Test
@@ -192,12 +180,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(
-        root,
-        contains(allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty()))));
-
-    AclTrace trace = new AclTrace(root);
-    assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
+    assertThat(root, empty());
   }
 
   @Test
@@ -223,12 +206,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(
-        root,
-        contains(allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty()))));
-
-    AclTrace trace = new AclTrace(root);
-    assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
+    assertThat(root, empty());
   }
 
   @Test
@@ -254,12 +232,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(
-        root,
-        contains(allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty()))));
-
-    AclTrace trace = new AclTrace(root);
-    assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
+    assertThat(root, empty());
   }
 
   @Test
@@ -280,12 +253,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(
-        root,
-        contains(allOf(hasTraceElement(defaultDeniedByIpAccessList(acl)), hasChildren(empty()))));
-
-    AclTrace trace = new AclTrace(root);
-    assertThat(trace, hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(acl)))));
+    assertThat(root, empty());
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -231,16 +231,6 @@ public class RegionTest {
             c.getIpAccessLists(),
             ImmutableMap.of(),
             ImmutableMap.of());
-    assertThat(
-        root,
-        contains(
-            allOf(
-                hasTraceElement(TraceElements.defaultDeniedByIpAccessList(ingressAcl)),
-                hasChildren(equalTo(ImmutableList.of())))));
-    trace = new AclTrace(root);
-    assertThat(
-        trace,
-        DataModelMatchers.hasEvents(
-            contains(TraceEvent.of(TraceElements.defaultDeniedByIpAccessList(ingressAcl)))));
+    assertThat(root, empty());
   }
 }

--- a/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
@@ -1,7 +1,6 @@
 package org.batfish.question.testfilters;
 
 import static org.batfish.datamodel.ExprAclLine.acceptingHeaderSpace;
-import static org.batfish.datamodel.acl.TraceElements.defaultDeniedByIpAccessList;
 import static org.batfish.datamodel.acl.TraceElements.permittedByAclLine;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpAccessLists;
 import static org.batfish.datamodel.matchers.DataModelMatchers.forAll;
@@ -12,6 +11,7 @@ import static org.batfish.datamodel.matchers.TableAnswerElementMatchers.hasRows;
 import static org.batfish.question.testfilters.TestFiltersAnswerer.COL_FILTER_NAME;
 import static org.batfish.question.testfilters.TestFiltersAnswerer.COL_NODE;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertThat;
@@ -159,10 +159,7 @@ public class TestFiltersAnswererTest {
         hasRows(
             forAll(
                 hasColumn(COL_FILTER_NAME, equalTo(referencedAcl.getName()), Schema.STRING),
-                hasColumn(
-                    TestFiltersAnswerer.COL_TRACE,
-                    hasEvents(contains(TraceEvent.of(defaultDeniedByIpAccessList(referencedAcl)))),
-                    Schema.ACL_TRACE))));
+                hasColumn(TestFiltersAnswerer.COL_TRACE, hasEvents(empty()), Schema.ACL_TRACE))));
   }
 
   @Test


### PR DESCRIPTION
The goal of a filter trace should be to explain why the filter matched.
When the filter does not match, there's no need to generate a trace node
saying so. It's redundant with the testFilters answer row.