### PR TITLE
Adding traceElements to MatchConditions generated by IpPermissions + Refactoring

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -25,12 +25,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.SortedMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -257,8 +257,8 @@ final class IpPermissions implements Serializable {
    * Returns a Map containing all Security Groups used as source/dest in this IpPermissions, keyed
    * by the corresponding IpSpace
    */
-  private SortedMap<IpSpace, String> collectSecurityGroups(Region region) {
-    ImmutableSortedMap.Builder<IpSpace, String> ipSpaceToSg = ImmutableSortedMap.naturalOrder();
+  private Map<IpSpace, String> collectSecurityGroups(Region region) {
+    ImmutableMap.Builder<IpSpace, String> ipSpaceToSg = ImmutableMap.builder();
     _securityGroups.stream()
         .map(sgID -> region.getSecurityGroups().get(sgID))
         .filter(Objects::nonNull)
@@ -276,9 +276,8 @@ final class IpPermissions implements Serializable {
    * Returns a Map containing all Prefix Lists used as source/dest in this IpPermissions, keyed by
    * the corresponding IpSpace
    */
-  private SortedMap<IpSpace, String> collectPrefixLists(Region region) {
-    ImmutableSortedMap.Builder<IpSpace, String> ipSpaceToPrefixLists =
-        ImmutableSortedMap.naturalOrder();
+  private Map<IpSpace, String> collectPrefixLists(Region region) {
+    ImmutableMap.Builder<IpSpace, String> ipSpaceToPrefixLists = ImmutableMap.builder();
     _prefixList.stream()
         .map(plId -> region.getPrefixLists().get(plId))
         .filter(Objects::nonNull)

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -454,11 +454,11 @@ final class IpPermissions implements Serializable {
   }
 
   private static List<ExprAclLine> collectPrefixListsIntoAclLines(
-      Map<PrefixList, IpSpace> sgs,
+      Map<PrefixList, IpSpace> prefixLists,
       List<AclLineMatchExpr> protocolAndPortExprs,
       boolean ingress,
       String aclLineName) {
-    return sgs.entrySet().stream()
+    return prefixLists.entrySet().stream()
         .map(
             entry ->
                 ExprAclLine.accepting()

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -255,8 +255,8 @@ final class IpPermissions implements Serializable {
   }
 
   /**
-   * Returns a Map containing all Security Groups used as source/dest in this IpPermissions, keyed
-   * by the corresponding Security Group
+   * Returns a Map containing all the Security Groups referred by this IPPermission instance and the
+   * corresponding IpSpaces
    */
   private Map<SecurityGroup, IpSpace> collectSecurityGroups(Region region) {
     ImmutableMap.Builder<SecurityGroup, IpSpace> sgToIpSpace = ImmutableMap.builder();
@@ -273,8 +273,8 @@ final class IpPermissions implements Serializable {
   }
 
   /**
-   * Returns a Map containing all Prefix Lists used as source/dest in this IpPermissions, keyed by
-   * the Prefix List
+   * Returns a Map containing all the Prefix Lists referred by this IPPermission instance and the
+   * corresponding IpSpaces
    */
   private Map<PrefixList, IpSpace> collectPrefixLists(Region region) {
     ImmutableMap.Builder<PrefixList, IpSpace> plToIpSpace = ImmutableMap.builder();
@@ -449,7 +449,6 @@ final class IpPermissions implements Serializable {
                     .setTraceElement(getTraceElementForRule(null))
                     .setName(aclLineName)
                     .build())
-        .filter(Objects::nonNull)
         .collect(ImmutableList.toImmutableList());
   }
 
@@ -476,7 +475,6 @@ final class IpPermissions implements Serializable {
                     .setTraceElement(getTraceElementForRule(null))
                     .setName(aclLineName)
                     .build())
-        .filter(Objects::nonNull)
         .collect(ImmutableList.toImmutableList());
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -294,54 +294,6 @@ final class IpPermissions implements Serializable {
   }
 
   /**
-   * Converts a security group (used as source/dest) into an ExprAclLine using protocol and dst
-   * ports in this IpPermission instance. Returns null if the provided inputs cannot form a valid
-   * ExprAclLine
-   */
-  @Nullable
-  private ExprAclLine securityGroupToMatchExpr(
-      boolean ingress, String sgName, IpSpace ipSpace, String aclLineName, Warnings warnings) {
-    ImmutableList.Builder<AclLineMatchExpr> matchesBuilder = ImmutableList.builder();
-    List<AclLineMatchExpr> matchExprs = getMatchExprsForProtocolAndPorts(aclLineName, warnings);
-    if (matchExprs == null) {
-      return null;
-    }
-    matchesBuilder.addAll(matchExprs);
-    matchesBuilder.add(exprForSrcOrDstIps(ipSpace, sgName, ingress, AddressType.SECURITY_GROUP));
-    return ExprAclLine.accepting()
-        .setMatchCondition(and(matchesBuilder.build()))
-        .setTraceElement(getTraceElementForRule(null))
-        .setName(aclLineName)
-        .build();
-  }
-
-  /**
-   * Converts a prefix list (used as source/dest) into an ExprAclLine using protocol and dst ports
-   * in this IpPermission instance. Returns null if the provided inputs cannot form a valid
-   * ExprAclLine
-   */
-  @Nullable
-  private ExprAclLine prefixlistToMatchExpr(
-      boolean ingress,
-      String prefixListId,
-      IpSpace ipSpace,
-      String aclLineName,
-      Warnings warnings) {
-    ImmutableList.Builder<AclLineMatchExpr> matchesBuilder = ImmutableList.builder();
-    List<AclLineMatchExpr> matchExprs = getMatchExprsForProtocolAndPorts(aclLineName, warnings);
-    if (matchExprs == null) {
-      return null;
-    }
-    matchesBuilder.addAll(matchExprs);
-    matchesBuilder.add(exprForSrcOrDstIps(ipSpace, prefixListId, ingress, AddressType.PREFIX_LIST));
-    return ExprAclLine.accepting()
-        .setMatchCondition(and(matchesBuilder.build()))
-        .setTraceElement(getTraceElementForRule(null))
-        .setName(aclLineName)
-        .build();
-  }
-
-  /**
    * Generates a list of AclLineMatchExprs (MatchHeaderSpaces) to match the IpProtocol and dst ports
    * in this IpPermission instance (or ICMP type and code, if protocol is ICMP). Returns null if IP
    * Protocol and ports are not consistent
@@ -384,7 +336,7 @@ final class IpPermissions implements Serializable {
   }
 
   /** Returns a MatchHeaderSpace to match the provided IpSpace either in ingress or egress mode */
-  private MatchHeaderSpace exprForSrcOrDstIps(
+  private static MatchHeaderSpace exprForSrcOrDstIps(
       IpSpace ipSpace, String vsAddressStructure, boolean ingress, AddressType addressType) {
     if (ingress) {
       return new MatchHeaderSpace(
@@ -415,7 +367,7 @@ final class IpPermissions implements Serializable {
    * after the protocol is determined to be ICMP
    */
   @Nullable
-  private MatchHeaderSpace exprForIcmpTypeAndCode(int type, int code) {
+  private static MatchHeaderSpace exprForIcmpTypeAndCode(int type, int code) {
     HeaderSpace.Builder hsBuilder = HeaderSpace.builder();
     if (type != -1) {
       hsBuilder.setIcmpTypes(type);
@@ -486,7 +438,7 @@ final class IpPermissions implements Serializable {
     return aclLines.build();
   }
 
-  private List<ExprAclLine> collectIntoAclLines(
+  private static List<ExprAclLine> collectIntoAclLines(
       Function<Region, Map<IpSpace, String>> collector,
       AddressType addressType,
       Region region,

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -71,14 +71,13 @@ final class SecurityGroup implements AwsVpcEntity, Serializable {
     for (ListIterator<IpPermissions> it = ipPerms.listIterator(); it.hasNext(); ) {
       int seq = it.nextIndex();
       IpPermissions p = it.next();
-      p.toIpAccessListLine(
+      aclLines.addAll(
+          p.toIpAccessListLines(
               ingress,
               region,
               String.format(
                   "%s - %s [%s] %s", _groupId, _groupName, ingress ? "ingress" : "egress", seq),
-              warnings,
-              seq)
-          .ifPresent(aclLines::add);
+              warnings));
     }
     return aclLines.build();
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -298,8 +298,11 @@ final class Utils {
     return textOfFirstXmlElementWithTag((Element) outerNodes.item(0), innerTag);
   }
 
-  public static TraceElement getTraceElementForRule(int ruleNumber) {
-    return TraceElement.of(String.format("Matched rule %s within security group", ruleNumber));
+  public static String getTraceTextForRule(@Nullable String ruleDescription) {
+    if (ruleDescription == null) {
+      return "Matched rule with no description";
+    }
+    return String.format("Matched rule with description %s", ruleDescription);
   }
 
   public static TraceElement getTraceElementForSecurityGroup(String securityGroupName) {

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -31,6 +31,7 @@ import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.vendor_family.AwsFamily;
+import org.batfish.representation.aws.IpPermissions.AddressType;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
@@ -310,8 +311,10 @@ final class Utils {
     return TraceElement.of(String.format("Matched security group %s", securityGroupName));
   }
 
-  static TraceElement traceElementForAddress(String direction, String vsAddressStructure) {
-    return TraceElement.of(String.format("Matched %s address %s", direction, vsAddressStructure));
+  static TraceElement traceElementForAddress(
+      String direction, String vsAddressStructure, AddressType addressType) {
+    return TraceElement.of(
+        String.format("Matched %s address %s %s", direction, addressType, vsAddressStructure));
   }
 
   static String traceElementForProtocol(IpProtocol protocol) {

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -5,6 +5,7 @@ import static org.batfish.representation.aws.AwsConfiguration.LINK_LOCAL_IP1;
 import static org.batfish.representation.aws.AwsConfiguration.LINK_LOCAL_IP2;
 
 import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -298,15 +299,40 @@ final class Utils {
     return textOfFirstXmlElementWithTag((Element) outerNodes.item(0), innerTag);
   }
 
-  public static String getTraceTextForRule(@Nullable String ruleDescription) {
+  public static TraceElement getTraceElementForRule(@Nullable String ruleDescription) {
     if (ruleDescription == null) {
-      return "Matched rule with no description";
+      return TraceElement.of("Matched rule with no description");
     }
-    return String.format("Matched rule with description %s", ruleDescription);
+    return TraceElement.of(String.format("Matched rule with description %s", ruleDescription));
   }
 
   public static TraceElement getTraceElementForSecurityGroup(String securityGroupName) {
     return TraceElement.of(String.format("Matched security group %s", securityGroupName));
+  }
+
+  static TraceElement traceElementForAddress(String direction, String vsAddressStructure) {
+    return TraceElement.of(String.format("Matched %s address %s", direction, vsAddressStructure));
+  }
+
+  static String traceElementForProtocol(IpProtocol protocol) {
+    return String.format("Matched protocol %s", protocol);
+  }
+
+  static TraceElement traceElementForDstPorts(int low, int high) {
+    if (low == high) {
+      return TraceElement.of(String.format("Matched destination port %s", low));
+    }
+    return TraceElement.of(String.format("Matched destination ports [%s-%s]", low, high));
+  }
+
+  static TraceElement traceElementForIcmp(int type, int code) {
+    assert type != -1;
+    List<String> traceElems = new ArrayList<>();
+    traceElems.add(String.format("Matched ICMP type %s", type));
+    if (code != -1) {
+      traceElems.add(String.format("Matched ICMP code %s", code));
+    }
+    return TraceElement.of(String.join(",", traceElems));
   }
 
   private Utils() {}

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -5,7 +5,6 @@ import static org.batfish.representation.aws.AwsConfiguration.LINK_LOCAL_IP1;
 import static org.batfish.representation.aws.AwsConfiguration.LINK_LOCAL_IP2;
 
 import com.google.common.collect.ImmutableList;
-import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -317,8 +316,8 @@ final class Utils {
         String.format("Matched %s address %s %s", direction, addressType, vsAddressStructure));
   }
 
-  static String traceElementForProtocol(IpProtocol protocol) {
-    return String.format("Matched protocol %s", protocol);
+  static TraceElement traceElementForProtocol(IpProtocol protocol) {
+    return TraceElement.of(String.format("Matched protocol %s", protocol));
   }
 
   static TraceElement traceElementForDstPorts(int low, int high) {
@@ -330,12 +329,12 @@ final class Utils {
 
   static TraceElement traceElementForIcmp(int type, int code) {
     assert type != -1;
-    List<String> traceElems = new ArrayList<>();
-    traceElems.add(String.format("Matched ICMP type %s", type));
+    TraceElement.Builder treBuilder =
+        TraceElement.builder().add(String.format("Matched ICMP type %s", type));
     if (code != -1) {
-      traceElems.add(String.format("Matched ICMP code %s", code));
+      treBuilder.add(String.format("Matched ICMP code %s", code));
     }
-    return TraceElement.of(String.join(",", traceElems));
+    return treBuilder.build();
   }
 
   private Utils() {}

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -49,6 +49,7 @@ import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
+import org.batfish.representation.aws.IpPermissions.AddressType;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -196,7 +197,8 @@ public class ElasticsearchDomainTest {
                 hasMatchCondition(
                     new MatchHeaderSpace(
                         HeaderSpace.builder().setDstIps(UniverseIpSpace.INSTANCE).build(),
-                        traceElementForAddress("destination", "0.0.0.0/0"))))));
+                        traceElementForAddress(
+                            "destination", "0.0.0.0/0", AddressType.CIDR_IP))))));
     assertThat(
         esDomain
             .getIpAccessLists()
@@ -212,7 +214,8 @@ public class ElasticsearchDomainTest {
                                 HeaderSpace.builder()
                                     .setSrcIps(Ip.parse("1.2.3.4").toIpSpace())
                                     .build(),
-                                traceElementForAddress("source", "1.2.3.4/32"))))),
+                                traceElementForAddress(
+                                    "source", "1.2.3.4/32", AddressType.CIDR_IP))))),
                 isExprAclLineThat(
                     hasMatchCondition(
                         and(
@@ -222,7 +225,10 @@ public class ElasticsearchDomainTest {
                                 HeaderSpace.builder()
                                     .setSrcIps(IpWildcard.parse("10.193.16.105/32").toIpSpace())
                                     .build(),
-                                traceElementForAddress("source", "Test-Instance-SG"))))))));
+                                traceElementForAddress(
+                                    "source",
+                                    "Test-Instance-SG",
+                                    AddressType.SECURITY_GROUP))))))));
     assertThat(
         esDomain.getIpAccessLists().get("~SECURITY_GROUP_INGRESS_ACL~").getLines(),
         equalTo(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -9,7 +9,6 @@ import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_DOMAIN_STATUS
 import static org.batfish.representation.aws.Utils.traceElementForAddress;
 import static org.batfish.representation.aws.Utils.traceElementForDstPorts;
 import static org.batfish.representation.aws.Utils.traceElementForProtocol;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -66,11 +65,6 @@ public class ElasticsearchDomainTest {
           HeaderSpace.builder().setIpProtocols(TCP).build(), traceElementForProtocol(TCP));
 
   public static MatchHeaderSpace matchPorts(int fromPort, int toPort) {
-    if (fromPort == toPort) {
-      return new MatchHeaderSpace(
-          HeaderSpace.builder().setDstPorts(SubRange.singleton(fromPort)).build(),
-          traceElementForDstPorts(fromPort, toPort));
-    }
     return new MatchHeaderSpace(
         HeaderSpace.builder().setDstPorts(new SubRange(fromPort, toPort)).build(),
         traceElementForDstPorts(fromPort, toPort));
@@ -204,7 +198,7 @@ public class ElasticsearchDomainTest {
             .getIpAccessLists()
             .get("~INGRESS~SECURITY-GROUP~Test Security Group~sg-0de0ddfa8a5a45810~"),
         hasLines(
-            contains(
+            containsInAnyOrder(
                 isExprAclLineThat(
                     hasMatchCondition(
                         and(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -8,7 +8,6 @@ import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_DB_INSTANCES;
 import static org.batfish.representation.aws.ElasticsearchDomainTest.matchPorts;
 import static org.batfish.representation.aws.ElasticsearchDomainTest.matchTcp;
 import static org.batfish.representation.aws.Utils.traceElementForAddress;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -162,7 +161,7 @@ public class RdsInstanceTest {
             .getIpAccessLists()
             .get("~INGRESS~SECURITY-GROUP~Test Security Group~sg-0de0ddfa8a5a45810~"),
         hasLines(
-            contains(
+            containsInAnyOrder(
                 isExprAclLineThat(
                     hasMatchCondition(
                         and(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -48,6 +48,7 @@ import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
+import org.batfish.representation.aws.IpPermissions.AddressType;
 import org.batfish.representation.aws.RdsInstance.Status;
 import org.junit.Before;
 import org.junit.Rule;
@@ -154,7 +155,8 @@ public class RdsInstanceTest {
                 hasMatchCondition(
                     new MatchHeaderSpace(
                         HeaderSpace.builder().setDstIps(UniverseIpSpace.INSTANCE).build(),
-                        traceElementForAddress("destination", "0.0.0.0/0"))))));
+                        traceElementForAddress(
+                            "destination", "0.0.0.0/0", AddressType.CIDR_IP))))));
     assertThat(
         testRds
             .getIpAccessLists()
@@ -170,7 +172,8 @@ public class RdsInstanceTest {
                                 HeaderSpace.builder()
                                     .setSrcIps(Ip.parse("1.2.3.4").toIpSpace())
                                     .build(),
-                                traceElementForAddress("source", "1.2.3.4/32"))))),
+                                traceElementForAddress(
+                                    "source", "1.2.3.4/32", AddressType.CIDR_IP))))),
                 isExprAclLineThat(
                     hasMatchCondition(
                         and(
@@ -180,7 +183,10 @@ public class RdsInstanceTest {
                                 HeaderSpace.builder()
                                     .setSrcIps(IpWildcard.parse("10.193.16.105/32").toIpSpace())
                                     .build(),
-                                traceElementForAddress("source", "Test-Instance-SG"))))))));
+                                traceElementForAddress(
+                                    "source",
+                                    "Test-Instance-SG",
+                                    AddressType.SECURITY_GROUP))))))));
     assertThat(
         testRds.getIpAccessLists().get("~SECURITY_GROUP_INGRESS_ACL~").getLines(),
         equalTo(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -1,9 +1,14 @@
 package org.batfish.representation.aws;
 
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.matchers.AclLineMatchers.isExprAclLineThat;
 import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchCondition;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_DB_INSTANCES;
+import static org.batfish.representation.aws.ElasticsearchDomainTest.matchPorts;
+import static org.batfish.representation.aws.ElasticsearchDomainTest.matchTcp;
+import static org.batfish.representation.aws.Utils.traceElementForAddress;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -16,7 +21,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -34,12 +38,11 @@ import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
-import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.Topology;
+import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.main.Batfish;
@@ -150,25 +153,34 @@ public class RdsInstanceTest {
             isExprAclLineThat(
                 hasMatchCondition(
                     new MatchHeaderSpace(
-                        HeaderSpace.builder()
-                            .setDstIps(Sets.newHashSet(IpWildcard.parse("0.0.0.0/0")))
-                            .build())))));
+                        HeaderSpace.builder().setDstIps(UniverseIpSpace.INSTANCE).build(),
+                        traceElementForAddress("destination", "0.0.0.0/0"))))));
     assertThat(
         testRds
             .getIpAccessLists()
             .get("~INGRESS~SECURITY-GROUP~Test Security Group~sg-0de0ddfa8a5a45810~"),
         hasLines(
-            isExprAclLineThat(
-                hasMatchCondition(
-                    new MatchHeaderSpace(
-                        HeaderSpace.builder()
-                            .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                            .setSrcIps(
-                                Sets.newHashSet(
-                                    IpWildcard.parse("1.2.3.4/32"),
-                                    IpWildcard.parse("10.193.16.105/32")))
-                            .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
-                            .build())))));
+            contains(
+                isExprAclLineThat(
+                    hasMatchCondition(
+                        and(
+                            matchTcp,
+                            matchPorts(45, 50),
+                            new MatchHeaderSpace(
+                                HeaderSpace.builder()
+                                    .setSrcIps(Ip.parse("1.2.3.4").toIpSpace())
+                                    .build(),
+                                traceElementForAddress("source", "1.2.3.4/32"))))),
+                isExprAclLineThat(
+                    hasMatchCondition(
+                        and(
+                            matchTcp,
+                            matchPorts(45, 50),
+                            new MatchHeaderSpace(
+                                HeaderSpace.builder()
+                                    .setSrcIps(IpWildcard.parse("10.193.16.105/32").toIpSpace())
+                                    .build(),
+                                traceElementForAddress("source", "Test-Instance-SG"))))))));
     assertThat(
         testRds.getIpAccessLists().get("~SECURITY_GROUP_INGRESS_ACL~").getLines(),
         equalTo(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -11,6 +11,7 @@ import static org.batfish.representation.aws.Utils.traceElementForProtocol;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
@@ -226,7 +227,7 @@ public class RegionTest {
                         allOf(
                             hasTraceElement(getTraceElementForRule(null)),
                             hasChildren(
-                                contains(
+                                containsInAnyOrder(
                                     hasTraceElement(traceElementForProtocol(TCP)),
                                     hasTraceElement(traceElementForDstPorts(22, 22)),
                                     hasTraceElement(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -5,6 +5,9 @@ import static org.batfish.datamodel.matchers.TraceTreeMatchers.hasChildren;
 import static org.batfish.datamodel.matchers.TraceTreeMatchers.hasTraceElement;
 import static org.batfish.representation.aws.Utils.getTraceElementForRule;
 import static org.batfish.representation.aws.Utils.getTraceElementForSecurityGroup;
+import static org.batfish.representation.aws.Utils.traceElementForAddress;
+import static org.batfish.representation.aws.Utils.traceElementForDstPorts;
+import static org.batfish.representation.aws.Utils.traceElementForProtocol;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
@@ -34,6 +37,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclTrace;
 import org.batfish.datamodel.acl.AclTracer;
 import org.batfish.datamodel.acl.TraceEvent;
@@ -220,14 +224,23 @@ public class RegionTest {
                 hasChildren(
                     contains(
                         allOf(
-                            hasTraceElement(getTraceElementForRule(0)), hasChildren(empty())))))));
+                            hasTraceElement(getTraceElementForRule(null)),
+                            hasChildren(
+                                contains(
+                                    hasTraceElement(TraceElement.of(traceElementForProtocol(TCP))),
+                                    hasTraceElement(traceElementForDstPorts(22, 22)),
+                                    hasTraceElement(
+                                        traceElementForAddress("source", "2.2.2.0/24"))))))))));
     AclTrace trace = new AclTrace(root);
     assertThat(
         trace,
         DataModelMatchers.hasEvents(
             contains(
                 TraceEvent.of(getTraceElementForSecurityGroup("sg-1")),
-                TraceEvent.of(getTraceElementForRule(0)))));
+                TraceEvent.of(getTraceElementForRule(null)),
+                TraceEvent.of(TraceElement.of(traceElementForProtocol(TCP))),
+                TraceEvent.of(traceElementForDstPorts(22, 22)),
+                TraceEvent.of(traceElementForAddress("source", "2.2.2.0/24")))));
 
     root =
         AclTracer.trace(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -44,6 +44,7 @@ import org.batfish.datamodel.acl.TraceEvent;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.matchers.DataModelMatchers;
 import org.batfish.datamodel.trace.TraceTree;
+import org.batfish.representation.aws.IpPermissions.AddressType;
 import org.batfish.representation.aws.IpPermissions.IpRange;
 import org.junit.Test;
 
@@ -230,7 +231,8 @@ public class RegionTest {
                                     hasTraceElement(TraceElement.of(traceElementForProtocol(TCP))),
                                     hasTraceElement(traceElementForDstPorts(22, 22)),
                                     hasTraceElement(
-                                        traceElementForAddress("source", "2.2.2.0/24"))))))))));
+                                        traceElementForAddress(
+                                            "source", "2.2.2.0/24", AddressType.CIDR_IP))))))))));
     AclTrace trace = new AclTrace(root);
     assertThat(
         trace,
@@ -240,7 +242,8 @@ public class RegionTest {
                 TraceEvent.of(getTraceElementForRule(null)),
                 TraceEvent.of(TraceElement.of(traceElementForProtocol(TCP))),
                 TraceEvent.of(traceElementForDstPorts(22, 22)),
-                TraceEvent.of(traceElementForAddress("source", "2.2.2.0/24")))));
+                TraceEvent.of(
+                    traceElementForAddress("source", "2.2.2.0/24", AddressType.CIDR_IP)))));
 
     root =
         AclTracer.trace(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -37,7 +37,6 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.AclTrace;
 import org.batfish.datamodel.acl.AclTracer;
 import org.batfish.datamodel.acl.TraceEvent;
@@ -228,7 +227,7 @@ public class RegionTest {
                             hasTraceElement(getTraceElementForRule(null)),
                             hasChildren(
                                 contains(
-                                    hasTraceElement(TraceElement.of(traceElementForProtocol(TCP))),
+                                    hasTraceElement(traceElementForProtocol(TCP)),
                                     hasTraceElement(traceElementForDstPorts(22, 22)),
                                     hasTraceElement(
                                         traceElementForAddress(
@@ -240,7 +239,7 @@ public class RegionTest {
             contains(
                 TraceEvent.of(getTraceElementForSecurityGroup("sg-1")),
                 TraceEvent.of(getTraceElementForRule(null)),
-                TraceEvent.of(TraceElement.of(traceElementForProtocol(TCP))),
+                TraceEvent.of(traceElementForProtocol(TCP)),
                 TraceEvent.of(traceElementForDstPorts(22, 22)),
                 TraceEvent.of(
                     traceElementForAddress("source", "2.2.2.0/24", AddressType.CIDR_IP)))));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -44,6 +44,7 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.representation.aws.IpPermissions.AddressType;
 import org.batfish.representation.aws.IpPermissions.IpRange;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -61,12 +62,12 @@ public class SecurityGroupsTest {
   private static final MatchHeaderSpace matchIp =
       new MatchHeaderSpace(
           HeaderSpace.builder().setSrcIps(Ip.parse("1.2.3.4").toIpSpace()).build(),
-          traceElementForAddress("source", "1.2.3.4/32"));
+          traceElementForAddress("source", "1.2.3.4/32", AddressType.CIDR_IP));
 
   private static final MatchHeaderSpace matchUniverse =
       new MatchHeaderSpace(
           HeaderSpace.builder().setSrcIps(UniverseIpSpace.INSTANCE).build(),
-          traceElementForAddress("source", "0.0.0.0/0"));
+          traceElementForAddress("source", "0.0.0.0/0", AddressType.CIDR_IP));
 
   private static final MatchHeaderSpace matchTcp =
       new MatchHeaderSpace(
@@ -273,7 +274,8 @@ public class SecurityGroupsTest {
                     matchPorts(80, 80),
                     new MatchHeaderSpace(
                         HeaderSpace.builder().setDstIps(Ip.parse("5.6.7.8").toIpSpace()).build(),
-                        traceElementForAddress("destination", "5.6.7.8/32"))))));
+                        traceElementForAddress(
+                            "destination", "5.6.7.8/32", AddressType.CIDR_IP))))));
   }
 
   @Test
