### PR TITLE
BatfishObjectMapper: disable inferring creators

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Task.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Task.java
@@ -51,8 +51,9 @@ public final class Task {
     }
 
     @JsonProperty(PROP_COMPLETED)
-    private void setCompleted(AtomicInteger completed) {
-      _completed = completed;
+    @Deprecated // only for Jackson
+    private void setCompleted(int completed) {
+      _completed = new AtomicInteger(completed);
     }
 
     @JsonProperty(PROP_DESCRIPTION)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
@@ -137,6 +137,7 @@ public final class BatfishObjectMapper {
   private static ObjectMapper baseMapper() {
     ObjectMapper mapper = new ObjectMapper();
 
+    mapper.disable(MapperFeature.AUTO_DETECT_CREATORS);
     mapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
     mapper.enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
     // Next two lines make Instant class serialize as an RFC-3339 timestamp

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SnmpCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SnmpCommunity.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.batfish.common.util.ComparableStructure;
 
@@ -13,6 +14,7 @@ public class SnmpCommunity extends ComparableStructure<String> {
 
   private boolean _rw;
 
+  @JsonCreator
   public SnmpCommunity(@JsonProperty(PROP_NAME) String name) {
     super(name);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SnmpHost.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/SnmpHost.java
@@ -1,10 +1,12 @@
 package org.batfish.datamodel;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.batfish.common.util.ComparableStructure;
 
 public class SnmpHost extends ComparableStructure<String> {
 
+  @JsonCreator
   public SnmpHost(@JsonProperty(PROP_NAME) String name) {
     super(name);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/NtpServer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/NtpServer.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.vendor_family.cisco;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.batfish.common.util.ComparableStructure;
 
@@ -7,6 +8,7 @@ public class NtpServer extends ComparableStructure<String> {
 
   private String _vrf;
 
+  @JsonCreator
   public NtpServer(@JsonProperty(PROP_NAME) String hostname) {
     super(hostname);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/SntpServer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco/SntpServer.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.vendor_family.cisco;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.batfish.common.util.ComparableStructure;
 
@@ -7,6 +8,7 @@ public class SntpServer extends ComparableStructure<String> {
 
   public Integer _version;
 
+  @JsonCreator
   public SntpServer(@JsonProperty(PROP_NAME) String hostname) {
     super(hostname);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco_xr/NtpServer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco_xr/NtpServer.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.vendor_family.cisco_xr;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.batfish.common.util.ComparableStructure;
 
@@ -7,6 +8,7 @@ public class NtpServer extends ComparableStructure<String> {
 
   private String _vrf;
 
+  @JsonCreator
   public NtpServer(@JsonProperty(PROP_NAME) String hostname) {
     super(hostname);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco_xr/SntpServer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vendor_family/cisco_xr/SntpServer.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.vendor_family.cisco_xr;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.batfish.common.util.ComparableStructure;
 
@@ -7,6 +8,7 @@ public class SntpServer extends ComparableStructure<String> {
 
   public Integer _version;
 
+  @JsonCreator
   public SntpServer(@JsonProperty(PROP_NAME) String hostname) {
     super(hostname);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/FilterGroup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/FilterGroup.java
@@ -3,6 +3,7 @@ package org.batfish.referencelibrary;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
@@ -21,6 +22,7 @@ public class FilterGroup implements Comparable<FilterGroup>, Serializable {
   @Nonnull private final List<String> _filters;
   @Nonnull private final String _name;
 
+  @JsonCreator
   public FilterGroup(
       @Nullable @JsonProperty(PROP_FILTERS) List<String> filters,
       @Nullable @JsonProperty(PROP_NAME) String name) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/ServiceEndpoint.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/ServiceEndpoint.java
@@ -2,6 +2,7 @@ package org.batfish.referencelibrary;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.List;
@@ -20,6 +21,7 @@ public class ServiceEndpoint implements Comparable<ServiceEndpoint>, Serializabl
   @Nonnull private String _name;
   @Nonnull private String _service;
 
+  @JsonCreator
   public ServiceEndpoint(
       @JsonProperty(PROP_ADDRESS) String address,
       @JsonProperty(PROP_NAME) String name,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/ServiceObject.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/ServiceObject.java
@@ -2,6 +2,7 @@ package org.batfish.referencelibrary;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.Objects;
@@ -21,6 +22,7 @@ public class ServiceObject implements Comparable<ServiceObject>, Serializable {
   @Nonnull private String _name;
   @Nonnull private SubRange _ports;
 
+  @JsonCreator
   public ServiceObject(
       @JsonProperty(PROP_IP_PROTOCOL) IpProtocol ipProtocol,
       @JsonProperty(PROP_NAME) String name,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/ServiceObjectGroup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/ServiceObjectGroup.java
@@ -3,6 +3,7 @@ package org.batfish.referencelibrary;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
@@ -21,6 +22,7 @@ public class ServiceObjectGroup implements Comparable<ServiceObjectGroup>, Seria
   @Nonnull private String _name;
   @Nonnull private SortedSet<String> _services;
 
+  @JsonCreator
   public ServiceObjectGroup(
       @JsonProperty(PROP_NAME) String name,
       @JsonProperty(PROP_SERVICES) SortedSet<String> services) {

--- a/projects/question/src/main/java/org/batfish/question/ospfarea/OspfAreaConfigurationQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/ospfarea/OspfAreaConfigurationQuestion.java
@@ -1,5 +1,6 @@
 package org.batfish.question.ospfarea;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
@@ -15,6 +16,7 @@ public class OspfAreaConfigurationQuestion extends Question {
 
   @Nullable private String _nodes;
 
+  @JsonCreator
   public OspfAreaConfigurationQuestion(@JsonProperty(PROP_NODES) @Nullable String nodes) {
     _nodes = nodes;
   }

--- a/projects/question/src/main/java/org/batfish/question/ospfsession/OspfSessionCompatibilityQuestion.java
+++ b/projects/question/src/main/java/org/batfish/question/ospfsession/OspfSessionCompatibilityQuestion.java
@@ -1,5 +1,6 @@
 package org.batfish.question.ospfsession;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
@@ -28,6 +29,7 @@ public class OspfSessionCompatibilityQuestion extends Question {
 
   @Nonnull private final Set<OspfSessionStatus> _expandedStatuses;
 
+  @JsonCreator
   public OspfSessionCompatibilityQuestion(
       @JsonProperty(PROP_NODES) @Nullable String nodes,
       @JsonProperty(PROP_REMOTE_NODES) @Nullable String remoteNodes,


### PR DESCRIPTION
Require explicit @JsonCreator annotation, even on constructors. Add a bunch that were missing.