### PR TITLE
AclTracer: simplify default ACL line TraceElements

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -1,8 +1,7 @@
 package org.batfish.datamodel.acl;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.batfish.datamodel.acl.TraceElements.deniedByAclLine;
-import static org.batfish.datamodel.acl.TraceElements.permittedByAclLine;
+import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Collection;
@@ -74,21 +73,13 @@ public final class AclTracer extends AclLineEvaluator {
     return _tracer.getTrace();
   }
 
-  private void setTraceElement(@Nonnull IpAccessList ipAccessList, int index, LineAction action) {
+  private void setTraceElement(@Nonnull IpAccessList ipAccessList, int index) {
     AclLine line = ipAccessList.getLines().get(index);
     TraceElement traceElement = line.getTraceElement();
     if (traceElement == null) {
-      recordAction(ipAccessList, index, action);
+      _tracer.setTraceElement(matchedByAclLine(ipAccessList, index));
     } else {
       _tracer.setTraceElement(traceElement);
-    }
-  }
-
-  public void recordAction(@Nonnull IpAccessList ipAccessList, int index, LineAction action) {
-    if (action == LineAction.PERMIT) {
-      _tracer.setTraceElement(permittedByAclLine(ipAccessList, index));
-    } else {
-      _tracer.setTraceElement(deniedByAclLine(ipAccessList, index));
     }
   }
 
@@ -282,7 +273,7 @@ public final class AclTracer extends AclLineEvaluator {
       AclLine line = lines.get(i);
       LineAction action = visit(line);
       if (action != null) {
-        setTraceElement(ipAccessList, i, action);
+        setTraceElement(ipAccessList, i);
         _tracer.endSubTrace();
         return action;
       }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TraceElements.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TraceElements.java
@@ -1,7 +1,5 @@
 package org.batfish.datamodel.acl;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -17,23 +15,11 @@ import org.batfish.datamodel.TraceElement;
 public final class TraceElements {
   private TraceElements() {}
 
-  public static TraceElement permittedByAclLine(IpAccessList acl, int index) {
-    return matchedByAclLine(acl, index, "permitted");
-  }
-
-  public static TraceElement deniedByAclLine(IpAccessList acl, int index) {
-    return matchedByAclLine(acl, index, "denied");
-  }
-
-  private static TraceElement matchedByAclLine(IpAccessList acl, int index, String action) {
-    String type = firstNonNull(acl.getSourceType(), "filter");
-    String name = firstNonNull(acl.getSourceName(), acl.getName());
+  public static TraceElement matchedByAclLine(IpAccessList acl, int index) {
     AclLine line = acl.getLines().get(index);
-    String lineDescription = line.getName() == null ? "" : ": " + line.getName();
-    String description =
-        String.format(
-            "Flow %s by %s named %s, index %d%s", action, type, name, index, lineDescription);
-    return TraceElement.of(description);
+    String lineDescription =
+        line.getName() == null ? String.format("at index %s", index) : line.getName();
+    return TraceElement.of("Matched line " + lineDescription);
   }
 
   public static TraceElement permittedByNamedIpSpace(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -2,8 +2,7 @@ package org.batfish.datamodel.acl;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.acl.AclTracer.DEST_IP_DESCRIPTION;
-import static org.batfish.datamodel.acl.TraceElements.deniedByAclLine;
-import static org.batfish.datamodel.acl.TraceElements.permittedByAclLine;
+import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
 import static org.batfish.datamodel.acl.TraceElements.permittedByNamedIpSpace;
 import static org.batfish.datamodel.acl.TraceTreeMatchers.hasChildren;
 import static org.batfish.datamodel.acl.TraceTreeMatchers.hasTraceElement;
@@ -117,11 +116,11 @@ public class AclTracerTest {
         root,
         contains(
             allOf(
-                hasTraceElement(deniedByAclLine(acl, 0)),
+                hasTraceElement(matchedByAclLine(acl, 0)),
                 hasChildren(
                     contains(
                         allOf(
-                            hasTraceElement(permittedByAclLine(aclIndirect, 0)),
+                            hasTraceElement(matchedByAclLine(aclIndirect, 0)),
                             hasChildren(empty())))))));
 
     AclTrace trace = new AclTrace(root);
@@ -129,8 +128,8 @@ public class AclTracerTest {
         trace,
         hasEvents(
             contains(
-                TraceEvent.of(deniedByAclLine(acl, 0)),
-                TraceEvent.of(permittedByAclLine(aclIndirect, 0)))));
+                TraceEvent.of(matchedByAclLine(acl, 0)),
+                TraceEvent.of(matchedByAclLine(aclIndirect, 0)))));
   }
 
   @Test
@@ -148,10 +147,10 @@ public class AclTracerTest {
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        root, contains(allOf(hasTraceElement(deniedByAclLine(acl, 0)), hasChildren(empty()))));
+        root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
-    assertThat(trace, hasEvents(contains(TraceEvent.of(deniedByAclLine(acl, 0)))));
+    assertThat(trace, hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 0)))));
   }
 
   @Test
