### PR TITLE
Add trace elements in AWS security groups

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -12,6 +12,7 @@ import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_PREFIX_LIST_I
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_TO_PORT;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_USER_GROUP_ID_PAIRS;
 import static org.batfish.representation.aws.Utils.checkNonNull;
+import static org.batfish.representation.aws.Utils.getTraceElementForRule;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -37,7 +38,6 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 
 /** IP packet permissions within AWS security groups */
@@ -308,8 +308,7 @@ final class IpPermissions implements Serializable {
     return Optional.ofNullable(
         ExprAclLine.accepting()
             .setMatchCondition(new MatchHeaderSpace(constraints.build()))
-            .setTraceElement(
-                TraceElement.of(String.format("Matched rule %s within security group", ruleNum)))
+            .setTraceElement(getTraceElementForRule(ruleNum))
             .setName(name)
             .build());
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -309,7 +309,7 @@ final class IpPermissions implements Serializable {
       updateAddresses("source", traceElementBuilder);
     } else {
       constraints.setDstIps(ips);
-      updateAddresses("target", traceElementBuilder);
+      updateAddresses("destination", traceElementBuilder);
     }
 
     return Optional.ofNullable(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -37,6 +37,7 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 
 /** IP packet permissions within AWS security groups */
@@ -244,11 +245,12 @@ final class IpPermissions implements Serializable {
    * unsupported definition of the affected IP addresses.
    */
   Optional<ExprAclLine> toIpAccessListLine(
-      boolean ingress, Region region, String name, Warnings warnings) {
+      boolean ingress, Region region, String name, Warnings warnings, int ruleNum) {
     if (_ipProtocol.equals("icmpv6")) {
       // Not valid in IPv4 packets.
       return Optional.empty();
     }
+    TraceElement.Builder traceElementBuilder = TraceElement.builder();
     Collection<IpWildcard> ips = collectIpWildCards(region);
     if (ips.isEmpty()) {
       // IPs should have been populated using either SG or IP ranges,  if not then this IpPermission
@@ -260,6 +262,7 @@ final class IpPermissions implements Serializable {
     HeaderSpace.Builder constraints = HeaderSpace.builder();
     IpProtocol protocol = Utils.toIpProtocol(_ipProtocol);
     if (protocol != null) {
+      traceElementBuilder.add(String.format("Matched protocol %s", protocol));
       constraints.setIpProtocols(protocol);
     }
     if (protocol == IpProtocol.TCP || protocol == IpProtocol.UDP) {
@@ -269,12 +272,15 @@ final class IpPermissions implements Serializable {
       if (low != 0 || hi != 65535) {
         constraints.setDstPorts(ImmutableSet.of(new SubRange(low, hi)));
       }
+      traceElementBuilder.add(String.format("Matched port range [%s, %s]", low, hi));
     } else if (protocol == IpProtocol.ICMP) {
       int type = firstNonNull(_fromPort, -1);
       int code = firstNonNull(_toPort, -1);
       if (type != -1) {
         constraints.setIcmpTypes(type);
+        traceElementBuilder.add(String.format("Matched ICMP type %s", type));
         if (code != -1) {
+          traceElementBuilder.add(String.format("Matched ICMP code %s", code));
           constraints.setIcmpCodes(code);
         }
       } else {
@@ -300,15 +306,40 @@ final class IpPermissions implements Serializable {
 
     if (ingress) {
       constraints.setSrcIps(ips);
+      updateAddresses("source", traceElementBuilder);
     } else {
       constraints.setDstIps(ips);
+      updateAddresses("target", traceElementBuilder);
     }
 
     return Optional.ofNullable(
         ExprAclLine.accepting()
-            .setMatchCondition(new MatchHeaderSpace(constraints.build()))
+            .setMatchCondition(
+                new MatchHeaderSpace(constraints.build(), traceElementBuilder.build()))
             .setName(name)
+            .setTraceElement(
+                TraceElement.builder()
+                    .add(String.format("Matched rule %s within security group", ruleNum))
+                    .build())
             .build());
+  }
+
+  private void updateAddresses(String direction, TraceElement.Builder traceElementBuilder) {
+    if (!_securityGroups.isEmpty()) {
+      traceElementBuilder.add(
+          String.format(
+              "Matched %s security group(s): %s", direction, String.join(",", _securityGroups)));
+    }
+    if (!_ipRanges.isEmpty()) {
+      traceElementBuilder.add(
+          String.format(
+              "Matched %s source address(s)",
+              String.join(
+                  ",",
+                  _ipRanges.stream()
+                      .map(Prefix::toString)
+                      .collect(ImmutableList.toImmutableList()))));
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -37,6 +37,7 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 
 /** IP packet permissions within AWS security groups */
@@ -244,7 +245,7 @@ final class IpPermissions implements Serializable {
    * unsupported definition of the affected IP addresses.
    */
   Optional<ExprAclLine> toIpAccessListLine(
-      boolean ingress, Region region, String name, Warnings warnings) {
+      boolean ingress, Region region, String name, Warnings warnings, int ruleNum) {
     if (_ipProtocol.equals("icmpv6")) {
       // Not valid in IPv4 packets.
       return Optional.empty();
@@ -307,6 +308,8 @@ final class IpPermissions implements Serializable {
     return Optional.ofNullable(
         ExprAclLine.accepting()
             .setMatchCondition(new MatchHeaderSpace(constraints.build()))
+            .setTraceElement(
+                TraceElement.of(String.format("Matched rule %s within security group", ruleNum)))
             .setName(name)
             .build());
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -659,23 +659,31 @@ final class Region implements Serializable {
           .forEach(
               securityGroup -> {
                 String sgName = String.format("Security Group %s", securityGroup.getGroupName());
-                TraceElement.Builder traceElemBuilder =
-                    TraceElement.builder()
-                        .add(
-                            String.format(
-                                "Matched security group %s", securityGroup.getGroupName()));
-
                 Optional.ofNullable(
                         securityGroupToIpAccessList(securityGroup, true, cfgNode, warnings))
-                    .map(acl -> new AclAclLine(sgName, acl.getName(), traceElemBuilder.build()))
+                    .map(
+                        acl ->
+                            new AclAclLine(
+                                sgName,
+                                acl.getName(),
+                                getTraceElement(securityGroup.getGroupName())))
                     .ifPresent(inAclAclLines::add);
                 Optional.ofNullable(
                         securityGroupToIpAccessList(securityGroup, false, cfgNode, warnings))
-                    .map(acl -> new AclAclLine(sgName, acl.getName(), traceElemBuilder.build()))
+                    .map(
+                        acl ->
+                            new AclAclLine(
+                                sgName,
+                                acl.getName(),
+                                getTraceElement(securityGroup.getGroupName())))
                     .ifPresent(outAclAclLines::add);
               });
       applyAclLinesToInterfaces(inAclAclLines, outAclAclLines, cfgNode);
     }
+  }
+
+  public static TraceElement getTraceElement(String securityGroupName) {
+    return TraceElement.of(String.format("Matched security group %s", securityGroupName));
   }
 
   private static void applyAclLinesToInterfaces(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -2,6 +2,7 @@ package org.batfish.representation.aws;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.representation.aws.Utils.getTraceElementForSecurityGroup;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -37,7 +38,6 @@ import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
-import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.representation.aws.Instance.Status;
 
@@ -666,7 +666,7 @@ final class Region implements Serializable {
                             new AclAclLine(
                                 sgName,
                                 acl.getName(),
-                                getTraceElement(securityGroup.getGroupName())))
+                                getTraceElementForSecurityGroup(securityGroup.getGroupName())))
                     .ifPresent(inAclAclLines::add);
                 Optional.ofNullable(
                         securityGroupToIpAccessList(securityGroup, false, cfgNode, warnings))
@@ -675,15 +675,11 @@ final class Region implements Serializable {
                             new AclAclLine(
                                 sgName,
                                 acl.getName(),
-                                getTraceElement(securityGroup.getGroupName())))
+                                getTraceElementForSecurityGroup(securityGroup.getGroupName())))
                     .ifPresent(outAclAclLines::add);
               });
       applyAclLinesToInterfaces(inAclAclLines, outAclAclLines, cfgNode);
     }
-  }
-
-  public static TraceElement getTraceElement(String securityGroupName) {
-    return TraceElement.of(String.format("Matched security group %s", securityGroupName));
   }
 
   private static void applyAclLinesToInterfaces(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -37,6 +37,7 @@ import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
+import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.representation.aws.Instance.Status;
 
@@ -658,13 +659,19 @@ final class Region implements Serializable {
           .forEach(
               securityGroup -> {
                 String sgName = String.format("Security Group %s", securityGroup.getGroupName());
+                TraceElement.Builder traceElemBuilder =
+                    TraceElement.builder()
+                        .add(
+                            String.format(
+                                "Matched security group %s", securityGroup.getGroupName()));
+
                 Optional.ofNullable(
                         securityGroupToIpAccessList(securityGroup, true, cfgNode, warnings))
-                    .map(acl -> new AclAclLine(sgName, acl.getName()))
+                    .map(acl -> new AclAclLine(sgName, acl.getName(), traceElemBuilder.build()))
                     .ifPresent(inAclAclLines::add);
                 Optional.ofNullable(
                         securityGroupToIpAccessList(securityGroup, false, cfgNode, warnings))
-                    .map(acl -> new AclAclLine(sgName, acl.getName()))
+                    .map(acl -> new AclAclLine(sgName, acl.getName(), traceElemBuilder.build()))
                     .ifPresent(outAclAclLines::add);
               });
       applyAclLinesToInterfaces(inAclAclLines, outAclAclLines, cfgNode);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -76,8 +76,7 @@ final class SecurityGroup implements AwsVpcEntity, Serializable {
               region,
               String.format(
                   "%s - %s [%s] %s", _groupId, _groupName, ingress ? "ingress" : "egress", seq),
-              warnings,
-              seq)
+              warnings)
           .ifPresent(aclLines::add);
     }
     return aclLines.build();

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -76,7 +76,8 @@ final class SecurityGroup implements AwsVpcEntity, Serializable {
               region,
               String.format(
                   "%s - %s [%s] %s", _groupId, _groupName, ingress ? "ingress" : "egress", seq),
-              warnings)
+              warnings,
+              seq)
           .ifPresent(aclLines::add);
     }
     return aclLines.build();

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -22,6 +22,7 @@ import org.batfish.datamodel.LinkLocalAddress;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
@@ -295,6 +296,14 @@ final class Utils {
     NodeList outerNodes = element.getElementsByTagName(outerTag);
     checkArgument(outerNodes.getLength() > 0, "OuterTag '%s' not found", outerTag);
     return textOfFirstXmlElementWithTag((Element) outerNodes.item(0), innerTag);
+  }
+
+  public static TraceElement getTraceElementForRule(int ruleNumber) {
+    return TraceElement.of(String.format("Matched rule %s within security group", ruleNumber));
+  }
+
+  public static TraceElement getTraceElementForSecurityGroup(String securityGroupName) {
+    return TraceElement.of(String.format("Matched security group %s", securityGroupName));
   }
 
   private Utils() {}

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -200,14 +200,16 @@ public class ElasticsearchDomainTest {
             ImmutableList.of(
                 new AclAclLine(
                     "Security Group Test Security Group",
-                    "~INGRESS~SECURITY-GROUP~Test Security Group~sg-0de0ddfa8a5a45810~"))));
+                    "~INGRESS~SECURITY-GROUP~Test Security Group~sg-0de0ddfa8a5a45810~",
+                    Utils.getTraceElementForSecurityGroup("Test Security Group")))));
     assertThat(
         esDomain.getIpAccessLists().get("~SECURITY_GROUP_EGRESS_ACL~").getLines(),
         equalTo(
             ImmutableList.of(
                 new AclAclLine(
                     "Security Group Test Security Group",
-                    "~EGRESS~SECURITY-GROUP~Test Security Group~" + "sg-0de0ddfa8a5a45810~"))));
+                    "~EGRESS~SECURITY-GROUP~Test Security Group~" + "sg-0de0ddfa8a5a45810~",
+                    Utils.getTraceElementForSecurityGroup("Test Security Group")))));
     for (Interface iface : esDomain.getAllInterfaces().values()) {
       assertThat(iface.getIncomingFilter().getName(), equalTo("~SECURITY_GROUP_INGRESS_ACL~"));
       assertThat(iface.getOutgoingFilter().getName(), equalTo("~SECURITY_GROUP_EGRESS_ACL~"));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -175,14 +175,16 @@ public class RdsInstanceTest {
             ImmutableList.of(
                 new AclAclLine(
                     "Security Group Test Security Group",
-                    "~INGRESS~SECURITY-GROUP~Test Security Group~sg-0de0ddfa8a5a45810~"))));
+                    "~INGRESS~SECURITY-GROUP~Test Security Group~sg-0de0ddfa8a5a45810~",
+                    Utils.getTraceElementForSecurityGroup("Test Security Group")))));
     assertThat(
         testRds.getIpAccessLists().get("~SECURITY_GROUP_EGRESS_ACL~").getLines(),
         equalTo(
             ImmutableList.of(
                 new AclAclLine(
                     "Security Group Test Security Group",
-                    "~EGRESS~SECURITY-GROUP~Test Security Group~" + "sg-0de0ddfa8a5a45810~"))));
+                    "~EGRESS~SECURITY-GROUP~Test Security Group~" + "sg-0de0ddfa8a5a45810~",
+                    Utils.getTraceElementForSecurityGroup("Test Security Group")))));
     for (Interface iface : testRds.getAllInterfaces().values()) {
       assertThat(iface.getIncomingFilter().getName(), equalTo("~SECURITY_GROUP_INGRESS_ACL~"));
       assertThat(iface.getOutgoingFilter().getName(), equalTo("~SECURITY_GROUP_EGRESS_ACL~"));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -36,7 +36,6 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.acl.AclTrace;
 import org.batfish.datamodel.acl.AclTracer;
-import org.batfish.datamodel.acl.TraceElements;
 import org.batfish.datamodel.acl.TraceEvent;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.matchers.DataModelMatchers;

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -3,7 +3,8 @@ package org.batfish.representation.aws;
 import static org.batfish.datamodel.IpProtocol.TCP;
 import static org.batfish.datamodel.acl.TraceTreeMatchers.hasChildren;
 import static org.batfish.datamodel.acl.TraceTreeMatchers.hasTraceElement;
-import static org.batfish.representation.aws.Region.getTraceElement;
+import static org.batfish.representation.aws.Utils.getTraceElementForRule;
+import static org.batfish.representation.aws.Utils.getTraceElementForSecurityGroup;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
@@ -33,7 +34,6 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclTrace;
 import org.batfish.datamodel.acl.AclTracer;
 import org.batfish.datamodel.acl.TraceElements;
@@ -160,11 +160,11 @@ public class RegionTest {
                 new AclAclLine(
                     "Security Group sg-2",
                     "~INGRESS~SECURITY-GROUP~sg-2~sg-002~",
-                    getTraceElement("sg-2")),
+                    getTraceElementForSecurityGroup("sg-2")),
                 new AclAclLine(
                     "Security Group sg-1",
                     "~INGRESS~SECURITY-GROUP~sg-1~sg-001~",
-                    getTraceElement("sg-1")))));
+                    getTraceElementForSecurityGroup("sg-1")))));
 
     assertThat(
         c.getAllInterfaces().get("~Interface_0~").getOutgoingFilter().getLines(), hasSize(0));
