### PR TITLE
Option to use interface roots in reachability analysis

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -1209,13 +1209,19 @@ public final class BDDReachabilityAnalysisFactory {
   }
 
   public BDDReachabilityAnalysis bddReachabilityAnalysis(IpSpaceAssignment srcIpSpaceAssignment) {
+    return bddReachabilityAnalysis(srcIpSpaceAssignment, false);
+  }
+
+  public BDDReachabilityAnalysis bddReachabilityAnalysis(
+      IpSpaceAssignment srcIpSpaceAssignment, boolean useInterfaceRoots) {
     return bddReachabilityAnalysis(
         srcIpSpaceAssignment,
         matchDst(UniverseIpSpace.INSTANCE),
         ImmutableSet.of(),
         ImmutableSet.of(),
         _configs.keySet(),
-        ImmutableSet.of(FlowDisposition.ACCEPTED));
+        ImmutableSet.of(FlowDisposition.ACCEPTED),
+        useInterfaceRoots);
   }
 
   public BDDLoopDetectionAnalysis bddLoopDetectionAnalysis(IpSpaceAssignment srcIpSpaceAssignment) {


### PR DESCRIPTION
This option is already exposed in the main `bddReachabilityAnalysis()` method that takes all options as parameters. The new method is just for convenience when `useInterfaceRoots` is the only option for which you want to use a non-default value.