@@ -410,7 +412,8 @@ public class SecurityGroupsTest {
                                 HeaderSpace.builder()
                                     .setSrcIps(Prefix.parse("2.2.2.0/24").toIpSpace())
                                     .build(),
-                                traceElementForAddress("source", "2.2.2.0/24"))))
+                                traceElementForAddress(
+                                    "source", "2.2.2.0/24", AddressType.CIDR_IP))))
                     .setTraceElement(getTraceElementForRule(null))
                     .build())));
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -1,10 +1,16 @@
 package org.batfish.representation.aws;
 
+import static org.batfish.datamodel.IpProtocol.ICMP;
 import static org.batfish.datamodel.IpProtocol.TCP;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.matchers.AclLineMatchers.isExprAclLineThat;
 import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchCondition;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_SECURITY_GROUPS;
 import static org.batfish.representation.aws.Utils.getTraceElementForRule;
+import static org.batfish.representation.aws.Utils.traceElementForAddress;
+import static org.batfish.representation.aws.Utils.traceElementForDstPorts;
+import static org.batfish.representation.aws.Utils.traceElementForIcmp;
+import static org.batfish.representation.aws.Utils.traceElementForProtocol;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -17,9 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
@@ -34,12 +38,11 @@ import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpProtocol;
-import org.batfish.datamodel.IpWildcard;
-import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.representation.aws.IpPermissions.IpRange;
 import org.hamcrest.Matchers;
