### PR TITLE
AWS: IGW should use non-forwarding routes for public IPs

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteDecoratorMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteDecoratorMatchers.java
@@ -23,7 +23,7 @@ public final class AbstractRouteDecoratorMatchers {
    * Provides a matcher that matches when the {@link AbstractRouteDecorator}'s administrative cost
    * is {@code expectedAdministrativeCost}.
    */
-  public static @Nonnull Matcher<AbstractRouteDecorator> hasAdministrativeCost(
+  public static @Nonnull HasAdministrativeCost hasAdministrativeCost(
       int expectedAdministrativeCost) {
     return new HasAdministrativeCost(equalTo(expectedAdministrativeCost));
   }
@@ -57,7 +57,7 @@ public final class AbstractRouteDecoratorMatchers {
    * Provides a matcher that matches when the route's nextHopInterface is {@code
    * expectedNextHopInterface}.
    */
-  public static @Nonnull Matcher<AbstractRouteDecorator> hasNextHopInterface(
+  public static @Nonnull HasNextHopInterface hasNextHopInterface(
       @Nonnull String expectedNextHopInterface) {
     return new HasNextHopInterface(equalTo(expectedNextHopInterface));
   }
@@ -75,8 +75,7 @@ public final class AbstractRouteDecoratorMatchers {
    * Provides a matcher that matches when the {@link AbstractRouteDecorator}'s nextHopIp is {@code
    * expectedNextHopIp}.
    */
-  public static @Nonnull Matcher<AbstractRouteDecorator> hasNextHopIp(
-      @Nonnull Ip expectedNextHopIp) {
+  public static @Nonnull HasNextHopIp hasNextHopIp(@Nonnull Ip expectedNextHopIp) {
     return new HasNextHopIp(equalTo(expectedNextHopIp));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -183,32 +183,43 @@ final class Utils {
 
   @Nonnull
   static StaticRoute toStaticRoute(Prefix targetPrefix, Ip nextHopIp) {
-    return StaticRoute.builder()
-        .setNetwork(targetPrefix)
-        .setNextHopIp(nextHopIp)
-        .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
-        .setMetric(Route.DEFAULT_STATIC_ROUTE_COST)
-        .build();
+    return toStaticRoute(targetPrefix, nextHopIp, false);
+  }
+
+  @Nonnull
+  static StaticRoute toStaticRoute(Prefix targetPrefix, Ip nextHopIp, boolean nonForwarding) {
+    return toStaticRoute(targetPrefix, null, nextHopIp, nonForwarding);
   }
 
   @Nonnull
   static StaticRoute toStaticRoute(Prefix targetPrefix, String nextHopInterfaceName) {
-    return StaticRoute.builder()
-        .setNetwork(targetPrefix)
-        .setNextHopInterface(nextHopInterfaceName)
-        .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
-        .setMetric(Route.DEFAULT_STATIC_ROUTE_COST)
-        .build();
+    return toStaticRoute(targetPrefix, nextHopInterfaceName, null, false);
+  }
+
+  @Nonnull
+  static StaticRoute toStaticRoute(
+      Prefix targetPrefix, String nextHopInterfaceName, boolean nonForwarding) {
+    return toStaticRoute(targetPrefix, nextHopInterfaceName, null, nonForwarding);
   }
 
   @Nonnull
   static StaticRoute toStaticRoute(Prefix targetPrefix, String nextHopInterfaceName, Ip nextHopIp) {
+    return toStaticRoute(targetPrefix, nextHopInterfaceName, nextHopIp, false);
+  }
+
+  @Nonnull
+  static StaticRoute toStaticRoute(
+      Prefix targetPrefix,
+      @Nullable String nextHopInterfaceName,
+      @Nullable Ip nextHopIp,
+      boolean nonForwarding) {
     return StaticRoute.builder()
         .setNetwork(targetPrefix)
         .setNextHopInterface(nextHopInterfaceName)
         .setNextHopIp(nextHopIp)
         .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
         .setMetric(Route.DEFAULT_STATIC_ROUTE_COST)
+        .setNonForwarding(nonForwarding)
         .build();
   }
 


### PR DESCRIPTION
This enables it to advertise those public IPs without preventing instance-instance traffic
on them.