### PR TITLE
introduce LocationInfo

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -40,6 +40,8 @@ import org.batfish.question.multipath.MultipathConsistencyParameters;
 import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationInfo;
 import org.batfish.specifier.SpecifierContext;
 
 public interface IBatfish extends IPluginConsumer {
@@ -66,6 +68,11 @@ public interface IBatfish extends IPluginConsumer {
   DataPlaneAnswerElement computeDataPlane(NetworkSnapshot snapshot);
 
   boolean debugFlagEnabled(String flag);
+
+  /**
+   * Return the {@link LocationInfo} of each {@link Location} in the {@link NetworkSnapshot}.
+   */
+  Map<Location, LocationInfo> getLocationInfo(NetworkSnapshot snapshot);
 
   ReferenceLibrary getReferenceLibraryData();
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -69,9 +69,7 @@ public interface IBatfish extends IPluginConsumer {
 
   boolean debugFlagEnabled(String flag);
 
-  /**
-   * Return the {@link LocationInfo} of each {@link Location} in the {@link NetworkSnapshot}.
-   */
+  /** Return the {@link LocationInfo} of each {@link Location} in the {@link NetworkSnapshot}. */
   Map<Location, LocationInfo> getLocationInfo(NetworkSnapshot snapshot);
 
   ReferenceLibrary getReferenceLibraryData();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AclIpSpace.java
@@ -132,6 +132,8 @@ public class AclIpSpace extends IpSpace {
       return null;
     } else if (ipSpace2 == null) {
       return ipSpace1;
+    } else if (EmptyIpSpace.INSTANCE.equals(ipSpace1)) {
+      return EmptyIpSpace.INSTANCE;
     }
     return builder()
         .thenRejecting(ipSpace2)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Prefix.java
@@ -32,6 +32,19 @@ public final class Prefix implements Comparable<Prefix>, Serializable {
   /** Multicast IPs are in "244.0.0.0/4". */
   public static final Prefix MULTICAST = create(Ip.parse("224.0.0.0"), 4);
 
+  /**
+   * /32s are loopback interfaces -- no hosts are connected.
+   *
+   * <p>/31s are point-to-point connections between nodes -- again, no hosts.
+   *
+   * <p>/30s could have hosts, but usually do not. Historically, each subnet was required to reserve
+   * two addresses: one identifying the network itself, and a broadcast address. This made /31s
+   * invalid, since there were no usable IPs left over. A /30 had 2 usable IPs, so was used for
+   * point-to-point connections. Eventually /31s were allowed, but we assume here that any /30s are
+   * hold-over point-to-point connections in the legacy model.
+   */
+  public static final int HOST_SUBNET_MAX_PREFIX_LENGTH = 29;
+
   private static long wildcardMaskForPrefixLength(int prefixLength) {
     assert 0 <= prefixLength && prefixLength <= Prefix.MAX_PREFIX_LENGTH;
     return (1L << (Prefix.MAX_PREFIX_LENGTH - prefixLength)) - 1;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InferFromLocationIpSpaceSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InferFromLocationIpSpaceSpecifier.java
@@ -1,11 +1,6 @@
 package org.batfish.specifier;
 
 import java.util.Set;
-import java.util.stream.Collectors;
-import javax.annotation.Nullable;
-import org.batfish.datamodel.AclIpSpace;
-import org.batfish.datamodel.ConcreteInterfaceAddress;
-import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.IpSpace;
 
 /**
@@ -14,72 +9,14 @@ import org.batfish.datamodel.IpSpace;
 public final class InferFromLocationIpSpaceSpecifier implements IpSpaceSpecifier {
   public static final InferFromLocationIpSpaceSpecifier INSTANCE =
       new InferFromLocationIpSpaceSpecifier();
-  /**
-   * /32s are loopback interfaces -- no hosts are connected.
-   *
-   * <p>/31s are point-to-point connections between nodes -- again, no hosts.
-   *
-   * <p>/30s could have hosts, but usually do not. Historically, each subnet was required to reserve
-   * two addresses: one identifying the network itself, and a broadcast address. This made /31s
-   * invalid, since there were no usable IPs left over. A /30 had 2 usable IPs, so was used for
-   * point-to-point connections. Eventually /31s were allowed, but we assume here that any /30s are
-   * hold-over point-to-point connections in the legacy model.
-   */
-  private static final int HOST_SUBNET_MAX_PREFIX_LENGTH = 29;
-
-  /** A {@link LocationVisitor} that returns the {@link IpSpace} owned by that {@link Location}. */
-  class IpSpaceLocationVisitor implements LocationVisitor<IpSpace> {
-    private final SpecifierContext _specifierContext;
-
-    IpSpaceLocationVisitor(SpecifierContext specifierContext) {
-      _specifierContext = specifierContext;
-    }
-
-    private Set<ConcreteInterfaceAddress> interfaceAddresses(String node, String iface) {
-      return _specifierContext
-          .getConfigs()
-          .get(node)
-          .getAllInterfaces()
-          .get(iface)
-          .getAllConcreteAddresses();
-    }
-
-    @Override
-    public IpSpace visitInterfaceLinkLocation(InterfaceLinkLocation interfaceLinkLocation) {
-      String node = interfaceLinkLocation.getNodeName();
-      String iface = interfaceLinkLocation.getInterfaceName();
-
-      @Nullable
-      IpSpace linkIpSpace =
-          AclIpSpace.union(
-              interfaceAddresses(node, iface).stream()
-                  /*
-                   * Only include addresses on networks that might have hosts.
-                   */
-                  .filter(address -> address.getNetworkBits() <= HOST_SUBNET_MAX_PREFIX_LENGTH)
-                  .map(address -> address.getPrefix().toHostIpSpace())
-                  .collect(Collectors.toList()));
-
-      return linkIpSpace == null
-          ? EmptyIpSpace.INSTANCE
-          : AclIpSpace.difference(linkIpSpace, _specifierContext.getSnapshotDeviceOwnedIps());
-    }
-
-    @Override
-    public IpSpace visitInterfaceLocation(InterfaceLocation interfaceLocation) {
-      return _specifierContext.getInterfaceOwnedIps(
-          interfaceLocation.getNodeName(), interfaceLocation.getInterfaceName());
-    }
-  }
 
   private InferFromLocationIpSpaceSpecifier() {}
 
   @Override
   public IpSpaceAssignment resolve(Set<Location> locations, SpecifierContext ctxt) {
-    IpSpaceLocationVisitor ipSpaceLocationVisitor = new IpSpaceLocationVisitor(ctxt);
     IpSpaceAssignment.Builder builder = IpSpaceAssignment.builder();
     locations.forEach(
-        location -> builder.assign(location, location.accept(ipSpaceLocationVisitor)));
+        location -> builder.assign(location, ctxt.getLocationInfo(location).getSourceIps()));
     return builder.build();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/Location.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/Location.java
@@ -1,8 +1,8 @@
 package org.batfish.specifier;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import org.batfish.datamodel.Interface;
 import javax.annotation.Nonnull;
+import org.batfish.datamodel.Interface;
 
 /**
  * Identifies a single location in the network -- an VRF, an interface, the link of an interface,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/Location.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/Location.java
@@ -1,6 +1,7 @@
 package org.batfish.specifier;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.batfish.datamodel.Interface;
 
 /**
  * Identifies a single location in the network -- an VRF, an interface, the link of an interface,
@@ -10,4 +11,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 public interface Location {
   <T> T accept(LocationVisitor<T> visitor);
+
+  static InterfaceLocation interfaceLocation(Interface iface) {
+    return new InterfaceLocation(iface.getOwner().getHostname(), iface.getName());
+  }
+
+  static InterfaceLinkLocation interfaceLinkLocation(Interface iface) {
+    return new InterfaceLinkLocation(iface.getOwner().getHostname(), iface.getName());
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfo.java
@@ -1,0 +1,48 @@
+package org.batfish.specifier;
+
+import org.batfish.datamodel.IpSpace;
+
+/** Information about whether/how to treat a location as a source or sink of traffic. */
+public final class LocationInfo {
+  private final boolean _isSource;
+  private final IpSpace _sourceIps;
+  private final IpSpace _arpIps;
+
+  public LocationInfo(boolean isSource, IpSpace sourceIps, IpSpace arpIps) {
+    _isSource = isSource;
+    _sourceIps = sourceIps;
+    _arpIps = arpIps;
+  }
+
+  /**
+   * Whether a location should be considered a source of traffic in batfish analyses. When false,
+   * the user can still explicitly specify to use the location as a source.
+   *
+   * <p>For example, this might be false for an infrastructure interface, since most of the time the
+   * user wants to analyze end-to-end network behavior. However, they can still explicitly source
+   * traffic from that location, which can be useful for debugging in some cases.
+   */
+  public boolean isSource() {
+    return _isSource;
+  }
+
+  /**
+   * The set of IP addresses to use as source IPs for flows originating from the location by
+   * default, when the location is used as a source of traffic. Users can override this via question
+   * parameters. For non-sources, these IPs will be used when the user explicitly specifies to use
+   * the location as a source but does not explicitly specify the source IPs to use.
+   */
+  public IpSpace getSourceIps() {
+    return _sourceIps;
+  }
+
+  /**
+   * For {@link InterfaceLinkLocation} only. Used for disposition assignment when a flow terminates
+   * at an {@link InterfaceLinkLocation}. Batfish will give a successful disposition for these IPs,
+   * as if ARP resolution indicates the presence of a device listening on that address at that
+   * location, without modeling the device itself.
+   */
+  public IpSpace getArpIps() {
+    return _arpIps;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfoUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfoUtils.java
@@ -1,0 +1,31 @@
+package org.batfish.specifier;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.batfish.datamodel.Prefix.HOST_SUBNET_MAX_PREFIX_LENGTH;
+
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.AclIpSpace;
+import org.batfish.datamodel.EmptyIpSpace;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.IpSpace;
+
+/** Utility methods for constructing {@link LocationInfo}. */
+public final class LocationInfoUtils {
+  private LocationInfoUtils() {}
+
+  @Nonnull
+  public static IpSpace connectedSubnetIps(Interface iface) {
+
+    return firstNonNull(
+        AclIpSpace.union(
+            iface.getAllConcreteAddresses().stream()
+                /*
+                 * Only include addresses on networks that might have hosts.
+                 */
+                .filter(address -> address.getNetworkBits() <= HOST_SUBNET_MAX_PREFIX_LENGTH)
+                .map(address -> address.getPrefix().toHostIpSpace())
+                .collect(Collectors.toList())),
+        EmptyIpSpace.INSTANCE);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
@@ -1,13 +1,10 @@
 package org.batfish.specifier;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.EmptyIpSpace;
-import org.batfish.datamodel.IpSpace;
 import org.batfish.referencelibrary.ReferenceBook;
 import org.batfish.role.NodeRoleDimension;
 
@@ -31,24 +28,7 @@ public interface SpecifierContext {
   Optional<NodeRoleDimension> getNodeRoleDimension(@Nullable String dimension);
 
   /**
-   * @return the {@link IpSpace}s owned by each interface in the network. Mapping: hostname -&gt;
-   *     interface name -&gt; IpSpace.
-   */
-  Map<String, Map<String, IpSpace>> getInterfaceOwnedIps();
-
-  /**
-   * Get the {@link IpSpace} owned by the input interface.
    *
-   * @param hostname The node the interface belongs to.
-   * @param iface The name of the interface.
-   * @return The {@link IpSpace} owned by the interface.
    */
-  default IpSpace getInterfaceOwnedIps(String hostname, String iface) {
-    return getInterfaceOwnedIps()
-        .getOrDefault(hostname, ImmutableMap.of())
-        .getOrDefault(iface, EmptyIpSpace.INSTANCE);
-  }
-
-  /** @return the {@link IpSpace} of IP addresses owned any device in the network. */
-  IpSpace getSnapshotDeviceOwnedIps();
+  LocationInfo getLocationInfo(Location location);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContext.java
@@ -27,8 +27,6 @@ public interface SpecifierContext {
   @Nonnull
   Optional<NodeRoleDimension> getNodeRoleDimension(@Nullable String dimension);
 
-  /**
-   *
-   */
+  /** */
   LocationInfo getLocationInfo(Location location);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContextImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/SpecifierContextImpl.java
@@ -1,19 +1,11 @@
 package org.batfish.specifier;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.common.topology.IpOwners;
-import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.EmptyIpSpace;
-import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpSpace;
 import org.batfish.referencelibrary.ReferenceBook;
 import org.batfish.role.NodeRoleDimension;
 
@@ -23,28 +15,12 @@ public class SpecifierContextImpl implements SpecifierContext {
 
   private final @Nonnull Map<String, Configuration> _configs;
 
-  private final @Nonnull Map<String, Map<String, IpSpace>> _interfaceOwnedIps;
-
-  private final @Nonnull IpSpace _snapshotDeviceOwnedIps;
+  private final Map<Location, LocationInfo> _locationInfo;
 
   public SpecifierContextImpl(@Nonnull IBatfish batfish, @Nonnull NetworkSnapshot networkSnapshot) {
     _batfish = batfish;
     _configs = _batfish.loadConfigurations(networkSnapshot);
-    IpOwners ipOwners = _batfish.getTopologyProvider().getIpOwners(networkSnapshot);
-
-    /* Include inactive interfaces here so their IPs are considered part of the network (even though
-     * they are unreachable). This means when ARP fails for those IPs we'll use NEIGHBOR_UNREACHABLE
-     * or INSUFFICIENT_INFO dispositions rather than DELIVERED_TO_SUBNET or EXITS_NETWORK.
-     */
-    _snapshotDeviceOwnedIps =
-        firstNonNull(
-            AclIpSpace.union(
-                ipOwners.getAllDeviceOwnedIps().keySet().stream()
-                    .map(Ip::toIpSpace)
-                    .collect(Collectors.toList())),
-            EmptyIpSpace.INSTANCE);
-
-    _interfaceOwnedIps = ipOwners.getInterfaceOwnedIpSpaces();
+    _locationInfo = _batfish.getLocationInfo(networkSnapshot);
   }
 
   @Nonnull
@@ -64,15 +40,8 @@ public class SpecifierContextImpl implements SpecifierContext {
     return _batfish.getNodeRoleDimension(dimension);
   }
 
-  @Nonnull
   @Override
-  public Map<String, Map<String, IpSpace>> getInterfaceOwnedIps() {
-    return _interfaceOwnedIps;
-  }
-
-  @Override
-  @Nonnull
-  public IpSpace getSnapshotDeviceOwnedIps() {
-    return _snapshotDeviceOwnedIps;
+  public LocationInfo getLocationInfo(Location location) {
+    return _locationInfo.get(location);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledInputValidator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledInputValidator.java
@@ -15,14 +15,14 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.CompletionMetadata;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
-import org.batfish.datamodel.EmptyIpSpace;
-import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.answers.InputValidationNotes;
 import org.batfish.datamodel.answers.InputValidationNotes.Validity;
 import org.batfish.referencelibrary.ReferenceBook;
 import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationInfo;
 import org.batfish.specifier.SpecifierContext;
 import org.parboiled.Rule;
 import org.parboiled.errors.InvalidInputError;
@@ -91,13 +91,8 @@ public final class ParboiledInputValidator {
     }
 
     @Override
-    public Map<String, Map<String, IpSpace>> getInterfaceOwnedIps() {
-      return ImmutableMap.of();
-    }
-
-    @Override
-    public IpSpace getSnapshotDeviceOwnedIps() {
-      return EmptyIpSpace.INSTANCE;
+    public LocationInfo getLocationInfo(Location location) {
+      throw new UnsupportedOperationException();
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -51,6 +51,8 @@ import org.batfish.question.multipath.MultipathConsistencyParameters;
 import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRoleDimension;
 import org.batfish.role.NodeRolesData;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationInfo;
 import org.batfish.specifier.SpecifierContext;
 import org.batfish.specifier.SpecifierContextImpl;
 
@@ -189,6 +191,11 @@ public class IBatfishTestAdapter implements IBatfish {
 
   @Override
   public boolean debugFlagEnabled(String flag) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Map<Location, LocationInfo> getLocationInfo(NetworkSnapshot snapshot) {
     throw new UnsupportedOperationException();
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/MockSpecifierContext.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/MockSpecifierContext.java
@@ -7,9 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
-import org.batfish.common.topology.IpOwners;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.IpSpace;
 import org.batfish.referencelibrary.ReferenceBook;
 import org.batfish.role.NodeRoleDimension;
 
@@ -19,33 +17,19 @@ public class MockSpecifierContext implements SpecifierContext {
     return new Builder();
   }
 
-  @Nonnull
-  public Map<String, Map<String, IpSpace>> get_interfaceOwnedIps() {
-    return _interfaceOwnedIps;
-  }
-
   public static final class Builder {
     private @Nonnull SortedSet<ReferenceBook> _referenceBooks = ImmutableSortedSet.of();
 
     private @Nonnull Map<String, Configuration> _configs = ImmutableMap.of();
 
-    private @Nonnull Map<String, Map<String, IpSpace>> _interfaceOwnedIps = ImmutableMap.of();
-
     private @Nonnull SortedSet<NodeRoleDimension> _nodeRoleDimensions = ImmutableSortedSet.of();
 
-    private @Nonnull IpSpace _snapshotOwnedIps;
-
-    private @Nonnull Map<String, Map<String, IpSpace>> _vrfOwnedIps = ImmutableMap.of();
+    private @Nonnull Map<Location, LocationInfo> _locationInfo = ImmutableMap.of();
 
     private Builder() {}
 
     public Builder setConfigs(Map<String, Configuration> configs) {
       _configs = ImmutableMap.copyOf(configs);
-      return this;
-    }
-
-    public Builder setInterfaceOwnedIps(Map<String, Map<String, IpSpace>> interfaceOwnedIps) {
-      _interfaceOwnedIps = interfaceOwnedIps;
       return this;
     }
 
@@ -59,40 +43,29 @@ public class MockSpecifierContext implements SpecifierContext {
       return this;
     }
 
-    public Builder setSnapshotOwnedIps(IpSpace snapshotOwnedIps) {
-      _snapshotOwnedIps = snapshotOwnedIps;
-      return this;
-    }
-
-    public Builder setVrfOwnedIps(Map<String, Map<String, IpSpace>> vrfOwnedIps) {
-      _vrfOwnedIps = vrfOwnedIps;
+    public Builder setLocationInfo(Map<Location, LocationInfo> locationInfo) {
+      _locationInfo = ImmutableMap.copyOf(locationInfo);
       return this;
     }
 
     public MockSpecifierContext build() {
-      if (_interfaceOwnedIps.isEmpty() & !_configs.isEmpty()) {
-        _interfaceOwnedIps = new IpOwners(_configs).getInterfaceOwnedIpSpaces();
-      }
       return new MockSpecifierContext(this);
     }
   }
 
   private final @Nonnull Map<String, Configuration> _configs;
 
-  private final @Nonnull Map<String, Map<String, IpSpace>> _interfaceOwnedIps;
-
   private final @Nonnull SortedSet<NodeRoleDimension> _nodeRoleDimensions;
 
   private final @Nonnull SortedSet<ReferenceBook> _referenceBooks;
 
-  private final @Nonnull IpSpace _snapshotOwnedIps;
+  private final @Nonnull Map<Location, LocationInfo> _locationInfo;
 
   private MockSpecifierContext(Builder builder) {
     _referenceBooks = builder._referenceBooks;
     _configs = builder._configs;
-    _interfaceOwnedIps = builder._interfaceOwnedIps;
     _nodeRoleDimensions = builder._nodeRoleDimensions;
-    _snapshotOwnedIps = builder._snapshotOwnedIps;
+    _locationInfo = builder._locationInfo;
   }
 
   @Override
@@ -103,19 +76,13 @@ public class MockSpecifierContext implements SpecifierContext {
 
   @Override
   @Nonnull
-  public Map<String, Map<String, IpSpace>> getInterfaceOwnedIps() {
-    return _interfaceOwnedIps;
-  }
-
-  @Override
-  public IpSpace getSnapshotDeviceOwnedIps() {
-    return _snapshotOwnedIps;
-  }
-
-  @Override
-  @Nonnull
   public Optional<NodeRoleDimension> getNodeRoleDimension(String dimension) {
     return _nodeRoleDimensions.stream().filter(dim -> dim.getName().equals(dimension)).findAny();
+  }
+
+  @Override
+  public LocationInfo getLocationInfo(Location location) {
+    return _locationInfo.get(location);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TestSpecifierContext.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/TestSpecifierContext.java
@@ -3,7 +3,6 @@ package org.batfish.specifier;
 import java.util.Map;
 import java.util.Optional;
 import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.IpSpace;
 import org.batfish.referencelibrary.ReferenceBook;
 import org.batfish.role.NodeRoleDimension;
 
@@ -15,22 +14,17 @@ public class TestSpecifierContext implements SpecifierContext {
   }
 
   @Override
-  public Map<String, Map<String, IpSpace>> getInterfaceOwnedIps() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public Optional<NodeRoleDimension> getNodeRoleDimension(String dimension) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public Optional<ReferenceBook> getReferenceBook(String bookName) {
+  public LocationInfo getLocationInfo(Location location) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public IpSpace getSnapshotDeviceOwnedIps() {
+  public Optional<ReferenceBook> getReferenceBook(String bookName) {
     throw new UnsupportedOperationException();
   }
 }

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesTest.java
@@ -15,9 +15,11 @@ import static org.batfish.question.edges.EdgesAnswerer.COL_VTEP_ADDRESS;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
 import org.batfish.common.NetworkSnapshot;
@@ -42,6 +44,8 @@ import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.identifiers.NetworkId;
 import org.batfish.identifiers.SnapshotId;
 import org.batfish.question.edges.EdgesQuestion.EdgeType;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationInfo;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -112,6 +116,11 @@ public final class EdgesTest {
           @Override
           public NetworkSnapshot getSnapshot() {
             return new NetworkSnapshot(new NetworkId("a"), new SnapshotId("b"));
+          }
+
+          @Override
+          public Map<Location, LocationInfo> getLocationInfo(NetworkSnapshot networkSnapshot) {
+            return ImmutableMap.of();
           }
 
           @Override
@@ -199,7 +208,13 @@ public final class EdgesTest {
           public NetworkSnapshot getSnapshot() {
             return new NetworkSnapshot(new NetworkId("a"), new SnapshotId("b"));
           }
+
+          @Override
+          public Map<Location, LocationInfo> getLocationInfo(NetworkSnapshot networkSnapshot) {
+            return ImmutableMap.of();
+          }
         };
+
     TableAnswerElement answer =
         (TableAnswerElement)
             new EdgesAnswerer(new EdgesQuestion(null, null, EdgeType.VXLAN, true), batfish)

--- a/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityTest.java
+++ b/projects/question/src/test/java/org/batfish/question/filterlinereachability/FilterLineReachabilityTest.java
@@ -19,11 +19,13 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Multiset;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.stream.Collectors;
 import org.batfish.common.NetworkSnapshot;
@@ -50,6 +52,8 @@ import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationInfo;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -486,6 +490,11 @@ public class FilterLineReachabilityTest {
           @Override
           public SortedMap<String, Configuration> loadConfigurations(NetworkSnapshot snapshot) {
             return ImmutableSortedMap.of(_c1.getHostname(), _c1, _c2.getHostname(), _c2);
+          }
+
+          @Override
+          public Map<Location, LocationInfo> getLocationInfo(NetworkSnapshot networkSnapshot) {
+            return ImmutableMap.of();
           }
         };
     FilterLineReachabilityAnswerer answerer = new FilterLineReachabilityAnswerer(q, batfish);

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/MockBatfish.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/MockBatfish.java
@@ -2,11 +2,15 @@ package org.batfish.question.searchfilters;
 
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import java.util.Map;
 import java.util.SortedMap;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.Configuration;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationInfo;
 
 /** A mock Batfish for search filters tests. */
 final class MockBatfish extends IBatfishTestAdapter {
@@ -28,5 +32,10 @@ final class MockBatfish extends IBatfishTestAdapter {
     assertTrue(snapshot.equals(getSnapshot()) || snapshot.equals(getReferenceSnapshot()));
     Configuration config = snapshot.equals(getSnapshot()) ? _baseConfig : _deltaConfig;
     return ImmutableSortedMap.of(config.getHostname(), config);
+  }
+
+  @Override
+  public Map<Location, LocationInfo> getLocationInfo(NetworkSnapshot networkSnapshot) {
+    return ImmutableMap.of();
   }
 }

--- a/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/specifiers/SpecifiersAnswererTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpWildcard;
@@ -33,6 +34,8 @@ import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.table.Row;
 import org.batfish.question.specifiers.SpecifiersQuestion.QueryType;
 import org.batfish.specifier.InterfaceLocation;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationInfo;
 import org.batfish.specifier.MockSpecifierContext;
 import org.batfish.specifier.SpecifierContext;
 import org.batfish.specifier.SpecifierFactories;
@@ -88,14 +91,18 @@ public class SpecifiersAnswererTest {
     _context =
         MockSpecifierContext.builder()
             .setConfigs(ImmutableSortedMap.of(_c1.getHostname(), _c1, _c2.getHostname(), _c2))
-            .setInterfaceOwnedIps(
+            .setLocationInfo(
                 ImmutableMap.of(
-                    _c1.getHostname(),
-                    ImmutableMap.of(
-                        _iface1.getName(), _iface1.getConcreteAddress().getIp().toIpSpace()),
-                    _c2.getHostname(),
-                    ImmutableMap.of(
-                        _iface2.getName(), _iface2.getConcreteAddress().getIp().toIpSpace())))
+                    Location.interfaceLocation(_iface1),
+                        new LocationInfo(
+                            true,
+                            _iface1.getConcreteAddress().getIp().toIpSpace(),
+                            EmptyIpSpace.INSTANCE),
+                    Location.interfaceLocation(_iface2),
+                        new LocationInfo(
+                            true,
+                            _iface2.getConcreteAddress().getIp().toIpSpace(),
+                            EmptyIpSpace.INSTANCE)))
             .build();
   }
 

--- a/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/testfilters/TestFiltersAnswererTest.java
@@ -8,6 +8,7 @@ import static org.batfish.datamodel.matchers.RowsMatchers.hasSize;
 import static org.batfish.datamodel.matchers.TableAnswerElementMatchers.hasRows;
 import static org.batfish.question.testfilters.TestFiltersAnswerer.COL_FILTER_NAME;
 import static org.batfish.question.testfilters.TestFiltersAnswerer.COL_NODE;
+import static org.batfish.specifier.Location.interfaceLocation;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -24,6 +25,7 @@ import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
@@ -38,6 +40,7 @@ import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.Rows;
 import org.batfish.datamodel.table.TableAnswerElement;
+import org.batfish.specifier.LocationInfo;
 import org.batfish.specifier.MockSpecifierContext;
 import org.batfish.specifier.SpecifierContext;
 import org.junit.Before;
@@ -213,14 +216,18 @@ public class TestFiltersAnswererTest {
             configs,
             MockSpecifierContext.builder()
                 .setConfigs(configs)
-                .setInterfaceOwnedIps(
+                .setLocationInfo(
                     ImmutableMap.of(
-                        "c1",
-                        ImmutableMap.of(
-                            "iface1",
+                        interfaceLocation(iface1),
+                        new LocationInfo(
+                            true,
                             iface1.getConcreteAddress().getIp().toIpSpace(),
-                            "iface2",
-                            iface2.getConcreteAddress().getIp().toIpSpace())))
+                            EmptyIpSpace.INSTANCE),
+                        interfaceLocation(iface2),
+                        new LocationInfo(
+                            true,
+                            iface2.getConcreteAddress().getIp().toIpSpace(),
+                            EmptyIpSpace.INSTANCE)))
                 .build());
 
     TestFiltersQuestion question = new TestFiltersQuestion(null, null, null, null);

--- a/projects/question/src/test/java/org/batfish/question/testroutepolicies/MockBatfish.java
+++ b/projects/question/src/test/java/org/batfish/question/testroutepolicies/MockBatfish.java
@@ -1,10 +1,14 @@
 package org.batfish.question.testroutepolicies;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import java.util.Map;
 import java.util.SortedMap;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.Configuration;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationInfo;
 
 final class MockBatfish extends IBatfishTestAdapter {
   private final SortedMap<String, Configuration> _baseConfigs;
@@ -24,5 +28,10 @@ final class MockBatfish extends IBatfishTestAdapter {
       return _deltaConfigs;
     }
     throw new IllegalArgumentException("Unknown snapshot: " + snapshot);
+  }
+
+  @Override
+  public Map<Location, LocationInfo> getLocationInfo(NetworkSnapshot networkSnapshot) {
+    return ImmutableMap.of();
   }
 }

--- a/projects/question/src/test/java/org/batfish/question/traceroute/TracerouteAnswererHelperTest.java
+++ b/projects/question/src/test/java/org/batfish/question/traceroute/TracerouteAnswererHelperTest.java
@@ -7,7 +7,9 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import org.batfish.common.NetworkSnapshot;
@@ -25,6 +27,7 @@ import org.batfish.identifiers.SnapshotId;
 import org.batfish.specifier.AllInterfacesLocationSpecifier;
 import org.batfish.specifier.InterfaceLinkLocation;
 import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationInfo;
 import org.batfish.specifier.SpecifierContextImpl;
 import org.batfish.specifier.SpecifierFactories;
 import org.junit.Test;
@@ -47,6 +50,11 @@ public class TracerouteAnswererHelperTest {
           @Override
           public SortedMap<String, Configuration> loadConfigurations(NetworkSnapshot snapshot) {
             return configs;
+          }
+
+          @Override
+          public Map<Location, LocationInfo> getLocationInfo(NetworkSnapshot networkSnapshot) {
+            return ImmutableMap.of();
           }
         };
 

--- a/projects/question/src/test/java/org/batfish/question/vxlanproperties/VxlanVniPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/vxlanproperties/VxlanVniPropertiesAnswererTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import org.batfish.common.NetworkSnapshot;
@@ -34,6 +35,8 @@ import org.batfish.datamodel.table.Row;
 import org.batfish.datamodel.table.Rows;
 import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.datamodel.vxlan.Layer2Vni;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationInfo;
 import org.junit.Test;
 
 /** Tests for {@link VxlanVniPropertiesAnswerer} */
@@ -193,6 +196,11 @@ public final class VxlanVniPropertiesAnswererTest {
                   .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
                   .build()));
       return MockDataPlane.builder().setConfigs(configs).setVniSettings(vnis).build();
+    }
+
+    @Override
+    public Map<Location, LocationInfo> getLocationInfo(NetworkSnapshot networkSnapshot) {
+      return ImmutableMap.of();
     }
   }
 }


### PR DESCRIPTION
LocationInfo defines how a location should be used in batfish analyses:
whether a location should be used as an endpoint by default, the source
IPs to use for it when sourcing traffic, and (specifically for
InterfaceLinkLocation) the IPs of external devices (not modeled by
batfish) the link would get an ARP reply from.

This is a first integration step: only the source IPs of a LocationInfo
are used, and the generation of LocationInfo objects is only temporary.
Batfish is creating them for now; in a future PR they will be generated
by VendorConfiguration and/or external input. Also, in a future PR we
will serialize them to disk; for now we recreate each time they are
needed.