### PR TITLE
BDD reachability: new methods/parameters for more flexibility

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BidirectionalReachabilityAnalysis.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BidirectionalReachabilityAnalysis.java
@@ -105,13 +105,13 @@ public final class BidirectionalReachabilityAnalysis {
                 ImmutableMap.of());
         BDD initialForwardHeaderSpaceBdd = ipAccessListToBdd.toBdd(initialForwardHeaderSpace);
         _forwardPassOriginationConstraints =
-            _factory.rootConstraints(srcIpSpaceAssignment, initialForwardHeaderSpaceBdd);
+            _factory.rootConstraints(srcIpSpaceAssignment, initialForwardHeaderSpaceBdd, false);
       }
 
       // Compute _originateStateToLocation
       {
         LocationVisitor<Optional<StateExpr>> locationToStateExpr =
-            new LocationToOriginationStateExpr(_configs);
+            new LocationToOriginationStateExpr(_configs, false);
         ImmutableMultimap.Builder<StateExpr, Location> builder = ImmutableMultimap.builder();
         srcIpSpaceAssignment.getEntries().stream()
             .flatMap(entry -> entry.getLocations().stream())

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/LocationToOriginationStateExpr.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/LocationToOriginationStateExpr.java
@@ -8,15 +8,26 @@ import org.batfish.datamodel.Interface;
 import org.batfish.specifier.InterfaceLinkLocation;
 import org.batfish.specifier.InterfaceLocation;
 import org.batfish.specifier.LocationVisitor;
+import org.batfish.symbolic.state.OriginateInterface;
 import org.batfish.symbolic.state.OriginateInterfaceLink;
 import org.batfish.symbolic.state.OriginateVrf;
 import org.batfish.symbolic.state.StateExpr;
 
-class LocationToOriginationStateExpr implements LocationVisitor<Optional<StateExpr>> {
+/**
+ * {@link LocationVisitor} that converts locations to corresponding origination {@link StateExpr}.
+ */
+public class LocationToOriginationStateExpr implements LocationVisitor<Optional<StateExpr>> {
   private final Map<String, Configuration> _configs;
+  private final boolean _useOriginateInterface;
 
-  LocationToOriginationStateExpr(Map<String, Configuration> configs) {
+  /**
+   * @param useOriginateInterface Whether visiting {@link InterfaceLocation} should return an {@link
+   *     OriginateInterface}. If false, it will return an {@link OriginateVrf} instead.
+   */
+  LocationToOriginationStateExpr(
+      Map<String, Configuration> configs, boolean useOriginateInterface) {
     _configs = configs;
+    _useOriginateInterface = useOriginateInterface;
   }
 
   @Override
@@ -44,6 +55,11 @@ class LocationToOriginationStateExpr implements LocationVisitor<Optional<StateEx
     Interface iface = config.getAllInterfaces().get(interfaceLocation.getInterfaceName());
     if (iface == null) {
       return Optional.empty();
+    }
+    if (_useOriginateInterface) {
+      return Optional.of(
+          new OriginateInterface(
+              interfaceLocation.getNodeName(), interfaceLocation.getInterfaceName()));
     }
     String vrf = iface.getVrfName();
     return Optional.of(new OriginateVrf(interfaceLocation.getNodeName(), vrf));

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateExprToLocation.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateExprToLocation.java
@@ -1,0 +1,253 @@
+package org.batfish.bddreachability;
+
+import java.util.Optional;
+import org.batfish.specifier.InterfaceLinkLocation;
+import org.batfish.specifier.InterfaceLocation;
+import org.batfish.specifier.Location;
+import org.batfish.symbolic.state.InterfaceAccept;
+import org.batfish.symbolic.state.NodeAccept;
+import org.batfish.symbolic.state.NodeDropAclIn;
+import org.batfish.symbolic.state.NodeDropAclOut;
+import org.batfish.symbolic.state.NodeDropNoRoute;
+import org.batfish.symbolic.state.NodeDropNullRoute;
+import org.batfish.symbolic.state.NodeInterfaceDeliveredToSubnet;
+import org.batfish.symbolic.state.NodeInterfaceExitsNetwork;
+import org.batfish.symbolic.state.NodeInterfaceInsufficientInfo;
+import org.batfish.symbolic.state.NodeInterfaceNeighborUnreachable;
+import org.batfish.symbolic.state.OriginateInterface;
+import org.batfish.symbolic.state.OriginateInterfaceLink;
+import org.batfish.symbolic.state.OriginateVrf;
+import org.batfish.symbolic.state.PostInInterface;
+import org.batfish.symbolic.state.PostInInterfacePostNat;
+import org.batfish.symbolic.state.PostInVrf;
+import org.batfish.symbolic.state.PostInVrfSession;
+import org.batfish.symbolic.state.PreInInterface;
+import org.batfish.symbolic.state.PreOutEdge;
+import org.batfish.symbolic.state.PreOutEdgePostNat;
+import org.batfish.symbolic.state.PreOutEdgeSession;
+import org.batfish.symbolic.state.PreOutInterfaceDeliveredToSubnet;
+import org.batfish.symbolic.state.PreOutInterfaceExitsNetwork;
+import org.batfish.symbolic.state.PreOutInterfaceInsufficientInfo;
+import org.batfish.symbolic.state.PreOutInterfaceNeighborUnreachable;
+import org.batfish.symbolic.state.PreOutVrf;
+import org.batfish.symbolic.state.PreOutVrfSession;
+import org.batfish.symbolic.state.StateExpr;
+import org.batfish.symbolic.state.StateExprVisitor;
+import org.batfish.symbolic.state.VrfAccept;
+
+/**
+ * Visitor to convert an origination {@link StateExpr} to its corresponding {@link Location}, if any
+ */
+public final class OriginationStateExprToLocation implements StateExprVisitor<Optional<Location>> {
+  private static final OriginationStateExprToLocation INSTANCE =
+      new OriginationStateExprToLocation();
+
+  public static Optional<Location> toLocation(StateExpr expr) {
+    return expr.accept(INSTANCE);
+  }
+
+  private OriginationStateExprToLocation() {}
+
+  @Override
+  public Optional<Location> visitAccept() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitDeliveredToSubnet() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitDropAclIn() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitDropAclOut() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitDropNoRoute() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitDropNullRoute() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitExitsNetwork() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitInsufficientInfo() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitInterfaceAccept(InterfaceAccept interfaceAccept) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitNeighborUnreachable() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitNodeAccept(NodeAccept nodeAccept) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitNodeDropAclIn(NodeDropAclIn nodeDropAclIn) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitNodeDropAclOut(NodeDropAclOut nodeDropAclOut) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitNodeDropNoRoute(NodeDropNoRoute nodeDropNoRoute) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitNodeDropNullRoute(NodeDropNullRoute nodeDropNullRoute) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitNodeInterfaceDeliveredToSubnet(
+      NodeInterfaceDeliveredToSubnet nodeInterfaceDeliveredToSubnet) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitNodeInterfaceExitsNetwork(
+      NodeInterfaceExitsNetwork nodeInterfaceExitsNetwork) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitNodeInterfaceInsufficientInfo(
+      NodeInterfaceInsufficientInfo nodeInterfaceInsufficientInfo) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitNodeInterfaceNeighborUnreachable(
+      NodeInterfaceNeighborUnreachable nodeInterfaceNeighborUnreachable) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitOriginateInterface(OriginateInterface originateInterface) {
+    return Optional.of(
+        new InterfaceLocation(originateInterface.getHostname(), originateInterface.getInterface()));
+  }
+
+  @Override
+  public Optional<Location> visitOriginateInterfaceLink(
+      OriginateInterfaceLink originateInterfaceLink) {
+    return Optional.of(
+        new InterfaceLinkLocation(
+            originateInterfaceLink.getHostname(), originateInterfaceLink.getInterface()));
+  }
+
+  @Override
+  public Optional<Location> visitOriginateVrf(OriginateVrf originateVrf) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPostInInterface(PostInInterface postInInterface) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPostInInterfacePostNat(
+      PostInInterfacePostNat postInInterfacePostNat) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPostInVrf(PostInVrf postInVrf) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPostInVrfSession(PostInVrfSession postInVrfSession) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPreInInterface(PreInInterface preInInterface) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPreOutEdge(PreOutEdge preOutEdge) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPreOutEdgePostNat(PreOutEdgePostNat preOutInterface) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPreOutEdgeSession(PreOutEdgeSession preOutEdgeSession) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPreOutInterfaceDeliveredToSubnet(
+      PreOutInterfaceDeliveredToSubnet preOutInterfaceDeliveredToSubnet) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPreOutInterfaceExitsNetwork(
+      PreOutInterfaceExitsNetwork preOutInterfaceExitsNetwork) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPreOutInterfaceInsufficientInfo(
+      PreOutInterfaceInsufficientInfo preOutInterfaceInsufficientInfo) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPreOutInterfaceNeighborUnreachable(
+      PreOutInterfaceNeighborUnreachable preOutInterfaceNeighborUnreachable) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPreOutVrf(PreOutVrf preOutVrf) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPreOutVrfSession(PreOutVrfSession preOutVrfSession) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitQuery() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitVrfAccept(VrfAccept vrfAccept) {
+    return Optional.empty();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -3086,7 +3086,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
       Set<String> requiredTransitNodes,
       Set<String> finalNodes,
       Set<FlowDisposition> actions,
-      boolean ignoreFilters) {
+      boolean ignoreFilters,
+      boolean useInterfaceRoots) {
     BDDReachabilityAnalysisFactory factory =
         getBddReachabilityAnalysisFactory(snapshot, pkt, ignoreFilters);
     return factory.bddReachabilityAnalysis(
@@ -3095,7 +3096,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
         forbiddenTransitNodes,
         requiredTransitNodes,
         finalNodes,
-        actions);
+        actions,
+        useInterfaceRoots);
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -197,7 +197,6 @@ public final class BDDReachabilityAnalysisFactoryTest {
 
     assertThat(configs.size(), equalTo(2));
     for (String node : configs.keySet()) {
-      String otherNode = configs.keySet().stream().filter(n -> !n.equals(node)).findFirst().get();
       BDDReachabilityAnalysisFactory factory =
           new BDDReachabilityAnalysisFactory(
               PKT,


### PR DESCRIPTION
- Adds BDDReachabilityAnalysis method `getSrcLocBdds()` to return a mapping of source `Location` to reachability BDD
- Adds version of `BDDReachabilityAnalysisFactory.bddReachabilityAnalysis()` that takes in a boolean `useInterfaceRoots`, which when set causes the analysis to use `OriginateInterface` roots instead of `OriginateVrf` roots

After #5566.