### PR TITLE
LocationInfo: infrastructure for VendorConfiguration to override

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -40,6 +40,9 @@ import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExpr;
 import org.batfish.datamodel.tracking.TrackMethod;
 import org.batfish.datamodel.vendor_family.VendorFamily;
 import org.batfish.referencelibrary.ReferenceBook;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationInfo;
+import org.batfish.specifier.LocationInfoUtils;
 
 /**
  * A Configuration represents an autonomous network device, such as a router, host, switch, or
@@ -220,6 +223,8 @@ public final class Configuration implements Serializable {
   private NavigableMap<String, IpsecPhase2Policy> _ipsecPhase2Policies;
 
   private NavigableMap<String, IpsecPhase2Proposal> _ipsecPhase2Proposals;
+
+  private @Nullable Map<Location, LocationInfo> _locationInfo;
 
   private NavigableSet<String> _loggingServers;
 
@@ -571,6 +576,11 @@ public final class Configuration implements Serializable {
     return _ipsecPhase2Proposals;
   }
 
+  @JsonIgnore
+  public @Nullable Map<Location, LocationInfo> getLocationInfo() {
+    return _locationInfo;
+  }
+
   @JsonProperty(PROP_LOGGING_SERVERS)
   public NavigableSet<String> getLoggingServers() {
     return _loggingServers;
@@ -813,6 +823,16 @@ public final class Configuration implements Serializable {
         ipsecPhase2Proposals == null
             ? ImmutableSortedMap.of()
             : ImmutableSortedMap.copyOf(ipsecPhase2Proposals);
+  }
+
+  /**
+   * Set the {@link LocationInfo} for {@link Location locations} on this node. Any missing locations
+   * will have their {@link LocationInfo} created automatically. See {@link
+   * LocationInfoUtils#computeLocationInfo}.
+   */
+  @JsonIgnore
+  public void setLocationInfo(Map<Location, LocationInfo> locationInfo) {
+    _locationInfo = ImmutableMap.copyOf(locationInfo);
   }
 
   @JsonProperty(PROP_LOGGING_SERVERS)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -42,7 +42,6 @@ import org.batfish.datamodel.vendor_family.VendorFamily;
 import org.batfish.referencelibrary.ReferenceBook;
 import org.batfish.specifier.Location;
 import org.batfish.specifier.LocationInfo;
-import org.batfish.specifier.LocationInfoUtils;
 
 /**
  * A Configuration represents an autonomous network device, such as a router, host, switch, or
@@ -828,7 +827,7 @@ public final class Configuration implements Serializable {
   /**
    * Set the {@link LocationInfo} for {@link Location locations} on this node. Any missing locations
    * will have their {@link LocationInfo} created automatically. See {@link
-   * LocationInfoUtils#computeLocationInfo}.
+   * org.batfish.specifier.LocationInfoUtils#computeLocationInfo(Map)}.
    */
   @JsonIgnore
   public void setLocationInfo(Map<Location, LocationInfo> locationInfo) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/Location.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/Location.java
@@ -1,6 +1,7 @@
 package org.batfish.specifier;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.io.Serializable;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.Interface;
 
@@ -10,7 +11,7 @@ import org.batfish.datamodel.Interface;
  * allows them to be inspected.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
