### PR TITLE
AclTracer: dont trace acl lines without a TraceElement

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ExprAclLine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ExprAclLine.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -28,6 +29,8 @@ public final class ExprAclLine extends AclLine {
 
     private TraceElement _traceElement;
 
+    private boolean _setTraceElement;
+
     private Builder() {}
 
     public Builder accepting() {
@@ -36,7 +39,10 @@ public final class ExprAclLine extends AclLine {
     }
 
     public ExprAclLine build() {
-      return new ExprAclLine(_action, _matchCondition, _name, _traceElement);
+      // If traceElement has not been set, create a default one from the name
+      TraceElement traceElement =
+          (!_setTraceElement && _name != null) ? matchedByAclLine(_name) : _traceElement;
+      return new ExprAclLine(_action, _matchCondition, _name, traceElement);
     }
 
     public Builder rejecting() {
@@ -60,6 +66,7 @@ public final class ExprAclLine extends AclLine {
     }
 
     public Builder setTraceElement(@Nullable TraceElement traceElement) {
+      _setTraceElement = true;
       _traceElement = traceElement;
       return this;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -1,7 +1,6 @@
 package org.batfish.datamodel.acl;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Collection;
@@ -96,9 +95,7 @@ public final class AclTracer extends AclLineEvaluator {
   private void setTraceElement(@Nonnull IpAccessList ipAccessList, int index) {
     AclLine line = ipAccessList.getLines().get(index);
     TraceElement traceElement = line.getTraceElement();
-    if (traceElement == null) {
-      _tracer.setTraceElement(matchedByAclLine(ipAccessList, index));
-    } else {
+    if (traceElement != null) {
       _tracer.setTraceElement(traceElement);
     }
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TraceElements.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TraceElements.java
@@ -15,11 +15,19 @@ import org.batfish.datamodel.TraceElement;
 public final class TraceElements {
   private TraceElements() {}
 
-  public static TraceElement matchedByAclLine(IpAccessList acl, int index) {
-    AclLine line = acl.getLines().get(index);
-    String lineDescription =
-        line.getName() == null ? String.format("at index %s", index) : line.getName();
-    return TraceElement.of("Matched line " + lineDescription);
+  public static @Nullable TraceElement matchedByAclLine(IpAccessList acl, int index) {
+    return matchedByAclLine(acl.getLines().get(index));
+  }
+
+  public static @Nullable TraceElement matchedByAclLine(AclLine line) {
+    if (line.getName() == null) {
+      return null;
+    }
+    return matchedByAclLine(line.getName());
+  }
+
+  public static TraceElement matchedByAclLine(String lineName) {
+    return TraceElement.of("Matched line " + lineName);
   }
 
   public static TraceElement permittedByNamedIpSpace(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -5431,34 +5431,19 @@ public final class CiscoGrammarTest {
     // from device
     {
       List<TraceTree> traces = trace.apply(null, insideInterface);
-      assertThat(
-          traces,
-          contains(
-              isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(PERMIT_TRAFFIC_FROM_DEVICE))));
+      assertThat(traces, contains(isTraceTree(PERMIT_TRAFFIC_FROM_DEVICE)));
     }
 
     // intra-security-level, but from/to different interfaces
     {
       List<TraceTree> traces = trace.apply(explicit100Interface, insideInterface);
-      assertThat(
-          traces,
-          contains(
-              isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(DENY_SAME_SECURITY_TRAFFIC_INTER_TRACE_ELEMENT))));
+      assertThat(traces, contains(isTraceTree(DENY_SAME_SECURITY_TRAFFIC_INTER_TRACE_ELEMENT)));
     }
 
     // hairpinning
     {
       List<TraceTree> traces = trace.apply(explicit100Interface, explicit100Interface);
-      assertThat(
-          traces,
-          contains(
-              isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(DENY_SAME_SECURITY_TRAFFIC_INTRA_TRACE_ELEMENT))));
+      assertThat(traces, contains(isTraceTree(DENY_SAME_SECURITY_TRAFFIC_INTRA_TRACE_ELEMENT)));
     }
   }
 
@@ -5510,23 +5495,13 @@ public final class CiscoGrammarTest {
     // intra-security-level, but from/to different interfaces
     {
       List<TraceTree> traces = trace.apply(ifaceAlias1, ifaceAlias2);
-      assertThat(
-          traces,
-          contains(
-              isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTER_TRACE_ELEMENT))));
+      assertThat(traces, contains(isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTER_TRACE_ELEMENT)));
     }
 
     // hairpinning
     {
       List<TraceTree> traces = trace.apply(ifaceAlias1, ifaceAlias1);
-      assertThat(
-          traces,
-          contains(
-              isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTRA_TRACE_ELEMENT))));
+      assertThat(traces, contains(isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTRA_TRACE_ELEMENT)));
     }
   }
 
@@ -5565,12 +5540,10 @@ public final class CiscoGrammarTest {
       assertThat(
           traces,
           contains(
+              isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTRA_TRACE_ELEMENT),
               isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTRA_TRACE_ELEMENT),
-                  isTraceTree(
-                      asaPermittedByOutputFilterTraceElement(filterOut.getName()),
-                      isTraceTree(matchedByAclLine(filterOut, 0))))));
+                  asaPermittedByOutputFilterTraceElement(filterOut.getName()),
+                  isTraceTree(matchedByAclLine(filterOut, 0)))));
     }
 
     // denied, intra-interface
@@ -5579,10 +5552,8 @@ public final class CiscoGrammarTest {
       assertThat(
           traces,
           contains(
-              isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTRA_TRACE_ELEMENT),
-                  isTraceTree(asaDeniedByOutputFilterTraceElement(filterOut.getName())))));
+              isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTRA_TRACE_ELEMENT),
+              isTraceTree(asaDeniedByOutputFilterTraceElement(filterOut.getName()))));
     }
 
     // permitted, inter-interface
@@ -5591,12 +5562,10 @@ public final class CiscoGrammarTest {
       assertThat(
           traces,
           contains(
+              isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTER_TRACE_ELEMENT),
               isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTER_TRACE_ELEMENT),
-                  isTraceTree(
-                      asaPermittedByOutputFilterTraceElement(filterOut.getName()),
-                      isTraceTree(matchedByAclLine(filterOut, 0))))));
+                  asaPermittedByOutputFilterTraceElement(filterOut.getName()),
+                  isTraceTree(matchedByAclLine(filterOut, 0)))));
     }
 
     // denied, inter-interface
@@ -5605,10 +5574,8 @@ public final class CiscoGrammarTest {
       assertThat(
           traces,
           contains(
-              isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTER_TRACE_ELEMENT),
-                  isTraceTree(asaDeniedByOutputFilterTraceElement(filterOut.getName())))));
+              isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTER_TRACE_ELEMENT),
+              isTraceTree(asaDeniedByOutputFilterTraceElement(filterOut.getName()))));
     }
 
     // permitted, low-to-high (low has ingress filter)
@@ -5617,12 +5584,10 @@ public final class CiscoGrammarTest {
       assertThat(
           traces,
           contains(
+              isTraceTree(asaPermitLowerSecurityLevelTraceElement(10)),
               isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(asaPermitLowerSecurityLevelTraceElement(10)),
-                  isTraceTree(
-                      asaPermittedByOutputFilterTraceElement(filterOut.getName()),
-                      isTraceTree(matchedByAclLine(filterOut, 0))))));
+                  asaPermittedByOutputFilterTraceElement(filterOut.getName()),
+                  isTraceTree(matchedByAclLine(filterOut, 0)))));
     }
 
     // denied, low-to-high (low has ingress filter)
@@ -5631,10 +5596,8 @@ public final class CiscoGrammarTest {
       assertThat(
           traces,
           contains(
-              isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(asaPermitLowerSecurityLevelTraceElement(10)),
-                  isTraceTree(asaDeniedByOutputFilterTraceElement(filterOut.getName())))));
+              isTraceTree(asaPermitLowerSecurityLevelTraceElement(10)),
+              isTraceTree(asaDeniedByOutputFilterTraceElement(filterOut.getName()))));
     }
 
     // permitted, high-to-low
