### PR TITLE
Juniper: better traces for matching source-address,destination-address

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -3869,10 +3869,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     FwFrom from;
     IpWildcard ipWildcard = formIpWildCard(ctx.fftfa_address_mask_prefix());
     if (ipWildcard != null) {
+      String text = getFullText(ctx.fftfa_address_mask_prefix());
       from =
           ctx.EXCEPT() != null
-              ? new FwFromDestinationAddressExcept(ipWildcard)
-              : new FwFromDestinationAddress(ipWildcard);
+              ? new FwFromDestinationAddressExcept(ipWildcard, text)
+              : new FwFromDestinationAddress(ipWildcard, text);
       _currentFwTerm.getFroms().add(from);
     }
   }
@@ -4047,10 +4048,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     FwFrom from;
     IpWildcard ipWildcard = formIpWildCard(ctx.fftfa_address_mask_prefix());
     if (ipWildcard != null) {
+      String text = getFullText(ctx.fftfa_address_mask_prefix());
       from =
           ctx.EXCEPT() != null
-              ? new FwFromSourceAddressExcept(ipWildcard)
-              : new FwFromSourceAddress(ipWildcard);
+              ? new FwFromSourceAddressExcept(ipWildcard, text)
+              : new FwFromSourceAddress(ipWildcard, text);
       _currentFwTerm.getFroms().add(from);
     }
   }