@@ -216,20 +216,18 @@ public class RegionTest {
         root,
         contains(
             allOf(
-                hasTraceElement(TraceElement.of("Matched security group sg-1")),
+                hasTraceElement(getTraceElementForSecurityGroup("sg-1")),
                 hasChildren(
                     contains(
                         allOf(
-                            hasTraceElement(
-                                TraceElement.of("Matched rule 0 within security group")),
-                            hasChildren(empty())))))));
+                            hasTraceElement(getTraceElementForRule(0)), hasChildren(empty())))))));
     AclTrace trace = new AclTrace(root);
     assertThat(
         trace,
         DataModelMatchers.hasEvents(
             contains(
-                TraceEvent.of(TraceElement.of("Matched security group sg-1")),
-                TraceEvent.of(TraceElement.of("Matched rule 0 within security group")))));
+                TraceEvent.of(getTraceElementForSecurityGroup("sg-1")),
+                TraceEvent.of(getTraceElementForRule(0)))));
 
     root =
         AclTracer.trace(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -32,6 +32,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclTrace;
 import org.batfish.datamodel.acl.AclTracer;
 import org.batfish.datamodel.acl.TraceElements;
@@ -204,24 +205,24 @@ public class RegionTest {
             ImmutableMap.of(),
             ImmutableMap.of());
 
-    IpAccessList referenceAcl = c.getIpAccessLists().get("~INGRESS~SECURITY-GROUP~sg-1~sg-001~");
     assertThat(
         root,
         contains(
             allOf(
-                hasTraceElement(TraceElements.permittedByAclLine(ingressAcl, 1)),
+                hasTraceElement(TraceElement.of("Matched security group sg-1")),
                 hasChildren(
                     contains(
                         allOf(
-                            hasTraceElement(TraceElements.permittedByAclLine(referenceAcl, 0)),
+                            hasTraceElement(
+                                TraceElement.of("Matched rule 0 within security group")),
                             hasChildren(empty())))))));
     AclTrace trace = new AclTrace(root);
     assertThat(
         trace,
         DataModelMatchers.hasEvents(
             contains(
-                TraceEvent.of(TraceElements.permittedByAclLine(ingressAcl, 1)),
-                TraceEvent.of(TraceElements.permittedByAclLine(referenceAcl, 0)))));
+                TraceEvent.of(TraceElement.of("Matched security group sg-1")),
+                TraceEvent.of(TraceElement.of("Matched rule 0 within security group")))));
 
     root =
         AclTracer.trace(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -3,6 +3,7 @@ package org.batfish.representation.aws;
 import static org.batfish.datamodel.IpProtocol.TCP;
 import static org.batfish.datamodel.acl.TraceTreeMatchers.hasChildren;
 import static org.batfish.datamodel.acl.TraceTreeMatchers.hasTraceElement;
+import static org.batfish.representation.aws.Region.getTraceElement;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
@@ -156,8 +157,14 @@ public class RegionTest {
         c.getAllInterfaces().get("~Interface_0~").getIncomingFilter().getLines(),
         equalTo(
             ImmutableList.of(
-                new AclAclLine("Security Group sg-2", "~INGRESS~SECURITY-GROUP~sg-2~sg-002~"),
-                new AclAclLine("Security Group sg-1", "~INGRESS~SECURITY-GROUP~sg-1~sg-001~"))));
+                new AclAclLine(
+                    "Security Group sg-2",
+                    "~INGRESS~SECURITY-GROUP~sg-2~sg-002~",
+                    getTraceElement("sg-2")),
+                new AclAclLine(
+                    "Security Group sg-1",
+                    "~INGRESS~SECURITY-GROUP~sg-1~sg-001~",
+                    getTraceElement("sg-1")))));
 
     assertThat(
         c.getAllInterfaces().get("~Interface_0~").getOutgoingFilter().getLines(), hasSize(0));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -4,6 +4,7 @@ import static org.batfish.datamodel.IpProtocol.TCP;
 import static org.batfish.datamodel.matchers.AclLineMatchers.isExprAclLineThat;
 import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchCondition;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_SECURITY_GROUPS;
