### PR TITLE
Arista: allow standard community-list without standard keyword

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -3474,6 +3474,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       name = ctx.num.getText();
     } else if (ctx.name != null) {
       name = ctx.name.getText();
+    } else if (ctx.name_cl != null) {
+      name = ctx.name_cl.getText();
     } else {
       throw new BatfishException("Invalid standard community-list name");
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -304,6 +304,12 @@ public class AristaGrammarTest {
   }
 
   @Test
+  public void testCommunityListExtraction() {
+    CiscoConfiguration config = parseVendorConfig("arista_community_list");
+    assertThat(config.getStandardCommunityLists(), hasKey("SOME_CL"));
+  }
+
+  @Test
   public void testNeighborExtraction() {
     CiscoConfiguration config = parseVendorConfig("arista_bgp_neighbors");
     {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_community_list
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_community_list
@@ -1,0 +1,7 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_community_list
+!
+! On Arista EOS, you can name a standard community-list even without the word `standard`
+ip community-list SOME_CL permit 1:1
+


### PR DESCRIPTION
This was parsed, but crashed in extraction.