### PR TITLE
Set LocationInfo for Hosts

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfoUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfoUtils.java
@@ -128,7 +128,14 @@ public final class LocationInfoUtils {
   private static LocationInfo getInterfaceLocationInfo(
       @Nullable LocationInfo vendorLocationInfo, IpSpace interfaceOwnedIps) {
     return firstNonNull(
-        vendorLocationInfo, new LocationInfo(true, interfaceOwnedIps, EmptyIpSpace.INSTANCE));
+        vendorLocationInfo,
+        new LocationInfo(
+            // assume the interface is infrastructure, and so not a source
+            false,
+            // when used as a source, pick one of its owned IPs
+            interfaceOwnedIps,
+            // interface locations do not have external ARP IPs
+            EmptyIpSpace.INSTANCE));
   }
 
   private static LocationInfo getInterfaceLinkLocationInfo(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfoUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/LocationInfoUtils.java
@@ -6,6 +6,7 @@ import static org.batfish.datamodel.AclIpSpace.difference;
 import static org.batfish.datamodel.Prefix.HOST_SUBNET_MAX_PREFIX_LENGTH;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.util.Map;
@@ -16,6 +17,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.topology.IpOwners;
 import org.batfish.datamodel.AclIpSpace;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Interface;
@@ -156,5 +158,15 @@ public final class LocationInfoUtils {
         locationInfo.isSource(),
         checkNotNull(difference(locationInfo.getSourceIps(), snapshotOwnedIps)),
         locationInfo.getArpIps());
+  }
+
+  public static IpSpace configuredIps(Interface iface) {
+    return firstNonNull(
+        AclIpSpace.union(
+            iface.getAllConcreteAddresses().stream()
+                .map(ConcreteInterfaceAddress::getIp)
+                .map(Ip::toIpSpace)
+                .collect(ImmutableList.toImmutableList())),
+        EmptyIpSpace.INSTANCE);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/LocationInfoUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/LocationInfoUtilsTest.java
@@ -59,7 +59,7 @@ public class LocationInfoUtilsTest {
     // iloc
     {
       LocationInfo info = locationInfo.get(iloc);
-      assertTrue(info.isSource());
+      assertFalse(info.isSource());
       // source Ips taken from interfaceOwnedIps.
       assertThat(info.getSourceIps(), containsIp(ip1));
       assertEquals(EmptyIpSpace.INSTANCE, info.getArpIps());

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsLocationInfoUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsLocationInfoUtils.java
@@ -1,30 +1,15 @@
 package org.batfish.representation.aws;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.batfish.specifier.LocationInfoUtils.configuredIps;
 import static org.batfish.specifier.LocationInfoUtils.connectedHostSubnetHostIps;
 
-import com.google.common.collect.ImmutableList;
-import org.batfish.datamodel.AclIpSpace;
-import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Interface;
-import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.IpSpace;
 import org.batfish.specifier.LocationInfo;
 
 /** Helpers for defining AWS-specific {@link LocationInfo}. */
 public final class AwsLocationInfoUtils {
   private AwsLocationInfoUtils() {}
-
-  private static IpSpace configuredIps(Interface iface) {
-    return firstNonNull(
-        AclIpSpace.union(
-            iface.getAllConcreteAddresses().stream()
-                .map(ConcreteInterfaceAddress::getIp)
-                .map(Ip::toIpSpace)
-                .collect(ImmutableList.toImmutableList())),
-        EmptyIpSpace.INSTANCE);
-  }
 
   static LocationInfo instanceInterfaceLocationInfo(Interface iface) {
     return new LocationInfo(


### PR DESCRIPTION
Default (VI) LocationInfo should not consider InterfaceLocations to be traffic sources. InterfaceLocations on hosts should be considered sources.