### PR TITLE
JunOS: trace firewall filters and security policies separately

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -3378,7 +3378,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       _currentFilter = _currentToZone.getFromHostFilter();
       if (_currentFilter == null) {
         _currentFilter = new ConcreteFirewallFilter(policyName, Family.INET);
-        _currentLogicalSystem.getFirewallFilters().put(policyName, _currentFilter);
+        _currentLogicalSystem.getSecurityPolicies().put(policyName, _currentFilter);
         _currentToZone.setFromHostFilter(_currentFilter);
       }
     } else if (ctx.to.JUNOS_HOST() != null) {
@@ -3386,7 +3386,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       _currentFilter = _currentFromZone.getToHostFilter();
       if (_currentFilter == null) {
         _currentFilter = new ConcreteFirewallFilter(policyName, Family.INET);
-        _currentLogicalSystem.getFirewallFilters().put(policyName, _currentFilter);
+        _currentLogicalSystem.getSecurityPolicies().put(policyName, _currentFilter);
         _currentFromZone.setToHostFilter(_currentFilter);
       }
     } else {
@@ -3394,7 +3394,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
       _currentFilter = _currentFromZone.getToZonePolicies().get(toName);
       if (_currentFilter == null) {
         _currentFilter = new ConcreteFirewallFilter(policyName, Family.INET);
-        _currentLogicalSystem.getFirewallFilters().put(policyName, _currentFilter);
+        _currentLogicalSystem.getSecurityPolicies().put(policyName, _currentFilter);
         _currentFromZone.getToZonePolicies().put(toName, _currentFilter);
       }
       // Add this filter to the to-zone for easy combination with egress ACL
@@ -3419,11 +3419,10 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void enterSep_global(Sep_globalContext ctx) {
     _currentFilter =
-        (ConcreteFirewallFilter)
-            _currentLogicalSystem
-                .getFirewallFilters()
-                .computeIfAbsent(
-                    ACL_NAME_GLOBAL_POLICY, n -> new ConcreteFirewallFilter(n, Family.INET));
+        _currentLogicalSystem
+            .getSecurityPolicies()
+            .computeIfAbsent(
+                ACL_NAME_GLOBAL_POLICY, n -> new ConcreteFirewallFilter(n, Family.INET));
     _currentSecurityPolicyName = ACL_NAME_GLOBAL_POLICY;
     _configuration.defineFlattenedStructure(SECURITY_POLICY, ACL_NAME_GLOBAL_POLICY, ctx, _parser);
     _configuration.referenceStructure(
@@ -3489,7 +3488,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
                 + "~INTERFACE~"
                 + _currentZoneInterface;
         _currentZoneInboundFilter = new ConcreteFirewallFilter(name, Family.INET);
-        _currentLogicalSystem.getFirewallFilters().put(name, _currentZoneInboundFilter);
+        _currentLogicalSystem.getSecurityPolicies().put(name, _currentZoneInboundFilter);
         _currentZone
             .getInboundInterfaceFilters()
             .put(_currentZoneInterface, _currentZoneInboundFilter);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/LogicalSystem.java
@@ -46,6 +46,8 @@ public class LogicalSystem implements Serializable {
 
   private final Map<String, FirewallFilter> _filters;
 
+  private final Map<String, ConcreteFirewallFilter> _securityPolicies;
+
   private final Map<String, IkeGateway> _ikeGateways;
 
   private final Map<String, IkePolicy> _ikePolicies;
@@ -129,6 +131,7 @@ public class LogicalSystem implements Serializable {
     _routeFilters = new TreeMap<>();
     _routingInstances = new TreeMap<>();
     _routingInstances.put(Configuration.DEFAULT_VRF_NAME, _defaultRoutingInstance);
+    _securityPolicies = new TreeMap<>();
     _syslogHosts = new TreeSet<>();
     _tacplusServers = new TreeSet<>();
     _namedVlans = new TreeMap<>();
@@ -203,6 +206,10 @@ public class LogicalSystem implements Serializable {
 
   public Map<String, FirewallFilter> getFirewallFilters() {
     return _filters;
+  }
+
+  public Map<String, ConcreteFirewallFilter> getSecurityPolicies() {
+    return _securityPolicies;
   }
 
   @Nonnull

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -129,6 +129,7 @@ import static org.batfish.representation.juniper.JuniperConfiguration.DEFAULT_IS
 import static org.batfish.representation.juniper.JuniperConfiguration.computeFirewallFilterTermName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computeOspfExportPolicyName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computePeerExportPolicyName;
+import static org.batfish.representation.juniper.JuniperConfiguration.computeSecurityPolicyTermName;
 import static org.batfish.representation.juniper.JuniperStructureType.APPLICATION;
 import static org.batfish.representation.juniper.JuniperStructureType.APPLICATION_OR_APPLICATION_SET;
 import static org.batfish.representation.juniper.JuniperStructureType.APPLICATION_SET;
@@ -137,6 +138,7 @@ import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_F
 import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER_TERM;
 import static org.batfish.representation.juniper.JuniperStructureType.INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureType.PREFIX_LIST;
+import static org.batfish.representation.juniper.JuniperStructureType.SECURITY_POLICY_TERM;
 import static org.batfish.representation.juniper.JuniperStructureType.VLAN;
 import static org.batfish.representation.juniper.JuniperStructureUsage.APPLICATION_SET_MEMBER_APPLICATION;
 import static org.batfish.representation.juniper.JuniperStructureUsage.APPLICATION_SET_MEMBER_APPLICATION_SET;
@@ -382,6 +384,20 @@ public final class FlatJuniperGrammarTest {
         .build();
   }
 
+  /** Returns a trace element for a security policy term for the given test config. */
+  private static TraceElement matchingSecurityPolicyTerm(
+      Configuration c, String aclName, String termName) {
+    return TraceElement.builder()
+        .add("Matched ")
+        .add(
+            termName,
+            new VendorStructureId(
+                "configs/" + c.getHostname(),
+                SECURITY_POLICY_TERM.getDescription(),
+                computeSecurityPolicyTermName(aclName, termName)))
+        .build();
+  }
+
   private static Flow createFlow(IpProtocol protocol, int port) {
     Flow.Builder fb =
         builder().setIngressNode("node").setIpProtocol(protocol).setDstPort(port).setSrcPort(port);
@@ -477,7 +493,7 @@ public final class FlatJuniperGrammarTest {
                                     .setSrcPorts(ImmutableList.of(SubRange.singleton(1)))
                                     .build()),
                             "p1",
-                            matchingFirewallFilterTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")),
+                            matchingSecurityPolicyTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")),
                         new ExprAclLine(
                             LineAction.PERMIT,
                             new MatchHeaderSpace(
@@ -486,7 +502,7 @@ public final class FlatJuniperGrammarTest {
                                     .setDstPorts(ImmutableList.of(SubRange.singleton(2)))
                                     .build()),
                             "p1",
-                            matchingFirewallFilterTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")),
+                            matchingSecurityPolicyTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")),
                         new ExprAclLine(
                             LineAction.PERMIT,
                             new MatchHeaderSpace(
@@ -495,7 +511,7 @@ public final class FlatJuniperGrammarTest {
                                     .setDstPorts(ImmutableList.of(SubRange.singleton(3)))
                                     .build()),
                             "p1",
-                            matchingFirewallFilterTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")))))));
+                            matchingSecurityPolicyTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")))))));
 
     /* Check that appset1 and appset2 are referenced, but appset3 is not */
     assertThat(ccae, hasNumReferrers(filename, APPLICATION_SET, "appset1", 1));
@@ -614,7 +630,7 @@ public final class FlatJuniperGrammarTest {
                                     .setSrcPorts(ImmutableList.of(SubRange.singleton(2)))
                                     .build()),
                             "p1",
-                            matchingFirewallFilterTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")),
+                            matchingSecurityPolicyTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")),
                         new ExprAclLine(
                             LineAction.PERMIT,
                             new MatchHeaderSpace(
@@ -624,7 +640,7 @@ public final class FlatJuniperGrammarTest {
                                     .setSrcPorts(ImmutableList.of(SubRange.singleton(4)))
                                     .build()),
                             "p1",
-                            matchingFirewallFilterTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")))))));
+                            matchingSecurityPolicyTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")))))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -126,19 +126,17 @@ import static org.batfish.main.BatfishTestUtils.TEST_SNAPSHOT;
 import static org.batfish.representation.juniper.JuniperConfiguration.ACL_NAME_GLOBAL_POLICY;
 import static org.batfish.representation.juniper.JuniperConfiguration.ACL_NAME_SECURITY_POLICY;
 import static org.batfish.representation.juniper.JuniperConfiguration.DEFAULT_ISIS_COST;
-import static org.batfish.representation.juniper.JuniperConfiguration.computeFirewallFilterTermName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computeOspfExportPolicyName;
 import static org.batfish.representation.juniper.JuniperConfiguration.computePeerExportPolicyName;
-import static org.batfish.representation.juniper.JuniperConfiguration.computeSecurityPolicyTermName;
+import static org.batfish.representation.juniper.JuniperConfiguration.matchingFirewallFilterTerm;
+import static org.batfish.representation.juniper.JuniperConfiguration.matchingSecurityPolicyTerm;
 import static org.batfish.representation.juniper.JuniperStructureType.APPLICATION;
 import static org.batfish.representation.juniper.JuniperStructureType.APPLICATION_OR_APPLICATION_SET;
 import static org.batfish.representation.juniper.JuniperStructureType.APPLICATION_SET;
 import static org.batfish.representation.juniper.JuniperStructureType.AUTHENTICATION_KEY_CHAIN;
 import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER;
-import static org.batfish.representation.juniper.JuniperStructureType.FIREWALL_FILTER_TERM;
 import static org.batfish.representation.juniper.JuniperStructureType.INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureType.PREFIX_LIST;
-import static org.batfish.representation.juniper.JuniperStructureType.SECURITY_POLICY_TERM;
 import static org.batfish.representation.juniper.JuniperStructureType.VLAN;
 import static org.batfish.representation.juniper.JuniperStructureUsage.APPLICATION_SET_MEMBER_APPLICATION;
 import static org.batfish.representation.juniper.JuniperStructureUsage.APPLICATION_SET_MEMBER_APPLICATION_SET;
@@ -344,7 +342,6 @@ import org.batfish.representation.juniper.TcpFinNoAck;
 import org.batfish.representation.juniper.TcpNoFlag;
 import org.batfish.representation.juniper.TcpSynFin;
 import org.batfish.representation.juniper.Zone;
-import org.batfish.vendor.VendorStructureId;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -368,34 +365,6 @@ public final class FlatJuniperGrammarTest {
     fb.setSrcIp(Ip.parse(sourceAddress));
     fb.setDstIp(Ip.parse(destinationAddress));
     return fb.build();
-  }
-
-  /** Returns a trace element for a firewall filter term for the given test config. */
-  private static TraceElement matchingFirewallFilterTerm(
-      Configuration c, String aclName, String termName) {
-    return TraceElement.builder()
-        .add("Matched ")
-        .add(
-            termName,
-            new VendorStructureId(
-                "configs/" + c.getHostname(),
-                FIREWALL_FILTER_TERM.getDescription(),
-                computeFirewallFilterTermName(aclName, termName)))
-        .build();
-  }
-
-  /** Returns a trace element for a security policy term for the given test config. */
-  private static TraceElement matchingSecurityPolicyTerm(
-      Configuration c, String aclName, String termName) {
-    return TraceElement.builder()
-        .add("Matched ")
-        .add(
-            termName,
-            new VendorStructureId(
-                "configs/" + c.getHostname(),
-                SECURITY_POLICY_TERM.getDescription(),
-                computeSecurityPolicyTermName(aclName, termName)))
-        .build();
   }
 
   private static Flow createFlow(IpProtocol protocol, int port) {
@@ -493,7 +462,8 @@ public final class FlatJuniperGrammarTest {
                                     .setSrcPorts(ImmutableList.of(SubRange.singleton(1)))
                                     .build()),
                             "p1",
-                            matchingSecurityPolicyTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")),
+                            matchingSecurityPolicyTerm(
+                                "configs/" + c.getHostname(), ACL_NAME_GLOBAL_POLICY, "p1")),
                         new ExprAclLine(
                             LineAction.PERMIT,
                             new MatchHeaderSpace(
@@ -502,7 +472,8 @@ public final class FlatJuniperGrammarTest {
                                     .setDstPorts(ImmutableList.of(SubRange.singleton(2)))
                                     .build()),
                             "p1",
-                            matchingSecurityPolicyTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")),
+                            matchingSecurityPolicyTerm(
+                                "configs/" + c.getHostname(), ACL_NAME_GLOBAL_POLICY, "p1")),
                         new ExprAclLine(
                             LineAction.PERMIT,
                             new MatchHeaderSpace(
@@ -511,7 +482,8 @@ public final class FlatJuniperGrammarTest {
                                     .setDstPorts(ImmutableList.of(SubRange.singleton(3)))
                                     .build()),
                             "p1",
-                            matchingSecurityPolicyTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")))))));
+                            matchingSecurityPolicyTerm(
+                                "configs/" + c.getHostname(), ACL_NAME_GLOBAL_POLICY, "p1")))))));
 
     /* Check that appset1 and appset2 are referenced, but appset3 is not */
     assertThat(ccae, hasNumReferrers(filename, APPLICATION_SET, "appset1", 1));
@@ -630,7 +602,8 @@ public final class FlatJuniperGrammarTest {
                                     .setSrcPorts(ImmutableList.of(SubRange.singleton(2)))
                                     .build()),
                             "p1",
-                            matchingSecurityPolicyTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")),
+                            matchingSecurityPolicyTerm(
+                                "configs/" + c.getHostname(), ACL_NAME_GLOBAL_POLICY, "p1")),
                         new ExprAclLine(
                             LineAction.PERMIT,
                             new MatchHeaderSpace(
@@ -640,7 +613,8 @@ public final class FlatJuniperGrammarTest {
                                     .setSrcPorts(ImmutableList.of(SubRange.singleton(4)))
                                     .build()),
                             "p1",
-                            matchingSecurityPolicyTerm(c, ACL_NAME_GLOBAL_POLICY, "p1")))))));
+                            matchingSecurityPolicyTerm(
+                                "configs/" + c.getHostname(), ACL_NAME_GLOBAL_POLICY, "p1")))))));
   }
 
   @Test