@@ -5745,7 +5747,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitSepctxpm_destination_address(Sepctxpm_destination_addressContext ctx) {
     Address_specifierContext addressSpecifierContext = ctx.address_specifier();
-    if (addressSpecifierContext.ANY() != null || addressSpecifierContext.ANY_IPV4() != null) {
+    if (addressSpecifierContext.ANY() != null) {
+      FwFromDestinationAddress match = new FwFromDestinationAddress(IpWildcard.ANY, "any");
+      _currentFwTerm.getFroms().add(match);
+      return;
+    } else if (addressSpecifierContext.ANY_IPV4() != null) {
+      FwFromDestinationAddress match = new FwFromDestinationAddress(IpWildcard.ANY, "any-ipv4");
+      _currentFwTerm.getFroms().add(match);
       return;
     }
 
@@ -5776,12 +5784,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitSepctxpm_source_address(Sepctxpm_source_addressContext ctx) {
     if (ctx.address_specifier().ANY() != null) {
-      return;
+      FwFromSourceAddress match = new FwFromSourceAddress(IpWildcard.ANY, "any");
+      _currentFwTerm.getFroms().add(match);
     } else if (ctx.address_specifier().ANY_IPV4() != null) {
-      return;
+      FwFromSourceAddress match = new FwFromSourceAddress(IpWildcard.ANY, "any-ipv4");
+      _currentFwTerm.getFroms().add(match);
     } else if (ctx.address_specifier().ANY_IPV6() != null) {
       _currentFwTerm.setIpv6(true);
-      return;
     } else if (ctx.address_specifier().variable() != null) {
       String addressBookEntryName = ctx.address_specifier().variable().getText();
       FwFrom match =

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddress.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddress.java
@@ -1,7 +1,7 @@
 package org.batfish.representation.juniper;
 
 import com.google.common.annotations.VisibleForTesting;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.HeaderSpace;
@@ -14,10 +14,16 @@ import org.batfish.representation.juniper.FwTerm.Field;
 /** Class for firewall filter from destination-address */
 public final class FwFromDestinationAddress implements FwFrom {
 
-  @Nullable private final IpWildcard _ipWildcard;
+  @Nonnull private final String _description;
+  @Nonnull private final IpWildcard _ipWildcard;
 
-  public FwFromDestinationAddress(IpWildcard ipWildcard) {
+  /**
+   * Creates a new {@link FwFromDestinationAddress}, matching the given {@link IpWildcard} and using
+   * the given {@code description} for the {@link TraceElement}.
+   */
+  public FwFromDestinationAddress(@Nonnull IpWildcard ipWildcard, @Nonnull String description) {
     _ipWildcard = ipWildcard;
+    _description = description;
   }
 
   public IpWildcard getIpWildcard() {
@@ -35,7 +41,7 @@ public final class FwFromDestinationAddress implements FwFrom {
   }
 
   private TraceElement getTraceElement() {
-    return TraceElement.of(String.format("Matched destination-address %s", _ipWildcard.toString()));
+    return TraceElement.of(String.format("Matched destination-address %s", _description));
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddressExcept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromDestinationAddressExcept.java
@@ -1,7 +1,7 @@
 package org.batfish.representation.juniper;
 
 import com.google.common.annotations.VisibleForTesting;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.HeaderSpace;
@@ -14,10 +14,16 @@ import org.batfish.representation.juniper.FwTerm.Field;
 /** Class for firewall filter from destination-address except */
 public final class FwFromDestinationAddressExcept implements FwFrom {
 
-  @Nullable private final IpWildcard _ipWildcard;
+  @Nonnull private final String _description;
+  @Nonnull private final IpWildcard _ipWildcard;
 
-  public FwFromDestinationAddressExcept(IpWildcard ipWildcard) {
+  /**
+   * Creates a new {@link FwFromDestinationAddressExcept}, matching everything except the given
+   * {@link IpWildcard} and using the given {@code description} for the {@link TraceElement}.
+   */
+  public FwFromDestinationAddressExcept(IpWildcard ipWildcard, String description) {
     _ipWildcard = ipWildcard;
+    _description = description;
   }
 
   public IpWildcard getIpWildcard() {
@@ -40,7 +46,6 @@ public final class FwFromDestinationAddressExcept implements FwFrom {
   }
 
   private TraceElement getTraceElement() {
-    return TraceElement.of(
-        String.format("Matched destination-address %s except", _ipWildcard.toString()));
+    return TraceElement.of(String.format("Matched destination-address %s except", _description));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddress.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddress.java
@@ -1,6 +1,6 @@
 package org.batfish.representation.juniper;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.HeaderSpace;
@@ -13,9 +13,15 @@ import org.batfish.representation.juniper.FwTerm.Field;
 /** Class for firewall filter from source-address */
 public final class FwFromSourceAddress implements FwFrom {
 
-  @Nullable private final IpWildcard _ipWildcard;
+  @Nonnull private final String _description;
+  @Nonnull private final IpWildcard _ipWildcard;
 
-  public FwFromSourceAddress(IpWildcard ipWildcard) {
+  /**
+   * Creates a new {@link FwFromSourceAddress}, matching the given {@link IpWildcard} and using the
+   * given {@code description} for the {@link TraceElement}.
+   */
+  public FwFromSourceAddress(@Nonnull IpWildcard ipWildcard, @Nonnull String description) {
+    _description = description;
     _ipWildcard = ipWildcard;
   }
 
@@ -34,7 +40,7 @@ public final class FwFromSourceAddress implements FwFrom {
   }
 
   private TraceElement getTraceElement() {
-    return TraceElement.of(String.format("Matched source-address %s", _ipWildcard.toString()));
+    return TraceElement.of(String.format("Matched source-address %s", _description));
   }
 
   private HeaderSpace toHeaderspace() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddressExcept.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/FwFromSourceAddressExcept.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.juniper;
 
+import javax.annotation.Nonnull;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.HeaderSpace;
@@ -12,9 +13,15 @@ import org.batfish.representation.juniper.FwTerm.Field;
 /** Class for firewall filter from source-address except */
 public final class FwFromSourceAddressExcept implements FwFrom {
 
-  private final IpWildcard _ipWildcard;
+  @Nonnull private final String _description;
+  @Nonnull private final IpWildcard _ipWildcard;
 
-  public FwFromSourceAddressExcept(IpWildcard ipWildcard) {
+  /**
+   * Creates a new {@link FwFromSourceAddressExcept}, matching everything except the given {@link
+   * IpWildcard} and using the given {@code description} for the {@link TraceElement}.
+   */
+  public FwFromSourceAddressExcept(@Nonnull IpWildcard ipWildcard, @Nonnull String description) {
+    _description = description;
     _ipWildcard = ipWildcard;
   }
 
@@ -33,8 +40,7 @@ public final class FwFromSourceAddressExcept implements FwFrom {
   }
 
   private TraceElement getTraceElement() {
-    return TraceElement.of(
-        String.format("Matched source-address %s except", _ipWildcard.toString()));
+    return TraceElement.of(String.format("Matched source-address %s except", _description));
   }
 
   private HeaderSpace toHeaderspace() {

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2777,14 +2777,14 @@ public final class FlatJuniperGrammarTest {
                                                             .toIpSpace())
                                                     .build(),
                                                 TraceElement.of(
-                                                    "Matched source-address 1.0.3.0:0.255.0.255")),
+                                                    "Matched source-address 1.2.3.4/255.0.255.0")),
                                             new MatchHeaderSpace(
                                                 HeaderSpace.builder()
                                                     .setSrcIps(
                                                         IpWildcard.parse("2.3.4.5/24").toIpSpace())
                                                     .build(),
                                                 TraceElement.of(
-                                                    "Matched source-address 2.3.4.0/24"))))))
+                                                    "Matched source-address 2.3.4.5/24"))))))
                             .setName("TERM")
                             .setTraceElement(
                                 matchingFirewallFilterTerm(
@@ -3083,14 +3083,14 @@ public final class FlatJuniperGrammarTest {
                                                             .toIpSpace())
                                                     .build(),
                                                 TraceElement.of(
-                                                    "Matched destination-address 1.0.3.0:0.255.0.255")),
+                                                    "Matched destination-address 1.2.3.4/255.0.255.0")),
                                             new MatchHeaderSpace(
                                                 HeaderSpace.builder()
                                                     .setDstIps(
                                                         IpWildcard.parse("2.3.4.5/24").toIpSpace())
                                                     .build(),
                                                 TraceElement.of(
-                                                    "Matched destination-address 2.3.4.0/24"))))))
+                                                    "Matched destination-address 2.3.4.5/24"))))))
                             .setName("TERM")
                             .setTraceElement(
                                 matchingFirewallFilterTerm(

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationAddressExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationAddressExceptTest.java
@@ -13,7 +13,7 @@ public class FwFromDestinationAddressExceptTest {
   @Test
   public void testToHeaderspace() {
     IpWildcard ips = IpWildcard.parse("1.1.1.0/24");
-    FwFromDestinationAddressExcept from = new FwFromDestinationAddressExcept(ips);
+    FwFromDestinationAddressExcept from = new FwFromDestinationAddressExcept(ips, ips.toString());
     assertThat(
         from.toHeaderspace(), equalTo(HeaderSpace.builder().setNotDstIps(ips.toIpSpace()).build()));
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationAddressTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromDestinationAddressTest.java
@@ -12,7 +12,8 @@ public class FwFromDestinationAddressTest {
 
   @Test
   public void testToHeaderspace() {
-    FwFromDestinationAddress from = new FwFromDestinationAddress(IpWildcard.parse("1.1.1.0/24"));
+    FwFromDestinationAddress from =
+        new FwFromDestinationAddress(IpWildcard.parse("1.1.1.0/24"), "1.1.1.0/24");
     assertThat(
         from.toHeaderspace(),
         equalTo(

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourceAddressExceptTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourceAddressExceptTest.java
@@ -14,7 +14,8 @@ public class FwFromSourceAddressExceptTest {
   @Test
   public void testToAclLineMatchExpr() {
     IpWildcard ipWildcard = IpWildcard.parse("1.1.1.0/24");
-    FwFromSourceAddressExcept from = new FwFromSourceAddressExcept(ipWildcard);
+    FwFromSourceAddressExcept from =
+        new FwFromSourceAddressExcept(ipWildcard, ipWildcard.toString());
     assertEquals(
         from.toAclLineMatchExpr(null, null, null),
         new MatchHeaderSpace(

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourceAddressTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/FwFromSourceAddressTest.java
@@ -14,11 +14,11 @@ public class FwFromSourceAddressTest {
   @Test
   public void testToAclLineMatchExpr() {
     IpWildcard ipWildcard = IpWildcard.parse("1.1.1.0/24");
-    FwFromSourceAddress from = new FwFromSourceAddress(ipWildcard);
+    FwFromSourceAddress from = new FwFromSourceAddress(ipWildcard, "1.1.1.0/24-desc");
     assertEquals(
         from.toAclLineMatchExpr(null, null, null),
         new MatchHeaderSpace(
             HeaderSpace.builder().setSrcIps(ipWildcard.toIpSpace()).build(),
-            TraceElement.of("Matched source-address 1.1.1.0/24")));
+            TraceElement.of("Matched source-address 1.1.1.0/24-desc")));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -97,7 +97,7 @@ public class JuniperConfigurationTest {
     ConcreteFirewallFilter filter = new ConcreteFirewallFilter("filter", Family.INET);
     FwTerm term = new FwTerm("term");
     String ipAddrPrefix = "1.2.3.0/24";
-    term.getFroms().add(new FwFromSourceAddress(IpWildcard.parse(ipAddrPrefix)));
+    term.getFroms().add(new FwFromSourceAddress(IpWildcard.parse(ipAddrPrefix), ipAddrPrefix));
     term.getThens().add(FwThenAccept.INSTANCE);
     filter.getTerms().put("term", term);
     IpAccessList headerSpaceAcl = config.filterToIpAccessList(filter);
@@ -137,7 +137,7 @@ public class JuniperConfigurationTest {
 
     FwTerm term = new FwTerm("term");
     String ipAddrPrefix = "1.2.3.0/24";
-    term.getFroms().add(new FwFromSourceAddress(IpWildcard.parse(ipAddrPrefix)));
+    term.getFroms().add(new FwFromSourceAddress(IpWildcard.parse(ipAddrPrefix), ipAddrPrefix));
     term.getThens().add(FwThenAccept.INSTANCE);
     filter.getTerms().put("term", term);
 

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_firewall
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_firewall
@@ -25,6 +25,7 @@ set firewall family inet filter blah term blorp from packet-length 70-12000
 set firewall family inet filter blah term blorp from protocol pim
 set firewall family inet filter blah term blorp from source-address 2.4.6.8/30
 set firewall family inet filter blah term blorp from ip-source-address 2.4.6.9/32
+set firewall family inet filter blah term blorp from source-address 5.5.5.5/31 except
 # 
 # using decimals for icmp type and code
 set firewall family inet filter blah term blorp from icmp-type 1

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -2769,7 +2769,7 @@
         "Source_Lines" : {
           "filename" : "configs/juniper_firewall",
           "lines" : [
-            42
+            43
           ]
         }
       },
@@ -2802,10 +2802,11 @@
             25,
             26,
             27,
-            30,
+            28,
             31,
-            33,
-            35
+            32,
+            34,
+            36
           ]
         }
       },
@@ -2815,9 +2816,9 @@
         "Source_Lines" : {
           "filename" : "configs/juniper_firewall",
           "lines" : [
-            37,
             38,
-            39
+            39,
+            40
           ]
         }
       },
@@ -2837,14 +2838,14 @@
         "Source_Lines" : {
           "filename" : "configs/juniper_firewall",
           "lines" : [
-            43,
             44,
             45,
             46,
             47,
             48,
             49,
-            50
+            50,
+            51
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -24381,7 +24381,7 @@
                             "fragments" : [
                               {
                                 "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                                "text" : "Matched destination-address 1.2.3.5"
+                                "text" : "Matched destination-address 1.2.3.5/32"
                               }
                             ]
                           }
@@ -24799,12 +24799,30 @@
                             "fragments" : [
                               {
                                 "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                                "text" : "Matched source-address 2.4.6.9"
+                                "text" : "Matched source-address 2.4.6.9/32"
                               }
                             ]
                           }
                         }
                       ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "negate" : false,
+                        "notSrcIps" : {
+                          "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                          "ipWildcard" : "5.5.5.4/31"
+                        }
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched source-address 5.5.5.5/31 except"
+                          }
+                        ]
+                      }
                     }
                   ]
                 },
@@ -24914,7 +24932,7 @@
                               "fragments" : [
                                 {
                                   "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                                  "text" : "Matched destination-address 1.2.3.5"
+                                  "text" : "Matched destination-address 1.2.3.5/32"
                                 }
                               ]
                             }
@@ -25332,12 +25350,30 @@
                               "fragments" : [
                                 {
                                   "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                                  "text" : "Matched source-address 2.4.6.9"
+                                  "text" : "Matched source-address 2.4.6.9/32"
                                 }
                               ]
                             }
                           }
                         ]