@@ -55,6 +58,43 @@ public class SecurityGroupsTest {
   private Warnings _warnings;
 
   public static String TEST_ACL = "test_acl";
+  private static final MatchHeaderSpace matchIp =
+      new MatchHeaderSpace(
+          HeaderSpace.builder().setSrcIps(Ip.parse("1.2.3.4").toIpSpace()).build(),
+          traceElementForAddress("source", "1.2.3.4/32"));
+
+  private static final MatchHeaderSpace matchUniverse =
+      new MatchHeaderSpace(
+          HeaderSpace.builder().setSrcIps(UniverseIpSpace.INSTANCE).build(),
+          traceElementForAddress("source", "0.0.0.0/0"));
+
+  private static final MatchHeaderSpace matchTcp =
+      new MatchHeaderSpace(
+          HeaderSpace.builder().setIpProtocols(TCP).build(), traceElementForProtocol(TCP));
+
+  private static final MatchHeaderSpace matchIcmp =
+      new MatchHeaderSpace(
+          HeaderSpace.builder().setIpProtocols(ICMP).build(), traceElementForProtocol(ICMP));
+
+  private static MatchHeaderSpace matchPorts(int fromPort, int toPort) {
+    if (fromPort == toPort) {
+      return new MatchHeaderSpace(
+          HeaderSpace.builder().setDstPorts(SubRange.singleton(fromPort)).build(),
+          traceElementForDstPorts(fromPort, toPort));
+    }
+    return new MatchHeaderSpace(
+        HeaderSpace.builder().setDstPorts(new SubRange(fromPort, toPort)).build(),
+        traceElementForDstPorts(fromPort, toPort));
+  }
+
+  private static MatchHeaderSpace matchIcmpTypeCode(int type, int code) {
+    HeaderSpace.Builder hsBuilder = HeaderSpace.builder();
+    hsBuilder.setIcmpTypes(type);
+    if (code != -1) {
+      hsBuilder.setIcmpCodes(code);
+    }
+    return new MatchHeaderSpace(hsBuilder.build(), traceElementForIcmp(type, code));
+  }
 
   @Before
   public void setup() throws IOException {
@@ -124,15 +164,7 @@ public class SecurityGroupsTest {
     SecurityGroup sg = _securityGroups.get(0);
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
-        line,
-        isExprAclLineThat(
-            hasMatchCondition(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
-                        .setDstPorts(Sets.newHashSet(SubRange.singleton(22)))
-                        .build()))));
+        line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(22, 22), matchIp))));
   }
 
   @Test
