### PR TITLE
Remove duplicate app specifiers

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/AutoCompleteUtils.java
@@ -243,7 +243,7 @@ public final class AutoCompleteUtils {
           {
             suggestions =
                 ParboiledAutoComplete.autoComplete(
-                    Grammar.APP_SPECIFIER,
+                    Grammar.APPLICATION_SPECIFIER,
                     network,
                     snapshot,
                     query,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/InputValidationUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/InputValidationUtils.java
@@ -36,7 +36,11 @@ public final class InputValidationUtils {
     switch (varType) {
       case APPLICATION_SPEC:
         return ParboiledInputValidator.validate(
-            Grammar.APP_SPECIFIER, query, completionMetadata, nodeRolesData, referenceLibrary);
+            Grammar.APPLICATION_SPECIFIER,
+            query,
+            completionMetadata,
+            nodeRolesData,
+            referenceLibrary);
       case BGP_PEER_PROPERTY_SPEC:
         return ParboiledInputValidator.validate(
             Grammar.BGP_PEER_PROPERTY_SPECIFIER,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Grammar.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Grammar.java
@@ -26,10 +26,6 @@ import org.batfish.specifier.SpecifierContext;
 
 /** Contains information on various expressions supported by this package */
 public enum Grammar {
-  /** new application specifier that allows tcp/80 syntax */
-  APP_SPECIFIER(
-      "applicationSpecifier",
-      "application-specifier"), // TODO: updated when we change documentation
   APPLICATION_SPECIFIER("applicationSpecifier", "application-specifier"),
   BGP_PEER_PROPERTY_SPECIFIER("bgpPeerPropertySpecifier", "bgp-peer-property-specifier"),
   BGP_PROCESS_PROPERTY_SPECIFIER("bgpProcessPropertySpecifier", "bgp-process-property-specifier"),

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAppSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAppSpecifier.java
@@ -91,20 +91,21 @@ public final class ParboiledAppSpecifier implements ApplicationSpecifier {
 
   /**
    * Returns an {@link ApplicationSpecifier} based on {@code input} which is parsed as {@link
-   * Grammar#APP_SPECIFIER}.
+   * Grammar#APPLICATION_SPECIFIER}.
    *
    * @throws IllegalArgumentException if the parsing fails or does not produce the expected AST
    */
   public static ParboiledAppSpecifier parse(String input) {
     ParsingResult<AstNode> result =
-        new ReportingParseRunner<AstNode>(Parser.instance().getInputRule(Grammar.APP_SPECIFIER))
+        new ReportingParseRunner<AstNode>(
+                Parser.instance().getInputRule(Grammar.APPLICATION_SPECIFIER))
             .run(input);
 
     if (!result.parseErrors.isEmpty()) {
       throw new IllegalArgumentException(
           ParserUtils.getErrorString(
               input,
-              Grammar.APP_SPECIFIER,
+              Grammar.APPLICATION_SPECIFIER,
               (InvalidInputError) result.parseErrors.get(0),
               Parser.ANCHORS));
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -114,9 +114,8 @@ public class Parser extends CommonParser {
   @Override
   Rule getInputRule(Grammar grammar) {
     switch (grammar) {
-      case APP_SPECIFIER:
-        return input(AppSpec());
       case APPLICATION_SPECIFIER:
+        return input(AppSpec());
       case BGP_PEER_PROPERTY_SPECIFIER:
       case BGP_PROCESS_PROPERTY_SPECIFIER:
       case BGP_SESSION_COMPAT_STATUS_SPECIFIER:

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserAppTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserAppTest.java
@@ -36,13 +36,14 @@ public class ParserAppTest {
   @Rule public ExpectedException _thrown = ExpectedException.none();
 
   private static AbstractParseRunner<AstNode> getRunner() {
-    return new ReportingParseRunner<>(Parser.instance().getInputRule(Grammar.APP_SPECIFIER));
+    return new ReportingParseRunner<>(
+        Parser.instance().getInputRule(Grammar.APPLICATION_SPECIFIER));
   }
 
   private static ParboiledAutoComplete getPAC(String query) {
     return new ParboiledAutoComplete(
         Parser.instance(),
-        Grammar.APP_SPECIFIER,
+        Grammar.APPLICATION_SPECIFIER,
         Parser.ANCHORS,
         "network",
         "snapshot",

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserEnumSetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserEnumSetTest.java
@@ -7,13 +7,11 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.batfish.common.CompletionMetadata;
 import org.batfish.datamodel.BgpSessionProperties.SessionType;
-import org.batfish.datamodel.Protocol;
 import org.batfish.datamodel.ospf.OspfSessionStatus;
 import org.batfish.datamodel.questions.BgpPeerPropertySpecifier;
 import org.batfish.datamodel.questions.BgpProcessPropertySpecifier;
@@ -313,68 +311,6 @@ public class ParserEnumSetTest {
     assertThat(
         ParserUtils.getAst(getRunner().run(String.format(" %s , /%s/ ", t1, t2Regex))),
         equalTo(expectedNode));
-  }
-
-  /** Test that application enums (which are not strings) work */
-  @Test
-  public void testApplication() {
-    String query = "";
-    Set<ParboiledAutoCompleteSuggestion> suggestions =
-        getPAC("", Grammar.APPLICATION_SPECIFIER).run();
-
-    assertThat(
-        suggestions,
-        equalTo(
-            Stream.concat(
-                    Arrays.stream(Protocol.values())
-                        .map(
-                            val ->
-                                new ParboiledAutoCompleteSuggestion(
-                                    val.toString(), query.length(), Type.ENUM_SET_VALUE)),
-                    ImmutableSet.of(
-                        new ParboiledAutoCompleteSuggestion("/", 0, Type.ENUM_SET_REGEX),
-                        new ParboiledAutoCompleteSuggestion("!", 0, Type.ENUM_SET_NOT))
-                        .stream())
-                .collect(ImmutableSet.toImmutableSet())));
-  }
-
-  /**
-   * Test that in enums where some options are substrings, we autocomplete to their super strings
-   * properly, instead of limiting ourselves to the first match.
-   */
-  @Test
-  public void testAutoCompleteSuperStrings() {
-    assertThat(
-        getPAC("ht", Grammar.APPLICATION_SPECIFIER).run(),
-        containsInAnyOrder(
-            new ParboiledAutoCompleteSuggestion(Protocol.HTTP.toString(), 0, Type.ENUM_SET_VALUE),
-            new ParboiledAutoCompleteSuggestion(
-                Protocol.HTTPS.toString(), 0, Type.ENUM_SET_VALUE)));
-
-    assertThat(
-        getPAC("http", Grammar.APPLICATION_SPECIFIER).run(),
-        containsInAnyOrder(
-            new ParboiledAutoCompleteSuggestion(",", 4, Type.ENUM_SET_SET_OP),
-            new ParboiledAutoCompleteSuggestion(Protocol.HTTP.toString(), 0, Type.ENUM_SET_VALUE),
-            new ParboiledAutoCompleteSuggestion(
-                Protocol.HTTPS.toString(), 0, Type.ENUM_SET_VALUE)));
-
-    assertThat(
-        getPAC("https", Grammar.APPLICATION_SPECIFIER).run(),
-        containsInAnyOrder(
-            new ParboiledAutoCompleteSuggestion(Protocol.HTTPS.toString(), 0, Type.ENUM_SET_VALUE),
-            new ParboiledAutoCompleteSuggestion(",", 5, Type.ENUM_SET_SET_OP)));
-  }
-
-  /** Test that we auto complete properly when the query is a non-prefix substring */
-  @Test
-  public void testAutoCompleteNonPrefixSubstrings() {
-    assertThat(
-        getPAC("tt", Grammar.APPLICATION_SPECIFIER).run(),
-        containsInAnyOrder(
-            new ParboiledAutoCompleteSuggestion(Protocol.HTTP.toString(), 0, Type.ENUM_SET_VALUE),
-            new ParboiledAutoCompleteSuggestion(
-                Protocol.HTTPS.toString(), 0, Type.ENUM_SET_VALUE)));
   }
 
   /** Test that bgp peer properties are being parsed */


### PR DESCRIPTION
Reclaim the old name since it was more consistent with our naming pattern. 