@@ -5643,12 +5606,10 @@ public final class CiscoGrammarTest {
       assertThat(
           traces,
           contains(
+              isTraceTree(asaPermitHigherSecurityLevelTrafficTraceElement(100)),
               isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(asaPermitHigherSecurityLevelTrafficTraceElement(100)),
-                  isTraceTree(
-                      asaPermittedByOutputFilterTraceElement(filterOut.getName()),
-                      isTraceTree(matchedByAclLine(filterOut, 0))))));
+                  asaPermittedByOutputFilterTraceElement(filterOut.getName()),
+                  isTraceTree(matchedByAclLine(filterOut, 0)))));
     }
 
     // denied, high-to-low
@@ -5657,10 +5618,8 @@ public final class CiscoGrammarTest {
       assertThat(
           traces,
           contains(
-              isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(asaPermitHigherSecurityLevelTrafficTraceElement(100)),
-                  isTraceTree(asaDeniedByOutputFilterTraceElement(filterOut.getName())))));
+              isTraceTree(asaPermitHigherSecurityLevelTrafficTraceElement(100)),
+              isTraceTree(asaDeniedByOutputFilterTraceElement(filterOut.getName()))));
     }
   }
 
@@ -5692,23 +5651,13 @@ public final class CiscoGrammarTest {
     // same security level, intra-interface (hairpinning)
     {
       List<TraceTree> traces = trace.apply(out);
-      assertThat(
-          traces,
-          contains(
-              isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(DENY_SAME_SECURITY_TRAFFIC_INTRA_TRACE_ELEMENT))));
+      assertThat(traces, contains(isTraceTree(DENY_SAME_SECURITY_TRAFFIC_INTRA_TRACE_ELEMENT)));
     }
 
     // same security level, inter-interface
     {
       List<TraceTree> traces = trace.apply(inSameLevel);
-      assertThat(
-          traces,
-          contains(
-              isTraceTree(
-                  anything(), // TODO: don't produce a trace element for the line
-                  isTraceTree(DENY_SAME_SECURITY_TRAFFIC_INTER_TRACE_ELEMENT))));
+      assertThat(traces, contains(isTraceTree(DENY_SAME_SECURITY_TRAFFIC_INTER_TRACE_ELEMENT)));
     }
 
     // lower security level, no ingress filter

--- a/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersAnswerer.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Multiset;
 import java.util.Comparator;
 import java.util.List;
@@ -71,7 +70,7 @@ public class TestFiltersAnswerer extends Answerer {
           new ColumnMetadata(COL_FLOW, Schema.FLOW, "Evaluated flow", true, false),
           new ColumnMetadata(COL_ACTION, Schema.STRING, "Outcome", false, true),
           new ColumnMetadata(COL_LINE_CONTENT, Schema.STRING, "Line content", false, true),
-          new ColumnMetadata(COL_TRACE, Schema.TRACE_TREE, "ACL trace", false, true));
+          new ColumnMetadata(COL_TRACE, Schema.list(Schema.TRACE_TREE), "ACL trace", false, true));
 
   public TestFiltersAnswerer(Question question, IBatfish batfish) {
     super(question, batfish);
@@ -203,16 +202,14 @@ public class TestFiltersAnswerer extends Answerer {
    */
   public static Row getRow(IpAccessList filter, Flow flow, Configuration c) {
     @Nullable
-    TraceTree trace =
-        Iterables.getOnlyElement(
-            AclTracer.trace(
-                filter,
-                flow,
-                flow.getIngressInterface(),
-                c.getIpAccessLists(),
-                c.getIpSpaces(),
-                c.getIpSpaceMetadata()),
-            null);
+    List<TraceTree> trace =
+        AclTracer.trace(
+            filter,
+            flow,
+            flow.getIngressInterface(),
+            c.getIpAccessLists(),
+            c.getIpSpaces(),
+            c.getIpSpaceMetadata());
     FilterResult result =
         filter.filter(flow, flow.getIngressInterface(), c.getIpAccessLists(), c.getIpSpaces());
     Integer matchLine = result.getMatchLine();

--- a/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
@@ -1,21 +1,16 @@
 package org.batfish.question.testfilters;
 
 import static org.batfish.datamodel.ExprAclLine.acceptingHeaderSpace;
-import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasIpAccessLists;
 import static org.batfish.datamodel.matchers.DataModelMatchers.forAll;
 import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
 import static org.batfish.datamodel.matchers.RowsMatchers.hasSize;
 import static org.batfish.datamodel.matchers.TableAnswerElementMatchers.hasRows;
-import static org.batfish.datamodel.matchers.TraceTreeMatchers.hasChildren;
-import static org.batfish.datamodel.matchers.TraceTreeMatchers.hasTraceElement;
 import static org.batfish.question.testfilters.TestFiltersAnswerer.COL_FILTER_NAME;
 import static org.batfish.question.testfilters.TestFiltersAnswerer.COL_NODE;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -151,16 +146,15 @@ public class TestFiltersAnswererTest {
             forAll(
                 hasColumn(COL_FILTER_NAME, equalTo(acl.getName()), Schema.STRING),
                 hasColumn(
-                    TestFiltersAnswerer.COL_TRACE,
-                    allOf(hasTraceElement(matchedByAclLine(acl, 1)), hasChildren(empty())),
-                    Schema.TRACE_TREE))));
+                    TestFiltersAnswerer.COL_TRACE, empty(), Schema.list(Schema.TRACE_TREE)))));
     /* Trace should be present for referenced acl with one event: not matching the referenced acl */
     assertThat(
         answer,
         hasRows(
             forAll(
                 hasColumn(COL_FILTER_NAME, equalTo(referencedAcl.getName()), Schema.STRING),
-                hasColumn(TestFiltersAnswerer.COL_TRACE, nullValue(), Schema.TRACE_TREE))));
+                hasColumn(
+                    TestFiltersAnswerer.COL_TRACE, empty(), Schema.list(Schema.TRACE_TREE)))));
   }
 
   @Test

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -1837,7 +1837,15 @@
                     }
                   }
                 },
-                "name" : "permit icmp 10.100.0.0 0.0.255.255 any"
+                "name" : "permit icmp 10.100.0.0 0.0.255.255 any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit icmp 10.100.0.0 0.0.255.255 any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1859,7 +1867,15 @@
                     }
                   }
                 },
-                "name" : "permit icmp any 10.100.0.0 0.0.255.255"
+                "name" : "permit icmp any 10.100.0.0 0.0.255.255",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit icmp any 10.100.0.0 0.0.255.255"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "2001",
@@ -1885,7 +1901,15 @@
                     }
                   }
                 },
-                "name" : "permit ip 10.1.30.0 0.0.0.255 any"
+                "name" : "permit ip 10.1.30.0 0.0.0.255 any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip 10.1.30.0 0.0.0.255 any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1904,7 +1928,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 10.10.30.2 host 10.10.30.1"
+                "name" : "permit ip host 10.10.30.2 host 10.10.30.1",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 10.10.30.2 host 10.10.30.1"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "LIMIT_PEER",
@@ -1930,7 +1962,15 @@
                     }
                   }
                 },
-                "name" : "permit ip any any"
+                "name" : "permit ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "MATCH_ALL_BGP",
@@ -2961,7 +3001,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -2972,7 +3020,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-7b78771d_egress",
@@ -2990,7 +3046,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3001,7 +3065,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-7b78771d_ingress",
@@ -3134,7 +3206,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3145,7 +3225,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-7b78771d_egress",
@@ -3163,7 +3251,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3174,7 +3270,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-7b78771d_ingress",
@@ -3307,7 +3411,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3318,7 +3430,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-4db39c28_egress",
@@ -3348,7 +3468,15 @@
                     }
                   }
                 },