@@ -140,15 +172,7 @@ public class SecurityGroupsTest {
     SecurityGroup sg = _securityGroups.get(1);
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
-        line,
-        isExprAclLineThat(
-            hasMatchCondition(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
-                        .setDstPorts(Sets.newHashSet(new SubRange(0, 22)))
-                        .build()))));
+        line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(0, 22), matchIp))));
   }
 
   @Test
@@ -157,29 +181,14 @@ public class SecurityGroupsTest {
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
         line,
-        isExprAclLineThat(
-            hasMatchCondition(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
-                        .setDstPorts(Sets.newHashSet(new SubRange(65530, 65535)))
-                        .build()))));
+        isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(65530, 65535), matchIp))));
   }
 
   @Test
   public void testFullInterval() {
     SecurityGroup sg = _securityGroups.get(3);
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
-    assertThat(
-        line,
-        isExprAclLineThat(
-            hasMatchCondition(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
-                        .build()))));
+    assertThat(line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchIp))));
   }
 
   @Test
@@ -189,13 +198,7 @@ public class SecurityGroupsTest {
     assertThat(
         line,
         isExprAclLineThat(
-            hasMatchCondition(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.ICMP))
-                        .setIcmpTypes(8)
-                        .setSrcIps(IpWildcardSetIpSpace.ANY)
-                        .build()))));
+            hasMatchCondition(and(matchIcmp, matchIcmpTypeCode(8, -1), matchUniverse))));
   }
 
   @Test
