### PR TITLE
fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To install Pybatfish run the following commands (in a virtual environment if app
 
 Afer installing Pybatfish, use your Python environment of choice (e.g., PyCharm, interactive Python shell, Jupyter, ..) to interact with Batfish. The [notebooks](https://github.com/batfish/pybatfish/tree/master/jupyter_notebooks) provide examples of such scripts. 
 
-See complete documentation of Pybatfish on [readthedocs](https://pybatfish.readthedocs.io/en/latest/quickstart.html).
+See complete documentation of Pybatfish on [readthedocs](https://pybatfish.readthedocs.io/en/latest/).
 
 
 ## System Requirements for running Batfish


### PR DESCRIPTION
quickstart no longer exists in pybatfish read the docs, so point to read the docs root