+                      },
+                      {
+                        "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                        "headerSpace" : {
+                          "negate" : false,
+                          "notSrcIps" : {
+                            "class" : "org.batfish.datamodel.IpWildcardIpSpace",
+                            "ipWildcard" : "5.5.5.4/31"
+                          }
+                        },
+                        "traceElement" : {
+                          "fragments" : [
+                            {
+                              "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                              "text" : "Matched source-address 5.5.5.5/31 except"
+                            }
+                          ]
+                        }
                       }
                     ],
                     "traceElement" : {

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -1318,63 +1318,63 @@
       },
       {
         "Filename" : "configs/juniper_firewall",
-        "Line" : 35,
+        "Line" : 36,
         "Text" : "next-ip 1.2.3.4/5",
         "Parser_Context" : "[fftt_next_ip fft_then ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "Filter-based forwarding with next-hop-ip is not currently supported"
       },
       {
         "Filename" : "configs/juniper_firewall",
-        "Line" : 43,
+        "Line" : 44,
         "Text" : "ip-options any",
         "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/juniper_firewall",
-        "Line" : 44,
+        "Line" : 45,
         "Text" : "ip-options loose-source-route",
         "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/juniper_firewall",
-        "Line" : 45,
+        "Line" : 46,
         "Text" : "ip-options route-record",
         "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/juniper_firewall",
-        "Line" : 46,
+        "Line" : 47,
         "Text" : "ip-options router-alert",
         "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/juniper_firewall",
-        "Line" : 47,
+        "Line" : 48,
         "Text" : "ip-options security",
         "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/juniper_firewall",
-        "Line" : 48,
+        "Line" : 49,
         "Text" : "ip-options stream-id",
         "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/juniper_firewall",
-        "Line" : 49,
+        "Line" : 50,
         "Text" : "ip-options strict-source-route",
         "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"
       },
       {
         "Filename" : "configs/juniper_firewall",
-        "Line" : 50,
+        "Line" : 51,
         "Text" : "ip-options timestamp",
         "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
         "Comment" : "This feature is not currently supported"

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -60760,6 +60760,33 @@
             "                      text = VARIABLE:'blorp')",
             "                    (fft_from",
             "                      FROM:'from'",
+            "                      (fftf_source_address",
+            "                        SOURCE_ADDRESS:'source-address'",
+            "                        (fftfa_address_mask_prefix",
+            "                          IP_PREFIX:'5.5.5.5/31')",
+            "                        EXCEPT:'except'))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_firewall",
+            "            FIREWALL:'firewall'",
+            "            (f_family",
+            "              FAMILY:'family'",
+            "              INET:'inet'",
+            "              (f_common",
+            "                (f_filter",
+            "                  FILTER:'filter'",
+            "                  name = (variable",
+            "                    text = VARIABLE:'blah')",
+            "                  (ff_term",
+            "                    TERM:'term'",
+            "                    name = (variable",
+            "                      text = VARIABLE:'blorp')",
+            "                    (fft_from",
+            "                      FROM:'from'",
             "                      (fftf_icmp_type",
             "                        ICMP_TYPE:'icmp-type'",
             "                        (icmp_type",
@@ -77816,55 +77843,55 @@
           "Parse warnings" : [
             {
               "Comment" : "Filter-based forwarding with next-hop-ip is not currently supported",
-              "Line" : 35,
+              "Line" : 36,
               "Parser_Context" : "[fftt_next_ip fft_then ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "next-ip 1.2.3.4/5"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 43,
+              "Line" : 44,
               "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "ip-options any"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 44,
+              "Line" : 45,
               "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "ip-options loose-source-route"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 45,
+              "Line" : 46,
               "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "ip-options route-record"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 46,
+              "Line" : 47,
               "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "ip-options router-alert"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 47,
+              "Line" : 48,
               "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "ip-options security"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 48,
+              "Line" : 49,
               "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "ip-options stream-id"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 49,
+              "Line" : 50,
               "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "ip-options strict-source-route"
             },
             {
               "Comment" : "This feature is not currently supported",
-              "Line" : 50,
+              "Line" : 51,
               "Parser_Context" : "[fftf_ip_options fft_from ff_term f_filter f_common f_family s_firewall s_common statement set_line_tail set_line flat_juniper_configuration]",
               "Text" : "ip-options timestamp"
             }
@@ -83904,7 +83931,7 @@
           "firewall filter" : {
             "ISP-INBOUND-L2" : {
               "definitionLines" : [
-                42
+                43
               ],
               "numReferrers" : 0
             },
@@ -83933,18 +83960,19 @@
                 25,
                 26,
                 27,
-                30,
+                28,
                 31,
-                33,
-                35
+                32,
+                34,
+                36
               ],
               "numReferrers" : 0
             },
             "blah6" : {
               "definitionLines" : [
-                37,
                 38,
-                39
+                39,
+                40
               ],
               "numReferrers" : 0
             },
@@ -83956,14 +83984,14 @@
             },
             "ip_options" : {
               "definitionLines" : [
-                43,
                 44,
                 45,
                 46,
                 47,
                 48,
                 49,
-                50
+                50,
+                51
               ],
               "numReferrers" : 0
             }
