### PR TITLE
Add getNodeName to Location

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceLinkLocation.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceLinkLocation.java
@@ -46,6 +46,7 @@ public final class InterfaceLinkLocation implements Location {
     return _interfaceName;
   }
 
+  @Override
   @JsonProperty(PROP_NODE_NAME)
   @Nonnull
   public String getNodeName() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceLocation.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceLocation.java
@@ -27,6 +27,7 @@ public final class InterfaceLocation implements Location {
     return _interfaceName;
   }
 
+  @Override
   @JsonProperty(PROP_NODE_NAME)
   public @Nonnull String getNodeName() {
     return _nodeName;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/Location.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/Location.java
@@ -1,6 +1,7 @@
 package org.batfish.specifier;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.Nonnull;
 
 /**
  * Identifies a single location in the network -- an VRF, an interface, the link of an interface,
@@ -10,4 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 public interface Location {
   <T> T accept(LocationVisitor<T> visitor);
+
+  @Nonnull
+  String getNodeName();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationVisitor.java
@@ -8,19 +8,4 @@ public interface LocationVisitor<T> {
   T visitInterfaceLinkLocation(InterfaceLinkLocation interfaceLinkLocation);
 
   T visitInterfaceLocation(InterfaceLocation interfaceLocation);
-
-  /** A visitor that returns true if the location is on {@code node} */
-  static LocationVisitor<Boolean> onNode(String node) {
-    return new LocationVisitor<Boolean>() {
-      @Override
-      public Boolean visitInterfaceLinkLocation(InterfaceLinkLocation interfaceLinkLocation) {
-        return interfaceLinkLocation.getNodeName().equals(node);
-      }
-
-      @Override
-      public Boolean visitInterfaceLocation(InterfaceLocation interfaceLocation) {
-        return interfaceLocation.getNodeName().equals(node);
-      }
-    };
-  }
 }

--- a/projects/question/src/main/java/org/batfish/question/FilterQuestionUtils.java
+++ b/projects/question/src/main/java/org/batfish/question/FilterQuestionUtils.java
@@ -121,7 +121,7 @@ public final class FilterQuestionUtils {
         };
 
     return startLocationSpecifier.resolve(specifierContext).stream()
-        .filter(LocationVisitor.onNode(node)::visit)
+        .filter(loc -> loc.getNodeName().equals(node))
         .map(locationToSource::visit)
         .collect(ImmutableSet.toImmutableSet());
   }

--- a/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testfilters/TestFiltersAnswerer.java
@@ -50,7 +50,6 @@ import org.batfish.specifier.InferFromLocationIpSpaceSpecifier;
 import org.batfish.specifier.IpSpaceAssignment;
 import org.batfish.specifier.IpSpaceAssignment.Entry;
 import org.batfish.specifier.Location;
-import org.batfish.specifier.LocationVisitor;
 import org.batfish.specifier.SpecifierContext;
 import org.batfish.specifier.SpecifierFactories;
 
@@ -111,7 +110,7 @@ public class TestFiltersAnswerer extends Answerer {
     String node = c.getHostname();
     Set<Location> srcLocations =
         question.getStartLocationSpecifier().resolve(context).stream()
-            .filter(LocationVisitor.onNode(node)::visit)
+            .filter(loc -> loc.getNodeName().equals(node))
             .collect(Collectors.toSet());
 
     ImmutableSortedSet.Builder<Flow> setBuilder = ImmutableSortedSet.naturalOrder();


### PR DESCRIPTION
Allows for easy removal of `LocationVisitor` method `onNode`.