-                "name" : "100 TCP [3306,3306] 162.243.144.192/32 ALLOW"
+                "name" : "100 TCP [3306,3306] 162.243.144.192/32 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 TCP [3306,3306] 162.243.144.192/32 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3359,7 +3487,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-4db39c28_ingress",
@@ -3492,7 +3628,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3503,7 +3647,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-7b78771d_egress",
@@ -3521,7 +3673,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3532,7 +3692,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-7b78771d_ingress",
@@ -3665,7 +3833,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3676,7 +3852,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-3d4f745b_egress",
@@ -3694,7 +3878,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3705,7 +3897,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-3d4f745b_ingress",
@@ -3838,7 +4038,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3849,7 +4057,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-7b78771d_egress",
@@ -3867,7 +4083,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3878,7 +4102,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-7b78771d_ingress",
@@ -4011,7 +4243,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4022,7 +4262,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-3d4f745b_egress",
@@ -4040,7 +4288,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4051,7 +4307,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-3d4f745b_ingress",
@@ -4184,7 +4448,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4195,7 +4467,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-4db39c28_egress",
@@ -4225,7 +4505,15 @@
                     }
                   }
                 },
-                "name" : "100 TCP [3306,3306] 162.243.144.192/32 ALLOW"
+                "name" : "100 TCP [3306,3306] 162.243.144.192/32 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 TCP [3306,3306] 162.243.144.192/32 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4236,7 +4524,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-4db39c28_ingress",
@@ -4369,7 +4665,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4380,7 +4684,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-4db39c28_egress",
@@ -4410,7 +4722,15 @@
                     }
                   }
                 },
-                "name" : "100 TCP [3306,3306] 162.243.144.192/32 ALLOW"
+                "name" : "100 TCP [3306,3306] 162.243.144.192/32 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 TCP [3306,3306] 162.243.144.192/32 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4421,7 +4741,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-4db39c28_ingress",
@@ -4554,7 +4882,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4565,7 +4901,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-7b78771d_egress",
@@ -4583,7 +4927,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW"
+                "name" : "100 ALL ALL 0.0.0.0/0 ALLOW",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 ALL ALL 0.0.0.0/0 ALLOW"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4594,7 +4946,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "* ALL ALL 0.0.0.0/0 DENY"
+                "name" : "* ALL ALL 0.0.0.0/0 DENY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line * ALL ALL 0.0.0.0/0 DENY"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl-7b78771d_ingress",

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -155,7 +155,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+              "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 1.0.1.0 host 255.255.255.0"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -174,7 +182,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+              "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 1.0.2.0 host 255.255.255.0"
+                  }
+                ]
+              }
             }
           ],
           "name" : "101",
@@ -238,7 +254,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+              "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 1.0.1.0 host 255.255.255.0"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -257,7 +281,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+              "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 1.0.2.0 host 255.255.255.0"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -276,7 +308,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+              "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 3.0.1.0 host 255.255.255.0"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -295,7 +335,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+              "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 3.0.2.0 host 255.255.255.0"
+                  }
+                ]
+              }
             }
           ],
           "name" : "105",
@@ -341,7 +389,15 @@
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
-              "name" : "default"
+              "name" : "default",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line default"
+                  }
+                ]
+              }
             }
           ],
           "name" : "filter::FORWARD"
@@ -363,7 +419,15 @@
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
-              "name" : "default"
+              "name" : "default",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line default"
+                  }
+                ]
+              }
             }
           ],
           "name" : "mangle::FORWARD"
@@ -385,7 +449,15 @@
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
-              "name" : "default"
+              "name" : "default",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line default"
+                  }
+                ]
+              }
             }
           ],
           "name" : "mangle::INPUT"
@@ -407,7 +479,15 @@
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
-              "name" : "default"
+              "name" : "default",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line default"
+                  }
+                ]
+              }
             }
           ],
           "name" : "mangle::OUTPUT"
@@ -429,7 +509,15 @@
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
-              "name" : "default"
+              "name" : "default",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line default"
+                  }
+                ]
+              }
             }
           ],
           "name" : "mangle::POSTROUTING"
@@ -451,7 +539,15 @@
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
-              "name" : "default"
+              "name" : "default",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line default"
+                  }
+                ]
+              }
             }
           ],
           "name" : "mangle::PREROUTING"
@@ -473,7 +569,15 @@
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
-              "name" : "default"
+              "name" : "default",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line default"
+                  }
+                ]
+              }
             }
           ],
           "name" : "nat::OUTPUT"
@@ -495,7 +599,15 @@
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
-              "name" : "default"
+              "name" : "default",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line default"
+                  }
+                ]
+              }
             }
           ],
           "name" : "nat::POSTROUTING"
@@ -517,7 +629,15 @@
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
-              "name" : "default"
+              "name" : "default",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line default"
+                  }
+                ]
+              }
             }
           ],
           "name" : "nat::PREROUTING"
@@ -728,7 +848,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+              "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 3.0.1.0 host 255.255.255.0"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -747,7 +875,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+              "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 3.0.2.0 host 255.255.255.0"
+                  }
+                ]
+              }
             }
           ],
           "name" : "103",
@@ -832,7 +968,15 @@
                   }
                 }
               },
-              "name" : "permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255"
+              "name" : "permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -851,7 +995,15 @@
                   }
                 }
               },
-              "name" : "permit ip 10.12.11.2 0.0.0.0 10.12.11.1 0.0.0.0"
+              "name" : "permit ip 10.12.11.2 0.0.0.0 10.12.11.1 0.0.0.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip 10.12.11.2 0.0.0.0 10.12.11.1 0.0.0.0"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -870,7 +1022,15 @@
                   }
                 }
               },
-              "name" : "deny   ip any any"
+              "name" : "deny   ip any any",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line deny   ip any any"
+                  }
+                ]
+              }
             }
           ],
           "name" : "INSIDE_TO_AS1",
@@ -904,7 +1064,15 @@
                   }
                 }
               },
-              "name" : "permit ip 2.0.0.0 0.255.255.255 3.0.0.0 0.255.255.255"
+              "name" : "permit ip 2.0.0.0 0.255.255.255 3.0.0.0 0.255.255.255",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip 2.0.0.0 0.255.255.255 3.0.0.0 0.255.255.255"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -923,7 +1091,15 @@
                   }
                 }
               },
-              "name" : "permit ip 10.23.21.2 0.0.0.0 10.23.21.3 0.0.0.0"
+              "name" : "permit ip 10.23.21.2 0.0.0.0 10.23.21.3 0.0.0.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip 10.23.21.2 0.0.0.0 10.23.21.3 0.0.0.0"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -942,7 +1118,15 @@
                   }
                 }
               },
-              "name" : "deny   ip any any"
+              "name" : "deny   ip any any",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line deny   ip any any"
+                  }
+                ]
+              }
             }
           ],
           "name" : "INSIDE_TO_AS3",
@@ -976,7 +1160,15 @@
                   }
                 }
               },
-              "name" : "permit ip 2.128.0.0 0.0.255.255 any"
+              "name" : "permit ip 2.128.0.0 0.0.255.255 any",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip 2.128.0.0 0.0.255.255 any"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -995,7 +1187,15 @@
                   }
                 }
               },
-              "name" : "deny   ip any any"
+              "name" : "deny   ip any any",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line deny   ip any any"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1017,7 +1217,15 @@
                   }
                 }
               },
-              "name" : "permit icmp any any"
+              "name" : "permit icmp any any",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit icmp any any"
+                  }
+                ]
+              }
             }
           ],
           "name" : "RESTRICT_HOST_TRAFFIC_IN",
@@ -1051,7 +1259,15 @@
                   }
                 }
               },
-              "name" : "permit ip any 2.128.0.0 0.0.255.255"
+              "name" : "permit ip any 2.128.0.0 0.0.255.255",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip any 2.128.0.0 0.0.255.255"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1070,7 +1286,15 @@
                   }
                 }
               },
-              "name" : "deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255"
+              "name" : "deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1089,7 +1313,15 @@
                   }
                 }
               },
-              "name" : "deny   ip any any"
+              "name" : "deny   ip any any",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line deny   ip any any"
+                  }
+                ]
+              }
             }
           ],
           "name" : "RESTRICT_HOST_TRAFFIC_OUT",
@@ -1129,7 +1361,15 @@
                   }
                 }
               },
-              "name" : "deny   tcp any any eq telnet"
+              "name" : "deny   tcp any any eq telnet",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line deny   tcp any any eq telnet"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1148,7 +1388,15 @@
                   }
                 }
               },