@@ -83971,7 +83999,7 @@
           "firewall filter term" : {
             "ISP-INBOUND-L2 ALLOW-ARP" : {
               "definitionLines" : [
-                42
+                43
               ],
               "numReferrers" : 1
             },
@@ -84000,28 +84028,29 @@
                 25,
                 26,
                 27,
-                30,
-                31
+                28,
+                31,
+                32
               ],
-              "numReferrers" : 25
+              "numReferrers" : 26
             },
             "blah t2" : {
               "definitionLines" : [
-                33
+                34
               ],
               "numReferrers" : 1
             },
             "blah t3" : {
               "definitionLines" : [
-                35
+                36
               ],
               "numReferrers" : 1
             },
             "blah6 blorp6" : {
               "definitionLines" : [
-                37,
                 38,
-                39
+                39,
+                40
               ],
               "numReferrers" : 3
             },
@@ -84033,14 +84062,14 @@
             },
             "ip_options t1" : {
               "definitionLines" : [
-                43,
                 44,
                 45,
                 46,
                 47,
                 48,
                 49,
-                50
+                50,
+                51
               ],
               "numReferrers" : 8
             }
@@ -91207,7 +91236,7 @@
           "firewall filter term" : {
             "ISP-INBOUND-L2 ALLOW-ARP" : {
               "firewall filter term" : [
-                42
+                43
               ]
             },
             "blah blorp" : {
@@ -91235,25 +91264,26 @@
                 25,
                 26,
                 27,
-                30,
-                31
+                28,
+                31,
+                32
               ]
             },
             "blah t2" : {
               "firewall filter term" : [
-                33
+                34
               ]
             },
             "blah t3" : {
               "firewall filter term" : [
-                35
+                36
               ]
             },
             "blah6 blorp6" : {
               "firewall filter term" : [
-                37,
                 38,
-                39
+                39,
+                40
               ]
             },
             "f1 t1" : {
@@ -91263,21 +91293,21 @@
             },
             "ip_options t1" : {
               "firewall filter term" : [
-                43,
                 44,
                 45,
                 46,
                 47,
                 48,
                 49,
-                50
+                50,
+                51
               ]
             }
           },
           "routing-instance" : {
             "OTHER_INSTANCE" : {
               "firewall filter then routing-instance" : [
-                33
+                34
               ]
             }
           }


### PR DESCRIPTION
Use the actual text in the config instead of re-string-ifying the wildcard.

Additionally, track the any and any-ipv4 lines.