### PR TITLE
Stop evpn type 5 route propagation

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5CumulusTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/EvpnType5CumulusTest.java
@@ -33,7 +33,7 @@ public class EvpnType5CumulusTest {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
-  @Test
+  @Test(expected = AssertionError.class) // xfail this until type 5 routes aren't broken
   public void testType5RoutePresence() throws IOException {
     String snapshotName = "evpn-type5-routes";
     List<String> configurationNames =


### PR DESCRIPTION
Type5 routes generate problems downstream (in Forwarding analysis) when we do vrf leaking