-              "name" : "permit ip any any"
+              "name" : "permit ip any any",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip any any"
+                  }
+                ]
+              }
             }
           ],
           "name" : "blocktelnet",
@@ -1461,7 +1709,15 @@
                   }
                 }
               },
-              "name" : "deny   ip 2.0.0.0 0.255.255.255 any"
+              "name" : "deny   ip 2.0.0.0 0.255.255.255 any",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line deny   ip 2.0.0.0 0.255.255.255 any"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1480,7 +1736,15 @@
                   }
                 }
               },
-              "name" : "deny   ip any host 2.128.1.101"
+              "name" : "deny   ip any host 2.128.1.101",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line deny   ip any host 2.128.1.101"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1499,7 +1763,15 @@
                   }
                 }
               },
-              "name" : "permit ip any any"
+              "name" : "permit ip any any",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip any any"
+                  }
+                ]
+              }
             }
           ],
           "name" : "OUTSIDE_TO_INSIDE",
@@ -1534,7 +1806,15 @@
                   "negate" : false
                 }
               },
-              "name" : "-p udp --dport 53 -j ACCEPT"
+              "name" : "-p udp --dport 53 -j ACCEPT",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line -p udp --dport 53 -j ACCEPT"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1551,7 +1831,15 @@
                   "negate" : false
                 }
               },
-              "name" : "-p tcp --dport 22 -j ACCEPT"
+              "name" : "-p tcp --dport 22 -j ACCEPT",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line -p tcp --dport 22 -j ACCEPT"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1559,7 +1847,15 @@
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
-              "name" : "default"
+              "name" : "default",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line default"
+                  }
+                ]
+              }
             }
           ],
           "name" : "filter::INPUT"
@@ -1583,7 +1879,15 @@
               "matchCondition" : {
                 "class" : "org.batfish.datamodel.acl.TrueExpr"
               },
-              "name" : "default"
+              "name" : "default",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line default"
+                  }
+                ]
+              }
             }
           ],
           "name" : "filter::OUTPUT"
@@ -1623,7 +1927,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
+              "name" : "permit ip host 2.0.0.0 host 255.0.0.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 2.0.0.0 host 255.0.0.0"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1642,7 +1954,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+              "name" : "permit ip host 2.128.0.0 host 255.255.0.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 2.128.0.0 host 255.255.0.0"
+                  }
+                ]
+              }
             }
           ],
           "name" : "102",

--- a/tests/basic/outliers.ref
+++ b/tests/basic/outliers.ref
@@ -34,7 +34,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+              "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 3.0.1.0 host 255.255.255.0"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -53,7 +61,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+              "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 3.0.2.0 host 255.255.255.0"
+                  }
+                ]
+              }
             }
           ],
           "name" : "103",

--- a/tests/basic/testfilters.ref
+++ b/tests/basic/testfilters.ref
@@ -43,7 +43,7 @@
           "isKey" : false,
           "isValue" : true,
           "name" : "Trace",
-          "schema" : "TraceTree"
+          "schema" : "List<TraceTree>"
         }
       ],
       "textDesc" : "Filter ${Filter_Name} on node ${Node} will ${Action} flow ${Flow} at line ${Line_Content}"
@@ -54,7 +54,7 @@
           "id" : "node-host2",
           "name" : "host2"
         },
-        "Filter_Name" : "filter::FORWARD",
+        "Filter_Name" : "filter::OUTPUT",
         "Flow" : {
           "dscp" : 0,
           "dstIp" : "1.1.1.1",
@@ -80,16 +80,18 @@
         },
         "Action" : "PERMIT",
         "Line_Content" : "default",
-        "Trace" : {
-          "traceElement" : {
-            "fragments" : [
-              {
-                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                "text" : "Matched line default"
-              }
-            ]
+        "Trace" : [
+          {
+            "traceElement" : {
+              "fragments" : [
+                {
+                  "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                  "text" : "Matched line default"
+                }
+              ]
+            }
           }
-        }
+        ]
       },
       {
         "Node" : {
@@ -122,21 +124,23 @@
         },
         "Action" : "DENY",
         "Line_Content" : "default",
-        "Trace" : {
-          "traceElement" : {
-            "fragments" : [
-              {
-                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                "text" : "Matched line default"
-              }
-            ]
+        "Trace" : [
+          {
+            "traceElement" : {
+              "fragments" : [
+                {
+                  "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                  "text" : "Matched line default"
+                }
+              ]
+            }
           }
-        }
+        ]
       },
       {
         "Node" : {
-          "id" : "node-host2",
-          "name" : "host2"
+          "id" : "node-host1",
+          "name" : "host1"
         },
         "Filter_Name" : "filter::OUTPUT",
         "Flow" : {
@@ -145,11 +149,11 @@
           "dstPort" : 80,
           "ecn" : 0,
           "fragmentOffset" : 0,
-          "ingressNode" : "host2",
+          "ingressNode" : "host1",
           "ingressVrf" : "default",
           "ipProtocol" : "TCP",
           "packetLength" : 512,
-          "srcIp" : "2.128.1.101",
+          "srcIp" : "2.128.0.101",
           "srcPort" : 49152,
           "state" : "NEW",
           "tag" : "tag",
@@ -164,16 +168,18 @@
         },
         "Action" : "PERMIT",
         "Line_Content" : "default",
-        "Trace" : {
-          "traceElement" : {
-            "fragments" : [
-              {
-                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                "text" : "Matched line default"
-              }
-            ]
+        "Trace" : [
+          {
+            "traceElement" : {
+              "fragments" : [
+                {
+                  "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                  "text" : "Matched line default"
+                }
+              ]
+            }
           }
-        }
+        ]
       },
       {
         "Node" : {
@@ -206,58 +212,18 @@
         },
         "Action" : "DENY",
         "Line_Content" : "default",
-        "Trace" : {
-          "traceElement" : {
-            "fragments" : [
-              {
-                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                "text" : "Matched line default"
-              }
-            ]
+        "Trace" : [
+          {
+            "traceElement" : {
+              "fragments" : [
+                {
+                  "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                  "text" : "Matched line default"
+                }
+              ]
+            }
           }
-        }
-      },
-      {
-        "Node" : {
-          "id" : "node-host1",
-          "name" : "host1"
-        },
-        "Filter_Name" : "filter::OUTPUT",
-        "Flow" : {
-          "dscp" : 0,
-          "dstIp" : "1.1.1.1",
-          "dstPort" : 80,
-          "ecn" : 0,
-          "fragmentOffset" : 0,
-          "ingressNode" : "host1",
-          "ingressVrf" : "default",
-          "ipProtocol" : "TCP",
-          "packetLength" : 512,
-          "srcIp" : "2.128.0.101",
-          "srcPort" : 49152,
-          "state" : "NEW",
-          "tag" : "tag",
-          "tcpFlagsAck" : 0,
-          "tcpFlagsCwr" : 0,
-          "tcpFlagsEce" : 0,
-          "tcpFlagsFin" : 0,
-          "tcpFlagsPsh" : 0,
-          "tcpFlagsRst" : 0,
-          "tcpFlagsSyn" : 0,
-          "tcpFlagsUrg" : 0
-        },
-        "Action" : "PERMIT",
-        "Line_Content" : "default",
-        "Trace" : {
-          "traceElement" : {
-            "fragments" : [
-              {
-                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                "text" : "Matched line default"
-              }
-            ]
-          }
-        }
+        ]
       },
       {
         "Node" : {
@@ -290,16 +256,62 @@
         },
         "Action" : "PERMIT",
         "Line_Content" : "default",
-        "Trace" : {
-          "traceElement" : {
-            "fragments" : [
-              {
-                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                "text" : "Matched line default"
-              }
-            ]
+        "Trace" : [
+          {
+            "traceElement" : {
+              "fragments" : [
+                {
+                  "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                  "text" : "Matched line default"
+                }
+              ]
+            }
           }
-        }
+        ]
+      },
+      {
+        "Node" : {
+          "id" : "node-host2",
+          "name" : "host2"
+        },
+        "Filter_Name" : "filter::FORWARD",
+        "Flow" : {
+          "dscp" : 0,
+          "dstIp" : "1.1.1.1",
+          "dstPort" : 80,
+          "ecn" : 0,
+          "fragmentOffset" : 0,
+          "ingressNode" : "host2",
+          "ingressVrf" : "default",
+          "ipProtocol" : "TCP",
+          "packetLength" : 512,
+          "srcIp" : "2.128.1.101",
+          "srcPort" : 49152,
+          "state" : "NEW",
+          "tag" : "tag",
+          "tcpFlagsAck" : 0,
+          "tcpFlagsCwr" : 0,
+          "tcpFlagsEce" : 0,
+          "tcpFlagsFin" : 0,
+          "tcpFlagsPsh" : 0,
+          "tcpFlagsRst" : 0,
+          "tcpFlagsSyn" : 0,
+          "tcpFlagsUrg" : 0
+        },
+        "Action" : "PERMIT",
+        "Line_Content" : "default",
+        "Trace" : [
+          {
+            "traceElement" : {
+              "fragments" : [
+                {
+                  "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                  "text" : "Matched line default"
+                }
+              ]
+            }
+          }
+        ]
       }
     ],
     "summary" : {

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -204,7 +204,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -223,7 +231,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "101",
@@ -249,7 +265,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
+                "name" : "permit ip host 2.0.0.0 host 255.0.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 2.0.0.0 host 255.0.0.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -268,7 +292,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 2.128.0.0 host 255.255.0.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "102",
@@ -294,7 +326,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -313,7 +353,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "103",
@@ -1474,7 +1522,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1493,7 +1549,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "101",
@@ -1519,7 +1583,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
+                "name" : "permit ip host 2.0.0.0 host 255.0.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 2.0.0.0 host 255.0.0.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1538,7 +1610,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 2.128.0.0 host 255.255.0.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "102",
@@ -1564,7 +1644,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "103",
@@ -3164,7 +3252,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3183,7 +3279,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "101",
@@ -3209,7 +3313,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3228,7 +3340,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "103",
@@ -3254,7 +3374,15 @@
                     }
                   }
                 },
-                "name" : "permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255"
+                "name" : "permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip 2.0.0.0 0.255.255.255 1.0.0.0 0.255.255.255"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3273,7 +3401,15 @@
                     }
                   }
                 },
