### PR TITLE
FlowTracer: record the correct interface for InboundStep

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
@@ -166,13 +167,18 @@ public class TracerouteEngineImplContext {
   }
 
   /**
-   * Whether {@code vrf} at {@code node} will accept (NB: not forward) packets destined for {@code
-   * ip}
+   * Returns the name of the interface on the given {@code node} that will accept (NB: not forward)
+   * packets destined for {@code ip} in the given {@code vrf}.
+   *
+   * <p>If the packet is not accepted at this node and vrf, returns {@link Optional#empty()}.
    */
-  boolean acceptsIp(String node, String vrf, Ip ip) {
+  @Nonnull
+  Optional<String> interfaceAcceptingIp(String node, String vrf, Ip ip) {
     return _forwardingAnalysis.getAcceptsIps().getOrDefault(node, ImmutableMap.of())
-        .getOrDefault(vrf, ImmutableMap.of()).values().stream()
-        .anyMatch(ipSpace -> ipSpace.containsIp(ip, ImmutableMap.of()));
+        .getOrDefault(vrf, ImmutableMap.of()).entrySet().stream()
+        .filter(e -> e.getValue().containsIp(ip, ImmutableMap.of()))
+        .map(Entry::getKey)
+        .findAny(); // Should be zero or one.
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/dataplane/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/BUILD
@@ -21,6 +21,7 @@ junit_tests(
         "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
         "//projects/batfish/src/test/java/org/batfish/dataplane/ibdp:testlib",
         "//projects/bdd",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_guava_guava_testlib",

--- a/tests/basic/traceroute-2-1.ref
+++ b/tests/basic/traceroute-2-1.ref
@@ -420,7 +420,7 @@
                     "type" : "Inbound",
                     "action" : "ACCEPTED",
                     "detail" : {
-                      "interface" : "GigabitEthernet1/0"
+                      "interface" : "GigabitEthernet0/0"
                     }
                   }
                 ]
@@ -762,7 +762,7 @@
                     "type" : "Inbound",
                     "action" : "ACCEPTED",
                     "detail" : {
-                      "interface" : "GigabitEthernet1/0"
+                      "interface" : "GigabitEthernet0/0"
                     }
                   }
                 ]
@@ -1104,7 +1104,7 @@
                     "type" : "Inbound",
                     "action" : "ACCEPTED",
                     "detail" : {
-                      "interface" : "GigabitEthernet1/0"
+                      "interface" : "GigabitEthernet0/0"
                     }
                   }
                 ]
@@ -1478,7 +1478,7 @@
                     "type" : "Inbound",
                     "action" : "ACCEPTED",
                     "detail" : {
-                      "interface" : "GigabitEthernet1/0"
+                      "interface" : "GigabitEthernet0/0"
                     }
                   }
                 ]


### PR DESCRIPTION
The prior implementation unconditionally used _ingressInterface. This was bad for many reasons:

1. The interface on which a packet was received is not necessarily the interface
   that owns the destination IP. In fact, this is common: e.g., for loopback
   IPs.
2. Packets originating on a device and destined to that device have no ingress
   interface. This was even worse: caused a crash because passing a null value
   to the InboundStepDetail is an API violation.