### PR TITLE
AclTracer: trace AclLineMatchExprs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -16,6 +16,7 @@ import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.TcpFlagsMatchConditions;
+import org.batfish.datamodel.TraceElement;
 
 public final class AclLineMatchExprs {
 
@@ -245,6 +246,11 @@ public final class AclLineMatchExprs {
 
   public static @Nonnull MatchSrcInterface matchSrcInterface(String... ifaces) {
     return matchSrcInterface(ImmutableList.copyOf(ifaces));
+  }
+
+  public static @Nonnull MatchSrcInterface matchSrcInterface(
+      TraceElement traceElement, String... ifaces) {
+    return new MatchSrcInterface(ImmutableList.copyOf(ifaces), traceElement);
   }
 
   public static @Nonnull AclLineMatchExpr matchTcpFlags(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -44,6 +44,10 @@ public final class AclLineMatchExprs {
   public static final AclLineMatchExpr NEW_FLOWS =
       implies(matchIpProtocol(IpProtocol.TCP), NEW_TCP_FLOWS);
 
+  public static AclLineMatchExpr and(String traceElement, AclLineMatchExpr... exprs) {
+    return new AndMatchExpr(ImmutableList.copyOf(exprs), traceElement);
+  }
+
   public static AclLineMatchExpr and(AclLineMatchExpr... exprs) {
     return and(ImmutableList.copyOf(exprs));
   }
@@ -264,6 +268,10 @@ public final class AclLineMatchExprs {
       return ((NotMatchExpr) expr).getOperand();
     }
     return new NotMatchExpr(expr);
+  }
+
+  public static AclLineMatchExpr or(String traceElement, AclLineMatchExpr... exprs) {
+    return new OrMatchExpr(ImmutableList.copyOf(exprs), traceElement);
   }
 
   public static AclLineMatchExpr or(AclLineMatchExpr... exprs) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -259,6 +259,10 @@ public final class AclLineMatchExprs {
         HeaderSpace.builder().setTcpFlags(ImmutableList.copyOf(tcpFlagsMatchConditions)).build());
   }
 
+  public static NotMatchExpr not(String traceElement, AclLineMatchExpr expr) {
+    return new NotMatchExpr(expr, TraceElement.of(traceElement));
+  }
+
   /**
    * Smart constructor for {@link NotMatchExpr} that does constant-time simplifications (i.e. when
    * expr is {@link #TRUE} or {@link #FALSE}).

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -389,4 +389,10 @@ public final class AclTracer extends AclLineEvaluator {
               return result;
             });
   }
+
+  @Override
+  public Boolean visitMatchSrcInterface(MatchSrcInterface matchSrcInterface) {
+    setTraceElement(matchSrcInterface.getTraceElement());
+    return super.visitMatchSrcInterface(matchSrcInterface);
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -11,6 +11,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.AclAclLine;
 import org.batfish.datamodel.AclLine;
+import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
@@ -333,6 +334,18 @@ public final class AclTracer extends AclLineEvaluator {
             "Reference to undefined IpAccessList %s",
             aclAclLine.getAclName());
     return trace(referencedAcl);
+  }
+
+  @Override
+  public LineAction visitExprAclLine(ExprAclLine exprAclLine) {
+    // current context is for the line; create a context for the top-level expression
+    _tracer.newSubTrace();
+    if (visit(exprAclLine.getMatchCondition())) {
+      _tracer.endSubTrace();
+      return exprAclLine.getAction();
+    }
+    _tracer.discardSubTrace();
+    return null;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -391,6 +391,19 @@ public final class AclTracer extends AclLineEvaluator {
   }
 
   @Override
+  public Boolean visitNotMatchExpr(NotMatchExpr notMatchExpr) {
+    setTraceElement(notMatchExpr.getTraceElement());
+    _tracer.newSubTrace();
+    boolean result = visit(notMatchExpr.getOperand());
+    if (result) {
+      _tracer.discardSubTrace();
+    } else {
+      _tracer.endSubTrace();
+    }
+    return !result;
+  }
+
+  @Override
   public Boolean visitMatchSrcInterface(MatchSrcInterface matchSrcInterface) {
     setTraceElement(matchSrcInterface.getTraceElement());
     return super.visitMatchSrcInterface(matchSrcInterface);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/trace/Tracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/trace/Tracer.java
@@ -28,7 +28,7 @@ public final class Tracer {
     private @Nullable TraceElement _traceElement;
     private final List<TraceTree> _children = new ArrayList<>();
 
-    void setTraceElement(TraceElement traceElement) {
+    void setTraceElement(@Nonnull TraceElement traceElement) {
       _traceElement = traceElement;
     }
 
@@ -59,6 +59,7 @@ public final class Tracer {
   public void setTraceElement(@Nonnull TraceElement traceElement) {
     checkState(!_stack.isEmpty(), "no trace in progress");
     TraceContext context = _stack.peek();
+    checkState(context.getTraceElement() == null, "TraceElement already set");
     context.setTraceElement(traceElement);
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.acl;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.batfish.datamodel.acl.AclTracer.DEST_IP_DESCRIPTION;
 import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
@@ -677,5 +678,28 @@ public class AclTracerTest {
             ImmutableMap.of(),
             ImmutableMap.of());
     assertThat(trace, contains(allOf(hasTraceElement(a), hasNoChildren())));
+  }
+
+  @Test
+  public void testNotMatchExpr_withoutTraceElement() {
+    List<TraceTree> trace = trace(not(falseExpr("false")));
+    assertThat(trace, contains(allOf(hasTraceElement("false"), hasNoChildren())));
+  }
+
+  @Test
+  public void testNotMatchExpr_withTraceElement() {
+    List<TraceTree> trace = trace(not("not", falseExpr("false")));
+    assertThat(
+        trace,
+        contains(
+            allOf(
+                hasTraceElement("not"),
+                hasChildren(contains(allOf(hasTraceElement("false"), hasNoChildren()))))));
+  }
+
+  @Test
+  public void testNotMatchExpr_false() {
+    List<TraceTree> trace = trace(not("not", trueExpr("true")));
+    assertThat(trace, empty());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -147,7 +147,7 @@ public class AclTracerTest {
                     contains(
                         allOf(
                             hasTraceElement(matchedByAclLine(aclIndirect, 0)),
-                            hasChildren(empty())))))));
+                            hasNoChildren()))))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(
@@ -172,8 +172,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(
-        root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasChildren(empty()))));
+    assertThat(root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasNoChildren())));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 0)))));
@@ -295,8 +294,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(
-        root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasChildren(empty()))));
+    assertThat(root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasNoChildren())));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 0)))));
@@ -338,7 +336,7 @@ public class AclTracerTest {
                                     DEST_IP_DESCRIPTION,
                                     ipSpaceMetadata,
                                     ipSpaceName)),
-                            hasChildren(empty())))))));
+                            hasNoChildren()))))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(
@@ -374,8 +372,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(
-        root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasChildren(empty()))));
+    assertThat(root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasNoChildren())));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 0)))));
@@ -400,8 +397,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(
-        root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasChildren(empty()))));
+    assertThat(root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasNoChildren())));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 0)))));
@@ -453,12 +449,10 @@ public class AclTracerTest {
                 hasTraceElement(matchedByAclLine(acl, 0)),
                 hasChildren(
                     contains(
-                        allOf(
-                            hasTraceElement(matchedByAclLine(aclIndirect1, 0)),
-                            hasChildren(empty())),
+                        allOf(hasTraceElement(matchedByAclLine(aclIndirect1, 0)), hasNoChildren()),
                         allOf(
                             hasTraceElement(matchedByAclLine(aclIndirect2, 0)),
-                            hasChildren(empty())))))));
+                            hasNoChildren()))))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(
@@ -499,8 +493,7 @@ public class AclTracerTest {
             allOf(
                 hasTraceElement(matchedByAclLine(testAcl, 0)),
                 hasChildren(
-                    contains(
-                        allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasChildren(empty())))))));
+                    contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasNoChildren()))))));
   }
 
   @Test
@@ -538,8 +531,7 @@ public class AclTracerTest {
         contains(
             allOf(
                 hasTraceElement(testAclTraceElement),
-                hasChildren(
-                    contains(allOf(hasTraceElement(aclTraceElement), hasChildren(empty())))))));
+                hasChildren(contains(allOf(hasTraceElement(aclTraceElement), hasNoChildren()))))));
   }
 
   @Test
@@ -554,8 +546,8 @@ public class AclTracerTest {
     assertThat(
         trace,
         contains(
-            allOf(hasTraceElement(TraceElement.of("a")), hasChildren(empty())),
-            allOf(hasTraceElement(TraceElement.of("b")), hasChildren(empty()))));
+            allOf(hasTraceElement(TraceElement.of("a")), hasNoChildren()),
+            allOf(hasTraceElement(TraceElement.of("b")), hasNoChildren())));
   }
 
   @Test
@@ -568,8 +560,8 @@ public class AclTracerTest {
                 hasTraceElement(TraceElement.of("and")),
                 hasChildren(
                     contains(
-                        allOf(hasTraceElement(TraceElement.of("a")), hasChildren(empty())),
-                        allOf(hasTraceElement(TraceElement.of("b")), hasChildren(empty())))))));
+                        allOf(hasTraceElement(TraceElement.of("a")), hasNoChildren()),
+                        allOf(hasTraceElement(TraceElement.of("b")), hasNoChildren()))))));
   }
 
   @Test
@@ -581,7 +573,7 @@ public class AclTracerTest {
   @Test
   public void testOr_withoutTraceElement() {
     List<TraceTree> trace = trace(or(falseExpr("a"), trueExpr("b"), falseExpr("c")));
-    assertThat(trace, contains(allOf(hasTraceElement(TraceElement.of("b")), hasChildren(empty()))));
+    assertThat(trace, contains(allOf(hasTraceElement(TraceElement.of("b")), hasNoChildren())));
   }
 
   @Test
@@ -593,8 +585,7 @@ public class AclTracerTest {
             allOf(
                 hasTraceElement(TraceElement.of("or")),
                 hasChildren(
-                    contains(
-                        allOf(hasTraceElement(TraceElement.of("b")), hasChildren(empty())))))));
+                    contains(allOf(hasTraceElement(TraceElement.of("b")), hasNoChildren()))))));
   }
 
   @Test
@@ -607,7 +598,7 @@ public class AclTracerTest {
   public void testMatchHeaderspace_withTraceElement() {
     TraceElement a = TraceElement.of("a");
     List<TraceTree> trace = trace(new MatchHeaderSpace(TRUE_HEADERSPACE, a));
-    assertThat(trace, contains(allOf(hasTraceElement(a), hasChildren(empty()))));
+    assertThat(trace, contains(allOf(hasTraceElement(a), hasNoChildren())));
   }
 
   @Test
@@ -630,8 +621,7 @@ public class AclTracerTest {
             allOf(
                 hasTraceElement(a),
                 hasChildren(
-                    contains(
-                        allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasChildren(empty())))))));
+                    contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasNoChildren()))))));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -8,9 +8,7 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.batfish.datamodel.acl.AclTracer.DEST_IP_DESCRIPTION;
 import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
 import static org.batfish.datamodel.acl.TraceElements.permittedByNamedIpSpace;
-import static org.batfish.datamodel.acl.TraceTreeMatchers.hasChildren;
-import static org.batfish.datamodel.acl.TraceTreeMatchers.hasNoChildren;
-import static org.batfish.datamodel.acl.TraceTreeMatchers.hasTraceElement;
+import static org.batfish.datamodel.acl.TraceTreeMatchers.isTraceTree;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasEvents;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
@@ -142,13 +140,7 @@ public class AclTracerTest {
     assertThat(
         root,
         contains(
-            allOf(
-                hasTraceElement(matchedByAclLine(acl, 0)),
-                hasChildren(
-                    contains(
-                        allOf(
-                            hasTraceElement(matchedByAclLine(aclIndirect, 0)),
-                            hasNoChildren()))))));
+            isTraceTree(matchedByAclLine(acl, 0), isTraceTree(matchedByAclLine(aclIndirect, 0)))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(
@@ -173,7 +165,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasNoChildren())));
+    assertThat(root, contains(isTraceTree(matchedByAclLine(acl, 0))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 0)))));
@@ -295,7 +287,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasNoChildren())));
+    assertThat(root, contains(isTraceTree(matchedByAclLine(acl, 0))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 0)))));
@@ -326,18 +318,11 @@ public class AclTracerTest {
     assertThat(
         root,
         contains(
-            allOf(
-                hasTraceElement(matchedByAclLine(acl, 0)),
-                hasChildren(
-                    contains(
-                        allOf(
-                            hasTraceElement(
-                                permittedByNamedIpSpace(
-                                    FLOW.getDstIp(),
-                                    DEST_IP_DESCRIPTION,
-                                    ipSpaceMetadata,
-                                    ipSpaceName)),
-                            hasNoChildren()))))));
+            isTraceTree(
+                matchedByAclLine(acl, 0),
+                isTraceTree(
+                    permittedByNamedIpSpace(
+                        FLOW.getDstIp(), DEST_IP_DESCRIPTION, ipSpaceMetadata, ipSpaceName)))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(
@@ -373,7 +358,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasNoChildren())));
+    assertThat(root, contains(isTraceTree(matchedByAclLine(acl, 0))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 0)))));
@@ -398,7 +383,7 @@ public class AclTracerTest {
         AclTracer.trace(
             acl, FLOW, SRC_INTERFACE, availableAcls, namedIpSpaces, namedIpSpaceMetadata);
 
-    assertThat(root, contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasNoChildren())));
+    assertThat(root, contains(isTraceTree(matchedByAclLine(acl, 0))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(trace, hasEvents(contains(TraceEvent.of(matchedByAclLine(acl, 0)))));
@@ -446,14 +431,10 @@ public class AclTracerTest {
     assertThat(
         root,
         contains(
-            allOf(
-                hasTraceElement(matchedByAclLine(acl, 0)),
-                hasChildren(
-                    contains(
-                        allOf(hasTraceElement(matchedByAclLine(aclIndirect1, 0)), hasNoChildren()),
-                        allOf(
-                            hasTraceElement(matchedByAclLine(aclIndirect2, 0)),
-                            hasNoChildren()))))));
+            isTraceTree(
+                matchedByAclLine(acl, 0),
+                isTraceTree(matchedByAclLine(aclIndirect1, 0)),
+                isTraceTree(matchedByAclLine(aclIndirect2, 0)))));
 
     AclTrace trace = new AclTrace(root);
     assertThat(
@@ -490,11 +471,7 @@ public class AclTracerTest {
 
     assertThat(
         root,
-        contains(
-            allOf(
-                hasTraceElement(matchedByAclLine(testAcl, 0)),
-                hasChildren(
-                    contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasNoChildren()))))));
+        contains(isTraceTree(matchedByAclLine(testAcl, 0), isTraceTree(matchedByAclLine(acl, 0)))));
   }
 
   @Test
@@ -527,12 +504,7 @@ public class AclTracerTest {
             ImmutableMap.of(),
             ImmutableMap.of());
 
-    assertThat(
-        root,
-        contains(
-            allOf(
-                hasTraceElement(testAclTraceElement),
-                hasChildren(contains(allOf(hasTraceElement(aclTraceElement), hasNoChildren()))))));
+    assertThat(root, contains(isTraceTree(testAclTraceElement, isTraceTree(aclTraceElement))));
   }
 
   @Test
@@ -544,25 +516,13 @@ public class AclTracerTest {
   @Test
   public void testAnd_withoutTraceElement() {
     List<TraceTree> trace = trace(and(trueExpr("a"), trueExpr("b")));
-    assertThat(
-        trace,
-        contains(
-            allOf(hasTraceElement(TraceElement.of("a")), hasNoChildren()),
-            allOf(hasTraceElement(TraceElement.of("b")), hasNoChildren())));
+    assertThat(trace, contains(isTraceTree("a"), isTraceTree("b")));
   }
 
   @Test
   public void testAnd_withTraceElement() {
     List<TraceTree> trace = trace(and("and", trueExpr("a"), trueExpr("b")));
-    assertThat(
-        trace,
-        contains(
-            allOf(
-                hasTraceElement(TraceElement.of("and")),
-                hasChildren(
-                    contains(
-                        allOf(hasTraceElement(TraceElement.of("a")), hasNoChildren()),
-                        allOf(hasTraceElement(TraceElement.of("b")), hasNoChildren()))))));
+    assertThat(trace, contains(isTraceTree("and", isTraceTree("a"), isTraceTree("b"))));
   }
 
   @Test
@@ -574,31 +534,19 @@ public class AclTracerTest {
   @Test
   public void testOr_withoutTraceElement() {
     List<TraceTree> trace = trace(or(falseExpr("a"), trueExpr("b"), falseExpr("c")));
-    assertThat(trace, contains(allOf(hasTraceElement(TraceElement.of("b")), hasNoChildren())));
+    assertThat(trace, contains(isTraceTree("b")));
   }
 
   @Test
   public void testOr_withTraceElement() {
     List<TraceTree> trace = trace(or("or", falseExpr("a"), trueExpr("b"), falseExpr("c")));
-    assertThat(
-        trace,
-        contains(
-            allOf(
-                hasTraceElement(TraceElement.of("or")),
-                hasChildren(
-                    contains(allOf(hasTraceElement(TraceElement.of("b")), hasNoChildren()))))));
+    assertThat(trace, contains(isTraceTree("or", isTraceTree("b"))));
   }
 
   @Test
   public void testOr_allTrue() {
     List<TraceTree> trace = trace(or("or", trueExpr("a"), trueExpr("b"), trueExpr("c")));
-    assertThat(
-        trace,
-        contains(
-            allOf(
-                hasTraceElement(TraceElement.of("or")),
-                hasChildren(
-                    contains(allOf(hasTraceElement(TraceElement.of("a")), hasNoChildren()))))));
+    assertThat(trace, contains(isTraceTree("or", isTraceTree("a"))));
   }
 
   @Test
@@ -611,7 +559,7 @@ public class AclTracerTest {
   public void testMatchHeaderspace_withTraceElement() {
     TraceElement a = TraceElement.of("a");
     List<TraceTree> trace = trace(new MatchHeaderSpace(TRUE_HEADERSPACE, a));
-    assertThat(trace, contains(allOf(hasTraceElement(a), hasNoChildren())));
+    assertThat(trace, contains(allOf(isTraceTree(a))));
   }
 
   @Test
@@ -628,13 +576,7 @@ public class AclTracerTest {
             ImmutableMap.of(aclName, acl),
             ImmutableMap.of(),
             ImmutableMap.of());
-    assertThat(
-        trace,
-        contains(
-            allOf(
-                hasTraceElement(a),
-                hasChildren(
-                    contains(allOf(hasTraceElement(matchedByAclLine(acl, 0)), hasNoChildren()))))));
+    assertThat(trace, contains(isTraceTree(a, isTraceTree(matchedByAclLine(acl, 0)))));
   }
 
   @Test
@@ -643,12 +585,7 @@ public class AclTracerTest {
     IpAccessList acl =
         IpAccessList.builder().setName("acl").setLines(ExprAclLine.accepting(expr)).build();
     List<TraceTree> trace = trace(acl);
-    assertThat(
-        trace,
-        contains(
-            allOf(
-                hasTraceElement(matchedByAclLine(acl, 0)),
-                hasChildren(contains(allOf(hasTraceElement("a"), hasNoChildren()))))));
+    assertThat(trace, contains(isTraceTree(matchedByAclLine(acl, 0), allOf(isTraceTree("a")))));
   }
 
   @Test
@@ -677,24 +614,19 @@ public class AclTracerTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of());
-    assertThat(trace, contains(allOf(hasTraceElement(a), hasNoChildren())));
+    assertThat(trace, contains(isTraceTree(a)));
   }
 
   @Test
   public void testNotMatchExpr_withoutTraceElement() {
     List<TraceTree> trace = trace(not(falseExpr("false")));
-    assertThat(trace, contains(allOf(hasTraceElement("false"), hasNoChildren())));
+    assertThat(trace, contains(isTraceTree("false")));
   }
 
   @Test
   public void testNotMatchExpr_withTraceElement() {
     List<TraceTree> trace = trace(not("not", falseExpr("false")));
-    assertThat(
-        trace,
-        contains(
-            allOf(
-                hasTraceElement("not"),
-                hasChildren(contains(allOf(hasTraceElement("false"), hasNoChildren()))))));
+    assertThat(trace, contains(isTraceTree("not", isTraceTree("false"))));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel.acl;
 
 import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.batfish.datamodel.acl.AclTracer.DEST_IP_DESCRIPTION;
 import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
@@ -645,5 +646,34 @@ public class AclTracerTest {
             allOf(
                 hasTraceElement(matchedByAclLine(acl, 0)),
                 hasChildren(contains(allOf(hasTraceElement("a"), hasNoChildren()))))));
+  }
+
+  @Test
+  public void testMatchSrcInterface_withoutTraceElement() {
+    String iface = "iface";
+    List<TraceTree> trace =
+        AclTracer.trace(
+            matchSrcInterface(iface),
+            FLOW,
+            iface,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of());
+    assertThat(trace, empty());
+  }
+
+  @Test
+  public void testMatchSrcInterface_withTraceElement() {
+    String iface = "iface";
+    TraceElement a = TraceElement.of("a");
+    List<TraceTree> trace =
+        AclTracer.trace(
+            matchSrcInterface(a, iface),
+            FLOW,
+            iface,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of());
+    assertThat(trace, contains(allOf(hasTraceElement(a), hasNoChildren())));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -589,6 +589,18 @@ public class AclTracerTest {
   }
 
   @Test
+  public void testOr_allTrue() {
+    List<TraceTree> trace = trace(or("or", trueExpr("a"), trueExpr("b"), trueExpr("c")));
+    assertThat(
+        trace,
+        contains(
+            allOf(
+                hasTraceElement(TraceElement.of("or")),
+                hasChildren(
+                    contains(allOf(hasTraceElement(TraceElement.of("a")), hasNoChildren()))))));
+  }
+
+  @Test
   public void testMatchHeaderspace_withoutTraceElement() {
     List<TraceTree> trace = trace(new MatchHeaderSpace(TRUE_HEADERSPACE));
     assertThat(trace, empty());

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -10,7 +10,6 @@ import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
 import static org.batfish.datamodel.acl.TraceElements.permittedByNamedIpSpace;
 import static org.batfish.datamodel.acl.TraceTreeMatchers.isTraceTree;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasEvents;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
@@ -559,7 +558,7 @@ public class AclTracerTest {
   public void testMatchHeaderspace_withTraceElement() {
     TraceElement a = TraceElement.of("a");
     List<TraceTree> trace = trace(new MatchHeaderSpace(TRUE_HEADERSPACE, a));
-    assertThat(trace, contains(allOf(isTraceTree(a))));
+    assertThat(trace, contains(isTraceTree(a)));
   }
 
   @Test
@@ -585,7 +584,7 @@ public class AclTracerTest {
     IpAccessList acl =
         IpAccessList.builder().setName("acl").setLines(ExprAclLine.accepting(expr)).build();
     List<TraceTree> trace = trace(acl);
-    assertThat(trace, contains(isTraceTree(matchedByAclLine(acl, 0), allOf(isTraceTree("a")))));
+    assertThat(trace, contains(isTraceTree(matchedByAclLine(acl, 0), isTraceTree("a"))));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/TraceTreeMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/TraceTreeMatchers.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.acl;
 
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.List;
@@ -18,6 +19,11 @@ public final class TraceTreeMatchers {
   }
 
   /** A {@link TraceTree} matcher on {@link TraceTree#getTraceElement()}. */
+  public static Matcher<TraceTree> hasTraceElement(String text) {
+    return new HasTraceElement(equalTo(TraceElement.of(text)));
+  }
+
+  /** A {@link TraceTree} matcher on {@link TraceTree#getTraceElement()}. */
   public static Matcher<TraceTree> hasTraceElement(TraceElement traceElement) {
     return new HasTraceElement(equalTo(traceElement));
   }
@@ -25,5 +31,10 @@ public final class TraceTreeMatchers {
   /** A {@link TraceTree} matcher on {@link TraceTree#getChildren()}. */
   public static Matcher<TraceTree> hasChildren(Matcher<? super List<TraceTree>> subMatcher) {
     return new HasChildren(subMatcher);
+  }
+
+  /** A {@link TraceTree} matcher on {@link TraceTree#getChildren()}. */
+  public static Matcher<TraceTree> hasNoChildren() {
+    return new HasChildren(empty());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/TraceTreeMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/TraceTreeMatchers.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.acl;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -9,6 +11,7 @@ import org.batfish.datamodel.acl.TraceTreeMatchersImpl.HasChildren;
 import org.batfish.datamodel.acl.TraceTreeMatchersImpl.HasTraceElement;
 import org.batfish.datamodel.trace.TraceTree;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 
 public final class TraceTreeMatchers {
   private TraceTreeMatchers() {}
@@ -26,6 +29,44 @@ public final class TraceTreeMatchers {
   /** A {@link TraceTree} matcher on {@link TraceTree#getTraceElement()}. */
   public static Matcher<TraceTree> hasTraceElement(TraceElement traceElement) {
     return new HasTraceElement(equalTo(traceElement));
+  }
+
+  /**
+   * A {@link TraceTree} matcher combining {@link TraceTreeMatchers#hasTraceElement(String)} and
+   * {@link TraceTreeMatchers#hasNoChildren()}.
+   */
+  public static Matcher<TraceTree> isTraceTree(String text) {
+    return allOf(hasTraceElement(text), hasNoChildren());
+  }
+
+  /**
+   * A {@link TraceTree} matcher combining {@link TraceTreeMatchers#hasTraceElement(TraceElement)}
+   * and {@link TraceTreeMatchers#hasNoChildren()}.
+   */
+  public static Matcher<TraceTree> isTraceTree(TraceElement traceElement) {
+    return allOf(hasTraceElement(traceElement), hasNoChildren());
+  }
+
+  /**
+   * A {@link TraceTree} matcher combining {@link TraceTreeMatchers#hasTraceElement(TraceElement)},
+   * {@link TraceTreeMatchers#hasChildren}, and {@link Matchers#contains}.
+   */
+  @SafeVarargs
+  @SuppressWarnings({"varargs"})
+  public static Matcher<TraceTree> isTraceTree(
+      TraceElement traceElement, Matcher<? super TraceTree>... childMatchers) {
+    return allOf(hasTraceElement(traceElement), hasChildren(contains(childMatchers)));
+  }
+
+  /**
+   * A {@link TraceTree} matcher combining {@link TraceTreeMatchers#hasTraceElement(String)}, {@link
+   * TraceTreeMatchers#hasChildren}, and {@link Matchers#contains}.
+   */
+  @SafeVarargs
+  @SuppressWarnings({"varargs"})
+  public static Matcher<TraceTree> isTraceTree(
+      String traceElement, Matcher<? super TraceTree>... childMatchers) {
+    return allOf(hasTraceElement(traceElement), hasChildren(contains(childMatchers)));
   }
 
   /** A {@link TraceTree} matcher on {@link TraceTree#getChildren()}. */


### PR DESCRIPTION
Makes AclTracer include TraceElements from AclLineMatchExprs in the generated trace.