-                "name" : "permit ip 10.12.11.2 0.0.0.0 10.12.11.1 0.0.0.0"
+                "name" : "permit ip 10.12.11.2 0.0.0.0 10.12.11.1 0.0.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip 10.12.11.2 0.0.0.0 10.12.11.1 0.0.0.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3292,7 +3428,15 @@
                     }
                   }
                 },
-                "name" : "deny   ip any any"
+                "name" : "deny   ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny   ip any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "INSIDE_TO_AS1",
@@ -3318,7 +3462,15 @@
                     }
                   }
                 },
-                "name" : "deny   ip 2.0.0.0 0.255.255.255 any"
+                "name" : "deny   ip 2.0.0.0 0.255.255.255 any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny   ip 2.0.0.0 0.255.255.255 any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3337,7 +3489,15 @@
                     }
                   }
                 },
-                "name" : "deny   ip any host 2.128.1.101"
+                "name" : "deny   ip any host 2.128.1.101",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny   ip any host 2.128.1.101"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -3356,7 +3516,15 @@
                     }
                   }
                 },
-                "name" : "permit ip any any"
+                "name" : "permit ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "OUTSIDE_TO_INSIDE",
@@ -4485,7 +4653,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4504,7 +4680,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "101",
@@ -4530,7 +4714,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4549,7 +4741,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "103",
@@ -4575,7 +4775,15 @@
                     }
                   }
                 },
-                "name" : "permit ip 2.0.0.0 0.255.255.255 3.0.0.0 0.255.255.255"
+                "name" : "permit ip 2.0.0.0 0.255.255.255 3.0.0.0 0.255.255.255",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip 2.0.0.0 0.255.255.255 3.0.0.0 0.255.255.255"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4594,7 +4802,15 @@
                     }
                   }
                 },
-                "name" : "permit ip 10.23.21.2 0.0.0.0 10.23.21.3 0.0.0.0"
+                "name" : "permit ip 10.23.21.2 0.0.0.0 10.23.21.3 0.0.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip 10.23.21.2 0.0.0.0 10.23.21.3 0.0.0.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4613,7 +4829,15 @@
                     }
                   }
                 },
-                "name" : "deny   ip any any"
+                "name" : "deny   ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny   ip any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "INSIDE_TO_AS3",
@@ -4639,7 +4863,15 @@
                     }
                   }
                 },
-                "name" : "deny   ip 2.0.0.0 0.255.255.255 any"
+                "name" : "deny   ip 2.0.0.0 0.255.255.255 any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny   ip 2.0.0.0 0.255.255.255 any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4658,7 +4890,15 @@
                     }
                   }
                 },
-                "name" : "permit ip any any"
+                "name" : "permit ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "OUTSIDE_TO_INSIDE",
@@ -5760,7 +6000,15 @@
                     }
                   }
                 },
-                "name" : "deny   tcp any any eq telnet"
+                "name" : "deny   tcp any any eq telnet",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny   tcp any any eq telnet"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5779,7 +6027,15 @@
                     }
                   }
                 },
-                "name" : "permit ip any any"
+                "name" : "permit ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "blocktelnet",
@@ -6994,7 +7250,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 2.128.0.0 host 255.255.255.0"
+                "name" : "permit ip host 2.128.0.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 2.128.0.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7013,7 +7277,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 2.128.1.0 host 255.255.255.0"
+                "name" : "permit ip host 2.128.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 2.128.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "102",
@@ -7039,7 +7311,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7058,7 +7338,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7077,7 +7365,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7096,7 +7392,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "105",
@@ -7122,7 +7426,15 @@
                     }
                   }
                 },
-                "name" : "permit ip 2.128.0.0 0.0.255.255 any"
+                "name" : "permit ip 2.128.0.0 0.0.255.255 any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip 2.128.0.0 0.0.255.255 any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7141,7 +7453,15 @@
                     }
                   }
                 },
-                "name" : "deny   ip any any"
+                "name" : "deny   ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny   ip any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7163,7 +7483,15 @@
                     }
                   }
                 },
-                "name" : "permit icmp any any"
+                "name" : "permit icmp any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit icmp any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "RESTRICT_HOST_TRAFFIC_IN",
@@ -7189,7 +7517,15 @@
                     }
                   }
                 },
-                "name" : "permit ip any 2.128.0.0 0.0.255.255"
+                "name" : "permit ip any 2.128.0.0 0.0.255.255",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip any 2.128.0.0 0.0.255.255"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7208,7 +7544,15 @@
                     }
                   }
                 },
-                "name" : "deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255"
+                "name" : "deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny   ip 1.128.0.0 0.0.255.255 2.128.0.0 0.0.255.255"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7227,7 +7571,15 @@
                     }
                   }
                 },
-                "name" : "deny   ip any any"
+                "name" : "deny   ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny   ip any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "RESTRICT_HOST_TRAFFIC_OUT",
@@ -7940,7 +8292,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 2.128.0.0 host 255.255.0.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "102",
@@ -7966,7 +8326,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7985,7 +8353,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -8004,7 +8380,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -8023,7 +8407,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "105",
@@ -8738,7 +9130,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 2.128.0.0 host 255.255.0.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "102",
@@ -8764,7 +9164,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -8783,7 +9191,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -8802,7 +9218,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -8821,7 +9245,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "105",
@@ -9525,7 +9957,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -9544,7 +9984,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "101",
@@ -9570,7 +10018,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
+                "name" : "permit ip host 2.0.0.0 host 255.0.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 2.0.0.0 host 255.0.0.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -9589,7 +10045,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 2.128.0.0 host 255.255.0.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "102",
@@ -9615,7 +10079,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -9634,7 +10106,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "103",
@@ -10665,7 +11145,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -10684,7 +11172,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 1.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 1.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 1.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "101",
@@ -10710,7 +11206,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
+                "name" : "permit ip host 2.0.0.0 host 255.0.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 2.0.0.0 host 255.0.0.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -10729,7 +11233,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+                "name" : "permit ip host 2.128.0.0 host 255.255.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 2.128.0.0 host 255.255.0.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "102",
@@ -10755,7 +11267,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.1.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.1.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.1.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -10774,7 +11294,15 @@
                     }
                   }
                 },
