### PR TITLE
AWS IpPermissions: Storing description for IpRanges

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -40,6 +40,7 @@ import org.batfish.datamodel.acl.TraceEvent;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.matchers.DataModelMatchers;
 import org.batfish.datamodel.trace.TraceTree;
+import org.batfish.representation.aws.IpPermissions.IpRange;
 import org.junit.Test;
 
 /** Tests for {@link Region} */
@@ -107,7 +108,7 @@ public class RegionTest {
                     "tcp",
                     22,
                     22,
-                    ImmutableList.of(Prefix.parse("2.2.2.0/24")),
+                    ImmutableList.of(new IpRange(Prefix.parse("2.2.2.0/24"))),
                     ImmutableList.of(),
                     ImmutableList.of()))));
     region.updateConfigurationSecurityGroups(
@@ -121,7 +122,7 @@ public class RegionTest {
                     "tcp",
                     25,
                     25,
-                    ImmutableList.of(Prefix.parse("2.2.2.0/24")),
+                    ImmutableList.of(new IpRange(Prefix.parse("2.2.2.0/24"))),
                     ImmutableList.of(),
                     ImmutableList.of()))));
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -158,13 +158,13 @@ public class RegionTest {
         equalTo(
             ImmutableList.of(
                 new AclAclLine(
-                    "Security Group sg-2",
-                    "~INGRESS~SECURITY-GROUP~sg-2~sg-002~",
-                    getTraceElementForSecurityGroup("sg-2")),
-                new AclAclLine(
                     "Security Group sg-1",
                     "~INGRESS~SECURITY-GROUP~sg-1~sg-001~",
-                    getTraceElementForSecurityGroup("sg-1")))));
+                    getTraceElementForSecurityGroup("sg-1")),
+                new AclAclLine(
+                    "Security Group sg-2",
+                    "~INGRESS~SECURITY-GROUP~sg-2~sg-002~",
+                    getTraceElementForSecurityGroup("sg-2")))));
 
     assertThat(
         c.getAllInterfaces().get("~Interface_0~").getOutgoingFilter().getLines(), hasSize(0));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -41,6 +41,7 @@ import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.representation.aws.IpPermissions.IpRange;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -97,7 +98,7 @@ public class SecurityGroupsTest {
                             "-1",
                             null,
                             null,
-                            ImmutableList.of(Prefix.parse("0.0.0.0/0")),
+                            ImmutableList.of(new IpRange(Prefix.parse("0.0.0.0/0"))),
                             ImmutableList.of(),
                             ImmutableList.of()),
                         new IpPermissions(
@@ -112,7 +113,8 @@ public class SecurityGroupsTest {
                             "tcp",
                             22,
                             22,
-                            ImmutableList.of(Prefix.parse("1.2.3.4/32")),
+                            ImmutableList.of(
+                                new IpRange("Allowing single port", Prefix.parse("1.2.3.4/32"))),
                             ImmutableList.of(),
                             ImmutableList.of()))))));
   }
@@ -434,7 +436,7 @@ public class SecurityGroupsTest {
                     "tcp",
                     22,
                     22,
-                    ImmutableList.of(Prefix.parse("2.2.2.0/24")),
+                    ImmutableList.of(new IpRange(Prefix.parse("2.2.2.0/24"))),
                     ImmutableList.of(),
                     ImmutableList.of())));
     List<AclLine> lines = sg.toAclLines(Region.builder("r").build(), true, new Warnings());


### PR DESCRIPTION
This would help us to provide more meta-data in the traces produced  by testFilters.
so a sample trace which is using this description would look like:
```
Matched security group SG-1
  Matched source-address 1.2.3.0/24 (allow HTTP traffic 1) . 
  Matched protocol TCP 
  Matched source port 80
  Matched destination port 80
```
Prioritizing IpRanges for now, can extend this to (source security groups or prefix list IDs) if we see more examples 