+import static org.batfish.representation.aws.Utils.getTraceElementForRule;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -39,7 +40,6 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -451,7 +451,7 @@ public class SecurityGroupsTest {
                                 .setIpProtocols(TCP)
                                 .setSrcIps(ImmutableSet.of(IpWildcard.parse("2.2.2.0/24")))
                                 .build()))
-                    .setTraceElement(TraceElement.of("Matched rule 0 within security group"))
+                    .setTraceElement(getTraceElementForRule(0))
                     .build())));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -39,7 +39,6 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
-import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -450,13 +449,7 @@ public class SecurityGroupsTest {
                                 .setDstPorts(SubRange.singleton(22))
                                 .setIpProtocols(TCP)
                                 .setSrcIps(ImmutableSet.of(IpWildcard.parse("2.2.2.0/24")))
-                                .build(),
-                            TraceElement.builder()
-                                .add("Matched protocol TCP")
-                                .add("Matched port range [22, 22]")
-                                .add("Matched 2.2.2.0/24 source address(s)")
                                 .build()))
-                    .setTraceElement(TraceElement.of("Matched rule 0 within security group"))
                     .build())));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -39,6 +39,7 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -449,7 +450,13 @@ public class SecurityGroupsTest {
                                 .setDstPorts(SubRange.singleton(22))
                                 .setIpProtocols(TCP)
                                 .setSrcIps(ImmutableSet.of(IpWildcard.parse("2.2.2.0/24")))
+                                .build(),
+                            TraceElement.builder()
+                                .add("Matched protocol TCP")
+                                .add("Matched port range [22, 22]")
+                                .add("Matched 2.2.2.0/24 source address(s)")
                                 .build()))