-                "name" : "permit ip host 3.0.2.0 host 255.255.255.0"
+                "name" : "permit ip host 3.0.2.0 host 255.255.255.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip host 3.0.2.0 host 255.255.255.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "103",
@@ -12210,7 +12738,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "filter::FORWARD"
@@ -12232,7 +12768,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "-p udp --dport 53 -j ACCEPT"
+                "name" : "-p udp --dport 53 -j ACCEPT",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line -p udp --dport 53 -j ACCEPT"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -12249,7 +12793,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "-p tcp --dport 22 -j ACCEPT"
+                "name" : "-p tcp --dport 22 -j ACCEPT",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line -p tcp --dport 22 -j ACCEPT"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -12257,7 +12809,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "filter::INPUT"
@@ -12270,7 +12830,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "filter::OUTPUT"
@@ -12283,7 +12851,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::FORWARD"
@@ -12296,7 +12872,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::INPUT"
@@ -12309,7 +12893,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::OUTPUT"
@@ -12322,7 +12914,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::POSTROUTING"
@@ -12335,7 +12935,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::PREROUTING"
@@ -12348,7 +12956,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "nat::OUTPUT"
@@ -12361,7 +12977,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "nat::POSTROUTING"
@@ -12374,7 +12998,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "nat::PREROUTING"
@@ -12444,7 +13076,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "filter::FORWARD"
@@ -12466,7 +13106,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "-p tcp --dport 22 -j ACCEPT"
+                "name" : "-p tcp --dport 22 -j ACCEPT",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line -p tcp --dport 22 -j ACCEPT"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -12474,7 +13122,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "filter::INPUT"
@@ -12494,7 +13150,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "-d 2.128.0.101 -j DROP"
+                "name" : "-d 2.128.0.101 -j DROP",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line -d 2.128.0.101 -j DROP"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -12502,7 +13166,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "filter::OUTPUT"
@@ -12515,7 +13187,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::FORWARD"
@@ -12528,7 +13208,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::INPUT"
@@ -12541,7 +13229,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::OUTPUT"
@@ -12554,7 +13250,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::POSTROUTING"
@@ -12567,7 +13271,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::PREROUTING"
@@ -12580,7 +13292,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "nat::OUTPUT"
@@ -12593,7 +13313,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "nat::POSTROUTING"
@@ -12606,7 +13334,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "nat::PREROUTING"

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -623,7 +623,15 @@
                     }
                   }
                 },
-                "name" : "5 permit vlan 123 0x000 udp any 224.0.0.0/4"
+                "name" : "5 permit vlan 123 0x000 udp any 224.0.0.0/4",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 5 permit vlan 123 0x000 udp any 224.0.0.0/4"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -672,7 +680,15 @@
                     ]
                   }
                 },
-                "name" : "10 deny tcp any 102.66.49.113/24 neq www https syn"
+                "name" : "10 deny tcp any 102.66.49.113/24 neq www https syn",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 10 deny tcp any 102.66.49.113/24 neq www https syn"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -691,7 +707,15 @@
                     }
                   }
                 },
-                "name" : "20 deny ip any any"
+                "name" : "20 deny ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 20 deny ip any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "abcd",
@@ -1000,7 +1024,15 @@
                     }
                   }
                 },
-                "name" : "10 permit 1.2.4.8/16"
+                "name" : "10 permit 1.2.4.8/16",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 10 permit 1.2.4.8/16"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "sshabc",
@@ -1100,7 +1132,15 @@
                     }
                   }
                 },
-                "name" : "permit ip any any"
+                "name" : "permit ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl1",
@@ -1666,7 +1706,15 @@
                     }
                   }
                 },
-                "name" : "permit host 0.0.0.0"
+                "name" : "permit host 0.0.0.0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit host 0.0.0.0"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "Local_LAN_Access",
@@ -1698,7 +1746,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-alternate-address any any"
+                "name" : "permit object icmp-alternate-address any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-alternate-address any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1723,7 +1779,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-conversion-error any any"
+                "name" : "permit object icmp-conversion-error any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-conversion-error any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1748,7 +1812,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-echo any any"
+                "name" : "permit object icmp-echo any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-echo any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1773,7 +1845,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-echo-reply any any"
+                "name" : "permit object icmp-echo-reply any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-echo-reply any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1798,7 +1878,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-information-reply any any"
+                "name" : "permit object icmp-information-reply any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-information-reply any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1823,7 +1911,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-information-request any any"
+                "name" : "permit object icmp-information-request any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-information-request any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1848,7 +1944,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-mask-reply any any"
+                "name" : "permit object icmp-mask-reply any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-mask-reply any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1873,7 +1977,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-mask-request any any"
+                "name" : "permit object icmp-mask-request any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-mask-request any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1898,7 +2010,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-mobile-redirect any any"
+                "name" : "permit object icmp-mobile-redirect any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-mobile-redirect any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1923,7 +2043,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-parameter-problem any any"
+                "name" : "permit object icmp-parameter-problem any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-parameter-problem any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1948,7 +2076,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-redirect any any"
+                "name" : "permit object icmp-redirect any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-redirect any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1973,7 +2109,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-router-advertisement any any"
+                "name" : "permit object icmp-router-advertisement any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-router-advertisement any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -1998,7 +2142,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-router-solicitation any any"
+                "name" : "permit object icmp-router-solicitation any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-router-solicitation any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -2023,7 +2175,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-source-quench any any"
+                "name" : "permit object icmp-source-quench any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-source-quench any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -2048,7 +2208,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-time-exceeded any any"
+                "name" : "permit object icmp-time-exceeded any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-time-exceeded any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -2073,7 +2241,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-timestamp-reply any any"
+                "name" : "permit object icmp-timestamp-reply any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-timestamp-reply any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -2098,7 +2274,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-timestamp-request any any"
+                "name" : "permit object icmp-timestamp-request any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-timestamp-request any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -2123,7 +2307,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-traceroute any any"
+                "name" : "permit object icmp-traceroute any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-traceroute any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -2148,7 +2340,15 @@
                     }
                   }
                 },
-                "name" : "permit object icmp-unreachable any any"
+                "name" : "permit object icmp-unreachable any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object icmp-unreachable any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -2170,7 +2370,15 @@
                     }
                   }
                 },
-                "name" : "permit object ospf any any"
+                "name" : "permit object ospf any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit object ospf any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "inline_specifiers",
@@ -2203,7 +2411,15 @@
                     }
                   }
                 },
-                "name" : "permit tcp object-group drawbridge_hosts interface outside eq https"
+                "name" : "permit tcp object-group drawbridge_hosts interface outside eq https",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp object-group drawbridge_hosts interface outside eq https"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "outside",
@@ -2235,7 +2451,15 @@
                     }
                   }
                 },
-                "name" : "permit udp any4 host 1.2.3.4 eq tftp"
+                "name" : "permit udp any4 host 1.2.3.4 eq tftp",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit udp any4 host 1.2.3.4 eq tftp"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "outside_in",
@@ -2403,7 +2627,15 @@
                     }
                   }
                 },
-                "name" : "permit tcp any object server02"
+                "name" : "permit tcp any object server02",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp any object server02"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "ALLOW_SERVER02",
@@ -4143,7 +4375,15 @@
                     }
                   }
                 },
-                "name" : "permit 1.2.3.0 0.0.0.255"
+                "name" : "permit 1.2.3.0 0.0.0.255",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit 1.2.3.0 0.0.0.255"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "50",
@@ -4169,7 +4409,15 @@
                     }
                   }
                 },
-                "name" : "permit 2.3.4.0 0.0.0.255"
+                "name" : "permit 2.3.4.0 0.0.0.255",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit 2.3.4.0 0.0.0.255"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -4188,7 +4436,15 @@
                     }
                   }
                 },
-                "name" : "deny   any"
+                "name" : "deny   any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny   any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "51",
@@ -4214,7 +4470,15 @@
                     }
                   }
                 },
