### PR TITLE
Reachability states for originate/accept at interface

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
@@ -9,6 +9,7 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import io.opentracing.ActiveSpan;
 import io.opentracing.util.GlobalTracer;
@@ -20,7 +21,6 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
@@ -48,6 +48,9 @@ public final class IpOwners {
   /** Mapping from hostname to interface name to IpSpace owned by that interface */
   private final Map<String, Map<String, IpSpace>> _hostToInterfaceToIpSpace;
 
+  /** Mapping from hostname to VRF name to interface name to IpSpace owned by that interface */
+  private final Map<String, Map<String, Map<String, IpSpace>>> _hostToVrfToInterfaceToIpSpace;
+
   /**
    * Mapping from hostname to interface name to host IP subnet.
    *
@@ -57,8 +60,6 @@ public final class IpOwners {
 
   /** Mapping from an IP to hostname to set of VRFs that own that IP. */
   private final Map<Ip, Map<String, Set<String>>> _ipVrfOwners;
-
-  private final Map<String, Map<String, IpSpace>> _vrfOwnedIpSpaces;
 
   public IpOwners(Map<String, Configuration> configurations) {
     /* Mapping from a hostname to a set of all (including inactive) interfaces that node owns */
@@ -71,35 +72,31 @@ public final class IpOwners {
     }
 
     {
-      _hostToInterfaceToIpSpace =
-          ImmutableMap.copyOf(computeInterfaceOwnedIpSpaces(_activeDeviceOwnedIps));
-      _allInterfaceHostIps = computeInterfaceHostSubnetIps(configurations, false);
+      Map<Ip, Map<String, Map<String, Set<String>>>> ipIfaceOwners =
+          computeIpIfaceOwners(allInterfaces, _activeDeviceOwnedIps);
+      _ipVrfOwners = computeIpVrfOwners(ipIfaceOwners);
+      _hostToVrfToInterfaceToIpSpace = computeIfaceOwnedIpSpaces(ipIfaceOwners);
     }
 
     {
-      _ipVrfOwners = computeIpVrfOwners(allInterfaces, _activeDeviceOwnedIps);
-      _vrfOwnedIpSpaces = computeVrfOwnedIpSpaces(_ipVrfOwners);
+      _hostToInterfaceToIpSpace = computeInterfaceOwnedIpSpaces(_hostToVrfToInterfaceToIpSpace);
+      _allInterfaceHostIps = computeInterfaceHostSubnetIps(configurations, false);
     }
   }
 
   /**
-   * Invert a mapping from {@link Ip} to owner interfaces (Ip -&gt; hostname -&gt; interface name)
-   * and convert the set of owned Ips into an IpSpace.
+   * Computes a map of hostname -&gt; interface name -&gt; {@link IpSpace} from a map of hostname
+   * -&gt; vrf name -&gt; interface name -&gt; {@link IpSpace}.
    */
   private static Map<String, Map<String, IpSpace>> computeInterfaceOwnedIpSpaces(
-      Map<Ip, Map<String, Set<String>>> ipInterfaceOwners) {
+      Map<String, Map<String, Map<String, IpSpace>>> ipOwners) {
     return toImmutableMap(
-        computeInterfaceOwnedIps(ipInterfaceOwners),
+        ipOwners,
         Entry::getKey, /* host */
         hostEntry ->
-            toImmutableMap(
-                hostEntry.getValue(),
-                Entry::getKey, /* interface */
-                ifaceEntry ->
-                    AclIpSpace.union(
-                        ifaceEntry.getValue().stream()
-                            .map(Ip::toIpSpace)
-                            .collect(Collectors.toList()))));
+            hostEntry.getValue().values().stream() /* Skip VRF keys */
+                .flatMap(ifaceMap -> ifaceMap.entrySet().stream())
+                .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue)));
   }
 
   @VisibleForTesting