@@ -205,14 +208,7 @@ public class SecurityGroupsTest {
     assertThat(
         line,
         isExprAclLineThat(
-            hasMatchCondition(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.ICMP))
-                        .setIcmpTypes(8)
-                        .setIcmpCodes(9)
-                        .setSrcIps(IpWildcardSetIpSpace.ANY)
-                        .build()))));
+            hasMatchCondition(and(matchIcmp, matchIcmpTypeCode(8, 9), matchUniverse))));
   }
 
   @Test
@@ -234,15 +230,7 @@ public class SecurityGroupsTest {
   public void testAllTrafficAllowed() {
     SecurityGroup sg = _securityGroups.get(4);
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
-    assertThat(
-        line,
-        isExprAclLineThat(
-            hasMatchCondition(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder()
-                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("0.0.0.0/0")))
-                        .setDstPorts(Sets.newHashSet())
-                        .build()))));
+    assertThat(line, isExprAclLineThat(hasMatchCondition(matchUniverse)));
   }
 
   @Test
@@ -250,15 +238,7 @@ public class SecurityGroupsTest {
     SecurityGroup sg = _securityGroups.get(5);
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
-        line,
-        isExprAclLineThat(
-            hasMatchCondition(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
-                        .setDstPorts(Sets.newHashSet(new SubRange(45, 50)))
-                        .build()))));
+        line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(45, 50), matchIp))));
   }
 
   @Test