@@ -271,10 +270,10 @@ public class AclTracerTest {
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        root, contains(allOf(hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty()))));
+        root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
-    assertThat(trace, hasEvents(contains(TraceEvent.of(permittedByAclLine(acl, 0)))));
+    assertThat(trace, hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 0)))));
   }
 
   @Test
@@ -303,7 +302,7 @@ public class AclTracerTest {
         root,
         contains(
             allOf(
-                hasTraceElement(permittedByAclLine(acl, 0)),
+                hasTraceElement(matchedByAclLine(acl, 0)),
                 hasChildren(
                     contains(
                         allOf(
@@ -320,7 +319,7 @@ public class AclTracerTest {
         trace,
         hasEvents(
             contains(
-                TraceEvent.of(permittedByAclLine(acl, 0)),
+                TraceEvent.of(matchedByAclLine(acl, 0)),
                 TraceEvent.of(
                     permittedByNamedIpSpace(
                         FLOW.getDstIp(), DEST_IP_DESCRIPTION, ipSpaceMetadata, ipSpaceName)))));
@@ -350,10 +349,10 @@ public class AclTracerTest {
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        root, contains(allOf(hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty()))));
+        root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
-    assertThat(trace, hasEvents(contains(TraceEvent.of(permittedByAclLine(acl, 0)))));
+    assertThat(trace, hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 0)))));
   }
 
   @Test
@@ -376,10 +375,10 @@ public class AclTracerTest {
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
     assertThat(
-        root, contains(allOf(hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty()))));
+        root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasChildren(empty()))));
 
     AclTrace trace = new AclTrace(root);
-    assertThat(trace, hasEvents(contains(TraceEvent.of(permittedByAclLine(acl, 0)))));
+    assertThat(trace, hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 0)))));
   }
 
   @Test
@@ -425,14 +424,14 @@ public class AclTracerTest {
         root,
         contains(
             allOf(
-                hasTraceElement(permittedByAclLine(acl, 0)),
+                hasTraceElement(matchedByAclLine(acl, 0)),
                 hasChildren(
                     contains(
                         allOf(
-                            hasTraceElement(permittedByAclLine(aclIndirect1, 0)),
+                            hasTraceElement(matchedByAclLine(aclIndirect1, 0)),
                             hasChildren(empty())),
                         allOf(
-                            hasTraceElement(permittedByAclLine(aclIndirect2, 0)),
+                            hasTraceElement(matchedByAclLine(aclIndirect2, 0)),
                             hasChildren(empty())))))));
 
     AclTrace trace = new AclTrace(root);