+                    .setTraceElement(TraceElement.of("Matched rule 0 within security group"))
                     .build())));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -39,6 +39,7 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -450,6 +451,7 @@ public class SecurityGroupsTest {
                                 .setIpProtocols(TCP)
                                 .setSrcIps(ImmutableSet.of(IpWildcard.parse("2.2.2.0/24")))
                                 .build()))
+                    .setTraceElement(TraceElement.of("Matched rule 0 within security group"))
                     .build())));
   }
 }

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -330,9 +330,25 @@
                       ]
                     },
                     "negate" : false
+                  },
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched 0.0.0.0/0 source address(s)"
+                      }
+                    ]
                   }
                 },
-                "name" : "sg-3dfb3140 - default [egress] 0"
+                "name" : "sg-3dfb3140 - default [egress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule 0 within security group"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
@@ -352,9 +368,25 @@
                         "192.168.1.3"
                       ]
                     }
+                  },
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched source security group(s): sg-55510831"
+                      }
+                    ]
                   }
                 },
-                "name" : "sg-3dfb3140 - default [ingress] 0"
+                "name" : "sg-3dfb3140 - default [ingress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule 0 within security group"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
@@ -364,7 +396,15 @@
               {
                 "class" : "org.batfish.datamodel.AclAclLine",
                 "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default"
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "~SECURITY_GROUP_EGRESS_ACL~"
@@ -374,7 +414,15 @@
               {
                 "class" : "org.batfish.datamodel.AclAclLine",
                 "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default"
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "~SECURITY_GROUP_INGRESS_ACL~"
@@ -4661,9 +4709,25 @@
                       ]
                     },
                     "negate" : false