@@ -266,15 +246,7 @@ public class SecurityGroupsTest {
     SecurityGroup sg = _securityGroups.get(6);
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
-        line,
-        isExprAclLineThat(
-            hasMatchCondition(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
-                        .setDstPorts(Sets.newHashSet(new SubRange(0, 50)))
-                        .build()))));
+        line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(0, 50), matchIp))));
   }
 
   @Test
@@ -282,15 +254,7 @@ public class SecurityGroupsTest {
     SecurityGroup sg = _securityGroups.get(7);
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
-        line,
-        isExprAclLineThat(
-            hasMatchCondition(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
-                        .setDstPorts(Sets.newHashSet(new SubRange(30, 65535)))
-                        .build()))));
+        line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(30, 65535), matchIp))));
   }
 
   @Test
@@ -298,26 +262,18 @@ public class SecurityGroupsTest {
     SecurityGroup sg = _securityGroups.get(8);
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
-        line,
-        isExprAclLineThat(
-            hasMatchCondition(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setSrcIps(Sets.newHashSet(IpWildcard.parse("1.2.3.4/32")))
-                        .setDstPorts(Sets.newHashSet(SubRange.singleton(22)))
-                        .build()))));
+        line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(22, 22), matchIp))));
     AclLine outline = Iterables.getOnlyElement(sg.toAclLines(_region, false, _warnings));
     assertThat(
         outline,
         isExprAclLineThat(
             hasMatchCondition(
-                new MatchHeaderSpace(
-                    HeaderSpace.builder()
-                        .setIpProtocols(Sets.newHashSet(IpProtocol.TCP))
-                        .setDstIps(Sets.newHashSet(IpWildcard.parse("5.6.7.8/32")))
-                        .setDstPorts(Sets.newHashSet(SubRange.singleton(80)))
-                        .build()))));
+                and(
+                    matchTcp,
+                    matchPorts(80, 80),
+                    new MatchHeaderSpace(
+                        HeaderSpace.builder().setDstIps(Ip.parse("5.6.7.8").toIpSpace()).build(),
+                        traceElementForAddress("destination", "5.6.7.8/32"))))));
   }
 
   @Test
