### PR TITLE
AWS IGW: Deny invalid private IPs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Maps.immutableEntry;
 import static org.batfish.representation.aws.AwsLocationInfoUtils.subnetInterfaceLinkLocationInfo;
 import static org.batfish.representation.aws.AwsLocationInfoUtils.subnetInterfaceLocationInfo;
-import static org.batfish.representation.aws.InternetGateway.INVALID_PRIVATE_IP_FILTER_NAME;
+import static org.batfish.representation.aws.InternetGateway.UNASSOCIATED_PRIVATE_IP_FILTER_NAME;
 import static org.batfish.representation.aws.Utils.addStaticRoute;
 import static org.batfish.representation.aws.Utils.connect;
 import static org.batfish.representation.aws.Utils.getInterfaceLinkLocalIp;
@@ -248,7 +248,7 @@ public class Subnet implements AwsVpcEntity, Serializable {
 
     // 1. connect the internet gateway if its a public subnet
     // 2. create static routes on it for the subnet's prefix
-    // 3. install the filter on the created IGW interface that drops invalid private IPs.
+    // 3. install the filter on the created IGW interface that drops unassociated private IPs.
     Optional<RouteTable> routeTable = region.findRouteTable(_vpcId, _subnetId);
     Optional<InternetGateway> optInternetGateway = region.findInternetGateway(_vpcId);
     if (optInternetGateway.isPresent()
@@ -263,7 +263,8 @@ public class Subnet implements AwsVpcEntity, Serializable {
       Ip nhipOnIgw = getInterfaceLinkLocalIp(cfgNode, igwConfig.getHostname());
       addStaticRoute(igwConfig, toStaticRoute(_cidrBlock, ifaceIgw.getName(), nhipOnIgw));
 
-      ifaceIgw.setIncomingFilter(igwConfig.getIpAccessLists().get(INVALID_PRIVATE_IP_FILTER_NAME));
+      ifaceIgw.setIncomingFilter(
+          igwConfig.getIpAccessLists().get(UNASSOCIATED_PRIVATE_IP_FILTER_NAME));
     }
 
     // process route tables to get outbound traffic going

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicPrivateSubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicPrivateSubnetTest.java
@@ -94,10 +94,24 @@ public class AwsConfigurationPublicPrivateSubnetTest {
     testTrace(flowTrace, expectedDisposition, expectedNodes);
   }
 
+  /** Returns an IP address of the node. */
+  private static Ip getFirstNodeIp(String nodeName) {
+    return _batfish
+        .loadConfigurations(_batfish.getSnapshot())
+        .get(nodeName)
+        .getAllInterfaces()
+        .values()
+        .iterator()
+        .next()
+        .getConcreteAddress()
+        .getIp();
+  }
+
   private static SortedMap<Flow, List<Trace>> getTraces(String ingressNode, Ip dstIp) {
     Flow flow =
         Flow.builder()
             .setIngressNode(ingressNode)
+            .setSrcIp(getFirstNodeIp(ingressNode))
             .setDstIp(dstIp) // this public IP does not exists in the network
             .build();
     return _batfish

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicSubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicSubnetTest.java
@@ -9,6 +9,7 @@ import static org.batfish.datamodel.transformation.IpField.SOURCE;
 import static org.batfish.representation.aws.InternetGateway.AWS_BACKBONE_NODE_NAME;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -170,14 +171,17 @@ public class AwsConfigurationPublicSubnetTest {
             _instance, _subnet, _igw, AWS_BACKBONE_NODE_NAME, IspModelingUtils.INTERNET_HOST_NAME));
 
     // Test NAT behavior
-    assertThat(
-        trace.getHops().get(2).getSteps().get(2),
-        equalTo(
-            new TransformationStep(
-                new TransformationStepDetail(
-                    TransformationType.SOURCE_NAT,
-                    ImmutableSortedSet.of(flowDiff(SOURCE, _privateIp, _publicIp))),
-                StepAction.TRANSFORMED)));
+    assertTrue(
+        trace
+            .getHops()
+            .get(2)
+            .getSteps()
+            .contains(
+                new TransformationStep(
+                    new TransformationStepDetail(
+                        TransformationType.SOURCE_NAT,
+                        ImmutableSortedSet.of(flowDiff(SOURCE, _privateIp, _publicIp))),
+                    StepAction.TRANSFORMED)));
   }
 
   /** Packets comes with a private IP for which we don't have a public IP association */

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicSubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicSubnetTest.java
@@ -8,8 +8,8 @@ import static org.batfish.datamodel.transformation.IpField.DESTINATION;
 import static org.batfish.datamodel.transformation.IpField.SOURCE;
 import static org.batfish.representation.aws.InternetGateway.AWS_BACKBONE_NODE_NAME;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -171,17 +171,14 @@ public class AwsConfigurationPublicSubnetTest {
             _instance, _subnet, _igw, AWS_BACKBONE_NODE_NAME, IspModelingUtils.INTERNET_HOST_NAME));
 
     // Test NAT behavior