@@ -286,58 +283,97 @@ public final class IpOwners {
    * Compute a mapping of IP addresses to the VRFs that "own" this IP (e.g., as a network interface
    * address).
    *
-   * @param allInterfaces A mapping of enabled interfaces hostname -&gt; interface name -&gt; {@link
-   *     Interface}
-   * @param activeDeviceOwnedIps Mapping from a IP to hostname to set of interfaces that own that IP
-   *     (for active interfaces only)
+   * @param ipVrfIfaceOwners A mapping of IP owners hostname -&gt; vrf name -&gt; interface names
    * @return A map of {@link Ip}s to a map of hostnames to vrfs that own the Ip.
    */
   @VisibleForTesting
   static Map<Ip, Map<String, Set<String>>> computeIpVrfOwners(
+      Map<Ip, Map<String, Map<String, Set<String>>>> ipVrfIfaceOwners) {
+    return toImmutableMap(
+        ipVrfIfaceOwners,
+        Entry::getKey, /* Ip */
+        ipEntry ->
+            toImmutableMap(
+                ipEntry.getValue(),
+                Entry::getKey, /* Hostname */
+                nodeEntry -> ImmutableSet.copyOf(nodeEntry.getValue().keySet()))); /* VRFs */
+  }
+
+  /**
+   * Compute a mapping of IP addresses to the VRFs and interfaces that "own" this IP (e.g., as a
+   * network interface address).
+   *
+   * @param allInterfaces A mapping of enabled interfaces hostname -&gt; set of {@link Interface}
+   * @param activeDeviceOwnedIps Mapping from a IP to hostname to set of interfaces that own that IP
+   *     (for active interfaces only)
+   * @return A map of {@link Ip}s to a map of hostnames to vrfs to interfaces that own the Ip.
+   */
+  @VisibleForTesting
+  static Map<Ip, Map<String, Map<String, Set<String>>>> computeIpIfaceOwners(
       Map<String, Set<Interface>> allInterfaces,
       Map<Ip, Map<String, Set<String>>> activeDeviceOwnedIps) {
 
-    // Helper mapping: Hostname -> interface name -> vrf name
-    Map<String, Map<String, String>> allInterfaceVrfs =
-        toImmutableMap(
-            allInterfaces,
-            Entry::getKey, /* hostname */
-            nodeInterfaces ->
-                nodeInterfaces.getValue().stream()
-                    .collect(
-                        ImmutableMap.toImmutableMap(Interface::getName, Interface::getVrfName)));
+    // Helper mapping: hostname -> vrf -> interfaces
+    Map<String, Map<String, Set<String>>> hostsToVrfsToIfaces = new HashMap<>();
+    allInterfaces.forEach(
+        (hostname, ifaces) ->
+            ifaces.forEach(
+                iface -> {
+                  hostsToVrfsToIfaces
+                      .computeIfAbsent(hostname, n -> new HashMap<>())
+                      .computeIfAbsent(iface.getVrfName(), n -> new HashSet<>())
+                      .add(iface.getName());
+                }));
 
     return toImmutableMap(
         activeDeviceOwnedIps,
         Entry::getKey, /* Ip */
-        ipInterfaceOwnersEntry ->
-            toImmutableMap(
-                ipInterfaceOwnersEntry.getValue(),
-                Entry::getKey, /* Hostname */
-                ipNodeInterfaceOwnersEntry ->
-                    ipNodeInterfaceOwnersEntry.getValue().stream()
-                        .map(allInterfaceVrfs.get(ipNodeInterfaceOwnersEntry.getKey())::get)
-                        .collect(ImmutableSet.toImmutableSet())));
+        ipEntry -> {
+          Map<String, Set<String>> owners = ipEntry.getValue();
+          return toImmutableMap(
+              owners,
+              Entry::getKey, /* hostname */
+              nodeEntry -> {
+                String hostname = nodeEntry.getKey();
+                Set<String> ownerIfaces = nodeEntry.getValue();
+                ImmutableMap.Builder<String, Set<String>> ownerVrfsAndIfaces =
+                    ImmutableMap.builder();
+                hostsToVrfsToIfaces
+                    .get(hostname)
+                    .forEach(
+                        (vrf, ifaces) -> {
+                          // Find interfaces in this VRF that own this IP
+                          Set<String> vrfOwnerIfaces = Sets.intersection(ownerIfaces, ifaces);
+                          if (!vrfOwnerIfaces.isEmpty()) {
+                            // Only include VRFs that have any interfaces that own this IP
+                            ownerVrfsAndIfaces.put(vrf, vrfOwnerIfaces);
+                          }
+                        });
+                return ownerVrfsAndIfaces.build();
+              });
+        });
   }
 
   /**
-   * Invert a mapping from Ip to VRF owners (Ip -&gt; host name -&gt; VRF name) and combine all IPs
-   * owned by each VRF into an IpSpace.
+   * Invert a mapping from Ip to interface owners (Ip -&gt; host name -&gt; VRF name -&gt; interface
+   * names) and combine all IPs owned by each interface into an IpSpace.
    */
-  private static Map<String, Map<String, IpSpace>> computeVrfOwnedIpSpaces(
-      Map<Ip, Map<String, Set<String>>> ipVrfOwners) {
-    Map<String, Map<String, AclIpSpace.Builder>> builders = new HashMap<>();
-    ipVrfOwners.forEach(
-        (ip, ipNodeVrfs) ->
-            ipNodeVrfs.forEach(
-                (node, vrfs) ->
-                    vrfs.forEach(
-                        vrf ->
-                            builders
-                                .computeIfAbsent(node, k -> new HashMap<>())
-                                .computeIfAbsent(vrf, k -> AclIpSpace.builder())
-                                .thenPermitting(ip.toIpSpace()))));
-
+  private static Map<String, Map<String, Map<String, IpSpace>>> computeIfaceOwnedIpSpaces(
+      Map<Ip, Map<String, Map<String, Set<String>>>> ipIfaceOwners) {
+    Map<String, Map<String, Map<String, AclIpSpace.Builder>>> builders = new HashMap<>();
+    ipIfaceOwners.forEach(
+        (ip, nodeMap) ->
+            nodeMap.forEach(
+                (node, vrfMap) ->
+                    vrfMap.forEach(
+                        (vrf, ifaces) ->
+                            ifaces.forEach(
+                                iface ->
+                                    builders
+                                        .computeIfAbsent(node, k -> new HashMap<>())
+                                        .computeIfAbsent(vrf, k -> new HashMap<>())
+                                        .computeIfAbsent(iface, k -> AclIpSpace.builder())
+                                        .thenPermitting(ip.toIpSpace())))));
     return toImmutableMap(
         builders,
         Entry::getKey, /* node */
@@ -345,7 +381,11 @@ public final class IpOwners {
             toImmutableMap(
                 nodeEntry.getValue(),
                 Entry::getKey, /* vrf */
-                vrfEntry -> vrfEntry.getValue().build()));
+                vrfEntry ->
+                    toImmutableMap(
+                        vrfEntry.getValue(),
+                        Entry::getKey, /* interface */
+                        ifaceEntry -> ifaceEntry.getValue().build())));
   }
 
   /**
@@ -388,10 +428,10 @@ public final class IpOwners {
   }
 
   /**
-   * Returns a mapping from hostname to vrf name to a space of IPs owned by that VRF. Only considers
-   * interface IPs. Considers <em>only active</em> interfaces.
+   * Returns a mapping from hostname to vrf name to interface name to a space of IPs owned by that
+   * interface. Only considers interface IPs. Considers <em>only active</em> interfaces.
    */
