### PR TITLE
Fix Cumulus model for extended community-lists & add support for "set comm-list delete".

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -5,6 +5,7 @@ options {
 }
 
 tokens {
+  QUOTED_TEXT,
   REMARK_TEXT,
   WORD
 }
@@ -150,6 +151,11 @@ COMMENT_LINE
   ) -> channel ( HIDDEN )
 ;
 
+COMM_LIST
+:
+  'comm-list' -> pushMode ( M_Word )
+;
+
 COMMUNITY
 :
   'community'
@@ -210,6 +216,11 @@ DEFAULTS
   'defaults'
 ;
 
+DELETE
+:
+  'delete'
+;
+
 DENY
 :
   'deny'
@@ -218,6 +229,11 @@ DENY
 DESCRIPTION
 :
   'description' -> pushMode ( M_Remark )
+;
+
+DOUBLE_QUOTE
+:
+  '"' -> pushMode ( M_DoubleQuote )
 ;
 
 EMERGENCIES
@@ -899,6 +915,24 @@ M_Default_Or_Word_WORD
 M_Default_Or_Word_WS
 :
   F_Whitespace+ -> channel ( HIDDEN )
+;
+
+mode M_DoubleQuote;
+
+M_DoubleQuote_DOUBLE_QUOTE
+:
+  '"' -> type ( DOUBLE_QUOTE ) , popMode
+;
+
+M_DoubleQuote_NEWLINE
+:
+// Break out if termination does not occur on same line
+  F_Newline+ -> type ( NEWLINE ) , popMode
+;
+
+M_DoubleQuote_QUOTED_TEXT
+:
+  ~["\r\n]+ -> type ( QUOTED_TEXT )
 ;
 
 mode M_Neighbor;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -273,7 +273,7 @@ EXIT_VRF
 
 EXPANDED
 :
-  'expanded' -> pushMode(M_Word)
+  'expanded' -> pushMode(M_Expanded)
 ;
 
 EXTENDED
@@ -934,6 +934,56 @@ M_DoubleQuote_QUOTED_TEXT
 :
   ~["\r\n]+ -> type ( QUOTED_TEXT )
 ;
+
+mode M_Expanded;
+
+M_Expanded_WORD
+:
+  F_Word -> type ( WORD ) , mode(M_Expanded2)
+;
+
+M_Expanded_WS
+:
+  F_Whitespace+ -> channel ( HIDDEN )
+;
+
+mode M_Expanded2;
+
+M_Expanded2_DENY
+:
+  'deny' -> type ( DENY ), mode(M_Expanded3)
+;
+
+M_Expanded2_PERMIT
+:
+  'permit' -> type ( PERMIT ), mode(M_Expanded3)
+;
+
+M_Expanded2_WS
+:
+  F_Whitespace+ -> channel ( HIDDEN )
+;
+
+mode M_Expanded3;
+
+M_Expanded3_WS
+:
+  F_Whitespace+ -> channel ( HIDDEN ), mode(M_Expanded4)
+;
+
+mode M_Expanded4;
+
+M_Expanded4_DOUBLE_QUOTE
+:
+  '"' -> type(DOUBLE_QUOTE), mode(M_DoubleQuote)
+;
+
+M_Expanded4_REMARK_TEXT
+:
+  ~["\r\n] F_NonWhitespace* (F_Whitespace+ F_NonWhitespace+)* -> type(REMARK_TEXT), popMode
+;
+
+
 
 mode M_Neighbor;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_common.g4
@@ -9,6 +9,11 @@ autonomous_system
   uint32
 ;
 
+double_quoted_string
+:
+  DOUBLE_QUOTE text = quoted_text? DOUBLE_QUOTE
+;
+
 ip_address
 :
   IP_ADDRESS
@@ -60,6 +65,11 @@ loglevel
 prefix
 :
   IP_PREFIX
+;
+
+quoted_text
+:
+  QUOTED_TEXT
 ;
 
 route_map_name

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_ip_community_list.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_ip_community_list.g4
@@ -14,5 +14,27 @@ ip_community_list
 icl_expanded
 :
   EXPANDED name = ip_community_list_name
-  action = line_action communities += literal_standard_community+ NEWLINE
+  (
+    SEQ seq = ip_community_list_seq
+  )? action = line_action
+  (
+    quoted = double_quoted_string
+    | regex = REMARK_TEXT
+  ) NEWLINE
+;
+
+ip_community_list_seq
+:
+// 1-4294967294
+  uint32
+;
+
+double_quoted_string
+:
+  DOUBLE_QUOTE text = quoted_text? DOUBLE_QUOTE
+;
+
+quoted_text
+:
+  QUOTED_TEXT
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_ip_community_list.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_ip_community_list.g4
@@ -20,13 +20,3 @@ icl_expanded
     | regex = REMARK_TEXT
   ) NEWLINE
 ;
-
-double_quoted_string
-:
-  DOUBLE_QUOTE text = quoted_text? DOUBLE_QUOTE
-;
-
-quoted_text
-:
-  QUOTED_TEXT
-;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_ip_community_list.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_ip_community_list.g4
@@ -14,19 +14,11 @@ ip_community_list
 icl_expanded
 :
   EXPANDED name = ip_community_list_name
-  (
-    SEQ seq = ip_community_list_seq
-  )? action = line_action
+  action = line_action
   (
     quoted = double_quoted_string
     | regex = REMARK_TEXT
   ) NEWLINE
-;
-
-ip_community_list_seq
-:
-// 1-4294967294
-  uint32
 ;
 
 double_quoted_string

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_routemap.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_routemap.g4
@@ -76,6 +76,7 @@ rm_set
   SET
   (
     rms_as_path
+    | rms_comm_list
     | rms_community
     | rms_ip
     | rms_local_preference
@@ -159,6 +160,11 @@ rmsip_next_hop
 rmsipnh_literal
 :
   next_hop = ip_address NEWLINE
+;
+
+rms_comm_list
+:
+  COMM_LIST name = ip_community_list_name DELETE NEWLINE
 ;
 
 rms_community

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.SortedMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.antlr.v4.runtime.ParserRuleContext;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -295,8 +295,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     return Optional.of(text);
   }
 
-  private @Nonnull String toString(
-      ParserRuleContext messageCtx, Ip_community_list_nameContext ctx) {
+  private @Nonnull String toString(Ip_community_list_nameContext ctx) {
     return ctx.getText();
   }
 
@@ -1030,7 +1029,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
 
   @Override
   public void exitRms_comm_list(Rms_comm_listContext ctx) {
-    String name = toString(ctx, ctx.name);
+    String name = toString(ctx.name);
     if (Strings.isNullOrEmpty(name)) {
       return;
     }
@@ -1063,7 +1062,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   }
 
   public void enterIcl_expanded(Icl_expandedContext ctx) {
-    String name = toString(ctx, ctx.name);
+    String name = toString(ctx.name);
     if (Strings.isNullOrEmpty(name)) {
       return;
     }
@@ -1082,10 +1081,10 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
       return;
     }
     IpCommunityListExpanded communityListExpanded = (IpCommunityListExpanded) communityList;
-    SortedMap<String, IpCommunityListExpandedLine> lines = communityListExpanded.getLines();
+    List<IpCommunityListExpandedLine> lines = communityListExpanded.getLines();
     communityListExpanded
         .getLines()
-        .put(name, new IpCommunityListExpandedLine(toLineAction(ctx.action), regex));
+        .add(new IpCommunityListExpandedLine(toLineAction(ctx.action), regex));
     _c.defineStructure(IP_COMMUNITY_LIST_EXPANDED, name, ctx);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -43,8 +43,8 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.common.Warnings.ParseWarning;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.Prefix;
@@ -172,8 +172,8 @@ import org.batfish.representation.cumulus.RouteMapMatchInterface;
 import org.batfish.representation.cumulus.RouteMapMatchIpAddressPrefixList;
 import org.batfish.representation.cumulus.RouteMapMatchTag;
 import org.batfish.representation.cumulus.RouteMapSetAsPath;
-import org.batfish.representation.cumulus.RouteMapSetCommunity;
 import org.batfish.representation.cumulus.RouteMapSetCommListDelete;
+import org.batfish.representation.cumulus.RouteMapSetCommunity;
 import org.batfish.representation.cumulus.RouteMapSetIpNextHopLiteral;
 import org.batfish.representation.cumulus.RouteMapSetLocalPreference;
 import org.batfish.representation.cumulus.RouteMapSetMetric;
@@ -188,7 +188,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   private final Warnings _w;
 
   private static final LongSpace IP_COMMUNITY_LIST_LINE_NUMBER_RANGE =
-          LongSpace.of(Range.closed(1L, 4294967294L));
+      LongSpace.of(Range.closed(1L, 4294967294L));
 
   private @Nullable Vrf _currentVrf;
   private @Nullable RouteMapEntry _currentRouteMapEntry;
@@ -226,7 +226,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
    * {@link Optional#empty}.
    */
   private @Nonnull Optional<Long> toLongInSpace(
-          ParserRuleContext messageCtx, ParserRuleContext ctx, LongSpace space, String name) {
+      ParserRuleContext messageCtx, ParserRuleContext ctx, LongSpace space, String name) {
     long num = Long.parseLong(ctx.getText());
     if (!space.contains(num)) {
       warn(messageCtx, String.format("Expected %s in range %s, but got '%d'", name, space, num));
@@ -236,9 +236,9 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   }
 
   private @Nonnull Optional<Long> toLong(
-          ParserRuleContext messageCtx, Ip_community_list_seqContext ctx) {
+      ParserRuleContext messageCtx, Ip_community_list_seqContext ctx) {
     return toLongInSpace(
-            messageCtx, ctx, IP_COMMUNITY_LIST_LINE_NUMBER_RANGE, "ip community-list line number");
+        messageCtx, ctx, IP_COMMUNITY_LIST_LINE_NUMBER_RANGE, "ip community-list line number");
   }
 
   private static @Nonnull Ip toIp(Ip_addressContext ctx) {
@@ -304,22 +304,22 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
    * IntegerSpace lengthSpace}, or else {@link Optional#empty}.
    */
   private @Nonnull Optional<String> toStringWithLengthInSpace(
-          ParserRuleContext messageCtx, ParserRuleContext ctx, IntegerSpace lengthSpace, String name) {
+      ParserRuleContext messageCtx, ParserRuleContext ctx, IntegerSpace lengthSpace, String name) {
     String text = ctx.getText();
     if (!lengthSpace.contains(text.length())) {
       warn(
-              messageCtx,
-              String.format(
-                      "Expected %s with length in range %s, but got '%s'", text, lengthSpace, name));
+          messageCtx,
+          String.format(
+              "Expected %s with length in range %s, but got '%s'", text, lengthSpace, name));
       return Optional.empty();
     }
     return Optional.of(text);
   }
 
   private @Nonnull Optional<String> toString(
-          ParserRuleContext messageCtx, Ip_community_list_nameContext ctx) {
+      ParserRuleContext messageCtx, Ip_community_list_nameContext ctx) {
     return toStringWithLengthInSpace(
-            messageCtx, ctx, IP_COMMUNITY_LIST_NAME_LENGTH_RANGE, "ip community-list name");
+        messageCtx, ctx, IP_COMMUNITY_LIST_NAME_LENGTH_RANGE, "ip community-list name");
   }
 
   private void clearOspfPassiveInterface() {
@@ -334,7 +334,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   }
 
   private static final IntegerSpace IP_COMMUNITY_LIST_NAME_LENGTH_RANGE =
-          IntegerSpace.of(Range.closed(1, 63));
+      IntegerSpace.of(Range.closed(1, 63));
 
   @Override
   public void enterS_bgp(S_bgpContext ctx) {
@@ -1062,7 +1062,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     String name = nameOrError.get();
     _currentRouteMapEntry.setSetCommListDelete(new RouteMapSetCommListDelete(name));
     _c.referenceStructure(
-            IP_COMMUNITY_LIST, name, ROUTE_MAP_SET_COMM_LIST_DELETE, ctx.getStart().getLine());
+        IP_COMMUNITY_LIST, name, ROUTE_MAP_SET_COMM_LIST_DELETE, ctx.getStart().getLine());
   }
 
   @Override
@@ -1087,6 +1087,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
       return LineAction.PERMIT;
     }
   }
