### PR TITLE
ASA: Add vendor structure link for "permitted/denied by output filter"

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -213,6 +213,7 @@ import org.batfish.representation.cisco.eos.AristaBgpVrfIpv4UnicastAddressFamily
 import org.batfish.representation.cisco.eos.AristaEosVxlan;
 import org.batfish.representation.cisco.eos.AristaRedistributeType;
 import org.batfish.vendor.VendorConfiguration;
+import org.batfish.vendor.VendorStructureId;
 
 public final class CiscoConfiguration extends VendorConfiguration {
   @VisibleForTesting
@@ -241,8 +242,14 @@ public final class CiscoConfiguration extends VendorConfiguration {
   }
 
   @VisibleForTesting
-  public static TraceElement asaPermittedByOutputFilterTraceElement(String filterName) {
-    return TraceElement.of("Permitted by output filter " + filterName);
+  public static TraceElement asaPermittedByOutputFilterTraceElement(
+      String filename, IpAccessList filter) {
+    return TraceElement.builder()
+        .add("Permitted by output filter")
+        .add(
+            filter.getName(),
+            new VendorStructureId(filename, filter.getSourceType(), filter.getSourceName()))
+        .build();
   }
 
   /** Matches anything but the IPv4 default route. */
@@ -2469,7 +2476,9 @@ public final class CiscoConfiguration extends VendorConfiguration {
                           securityLevelPolicies,
                           new PermittedByAcl(
                               oldOutgoingFilterName,
-                              asaPermittedByOutputFilterTraceElement(oldOutgoingFilterName)))))
+                              asaPermittedByOutputFilterTraceElement(
+                                  c.getHostname(),
+                                  c.getIpAccessLists().get(oldOutgoingFilterName))))))
               .build());
     } else {
       lineBuilder.add(ExprAclLine.accepting().setMatchCondition(securityLevelPolicies).build());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -237,8 +237,14 @@ public final class CiscoConfiguration extends VendorConfiguration {
       TraceElement.of("same-security-traffic permit inter-interface is not set");
 
   @VisibleForTesting
-  public static TraceElement asaDeniedByOutputFilterTraceElement(String filterName) {
-    return TraceElement.of("Denied by output filter " + filterName);
+  public static TraceElement asaDeniedByOutputFilterTraceElement(
+      String filename, IpAccessList filter) {
+    return TraceElement.builder()
+        .add("Denied by output filter")
+        .add(
+            filter.getName(),
+            new VendorStructureId(filename, filter.getSourceType(), filter.getSourceName()))
+        .build();
   }
 
   @VisibleForTesting
@@ -2461,7 +2467,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
                        */
                       new NotMatchExpr(
                           new PermittedByAcl(oldOutgoingFilterName),
-                          asaDeniedByOutputFilterTraceElement(oldOutgoingFilterName))))
+                          asaDeniedByOutputFilterTraceElement(
+                              c.getHostname(), c.getIpAccessLists().get(oldOutgoingFilterName)))))
               .build());
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -240,7 +240,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
   public static TraceElement asaDeniedByOutputFilterTraceElement(
       String filename, IpAccessList filter) {
     return TraceElement.builder()
-        .add("Denied by output filter")
+        .add("Denied by output filter ")
         .add(
             filter.getName(),
             new VendorStructureId(filename, filter.getSourceType(), filter.getSourceName()))
@@ -251,7 +251,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
   public static TraceElement asaPermittedByOutputFilterTraceElement(
       String filename, IpAccessList filter) {
     return TraceElement.builder()
-        .add("Permitted by output filter")
+        .add("Permitted by output filter ")
         .add(
             filter.getName(),
             new VendorStructureId(filename, filter.getSourceType(), filter.getSourceName()))

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -5554,7 +5554,9 @@ public final class CiscoGrammarTest {
           traces,
           contains(
               isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTRA_TRACE_ELEMENT),
-              isTraceTree(asaDeniedByOutputFilterTraceElement(filterOut.getName()))));
+              isTraceTree(
+                  asaDeniedByOutputFilterTraceElement(
+                      "asa-security-level-permit-tracing", filterOut))));
     }
 
     // permitted, inter-interface
@@ -5577,7 +5579,9 @@ public final class CiscoGrammarTest {
           traces,
           contains(
               isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTER_TRACE_ELEMENT),
-              isTraceTree(asaDeniedByOutputFilterTraceElement(filterOut.getName()))));
+              isTraceTree(
+                  asaDeniedByOutputFilterTraceElement(
+                      "asa-security-level-permit-tracing", filterOut))));
     }
 
     // permitted, low-to-high (low has ingress filter)
@@ -5600,7 +5604,9 @@ public final class CiscoGrammarTest {
           traces,
           contains(
               isTraceTree(asaPermitLowerSecurityLevelTraceElement(10)),
-              isTraceTree(asaDeniedByOutputFilterTraceElement(filterOut.getName()))));
+              isTraceTree(
+                  asaDeniedByOutputFilterTraceElement(
+                      "asa-security-level-permit-tracing", filterOut))));
     }
 
     // permitted, high-to-low
@@ -5623,7 +5629,9 @@ public final class CiscoGrammarTest {
           traces,
           contains(
               isTraceTree(asaPermitHigherSecurityLevelTrafficTraceElement(100)),
-              isTraceTree(asaDeniedByOutputFilterTraceElement(filterOut.getName()))));
+              isTraceTree(
+                  asaDeniedByOutputFilterTraceElement(
+                      "asa-security-level-permit-tracing", filterOut))));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -5542,7 +5542,8 @@ public final class CiscoGrammarTest {
           contains(
               isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTRA_TRACE_ELEMENT),
               isTraceTree(
-                  asaPermittedByOutputFilterTraceElement(filterOut.getName()),
+                  asaPermittedByOutputFilterTraceElement(
+                      "asa-security-level-permit-tracing", filterOut),
                   isTraceTree(matchedByAclLine(filterOut, 0)))));
     }
 
@@ -5564,7 +5565,8 @@ public final class CiscoGrammarTest {
           contains(
               isTraceTree(PERMIT_SAME_SECURITY_TRAFFIC_INTER_TRACE_ELEMENT),
               isTraceTree(
-                  asaPermittedByOutputFilterTraceElement(filterOut.getName()),
+                  asaPermittedByOutputFilterTraceElement(
+                      "asa-security-level-permit-tracing", filterOut),
                   isTraceTree(matchedByAclLine(filterOut, 0)))));
     }
 
@@ -5586,7 +5588,8 @@ public final class CiscoGrammarTest {
           contains(
               isTraceTree(asaPermitLowerSecurityLevelTraceElement(10)),
               isTraceTree(
-                  asaPermittedByOutputFilterTraceElement(filterOut.getName()),
+                  asaPermittedByOutputFilterTraceElement(
+                      "asa-security-level-permit-tracing", filterOut),
                   isTraceTree(matchedByAclLine(filterOut, 0)))));
     }
 
@@ -5608,7 +5611,8 @@ public final class CiscoGrammarTest {
           contains(
               isTraceTree(asaPermitHigherSecurityLevelTrafficTraceElement(100)),
               isTraceTree(
-                  asaPermittedByOutputFilterTraceElement(filterOut.getName()),
+                  asaPermittedByOutputFilterTraceElement(
+                      "asa-security-level-permit-tracing", filterOut),
                   isTraceTree(matchedByAclLine(filterOut, 0)))));
     }
 


### PR DESCRIPTION
Add `LinkFragment` to `TraceElement` of "permitted by output filter" and "denied by output filter" lines.