### PR TITLE
Some fixes to ease converting PacketHeaderConstraints to AclLineMatchExpr

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
@@ -66,6 +66,9 @@ public class BDDInteger {
 
   /** @param satAssignment a satisfying assignment (i.e. produced by fullSat, allSat, etc) */
   public Long satAssignmentToLong(BDD satAssignment) {
+    // TODO this check could be better (should be exactly 1 path from root to the one node).
+    checkArgument(!satAssignment.isZero(), "not a satisfying assignment");
+
     if (_bitvec.length > Long.SIZE) {
       throw new IllegalArgumentException(
           "Can't get a representative of a BDDInteger with more than Long.SIZE bits");

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -64,6 +64,7 @@ public class BDDPacket {
   private static final int IP_PROTOCOL_LENGTH = 8;
   private static final int PORT_LENGTH = 16;
   private static final int TCP_FLAG_LENGTH = 1;
+  private static final int PACKET_LENGTH_LENGTH = 16;
 
   private final Map<Integer, String> _bitNames;
   private final BDDFactory _factory;
@@ -78,6 +79,7 @@ public class BDDPacket {
   private final @Nonnull BDDIcmpCode _icmpCode;
   private final @Nonnull BDDIcmpType _icmpType;
   private final @Nonnull BDDIpProtocol _ipProtocol;
+  private final @Nonnull BDDPacketLength _packetLength;
   private final @Nonnull BDDInteger _srcIp;
   private final @Nonnull BDDInteger _srcPort;
   private final @Nonnull BDD _tcpAck;
@@ -129,7 +131,8 @@ public class BDDPacket {
             + TCP_FLAG_LENGTH * 8
             + DSCP_LENGTH
             + ECN_LENGTH
-            + FRAGMENT_OFFSET_LENGTH;
+            + FRAGMENT_OFFSET_LENGTH
+            + PACKET_LENGTH_LENGTH;
     if (_factory.varNum() < numNeeded) {
       _factory.setVarNum(numNeeded);
     }
@@ -154,6 +157,8 @@ public class BDDPacket {
     _dscp = allocateBDDInteger("dscp", DSCP_LENGTH, false);
     _ecn = allocateBDDInteger("ecn", ECN_LENGTH, false);
     _fragmentOffset = allocateBDDInteger("fragmentOffset", FRAGMENT_OFFSET_LENGTH, false);
+    _packetLength =
+        new BDDPacketLength(allocateBDDInteger("packetLength", PACKET_LENGTH_LENGTH, false));
 
     _pairing = _factory.makePair();
     _swapSourceAndDestinationPairing =
@@ -319,6 +324,11 @@ public class BDDPacket {
   @Nonnull
   public BDDIpProtocol getIpProtocol() {
     return _ipProtocol;
+  }
+
+  @Nonnull
+  public BDDPacketLength getPacketLength() {
+    return _packetLength;
   }
 
   @Nonnull

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -283,6 +283,7 @@ public class BDDPacket {
     fb.setDscp(_dscp.satAssignmentToLong(satAssignment).intValue());
     fb.setEcn(_ecn.satAssignmentToLong(satAssignment).intValue());
     fb.setFragmentOffset(_fragmentOffset.satAssignmentToLong(satAssignment).intValue());
+    fb.setPacketLength(_packetLength.satAssignmentToValue(satAssignment).intValue());
     return fb;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacketLength.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacketLength.java
@@ -15,21 +15,18 @@ public final class BDDPacketLength {
 
   /** @return a constraint that the packet length have the specified value. */
   public BDD value(int v) {
-    checkArgument(v >= 20, "Minimum packet length is 20");
     checkArgument(v <= 65535, "Maximum packet length is 65535");
     return _var.value(v);
   }
 
   /** @return a constraint that the packet length have the specified value. */
   public BDD geq(int v) {
-    checkArgument(v >= 20, "Minimum packet length is 20");
     checkArgument(v <= 65535, "Maximum packet length is 65535");
     return _var.geq(v);
   }
 
   /** @return a constraint that the packet length have the specified value. */
   public BDD leq(int v) {
-    checkArgument(v >= 20, "Minimum packet length is 20");
     checkArgument(v <= 65535, "Maximum packet length is 65535");
     return _var.leq(v);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacketLength.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacketLength.java
@@ -1,0 +1,60 @@
+package org.batfish.common.bdd;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import net.sf.javabdd.BDD;
+
+/** Symbolic packet length variable represented by a 16-bit {@link BDD}. */
+public final class BDDPacketLength {
+  private final BDDInteger _var;
+
+  public BDDPacketLength(BDDInteger var) {
+    checkArgument(var.getBitvec().length == 16, "Packet length field requires 16 bits");
+    _var = var;
+  }
+
+  /** @return a constraint that the packet length have the specified value. */
+  public BDD value(int v) {
+    checkArgument(v >= 20, "Minimum packet length is 20");
+    checkArgument(v <= 65535, "Maximum packet length is 65535");
+    return _var.value(v);
+  }
+
+  /** @return a constraint that the packet length have the specified value. */
+  public BDD geq(int v) {
+    checkArgument(v >= 20, "Minimum packet length is 20");
+    checkArgument(v <= 65535, "Maximum packet length is 65535");
+    return _var.geq(v);
+  }
+
+  /** @return a constraint that the packet length have the specified value. */
+  public BDD leq(int v) {
+    checkArgument(v >= 20, "Minimum packet length is 20");
+    checkArgument(v <= 65535, "Maximum packet length is 65535");
+    return _var.leq(v);
+  }
+
+  /** @return a constraint that the packet length be within the specified range. */
+  public BDD range(int low, int high) {
+    return geq(low).and(leq(high));
+  }
+
+  /**
+   * Extract the value from a satisfying assignment.
+   *
+   * @param satAssignment a satisfying assignment (i.e. produced by fullSat, allSat, etc)
+   */
+  public Long satAssignmentToValue(BDD satAssignment) {
+    // the sat assignment will be the minimum value of the original BDD. If the BDD did not
+    // constrain packet length, the sat assignment will have value 0, which is below the minimum
+    // value of 20. Rather than maintaining this minimum in every BDD (expensive), we do it here.
+    // Note that we can get weird behavior is clients constrain the underlying BDDs bits directly
+    // (i.e. without going through this class).
+    return Long.max(_var.satAssignmentToLong(satAssignment).intValue(), 20);
+  }
+
+  /** @return the {@link BDDInteger} backing this. */
+  public BDDInteger getBDDInteger() {
+    return _var;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpaceToFlow.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/HeaderSpaceToFlow.java
@@ -1,7 +1,5 @@
 package org.batfish.datamodel;
 
-import static org.batfish.datamodel.PacketHeaderConstraintsUtil.DEFAULT_PACKET_LENGTH;
-
 import java.util.Map;
 import java.util.Optional;
 import org.batfish.common.bdd.BDDFlowConstraintGenerator.FlowPreference;
@@ -18,16 +16,7 @@ public final class HeaderSpaceToFlow {
 
   /** Get a representative flow from a header space according to a flow preference. */
   public Optional<Flow.Builder> getRepresentativeFlow(HeaderSpace hs) {
-    int packetLength =
-        hs.getPacketLengths().stream()
-            .filter(l -> !l.isEmpty())
-            .findFirst()
-            .map(SubRange::getStart)
-            .orElse(DEFAULT_PACKET_LENGTH);
-
-    return BDD_PACKET
-        .getFlow(_headerSpaceToBDD.toBDD(hs), _preference)
-        .map(flowBuilder -> flowBuilder.setPacketLength(packetLength));
+    return BDD_PACKET.getFlow(_headerSpaceToBDD.toBDD(hs), _preference);
   }
 
   private static final BDDPacket BDD_PACKET = new BDDPacket();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraintsUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraintsUtil.java
@@ -46,7 +46,8 @@ public class PacketHeaderConstraintsUtil {
    * @param srcIpSpace Resolved source IP space
    * @param dstIpSpace Resolved destination IP space
    */
-  public static BDD toBDD(BDDPacket pkt, PacketHeaderConstraints phc, IpSpace srcIpSpace, IpSpace dstIpSpace) {
+  public static BDD toBDD(
+      BDDPacket pkt, PacketHeaderConstraints phc, IpSpace srcIpSpace, IpSpace dstIpSpace) {
     return toBDD(pkt, phc, ImmutableMap.of(), srcIpSpace, dstIpSpace);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraintsUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PacketHeaderConstraintsUtil.java
@@ -41,30 +41,33 @@ public class PacketHeaderConstraintsUtil {
   /**
    * Convert given {@link PacketHeaderConstraints} to a BDD
    *
+   * @param pkt the {@link BDDPacket} to use
    * @param phc the packet header constraints
    * @param srcIpSpace Resolved source IP space
    * @param dstIpSpace Resolved destination IP space
    */
-  public static BDD toBDD(PacketHeaderConstraints phc, IpSpace srcIpSpace, IpSpace dstIpSpace) {
-    return toBDD(phc, ImmutableMap.of(), srcIpSpace, dstIpSpace);
+  public static BDD toBDD(BDDPacket pkt, PacketHeaderConstraints phc, IpSpace srcIpSpace, IpSpace dstIpSpace) {
+    return toBDD(pkt, phc, ImmutableMap.of(), srcIpSpace, dstIpSpace);
   }
 
   /**
    * Convert given {@link PacketHeaderConstraints} to a BDD, also taking into account named IP
    * spaces
    *
+   * @param pkt the {@link BDDPacket} to use
    * @param phc the packet header constraints
    * @param namedIpSpaces map of named IP spaces
    * @param srcIpSpace Resolved source IP space
    * @param dstIpSpace Resolved destination IP space
    */
   public static BDD toBDD(
+      BDDPacket pkt,
       PacketHeaderConstraints phc,
       Map<String, IpSpace> namedIpSpaces,
       IpSpace srcIpSpace,
       IpSpace dstIpSpace) {
     HeaderSpace.Builder b = toHeaderSpaceBuilder(phc).setSrcIps(srcIpSpace).setDstIps(dstIpSpace);
-    return new HeaderSpaceToBDD(new BDDPacket(), namedIpSpaces).toBDD(b.build());
+    return new HeaderSpaceToBDD(pkt, namedIpSpaces).toBDD(b.build());
   }
 
   private static SortedSet<SubRange> extractSubranges(@Nullable IntegerSpace space) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketLengthTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketLengthTest.java
@@ -1,0 +1,34 @@
+package org.batfish.common.bdd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import net.sf.javabdd.BDD;
+import org.junit.Test;
+
+/** Test for {@link BDDPacketLength}. */
+public final class BDDPacketLengthTest {
+  private static final BDDPacket PKT = new BDDPacket();
+  private static final BDDPacketLength PKT_LEN = PKT.getPacketLength();
+
+  @Test
+  public void testSatAssignment() {
+    // unconstrained
+    {
+      BDD satAssignment = PKT.getFactory().one().fullSatOne();
+      assertThat(PKT_LEN.satAssignmentToValue(satAssignment), equalTo(20L));
+    }
+
+    // constrained to a single value
+    {
+      BDD satAssignment = PKT_LEN.value(100).fullSatOne();
+      assertThat(PKT_LEN.satAssignmentToValue(satAssignment), equalTo(100L));
+    }
+
+    // constrained to a range
+    {
+      BDD satAssignment = PKT_LEN.range(100, 200).fullSatOne();
+      assertThat(PKT_LEN.satAssignmentToValue(satAssignment), equalTo(100L));
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
@@ -1,5 +1,6 @@
 package org.batfish.common.bdd;
 
+import static org.batfish.datamodel.PacketHeaderConstraintsUtil.DEFAULT_PACKET_LENGTH;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasDstIp;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasDstPort;
 import static org.batfish.datamodel.matchers.FlowMatchers.hasIcmpCode;
@@ -17,6 +18,7 @@ import static org.batfish.datamodel.matchers.FlowMatchers.hasTcpFlagsUrg;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -141,6 +143,18 @@ public class BDDPacketTest {
     assertThat(flow, hasTcpFlagsPsh(tcpPsh));
     assertThat(flow, hasTcpFlagsRst(tcpRst));
     assertThat(flow, hasTcpFlagsUrg(tcpUrg));
+  }
+
+  @Test
+  public void testGetFlow_packetLength() {
+    BDDPacket pkt = new BDDPacket();
+
+    // getFlow prefers DEFAULT_PACKET_LENGTH
+    assertEquals(
+        DEFAULT_PACKET_LENGTH, pkt.getFlow(pkt.getFactory().one()).get().getPacketLength());
+
+    BDD bdd = pkt.getPacketLength().value(50);
+    assertEquals(50, pkt.getFlow(bdd).get().getPacketLength());
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/HeaderSpaceToFlowTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/HeaderSpaceToFlowTest.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel;
 
+import static org.batfish.datamodel.PacketHeaderConstraintsUtil.DEFAULT_PACKET_LENGTH;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -24,7 +25,7 @@ public class HeaderSpaceToFlowTest {
 
     assertTrue(flowBuilder.isPresent());
     assertThat(flowBuilder.get().getSrcIp(), equalTo(Ip.parse("1.2.3.4")));
-    assertThat(flowBuilder.get().getPacketLength(), equalTo(512));
+    assertThat(flowBuilder.get().getPacketLength(), equalTo(DEFAULT_PACKET_LENGTH));
   }
 
   @Test
@@ -57,7 +58,7 @@ public class HeaderSpaceToFlowTest {
 
     assertTrue(flowBuilder.isPresent());
     assertThat(flowBuilder.get().getSrcIp(), equalTo(Ip.parse("1.2.3.4")));
-    assertThat(flowBuilder.get().getPacketLength(), equalTo(512));
+    assertThat(flowBuilder.get().getPacketLength(), equalTo(DEFAULT_PACKET_LENGTH));
   }
 
   @Test
@@ -78,7 +79,7 @@ public class HeaderSpaceToFlowTest {
     assertThat(flowBuilder.get().getIpProtocol(), equalTo(IpProtocol.UDP));
     assertThat(flowBuilder.get().getDstPort(), equalTo(1));
     assertThat(flowBuilder.get().getSrcPort(), equalTo(2));
-    assertThat(flowBuilder.get().getPacketLength(), equalTo(512));
+    assertThat(flowBuilder.get().getPacketLength(), equalTo(DEFAULT_PACKET_LENGTH));
   }
 
   @Test
@@ -98,7 +99,7 @@ public class HeaderSpaceToFlowTest {
     assertThat(flowBuilder.get().getIpProtocol(), equalTo(IpProtocol.UDP));
     assertThat(flowBuilder.get().getDstPort(), equalTo(1));
     assertThat(flowBuilder.get().getSrcPort(), equalTo(2));
-    assertThat(flowBuilder.get().getPacketLength(), equalTo(512));
+    assertThat(flowBuilder.get().getPacketLength(), equalTo(DEFAULT_PACKET_LENGTH));
   }
 
   @Test
@@ -118,7 +119,7 @@ public class HeaderSpaceToFlowTest {
     assertThat(flowBuilder.get().getIpProtocol(), equalTo(IpProtocol.TCP));
     assertThat(flowBuilder.get().getDstPort(), equalTo(1));
     assertThat(flowBuilder.get().getSrcPort(), equalTo(2));
-    assertThat(flowBuilder.get().getPacketLength(), equalTo(512));
+    assertThat(flowBuilder.get().getPacketLength(), equalTo(DEFAULT_PACKET_LENGTH));
   }
 
   @Test
@@ -138,7 +139,7 @@ public class HeaderSpaceToFlowTest {
     assertThat(flowBuilder.get().getIpProtocol(), equalTo(IpProtocol.UDP));
     assertThat(flowBuilder.get().getDstPort(), equalTo(NamedPort.HTTP.number()));
     assertThat(flowBuilder.get().getSrcPort(), equalTo(2));
-    assertThat(flowBuilder.get().getPacketLength(), equalTo(512));
+    assertThat(flowBuilder.get().getPacketLength(), equalTo(DEFAULT_PACKET_LENGTH));
   }
 
   @Test
@@ -158,7 +159,7 @@ public class HeaderSpaceToFlowTest {
     assertThat(flowBuilder.get().getIpProtocol(), equalTo(IpProtocol.UDP));
     assertThat(flowBuilder.get().getDstPort(), equalTo(1));
     assertThat(flowBuilder.get().getSrcPort(), equalTo(NamedPort.EPHEMERAL_LOWEST.number()));
-    assertThat(flowBuilder.get().getPacketLength(), equalTo(512));
+    assertThat(flowBuilder.get().getPacketLength(), equalTo(DEFAULT_PACKET_LENGTH));
   }
 
   @Test
@@ -175,8 +176,6 @@ public class HeaderSpaceToFlowTest {
     assertTrue(flowBuilder.isPresent());
     assertThat(flowBuilder.get().getDstIp(), equalTo(Ip.parse("1.1.1.1")));
     assertThat(flowBuilder.get().getIpProtocol(), equalTo(IpProtocol.ICMP));
-    assertThat(flowBuilder.get().getDstPort(), equalTo(0));
-    assertThat(flowBuilder.get().getSrcPort(), equalTo(0));
-    assertThat(flowBuilder.get().getPacketLength(), equalTo(512));
+    assertThat(flowBuilder.get().getPacketLength(), equalTo(DEFAULT_PACKET_LENGTH));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
@@ -74,9 +74,6 @@ public class PacketHeaderConstraintsUtilTest {
         PacketHeaderConstraints.builder()
             .setApplications(ImmutableSet.of(Protocol.SSH, Protocol.DNS))
             .build();
-    System.out.println(
-        PacketHeaderConstraintsUtil.toAclLineMatchExpr(
-            phc, UniverseIpSpace.INSTANCE, UniverseIpSpace.INSTANCE));
     assertThat(
         PacketHeaderConstraintsUtil.toBDD(
             packet, phc, UniverseIpSpace.INSTANCE, UniverseIpSpace.INSTANCE),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import net.sf.javabdd.BDD;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.datamodel.Flow.Builder;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -63,7 +64,8 @@ public class PacketHeaderConstraintsUtilTest {
         equalTo(packet.getFactory().one()));
   }
 
-  @Test
+  /** Known bug with current conversion from PacketHeaderConstraints to HeaderSpace. */
+  @Ignore
   public void testApplications() {
     BDDPacket packet = new BDDPacket();
     BDD ssh = packet.getIpProtocol().value(IpProtocol.TCP).and(packet.getDstPort().value(22));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
@@ -66,6 +66,7 @@ public class PacketHeaderConstraintsUtilTest {
 
   /** Known bug with current conversion from PacketHeaderConstraints to HeaderSpace. */
   @Ignore
+  @Test
   public void testApplications() {
     BDDPacket packet = new BDDPacket();
     BDD ssh = packet.getIpProtocol().value(IpProtocol.TCP).and(packet.getDstPort().value(22));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Collections;
+import net.sf.javabdd.BDD;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.datamodel.Flow.Builder;
 import org.junit.Rule;
@@ -60,6 +61,24 @@ public class PacketHeaderConstraintsUtilTest {
             UniverseIpSpace.INSTANCE,
             UniverseIpSpace.INSTANCE),
         equalTo(packet.getFactory().one()));
+  }
+
+  @Test
+  public void testApplications() {
+    BDDPacket packet = new BDDPacket();
+    BDD ssh = packet.getIpProtocol().value(IpProtocol.TCP).and(packet.getDstPort().value(22));
+    BDD dns = packet.getIpProtocol().value(IpProtocol.UDP).and(packet.getDstPort().value(53));
+    PacketHeaderConstraints phc =
+        PacketHeaderConstraints.builder()
+            .setApplications(ImmutableSet.of(Protocol.SSH, Protocol.DNS))
+            .build();
+    System.out.println(
+        PacketHeaderConstraintsUtil.toAclLineMatchExpr(
+            phc, UniverseIpSpace.INSTANCE, UniverseIpSpace.INSTANCE));
+    assertThat(
+        PacketHeaderConstraintsUtil.toBDD(
+            packet, phc, UniverseIpSpace.INSTANCE, UniverseIpSpace.INSTANCE),
+        equalTo(ssh.or(dns)));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsUtilTest.java
@@ -55,6 +55,7 @@ public class PacketHeaderConstraintsUtilTest {
     BDDPacket packet = new BDDPacket();
     assertThat(
         PacketHeaderConstraintsUtil.toBDD(
+            packet,
             PacketHeaderConstraints.unconstrained(),
             UniverseIpSpace.INSTANCE,
             UniverseIpSpace.INSTANCE),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -2570,10 +2570,10 @@ public final class CiscoNxosGrammarTest {
               .collect(ImmutableList.toImmutableList()),
           contains(
               toBDD(matchPacketLength(100)),
-              toBDD(matchPacketLength(IntegerSpace.of(Range.closed(0, 199)))),
+              toBDD(matchPacketLength(IntegerSpace.of(Range.closed(20, 199)))),
               toBDD(
                   matchPacketLength(
-                      IntegerSpace.of(Range.closed(300, Integer.MAX_VALUE))
+                      IntegerSpace.of(Range.closed(301, Integer.MAX_VALUE))
                           .intersection(PACKET_LENGTH_RANGE))),
               toBDD(matchPacketLength(PACKET_LENGTH_RANGE.difference(IntegerSpace.of(400)))),
               toBDD(matchPacketLength(IntegerSpace.of(Range.closed(500, 600))))));


### PR DESCRIPTION
PacketHeaderConstraints currently converts to HeaderSpace, which has limited expressiveness (e.g. you can't express "SSH or DNS"). These changes pave the way for us to convert PHCs to AclLineMatchExprs, which can express anything.

cc @yifeiyuan 