@@ -2787,7 +2761,9 @@ public final class FlatJuniperGrammarTest {
                                                 TraceElement.of(
                                                     "Matched source-address 2.3.4.0/24"))))))
                             .setName("TERM")
-                            .setTraceElement(matchingFirewallFilterTerm(c, filterNameV4, "TERM"))
+                            .setTraceElement(
+                                matchingFirewallFilterTerm(
+                                    "configs/" + c.getHostname(), filterNameV4, "TERM"))
                             .build())))));
   }
 
@@ -3091,7 +3067,9 @@ public final class FlatJuniperGrammarTest {
                                                 TraceElement.of(
                                                     "Matched destination-address 2.3.4.0/24"))))))
                             .setName("TERM")
-                            .setTraceElement(matchingFirewallFilterTerm(c, filterNameV4, "TERM"))
+                            .setTraceElement(
+                                matchingFirewallFilterTerm(
+                                    "configs/" + c.getHostname(), filterNameV4, "TERM"))
                             .build())))));
   }
 
@@ -5014,7 +4992,8 @@ public final class FlatJuniperGrammarTest {
                                             .build(),
                                         TraceElement.of("Matched source-address 1.2.3.6")))),
                             "TERM",
-                            matchingFirewallFilterTerm(config, "FILTER1", "TERM"))))
+                            matchingFirewallFilterTerm(
+                                "configs/" + config.getHostname(), "FILTER1", "TERM"))))
                 .build()));
 
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -731,8 +731,7 @@ public class JuniperConfigurationTest {
     FwTerm term = new FwTerm("term");
     term.getThens().add(FwThenAccept.INSTANCE);
     List<FwTerm> terms = ImmutableList.of(term);
-    IpAccessList acl =
-        config.fwTermsToIpAccessList("acl", terms, null, FIREWALL_FILTER, FIREWALL_FILTER_TERM);
+    IpAccessList acl = config.fwTermsToIpAccessList("acl", terms, null, FIREWALL_FILTER);
 
     assertThat(acl.getLines(), hasSize(1));
 

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -28076,7 +28076,7 @@
             ],
             "name" : "zone~A~to~zone~B",
             "sourceName" : "zone~A~to~zone~B",
-            "sourceType" : "firewall filter"
+            "sourceType" : "security policy"
           },
           "~GLOBAL_SECURITY_POLICY~" : {
             "lines" : [
@@ -28108,7 +28108,7 @@
             ],
             "name" : "~GLOBAL_SECURITY_POLICY~",
             "sourceName" : "~GLOBAL_SECURITY_POLICY~",
-            "sourceType" : "firewall filter"
+            "sourceType" : "security policy"
           },
           "~INBOUND_ZONE_FILTER~ZONE-protocols" : {
             "lines" : [


### PR DESCRIPTION
Before, we always marked them as firewall filters/terms in the trace.
To do this better, make a trivial start at separating these in the VS.

* Security policies moved to their own structure
* Security policy terms are always concrete
* Plumb types down into the functions that make the ultimate ACL lines