### PR TITLE
AWS Tracing: Extract and add rule description for rules with UserIdGroupPairs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -417,8 +417,7 @@ final class IpPermissions implements Serializable {
     return aclLines.build();
   }
 
-  @VisibleForTesting
-  List<ExprAclLine> userIdGroupsToAclLines(
+  private List<ExprAclLine> userIdGroupsToAclLines(
       Region region,
       List<AclLineMatchExpr> protocolAndPortExprs,
       boolean ingress,

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -38,6 +38,7 @@ import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.SubRange;
@@ -217,7 +218,10 @@ public class ElasticsearchDomainTest {
                             matchPorts(45, 50),
                             new MatchHeaderSpace(
                                 HeaderSpace.builder()
-                                    .setSrcIps(IpWildcard.parse("10.193.16.105/32").toIpSpace())
+                                    .setSrcIps(
+                                        IpWildcardSetIpSpace.builder()
+                                            .including(IpWildcard.parse("10.193.16.105/32"))
+                                            .build())
                                     .build(),
                                 traceElementForAddress(
                                     "source",

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/IpPermissionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/IpPermissionsTest.java
@@ -1,17 +1,23 @@
 package org.batfish.representation.aws;
 
+import static org.batfish.datamodel.IpProtocol.TCP;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchCondition;
+import static org.batfish.representation.aws.Utils.getTraceElementForRule;
+import static org.batfish.representation.aws.Utils.traceElementForDstPorts;
+import static org.batfish.representation.aws.Utils.traceElementForProtocol;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.util.List;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
-import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.representation.aws.IpPermissions.UserIdGroupPair;
 import org.junit.Test;
@@ -20,6 +26,16 @@ import org.junit.Test;
 public class IpPermissionsTest {
   private static final String SG_NAME = "sg";
   private static final String SG_ID = "sg-id";
+  private static final String SG_DESC = "sg desc";
+
+  private static final MatchHeaderSpace matchTcp =
+      new MatchHeaderSpace(
+          HeaderSpace.builder().setIpProtocols(TCP).build(), traceElementForProtocol(TCP));
+
+  private static final MatchHeaderSpace matchSSH =
+      new MatchHeaderSpace(
+          HeaderSpace.builder().setDstPorts(SubRange.singleton(22)).build(),
+          traceElementForDstPorts(22, 22));
 
   private static Region testRegion() {
     Region region = new Region("test");
@@ -39,26 +55,29 @@ public class IpPermissionsTest {
             22,
             ImmutableList.of(),
             ImmutableList.of(),
-            ImmutableList.of(new UserIdGroupPair(SG_ID, "sg desc")));
+            ImmutableList.of(new UserIdGroupPair(SG_ID, SG_DESC)));
     List<ExprAclLine> lines =
-        ipPermissions.userIdGroupsToAclLines(testRegion(), ImmutableList.of(), true, "acl line");
+        ipPermissions.toIpAccessListLines(true, testRegion(), "acl line", new Warnings());
 
     // check if source IPs are populated from all UserIpSpaces in the referred security group
     assertThat(
         Iterables.getOnlyElement(lines),
         hasMatchCondition(
-            new MatchHeaderSpace(
-                HeaderSpace.builder()
-                    .setSrcIps(
-                        IpWildcardSetIpSpace.builder()
-                            .including(IpWildcard.parse("1.1.1.0/24"))
-                            .including(IpWildcard.parse("2.2.2.0/24"))
-                            .build())
-                    .build(),
-                "Matched source address Security Group sg")));
+            and(
+                matchTcp,
+                matchSSH,
+                new MatchHeaderSpace(
+                    HeaderSpace.builder()
+                        .setSrcIps(
+                            IpWildcardSetIpSpace.builder()
+                                .including(IpWildcard.parse("1.1.1.0/24"))
+                                .including(IpWildcard.parse("2.2.2.0/24"))
+                                .build())
+                        .build(),
+                    "Matched source address Security Group sg"))));
     // check if rule description is populated from UserIdGroup description
     assertThat(
         Iterables.getOnlyElement(lines).getTraceElement(),
-        equalTo(TraceElement.of("Matched rule with description sg desc")));
+        equalTo(getTraceElementForRule(SG_DESC)));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/IpPermissionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/IpPermissionsTest.java
@@ -1,0 +1,64 @@
+package org.batfish.representation.aws;
+
+import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchCondition;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import java.util.List;
+import org.batfish.datamodel.ExprAclLine;
+import org.batfish.datamodel.HeaderSpace;
+import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IpWildcardSetIpSpace;
+import org.batfish.datamodel.TraceElement;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.representation.aws.IpPermissions.UserIdGroupPair;
+import org.junit.Test;
+
+/** Test for {@link IpPermissions} */
+public class IpPermissionsTest {
+  private static final String SG_NAME = "sg";
+  private static final String SG_ID = "sg-id";
+
+  private static Region testRegion() {
+    Region region = new Region("test");
+    SecurityGroup sg = new SecurityGroup(SG_ID, SG_NAME, ImmutableList.of(), ImmutableList.of());
+    sg.getUsersIpSpace().add(IpWildcard.parse("1.1.1.0/24"));
+    sg.getUsersIpSpace().add(IpWildcard.parse("2.2.2.0/24"));
+    region.getSecurityGroups().put(sg.getGroupId(), sg);
+    return region;
+  }
+
+  @Test
+  public void userIdGroupsToAclLines() {
+    IpPermissions ipPermissions =
+        new IpPermissions(
+            "tcp",
+            22,
+            22,
+            ImmutableList.of(),
+            ImmutableList.of(),
+            ImmutableList.of(new UserIdGroupPair(SG_ID, "sg desc")));
+    List<ExprAclLine> lines =
+        ipPermissions.userIdGroupsToAclLines(testRegion(), ImmutableList.of(), true, "acl line");
+
+    // check if source IPs are populated from all UserIpSpaces in the referred security group
+    assertThat(
+        Iterables.getOnlyElement(lines),
+        hasMatchCondition(
+            new MatchHeaderSpace(
+                HeaderSpace.builder()
+                    .setSrcIps(
+                        IpWildcardSetIpSpace.builder()
+                            .including(IpWildcard.parse("1.1.1.0/24"))
+                            .including(IpWildcard.parse("2.2.2.0/24"))
+                            .build())
+                    .build(),
+                "Matched source address Security Group sg")));
+    // check if rule description is populated from UserIdGroup description
+    assertThat(
+        Iterables.getOnlyElement(lines).getTraceElement(),
+        equalTo(TraceElement.of("Matched rule with description sg desc")));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/IpPermissionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/IpPermissionsTest.java
@@ -4,6 +4,7 @@ import static org.batfish.datamodel.IpProtocol.TCP;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchCondition;
 import static org.batfish.representation.aws.Utils.getTraceElementForRule;
+import static org.batfish.representation.aws.Utils.traceElementForAddress;
 import static org.batfish.representation.aws.Utils.traceElementForDstPorts;
 import static org.batfish.representation.aws.Utils.traceElementForProtocol;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -19,6 +20,7 @@ import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.representation.aws.IpPermissions.AddressType;
 import org.batfish.representation.aws.IpPermissions.UserIdGroupPair;
 import org.junit.Test;
 
@@ -74,7 +76,7 @@ public class IpPermissionsTest {
                                 .including(IpWildcard.parse("2.2.2.0/24"))
                                 .build())
                         .build(),
-                    "Matched source address Security Group sg"))));
+                    traceElementForAddress("source", SG_NAME, AddressType.SECURITY_GROUP)))));
     // check if rule description is populated from UserIdGroup description
     assertThat(
         Iterables.getOnlyElement(lines).getTraceElement(),

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -38,6 +38,7 @@ import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Topology;
@@ -180,7 +181,10 @@ public class RdsInstanceTest {
                             matchPorts(45, 50),
                             new MatchHeaderSpace(
                                 HeaderSpace.builder()
-                                    .setSrcIps(IpWildcard.parse("10.193.16.105/32").toIpSpace())
+                                    .setSrcIps(
+                                        IpWildcardSetIpSpace.builder()
+                                            .including(IpWildcard.parse("10.193.16.105/32"))
+                                            .build())
                                     .build(),
                                 traceElementForAddress(
                                     "source",

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -360,8 +360,10 @@
                   "headerSpace" : {
                     "negate" : false,
                     "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                      "ipWildcard" : "192.168.1.3"
+                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
+                      "whitelist" : [
+                        "192.168.1.3"
+                      ]
                     }
                   },
                   "traceElement" : {


### PR DESCRIPTION
- also does some refactoring to pass rule description to line's traceelement

NB (fixes a bug in https://github.com/batfish/batfish/pull/5471, where a security group used by multiple instances would only contain reference to the last one, if used as a source in IpPermissions)