-  public Map<String, Map<String, IpSpace>> getVrfOwnedIpSpaces() {
-    return _vrfOwnedIpSpaces;
+  public Map<String, Map<String, Map<String, IpSpace>>> getVrfIfaceOwnedIpSpaces() {
+    return _hostToVrfToInterfaceToIpSpace;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysis.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysis.java
@@ -5,11 +5,11 @@ import javax.annotation.Nonnull;
 
 public interface ForwardingAnalysis {
   /**
-   * Return IP spaces accepted at each VRF <br>
-   * Mapping: hostname -&gt; vrfName -&gt; space of IPs accepted by that VRF
+   * Return IP spaces accepted at each interface <br>
+   * Mapping: hostname -&gt; vrfName -&gt; ifaceName -&gt; space of IPs accepted by that interface
    */
   @Nonnull
-  Map<String, Map<String, IpSpace>> getAcceptsIps();
+  Map<String, Map<String, Map<String, IpSpace>>> getAcceptsIps();
 
   /** Mapping: hostname -&gt; inInterface -&gt; ipsToArpReplyTo */
   Map<String, Map<String, IpSpace>> getArpReplies();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ForwardingAnalysisImpl.java
@@ -36,8 +36,9 @@ import org.batfish.specifier.LocationInfo;
 
 /** Implementation of {@link ForwardingAnalysis}. */
 public final class ForwardingAnalysisImpl implements ForwardingAnalysis {
-  // node -> vrf -> ips accepted by that vrf
-  private Map<String, Map<String, IpSpace>> _acceptedIps;
+
+  /** node -&gt; vrf -&gt; interface -&gt; ips accepted by that interface */
+  private Map<String, Map<String, Map<String, IpSpace>>> _acceptedIps;
 
   // node -> interface -> ips that the interface would reply arp request
   private final Map<String, Map<String, IpSpace>> _arpReplies;
@@ -287,13 +288,13 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis {
   }
 
   /**
-   * Compute the space of IPs accepted by a VRF<br>
-   * Mapping: hostname -&gt; vrf name -&gt; space of IPs
+   * Compute the space of IPs accepted by an interface<br>
+   * Mapping: hostname -&gt; vrf name -&gt; interface name -&gt; space of IPs
    */
-  private Map<String, Map<String, IpSpace>> computeAcceptedIps(IpOwners ipOwners) {
-
-    // TODO: also special case VRF-accepted IPs that are not interface IPs here.
-    return ipOwners.getVrfOwnedIpSpaces();
+  // TODO: Account for special case VRF-accepted IPs that are not interface IPs.
+  private static Map<String, Map<String, Map<String, IpSpace>>> computeAcceptedIps(
+      IpOwners ipOwners) {
+    return ipOwners.getVrfIfaceOwnedIpSpaces();
   }
 
   /**
@@ -1064,7 +1065,7 @@ public final class ForwardingAnalysisImpl implements ForwardingAnalysis {
 
   @Nonnull
   @Override
-  public Map<String, Map<String, IpSpace>> getAcceptsIps() {
+  public Map<String, Map<String, Map<String, IpSpace>>> getAcceptsIps() {
     return _acceptedIps;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockForwardingAnalysis.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockForwardingAnalysis.java
@@ -9,7 +9,7 @@ public class MockForwardingAnalysis implements ForwardingAnalysis {
 
   public static class Builder {
 
-    private Map<String, Map<String, IpSpace>> _acceptedIps;
+    private Map<String, Map<String, Map<String, IpSpace>>> _acceptedIps;
     private Map<String, Map<String, IpSpace>> _arpReplies;
     private Map<
             String, Map<String, Map<AbstractRoute, Map<String, Map<ArpIpChoice, Set<IpSpace>>>>>>
@@ -35,7 +35,7 @@ public class MockForwardingAnalysis implements ForwardingAnalysis {
       return new MockForwardingAnalysis(this);
     }
 
-    public Builder setAcceptedIps(Map<String, Map<String, IpSpace>> acceptedIps) {
+    public Builder setAcceptedIps(Map<String, Map<String, Map<String, IpSpace>>> acceptedIps) {
       _acceptedIps = acceptedIps;
       return this;
     }
@@ -83,7 +83,7 @@ public class MockForwardingAnalysis implements ForwardingAnalysis {
     return new Builder();
   }
 
-  private Map<String, Map<String, IpSpace>> _acceptedIps;
+  private final Map<String, Map<String, Map<String, IpSpace>>> _acceptedIps;
   private final Map<String, Map<String, IpSpace>> _arpReplies;
   private final Map<
           String, Map<String, Map<AbstractRoute, Map<String, Map<ArpIpChoice, Set<IpSpace>>>>>>
@@ -107,7 +107,7 @@ public class MockForwardingAnalysis implements ForwardingAnalysis {
 
   @Nonnull
   @Override
-  public Map<String, Map<String, IpSpace>> getAcceptsIps() {
+  public Map<String, Map<String, Map<String, IpSpace>>> getAcceptsIps() {
     return _acceptedIps;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -1618,7 +1618,7 @@ public final class BDDReachabilityAnalysisFactory {
                   Map<String, IpSpace> vrfAcceptIps =
                       nodeAcceptIps.getOrDefault(vrf, ImmutableMap.of());
                   // Create entry for every interface in the current VRF
-                  return c.getActiveInterfaces().values().stream()
+                  return c.getAllInterfaces().values().stream()
                       .filter(iface -> iface.getVrfName().equals(vrf))
                       .map(Interface::getName)
                       .collect(

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateToTerminationState.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateToTerminationState.java
@@ -3,6 +3,7 @@ package org.batfish.bddreachability;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.batfish.symbolic.state.InterfaceAccept;
 import org.batfish.symbolic.state.NodeAccept;
 import org.batfish.symbolic.state.NodeDropAclIn;
 import org.batfish.symbolic.state.NodeDropAclOut;
@@ -12,6 +13,7 @@ import org.batfish.symbolic.state.NodeInterfaceDeliveredToSubnet;
 import org.batfish.symbolic.state.NodeInterfaceExitsNetwork;
 import org.batfish.symbolic.state.NodeInterfaceInsufficientInfo;
 import org.batfish.symbolic.state.NodeInterfaceNeighborUnreachable;
+import org.batfish.symbolic.state.OriginateInterface;
 import org.batfish.symbolic.state.OriginateInterfaceLink;
 import org.batfish.symbolic.state.OriginateVrf;
 import org.batfish.symbolic.state.PostInInterface;
@@ -87,6 +89,11 @@ public class OriginationStateToTerminationState implements StateExprVisitor<List
   }
 
   @Override
+  public List<StateExpr> visitInterfaceAccept(InterfaceAccept interfaceAccept) {
+    return null;
+  }
+
+  @Override
   public List<StateExpr> visitNeighborUnreachable() {
     return null;
   }
@@ -138,6 +145,12 @@ public class OriginationStateToTerminationState implements StateExprVisitor<List
   public List<StateExpr> visitNodeInterfaceNeighborUnreachable(
       NodeInterfaceNeighborUnreachable nodeInterfaceNeighborUnreachable) {
     return null;
+  }
+
+  @Override
+  public List<StateExpr> visitOriginateInterface(OriginateInterface originateInterface) {
+    return ImmutableList.of(
+        new InterfaceAccept(originateInterface.getHostname(), originateInterface.getInterface()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/PreOutgoingTransformationNodeVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/PreOutgoingTransformationNodeVisitor.java
@@ -1,6 +1,7 @@
 package org.batfish.bddreachability;
 
 import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.symbolic.state.InterfaceAccept;
 import org.batfish.symbolic.state.NodeAccept;
 import org.batfish.symbolic.state.NodeDropAclIn;
 import org.batfish.symbolic.state.NodeDropAclOut;
@@ -10,6 +11,7 @@ import org.batfish.symbolic.state.NodeInterfaceDeliveredToSubnet;
 import org.batfish.symbolic.state.NodeInterfaceExitsNetwork;
 import org.batfish.symbolic.state.NodeInterfaceInsufficientInfo;
 import org.batfish.symbolic.state.NodeInterfaceNeighborUnreachable;
+import org.batfish.symbolic.state.OriginateInterface;
 import org.batfish.symbolic.state.OriginateInterfaceLink;
 import org.batfish.symbolic.state.OriginateVrf;
 import org.batfish.symbolic.state.PostInInterface;
@@ -80,6 +82,11 @@ public class PreOutgoingTransformationNodeVisitor implements StateExprVisitor<No
   }
 
   @Override
+  public NodeInterfacePair visitInterfaceAccept(InterfaceAccept interfaceAccept) {
+    return null;
+  }
+
+  @Override
   public NodeInterfacePair visitNeighborUnreachable() {
     return null;
   }
@@ -130,6 +137,11 @@ public class PreOutgoingTransformationNodeVisitor implements StateExprVisitor<No
   @Override
   public NodeInterfacePair visitNodeInterfaceNeighborUnreachable(
       NodeInterfaceNeighborUnreachable nodeInterfaceNeighborUnreachable) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitOriginateInterface(OriginateInterface originateInterface) {
     return null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/ReversePassOriginationState.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/ReversePassOriginationState.java
@@ -2,6 +2,7 @@ package org.batfish.bddreachability;
 
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
+import org.batfish.symbolic.state.InterfaceAccept;
 import org.batfish.symbolic.state.NodeAccept;
 import org.batfish.symbolic.state.NodeDropAclIn;
 import org.batfish.symbolic.state.NodeDropAclOut;
@@ -11,6 +12,7 @@ import org.batfish.symbolic.state.NodeInterfaceDeliveredToSubnet;
 import org.batfish.symbolic.state.NodeInterfaceExitsNetwork;
 import org.batfish.symbolic.state.NodeInterfaceInsufficientInfo;
 import org.batfish.symbolic.state.NodeInterfaceNeighborUnreachable;
+import org.batfish.symbolic.state.OriginateInterface;
 import org.batfish.symbolic.state.OriginateInterfaceLink;
 import org.batfish.symbolic.state.OriginateVrf;
 import org.batfish.symbolic.state.PostInInterface;
@@ -96,6 +98,14 @@ public class ReversePassOriginationState implements StateExprVisitor<StateExpr> 
   }
 
   @Override
+  public StateExpr visitInterfaceAccept(InterfaceAccept interfaceAccept) {
+    String hostname = interfaceAccept.getHostname();
+    return _isFinalNode.test(hostname)
+        ? new OriginateInterface(hostname, interfaceAccept.getInterface())
+        : null;
+  }
+
+  @Override
   public StateExpr visitNeighborUnreachable() {
     return null;
   }
@@ -150,6 +160,11 @@ public class ReversePassOriginationState implements StateExprVisitor<StateExpr> 
   @Override
   public StateExpr visitNodeInterfaceNeighborUnreachable(
       NodeInterfaceNeighborUnreachable nodeInterfaceNeighborUnreachable) {
+    return null;
+  }
+
+  @Override
+  public StateExpr visitOriginateInterface(OriginateInterface originateInterface) {
     return null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/SessionCreationNodeVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/SessionCreationNodeVisitor.java
@@ -1,6 +1,7 @@
 package org.batfish.bddreachability;
 
 import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.symbolic.state.InterfaceAccept;
 import org.batfish.symbolic.state.NodeAccept;
 import org.batfish.symbolic.state.NodeDropAclIn;
 import org.batfish.symbolic.state.NodeDropAclOut;
@@ -10,6 +11,7 @@ import org.batfish.symbolic.state.NodeInterfaceDeliveredToSubnet;
 import org.batfish.symbolic.state.NodeInterfaceExitsNetwork;
 import org.batfish.symbolic.state.NodeInterfaceInsufficientInfo;
 import org.batfish.symbolic.state.NodeInterfaceNeighborUnreachable;
+import org.batfish.symbolic.state.OriginateInterface;
 import org.batfish.symbolic.state.OriginateInterfaceLink;
 import org.batfish.symbolic.state.OriginateVrf;
 import org.batfish.symbolic.state.PostInInterface;
@@ -86,6 +88,11 @@ final class SessionCreationNodeVisitor implements StateExprVisitor<NodeInterface
   }
 
   @Override
+  public NodeInterfacePair visitInterfaceAccept(InterfaceAccept interfaceAccept) {
+    return null;
+  }
+
+  @Override
   public NodeInterfacePair visitNeighborUnreachable() {
     return null;
   }
@@ -135,6 +142,11 @@ final class SessionCreationNodeVisitor implements StateExprVisitor<NodeInterface
   @Override
   public NodeInterfacePair visitNodeInterfaceNeighborUnreachable(
       NodeInterfaceNeighborUnreachable nodeInterfaceNeighborUnreachable) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitOriginateInterface(OriginateInterface originateInterface) {
     return null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -20,7 +20,6 @@ import javax.annotation.Nonnull;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
-import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
@@ -171,11 +170,9 @@ public class TracerouteEngineImplContext {
    * ip}
    */
   boolean acceptsIp(String node, String vrf, Ip ip) {
-    return _forwardingAnalysis
-        .getAcceptsIps()
-        .getOrDefault(node, ImmutableMap.of())
-        .getOrDefault(vrf, EmptyIpSpace.INSTANCE)
-        .containsIp(ip, ImmutableMap.of());
+    return _forwardingAnalysis.getAcceptsIps().getOrDefault(node, ImmutableMap.of())
+        .getOrDefault(vrf, ImmutableMap.of()).values().stream()
+        .anyMatch(ipSpace -> ipSpace.containsIp(ip, ImmutableMap.of()));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -547,10 +547,11 @@ public final class BDDReachabilityAnalysisFactoryTest {
               new IpsRoutedOutInterfacesFactory(dataPlane.getFibs()),
               false,
               false);
-      assertThat(
-          factory.getVrfAcceptBDDs(),
-          hasEntry(
-              equalTo(config.getHostname()), hasEntry(equalTo(vrf.getName()), equalTo(ipBDD))));
+      Map<String, Map<String, Map<String, BDD>>> expectedAcceptBdds =
+          ImmutableMap.of(
+              config.getHostname(),
+              ImmutableMap.of(vrf.getName(), ImmutableMap.of(iface.getName(), ipBDD)));
+      assertThat(factory.getIfaceAcceptBDDs(), equalTo(expectedAcceptBdds));
     }
 
     // when interface is inactive, its Ip does not belong to the VRF
@@ -567,11 +568,10 @@ public final class BDDReachabilityAnalysisFactoryTest {
               new IpsRoutedOutInterfacesFactory(dataPlane.getFibs()),
               false,
               false);
-      assertThat(
-          factory.getVrfAcceptBDDs(),
-          hasEntry(
-              equalTo(config.getHostname()),
-              hasEntry(equalTo(vrf.getName()), equalTo(PKT.getFactory().zero()))));
+      // Interface isn't active, so shouldn't appear in map
+      Map<String, Map<String, Map<String, BDD>>> expectedAcceptBdds =
+          ImmutableMap.of(config.getHostname(), ImmutableMap.of(vrf.getName(), ImmutableMap.of()));
+      assertThat(factory.getIfaceAcceptBDDs(), equalTo(expectedAcceptBdds));
     }
 
     // when interface is blacklisted, its Ip does not belong to the VRF
@@ -589,11 +589,10 @@ public final class BDDReachabilityAnalysisFactoryTest {
               new IpsRoutedOutInterfacesFactory(dataPlane.getFibs()),
               false,
               false);
-      assertThat(
-          factory.getVrfAcceptBDDs(),
-          hasEntry(
-              equalTo(config.getHostname()),
-              hasEntry(equalTo(vrf.getName()), equalTo(PKT.getFactory().zero()))));
+      // Interface isn't active, so shouldn't appear in map
+      Map<String, Map<String, Map<String, BDD>>> expectedAcceptBdds =
+          ImmutableMap.of(config.getHostname(), ImmutableMap.of(vrf.getName(), ImmutableMap.of()));
+      assertThat(factory.getIfaceAcceptBDDs(), equalTo(expectedAcceptBdds));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -554,7 +554,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
       assertThat(factory.getIfaceAcceptBDDs(), equalTo(expectedAcceptBdds));
     }
 
-    // when interface is inactive, its Ip does not belong to the VRF
+    // when interface is inactive, it doesn't own any IPs
     {
       iface.setActive(false);
       Batfish batfish = BatfishTestUtils.getBatfish(configs, temp);
@@ -568,13 +568,15 @@ public final class BDDReachabilityAnalysisFactoryTest {
               new IpsRoutedOutInterfacesFactory(dataPlane.getFibs()),
               false,
               false);
-      // Interface isn't active, so shouldn't appear in map
       Map<String, Map<String, Map<String, BDD>>> expectedAcceptBdds =
-          ImmutableMap.of(config.getHostname(), ImmutableMap.of(vrf.getName(), ImmutableMap.of()));
+          ImmutableMap.of(
+              config.getHostname(),
+              ImmutableMap.of(
+                  vrf.getName(), ImmutableMap.of(iface.getName(), PKT.getFactory().zero())));
       assertThat(factory.getIfaceAcceptBDDs(), equalTo(expectedAcceptBdds));
     }
 
-    // when interface is blacklisted, its Ip does not belong to the VRF
+    // when interface is blacklisted, it doesn't own any IPs
     {
       iface.blacklist();
       Batfish batfish = BatfishTestUtils.getBatfish(configs, temp);
@@ -589,9 +591,11 @@ public final class BDDReachabilityAnalysisFactoryTest {
               new IpsRoutedOutInterfacesFactory(dataPlane.getFibs()),
               false,
               false);
-      // Interface isn't active, so shouldn't appear in map
       Map<String, Map<String, Map<String, BDD>>> expectedAcceptBdds =
-          ImmutableMap.of(config.getHostname(), ImmutableMap.of(vrf.getName(), ImmutableMap.of()));
+          ImmutableMap.of(
+              config.getHostname(),
+              ImmutableMap.of(
+                  vrf.getName(), ImmutableMap.of(iface.getName(), PKT.getFactory().zero())));
       assertThat(factory.getIfaceAcceptBDDs(), equalTo(expectedAcceptBdds));
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.sf.javabdd.BDD;
@@ -46,6 +47,7 @@ import org.batfish.specifier.InterfaceLocation;
 import org.batfish.specifier.IpSpaceAssignment;
 import org.batfish.symbolic.state.Accept;
 import org.batfish.symbolic.state.DropNoRoute;
+import org.batfish.symbolic.state.InterfaceAccept;
 import org.batfish.symbolic.state.NodeAccept;
 import org.batfish.symbolic.state.NodeDropAclIn;
 import org.batfish.symbolic.state.NodeDropAclOut;
@@ -89,6 +91,10 @@ public final class BDDReachabilityAnalysisTest {
   private String _dstIface2Name;
   private String _dstName;
   private VrfAccept _dstVrfAccept;
+  private InterfaceAccept _link1DstAccept;
+  private InterfaceAccept _link2DstAccept;
+  private InterfaceAccept _dstIface1Accept;
+  private InterfaceAccept _dstIface2Accept;
   private NodeAccept _dstNodeAccept;
   private PostInInterface _dstPostInInterface1;
   private PostInInterface _dstPostInInterface2;
@@ -105,15 +111,19 @@ public final class BDDReachabilityAnalysisTest {
   private String _link1DstName;
 
   private BDD _link1SrcIpBDD;
+  private String _link1SrcName;
 
   private BDD _link2DstIpBDD;
   private String _link2DstName;
 
   private BDD _link2SrcIpBDD;
+  private String _link2SrcName;
 
   private String _srcName;
   private NodeAccept _srcNodeAccept;
   private VrfAccept _srcVrfAccept;
+  private InterfaceAccept _link1SrcAccept;
+  private InterfaceAccept _link2SrcAccept;
   private PostInVrf _srcPostInVrf;
   private PreInInterface _srcPreInInterface1;
   private PreInInterface _srcPreInInterface2;
@@ -129,6 +139,18 @@ public final class BDDReachabilityAnalysisTest {
   public void setup() throws IOException {
     _net = new TestNetwork();
     Batfish batfish = BatfishTestUtils.getBatfish(_net._configs, temp);
+
+    _link1DstIpBDD = dstIpBDD(LINK_1_NETWORK.getEndIp());
+    _link1DstName = _net._link1Dst.getName();
+
+    _link1SrcIpBDD = dstIpBDD(LINK_1_NETWORK.getStartIp());
+    _link1SrcName = _net._link1Src.getName();
+
+    _link2DstIpBDD = dstIpBDD(LINK_2_NETWORK.getEndIp());
+    _link2DstName = _net._link2Dst.getName();
+
+    _link2SrcIpBDD = dstIpBDD(LINK_2_NETWORK.getStartIp());
+    _link2SrcName = _net._link2Src.getName();
 
     batfish.computeDataPlane(batfish.getSnapshot());
     DataPlane dataPlane = batfish.loadDataPlane(batfish.getSnapshot());
@@ -158,23 +180,18 @@ public final class BDDReachabilityAnalysisTest {
     _dstName = _net._dstNode.getHostname();
     _dstNodeAccept = new NodeAccept(_dstName);
     _dstVrfAccept = new VrfAccept(_dstName, DEFAULT_VRF_NAME);
+    _link1DstAccept = new InterfaceAccept(_dstName, _link1DstName);
+    _link2DstAccept = new InterfaceAccept(_dstName, _link2DstName);
+    _dstIface1Accept = new InterfaceAccept(_dstName, _dstIface1Name);
+    _dstIface2Accept = new InterfaceAccept(_dstName, _dstIface2Name);
     _dstPostInVrf = new PostInVrf(_dstName, DEFAULT_VRF_NAME);
     _dstPreOutVrf = new PreOutVrf(_dstName, DEFAULT_VRF_NAME);
-
-    _link1DstIpBDD = dstIpBDD(LINK_1_NETWORK.getEndIp());
-    _link1DstName = _net._link1Dst.getName();
-
-    _link1SrcIpBDD = dstIpBDD(LINK_1_NETWORK.getStartIp());
-
-    _link2DstIpBDD = dstIpBDD(LINK_2_NETWORK.getEndIp());
-    _link2DstName = _net._link2Dst.getName();
-
-    _link2SrcIpBDD = dstIpBDD(LINK_2_NETWORK.getStartIp());
-    String link2SrcName = _net._link2Src.getName();
 
     _srcName = _net._srcNode.getHostname();
     _srcNodeAccept = new NodeAccept(_srcName);
     _srcVrfAccept = new VrfAccept(_srcName, DEFAULT_VRF_NAME);
+    _link1SrcAccept = new InterfaceAccept(_srcName, _link1SrcName);
+    _link2SrcAccept = new InterfaceAccept(_srcName, _link2SrcName);
     _srcPostInVrf = new PostInVrf(_srcName, DEFAULT_VRF_NAME);
 
     _dstPostInInterface1 = new PostInInterface(_dstName, _link1DstName);
@@ -184,18 +201,20 @@ public final class BDDReachabilityAnalysisTest {
     _dstPreInInterface2 = new PreInInterface(_dstName, _link2DstName);
 
     _srcPreInInterface1 = new PreInInterface(_srcName, _net._link1Src.getName());
-    _srcPreInInterface2 = new PreInInterface(_srcName, link2SrcName);
+    _srcPreInInterface2 = new PreInInterface(_srcName, _link2SrcName);
 
     _dstPreOutEdge1 = new PreOutEdge(_dstName, _link1DstName, _srcName, _net._link1Src.getName());
-    _dstPreOutEdge2 = new PreOutEdge(_dstName, _link2DstName, _srcName, link2SrcName);
+    _dstPreOutEdge2 = new PreOutEdge(_dstName, _link2DstName, _srcName, _link2SrcName);
     _dstPreOutEdgePostNat1 =
         new PreOutEdgePostNat(_dstName, _link1DstName, _srcName, _net._link1Src.getName());
-    _dstPreOutEdgePostNat2 = new PreOutEdgePostNat(_dstName, _link2DstName, _srcName, link2SrcName);
+    _dstPreOutEdgePostNat2 =
+        new PreOutEdgePostNat(_dstName, _link2DstName, _srcName, _link2SrcName);
     _srcPreOutEdge1 = new PreOutEdge(_srcName, _net._link1Src.getName(), _dstName, _link1DstName);
-    _srcPreOutEdge2 = new PreOutEdge(_srcName, link2SrcName, _dstName, _link2DstName);
+    _srcPreOutEdge2 = new PreOutEdge(_srcName, _link2SrcName, _dstName, _link2DstName);
     _srcPreOutEdgePostNat1 =
         new PreOutEdgePostNat(_srcName, _net._link1Src.getName(), _dstName, _link1DstName);
-    _srcPreOutEdgePostNat2 = new PreOutEdgePostNat(_srcName, link2SrcName, _dstName, _link2DstName);
+    _srcPreOutEdgePostNat2 =
+        new PreOutEdgePostNat(_srcName, _link2SrcName, _dstName, _link2DstName);
     _srcPreOutVrf = new PreOutVrf(_srcName, DEFAULT_VRF_NAME);
   }
 
@@ -232,16 +251,37 @@ public final class BDDReachabilityAnalysisTest {
     return _bddOps.or(bdds);
   }
 
-  private BDD vrfAcceptBDD(String node) {
-    return _graphFactory.getVrfAcceptBDDs().get(node).get(DEFAULT_VRF_NAME);
+  private Map<String, BDD> ifaceAcceptBDDs(String node) {
+    return _graphFactory.getIfaceAcceptBDDs().get(node).get(DEFAULT_VRF_NAME);
   }
 
   @Test
-  public void testVrfAcceptBDDs() {
+  public void testIfaceAcceptBDDs() {
     assertThat(
-        vrfAcceptBDD(_dstName),
-        equalTo(or(_link1DstIpBDD, _link2DstIpBDD, _dstIface1IpBDD, _dstIface2IpBDD)));
-    assertThat(vrfAcceptBDD(_srcName), equalTo(or(_link1SrcIpBDD, _link2SrcIpBDD)));
+        ifaceAcceptBDDs(_dstName),
+        equalTo(
+            ImmutableMap.of(
+                _link1DstName,
+                _link1DstIpBDD,
+                _link2DstName,
+                _link2DstIpBDD,
+                _dstIface1Name,
+                _dstIface1IpBDD,
+                _dstIface2Name,
+                _dstIface2IpBDD)));
+    assertThat(
+        ifaceAcceptBDDs(_srcName),
+        equalTo(ImmutableMap.of(_link1SrcName, _link1SrcIpBDD, _link2SrcName, _link2SrcIpBDD)));
+  }
+
+  @Test
+  public void testBDDTransitions_InterfaceAccept_VrfAccept() {
+    assertThat(bddTransition(_link1SrcAccept, _srcVrfAccept), isOne());
+    assertThat(bddTransition(_link2SrcAccept, _srcVrfAccept), isOne());
+    assertThat(bddTransition(_link1DstAccept, _dstVrfAccept), isOne());
+    assertThat(bddTransition(_link2DstAccept, _dstVrfAccept), isOne());
+    assertThat(bddTransition(_dstIface1Accept, _dstVrfAccept), isOne());
+    assertThat(bddTransition(_dstIface2Accept, _dstVrfAccept), isOne());
   }
 
   @Test
@@ -258,23 +298,60 @@ public final class BDDReachabilityAnalysisTest {
 
   @Test
   public void testBDDTransitions_PostInVrf_outEdges() {
-    BDD vrfAccept = bddTransition(_srcPostInVrf, _srcVrfAccept);
-    BDD nodeDropNoRoute = bddTransition(_srcPostInVrf, new NodeDropNoRoute(_srcName));
-    BDD preOutVrf = bddTransition(_srcPostInVrf, _srcPreOutVrf);
+    Set<StateExpr> srcPostInVrfOutStates = _graph.getForwardEdgeMap().get(_srcPostInVrf).keySet();
+    Set<StateExpr> dstPostInVrfOutStates = _graph.getForwardEdgeMap().get(_dstPostInVrf).keySet();
 
-    // test that out edges are mutually exclusive
-    assertThat(vrfAccept, not(intersects(nodeDropNoRoute)));
-    assertThat(vrfAccept, not(intersects(preOutVrf)));
-    assertThat(nodeDropNoRoute, not(intersects(preOutVrf)));
+    // Confirm out edges are as expected
+    assertThat(
+        srcPostInVrfOutStates,
+        containsInAnyOrder(
+            _link1SrcAccept, _link2SrcAccept, new NodeDropNoRoute(_srcName), _srcPreOutVrf));
+    assertThat(
+        dstPostInVrfOutStates,
+        containsInAnyOrder(
+            _link1DstAccept,
+            _link2DstAccept,
+            _dstIface1Accept,
+            _dstIface2Accept,
+            new NodeDropNoRoute(_dstName),
+            _dstPreOutVrf));
+
+    // Test that out edges are mutually exclusive
+    List<BDD> srcOutBdds =
+        srcPostInVrfOutStates.stream()
+            .map(outState -> bddTransition(_srcPostInVrf, outState))
+            .collect(ImmutableList.toImmutableList());
+    List<BDD> dstOutBdds =
+        dstPostInVrfOutStates.stream()
+            .map(outState -> bddTransition(_dstPostInVrf, outState))
+            .collect(ImmutableList.toImmutableList());
+    testMutuallyExclusive(srcOutBdds);
+    testMutuallyExclusive(dstOutBdds);
+  }
+
+  private void testMutuallyExclusive(List<BDD> bdds) {
+    for (int i = 0; i < bdds.size(); i++) {
+      for (int j = i + 1; j < bdds.size(); j++) {
+        assertThat(bdds.get(i), not(intersects(bdds.get(j))));
+      }
+    }
   }
 
   @Test
-  public void testBDDTransitions_PostInVrf_VrfAccept() {
-    assertThat(
-        bddTransition(_srcPostInVrf, _srcVrfAccept), equalTo(or(_link1SrcIpBDD, _link2SrcIpBDD)));
-    assertThat(
-        bddTransition(_dstPostInVrf, _dstVrfAccept),
-        equalTo(or(_link1DstIpBDD, _link2DstIpBDD, _dstIface1IpBDD, _dstIface2IpBDD)));
+  public void testBDDTransitions_PostInVrf_InterfaceAccept() {
+    BDD link1SrcAcceptBdd = bddTransition(_srcPostInVrf, _link1SrcAccept);
+    BDD link2SrcAcceptBdd = bddTransition(_srcPostInVrf, _link2SrcAccept);
+    assertThat(link1SrcAcceptBdd, equalTo(_link1SrcIpBDD));
+    assertThat(link2SrcAcceptBdd, equalTo(_link2SrcIpBDD));
+
+    BDD link1DstAcceptBdd = bddTransition(_dstPostInVrf, _link1DstAccept);
+    BDD link2DstAcceptBdd = bddTransition(_dstPostInVrf, _link2DstAccept);
+    BDD dstIface1AcceptBdd = bddTransition(_dstPostInVrf, _dstIface1Accept);
+    BDD dstIface2AcceptBdd = bddTransition(_dstPostInVrf, _dstIface2Accept);
+    assertThat(link1DstAcceptBdd, equalTo(_link1DstIpBDD));
+    assertThat(link2DstAcceptBdd, equalTo(_link2DstIpBDD));
+    assertThat(dstIface1AcceptBdd, equalTo(_dstIface1IpBDD));
+    assertThat(dstIface2AcceptBdd, equalTo(_dstIface2IpBDD));
   }
 
   @Test

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/InterfaceAccept.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/InterfaceAccept.java
@@ -1,0 +1,15 @@
+package org.batfish.symbolic.state;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class InterfaceAccept extends InterfaceStateExpr {
+  public InterfaceAccept(String hostname, String ifaceName) {
+    super(hostname, ifaceName);
+  }
+
+  @Override
+  public <R> R accept(StateExprVisitor<R> visitor) {
+    return visitor.visitInterfaceAccept(this);
+  }
+}

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/OriginateInterface.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/OriginateInterface.java
@@ -1,0 +1,15 @@
+package org.batfish.symbolic.state;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class OriginateInterface extends InterfaceStateExpr {
+  public OriginateInterface(String hostname, String ifaceName) {
+    super(hostname, ifaceName);
+  }
+
+  @Override
+  public <R> R accept(StateExprVisitor<R> visitor) {
+    return visitor.visitOriginateInterface(this);
+  }
+}

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/StateExprVisitor.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/StateExprVisitor.java
@@ -18,6 +18,8 @@ public interface StateExprVisitor<R> {
 
   R visitInsufficientInfo();
 
+  R visitInterfaceAccept(InterfaceAccept interfaceAccept);
+
   R visitNeighborUnreachable();
 
   R visitNodeAccept(NodeAccept nodeAccept);
@@ -39,6 +41,8 @@ public interface StateExprVisitor<R> {
 
   R visitNodeInterfaceNeighborUnreachable(
       NodeInterfaceNeighborUnreachable nodeInterfaceNeighborUnreachable);
+
+  R visitOriginateInterface(OriginateInterface originateInterface);
 
   R visitOriginateInterfaceLink(OriginateInterfaceLink originateInterfaceLink);
 


### PR DESCRIPTION
New states are `OriginateInterface` and `AcceptInterface`. They have been integrated into the reachability graph as follows:

Replace the existing `OriginateVrf -> PostInVrf` edge with:
- Edge from `OriginateVrf` to each corresponding `OriginateInterface` state, with `srcIp` constraint to specify each interface
- Edge from each `OriginateInterface` to `PostInVrf`

Replace the existing `PostInVrf -> VrfAccept` edge with:
- Edge from `PostInVrf` to each corresponding `InterfaceAccept`, with `dstIp` constraint
- Edge from each `InterfaceAccept` to `VrfAccept`

For more details, see [design doc](https://docs.google.com/document/d/1iQB939MxY4cAsbZta3R-j47MCZAj7d4UEuppOYVnwvI).