@@ -447,13 +403,15 @@ public class SecurityGroupsTest {
                 ExprAclLine.accepting()
                     .setName("sg-001 - sg-1 [ingress] 0")
                     .setMatchCondition(
-                        new MatchHeaderSpace(
-                            HeaderSpace.builder()
-                                .setDstPorts(SubRange.singleton(22))
-                                .setIpProtocols(TCP)
-                                .setSrcIps(ImmutableSet.of(IpWildcard.parse("2.2.2.0/24")))
-                                .build()))
-                    .setTraceElement(getTraceElementForRule(0))
+                        and(
+                            matchTcp,
+                            matchPorts(22, 22),
+                            new MatchHeaderSpace(
+                                HeaderSpace.builder()
+                                    .setSrcIps(Prefix.parse("2.2.2.0/24").toIpSpace())
+                                    .build(),
+                                traceElementForAddress("source", "2.2.2.0/24"))))
+                    .setTraceElement(getTraceElementForRule(null))
                     .build())));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -78,11 +78,6 @@ public class SecurityGroupsTest {
           HeaderSpace.builder().setIpProtocols(ICMP).build(), traceElementForProtocol(ICMP));
 
   private static MatchHeaderSpace matchPorts(int fromPort, int toPort) {
-    if (fromPort == toPort) {
-      return new MatchHeaderSpace(
-          HeaderSpace.builder().setDstPorts(SubRange.singleton(fromPort)).build(),
-          traceElementForDstPorts(fromPort, toPort));
-    }
     return new MatchHeaderSpace(
         HeaderSpace.builder().setDstPorts(new SubRange(fromPort, toPort)).build(),
         traceElementForDstPorts(fromPort, toPort));

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -324,12 +324,17 @@
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
                     "dstIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
-                      "whitelist" : [
-                        "0.0.0.0/0"
-                      ]
+                      "class" : "org.batfish.datamodel.UniverseIpSpace"
                     },
                     "negate" : false
+                  },
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched destination address 0.0.0.0/0"
+                      }
+                    ]
                   }
                 },
                 "name" : "sg-3dfb3140 - default [egress] 0",
@@ -337,7 +342,7 @@
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule 0 within security group"
+                      "text" : "Matched rule with no description"
                     }
                   ]
                 }
@@ -355,11 +360,17 @@
                   "headerSpace" : {
                     "negate" : false,
                     "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
-                      "whitelist" : [
-                        "192.168.1.3"
-                      ]
+                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                      "ipWildcard" : "192.168.1.3"
                     }
+                  },
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched source address default"
+                      }
+                    ]
                   }
                 },
                 "name" : "sg-3dfb3140 - default [ingress] 0",
@@ -367,7 +378,7 @@
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule 0 within security group"
+                      "text" : "Matched rule with no description"
                     }
                   ]
                 }
@@ -4687,12 +4698,17 @@
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
                     "dstIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
-                      "whitelist" : [
-                        "0.0.0.0/0"
-                      ]
+                      "class" : "org.batfish.datamodel.UniverseIpSpace"
                     },
                     "negate" : false
+                  },
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched destination address 0.0.0.0/0"
+                      }
+                    ]
                   }
                 },
                 "name" : "sg-55510831 - default [egress] 0",
@@ -4700,7 +4716,7 @@
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule 0 within security group"
+                      "text" : "Matched rule with no description"
                     }
                   ]
                 }
@@ -4714,33 +4730,348 @@
                 "class" : "org.batfish.datamodel.ExprAclLine",
                 "action" : "PERMIT",
                 "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "dstPorts" : [
-                      "3306-3306"
-                    ],
-                    "ipProtocols" : [
-                      "TCP"
-                    ],
-                    "negate" : false,
-                    "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
-                      "whitelist" : [
-                        "10.193.0.0/16",
-                        "67.170.86.87",
-                        "104.236.156.171",
-                        "107.170.243.58",
-                        "162.243.144.192"
-                      ]
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "ipProtocols" : [
+                          "TCP"
+                        ],
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched protocol TCP"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "dstPorts" : [
+                          "3306-3306"
+                        ],
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched destination port 3306"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "negate" : false,
+                        "srcIps" : {
+                          "class" : "org.batfish.datamodel.IpIpSpace",
+                          "ip" : "67.170.86.87"
+                        }
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched source address 67.170.86.87/32"
+                          }
+                        ]
+                      }
                     }
-                  }
+                  ]
                 },
                 "name" : "sg-55510831 - default [ingress] 0",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule 0 within security group"