-                "name" : "permit 3.4.5.6"
+                "name" : "permit 3.4.5.6",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit 3.4.5.6"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "99",
@@ -5467,7 +5731,15 @@
                     }
                   }
                 },
-                "name" : "10 permit icmp any any packet-too-big"
+                "name" : "10 permit icmp any any packet-too-big",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 10 permit icmp any any packet-too-big"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5494,7 +5766,15 @@
                     }
                   ]
                 },
-                "name" : "20 permit ip any any tracked"
+                "name" : "20 permit ip any any tracked",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 20 permit ip any any tracked"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5516,7 +5796,15 @@
                     }
                   }
                 },
-                "name" : "30 permit ospf any any"
+                "name" : "30 permit ospf any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 30 permit ospf any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5541,7 +5829,15 @@
                     }
                   }
                 },
-                "name" : "40 permit tcp any any eq bgp"
+                "name" : "40 permit tcp any any eq bgp",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 40 permit tcp any any eq bgp"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5567,7 +5863,15 @@
                     }
                   }
                 },
-                "name" : "50 permit udp any any eq bootps bootpc ntp"
+                "name" : "50 permit udp any any eq bootps bootpc ntp",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 50 permit udp any any eq bootps bootpc ntp"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5594,7 +5898,15 @@
                     }
                   ]
                 },
-                "name" : "60 permit tcp any any eq mlag ttl eq 255"
+                "name" : "60 permit tcp any any eq mlag ttl eq 255",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 60 permit tcp any any eq mlag ttl eq 255"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5621,7 +5933,15 @@
                     }
                   ]
                 },
-                "name" : "70 permit udp any any eq mlag ttl eq 255"
+                "name" : "70 permit udp any any eq mlag ttl eq 255",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 70 permit udp any any eq mlag ttl eq 255"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5643,7 +5963,15 @@
                     }
                   }
                 },
-                "name" : "80 permit vrrp any any"
+                "name" : "80 permit vrrp any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 80 permit vrrp any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5665,7 +5993,15 @@
                     }
                   }
                 },
-                "name" : "90 permit ahp any any"
+                "name" : "90 permit ahp any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 90 permit ahp any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5687,7 +6023,15 @@
                     }
                   }
                 },
-                "name" : "100 permit pim any any"
+                "name" : "100 permit pim any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 100 permit pim any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5709,7 +6053,15 @@
                     }
                   }
                 },
-                "name" : "110 permit igmp any any"
+                "name" : "110 permit igmp any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 110 permit igmp any any"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5734,7 +6086,15 @@
                     }
                   }
                 },
-                "name" : "120 permit tcp any any range 1 10"
+                "name" : "120 permit tcp any any range 1 10",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 120 permit tcp any any range 1 10"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5759,7 +6119,15 @@
                     }
                   }
                 },
-                "name" : "140 permit udp 10.0.0.0/19 any eq snmp"
+                "name" : "140 permit udp 10.0.0.0/19 any eq snmp",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 140 permit udp 10.0.0.0/19 any eq snmp"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5784,7 +6152,15 @@
                     }
                   }
                 },
-                "name" : "180 permit udp host 10.0.0.0 any eq snmp"
+                "name" : "180 permit udp host 10.0.0.0 any eq snmp",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 180 permit udp host 10.0.0.0 any eq snmp"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5809,7 +6185,15 @@
                     }
                   }
                 },
-                "name" : "220 permit tcp 10.0.0.0/19 any eq ssh"
+                "name" : "220 permit tcp 10.0.0.0/19 any eq ssh",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 220 permit tcp 10.0.0.0/19 any eq ssh"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5834,7 +6218,15 @@
                     }
                   }
                 },
-                "name" : "260 permit tcp host 10.0.0.0 any eq ssh"
+                "name" : "260 permit tcp host 10.0.0.0 any eq ssh",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 260 permit tcp host 10.0.0.0 any eq ssh"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5860,7 +6252,15 @@
                     }
                   }
                 },
-                "name" : "270 permit tcp any any eq microsoft-ds 5432"
+                "name" : "270 permit tcp any any eq microsoft-ds 5432",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 270 permit tcp any any eq microsoft-ds 5432"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5888,7 +6288,15 @@
                     }
                   }
                 },
-                "name" : "280 permit icmp any any 5 2"
+                "name" : "280 permit icmp any any 5 2",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 280 permit icmp any any 5 2"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5913,7 +6321,15 @@
                     }
                   }
                 },
-                "name" : "290 permit icmp any any time-exceeded ! believe this is type 11, any code"
+                "name" : "290 permit icmp any any time-exceeded ! believe this is type 11, any code",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 290 permit icmp any any time-exceeded ! believe this is type 11, any code"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5941,7 +6357,15 @@
                     }
                   }
                 },
-                "name" : "300 permit icmp any any ttl-exceeded  ! type 11, code 0"
+                "name" : "300 permit icmp any any ttl-exceeded  ! type 11, code 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 300 permit icmp any any ttl-exceeded  ! type 11, code 0"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -5960,7 +6384,15 @@
                     }
                   }
                 },
-                "name" : "410 deny ip any any log"
+                "name" : "410 deny ip any any log",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 410 deny ip any any log"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "BLAH-BLAH",
@@ -5986,7 +6418,15 @@
                     }
                   }
                 },
-                "name" : "deny ip any any log 7 interval 600"
+                "name" : "deny ip any any log 7 interval 600",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny ip any any log 7 interval 600"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -6005,7 +6445,15 @@
                     }
                   }
                 },
-                "name" : "deny ip any any log default"
+                "name" : "deny ip any any log default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny ip any any log default"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -6024,7 +6472,15 @@
                     }
                   }
                 },
-                "name" : "deny ip any any log disable"
+                "name" : "deny ip any any log disable",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny ip any any log disable"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "TEST",
@@ -6050,7 +6506,15 @@
                     }
                   }
                 },
-                "name" : "10 permit ip any any"
+                "name" : "10 permit ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 10 permit ip any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "blah",
@@ -6092,7 +6556,15 @@
                     }
                   }
                 },
-                "name" : "10 permit udp any any eq bfd"
+                "name" : "10 permit udp any any eq bfd",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 10 permit udp any any eq bfd"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -6117,7 +6589,15 @@
                     }
                   }
                 },
-                "name" : "20 permit udp any any eq bfd-echo"
+                "name" : "20 permit udp any any eq bfd-echo",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 20 permit udp any any eq bfd-echo"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "test-codes",
@@ -6306,7 +6786,15 @@
                     }
                   }
                 },
-                "name" : "deny any"
+                "name" : "deny any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line deny any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "5",
@@ -7551,7 +8039,15 @@
                     }
                   }
                 },
-                "name" : "permit tcp 30.9.132.0 0.0.1.255 host 1.1.1.1 range 48000 48060"
+                "name" : "permit tcp 30.9.132.0 0.0.1.255 host 1.1.1.1 range 48000 48060",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp 30.9.132.0 0.0.1.255 host 1.1.1.1 range 48000 48060"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7576,7 +8072,15 @@
                     }
                   }
                 },
-                "name" : "permit tcp host 1.1.1.1 any eq 27401"
+                "name" : "permit tcp host 1.1.1.1 any eq 27401",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp host 1.1.1.1 any eq 27401"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7601,7 +8105,15 @@
                     }
                   }
                 },
-                "name" : "permit tcp any host 1.1.1.1 eq 65001"
+                "name" : "permit tcp any host 1.1.1.1 eq 65001",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp any host 1.1.1.1 eq 65001"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7626,7 +8138,15 @@
                     }
                   }
                 },
-                "name" : "permit tcp host 1.1.1.1 any eq 20000"
+                "name" : "permit tcp host 1.1.1.1 any eq 20000",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp host 1.1.1.1 any eq 20000"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -7651,7 +8171,15 @@
                     }
                   }
                 },
-                "name" : "permit tcp any host 1.1.1.1 eq 65111"
+                "name" : "permit tcp any host 1.1.1.1 eq 65111",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp any host 1.1.1.1 eq 65111"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "bippety",
@@ -7683,7 +8211,15 @@
                     }
                   }
                 },