-    assertTrue(
-        trace
-            .getHops()
-            .get(2)
-            .getSteps()
-            .contains(
-                new TransformationStep(
-                    new TransformationStepDetail(
-                        TransformationType.SOURCE_NAT,
-                        ImmutableSortedSet.of(flowDiff(SOURCE, _privateIp, _publicIp))),
-                    StepAction.TRANSFORMED)));
+    assertThat(
+        trace.getHops().get(2).getSteps(),
+        hasItem(
+            new TransformationStep(
+                new TransformationStepDetail(
+                    TransformationType.SOURCE_NAT,
+                    ImmutableSortedSet.of(flowDiff(SOURCE, _privateIp, _publicIp))),
+                StepAction.TRANSFORMED)));
   }
 
   /** Packets comes with a private IP for which we don't have a public IP association */

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/InternetGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/InternetGatewayTest.java
@@ -232,10 +232,10 @@ public class InternetGatewayTest {
   public void testComputeUnassociatedPrivateIpFilter() {
     Ip associatedPrivateIp = Ip.parse("1.1.1.1");
     Ip unassociatedPrivateIp = Ip.parse("6.6.6.6");
-    IpAccessList invalidIpFilter =
+    IpAccessList unassociatedIpFilter =
         computeUnassociatedPrivateIpFilter(ImmutableList.of(associatedPrivateIp));
     assertThat(
-        invalidIpFilter
+        unassociatedIpFilter
             .filter(
                 Flow.builder().setSrcIp(associatedPrivateIp).setIngressNode("aa").build(),
                 null,
@@ -244,7 +244,7 @@ public class InternetGatewayTest {
             .getAction(),
         equalTo(LineAction.PERMIT));
     assertThat(
-        invalidIpFilter
+        unassociatedIpFilter
             .filter(
                 Flow.builder().setSrcIp(unassociatedPrivateIp).setIngressNode("aa").build(),
                 null,

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
@@ -8,6 +8,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVrfName;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_SUBNETS;
 import static org.batfish.representation.aws.AwsVpcEntity.TAG_NAME;
+import static org.batfish.representation.aws.InternetGateway.INVALID_PRIVATE_IP_FILTER_NAME;
 import static org.batfish.representation.aws.NetworkAcl.getAclName;
 import static org.batfish.representation.aws.Subnet.findMyNetworkAcl;
 import static org.batfish.representation.aws.Subnet.instancesInterfaceName;
@@ -353,6 +354,15 @@ public class SubnetTest {
                     subnet.getCidrBlock(),
                     interfaceNameToRemote(subnetCfg),
                     Utils.getInterfaceLinkLocalIp(subnetCfg, igw.getId())))));
+
+    // igw's subnet facing interface should have the filter to block private IPs.
+    assertThat(
+        igwConfig
+            .getAllInterfaces()
+            .get(interfaceNameToRemote(subnetCfg))
+            .getIncomingFilter()
+            .getName(),
+        equalTo(INVALID_PRIVATE_IP_FILTER_NAME));
 
     // the subnet router should have routes from the table and to the public ip
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
@@ -9,6 +9,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVrfName;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_SUBNETS;
 import static org.batfish.representation.aws.AwsVpcEntity.TAG_NAME;
 import static org.batfish.representation.aws.InternetGateway.UNASSOCIATED_PRIVATE_IP_FILTER_NAME;
+import static org.batfish.representation.aws.InternetGateway.computeUnassociatedPrivateIpFilter;
 import static org.batfish.representation.aws.NetworkAcl.getAclName;
 import static org.batfish.representation.aws.Subnet.findMyNetworkAcl;
 import static org.batfish.representation.aws.Subnet.instancesInterfaceName;
@@ -272,6 +273,10 @@ public class SubnetTest {
     InternetGateway igw =
         new InternetGateway("igw", ImmutableList.of(vpc.getId()), ImmutableMap.of());
     Configuration igwConfig = Utils.newAwsConfiguration(igw.getId(), "awstest");
+    igwConfig.setIpAccessLists(
+        ImmutableMap.of(
+            UNASSOCIATED_PRIVATE_IP_FILTER_NAME,
+            computeUnassociatedPrivateIpFilter(ImmutableSet.of())));
 
     Ip privateIp = Ip.parse("10.10.10.10");
     Prefix privatePrefix = Prefix.create(privateIp, 24);
@@ -355,7 +360,7 @@ public class SubnetTest {
                     interfaceNameToRemote(subnetCfg),
                     Utils.getInterfaceLinkLocalIp(subnetCfg, igw.getId())))));
 
-    // igw's subnet facing interface should have the filter to block private IPs.
+    // igw's subnet facing interface should have the filter to block unassociated private IPs.
     assertThat(
         igwConfig
             .getAllInterfaces()

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
@@ -8,7 +8,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasVrfName;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_SUBNETS;
 import static org.batfish.representation.aws.AwsVpcEntity.TAG_NAME;
-import static org.batfish.representation.aws.InternetGateway.INVALID_PRIVATE_IP_FILTER_NAME;
+import static org.batfish.representation.aws.InternetGateway.UNASSOCIATED_PRIVATE_IP_FILTER_NAME;
 import static org.batfish.representation.aws.NetworkAcl.getAclName;
 import static org.batfish.representation.aws.Subnet.findMyNetworkAcl;
 import static org.batfish.representation.aws.Subnet.instancesInterfaceName;
@@ -362,7 +362,7 @@ public class SubnetTest {
             .get(interfaceNameToRemote(subnetCfg))
             .getIncomingFilter()
             .getName(),
-        equalTo(INVALID_PRIVATE_IP_FILTER_NAME));
+        equalTo(UNASSOCIATED_PRIVATE_IP_FILTER_NAME));
 
     // the subnet router should have routes from the table and to the public ip
     assertThat(

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -13984,6 +13984,7 @@
             "autostate" : true,
             "bandwidth" : 1.0E12,
             "description" : "To subnet-1f315846",
+            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -14006,6 +14007,7 @@
             "autostate" : true,
             "bandwidth" : 1.0E12,
             "description" : "To subnet-9c8adceb",
+            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -14028,6 +14030,7 @@
             "autostate" : true,
             "bandwidth" : 1.0E12,
             "description" : "To subnet-d9cafabc",
+            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -14039,6 +14042,51 @@
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
             "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "~DENY~UNASSOCIATED~PRIVATE~IPs~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace"
+                    }
+                  }
+                },
+                "name" : "Allow private instance IPs associated with a public IP.",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line Allow private instance IPs associated with a public IP."
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "Deny private instance IPs not associated with a public IP",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line Deny private instance IPs not associated with a public IP"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~DENY~UNASSOCIATED~PRIVATE~IPs~"
           }
         },
         "routingPolicies" : {
@@ -14208,6 +14256,7 @@
             "autostate" : true,
             "bandwidth" : 1.0E12,
             "description" : "To subnet-073b8061",
+            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -14230,6 +14279,7 @@
             "autostate" : true,
             "bandwidth" : 1.0E12,
             "description" : "To subnet-1641fa70",
+            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -14252,6 +14302,7 @@
             "autostate" : true,
             "bandwidth" : 1.0E12,
             "description" : "To subnet-30398256",
+            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -14274,6 +14325,7 @@
             "autostate" : true,
             "bandwidth" : 1.0E12,
             "description" : "To subnet-7044ff16",
+            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -14296,6 +14348,7 @@
             "autostate" : true,
             "bandwidth" : 1.0E12,
             "description" : "To subnet-f73a8191",
+            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -14307,6 +14360,51 @@
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
             "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "~DENY~UNASSOCIATED~PRIVATE~IPs~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace"
+                    }
+                  }
+                },
+                "name" : "Allow private instance IPs associated with a public IP.",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line Allow private instance IPs associated with a public IP."
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "Deny private instance IPs not associated with a public IP",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line Deny private instance IPs not associated with a public IP"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~DENY~UNASSOCIATED~PRIVATE~IPs~"
           }
         },
         "routingPolicies" : {
@@ -14493,6 +14591,7 @@
             "autostate" : true,
             "bandwidth" : 1.0E12,
             "description" : "To subnet-62f14104",
+            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -14504,6 +14603,51 @@
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
             "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "~DENY~UNASSOCIATED~PRIVATE~IPs~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace"
+                    }
+                  }
+                },
+                "name" : "Allow private instance IPs associated with a public IP.",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line Allow private instance IPs associated with a public IP."
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "Deny private instance IPs not associated with a public IP",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched line Deny private instance IPs not associated with a public IP"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~DENY~UNASSOCIATED~PRIVATE~IPs~"
           }
         },
         "routingPolicies" : {

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -14059,12 +14059,11 @@
                     }
                   }
                 },