-public interface Location {
+public interface Location extends Serializable {
   <T> T accept(LocationVisitor<T> visitor);
 
   @Nonnull

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfo.java
@@ -1,9 +1,12 @@
 package org.batfish.specifier;
 
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.IpSpace;
 
 /** Information about whether/how to treat a location as a source or sink of traffic. */
-public final class LocationInfo {
+public final class LocationInfo implements Serializable {
   private final boolean _isSource;
   private final IpSpace _sourceIps;
   private final IpSpace _arpIps;
@@ -12,6 +15,25 @@ public final class LocationInfo {
     _isSource = isSource;
     _sourceIps = sourceIps;
     _arpIps = arpIps;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LocationInfo)) {
+      return false;
+    }
+    LocationInfo other = (LocationInfo) o;
+    return _isSource == other._isSource
+        && _sourceIps.equals(other._sourceIps)
+        && _arpIps.equals(other._arpIps);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_isSource, _sourceIps, _arpIps);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTest.java
@@ -24,6 +24,9 @@ import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExpr;
 import org.batfish.datamodel.routing_policy.communities.HasCommunity;
 import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
 import org.batfish.datamodel.routing_policy.statement.CallStatement;
+import org.batfish.specifier.InterfaceLocation;
+import org.batfish.specifier.Location;
+import org.batfish.specifier.LocationInfo;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -178,16 +181,22 @@ public final class ConfigurationTest {
         ImmutableMap.of("csme", new HasCommunity(AllStandardCommunities.instance()));
     Map<String, CommunitySet> communitySets =
         ImmutableMap.of("cs", CommunitySet.of(StandardCommunity.of(1L)));
+    Map<Location, LocationInfo> locationInfo =
+        ImmutableMap.of(
+            new InterfaceLocation("n", "i"),
+            new LocationInfo(true, UniverseIpSpace.INSTANCE, EmptyIpSpace.INSTANCE));
     Configuration c = new Configuration("h", ConfigurationFormat.CISCO_IOS);
     c.setCommunityMatchExprs(communityMatchExprs);
     c.setCommunitySetExprs(communitySetExprs);
     c.setCommunitySetMatchExprs(communitySetMatchExprs);
     c.setCommunitySets(communitySets);
+    c.setLocationInfo(locationInfo);
     Configuration cloned = SerializationUtils.clone(c);
 
     assertThat(cloned.getCommunityMatchExprs(), equalTo(communityMatchExprs));
     assertThat(cloned.getCommunitySetExprs(), equalTo(communitySetExprs));
     assertThat(cloned.getCommunitySetMatchExprs(), equalTo(communitySetMatchExprs));
     assertThat(cloned.getCommunitySets(), equalTo(communitySets));
+    assertThat(cloned.getLocationInfo(), equalTo(locationInfo));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/LocationInfoUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/LocationInfoUtilsTest.java
@@ -47,7 +47,6 @@ public class LocationInfoUtilsTest {
     Ip ip1 = Ip.parse("1.1.1.1");
     Ip ip2 = Ip.parse("1.1.1.2");
     Ip ip3 = Ip.parse("1.1.1.3");
-    IpSpace ips12 = checkNotNull(AclIpSpace.union(ip1.toIpSpace(), ip2.toIpSpace()));
 
     Map<String, Map<String, IpSpace>> interfaceOwnedIps =
         ImmutableMap.of("a", ImmutableMap.of("i", ip1.toIpSpace()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/LocationInfoUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/LocationInfoUtilsTest.java
@@ -1,0 +1,179 @@
+package org.batfish.specifier;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
+import static org.batfish.specifier.Location.interfaceLinkLocation;
+import static org.batfish.specifier.Location.interfaceLocation;
+import static org.batfish.specifier.LocationInfoUtils.computeLocationInfo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.batfish.datamodel.AclIpSpace;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.EmptyIpSpace;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.Vrf;
+import org.junit.Test;
+
+public class LocationInfoUtilsTest {
+  @Test
+  public void testComputeLocationInfo_default() {
+    NetworkFactory nf = new NetworkFactory();
+
+    Configuration config =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname("a")
+            .build();
+    Vrf vrf = nf.vrfBuilder().setOwner(config).build();
+    Interface.Builder ib = nf.interfaceBuilder().setOwner(config).setActive(true).setVrf(vrf);
+    Interface i = ib.setName("i").setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/29")).build();
+
+    // i has no LocationInfo -- will use default VI logic
+    InterfaceLocation iloc = interfaceLocation(i);
+    InterfaceLinkLocation linkLoc = interfaceLinkLocation(i);
+
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("1.1.1.2");
+    Ip ip3 = Ip.parse("1.1.1.3");
+    IpSpace ips12 = checkNotNull(AclIpSpace.union(ip1.toIpSpace(), ip2.toIpSpace()));
+
+    Map<String, Map<String, IpSpace>> interfaceOwnedIps =
+        ImmutableMap.of("a", ImmutableMap.of("i", ip1.toIpSpace()));
+    Map<String, Map<String, IpSpace>> activeInterfaceHostIps =
+        ImmutableMap.of("a", ImmutableMap.of("i", ip3.toIpSpace()));
+    Map<Location, LocationInfo> locationInfo =
+        computeLocationInfo(
+            ip1.toIpSpace(), // ip1 is owned, so subtracted from link locations' source IPs
+            interfaceOwnedIps,
+            activeInterfaceHostIps,
+            ImmutableMap.of(config.getHostname(), config));
+
+    // iloc
+    {
+      LocationInfo info = locationInfo.get(iloc);
+      assertTrue(info.isSource());
+      // source Ips taken from interfaceOwnedIps.
+      assertThat(info.getSourceIps(), containsIp(ip1));
+      assertEquals(EmptyIpSpace.INSTANCE, info.getArpIps());
+    }
+
+    // linkLoc
+    {
+      LocationInfo info = locationInfo.get(linkLoc);
+      assertTrue(info.isSource());
+      // source IPs computed from i1's concrete address, excluding the snapshot-owned IP ip1
+      assertThat(info.getSourceIps(), allOf(not(containsIp(ip1)), containsIp(ip2)));
+      assertThat(info.getArpIps(), containsIp(ip3));
+    }
+  }
+
+  @Test
+  public void testComputeLocationInfo_vendorSupplied() {
+    NetworkFactory nf = new NetworkFactory();
+
+    Configuration config =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname("a")
+            .build();
+    Vrf vrf = nf.vrfBuilder().setOwner(config).build();
+    Interface.Builder ib = nf.interfaceBuilder().setOwner(config).setActive(true).setVrf(vrf);
+    Interface i = ib.setName("i").build();
+
+    // i has LocationInfo -- will subtract snapshotOwnedIps
+    InterfaceLocation iLoc = interfaceLocation(i);
+    InterfaceLinkLocation linkLoc = interfaceLinkLocation(i);
+
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("1.1.1.2");
+    IpSpace ips12 = checkNotNull(AclIpSpace.union(ip1.toIpSpace(), ip2.toIpSpace()));
+
+    // mock vendor-supplied LocationInfo
+    {
+      LocationInfo info = new LocationInfo(true, ips12, ips12);
+      config.setLocationInfo(ImmutableMap.of(iLoc, info, linkLoc, info));
+    }
+
+    Map<Location, LocationInfo> locationInfo =
+        computeLocationInfo(
+            ip1.toIpSpace(), // ip1 is owned, so subtracted from link locations' source IPs
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of(config.getHostname(), config));
+
+    // iLoc
+    {
+      LocationInfo info = locationInfo.get(iLoc);
+      assertTrue(info.isSource());
+      assertThat(info.getSourceIps(), allOf(containsIp(ip1), containsIp(ip2)));
+      assertThat(info.getArpIps(), allOf(containsIp(ip1), containsIp(ip2)));
+    }
+    // linkLoc
+    {
+      LocationInfo info = locationInfo.get(linkLoc);
+      assertTrue(info.isSource());
+      // source IPs taken from vendor-supplied location info
+      assertThat(info.getSourceIps(), allOf(not(containsIp(ip1)), containsIp(ip2)));
+      assertThat(info.getArpIps(), allOf(containsIp(ip1), containsIp(ip2)));
+    }
+  }
+
+  @Test
+  public void testComputeLocationInfo_inactive() {
+    NetworkFactory nf = new NetworkFactory();
+
+    Configuration config =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname("a")
+            .build();
+    Vrf vrf = nf.vrfBuilder().setOwner(config).build();
+    Interface.Builder ib = nf.interfaceBuilder().setOwner(config).setActive(true).setVrf(vrf);
+    Interface i3 = ib.setName("i3").setActive(false).build();
+
+    // i3 has LocationInfo but is inactive
+    InterfaceLocation iface3 = interfaceLocation(i3);
+    InterfaceLinkLocation link3 = interfaceLinkLocation(i3);
+
+    Ip ip1 = Ip.parse("1.1.1.1");
+    Ip ip2 = Ip.parse("1.1.1.2");
+    IpSpace ips12 = checkNotNull(AclIpSpace.union(ip1.toIpSpace(), ip2.toIpSpace()));
+
+    // mock vendor-supplied LocationInfo
+    {
+      LocationInfo info = new LocationInfo(true, ips12, ips12);
+      config.setLocationInfo(ImmutableMap.of(iface3, info, link3, info));
+    }
+
+    Map<Location, LocationInfo> locationInfo =
+        computeLocationInfo(
+            ip1.toIpSpace(), // ip1 is owned, so subtracted from link locations' source IPs
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of(config.getHostname(), config));
+
+    // iface3
+    {
+      LocationInfo info = locationInfo.get(iface3);
+      // since inactive, not a source (even though vendor LocationInfo says it is).
+      assertFalse(info.isSource());
+    }
+    // link3
+    {
+      LocationInfo info = locationInfo.get(link3);
+      assertFalse(info.isSource());
+    }
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -24,6 +24,7 @@ import static org.batfish.common.util.IspModelingUtils.INTERNET_HOST_NAME;
 import static org.batfish.common.util.IspModelingUtils.getInternetAndIspNodes;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
 import static org.batfish.main.ReachabilityParametersResolver.resolveReachabilityParameters;
+import static org.batfish.specifier.LocationInfoUtils.computeLocationInfo;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -218,7 +219,6 @@ import org.batfish.specifier.InferFromLocationIpSpaceSpecifier;
 import org.batfish.specifier.IpSpaceAssignment;
 import org.batfish.specifier.Location;
 import org.batfish.specifier.LocationInfo;
-import org.batfish.specifier.LocationInfoUtils;
 import org.batfish.specifier.SpecifierContext;
 import org.batfish.specifier.SpecifierContextImpl;
 import org.batfish.specifier.UnionLocationSpecifier;
@@ -835,11 +835,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   @Override
   public Map<Location, LocationInfo> getLocationInfo(NetworkSnapshot snapshot) {
-    /* TODO this should be deserialized from disk. Ultimate source will be a combination of vendor
-     * configs and user input. For now, consolidating the default logic here. This logic will become
-     * the default implementation of the vendor config method.
-     */
-    return LocationInfoUtils.computeLocationInfo(
+    return computeLocationInfo(
         getTopologyProvider().getIpOwners(snapshot), loadConfigurations(snapshot));
   }
 


### PR DESCRIPTION
Adds a map Location -> LocationInfo to VI Configuration that conversion
code can populate. Overrides the default VI LocationInfo definition.
Snapshot owned IPs are subtracted from the source IPs specified in the
vendor-supplied LocationInfo.