### PR TITLE
AWS: Use the same link local IP on both ends

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -32,9 +32,7 @@ import org.batfish.vendor.VendorConfiguration;
 @ParametersAreNonnullByDefault
 public class AwsConfiguration extends VendorConfiguration {
 
-  static Ip LINK_LOCAL_IP1 = Ip.parse("169.254.0.1");
-
-  static Ip LINK_LOCAL_IP2 = Ip.parse("169.254.0.2");
+  static Ip LINK_LOCAL_IP = Ip.parse("169.254.0.1");
 
   @Nullable private ConvertedConfiguration _convertedConfiguration;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGateway.java
@@ -1,7 +1,7 @@
 package org.batfish.representation.aws;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.batfish.representation.aws.AwsConfiguration.LINK_LOCAL_IP1;
+import static org.batfish.representation.aws.AwsConfiguration.LINK_LOCAL_IP;
 import static org.batfish.representation.aws.Utils.ACCEPT_ALL_BGP;
 import static org.batfish.representation.aws.Utils.ACCEPT_ALL_BGP_AND_STATIC;
 import static org.batfish.representation.aws.Utils.addStaticRoute;
@@ -441,7 +441,7 @@ final class TransitGateway implements AwsVpcEntity, Serializable {
   @VisibleForTesting
   static void createBgpProcess(
       Configuration tgwCfg, Vrf vrf, ConvertedConfiguration awsConfiguration) {
-    LinkLocalAddress loopbackBgpAddress = LinkLocalAddress.of(LINK_LOCAL_IP1);
+    LinkLocalAddress loopbackBgpAddress = LinkLocalAddress.of(LINK_LOCAL_IP);
     Utils.newInterface(
         "bgp-loopback-" + vrf.getName(),
         tgwCfg,

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -1,8 +1,7 @@
 package org.batfish.representation.aws;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.batfish.representation.aws.AwsConfiguration.LINK_LOCAL_IP1;
-import static org.batfish.representation.aws.AwsConfiguration.LINK_LOCAL_IP2;
+import static org.batfish.representation.aws.AwsConfiguration.LINK_LOCAL_IP;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -209,11 +208,11 @@ final class Utils {
       String ifaceNameSuffix) {
     String ifaceName1 = interfaceNameToRemote(cfgNode2, ifaceNameSuffix);
     Utils.newInterface(
-        ifaceName1, cfgNode1, vrfName1, LinkLocalAddress.of(LINK_LOCAL_IP1), "To " + ifaceName1);
+        ifaceName1, cfgNode1, vrfName1, LinkLocalAddress.of(LINK_LOCAL_IP), "To " + ifaceName1);
 
     String ifaceName2 = interfaceNameToRemote(cfgNode1, ifaceNameSuffix);
     Utils.newInterface(
-        ifaceName2, cfgNode2, vrfName2, LinkLocalAddress.of(LINK_LOCAL_IP2), "To " + ifaceName2);
+        ifaceName2, cfgNode2, vrfName2, LinkLocalAddress.of(LINK_LOCAL_IP), "To " + ifaceName2);
 
     addLayer1Edge(
         awsConfiguration, cfgNode1.getHostname(), ifaceName1, cfgNode2.getHostname(), ifaceName2);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnGateway.java
@@ -3,7 +3,7 @@ package org.batfish.representation.aws;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.common.util.IspModelingUtils.installRoutingPolicyAdvertiseStatic;
 import static org.batfish.datamodel.Interface.NULL_INTERFACE_NAME;
-import static org.batfish.representation.aws.AwsConfiguration.LINK_LOCAL_IP1;
+import static org.batfish.representation.aws.AwsConfiguration.LINK_LOCAL_IP;
 import static org.batfish.representation.aws.Utils.ACCEPT_ALL_BGP;
 import static org.batfish.representation.aws.Utils.addStaticRoute;
 import static org.batfish.representation.aws.Utils.toStaticRoute;
@@ -110,7 +110,7 @@ final class VpnGateway implements AwsVpcEntity, Serializable {
 
     if (doBgp) {
       String loopbackBgp = "loopbackBgp";
-      LinkLocalAddress loopbackBgpAddress = LinkLocalAddress.of(LINK_LOCAL_IP1);
+      LinkLocalAddress loopbackBgpAddress = LinkLocalAddress.of(LINK_LOCAL_IP);
       Utils.newInterface(loopbackBgp, cfgNode, loopbackBgpAddress, "BGP loopback");
 
       BgpProcess proc =

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -499,7 +499,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-1f315846",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -521,7 +521,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-9c8adceb",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -543,7 +543,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-d9cafabc",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -721,7 +721,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-073b8061",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -743,7 +743,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-1641fa70",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -765,7 +765,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-30398256",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -787,7 +787,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-7044ff16",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -809,7 +809,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-f73a8191",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -1005,7 +1005,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-62f14104",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -1027,7 +1027,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-8d0cbdeb",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -3109,7 +3109,7 @@
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
                 "nextHopInterface" : "igw-9b93ddfc",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
               {
@@ -3118,7 +3118,7 @@
                 "metric" : 0,
                 "network" : "192.168.0.0/16",
                 "nextHopInterface" : "vpc-b390fad5",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }
             ]
@@ -3314,7 +3314,7 @@
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
                 "nextHopInterface" : "igw-9b93ddfc",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
               {
@@ -3323,7 +3323,7 @@
                 "metric" : 0,
                 "network" : "192.168.0.0/16",
                 "nextHopInterface" : "vpc-b390fad5",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }
             ]
@@ -3531,7 +3531,7 @@
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
                 "nextHopInterface" : "igw-068fee63",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
               {
@@ -3540,7 +3540,7 @@
                 "metric" : 0,
                 "network" : "172.31.0.0/16",
                 "nextHopInterface" : "vpc-f8fad69d",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }
             ]
@@ -3736,7 +3736,7 @@
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
                 "nextHopInterface" : "igw-9b93ddfc",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
               {
@@ -3745,7 +3745,7 @@
                 "metric" : 0,
                 "network" : "192.168.0.0/16",
                 "nextHopInterface" : "vpc-b390fad5",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }
             ]
@@ -3941,7 +3941,7 @@
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
                 "nextHopInterface" : "igw-fac5839d",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
               {
@@ -3950,7 +3950,7 @@
                 "metric" : 0,
                 "network" : "10.0.0.0/16",
                 "nextHopInterface" : "vpc-925131f4",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }
             ]