+                      "text" : "Matched rule with description surf"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "ipProtocols" : [
+                          "TCP"
+                        ],
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched protocol TCP"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "dstPorts" : [
+                          "3306-3306"
+                        ],
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched destination port 3306"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "negate" : false,
+                        "srcIps" : {
+                          "class" : "org.batfish.datamodel.IpIpSpace",
+                          "ip" : "104.236.156.171"
+                        }
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched source address 104.236.156.171/32"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "name" : "sg-55510831 - default [ingress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule with description intentionet-dev"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "ipProtocols" : [
+                          "TCP"
+                        ],
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched protocol TCP"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "dstPorts" : [
+                          "3306-3306"
+                        ],
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched destination port 3306"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "negate" : false,
+                        "srcIps" : {
+                          "class" : "org.batfish.datamodel.IpIpSpace",
+                          "ip" : "107.170.243.58"
+                        }
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched source address 107.170.243.58/32"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "name" : "sg-55510831 - default [ingress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule with description inentionet-test"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "ipProtocols" : [
+                          "TCP"
+                        ],
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched protocol TCP"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "dstPorts" : [
+                          "3306-3306"
+                        ],
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched destination port 3306"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "negate" : false,
+                        "srcIps" : {
+                          "class" : "org.batfish.datamodel.IpIpSpace",
+                          "ip" : "162.243.144.192"
+                        }
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched source address 162.243.144.192/32"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "name" : "sg-55510831 - default [ingress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule with description intentionet-web"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "ipProtocols" : [
+                          "TCP"
+                        ],
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched protocol TCP"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "dstPorts" : [
+                          "3306-3306"
+                        ],
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched destination port 3306"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "negate" : false,
+                        "srcIps" : {
+                          "class" : "org.batfish.datamodel.PrefixIpSpace",
+                          "prefix" : "10.193.0.0/16"
+                        }
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched source address 10.193.0.0/16"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "name" : "sg-55510831 - default [ingress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule with description Internal traffic"
                     }
                   ]
                 }

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -332,7 +332,7 @@
                     "fragments" : [
                       {
                         "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched destination address 0.0.0.0/0"
+                        "text" : "Matched destination address CIDR IP 0.0.0.0/0"
                       }
                     ]
                   }
@@ -368,7 +368,7 @@
                     "fragments" : [
                       {
                         "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched source address default"
+                        "text" : "Matched source address Security Group default"
                       }
                     ]
                   }
@@ -4706,7 +4706,7 @@
                     "fragments" : [
                       {
                         "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched destination address 0.0.0.0/0"
+                        "text" : "Matched destination address CIDR IP 0.0.0.0/0"
                       }
                     ]
                   }
@@ -4771,15 +4771,15 @@
                       "headerSpace" : {
                         "negate" : false,
                         "srcIps" : {
-                          "class" : "org.batfish.datamodel.IpIpSpace",
-                          "ip" : "67.170.86.87"
+                          "class" : "org.batfish.datamodel.PrefixIpSpace",
+                          "prefix" : "10.193.0.0/16"
                         }
                       },
                       "traceElement" : {
                         "fragments" : [
                           {
                             "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched source address 67.170.86.87/32"
+                            "text" : "Matched source address CIDR IP 10.193.0.0/16"
                           }
                         ]
                       }
@@ -4791,77 +4791,7 @@
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with description surf"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "PERMIT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "ipProtocols" : [
-                          "TCP"
-                        ],
-                        "negate" : false
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched protocol TCP"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "dstPorts" : [
-                          "3306-3306"
-                        ],
-                        "negate" : false
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched destination port 3306"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "negate" : false,
-                        "srcIps" : {
-                          "class" : "org.batfish.datamodel.IpIpSpace",
-                          "ip" : "104.236.156.171"
-                        }
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched source address 104.236.156.171/32"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                "name" : "sg-55510831 - default [ingress] 0",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with description intentionet-dev"
+                      "text" : "Matched rule with description Internal traffic"
                     }
                   ]
                 }
@@ -4919,7 +4849,7 @@
                         "fragments" : [
                           {
                             "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched source address 107.170.243.58/32"
+                            "text" : "Matched source address CIDR IP 107.170.243.58/32"
                           }
                         ]
                       }
@@ -4982,6 +4912,76 @@
                         "negate" : false,
                         "srcIps" : {
                           "class" : "org.batfish.datamodel.IpIpSpace",
+                          "ip" : "104.236.156.171"
+                        }
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched source address CIDR IP 104.236.156.171/32"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "name" : "sg-55510831 - default [ingress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule with description intentionet-dev"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "ipProtocols" : [
+                          "TCP"
+                        ],
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched protocol TCP"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "dstPorts" : [
+                          "3306-3306"
+                        ],
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched destination port 3306"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "negate" : false,
+                        "srcIps" : {
+                          "class" : "org.batfish.datamodel.IpIpSpace",
                           "ip" : "162.243.144.192"
                         }
                       },
@@ -4989,7 +4989,7 @@
                         "fragments" : [
                           {
                             "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched source address 162.243.144.192/32"
+                            "text" : "Matched source address CIDR IP 162.243.144.192/32"
                           }
                         ]
                       }
@@ -5051,15 +5051,15 @@
                       "headerSpace" : {
                         "negate" : false,
                         "srcIps" : {
-                          "class" : "org.batfish.datamodel.PrefixIpSpace",
-                          "prefix" : "10.193.0.0/16"
+                          "class" : "org.batfish.datamodel.IpIpSpace",
+                          "ip" : "67.170.86.87"
                         }
                       },
                       "traceElement" : {
                         "fragments" : [
                           {
                             "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched source address 10.193.0.0/16"
+                            "text" : "Matched source address CIDR IP 67.170.86.87/32"
                           }
                         ]
                       }
@@ -5071,7 +5071,7 @@
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with description Internal traffic"
+                      "text" : "Matched rule with description surf"
                     }
                   ]
                 }


### PR DESCRIPTION
contents:
1. Refactored `IpPermissions.toIpAccessListLine` to generate one `ExprAclLine` per `IpRange`, per `SecurityGroup` and per `PrefixListId`. So now an `IpPermission` object can generate multiple `ExprAclLine`s. This was done to get desired form of traces and to also use the user-specified description at the rule level. Also the match condition for every line is an `and` of smaller `MatchHeaderSpace`s. 
2. Tried to get rid of obsolete `IpWildCard`s from `IpPermissions`
3. The name of an `ExprAclLine` will be duplicated if an IpPermission generates multiple `ExprAclLine`, but since now we don't use that name anywhere, it should not have any side-effect. Making it unique will make the code unnecessarily convoluted.
Testfilters trace using this PR looks like below:
<img width="1010" alt="Screen Shot 2020-01-23 at 3 26 13 AM" src="https://user-images.githubusercontent.com/15151202/72984910-a07c1b00-3d99-11ea-8f0c-310cde3a93ed.png">
