### PR TITLE
Stop autodetecting pojo Node creators

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Node.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Node.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.DeviceType;
 
-@JsonAutoDetect(creatorVisibility= JsonAutoDetect.Visibility.NONE)
+@JsonAutoDetect(creatorVisibility = JsonAutoDetect.Visibility.NONE)
 public class Node extends BfObject {
   private static final String PROP_NAME = "name";
   private static final String PROP_MODEL = "model";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Node.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Node.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.pojo;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
@@ -12,6 +13,7 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.DeviceType;
 
+@JsonAutoDetect(creatorVisibility= JsonAutoDetect.Visibility.NONE)
 public class Node extends BfObject {
   private static final String PROP_NAME = "name";
   private static final String PROP_MODEL = "model";

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/TypedRowBuilderTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/TypedRowBuilderTest.java
@@ -75,4 +75,13 @@ public class TypedRowBuilderTest {
     assertThat(row.getColumnNames(), contains("col"));
     assertThat(row.hasNonNull("col"), equalTo(false));
   }
+
+  @Test
+  public void testPutStringIntoNodeSchema() {
+    String colName = "Node";
+    _thrown.expect(IllegalArgumentException.class);
+    Row.builder(ImmutableMap.of(colName, new ColumnMetadata(colName, Schema.NODE, "desc")))
+        .put(colName, "Just_a_string")
+        .build();
+  }
 }


### PR DESCRIPTION
This fixes TypedRowBuilder type enforcement (which was uncovered by #5545)