+                  },
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched 0.0.0.0/0 source address(s)"
+                      }
+                    ]
                   }
                 },
-                "name" : "sg-55510831 - default [egress] 0"
+                "name" : "sg-55510831 - default [egress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule 0 within security group"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "~EGRESS~SECURITY-GROUP~default~sg-55510831~"
@@ -4693,9 +4757,37 @@
                         "162.243.144.192"
                       ]
                     }
+                  },
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched protocol TCP"
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched port range [3306, 3306]"
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched source security group(s): sg-cf3f86b3"
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched 10.193.0.0/16,107.170.243.58/32,104.236.156.171/32,162.243.144.192/32,67.170.86.87/32 source address(s)"
+                      }
+                    ]
                   }
                 },
-                "name" : "sg-55510831 - default [ingress] 0"
+                "name" : "sg-55510831 - default [ingress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule 0 within security group"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "~INGRESS~SECURITY-GROUP~default~sg-55510831~"
@@ -4705,7 +4797,15 @@
               {
                 "class" : "org.batfish.datamodel.AclAclLine",
                 "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-55510831~",
-                "name" : "Security Group default"
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "~SECURITY_GROUP_EGRESS_ACL~"
@@ -4715,7 +4815,15 @@
               {
                 "class" : "org.batfish.datamodel.AclAclLine",
                 "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-55510831~",
-                "name" : "Security Group default"
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "~SECURITY_GROUP_INGRESS_ACL~"

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -330,14 +330,6 @@
                       ]
                     },
                     "negate" : false