@@ -440,9 +439,9 @@ public class AclTracerTest {
         trace,
         hasEvents(
             contains(
-                TraceEvent.of(permittedByAclLine(acl, 0)),
-                TraceEvent.of(permittedByAclLine(aclIndirect1, 0)),
-                TraceEvent.of(permittedByAclLine(aclIndirect2, 0)))));
+                TraceEvent.of(matchedByAclLine(acl, 0)),
+                TraceEvent.of(matchedByAclLine(aclIndirect1, 0)),
+                TraceEvent.of(matchedByAclLine(aclIndirect2, 0)))));
   }
 
   @Test
@@ -472,11 +471,10 @@ public class AclTracerTest {
         root,
         contains(
             allOf(
-                hasTraceElement(permittedByAclLine(testAcl, 0)),
+                hasTraceElement(matchedByAclLine(testAcl, 0)),
                 hasChildren(
                     contains(
-                        allOf(
-                            hasTraceElement(permittedByAclLine(acl, 0)), hasChildren(empty())))))));
+                        allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasChildren(empty())))))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -1,7 +1,6 @@
 package org.batfish.representation.aws;
 
 import static org.batfish.datamodel.IpProtocol.TCP;
-import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
 import static org.batfish.datamodel.acl.TraceTreeMatchers.hasChildren;
 import static org.batfish.datamodel.acl.TraceTreeMatchers.hasTraceElement;
 import static org.batfish.representation.aws.Utils.getTraceElementForRule;

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.aws;
 
 import static org.batfish.datamodel.IpProtocol.TCP;
+import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
 import static org.batfish.datamodel.acl.TraceTreeMatchers.hasChildren;
 import static org.batfish.datamodel.acl.TraceTreeMatchers.hasTraceElement;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -34,7 +35,6 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.acl.AclTrace;
 import org.batfish.datamodel.acl.AclTracer;
-import org.batfish.datamodel.acl.TraceElements;
 import org.batfish.datamodel.acl.TraceEvent;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.matchers.DataModelMatchers;
