### PR TITLE
AWS: vendor-specific LocationInfo for subnet locations

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsLocationInfoUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsLocationInfoUtils.java
@@ -1,0 +1,45 @@
+package org.batfish.representation.aws;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.batfish.specifier.LocationInfoUtils.connectedHostSubnetHostIps;
+
+import com.google.common.collect.ImmutableList;
+import org.batfish.datamodel.AclIpSpace;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.EmptyIpSpace;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
+import org.batfish.specifier.LocationInfo;
+
+/** Helpers for defining AWS-specific {@link LocationInfo}. */
+public final class AwsLocationInfoUtils {
+  private AwsLocationInfoUtils() {}
+
+  static LocationInfo subnetInterfaceLocationInfo(Interface iface) {
+    return new LocationInfo(
+        // infrastructure interface; not a source
+        false,
+        // if user explicitly selects this location to be a source, use
+        // its configured IPs for source IPs by default
+        firstNonNull(
+            AclIpSpace.union(
+                iface.getAllConcreteAddresses().stream()
+                    .map(ConcreteInterfaceAddress::getIp)
+                    .map(Ip::toIpSpace)
+                    .collect(ImmutableList.toImmutableList())),
+            EmptyIpSpace.INSTANCE),
+        // interface locations never have external ARP IPs
+        EmptyIpSpace.INSTANCE);
+  }
+
+  static LocationInfo subnetInterfaceLinkLocationInfo(Interface iface) {
+    return new LocationInfo(
+        // not a source of traffic
+        false,
+        // if user explicitly selects this location to be a source, use
+        // these source IPs by default
+        connectedHostSubnetHostIps(iface),
+        // no external ARP replies
+        EmptyIpSpace.INSTANCE);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
@@ -1,24 +1,32 @@
 package org.batfish.representation.aws;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Maps.immutableEntry;
+import static org.batfish.representation.aws.AwsLocationInfoUtils.subnetInterfaceLinkLocationInfo;
+import static org.batfish.representation.aws.AwsLocationInfoUtils.subnetInterfaceLocationInfo;
 import static org.batfish.representation.aws.Utils.addStaticRoute;
 import static org.batfish.representation.aws.Utils.connect;
 import static org.batfish.representation.aws.Utils.getInterfaceLinkLocalIp;
 import static org.batfish.representation.aws.Utils.interfaceNameToRemote;
 import static org.batfish.representation.aws.Utils.toStaticRoute;
+import static org.batfish.specifier.Location.interfaceLinkLocation;
+import static org.batfish.specifier.Location.interfaceLocation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -264,6 +272,18 @@ public class Subnet implements AwsVpcEntity, Serializable {
     cfgNode.getVendorFamily().getAws().setVpcId(_vpcId);
     cfgNode.getVendorFamily().getAws().setSubnetId(_subnetId);
     cfgNode.getVendorFamily().getAws().setRegion(region.getName());
+
+    // create LocationInfo for each link location on the node.
+    cfgNode.setLocationInfo(
+        cfgNode.getAllInterfaces().values().stream()
+            .flatMap(
+                iface ->
+                    Stream.of(
+                        immutableEntry(
+                            interfaceLocation(iface), subnetInterfaceLocationInfo(iface)),
+                        immutableEntry(
+                            interfaceLinkLocation(iface), subnetInterfaceLinkLocationInfo(iface))))
+            .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue)));
 
     return cfgNode;
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPrivateSubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPrivateSubnetTest.java
@@ -108,7 +108,7 @@ public class AwsConfigurationPrivateSubnetTest {
     testTrace(
         _onPremRouter,
         Ip.parse("10.0.1.205"),
-        FlowDisposition.DELIVERED_TO_SUBNET,
+        FlowDisposition.NEIGHBOR_UNREACHABLE,
         ImmutableList.of(_onPremRouter, _vgw, _subnet));
 
     // to a private IP outside the subnet

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationVpcPeeringTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationVpcPeeringTest.java
@@ -161,7 +161,7 @@ public class AwsConfigurationVpcPeeringTest {
     testTrace(
         _instanceB,
         Ip.parse("10.10.10.11"),
-        FlowDisposition.DELIVERED_TO_SUBNET,
+        FlowDisposition.NEIGHBOR_UNREACHABLE,
         ImmutableList.of(_instanceB, _subnetB, _vpcB, _vpcA, _subnetA));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsLocationInfoUtilsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsLocationInfoUtilsTest.java
@@ -1,0 +1,55 @@
+package org.batfish.representation.aws;
+
+import static org.batfish.datamodel.matchers.IpSpaceMatchers.containsIp;
+import static org.batfish.representation.aws.AwsLocationInfoUtils.subnetInterfaceLinkLocationInfo;
+import static org.batfish.representation.aws.AwsLocationInfoUtils.subnetInterfaceLocationInfo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertFalse;
+
+import com.google.common.collect.ImmutableList;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.EmptyIpSpace;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
+import org.batfish.specifier.LocationInfo;
+import org.junit.Test;
+
+/** Test for {@link AwsLocationInfoUtils}. */
+public class AwsLocationInfoUtilsTest {
+  private static final Interface IFACE;
+
+  static {
+    IFACE = Interface.builder().setName("i").build();
+    IFACE.setAllAddresses(
+        ImmutableList.of(
+            ConcreteInterfaceAddress.parse("1.1.1.1/24"),
+            ConcreteInterfaceAddress.parse("2.2.2.2/24")));
+  }
+
+  @Test
+  public void testSubnetInteraceLocationInfo() {
+    LocationInfo info = subnetInterfaceLocationInfo(IFACE);
+    assertFalse(info.isSource());
+    assertThat(
+        info.getSourceIps(),
+        allOf(
+            containsIp(Ip.parse("1.1.1.1")),
+            containsIp(Ip.parse("2.2.2.2")),
+            not(containsIp(Ip.parse("1.1.1.2"))),
+            not(containsIp(Ip.parse("2.2.2.3")))));
+    assertThat(info.getArpIps(), equalTo(EmptyIpSpace.INSTANCE));
+  }
+
+  @Test
+  public void testSubnetInteraceLinkLocationInfo() {
+    LocationInfo info = subnetInterfaceLinkLocationInfo(IFACE);
+    assertFalse(info.isSource());
+    assertThat(
+        info.getSourceIps(),
+        allOf(containsIp(Ip.parse("1.1.1.2")), containsIp(Ip.parse("2.2.2.3"))));
+    assertThat(info.getArpIps(), equalTo(EmptyIpSpace.INSTANCE));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsLocationInfoUtilsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsLocationInfoUtilsTest.java
@@ -30,7 +30,7 @@ public class AwsLocationInfoUtilsTest {
   }
 
   @Test
-  public void testSubnetInteraceLocationInfo() {
+  public void testSubnetInterfaceLocationInfo() {
     LocationInfo info = subnetInterfaceLocationInfo(IFACE);
     assertFalse(info.isSource());
     assertThat(
@@ -44,7 +44,7 @@ public class AwsLocationInfoUtilsTest {
   }
 
   @Test
-  public void testSubnetInteraceLinkLocationInfo() {
+  public void testSubnetInterfaceLinkLocationInfo() {
     LocationInfo info = subnetInterfaceLinkLocationInfo(IFACE);
     assertFalse(info.isSource());
     assertThat(


### PR DESCRIPTION
LocationInfo for AWS Subnet locations (interfaces and interface links). Departures from VI behavior:
- InterfaceLocation:
  - not a source
- InterfaceLinkLocation:
  - not a source
  - no external ARP IPs