-                "name" : "Allow private instance IPs associated with a public IP.",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line Allow private instance IPs associated with a public IP."
+                      "text" : "Allowed private instance IPs associated with a public IP"
                     }
                   ]
                 }
@@ -14075,12 +14074,11 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "Deny private instance IPs not associated with a public IP",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line Deny private instance IPs not associated with a public IP"
+                      "text" : "Denied private instance IPs NOT associated with a public IP"
                     }
                   ]
                 }
@@ -14377,12 +14375,11 @@
                     }
                   }
                 },
-                "name" : "Allow private instance IPs associated with a public IP.",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line Allow private instance IPs associated with a public IP."
+                      "text" : "Allowed private instance IPs associated with a public IP"
                     }
                   ]
                 }
@@ -14393,12 +14390,11 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "Deny private instance IPs not associated with a public IP",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line Deny private instance IPs not associated with a public IP"
+                      "text" : "Denied private instance IPs NOT associated with a public IP"
                     }
                   ]
                 }
@@ -14620,12 +14616,11 @@
                     }
                   }
                 },
-                "name" : "Allow private instance IPs associated with a public IP.",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line Allow private instance IPs associated with a public IP."
+                      "text" : "Allowed private instance IPs associated with a public IP"
                     }
                   ]
                 }
@@ -14636,12 +14631,11 @@
                 "matchCondition" : {
                   "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
-                "name" : "Deny private instance IPs not associated with a public IP",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line Deny private instance IPs not associated with a public IP"
+                      "text" : "Denied private instance IPs NOT associated with a public IP"
                     }
                   ]
                 }


### PR DESCRIPTION
Before this PR, if a packet with an invalid private IP would show up at the IGW, it wouldn't be NAT'd (since there is no mapping) and would be sent to the Internet. 