-                "name" : "permit tcp addrgroup bleep_blorp any eq 13000"
+                "name" : "permit tcp addrgroup bleep_blorp any eq 13000",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp addrgroup bleep_blorp any eq 13000"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "bloop_blop",
@@ -8694,7 +9230,15 @@
                     }
                   }
                 },
-                "name" : "10 permit tcp any any"
+                "name" : "10 permit tcp any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 10 permit tcp any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "abc",
@@ -11273,7 +11817,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "class-default action: PERMIT"
+                "name" : "class-default action: PERMIT",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line class-default action: PERMIT"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "~INSPECT_POLICY_MAP_ACL~pminspect~",
@@ -11930,7 +12482,15 @@
                     }
                   }
                 },
-                "name" : "permit ip any any"
+                "name" : "permit ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit ip any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "blah",
@@ -11977,7 +12537,15 @@
                     }
                   }
                 },
-                "name" : "permit any"
+                "name" : "permit any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "1",
@@ -17549,7 +18117,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "ACCEPT_ALL"
+                "name" : "ACCEPT_ALL",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line ACCEPT_ALL"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "~incoming_filter:/Common/MYVLAN~"
@@ -17897,7 +18473,15 @@
                     }
                   }
                 },
-                "name" : "access-list acl1 permit any\n"
+                "name" : "access-list acl1 permit any\n",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line access-list acl1 permit any\n"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl1"
@@ -17917,7 +18501,15 @@
                     }
                   }
                 },
-                "name" : "access-list acl2 permit 192.0.2.0/24\n"
+                "name" : "access-list acl2 permit 192.0.2.0/24\n",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line access-list acl2 permit 192.0.2.0/24\n"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "acl2"
@@ -18565,7 +19157,15 @@
                     }
                   }
                 },
-                "name" : "-s 1.2.3.4/32 -p tcp -m tcp --dport 22 -j ACCEPT"
+                "name" : "-s 1.2.3.4/32 -p tcp -m tcp --dport 22 -j ACCEPT",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line -s 1.2.3.4/32 -p tcp -m tcp --dport 22 -j ACCEPT"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -18586,7 +19186,15 @@
                     }
                   }
                 },
-                "name" : "-s 11.22.33.44/32 -p tcp -m tcp --dport 25 -j ACCEPT"
+                "name" : "-s 11.22.33.44/32 -p tcp -m tcp --dport 25 -j ACCEPT",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line -s 11.22.33.44/32 -p tcp -m tcp --dport 25 -j ACCEPT"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -18607,7 +19215,15 @@
                     }
                   }
                 },
-                "name" : "-s 111.222.111.222/32 -p tcp -m tcp --dport 80 -j ACCEPT"
+                "name" : "-s 111.222.111.222/32 -p tcp -m tcp --dport 80 -j ACCEPT",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line -s 111.222.111.222/32 -p tcp -m tcp --dport 80 -j ACCEPT"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -18628,7 +19244,15 @@
                     }
                   }
                 },
-                "name" : "-s 4.3.2.1/32 -p tcp -m tcp --dport 110 -j ACCEPT"
+                "name" : "-s 4.3.2.1/32 -p tcp -m tcp --dport 110 -j ACCEPT",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line -s 4.3.2.1/32 -p tcp -m tcp --dport 110 -j ACCEPT"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -18649,7 +19273,15 @@
                     }
                   }
                 },
-                "name" : "-s 44.22.33.11/32 -p tcp -m tcp --dport 143 -j ACCEPT"
+                "name" : "-s 44.22.33.11/32 -p tcp -m tcp --dport 143 -j ACCEPT",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line -s 44.22.33.11/32 -p tcp -m tcp --dport 143 -j ACCEPT"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -18657,7 +19289,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "filter::INPUT"
@@ -18670,7 +19310,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "filter::OUTPUT"
@@ -18683,7 +19331,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::FORWARD"
@@ -18696,7 +19352,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::INPUT"
@@ -18709,7 +19373,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::OUTPUT"
@@ -18722,7 +19394,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::POSTROUTING"
@@ -18735,7 +19415,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "mangle::PREROUTING"
@@ -18748,7 +19436,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "nat::OUTPUT"
@@ -18761,7 +19457,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "nat::POSTROUTING"
@@ -18774,7 +19478,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "nat::PREROUTING"
@@ -18902,7 +19614,15 @@
                     }
                   }
                 },
-                "name" : "-s 2.128.0.101/32 -i eth0 -j ACCEPT"
+                "name" : "-s 2.128.0.101/32 -i eth0 -j ACCEPT",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line -s 2.128.0.101/32 -i eth0 -j ACCEPT"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -18913,7 +19633,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "-j DROP"
+                "name" : "-j DROP",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line -j DROP"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -18921,7 +19649,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "iptables_Ethernet0_ingress"
@@ -18937,7 +19673,15 @@
                     "negate" : false
                   }
                 },
-                "name" : "-j DROP"
+                "name" : "-j DROP",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line -j DROP"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -18945,7 +19689,15 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "default"
+                "name" : "default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line default"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "iptables_Ethernet1_ingress"
@@ -29031,7 +29783,15 @@
                     }
                   }
                 },
-                "name" : "10 permit ip any any"
+                "name" : "10 permit ip any any",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line 10 permit ip any any"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "blah",
@@ -36618,7 +37378,15 @@
                     ]
                   }
                 },
-                "name" : "permit tcp 1.2.3.4/31 any ack"
+                "name" : "permit tcp 1.2.3.4/31 any ack",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp 1.2.3.4/31 any ack"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -36662,7 +37430,15 @@
                     ]
                   }
                 },
-                "name" : "permit tcp 1.2.3.4/31 any rst"
+                "name" : "permit tcp 1.2.3.4/31 any rst",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp 1.2.3.4/31 any rst"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -36846,7 +37622,15 @@
                     ]
                   }
                 },
-                "name" : "permit tcp 1.2.3.4/31 any syn ack urg psh rst ece fin cwr"
+                "name" : "permit tcp 1.2.3.4/31 any syn ack urg psh rst ece fin cwr",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp 1.2.3.4/31 any syn ack urg psh rst ece fin cwr"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -36890,7 +37674,15 @@
                     ]
                   }
                 },
-                "name" : "permit tcp 1.2.3.4/31 any fin"
+                "name" : "permit tcp 1.2.3.4/31 any fin",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp 1.2.3.4/31 any fin"
+                    }
+                  ]
+                }
               },
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -36954,7 +37746,15 @@
                     ]
                   }
                 },
-                "name" : "permit tcp 1.2.3.4/31 any fin ack"
+                "name" : "permit tcp 1.2.3.4/31 any fin ack",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line permit tcp 1.2.3.4/31 any fin ack"
+                    }
+                  ]
+                }
               }
             ],
             "name" : "100",

--- a/tests/roles/perRoleOutliers.ref
+++ b/tests/roles/perRoleOutliers.ref
@@ -142,7 +142,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 2.0.0.0 host 255.0.0.0"
+              "name" : "permit ip host 2.0.0.0 host 255.0.0.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 2.0.0.0 host 255.0.0.0"
+                  }
+                ]
+              }
             },
             {
               "class" : "org.batfish.datamodel.ExprAclLine",
@@ -161,7 +169,15 @@
                   }
                 }
               },
-              "name" : "permit ip host 2.128.0.0 host 255.255.0.0"
+              "name" : "permit ip host 2.128.0.0 host 255.255.0.0",
+              "traceElement" : {
+                "fragments" : [
+                  {
+                    "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                    "text" : "Matched line permit ip host 2.128.0.0 host 255.255.0.0"
+                  }
+                ]
+              }
             }
           ],
           "name" : "102",


### PR DESCRIPTION
Not all lines should have trace nodes, e.g. lines batfish constructs to
encode vendor semantics but that do not correspond to the configuration
file in a meaningful way.

To preserve legacy traces, ExprAclLine.Builder will create a default
TraceElement from the line name if there is one and the TraceElement was
not manually set. To build a line with a name but no TraceElement, we can 
explicitly call `setTraceElement(null)`.

TestFilters can now return a list of ACL traces when the matched line
does not create a trace node but does create multiple subtraces.