+
   public void enterIcl_expanded(Icl_expandedContext ctx) {
     Long explicitSeq;
     if (ctx.seq != null) {
@@ -1104,17 +1105,17 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     }
     String name = nameOpt.get();
     String regex =
-            ctx.quoted != null
-                    ? ctx.quoted.text != null ? ctx.quoted.text.getText() : ""
-                    : ctx.regex.getText();
+        ctx.quoted != null
+            ? ctx.quoted.text != null ? ctx.quoted.text.getText() : ""
+            : ctx.regex.getText();
     IpCommunityList communityList =
-            _c.getIpCommunityLists().computeIfAbsent(name, IpCommunityListExpanded::new);
+        _c.getIpCommunityLists().computeIfAbsent(name, IpCommunityListExpanded::new);
     if (!(communityList instanceof IpCommunityListExpanded)) {
       warn(
-              ctx,
-              String.format(
-                      "Cannot define expanded community-list '%s' because another community-list with that name but a different type already exists.",
-                      name));
+          ctx,
+          String.format(
+              "Cannot define expanded community-list '%s' because another community-list with that name but a different type already exists.",
+              name));
       return;
     }
     IpCommunityListExpanded communityListExpanded = (IpCommunityListExpanded) communityList;
@@ -1128,8 +1129,8 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
       seq = 1L;
     }
     communityListExpanded
-            .getLines()
-            .put(seq, new IpCommunityListExpandedLine(toLineAction(ctx.action), seq, regex));
+        .getLines()
+        .put(seq, new IpCommunityListExpandedLine(toLineAction(ctx.action), seq, regex));
     _c.defineStructure(IP_COMMUNITY_LIST_EXPANDED, name, ctx);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -27,7 +27,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Range;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,6 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
