### PR TITLE
Juniper class-of-service parsing

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -16,6 +16,7 @@ tokens {
    DYNAMIC_DB,
    FIN,
    INTERFACE_NAME,
+   INTERFACE_WILDCARD,
    ISO_ADDRESS,
    LITERAL_OR_REGEX_COMMUNITY,
    PIPE,
@@ -2064,7 +2065,14 @@ INTERFACE_TRANSMIT_STATISTICS
 
 INTERFACES
 :
-   'interfaces' -> pushMode ( M_Interface )
+  'interfaces'
+  {
+    if (lastTokenType() == CLASS_OF_SERVICE) {
+      pushMode(M_InterfaceWildcard);
+    } else {
+      pushMode(M_Interface);
+    }
+  }
 ;
 
 INTERFACE_ROUTES
@@ -7187,6 +7195,36 @@ M_InterfaceQuote_WILDCARD
 M_InterfaceQuote_DOUBLE_QUOTED_STRING
 :
     ~'"'+ -> type ( DOUBLE_QUOTED_STRING )
+;
+
+mode M_InterfaceWildcard;
+
+M_InterfaceWildcard_APPLY_GROUPS
+:
+  'apply-groups' -> type(APPLY_GROUPS), popMode
+;
+
+M_InterfaceWildcard_APPLY_GROUPS_EXCEPT
+:
+  'apply-groups' -> type(APPLY_GROUPS_EXCEPT), popMode
+;
+
+M_InterfaceWildcard_NEWLINE
+:
+  F_NewlineChar+ -> type(NEWLINE), popMode
+;
+
+M_InterfaceWildcard_INTERFACE_WILDCARD
+:
+  (
+    [A-Za-z]+ [-A-Za-z0-9]+ '*'?
+    | '*'
+  ) -> type(INTERFACE_WILDCARD), popMode
+;
+
+M_InterfaceWildcard_WS
+:
+  F_WhitespaceChar+ -> channel(HIDDEN)
 ;
 
 mode M_ISO;

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -778,7 +778,7 @@ public final class FlatJuniperGrammarTest {
   public void testClassOfServiceParsing() {
     parseJuniperConfig("juniper-class-of-service");
   }
-  
+
   @Test
   public void testParentChildTopology() throws IOException {
     String resourcePrefix = "org/batfish/grammar/juniper/testrigs/topology";

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -775,6 +775,11 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testClassOfServiceParsing() {
+    parseJuniperConfig("juniper-class-of-service");
+  }
+  
+  @Test
   public void testParentChildTopology() throws IOException {
     String resourcePrefix = "org/batfish/grammar/juniper/testrigs/topology";
     Batfish batfish =

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-class-of-service
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-class-of-service
@@ -1,0 +1,14 @@
+#
+set system host-name juniper-class-of-service
+#
+set groups QOS_INTERFACES class-of-service interfaces et-* forwarding-class-set FC_SET_FOO output-traffic-control-profile TCP_FOO
+set groups QOS_INTERFACES class-of-service interfaces et-* unit * classifiers dscp CL_FOO_DSCP
+set groups QOS_INTERFACES class-of-service interfaces et-* classifiers dscp CL_FOO_DSCP
+set groups QOS_INTERFACES class-of-service interfaces xe-* forwarding-class-set FC_SET_FOO output-traffic-control-profile TCP_FOO
+set groups QOS_INTERFACES class-of-service interfaces xe-* unit * classifiers dscp CL_FOO_DSCP
+set groups QOS_INTERFACES class-of-service interfaces xe-* classifiers dscp CL_FOO_DSCP
+set groups QOS_INTERFACES class-of-service interfaces ae* forwarding-class-set FC_SET_FOO output-traffic-control-profile TCP_FOO
+set groups QOS_INTERFACES class-of-service interfaces ae* unit * classifiers dscp CL_FOO_DSCP
+set groups QOS_INTERFACES class-of-service interfaces ae* classifiers dscp CL_FOO_DSCP
+set apply-groups FOOBAR
+#


### PR DESCRIPTION
- don't trip up on interface wildcards after `set class-of-service interfaces`