-                  },
-                  "traceElement" : {
-                    "fragments" : [
-                      {
-                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched 0.0.0.0/0 source address(s)"
-                      }
-                    ]
                   }
                 },
                 "name" : "sg-3dfb3140 - default [egress] 0",
@@ -368,14 +360,6 @@
                         "192.168.1.3"
                       ]
                     }
-                  },
-                  "traceElement" : {
-                    "fragments" : [
-                      {
-                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched source security group(s): sg-55510831"
-                      }
-                    ]
                   }
                 },
                 "name" : "sg-3dfb3140 - default [ingress] 0",
@@ -4709,14 +4693,6 @@
                       ]
                     },
                     "negate" : false
-                  },
-                  "traceElement" : {
-                    "fragments" : [
-                      {
-                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched 0.0.0.0/0 source address(s)"
-                      }
-                    ]
                   }
                 },
                 "name" : "sg-55510831 - default [egress] 0",
@@ -4757,26 +4733,6 @@
                         "162.243.144.192"
                       ]
                     }
-                  },
-                  "traceElement" : {
-                    "fragments" : [
-                      {
-                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched protocol TCP"
-                      },
-                      {
-                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched port range [3306, 3306]"
-                      },
-                      {
-                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched source security group(s): sg-cf3f86b3"
-                      },
-                      {
-                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched 10.193.0.0/16,107.170.243.58/32,104.236.156.171/32,162.243.144.192/32,67.170.86.87/32 source address(s)"
-                      }
-                    ]
                   }
                 },
                 "name" : "sg-55510831 - default [ingress] 0",


### PR DESCRIPTION
The current `TraceTree` will look like 
```
Matched security group sg-1
    Matched rule 0 within security group
```
I also added trace elements within `MatchHeaderSpace` for the acl lines generated for a single rule, but it seems `AclTracer` does not pick them up yet.