@@ -185,9 +183,6 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   private final CumulusFrrConfiguration _frr;
   private final CumulusFrrCombinedParser _parser;
   private final Warnings _w;
-
-  private static final LongSpace IP_COMMUNITY_LIST_LINE_NUMBER_RANGE =
-      LongSpace.of(Range.closed(1L, 4294967294L));
 
   private @Nullable Vrf _currentVrf;
   private @Nullable RouteMapEntry _currentRouteMapEntry;
@@ -1060,6 +1055,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     }
   }
 
+  @Override
   public void enterIcl_expanded(Icl_expandedContext ctx) {
     String name = toString(ctx.name);
     if (Strings.isNullOrEmpty(name)) {
@@ -1080,7 +1076,6 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
       return;
     }
     IpCommunityListExpanded communityListExpanded = (IpCommunityListExpanded) communityList;
-    List<IpCommunityListExpandedLine> lines = communityListExpanded.getLines();
     communityListExpanded
         .getLines()
         .add(new IpCommunityListExpandedLine(toLineAction(ctx.action), regex));

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -1133,30 +1133,6 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     _c.defineStructure(IP_COMMUNITY_LIST_EXPANDED, name, ctx);
   }
 
-/*
-  @Override
-  public void exitIcl_expanded(Icl_expandedContext ctx) {
-    String name = ctx.name.getText();
-
-    LineAction action;
-    if (ctx.action.permit != null) {
-      action = LineAction.PERMIT;
-    } else if (ctx.action.deny != null) {
-      action = LineAction.DENY;
-    } else {
-      throw new IllegalStateException("only support permit and deny in route map");
-    }
-
-    List<StandardCommunity> communityList =
-        ctx.communities.stream()
-            .map(RuleContext::getText)
-            .map(StandardCommunity::parse)
-            .collect(ImmutableList.toImmutableList());
-
-    _c.defineStructure(IP_COMMUNITY_LIST, name, ctx);
-    _frr.getIpCommunityLists().put(name, new IpCommunityListExpanded(name, action, communityList));
-  }
-*/
   @Override
   public void enterIp_prefix_list(Ip_prefix_listContext ctx) {
     String name = ctx.name.getText();

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -42,7 +42,6 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
 import org.batfish.common.Warnings.ParseWarning;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
-import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
@@ -270,23 +269,6 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
 
   private static long toLong(TerminalNode t) {
     return Long.parseLong(t.getText());
-  }
-
-  /**
-   * Return the text of the provided {@code ctx} if its length is within the provided {@link
-   * IntegerSpace lengthSpace}, or else {@link Optional#empty}.
-   */
-  private @Nonnull Optional<String> toStringWithLengthInSpace(
-      ParserRuleContext messageCtx, ParserRuleContext ctx, IntegerSpace lengthSpace, String name) {
-    String text = ctx.getText();
-    if (!lengthSpace.contains(text.length())) {
-      warn(
-          messageCtx,
-          String.format(
-              "Expected %s with length in range %s, but got '%s'", text, lengthSpace, name));
-      return Optional.empty();
-    }
-    return Optional.of(text);
   }
 
   private @Nonnull String toString(Ip_community_list_nameContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -1337,9 +1337,9 @@ public final class CumulusConversions {
   }
 
   @VisibleForTesting
-  static CommunityMatchExpr toCommunityMatchExpr(IpCommunityListExpanded ipCommunityListExpanded) {
+  static @Nonnull CommunityMatchExpr toCommunityMatchExpr(IpCommunityListExpanded ipCommunityListExpanded) {
     return new CommunityAcl(
-        ipCommunityListExpanded.getLines().values().stream()
+        ipCommunityListExpanded.getLines().stream()
             .map(CumulusConversions::toCommunityAclLine)
             .collect(ImmutableList.toImmutableList()));
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -1296,6 +1296,7 @@ public final class CumulusConversions {
   static void convertIpCommunityLists(
       Configuration c, Map<String, IpCommunityList> ipCommunityLists) {
 
+    // The following code-block is only for "set comm-list delete" statements.
     ipCommunityLists.forEach(
         (name, list) -> {
           if (list instanceof IpCommunityListStandard) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -1299,7 +1299,7 @@ public final class CumulusConversions {
     ipCommunityLists.forEach(
         (name, list) -> {
           if (list instanceof IpCommunityListStandard) {
-            c.getCommunityLists().put(name, toCommunityMatchExpr((IpCommunityListStandard) list));
+            c.getCommunityLists().put(name, toCommunityList((IpCommunityListStandard) list));
           } else if (list instanceof IpCommunityListExpanded) {
             c.getCommunityMatchExprs()
                 .put(name, toCommunityMatchExpr((IpCommunityListExpanded) list));
@@ -1308,7 +1308,7 @@ public final class CumulusConversions {
   }
 
   @VisibleForTesting
-  static CommunityList toCommunityMatchExpr(IpCommunityListStandard ipCommunityListStandard) {
+  static CommunityList toCommunityList(IpCommunityListStandard ipCommunityListStandard) {
     Set<Community> whitelist = new HashSet<>();
     Set<Community> blacklist = new HashSet<>();
     for (IpCommunityListStandardLine line : ipCommunityListStandard.getLines().values()) {
@@ -1360,31 +1360,6 @@ public final class CumulusConversions {
     String output = withoutQuotes.replaceAll("_", underscoreReplacement);
     return output;
   }
-
-  /* TODO: Enable when IpCommunityListStandard is supported for Cumulus in Batfish.
-  private static @Nonnull CommunityMatchExpr toCommunityMatchExpr(
-          IpCommunityListStandard ipCommunityListStandard) {
-    Set<Community> whitelist = new HashSet<>();
-    Set<Community> blacklist = new HashSet<>();
-    for (IpCommunityListStandardLine line : ipCommunityListStandard.getLines().values()) {
-      if (line.getCommunities().size() != 1) {
-        continue;
-      }
-      Community community = Iterables.getOnlyElement(line.getCommunities());
-      if (line.getAction() == LineAction.PERMIT) {
-        if (!blacklist.contains(community)) {
-          whitelist.add(community);
-        }
-      } else {
-        // DENY
-        if (!whitelist.contains(community)) {
-          blacklist.add(community);
-        }
-      }
-    }
-    return new CommunityIn(new LiteralCommunitySet(CommunitySet.of(whitelist)));
-  }
-  */
 
   static void convertIpAsPathAccessLists(
       Configuration c, Map<String, IpAsPathAccessList> ipAsPathAccessLists) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -52,8 +52,6 @@ import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.BumTransportMethod;
-import org.batfish.datamodel.CommunityList;
-import org.batfish.datamodel.CommunityListLine;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -93,7 +91,6 @@ import org.batfish.datamodel.routing_policy.communities.CommunityIn;
 import org.batfish.datamodel.routing_policy.communities.CommunityMatchExpr;
 import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
-import org.batfish.datamodel.routing_policy.communities.CommunitySetExpr;
 import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
 import org.batfish.datamodel.routing_policy.expr.BooleanExprs;
@@ -102,7 +99,6 @@ import org.batfish.datamodel.routing_policy.expr.Conjunction;
 import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
 import org.batfish.datamodel.routing_policy.expr.Disjunction;
 import org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet;
-import org.batfish.datamodel.routing_policy.expr.LiteralCommunity;
 import org.batfish.datamodel.routing_policy.expr.LiteralOrigin;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
@@ -1303,7 +1299,8 @@ public final class CumulusConversions {
     ipCommunityLists.forEach(
         (name, list) -> {
           if (list instanceof IpCommunityListStandard) {
-            c.getCommunityMatchExprs().put(name, toCommunityMatchExpr((IpCommunityListStandard) list));
+            c.getCommunityMatchExprs()
+                .put(name, toCommunityMatchExpr((IpCommunityListStandard) list));
           } else if (list instanceof IpCommunityListExpanded) {
             c.getCommunityMatchExprs()
                 .put(name, toCommunityMatchExpr((IpCommunityListExpanded) list));
@@ -1313,7 +1310,7 @@ public final class CumulusConversions {
 
   @VisibleForTesting
   static @Nonnull CommunityMatchExpr toCommunityMatchExpr(
-          IpCommunityListStandard ipCommunityListStandard) {
+      IpCommunityListStandard ipCommunityListStandard) {
     Set<Community> whitelist = new HashSet<>();
     Set<Community> blacklist = new HashSet<>();
     for (IpCommunityListStandardLine line : ipCommunityListStandard.getLines().values()) {
@@ -1335,9 +1332,9 @@ public final class CumulusConversions {
     return new CommunityIn(new LiteralCommunitySet(CommunitySet.of(whitelist)));
   }
 
-
   @VisibleForTesting
-  static @Nonnull CommunityMatchExpr toCommunityMatchExpr(IpCommunityListExpanded ipCommunityListExpanded) {
+  static @Nonnull CommunityMatchExpr toCommunityMatchExpr(
+      IpCommunityListExpanded ipCommunityListExpanded) {
     return new CommunityAcl(
         ipCommunityListExpanded.getLines().stream()
             .map(CumulusConversions::toCommunityAclLine)

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -75,14 +75,13 @@ import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
 import org.batfish.datamodel.bgp.BgpConfederation;
-import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.Layer2VniConfig;
 import org.batfish.datamodel.bgp.Layer3VniConfig;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
+import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
-import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.routing_policy.Common;
@@ -92,8 +91,6 @@ import org.batfish.datamodel.routing_policy.communities.CommunityAcl;
 import org.batfish.datamodel.routing_policy.communities.CommunityAclLine;
 import org.batfish.datamodel.routing_policy.communities.CommunityMatchExpr;
 import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
-import org.batfish.datamodel.routing_policy.communities.CommunitySet;
-import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
 import org.batfish.datamodel.routing_policy.expr.BooleanExprs;
 import org.batfish.datamodel.routing_policy.expr.CallExpr;
@@ -1302,12 +1299,13 @@ public final class CumulusConversions {
     ipCommunityLists.forEach(
         (name, list) -> {
           if (list instanceof IpCommunityListStandard) {
-            c.getCommunityLists().put(name, toCommunityMatchExpr((IpCommunityListStandard)list));
+            c.getCommunityLists().put(name, toCommunityMatchExpr((IpCommunityListStandard) list));
           } else if (list instanceof IpCommunityListExpanded) {
-            c.getCommunityMatchExprs().put(name, toCommunityMatchExpr((IpCommunityListExpanded)list));
+            c.getCommunityMatchExprs()
+                .put(name, toCommunityMatchExpr((IpCommunityListExpanded) list));
           }
         });
-    }
+  }
 
   @VisibleForTesting
   static CommunityList toCommunityMatchExpr(IpCommunityListStandard ipCommunityListStandard) {
@@ -1329,25 +1327,26 @@ public final class CumulusConversions {
         }
       }
     }
-    return new CommunityList(ipCommunityListStandard.getName(),
-            whitelist.stream().map(k -> new CommunityListLine(LineAction.PERMIT, new LiteralCommunity(k)))
-                    .collect(ImmutableList.toImmutableList())  ,
-            false);
+    return new CommunityList(
+        ipCommunityListStandard.getName(),
+        whitelist.stream()
+            .map(k -> new CommunityListLine(LineAction.PERMIT, new LiteralCommunity(k)))
+            .collect(ImmutableList.toImmutableList()),
+        false);
   }
 
   @VisibleForTesting
-  static CommunityMatchExpr toCommunityMatchExpr(
-          IpCommunityListExpanded ipCommunityListExpanded) {
+  static CommunityMatchExpr toCommunityMatchExpr(IpCommunityListExpanded ipCommunityListExpanded) {
     return new CommunityAcl(
-            ipCommunityListExpanded.getLines().values().stream()
-                    .map(CumulusConversions::toCommunityAclLine)
-                    .collect(ImmutableList.toImmutableList()));
+        ipCommunityListExpanded.getLines().values().stream()
+            .map(CumulusConversions::toCommunityAclLine)
+            .collect(ImmutableList.toImmutableList()));
   }
 
   private static @Nonnull CommunityAclLine toCommunityAclLine(IpCommunityListExpandedLine line) {
     return new CommunityAclLine(
-            line.getAction(),
-            new CommunityMatchRegex(ColonSeparatedRendering.instance(), toJavaRegex(line.getRegex())));
+        line.getAction(),
+        new CommunityMatchRegex(ColonSeparatedRendering.instance(), toJavaRegex(line.getRegex())));
   }
 
   private static @Nonnull String toJavaRegex(String cumulusRegex) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusStructureType.java
@@ -9,6 +9,8 @@ public enum CumulusStructureType implements StructureType {
   IP_AS_PATH_ACCESS_LIST("ip as-path access-list"),
   IP_COMMUNITY_LIST("ip community-list"),
   INTERFACE("interface"),
+  IP_COMMUNITY_LIST_EXPANDED("ip community-list expanded"),
+  IP_COMMUNITY_LIST_STANDARD("ip community-list standard"),
   IP_PREFIX_LIST("ip_prefix_list"),
   LOOPBACK("loopback"),
   ROUTE_MAP("route-map"),

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusStructureUsage.java
@@ -29,6 +29,7 @@ public enum CumulusStructureUsage implements StructureUsage {
   ROUTE_MAP_MATCH_INTERFACE("route-map match interface"),
   ROUTE_MAP_MATCH_AS_PATH("route-map match as-path"),
   ROUTE_MAP_MATCH_IP_ADDRESS_PREFIX_LIST("route-map match ip prefix-list"),
+  ROUTE_MAP_SET_COMM_LIST_DELETE("route-map set comm-list delete"),
   VLAN_SELF_REFERENCE("vlan self-reference"),
   VLAN_VRF("vlan vrf"),
   VRF_SELF_REFERENCE("vrf self-reference"),

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
@@ -11,7 +11,6 @@ import org.batfish.datamodel.bgp.community.StandardCommunity;
 /** A expanded Ip community list */
 public class IpCommunityListExpanded extends IpCommunityList {
 
-
   private final LineAction _action;
   private final @Nonnull List<StandardCommunity> _communities;
   private final @Nonnull SortedMap<Long, IpCommunityListExpandedLine> _lines;
@@ -35,7 +34,6 @@ public class IpCommunityListExpanded extends IpCommunityList {
   public <T> T accept(IpCommunityListVisitor<T> visitor) {
     return visitor.visitIpCommunityListExpanded(this);
   }
-
 
   public @Nonnull List<StandardCommunity> getCommunities() {
     return _communities;

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
@@ -1,31 +1,25 @@
 package org.batfish.representation.cumulus;
 
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.LineAction;
-import org.batfish.datamodel.bgp.community.StandardCommunity;
 
 /** A expanded Ip community list */
 public class IpCommunityListExpanded extends IpCommunityList {
 
   private final LineAction _action;
-  private final @Nonnull List<StandardCommunity> _communities;
   private final @Nonnull List<IpCommunityListExpandedLine> _lines;
 
-  public IpCommunityListExpanded(
-      String name, LineAction action, List<StandardCommunity> communities) {
+  public IpCommunityListExpanded(String name, LineAction action) {
     super(name);
     _action = action;
-    _communities = ImmutableList.copyOf(communities);
     _lines = null;
   }
 
   public IpCommunityListExpanded(String name) {
     super(name);
     _action = null;
-    _communities = null;
     _lines = new ArrayList<>();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
@@ -2,6 +2,8 @@ package org.batfish.representation.cumulus;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
@@ -9,14 +11,24 @@ import org.batfish.datamodel.bgp.community.StandardCommunity;
 /** A expanded Ip community list */
 public class IpCommunityListExpanded extends IpCommunityList {
 
+
   private final LineAction _action;
   private final @Nonnull List<StandardCommunity> _communities;
+  private final @Nonnull SortedMap<Long, IpCommunityListExpandedLine> _lines;
 
   public IpCommunityListExpanded(
       String name, LineAction action, List<StandardCommunity> communities) {
     super(name);
     _action = action;
     _communities = ImmutableList.copyOf(communities);
+    _lines = null;
+  }
+
+  public IpCommunityListExpanded(String name) {
+    super(name);
+    _action = null;
+    _communities = null;
+    _lines = new TreeMap<>();
   }
 
   @Override
@@ -24,11 +36,16 @@ public class IpCommunityListExpanded extends IpCommunityList {
     return visitor.visitIpCommunityListExpanded(this);
   }
 
+
   public @Nonnull List<StandardCommunity> getCommunities() {
     return _communities;
   }
 
   public @Nonnull LineAction getAction() {
     return _action;
+  }
+
+  public @Nonnull SortedMap<Long, IpCommunityListExpandedLine> getLines() {
+    return _lines;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
@@ -13,7 +13,7 @@ public class IpCommunityListExpanded extends IpCommunityList {
 
   private final LineAction _action;
   private final @Nonnull List<StandardCommunity> _communities;
-  private final @Nonnull SortedMap<Long, IpCommunityListExpandedLine> _lines;
+  private final @Nonnull SortedMap<String, IpCommunityListExpandedLine> _lines;
 
   public IpCommunityListExpanded(
       String name, LineAction action, List<StandardCommunity> communities) {
@@ -43,7 +43,7 @@ public class IpCommunityListExpanded extends IpCommunityList {
     return _action;
   }
 
-  public @Nonnull SortedMap<Long, IpCommunityListExpandedLine> getLines() {
+  public @Nonnull SortedMap<String, IpCommunityListExpandedLine> getLines() {
     return _lines;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
@@ -34,10 +34,6 @@ public class IpCommunityListExpanded extends IpCommunityList {
     return visitor.visitIpCommunityListExpanded(this);
   }
 
-  public @Nonnull List<StandardCommunity> getCommunities() {
-    return _communities;
-  }
-
   public @Nonnull LineAction getAction() {
     return _action;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
@@ -3,8 +3,6 @@ package org.batfish.representation.cumulus;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.bgp.community.StandardCommunity;

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpanded.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.cumulus;
 
 import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -13,7 +14,7 @@ public class IpCommunityListExpanded extends IpCommunityList {
 
   private final LineAction _action;
   private final @Nonnull List<StandardCommunity> _communities;
-  private final @Nonnull SortedMap<String, IpCommunityListExpandedLine> _lines;
+  private final @Nonnull List<IpCommunityListExpandedLine> _lines;
 
   public IpCommunityListExpanded(
       String name, LineAction action, List<StandardCommunity> communities) {
@@ -27,7 +28,7 @@ public class IpCommunityListExpanded extends IpCommunityList {
     super(name);
     _action = null;
     _communities = null;
-    _lines = new TreeMap<>();
+    _lines = new ArrayList<>();
   }
 
   @Override
@@ -43,7 +44,7 @@ public class IpCommunityListExpanded extends IpCommunityList {
     return _action;
   }
 
-  public @Nonnull SortedMap<String, IpCommunityListExpandedLine> getLines() {
+  public @Nonnull List<IpCommunityListExpandedLine> getLines() {
     return _lines;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpandedLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpandedLine.java
@@ -1,0 +1,35 @@
+package org.batfish.representation.cumulus;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.LineAction;
+
+/**
+ * A line of an {@link IpCommunityListExpanded}.
+ *
+ * <p>A route's community attribute string rendering must contain a substring matched by {@link
+ * #getRegex} to be matched by this line.
+ */
+public final class IpCommunityListExpandedLine implements Serializable {
+  private final @Nonnull LineAction _action;
+  private final @Nonnull String _regex;
+  private final long _line;
+
+  public IpCommunityListExpandedLine(LineAction action, long line, String regex) {
+    _action = action;
+    _line = line;
+    _regex = regex;
+  }
+
+  public @Nonnull LineAction getAction() {
+    return _action;
+  }
+
+  public @Nonnull String getRegex() {
+    return _regex;
+  }
+
+  public long getLine() {
+    return _line;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpandedLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListExpandedLine.java
@@ -13,11 +13,9 @@ import org.batfish.datamodel.LineAction;
 public final class IpCommunityListExpandedLine implements Serializable {
   private final @Nonnull LineAction _action;
   private final @Nonnull String _regex;
-  private final long _line;
 
-  public IpCommunityListExpandedLine(LineAction action, long line, String regex) {
+  public IpCommunityListExpandedLine(LineAction action, String regex) {
     _action = action;
-    _line = line;
     _regex = regex;
   }
 
@@ -27,9 +25,5 @@ public final class IpCommunityListExpandedLine implements Serializable {
 
   public @Nonnull String getRegex() {
     return _regex;
-  }
-
-  public long getLine() {
-    return _line;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListStandard.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListStandard.java
@@ -1,0 +1,28 @@
+package org.batfish.representation.cumulus;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+import javax.annotation.Nonnull;
+
+/**
+ * An access-list that matches a route's standard communities attribute against a set of literal
+ * standard communities.
+ */
+public final class IpCommunityListStandard extends IpCommunityList {
+
+  private final @Nonnull SortedMap<Long, IpCommunityListStandardLine> _lines;
+
+  public IpCommunityListStandard(String name) {
+    super(name);
+    _lines = new TreeMap<>();
+  }
+
+  @Override
+  public <T> T accept(IpCommunityListVisitor<T> visitor) {
+    return visitor.visitIpCommunityListStandard(this);
+  }
+
+  public @Nonnull SortedMap<Long, IpCommunityListStandardLine> getLines() {
+    return _lines;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListStandardLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListStandardLine.java
@@ -1,0 +1,37 @@
+package org.batfish.representation.cumulus;
+
+import java.io.Serializable;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.bgp.community.StandardCommunity;
+
+/**
+ * A line of an {@link IpCommunityListStandard}.
+ *
+ * <p>A route must contain every community from {@link #getCommunities} to be matched by this line.
+ */
+public final class IpCommunityListStandardLine implements Serializable {
+  private final @Nonnull LineAction _action;
+  private final @Nonnull Set<StandardCommunity> _communities;
+  private final long _line;
+
+  public IpCommunityListStandardLine(
+      LineAction action, long line, Set<StandardCommunity> communities) {
+    _action = action;
+    _line = line;
+    _communities = communities;
+  }
+
+  public @Nonnull LineAction getAction() {
+    return _action;
+  }
+
+  public @Nonnull Set<StandardCommunity> getCommunities() {
+    return _communities;
+  }
+
+  public long getLine() {
+    return _line;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/IpCommunityListVisitor.java
@@ -2,5 +2,8 @@ package org.batfish.representation.cumulus;
 
 /** A visitor of {@link IpCommunityList}. */
 public interface IpCommunityListVisitor<T> {
+
   T visitIpCommunityListExpanded(IpCommunityListExpanded ipCommunityListExpanded);
+
+  T visitIpCommunityListStandard(IpCommunityListStandard ipCommunityListStandard);
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapEntry.java
@@ -26,6 +26,7 @@ public final class RouteMapEntry implements Serializable {
   private @Nullable RouteMapSetAsPath _setAsPath;
   private @Nullable RouteMapSetMetric _setMetric;
   private @Nullable RouteMapSetIpNextHopLiteral _setIpNextHop;
+  private @Nullable RouteMapSetCommListDelete _setCommListDelete;
   private @Nullable RouteMapSetCommunity _setCommunity;
   private @Nullable RouteMapSetLocalPreference _setLocalPreference;
   private @Nullable RouteMapSetTag _setTag;
@@ -91,7 +92,7 @@ public final class RouteMapEntry implements Serializable {
   /** Return stream of set statements for this entry. */
   public @Nonnull Stream<RouteMapSet> getSets() {
     return Stream.of(
-            _setAsPath, _setMetric, _setIpNextHop, _setCommunity, _setLocalPreference, _setTag)
+            _setAsPath, _setCommListDelete, _setMetric, _setIpNextHop, _setCommunity, _setLocalPreference, _setTag)
         .filter(Objects::nonNull);
   }
 
@@ -105,6 +106,10 @@ public final class RouteMapEntry implements Serializable {
 
   public @Nullable RouteMapSetIpNextHopLiteral getSetIpNextHop() {
     return _setIpNextHop;
+  }
+
+  public @Nullable RouteMapSetCommListDelete getSetCommListDelete() {
+    return _setCommListDelete;
   }
 
   public @Nullable RouteMapSetCommunity getSetCommunity() {
@@ -142,6 +147,10 @@ public final class RouteMapEntry implements Serializable {
 
   public void setSetMetric(@Nullable RouteMapSetMetric setMetric) {
     _setMetric = setMetric;
+  }
+
+  public void setSetCommListDelete(@Nullable RouteMapSetCommListDelete setCommListDelete) {
+    _setCommListDelete = setCommListDelete;
   }
 
   public void setSetCommunity(@Nullable RouteMapSetCommunity setCommunity) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapEntry.java
@@ -92,7 +92,13 @@ public final class RouteMapEntry implements Serializable {
   /** Return stream of set statements for this entry. */
   public @Nonnull Stream<RouteMapSet> getSets() {
     return Stream.of(
-            _setAsPath, _setCommListDelete, _setMetric, _setIpNextHop, _setCommunity, _setLocalPreference, _setTag)
+            _setAsPath,
+            _setCommListDelete,
+            _setMetric,
+            _setIpNextHop,
+            _setCommunity,
+            _setLocalPreference,
+            _setTag)
         .filter(Objects::nonNull);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetCommListDelete.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetCommListDelete.java
@@ -4,13 +4,11 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.routing_policy.expr.LongExpr;
-import org.batfish.datamodel.routing_policy.statement.SetMetric;
-import org.batfish.datamodel.routing_policy.statement.Statement;
-import org.batfish.datamodel.routing_policy.communities.CommunitySetDifference;
 import org.batfish.datamodel.routing_policy.communities.CommunityMatchExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetDifference;
 import org.batfish.datamodel.routing_policy.communities.InputCommunities;
 import org.batfish.datamodel.routing_policy.communities.SetCommunities;
+import org.batfish.datamodel.routing_policy.statement.Statement;
 
 /** Clause of set comm-list delete in route map. */
 public class RouteMapSetCommListDelete implements RouteMapSet {
@@ -25,9 +23,9 @@ public class RouteMapSetCommListDelete implements RouteMapSet {
   @Override
   public Stream<Statement> toStatements(Configuration c, CumulusNodeConfiguration vc, Warnings w) {
     return Stream.of(
-            new SetCommunities(
-                    new CommunitySetDifference(
-                            InputCommunities.instance(), new CommunityMatchExprReference(_name))));
+        new SetCommunities(
+            new CommunitySetDifference(
+                InputCommunities.instance(), new CommunityMatchExprReference(_name))));
   }
 
   public @Nonnull String getName() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetCommListDelete.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetCommListDelete.java
@@ -1,0 +1,39 @@
+package org.batfish.representation.cumulus;
+
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.expr.LongExpr;
+//import org.batfish.datamodel.routing_policy.expr.NamedCommunitySet;
+//import org.batfish.datamodel.routing_policy.statement.DeleteCommunity;
+import org.batfish.datamodel.routing_policy.statement.SetMetric;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetDifference;
+import org.batfish.datamodel.routing_policy.communities.CommunityMatchExprReference;
+import org.batfish.datamodel.routing_policy.communities.InputCommunities;
+import org.batfish.datamodel.routing_policy.communities.SetCommunities;
+
+/** Clause of set comm-list delete in route map. */
+public class RouteMapSetCommListDelete implements RouteMapSet {
+
+  @Nonnull private final String _name;
+
+  public RouteMapSetCommListDelete(@Nonnull String name) {
+    _name = name;
+  }
+
+  @Nonnull
+  @Override
+  public Stream<Statement> toStatements(Configuration c, CumulusNodeConfiguration vc, Warnings w) {
+    //return Stream.of(new DeleteCommunity(new NamedCommunitySet(_name)));
+    return Stream.of(
+            new SetCommunities(
+                    new CommunitySetDifference(
+                            InputCommunities.instance(), new CommunityMatchExprReference(_name))));
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetCommListDelete.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapSetCommListDelete.java
@@ -5,8 +5,6 @@ import javax.annotation.Nonnull;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.routing_policy.expr.LongExpr;
-//import org.batfish.datamodel.routing_policy.expr.NamedCommunitySet;
-//import org.batfish.datamodel.routing_policy.statement.DeleteCommunity;
 import org.batfish.datamodel.routing_policy.statement.SetMetric;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetDifference;
@@ -26,7 +24,6 @@ public class RouteMapSetCommListDelete implements RouteMapSet {
   @Nonnull
   @Override
   public Stream<Statement> toStatements(Configuration c, CumulusNodeConfiguration vc, Warnings w) {
-    //return Stream.of(new DeleteCommunity(new NamedCommunitySet(_name)));
     return Stream.of(
             new SetCommunities(
                     new CommunitySetDifference(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
@@ -12,9 +12,9 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.hamcrest.Matchers.hasSize;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -391,23 +391,27 @@ public class CumulusConcatenatedGrammarTest {
   public void testSetCommListDelete() throws IOException {
     Ip origNextHopIp = Ip.parse("192.0.2.254");
     Bgpv4Route base =
-            Bgpv4Route.builder()
-                    .setAsPath(AsPath.ofSingletonAsSets(2L))
-                    .setOriginatorIp(Ip.ZERO)
-                    .setOriginType(OriginType.INCOMPLETE)
-                    .setProtocol(RoutingProtocol.BGP)
-                    .setNextHopIp(origNextHopIp)
-                    .setNetwork(Prefix.parse("10.20.30.0/31"))
-                    .setTag(0L)
-                    .build();
+        Bgpv4Route.builder()
+            .setAsPath(AsPath.ofSingletonAsSets(2L))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginType(OriginType.INCOMPLETE)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(origNextHopIp)
+            .setNetwork(Prefix.parse("10.20.30.0/31"))
+            .setTag(0L)
+            .build();
     Configuration c = parseConfig("set_comm_list_delete_test");
     Bgpv4Route inRoute =
-            base.toBuilder().setCommunities(ImmutableSet.of(StandardCommunity.of(1, 1),
+        base.toBuilder()
+            .setCommunities(
+                ImmutableSet.of(
+                    StandardCommunity.of(1, 1),
                     StandardCommunity.of(1, 2),
                     StandardCommunity.of(2, 1),
                     StandardCommunity.of(2, 2),
                     StandardCommunity.of(3, 1),
-                    StandardCommunity.of(3, 2))).build();
+                    StandardCommunity.of(3, 2)))
+            .build();
 
     RoutingPolicy rp1 = c.getRoutingPolicies().get("RM_EXPANDED_TEST_DELETE_ALL_COMMUNITIES");
     RoutingPolicy rp2 = c.getRoutingPolicies().get("RM_EXPANDED_TEST_DELETE_COMM_BEGIN_WITH_1");
@@ -417,12 +421,27 @@ public class CumulusConcatenatedGrammarTest {
     Bgpv4Route outputRoute2 = processRouteIn(rp2, inRoute);
     Bgpv4Route outputRoute3 = processRouteIn(rp3, inRoute);
     Bgpv4Route outputRoute4 = processRouteIn(rp4, inRoute);
-    assertThat(outputRoute1.getCommunities(),hasSize(0));
-    assertThat(outputRoute2.getCommunities(), contains(StandardCommunity.of(2, 1), StandardCommunity.of(2, 2),
-            StandardCommunity.of(3, 1), StandardCommunity.of(3, 2)));
-    assertThat(outputRoute3.getCommunities(), contains(StandardCommunity.of(1, 1), StandardCommunity.of(1, 2),
-            StandardCommunity.of(3, 1), StandardCommunity.of(3, 2)));
-    assertThat(outputRoute4.getCommunities(), contains(StandardCommunity.of(1, 1), StandardCommunity.of(1, 2),
-            StandardCommunity.of(2, 1), StandardCommunity.of(2, 2)));
+    assertThat(outputRoute1.getCommunities(), hasSize(0));
+    assertThat(
+        outputRoute2.getCommunities(),
+        contains(
+            StandardCommunity.of(2, 1),
+            StandardCommunity.of(2, 2),
+            StandardCommunity.of(3, 1),
+            StandardCommunity.of(3, 2)));
+    assertThat(
+        outputRoute3.getCommunities(),
+        contains(
+            StandardCommunity.of(1, 1),
+            StandardCommunity.of(1, 2),
+            StandardCommunity.of(3, 1),
+            StandardCommunity.of(3, 2)));
+    assertThat(
+        outputRoute4.getCommunities(),
+        contains(
+            StandardCommunity.of(1, 1),
+            StandardCommunity.of(1, 2),
+            StandardCommunity.of(2, 1),
+            StandardCommunity.of(2, 2)));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -32,8 +32,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.graph.ValueGraph;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -83,6 +85,7 @@ import org.batfish.representation.cumulus.CumulusConcatenatedConfiguration;
 import org.batfish.representation.cumulus.CumulusFrrConfiguration;
 import org.batfish.representation.cumulus.CumulusStructureType;
 import org.batfish.representation.cumulus.CumulusStructureUsage;
+import org.batfish.representation.cumulus.IpCommunityListExpandedLine;
 import org.batfish.representation.cumulus.FrrInterface;
 import org.batfish.representation.cumulus.InterfacesInterface;
 import org.batfish.representation.cumulus.IpAsPathAccessList;
@@ -921,15 +924,11 @@ public class CumulusFrrGrammarTest {
     IpCommunityListExpanded communityList =
         (IpCommunityListExpanded) _frr.getIpCommunityLists().get(name);
 
-    assertThat(
-        communityList.getCommunities(),
-        equalTo(
-            ImmutableList.of(
-                StandardCommunity.parse("10000:10"), StandardCommunity.parse("20000:20"))));
-
-    assertThat(
-        getDefinedStructureInfo(IP_COMMUNITY_LIST, name).getDefinitionLines(),
-        equalTo(ImmutableSet.of(1)));
+    List<IpCommunityListExpandedLine> expected = Lists.newArrayList(new IpCommunityListExpandedLine(LineAction.PERMIT, "10000:10 20000:20"));
+    List<IpCommunityListExpandedLine> actual = communityList.getLines();
+    assertThat(expected.size(), equalTo(actual.size()));
+    assertThat(expected.get(0).getAction(), equalTo(actual.get(0).getAction()));
+    assertThat(expected.get(0).getRegex(), equalTo(actual.get(0).getRegex()));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -35,7 +35,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.graph.ValueGraph;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -85,12 +84,12 @@ import org.batfish.representation.cumulus.CumulusConcatenatedConfiguration;
 import org.batfish.representation.cumulus.CumulusFrrConfiguration;
 import org.batfish.representation.cumulus.CumulusStructureType;
 import org.batfish.representation.cumulus.CumulusStructureUsage;
-import org.batfish.representation.cumulus.IpCommunityListExpandedLine;
 import org.batfish.representation.cumulus.FrrInterface;
 import org.batfish.representation.cumulus.InterfacesInterface;
 import org.batfish.representation.cumulus.IpAsPathAccessList;
 import org.batfish.representation.cumulus.IpAsPathAccessListLine;
 import org.batfish.representation.cumulus.IpCommunityListExpanded;
+import org.batfish.representation.cumulus.IpCommunityListExpandedLine;
 import org.batfish.representation.cumulus.IpPrefixList;
 import org.batfish.representation.cumulus.IpPrefixListLine;
 import org.batfish.representation.cumulus.OspfNetworkType;
@@ -924,7 +923,8 @@ public class CumulusFrrGrammarTest {
     IpCommunityListExpanded communityList =
         (IpCommunityListExpanded) _frr.getIpCommunityLists().get(name);
 
-    List<IpCommunityListExpandedLine> expected = Lists.newArrayList(new IpCommunityListExpandedLine(LineAction.PERMIT, "10000:10 20000:20"));
+    List<IpCommunityListExpandedLine> expected =
+        Lists.newArrayList(new IpCommunityListExpandedLine(LineAction.PERMIT, "10000:10 20000:20"));
     List<IpCommunityListExpandedLine> actual = communityList.getLines();
     assertThat(expected.size(), equalTo(actual.size()));
     assertThat(expected.get(0).getAction(), equalTo(actual.get(0).getAction()));

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -336,32 +336,6 @@ public final class CumulusConversionsTest {
     assertFalse(viList.permits(AsPath.ofSingletonAsSets(other)));
   }
 
-  // TODO: Fix up this test once standard community list is implemented.
-  // Coverage for expanded community-lists is available in CumulusConcatenatedGrammarTest.java.
-  /*
-  @Test
-  public void testToIpCommunityList() {
-    String name = "name";
-    IpCommunityListExpanded ipCommunityList =
-        new IpCommunityListExpanded(
-            name,
-            LineAction.PERMIT,
-            ImmutableList.of(StandardCommunity.of(10000, 1), StandardCommunity.of(20000, 2)));
-    CommunityList result = toCommunityList(ipCommunityList);
-    assertThat(
-        result,
-        equalTo(
-            new CommunityList(
-                name,
-                ImmutableList.of(
-                    new CommunityListLine(
-                        LineAction.PERMIT, new LiteralCommunity(StandardCommunity.of(10000, 1))),
-                    new CommunityListLine(
-                        LineAction.PERMIT, new LiteralCommunity(StandardCommunity.of(20000, 2)))),
-                false)));
-  }
-   */
-
   @Test
   public void testGetAcceptStatements() {
     BgpNeighbor bgpNeighbor = new BgpIpNeighbor("10.0.0.1");

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -29,7 +29,6 @@ import static org.batfish.representation.cumulus.CumulusConversions.resolveLocal
 import static org.batfish.representation.cumulus.CumulusConversions.suppressSummarizedPrefixes;
 import static org.batfish.representation.cumulus.CumulusConversions.toAsPathAccessList;
 import static org.batfish.representation.cumulus.CumulusConversions.toBgpProcess;
-import static org.batfish.representation.cumulus.CumulusConversions.toCommunityList;
 import static org.batfish.representation.cumulus.CumulusConversions.toOspfProcess;
 import static org.batfish.representation.cumulus.CumulusConversions.toRouteFilterLine;
 import static org.batfish.representation.cumulus.CumulusConversions.toRouteFilterList;
@@ -68,8 +67,6 @@ import org.batfish.datamodel.BgpUnnumberedPeerConfig;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Bgpv4Route.Builder;
 import org.batfish.datamodel.BumTransportMethod;
-import org.batfish.datamodel.CommunityList;
-import org.batfish.datamodel.CommunityListLine;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -339,6 +339,9 @@ public final class CumulusConversionsTest {
     assertFalse(viList.permits(AsPath.ofSingletonAsSets(other)));
   }
 
+  // TODO: Fix up this test once standard community list is implemented.
+  // Coverage for expanded community-lists is available in CumulusConcatenatedGrammarTest.java.
+  /*
   @Test
   public void testToIpCommunityList() {
     String name = "name";
@@ -360,6 +363,7 @@ public final class CumulusConversionsTest {
                         LineAction.PERMIT, new LiteralCommunity(StandardCommunity.of(20000, 2)))),
                 false)));
   }
+   */
 
   @Test
   public void testGetAcceptStatements() {

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/RouteMapMatchCommunityTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/RouteMapMatchCommunityTest.java
@@ -29,8 +29,8 @@ public class RouteMapMatchCommunityTest {
         .getIpCommunityLists()
         .putAll(
             ImmutableMap.of(
-                "M1", new IpCommunityListExpanded("M1", LineAction.PERMIT, ImmutableList.of()),
-                "M2", new IpCommunityListExpanded("M2", LineAction.PERMIT, ImmutableList.of())));
+                "M1", new IpCommunityListExpanded("M1", LineAction.PERMIT),
+                "M2", new IpCommunityListExpanded("M2", LineAction.PERMIT)));
     BooleanExpr result = match.toBooleanExpr(null, cumulusNcluConfiguration, null);
 
     assertThat(

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/set_comm_list_delete_test
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/set_comm_list_delete_test
@@ -1,0 +1,38 @@
+set_comm_list_delete_test
+# This file describes the network interfaces
+
+iface eth0
+ address 10.20.30.0/31
+
+### end /etc/network/interfaces
+
+# ports.conf --
+
+### start of frr.conf
+frr version
+agentx
+!
+router bgp 12345
+ bgp router-id 1.2.3.4
+ address-family ipv4 unicast
+  network 10.20.0.0/16
+ exit-address-family
+!
+! The input route for the test will have the following communities 1:1, 1:2, 2:1, 2:2, 3:1, 3:2
+ip community-list expanded test_expanded_delete_all_communities permit "[0-9]+:[0-9]+"
+ip community-list expanded test_expanded_delete_comm_begin_with_1 permit "1:.*"
+ip community-list expanded test_expanded_delete_comm_begin_with_2 permit "2:.*"
+ip community-list expanded test_expanded_delete_comm_begin_with_3 permit "3:.*"
+!
+route-map RM_EXPANDED_TEST_DELETE_ALL_COMMUNITIES permit 1
+ set comm-list test_expanded_delete_all_communities delete
+route-map RM_EXPANDED_TEST_DELETE_COMM_BEGIN_WITH_1 permit 1
+ set comm-list test_expanded_delete_comm_begin_with_1  delete
+route-map RM_EXPANDED_TEST_DELETE_COMM_BEGIN_WITH_2 permit 1
+ set comm-list test_expanded_delete_comm_begin_with_2  delete
+route-map RM_EXPANDED_TEST_DELETE_COMM_BEGIN_WITH_3 permit 1
+ set comm-list test_expanded_delete_comm_begin_with_3  delete
+!
+line vty
+!
+!### end frr.conf


### PR DESCRIPTION
Fix Cumulus model for extended community-lists. A community list should be a collection of lines, each with an action and set of communities.

Add support for "set comm-list delete" with expanded community-lists.
Add VI conversion for standard community-lists.

Minor refactor in UTs.