@@ -4146,7 +4146,7 @@
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
                 "nextHopInterface" : "igw-9b93ddfc",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
               {
@@ -4155,7 +4155,7 @@
                 "metric" : 0,
                 "network" : "192.168.0.0/16",
                 "nextHopInterface" : "vpc-b390fad5",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }
             ]
@@ -4360,7 +4360,7 @@
                 "metric" : 0,
                 "network" : "10.0.0.0/16",
                 "nextHopInterface" : "vpc-925131f4",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }
             ]
@@ -4568,7 +4568,7 @@
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
                 "nextHopInterface" : "igw-068fee63",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
               {
@@ -4577,7 +4577,7 @@
                 "metric" : 0,
                 "network" : "172.31.0.0/16",
                 "nextHopInterface" : "vpc-f8fad69d",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }
             ]
@@ -4785,7 +4785,7 @@
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
                 "nextHopInterface" : "igw-068fee63",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
               {
@@ -4794,7 +4794,7 @@
                 "metric" : 0,
                 "network" : "172.31.0.0/16",
                 "nextHopInterface" : "vpc-f8fad69d",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }
             ]
@@ -4990,7 +4990,7 @@
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
                 "nextHopInterface" : "igw-9b93ddfc",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
               {
@@ -4999,7 +4999,7 @@
                 "metric" : 0,
                 "network" : "192.168.0.0/16",
                 "nextHopInterface" : "vpc-b390fad5",
-                "nextHopIp" : "169.254.0.2",
+                "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }
             ]
@@ -5966,7 +5966,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-62f14104",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -5988,7 +5988,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-8d0cbdeb",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -6060,7 +6060,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-073b8061",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -6082,7 +6082,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-1641fa70",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -6104,7 +6104,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-30398256",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -6126,7 +6126,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-7044ff16",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -6148,7 +6148,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-f73a8191",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -6247,7 +6247,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-1f315846",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -6269,7 +6269,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-9c8adceb",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -6291,7 +6291,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet-d9cafabc",
             "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.2",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,


### PR DESCRIPTION
No reason I can see to use two different IPs.