@@ -209,19 +209,19 @@ public class RegionTest {
         root,
         contains(
             allOf(
-                hasTraceElement(TraceElements.matchedByAclLine(ingressAcl, 1)),
+                hasTraceElement(matchedByAclLine(ingressAcl, 1)),
                 hasChildren(
                     contains(
                         allOf(
-                            hasTraceElement(TraceElements.matchedByAclLine(referenceAcl, 0)),
+                            hasTraceElement(matchedByAclLine(referenceAcl, 0)),
                             hasChildren(empty())))))));
     AclTrace trace = new AclTrace(root);
     assertThat(
         trace,
         DataModelMatchers.hasEvents(
             contains(
-                TraceEvent.of(TraceElements.matchedByAclLine(ingressAcl, 1)),
-                TraceEvent.of(TraceElements.matchedByAclLine(referenceAcl, 0)))));
+                TraceEvent.of(matchedByAclLine(ingressAcl, 1)),
+                TraceEvent.of(matchedByAclLine(referenceAcl, 0)))));
 
     root =
         AclTracer.trace(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -209,19 +209,19 @@ public class RegionTest {
         root,
         contains(
             allOf(
-                hasTraceElement(TraceElements.permittedByAclLine(ingressAcl, 1)),
+                hasTraceElement(TraceElements.matchedByAclLine(ingressAcl, 1)),
                 hasChildren(
                     contains(
                         allOf(
-                            hasTraceElement(TraceElements.permittedByAclLine(referenceAcl, 0)),
+                            hasTraceElement(TraceElements.matchedByAclLine(referenceAcl, 0)),
                             hasChildren(empty())))))));
     AclTrace trace = new AclTrace(root);
     assertThat(
         trace,
         DataModelMatchers.hasEvents(
             contains(
-                TraceEvent.of(TraceElements.permittedByAclLine(ingressAcl, 1)),
-                TraceEvent.of(TraceElements.permittedByAclLine(referenceAcl, 0)))));
+                TraceEvent.of(TraceElements.matchedByAclLine(ingressAcl, 1)),
+                TraceEvent.of(TraceElements.matchedByAclLine(referenceAcl, 0)))));
 
     root =
         AclTracer.trace(

--- a/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
@@ -1,6 +1,7 @@
 package org.batfish.question.testfilters;
 
 import static org.batfish.datamodel.ExprAclLine.acceptingHeaderSpace;
+import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpAccessLists;
 import static org.batfish.datamodel.matchers.DataModelMatchers.forAll;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasEvents;
@@ -35,7 +36,6 @@ import org.batfish.datamodel.PacketHeaderConstraints;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.PermittedByAcl;
-import org.batfish.datamodel.acl.TraceElements;
 import org.batfish.datamodel.acl.TraceEvent;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.pojo.Node;
@@ -151,7 +151,7 @@ public class TestFiltersAnswererTest {
                 hasColumn(COL_FILTER_NAME, equalTo(acl.getName()), Schema.STRING),
                 hasColumn(
                     TestFiltersAnswerer.COL_TRACE,
-                    hasEvents(contains(TraceEvent.of(TraceElements.matchedByAclLine(acl, 1)))),
+                    hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 1)))),
                     Schema.ACL_TRACE))));
     /* Trace should be present for referenced acl with one event: not matching the referenced acl */
     assertThat(

--- a/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
@@ -1,7 +1,6 @@
 package org.batfish.question.testfilters;
 
 import static org.batfish.datamodel.ExprAclLine.acceptingHeaderSpace;
-import static org.batfish.datamodel.acl.TraceElements.permittedByAclLine;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpAccessLists;
 import static org.batfish.datamodel.matchers.DataModelMatchers.forAll;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasEvents;
@@ -36,6 +35,7 @@ import org.batfish.datamodel.PacketHeaderConstraints;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.PermittedByAcl;
+import org.batfish.datamodel.acl.TraceElements;
 import org.batfish.datamodel.acl.TraceEvent;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.pojo.Node;
@@ -151,7 +151,7 @@ public class TestFiltersAnswererTest {
                 hasColumn(COL_FILTER_NAME, equalTo(acl.getName()), Schema.STRING),
                 hasColumn(
                     TestFiltersAnswerer.COL_TRACE,
-                    hasEvents(contains(TraceEvent.of(permittedByAclLine(acl, 1)))),
+                    hasEvents(contains(TraceEvent.of(TraceElements.matchedByAclLine(acl, 1)))),
                     Schema.ACL_TRACE))));
     /* Trace should be present for referenced acl with one event: not matching the referenced acl */
     assertThat(

--- a/tests/basic/testfilters.ref
+++ b/tests/basic/testfilters.ref
@@ -51,8 +51,8 @@
     "rows" : [
       {
         "Node" : {
-          "id" : "node-host1",
-          "name" : "host1"
+          "id" : "node-host2",
+          "name" : "host2"
         },
         "Filter_Name" : "filter::OUTPUT",
         "Flow" : {
@@ -61,11 +61,11 @@
           "dstPort" : 80,
           "ecn" : 0,
           "fragmentOffset" : 0,
-          "ingressNode" : "host1",
+          "ingressNode" : "host2",
           "ingressVrf" : "default",
           "ipProtocol" : "TCP",
           "packetLength" : 512,
-          "srcIp" : "2.128.0.101",
+          "srcIp" : "2.128.1.101",
           "srcPort" : 49152,
           "state" : "NEW",
           "tag" : "tag",
@@ -83,46 +83,7 @@
         "Trace" : {
           "events" : [
             {
-              "description" : "Flow permitted by filter named filter::OUTPUT, index 0: default"
-            }
-          ]
-        }
-      },
-      {
-        "Node" : {
-          "id" : "node-host1",
-          "name" : "host1"
-        },
-        "Filter_Name" : "filter::INPUT",
-        "Flow" : {
-          "dscp" : 0,
-          "dstIp" : "1.1.1.1",
-          "dstPort" : 80,
-          "ecn" : 0,
-          "fragmentOffset" : 0,
-          "ingressNode" : "host1",
-          "ingressVrf" : "default",
-          "ipProtocol" : "TCP",
-          "packetLength" : 512,
-          "srcIp" : "2.128.0.101",
-          "srcPort" : 49152,
-          "state" : "NEW",
-          "tag" : "tag",
-          "tcpFlagsAck" : 0,
-          "tcpFlagsCwr" : 0,
-          "tcpFlagsEce" : 0,
-          "tcpFlagsFin" : 0,
-          "tcpFlagsPsh" : 0,
-          "tcpFlagsRst" : 0,
-          "tcpFlagsSyn" : 0,
-          "tcpFlagsUrg" : 0
-        },
-        "Action" : "DENY",
-        "Line_Content" : "default",
-        "Trace" : {
-          "events" : [
-            {
-              "description" : "Flow denied by filter named filter::INPUT, index 2: default"
+              "description" : "Matched line default"
             }
           ]
         }
@@ -161,85 +122,7 @@
         "Trace" : {
           "events" : [
             {
-              "description" : "Flow permitted by filter named filter::FORWARD, index 0: default"
-            }
-          ]
-        }
-      },
-      {
-        "Node" : {
-          "id" : "node-host2",
-          "name" : "host2"
-        },
-        "Filter_Name" : "filter::OUTPUT",
-        "Flow" : {
-          "dscp" : 0,
-          "dstIp" : "1.1.1.1",
-          "dstPort" : 80,
-          "ecn" : 0,
-          "fragmentOffset" : 0,
-          "ingressNode" : "host2",
-          "ingressVrf" : "default",
-          "ipProtocol" : "TCP",
-          "packetLength" : 512,
-          "srcIp" : "2.128.1.101",
-          "srcPort" : 49152,
-          "state" : "NEW",
-          "tag" : "tag",
-          "tcpFlagsAck" : 0,
-          "tcpFlagsCwr" : 0,
-          "tcpFlagsEce" : 0,
-          "tcpFlagsFin" : 0,
-          "tcpFlagsPsh" : 0,
-          "tcpFlagsRst" : 0,
-          "tcpFlagsSyn" : 0,
-          "tcpFlagsUrg" : 0
-        },
-        "Action" : "PERMIT",
-        "Line_Content" : "default",
-        "Trace" : {
-          "events" : [
-            {
-              "description" : "Flow permitted by filter named filter::OUTPUT, index 1: default"
-            }
-          ]
-        }
-      },
-      {
-        "Node" : {
-          "id" : "node-host1",
-          "name" : "host1"
-        },
-        "Filter_Name" : "filter::FORWARD",
-        "Flow" : {
-          "dscp" : 0,
-          "dstIp" : "1.1.1.1",
-          "dstPort" : 80,
-          "ecn" : 0,
-          "fragmentOffset" : 0,
-          "ingressNode" : "host1",
-          "ingressVrf" : "default",
-          "ipProtocol" : "TCP",
-          "packetLength" : 512,
-          "srcIp" : "2.128.0.101",
-          "srcPort" : 49152,
-          "state" : "NEW",
-          "tag" : "tag",
-          "tcpFlagsAck" : 0,
-          "tcpFlagsCwr" : 0,
-          "tcpFlagsEce" : 0,
-          "tcpFlagsFin" : 0,
-          "tcpFlagsPsh" : 0,
-          "tcpFlagsRst" : 0,
-          "tcpFlagsSyn" : 0,
-          "tcpFlagsUrg" : 0
-        },
-        "Action" : "PERMIT",
-        "Line_Content" : "default",
-        "Trace" : {
-          "events" : [
-            {
-              "description" : "Flow permitted by filter named filter::FORWARD, index 0: default"
+              "description" : "Matched line default"
             }
           ]
         }
@@ -278,7 +161,124 @@
         "Trace" : {
           "events" : [
             {
-              "description" : "Flow denied by filter named filter::INPUT, index 1: default"
+              "description" : "Matched line default"
+            }
+          ]
+        }
+      },
+      {
+        "Node" : {
+          "id" : "node-host1",
+          "name" : "host1"
+        },
+        "Filter_Name" : "filter::FORWARD",
+        "Flow" : {
+          "dscp" : 0,
+          "dstIp" : "1.1.1.1",
+          "dstPort" : 80,
+          "ecn" : 0,
+          "fragmentOffset" : 0,
+          "ingressNode" : "host1",
+          "ingressVrf" : "default",
+          "ipProtocol" : "TCP",
+          "packetLength" : 512,
+          "srcIp" : "2.128.0.101",
+          "srcPort" : 49152,
+          "state" : "NEW",
+          "tag" : "tag",
+          "tcpFlagsAck" : 0,
+          "tcpFlagsCwr" : 0,
+          "tcpFlagsEce" : 0,
+          "tcpFlagsFin" : 0,
+          "tcpFlagsPsh" : 0,
+          "tcpFlagsRst" : 0,
+          "tcpFlagsSyn" : 0,
+          "tcpFlagsUrg" : 0
+        },
+        "Action" : "PERMIT",
+        "Line_Content" : "default",
+        "Trace" : {
+          "events" : [
+            {
+              "description" : "Matched line default"
+            }
+          ]
+        }
+      },
+      {
+        "Node" : {
+          "id" : "node-host1",
+          "name" : "host1"
+        },
+        "Filter_Name" : "filter::INPUT",
+        "Flow" : {
+          "dscp" : 0,
+          "dstIp" : "1.1.1.1",
+          "dstPort" : 80,
+          "ecn" : 0,
+          "fragmentOffset" : 0,
+          "ingressNode" : "host1",
+          "ingressVrf" : "default",
+          "ipProtocol" : "TCP",
+          "packetLength" : 512,
+          "srcIp" : "2.128.0.101",
+          "srcPort" : 49152,
+          "state" : "NEW",
+          "tag" : "tag",
+          "tcpFlagsAck" : 0,
+          "tcpFlagsCwr" : 0,
+          "tcpFlagsEce" : 0,
+          "tcpFlagsFin" : 0,
+          "tcpFlagsPsh" : 0,
+          "tcpFlagsRst" : 0,
+          "tcpFlagsSyn" : 0,
+          "tcpFlagsUrg" : 0
+        },
+        "Action" : "DENY",
+        "Line_Content" : "default",
+        "Trace" : {
+          "events" : [
+            {
+              "description" : "Matched line default"
+            }
+          ]
+        }
+      },
+      {
+        "Node" : {
+          "id" : "node-host1",
+          "name" : "host1"
+        },
+        "Filter_Name" : "filter::OUTPUT",
+        "Flow" : {
+          "dscp" : 0,
+          "dstIp" : "1.1.1.1",
+          "dstPort" : 80,
+          "ecn" : 0,
+          "fragmentOffset" : 0,
+          "ingressNode" : "host1",
+          "ingressVrf" : "default",
+          "ipProtocol" : "TCP",
+          "packetLength" : 512,
+          "srcIp" : "2.128.0.101",
+          "srcPort" : 49152,
+          "state" : "NEW",
+          "tag" : "tag",
+          "tcpFlagsAck" : 0,
+          "tcpFlagsCwr" : 0,
+          "tcpFlagsEce" : 0,
+          "tcpFlagsFin" : 0,
+          "tcpFlagsPsh" : 0,
+          "tcpFlagsRst" : 0,
+          "tcpFlagsSyn" : 0,
+          "tcpFlagsUrg" : 0
+        },
+        "Action" : "PERMIT",
+        "Line_Content" : "default",
+        "Trace" : {
+          "events" : [
+            {
+              "description" : "Matched line default"
             }
           ]
         }


### PR DESCRIPTION
Exclude the filter name and action, since they're clear from context.
Only show the index if there's no name.