### PR TITLE
BatfishObjectMapper: remove exception from clone

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/BatfishObjectMapper.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import org.batfish.common.util.serialization.BatfishThirdPartySerializationModule;
 
@@ -45,13 +46,23 @@ public final class BatfishObjectMapper {
   }
 
   /** Uses Jackson to clone the given object using the given type. */
-  public static <T> T clone(Object o, Class<T> clazz) throws IOException {
-    return MAPPER.readValue(WRITER.writeValueAsBytes(o), clazz);
+  @VisibleForTesting // used in JSON serde tests.
+  public static <T> T clone(Object o, Class<T> clazz) {
+    try {
+      return MAPPER.readValue(WRITER.writeValueAsBytes(o), clazz);
+    } catch (IOException e) {
+      throw new RuntimeException("Error cloning with Jackson", e);
+    }
   }
 
   /** Uses Jackson to clone the given object using the given type. */
-  public static <T> T clone(Object o, TypeReference<T> type) throws IOException {
-    return MAPPER.readValue(WRITER.writeValueAsBytes(o), type);
+  @VisibleForTesting // used in JSON serde tests.
+  public static <T> T clone(Object o, TypeReference<T> type) {
+    try {
+      return MAPPER.readValue(WRITER.writeValueAsBytes(o), type);
+    } catch (IOException e) {
+      throw new RuntimeException("Error cloning with Jackson", e);
+    }
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/CompletionMetadataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/CompletionMetadataTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
@@ -33,7 +32,7 @@ public class CompletionMetadataTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     CompletionMetadata completionMetadata =
         CompletionMetadata.builder()
             .setFilterNames(ImmutableSet.of("filter"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/ParseWarningTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/ParseWarningTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.Warnings.ParseWarning;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -32,7 +31,7 @@ public class ParseWarningTest {
   }
 
   @Test
-  public void testParseWarningsJsonSerialization() throws IOException {
+  public void testParseWarningsJsonSerialization() {
     ParseWarning pw = new ParseWarning(1, "", "", null);
     assertThat(BatfishObjectMapper.clone(pw, ParseWarning.class), equalTo(pw));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/WarningTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/WarningTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.SerializationUtils;
@@ -25,7 +24,7 @@ public class WarningTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Warning w = new Warning("A", "B");
     assertThat(BatfishObjectMapper.clone(w, Warning.class), equalTo(w));
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/autocomplete/IpCompletionMetadataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/autocomplete/IpCompletionMetadataTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -28,7 +27,7 @@ public class IpCompletionMetadataTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     IpCompletionMetadata metadata = new IpCompletionMetadata(new IpCompletionRelevance("a"));
     IpCompletionMetadata clone = BatfishObjectMapper.clone(metadata, IpCompletionMetadata.class);
     assertEquals(metadata, clone);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/autocomplete/IpCompletionRelevanceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/autocomplete/IpCompletionRelevanceTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
@@ -44,7 +43,7 @@ public class IpCompletionRelevanceTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     IpCompletionRelevance metadata = new IpCompletionRelevance("a", "b");
     IpCompletionRelevance clone = BatfishObjectMapper.clone(metadata, IpCompletionRelevance.class);
     assertEquals(metadata, clone);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/autocomplete/NodeCompletionMetadataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/autocomplete/NodeCompletionMetadataTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -21,7 +20,7 @@ public final class NodeCompletionMetadataTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     NodeCompletionMetadata metadata = new NodeCompletionMetadata("a");
     NodeCompletionMetadata clone =
         BatfishObjectMapper.clone(metadata, NodeCompletionMetadata.class);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/runtime/InterfaceRuntimeDataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/runtime/InterfaceRuntimeDataTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
@@ -30,7 +29,7 @@ public class InterfaceRuntimeDataTest {
   }
 
   @Test
-  public void testInterfaceRuntimeDataJsonSerialization() throws IOException {
+  public void testInterfaceRuntimeDataJsonSerialization() {
     InterfaceRuntimeData.Builder irdBuilder =
         InterfaceRuntimeData.builder().setBandwidth(1d).setLineUp(true).setSpeed(2d);
     assertThat(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/runtime/RuntimeDataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/runtime/RuntimeDataTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
-import java.io.IOException;
 import java.util.Map;
 import java.util.TreeMap;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -16,7 +15,7 @@ import org.junit.Test;
 public class RuntimeDataTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     RuntimeData.Builder builder =
         RuntimeData.builder()
             .setInterfaces(ImmutableMap.of("iface", InterfaceRuntimeData.builder().build()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/runtime/SnapshotRuntimeDataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/runtime/SnapshotRuntimeDataTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -21,7 +20,7 @@ public class SnapshotRuntimeDataTest {
   @Rule public ExpectedException _thrown = ExpectedException.none();
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     SnapshotRuntimeData.Builder builder =
         SnapshotRuntimeData.builder()
             .setRuntimeData(ImmutableMap.of("hostname", RuntimeData.EMPTY_RUNTIME_DATA));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer2TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer2TopologyTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
@@ -32,7 +31,7 @@ public final class Layer2TopologyTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     Layer2Topology topology =
         Layer2Topology.fromDomains(
             ImmutableSet.of(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer3EdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer3EdgeTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Ip;
@@ -38,7 +37,7 @@ public class Layer3EdgeTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Layer3Edge layer3Edge =
         new Layer3Edge(
             NodeInterfacePair.of("node1", "interface1"),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/UndirectedEdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/UndirectedEdgeTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
 import org.junit.Test;
@@ -28,7 +27,7 @@ public final class UndirectedEdgeTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     UndirectedEdge<Ip> edge = new UndirectedEdge<>(Ip.ZERO, Ip.ZERO);
 
     assertEquals(edge, BatfishObjectMapper.clone(edge, new TypeReference<UndirectedEdge<Ip>>() {}));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/ValueEdgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/ValueEdgeTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
 import org.junit.Test;
@@ -30,7 +29,7 @@ public final class ValueEdgeTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     ValueEdge<Ip, String> edge = new ValueEdge<>(Ip.ZERO, Ip.ZERO, "a");
 
     assertEquals(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclAclLineTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AclAclLineTest.java
@@ -10,7 +10,6 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -92,7 +91,7 @@ public class AclAclLineTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     {
       AclAclLine aclAclLine = new AclAclLine("lineName", "aclName");
       AclAclLine clone = (AclAclLine) BatfishObjectMapper.clone(aclAclLine, AclLine.class);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AsSetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/AsSetTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
@@ -48,7 +47,7 @@ public class AsSetTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     AsSet set = AsSet.of(1);
     assertThat(BatfishObjectMapper.clone(set, AsSet.class), equalTo(set));
     set = AsSet.confed(1);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpPeerConfigIdTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpPeerConfigIdTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.List;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -29,7 +28,7 @@ public class BgpPeerConfigIdTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     BgpPeerConfigId id = new BgpPeerConfigId("c1", "vrf1", Prefix.ZERO, false);
     assertThat(BatfishObjectMapper.clone(id, BgpPeerConfigId.class), equalTo(id));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpSessionPropertiesTest.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.EnumSet;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.BgpSessionProperties.Builder;
@@ -96,7 +95,7 @@ public class BgpSessionPropertiesTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Ip headIp = Ip.parse("1.1.1.1");
     Ip tailIp = Ip.parse("2.2.2.2");
     BgpSessionProperties bsp =

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpUnnumberedPeerConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpUnnumberedPeerConfigTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang3.SerializationUtils;
@@ -94,7 +93,7 @@ public final class BgpUnnumberedPeerConfigTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     BgpUnnumberedPeerConfig bgpUnnumberedPeerConfig =
         BgpUnnumberedPeerConfig.builder()
             .setAppliedRibGroup(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Bgpv4RouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/Bgpv4RouteTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Bgpv4Route.Builder;
@@ -32,7 +31,7 @@ public class Bgpv4RouteTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Bgpv4Route br =
         Bgpv4Route.builder()
             .setNetwork(Prefix.parse("1.1.1.0/24"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConcreteInterfaceAddressTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConcreteInterfaceAddressTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Rule;
@@ -40,7 +39,7 @@ public class ConcreteInterfaceAddressTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     ConcreteInterfaceAddress cia = ConcreteInterfaceAddress.parse("1.1.1.1/24");
     assertThat(BatfishObjectMapper.clone(cia, ConcreteInterfaceAddress.class), equalTo(cia));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConfigurationTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -147,7 +146,7 @@ public final class ConfigurationTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     // TODO: other properties
     Map<String, CommunityMatchExpr> communityMatchExprs =
         ImmutableMap.of("cme", AllStandardCommunities.instance());

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteMetadataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteMetadataTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.ConnectedRouteMetadata.Builder;
@@ -36,7 +35,7 @@ public class ConnectedRouteMetadataTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     ConnectedRouteMetadata crm =
         ConnectedRouteMetadata.builder().setAdmin(2).setGenerateLocalRoutes(true).setTag(1).build();
     assertThat(BatfishObjectMapper.clone(crm, ConnectedRouteMetadata.class), equalTo(crm));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ConnectedRouteTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -18,7 +17,7 @@ public class ConnectedRouteTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     ConnectedRoute cr = new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "Ethernet0", 3, 4L);
     assertThat(BatfishObjectMapper.clone(cr, ConnectedRoute.class), equalTo(cr));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EigrpRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EigrpRouteTest.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
 import org.batfish.datamodel.eigrp.WideMetric;
@@ -16,7 +15,7 @@ import org.junit.runners.JUnit4;
 public class EigrpRouteTest {
 
   @Test
-  public void testEigrpInternalRouteClone() throws IOException {
+  public void testEigrpInternalRouteClone() {
     EigrpInternalRoute route =
         EigrpInternalRoute.builder()
             .setNetwork(Prefix.parse("1.1.1.1/32"))
@@ -31,7 +30,7 @@ public class EigrpRouteTest {
   }
 
   @Test
-  public void testEigrpExternalRouteClone() throws IOException {
+  public void testEigrpExternalRouteClone() {
     EigrpExternalRoute route =
         EigrpExternalRoute.builder()
             .setNetwork(Prefix.parse("1.1.1.1/32"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnType2RouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnType2RouteTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.EvpnType2Route.Builder;
@@ -36,7 +35,7 @@ public class EvpnType2RouteTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     EvpnType2Route er =
         EvpnType2Route.builder()
             .setIp(Ip.parse("1.1.1.1"))
@@ -117,7 +116,7 @@ public class EvpnType2RouteTest {
   }
 
   @Test
-  public void testJsonSerializationNetworkOverwrite() throws IOException {
+  public void testJsonSerializationNetworkOverwrite() {
     EvpnType2Route er =
         EvpnType2Route.builder()
             .setIp(Ip.parse("1.1.1.1"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnType3RouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnType3RouteTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.EvpnType3Route.Builder;
@@ -35,7 +34,7 @@ public class EvpnType3RouteTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     EvpnType3Route er =
         EvpnType3Route.builder()
             .setNetwork(Prefix.parse("1.1.1.0/24"))
@@ -113,7 +112,7 @@ public class EvpnType3RouteTest {
   }
 
   @Test
-  public void testJsonSerializationNetworkOverwrite() throws IOException {
+  public void testJsonSerializationNetworkOverwrite() {
     EvpnType3Route er =
         EvpnType3Route.builder()
             .setVniIp(Ip.parse("1.1.1.1"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnType5RouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EvpnType5RouteTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.EvpnType5Route.Builder;
@@ -34,7 +33,7 @@ public class EvpnType5RouteTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     EvpnType5Route er =
         EvpnType5Route.builder()
             .setNetwork(Prefix.parse("1.1.1.0/24"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ExprAclLineTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ExprAclLineTest.java
@@ -4,7 +4,6 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.acl.FalseExpr;
 import org.batfish.datamodel.acl.OriginatingFromDevice;
@@ -49,7 +48,7 @@ public class ExprAclLineTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     {
       ExprAclLine l = new ExprAclLine(LineAction.PERMIT, OriginatingFromDevice.INSTANCE, "name");
       ExprAclLine clone = (ExprAclLine) BatfishObjectMapper.clone(l, AclLine.class);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FlowDiffTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FlowDiffTest.java
@@ -12,7 +12,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
@@ -66,7 +65,7 @@ public final class FlowDiffTest {
   }
 
   @Test
-  public void testJackson() throws IOException {
+  public void testJackson() {
     FlowDiff fd = new FlowDiff(PROP_DST_IP, "old", "new");
     assertEquals(BatfishObjectMapper.clone(fd, FlowDiff.class), fd);
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/GeneratedRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/GeneratedRouteTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.List;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -74,7 +73,7 @@ public class GeneratedRouteTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     GeneratedRoute gr =
         GeneratedRoute.builder().setNetwork(Prefix.parse("1.1.1.0/24")).setMetric(1L).build();
     assertThat(BatfishObjectMapper.clone(gr, GeneratedRoute.class), equalTo(gr));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IntegerSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IntegerSpaceTest.java
@@ -14,7 +14,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Range;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import org.apache.commons.lang3.SerializationUtils;
@@ -208,7 +207,7 @@ public final class IntegerSpaceTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(IntegerSpace.PORTS, IntegerSpace.class),
         equalTo(IntegerSpace.PORTS));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InterfaceTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
@@ -63,7 +62,7 @@ public class InterfaceTest {
   }
 
   @Test
-  public void testSerialization() throws IOException {
+  public void testSerialization() {
     Interface i =
         Interface.builder()
             .setMtu(7)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpLinkTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/IpLinkTest.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
@@ -25,7 +24,7 @@ public final class IpLinkTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     IpLink link = new IpLink(Ip.ZERO, Ip.ZERO);
 
     assertEquals(link, BatfishObjectMapper.clone(link, IpLink.class));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/KernelRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/KernelRouteTest.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -22,7 +21,7 @@ public final class KernelRouteTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     KernelRoute route = new KernelRoute(Prefix.ZERO);
     assertEquals(route, BatfishObjectMapper.clone(route, KernelRoute.class));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/LinkLocalAddressTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/LinkLocalAddressTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Rule;
@@ -35,7 +34,7 @@ public class LinkLocalAddressTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Ip ip = Ip.parse("169.254.0.1");
     LinkLocalAddress lla = LinkLocalAddress.of(ip);
     assertThat(BatfishObjectMapper.clone(lla, LinkLocalAddress.class), equalTo(lla));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/LocalRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/LocalRouteTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -18,7 +17,7 @@ public class LocalRouteTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     LocalRoute lr = new LocalRoute(ConcreteInterfaceAddress.parse("1.1.1.1/24"), "Ethernet0");
     assertThat(BatfishObjectMapper.clone(lr, LocalRoute.class), equalTo(lr));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/LongSpaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/LongSpaceTest.java
@@ -324,7 +324,7 @@ public final class LongSpaceTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(LONGSPACE1, LongSpace.class), equalTo(LONGSPACE1));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MacAddressTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MacAddressTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -46,7 +45,7 @@ public final class MacAddressTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     MacAddress macAddress = of(5L);
 
     assertThat(BatfishObjectMapper.clone(macAddress, MacAddress.class), equalTo(macAddress));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MlagTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MlagTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -46,7 +45,7 @@ public final class MlagTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Mlag m =
         Mlag.builder()
             .setId("ID")

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfInterAreaRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfInterAreaRouteTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -35,7 +34,7 @@ public class OspfInterAreaRouteTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     OspfInterAreaRoute r = OspfInterAreaRoute.builder().setArea(0).setNetwork(Prefix.ZERO).build();
     assertThat(BatfishObjectMapper.clone(r, OspfInterAreaRoute.class), equalTo(r));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfIntraAreaRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfIntraAreaRouteTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -35,7 +34,7 @@ public class OspfIntraAreaRouteTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     OspfIntraAreaRoute r = OspfIntraAreaRoute.builder().setArea(0).setNetwork(Prefix.ZERO).build();
     assertThat(BatfishObjectMapper.clone(r, OspfIntraAreaRoute.class), equalTo(r));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/PacketHeaderConstraintsTest.java
@@ -466,7 +466,7 @@ public class PacketHeaderConstraintsTest {
   }
 
   @Test
-  public void testSerialization() throws IOException {
+  public void testSerialization() {
     PacketHeaderConstraints phc =
         PacketHeaderConstraints.builder()
             .setIpProtocols(ImmutableSet.of(TCP, UDP))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RouteFilterLineTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/RouteFilterLineTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -44,7 +43,7 @@ public class RouteFilterLineTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     RouteFilterLine rfl =
         new RouteFilterLine(LineAction.PERMIT, IpWildcard.parse("1.1.1.1"), new SubRange(30, 32));
     assertThat(BatfishObjectMapper.clone(rfl, RouteFilterLine.class), equalTo(rfl));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/StaticRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/StaticRouteTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Rule;
@@ -115,7 +114,7 @@ public final class StaticRouteTest {
   }
 
   @Test
-  public void checkJsonSerialization() throws IOException {
+  public void checkJsonSerialization() {
     StaticRoute sr =
         StaticRoute.builder()
             .setNextHopIp(Ip.parse("192.168.1.1"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TopologyTest.java
@@ -8,7 +8,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.Set;
 import java.util.SortedSet;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -155,7 +154,7 @@ public class TopologyTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     Topology topo = new Topology(_bothEdges);
     assertEquals(BatfishObjectMapper.clone(topo, Topology.class), topo);
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TraceElementTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TraceElementTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.List;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.TraceElement.Fragment;
@@ -24,7 +23,7 @@ public final class TraceElementTest {
   }
 
   @Test
-  public void testTextFragment_JsonSerialization() throws IOException {
+  public void testTextFragment_JsonSerialization() {
     TextFragment fragment = new TextFragment("asdf");
     TextFragment clone = (TextFragment) BatfishObjectMapper.clone(fragment, Fragment.class);
     assertEquals(fragment, clone);
@@ -46,7 +45,7 @@ public final class TraceElementTest {
   }
 
   @Test
-  public void testLinkFragment_JsonSerialization() throws IOException {
+  public void testLinkFragment_JsonSerialization() {
     LinkFragment fragment = new LinkFragment("asdf", new VendorStructureId("f", "t", "n"));
     LinkFragment clone = (LinkFragment) BatfishObjectMapper.clone(fragment, Fragment.class);
     assertEquals(fragment, clone);
@@ -63,7 +62,7 @@ public final class TraceElementTest {
   }
 
   @Test
-  public void testTraceElement_JsonSerialization() throws IOException {
+  public void testTraceElement_JsonSerialization() {
     TraceElement traceElement = new TraceElement(ImmutableList.of(new TextFragment("a")));
     TraceElement clone = BatfishObjectMapper.clone(traceElement, TraceElement.class);
     assertEquals(traceElement, clone);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TunnelConfigurationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/TunnelConfigurationTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.TunnelConfiguration.Builder;
@@ -38,7 +37,7 @@ public class TunnelConfigurationTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     TunnelConfiguration tc =
         TunnelConfiguration.builder()
             .setDestinationAddress(Ip.parse("1.1.1.1"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSortedMap;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.isis.IsisProcess;
 import org.batfish.datamodel.ospf.OspfProcess;
@@ -20,7 +19,7 @@ import org.junit.Test;
 public class VrfTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Vrf vrf = new Vrf("vrf");
     vrf.setOspfProcesses(
         ImmutableSortedMap.of(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/DeniedByAclTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/DeniedByAclTest.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel.acl;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.TraceElement;
 import org.junit.Test;
@@ -24,7 +23,7 @@ public final class DeniedByAclTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     DeniedByAcl expected = new DeniedByAcl("name", "te");
     DeniedByAcl clone = (DeniedByAcl) BatfishObjectMapper.clone(expected, AclLineMatchExpr.class);
     assertEquals(expected, clone);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerSummaryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/AnswerSummaryTest.java
@@ -33,7 +33,7 @@ public class AnswerSummaryTest {
   }
 
   @Test
-  public void serializationTest() throws IOException {
+  public void serializationTest() {
     AnswerSummary summary = new AnswerSummary("notes1", 21, 23, 42);
 
     // The summary should survive cloning through JSON.

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/InputValidationNotesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/answers/InputValidationNotesTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
@@ -37,7 +36,7 @@ public class InputValidationNotesTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     InputValidationNotes validationNotes =
         new InputValidationNotes(
             VALID, "some description", 3, ImmutableList.of("expansion1", "expansion2"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/AddressFamilyCapabilitiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/AddressFamilyCapabilitiesTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities.Builder;
@@ -51,7 +50,7 @@ public class AddressFamilyCapabilitiesTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     AddressFamilyCapabilities afs =
         builder()
             .setAdditionalPathsReceive(true)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpAdvertisementGroupTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpAdvertisementGroupTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.AsPath;
@@ -39,7 +38,7 @@ public final class BgpAdvertisementGroupTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     BgpAdvertisementGroup bgpAdvertisementGroup =
         BgpAdvertisementGroup.builder()
             .setAsPath(AsPath.ofSingletonAsSets(2L))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpConfederationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpConfederationTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Rule;
@@ -34,7 +33,7 @@ public class BgpConfederationTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     BgpConfederation bc = new BgpConfederation(1, ImmutableSet.of(2L));
     assertThat(BatfishObjectMapper.clone(bc, BgpConfederation.class), equalTo(bc));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpTopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpTopologyTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.graph.MutableValueGraph;
 import com.google.common.graph.ValueGraphBuilder;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -49,7 +48,7 @@ public final class BgpTopologyTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertEquals(
         nonTrivialTopology(), BatfishObjectMapper.clone(nonTrivialTopology(), BgpTopology.class));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/EvpnAddressFamilyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/EvpnAddressFamilyTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.Matchers.equalTo;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.bgp.EvpnAddressFamily.Builder;
@@ -84,7 +83,7 @@ public class EvpnAddressFamilyTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Builder builder =
         builder()
             .setAddressFamilyCapabilities(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Ipv4UnicastAddressFamilyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Ipv4UnicastAddressFamilyTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily.Builder;
@@ -46,7 +45,7 @@ public class Ipv4UnicastAddressFamilyTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Ipv4UnicastAddressFamily af =
         Ipv4UnicastAddressFamily.builder()
             .setExportPolicy("export")

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Layer2VniConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Layer2VniConfigTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
@@ -45,7 +44,7 @@ public class Layer2VniConfigTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Layer2VniConfig vni =
         Layer2VniConfig.builder()
             .setVni(1)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Layer3VniConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/Layer3VniConfigTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
@@ -54,7 +53,7 @@ public class Layer3VniConfigTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Layer3VniConfig vni =
         Layer3VniConfig.builder()
             .setVni(1)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/RouteDistinguisherTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/RouteDistinguisherTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
@@ -37,7 +36,7 @@ public class RouteDistinguisherTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(RouteDistinguisher.from(0, 0L), RouteDistinguisher.class),
         equalTo(RouteDistinguisher.from(0, 0L)));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/ExtendedCommunityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/ExtendedCommunityTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.math.BigInteger;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -40,7 +39,7 @@ public final class ExtendedCommunityTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     ExtendedCommunity ec = ExtendedCommunity.of(1, 2L, 123L);
     assertThat(BatfishObjectMapper.clone(ec, ExtendedCommunity.class), equalTo(ec));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/StandardCommunityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/StandardCommunityTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.math.BigInteger;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -74,7 +73,7 @@ public class StandardCommunityTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(StandardCommunity.of(1), StandardCommunity.class),
         equalTo(StandardCommunity.of(1)));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/collections/FileLinesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/collections/FileLinesTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
@@ -23,7 +22,7 @@ public class FileLinesTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     FileLines f = new FileLines("a", ImmutableSortedSet.of(1));
     assertThat(f, equalTo(BatfishObjectMapper.clone(f, FileLines.class)));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/collections/NodeInterfacePairTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/collections/NodeInterfacePairTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.List;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -50,7 +49,7 @@ public class NodeInterfacePairTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     NodeInterfacePair nip = NodeInterfacePair.of("host", "iface");
     assertThat(BatfishObjectMapper.clone(nip, NodeInterfacePair.class), equalTo(nip));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/dataplane/rib/RibGroupTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/dataplane/rib/RibGroupTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -41,7 +40,7 @@ public class RibGroupTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     RibId rib1 = new RibId("hostname", "vrfname", "ribname");
     RibId exportRib = new RibId("hostname", "vrfname", "exportRib");
     RibGroup rg = new RibGroup("name", ImmutableList.of(rib1), "policy1", exportRib);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/dataplane/rib/RibIdTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/dataplane/rib/RibIdTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -32,7 +31,7 @@ public class RibIdTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     RibId ribId = new RibId("h", "v", "r");
     assertThat(BatfishObjectMapper.clone(ribId, RibId.class), equalTo(ribId));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/ClassicMetricTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/ClassicMetricTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.eigrp.ClassicMetric.Builder;
@@ -40,7 +39,7 @@ public class ClassicMetricTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     ClassicMetric cm = ClassicMetric.builder().setValues(_values).setK1(2).setK1(2).build();
     assertThat(BatfishObjectMapper.clone(cm, ClassicMetric.class), equalTo(cm));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/EigrpMetricValuesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/EigrpMetricValuesTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.eigrp.EigrpMetricValues.Builder;
@@ -46,7 +45,7 @@ public class EigrpMetricValuesTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     EigrpMetricValues v =
         EigrpMetricValues.builder()
             .setBandwidth(1)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/EigrpNeighborConfigIdTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/EigrpNeighborConfigIdTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -30,7 +29,7 @@ public class EigrpNeighborConfigIdTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     EigrpNeighborConfigId ei = new EigrpNeighborConfigId(1L, "h", "i", "v");
     assertThat(BatfishObjectMapper.clone(ei, EigrpNeighborConfigId.class), equalTo(ei));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/EigrpNeighborConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/EigrpNeighborConfigTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
@@ -50,7 +49,7 @@ public class EigrpNeighborConfigTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     EigrpNeighborConfig c =
         EigrpNeighborConfig.builder()
             .setAsn(1L)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/EigrpTopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/EigrpTopologyTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -41,7 +40,7 @@ public final class EigrpTopologyTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertEquals(
         nonTrivialTopology(), BatfishObjectMapper.clone(nonTrivialTopology(), EigrpTopology.class));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/WideMetricTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/WideMetricTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.eigrp.WideMetric.Builder;
@@ -39,7 +38,7 @@ public class WideMetricTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     WideMetric cm = WideMetric.builder().setValues(_values).setK1(2).setK1(2).build();
     assertThat(BatfishObjectMapper.clone(cm, WideMetric.class), equalTo(cm));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/AcceptTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/AcceptTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -22,7 +21,7 @@ public final class AcceptTest {
   }
 
   @Test
-  public void testSerialization() throws IOException {
+  public void testSerialization() {
     SessionAction clone = BatfishObjectMapper.clone(Accept.INSTANCE, SessionAction.class);
     assertThat(clone, equalTo(Accept.INSTANCE));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/ArpErrorStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/ArpErrorStepTest.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel.flow;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.collections.NodeInterfacePair;
@@ -13,7 +12,7 @@ import org.junit.Test;
 public class ArpErrorStepTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     ArpErrorStep step =
         ArpErrorStep.builder()
             .setAction(StepAction.NEIGHBOR_UNREACHABLE)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/DeliveredStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/DeliveredStepTest.java
@@ -3,7 +3,6 @@ package org.batfish.datamodel.flow;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.collections.NodeInterfacePair;
@@ -12,7 +11,7 @@ import org.junit.Test;
 
 public class DeliveredStepTest {
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     DeliveredStep step =
         DeliveredStep.builder()
             .setAction(StepAction.DELIVERED_TO_SUBNET)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/FibLookupTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/FibLookupTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -23,7 +22,7 @@ public final class FibLookupTest {
   }
 
   @Test
-  public void testSerialization() throws IOException {
+  public void testSerialization() {
     SessionAction clone = BatfishObjectMapper.clone(FibLookup.INSTANCE, SessionAction.class);
     assertThat(clone, equalTo(FibLookup.INSTANCE));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/ForwardOutInterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/ForwardOutInterfaceTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.collections.NodeInterfacePair;
@@ -26,7 +25,7 @@ public final class ForwardOutInterfaceTest {
   }
 
   @Test
-  public void testSerialization() throws IOException {
+  public void testSerialization() {
     ForwardOutInterface f = new ForwardOutInterface("a", null);
     SessionAction clone = BatfishObjectMapper.clone(f, SessionAction.class);
     assertThat(clone, equalTo(f));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/InboundStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/InboundStepTest.java
@@ -2,7 +2,6 @@ package org.batfish.datamodel.flow;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.flow.InboundStep.InboundStepDetail;
 import org.junit.Test;
@@ -28,7 +27,7 @@ public final class InboundStepTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     String iface = "GigabitEthernet1/0";
     InboundStep step = InboundStep.builder().setDetail(new InboundStepDetail(iface)).build();
     InboundStep clone = BatfishObjectMapper.clone(step, InboundStep.class);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
-import java.io.IOException;
 import java.util.Set;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.FlowDiff;
@@ -42,7 +41,7 @@ public final class MatchSessionStepTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Set<String> incomingInterfaces = ImmutableSet.of("b");
     ForwardOutInterface forwardAction =
         new ForwardOutInterface("a", NodeInterfacePair.of("a", "b"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/PolicyStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/PolicyStepTest.java
@@ -1,6 +1,5 @@
 package org.batfish.datamodel.flow;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.flow.PolicyStep.PolicyStepDetail;
 import org.junit.Test;
@@ -8,7 +7,7 @@ import org.junit.Test;
 /** Tests of {@link PolicyStep} */
 public class PolicyStepTest {
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     PolicyStep ps = new PolicyStep(new PolicyStepDetail("pol"), StepAction.PERMITTED);
     // Don't trow
     BatfishObjectMapper.clone(ps, PolicyStep.class);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/RoutingStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/RoutingStepTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
@@ -16,7 +15,7 @@ import org.junit.Test;
 public class RoutingStepTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     RoutingStepDetail routingStepDetail =
         RoutingStepDetail.builder()
             .setRoutes(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SessionMatchExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SessionMatchExprTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Ip;
@@ -59,7 +58,7 @@ public class SessionMatchExprTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     SessionMatchExpr matcher =
         new SessionMatchExpr(IpProtocol.ICMP, Ip.parse("1.1.1.2"), Ip.parse("1.1.2.2"), null, null);
     SessionMatchExpr clone = BatfishObjectMapper.clone(matcher, SessionMatchExpr.class);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SetupSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/SetupSessionStepTest.java
@@ -4,7 +4,6 @@ import static org.batfish.datamodel.FlowDiff.flowDiff;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
-import java.io.IOException;
 import java.util.Set;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.FlowDiff;
@@ -40,7 +39,7 @@ public final class SetupSessionStepTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Set<String> incomingInterfaces = ImmutableSet.of("b");
     ForwardOutInterface forwardAction =
         new ForwardOutInterface("a", NodeInterfacePair.of("a", "b"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isis/IsisTopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isis/IsisTopologyTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -41,7 +40,7 @@ public final class IsisTopologyTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertEquals(
         nonTrivialTopology(), BatfishObjectMapper.clone(nonTrivialTopology(), IsisTopology.class));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isp_configuration/BorderInterfaceInfoTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isp_configuration/BorderInterfaceInfoTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.junit.Test;
@@ -23,7 +22,7 @@ public class BorderInterfaceInfoTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     BorderInterfaceInfo borderInterfaceInfo =
         new BorderInterfaceInfo(NodeInterfacePair.of("node", "interface"));
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isp_configuration/IspConfigurationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isp_configuration/IspConfigurationTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.collections.NodeInterfacePair;
@@ -50,7 +49,7 @@ public class IspConfigurationTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     IspConfiguration ispConfiguration =
         new IspConfiguration(
             ImmutableList.of(new BorderInterfaceInfo(NodeInterfacePair.of("node", "interface"))),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isp_configuration/IspFilterTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isp_configuration/IspFilterTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
 import org.junit.Test;
@@ -26,7 +25,7 @@ public class IspFilterTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     IspFilter ispFilter =
         new IspFilter(ImmutableList.of(5678L), ImmutableList.of(Ip.parse("1.1.1.1")));
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isp_configuration/IspNodeInfoTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/isp_configuration/IspNodeInfoTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.List;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Prefix;
@@ -29,7 +28,7 @@ public class IspNodeInfoTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     IspNodeInfo ispNodeInfo =
         new IspNodeInfo(
             42, "n1", ImmutableList.of(new IspAnnouncement(Prefix.parse("1.1.1.1/32"))));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfAreaSummaryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfAreaSummaryTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -29,7 +28,7 @@ public class OspfAreaSummaryTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     OspfAreaSummary summary = new OspfAreaSummary(true, 100L);
     assertThat(BatfishObjectMapper.clone(summary, OspfAreaSummary.class), equalTo(summary));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfInterfaceSettingsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfInterfaceSettingsTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
@@ -13,7 +12,7 @@ import org.junit.Test;
 
 public class OspfInterfaceSettingsTest {
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     OspfInterfaceSettings s =
         OspfInterfaceSettings.builder()
             .setProcess("proc")

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfNeighborConfigIdTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfNeighborConfigIdTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
@@ -48,7 +47,7 @@ public class OspfNeighborConfigIdTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     OspfNeighborConfigId cid =
         new OspfNeighborConfigId(
             "h", "v", "p", "i", ConcreteInterfaceAddress.parse("192.0.2.2/31"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfNeighborConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfNeighborConfigTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
@@ -48,7 +47,7 @@ public class OspfNeighborConfigTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     OspfNeighborConfig c =
         OspfNeighborConfig.builder()
             .setArea(1L)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfTopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfTopologyTest.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.MutableValueGraph;
 import com.google.common.graph.ValueGraphBuilder;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import javax.annotation.Nonnull;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
@@ -122,7 +121,7 @@ public final class OspfTopologyTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertEquals(
         nonTrivialTopology(), BatfishObjectMapper.clone(nonTrivialTopology(), OspfTopology.class));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/ApplyTransformationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/ApplyTransformationTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.acl.FalseExpr;
@@ -38,7 +37,7 @@ public class ApplyTransformationTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     ApplyTransformation at =
         new ApplyTransformation(Transformation.always().apply(ImmutableList.of()).build());
     assertThat(BatfishObjectMapper.clone(at, ApplyTransformation.class), equalTo(at));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/ConjunctionTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/ConjunctionTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -28,7 +27,7 @@ public class ConjunctionTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     BoolExpr c = Conjunction.of(TrueExpr.instance());
     assertThat(BatfishObjectMapper.clone(c, Conjunction.class), equalTo(c));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/DropTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/DropTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -27,7 +26,7 @@ public class DropTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     assertThat(BatfishObjectMapper.clone(Drop.instance(), Drop.class), equalTo(Drop.instance()));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FalseExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FalseExprTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -25,7 +24,7 @@ public class FalseExprTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(FalseExpr.instance(), FalseExpr.class),
         equalTo(FalseExpr.instance()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FibLookupOutgoingInterfaceIsOneOfTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FibLookupOutgoingInterfaceIsOneOfTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -39,7 +38,7 @@ public class FibLookupOutgoingInterfaceIsOneOfTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     FibLookupOutgoingInterfaceIsOneOf expr =
         new FibLookupOutgoingInterfaceIsOneOf(
             IngressInterfaceVrf.instance(), ImmutableSet.of("iface"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FibLookupOverrideLookupIpTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FibLookupOverrideLookupIpTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
@@ -48,7 +47,7 @@ public class FibLookupOverrideLookupIpTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     FibLookupOverrideLookupIp fl =
         FibLookupOverrideLookupIp.builder()
             .setIps(ImmutableList.of(Ip.ZERO))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FibLookupTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/FibLookupTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -30,7 +29,7 @@ public class FibLookupTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     FibLookup fl = new FibLookup(new LiteralVrfName("name"));
     assertThat(BatfishObjectMapper.clone(fl, FibLookup.class), equalTo(fl));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/IfTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/IfTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.acl.FalseExpr;
@@ -38,7 +37,7 @@ public class IfTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     If ifExpr = new If(new PacketMatchExpr(FalseExpr.INSTANCE), ImmutableList.of());
     assertThat(BatfishObjectMapper.clone(ifExpr, If.class), equalTo(ifExpr));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/IngressInterfaceVrfTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/IngressInterfaceVrfTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -24,7 +23,7 @@ public class IngressInterfaceVrfTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     IngressInterfaceVrf iiv = IngressInterfaceVrf.instance();
     assertThat(BatfishObjectMapper.clone(iiv, IngressInterfaceVrf.class), equalTo(iiv));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/LiteralVrfNameTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/LiteralVrfNameTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -28,7 +27,7 @@ public class LiteralVrfNameTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     LiteralVrfName lv = new LiteralVrfName("vrf");
     assertThat(BatfishObjectMapper.clone(lv, LiteralVrfName.class), equalTo(lv));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketMatchExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketMatchExprTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.acl.FalseExpr;
@@ -32,7 +31,7 @@ public class PacketMatchExprTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     PacketMatchExpr pm = new PacketMatchExpr(TrueExpr.INSTANCE);
     assertThat(BatfishObjectMapper.clone(pm, PacketMatchExpr.class), equalTo(pm));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketPolicyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/PacketPolicyTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -42,7 +41,7 @@ public class PacketPolicyTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     PacketPolicy p =
         new PacketPolicy("name", ImmutableList.of(new Return(Drop.instance())), _defaultAction);
     assertThat(BatfishObjectMapper.clone(p, PacketPolicy.class), equalTo(p));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/ReturnTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/ReturnTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -29,7 +28,7 @@ public class ReturnTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Return r = new Return(Drop.instance());
     assertThat(BatfishObjectMapper.clone(r, Return.class), equalTo(r));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/TrueExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/packet_policy/TrueExprTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -26,7 +25,7 @@ public class TrueExprTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(TrueExpr.instance(), TrueExpr.class),
         equalTo(TrueExpr.instance()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/AggregateTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/AggregateTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.pojo.Aggregate.AggregateType;
 import org.junit.Rule;
@@ -18,7 +17,7 @@ public class AggregateTest {
   @Rule public ExpectedException _thrown = ExpectedException.none();
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Aggregate a = new Aggregate("someAgg", AggregateType.REGION);
     a.setContents(ImmutableSet.of("id1", "id2"));
 
@@ -26,7 +25,7 @@ public class AggregateTest {
   }
 
   @Test
-  public void testEquals() throws IOException {
+  public void testEquals() {
     Aggregate emptyCloud = new Aggregate("cloud", AggregateType.CLOUD);
     Aggregate emptyCloudCloned = BatfishObjectMapper.clone(emptyCloud, Aggregate.class);
     Aggregate diffName = new Aggregate("cloud2", AggregateType.CLOUD);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
@@ -19,7 +18,7 @@ import org.junit.Test;
 public class TopologyTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     Node node = new Node("node");
     Link link = new Link("src", "dst");
     Interface iface = new Interface(node.getId(), "iface");

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteDiffTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteDiffTest.java
@@ -12,7 +12,6 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.Ip;
@@ -26,7 +25,7 @@ import org.junit.Test;
 /** Tests of {@link BgpRouteDiff}. */
 public class BgpRouteDiffTest {
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     BgpRouteDiff diff = new BgpRouteDiff(PROP_AS_PATH, "A", "B");
     assertEquals(diff, BatfishObjectMapper.clone(diff, BgpRouteDiff.class));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteDiffsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteDiffsTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
@@ -21,7 +20,7 @@ public class BgpRouteDiffsTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     BgpRouteDiffs diffs =
         new BgpRouteDiffs(ImmutableSet.of(new BgpRouteDiff(BgpRoute.PROP_AS_PATH, "B", "C")));
     assertEquals(diffs, BatfishObjectMapper.clone(diffs, BgpRouteDiffs.class));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/BgpRouteTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.Ip;
@@ -20,7 +19,7 @@ import org.junit.Test;
 public class BgpRouteTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     BgpRoute br =
         BgpRoute.builder()
             .setNetwork(Prefix.parse("1.1.1.0/24"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/InstanceDataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/InstanceDataTest.java
@@ -47,12 +47,12 @@ public class InstanceDataTest {
     assertThat(instanceData.getOrderedVariableNames(), equalTo(ImmutableList.of("r", "a", "d")));
   }
 
-  private static InstanceData clone(InstanceData instanceData) throws IOException {
+  private static InstanceData clone(InstanceData instanceData) {
     return BatfishObjectMapper.clone(instanceData, InstanceData.class);
   }
 
   @Test
-  public void testEquals() throws IOException {
+  public void testEquals() {
     InstanceData instanceData = new InstanceData();
     InstanceData initialInstance = clone(instanceData);
     EqualsTester equalsTester = new EqualsTester();
@@ -79,7 +79,7 @@ public class InstanceDataTest {
    * InstanceData object produces an object equal to the original instance
    */
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     InstanceData instanceData = new InstanceData();
     instanceData.setInstanceName("instanceName");
     instanceData.setDescription("The description");

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/VariableTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/VariableTest.java
@@ -30,12 +30,12 @@ public final class VariableTest {
 
   @Rule public ExpectedException _thrown = ExpectedException.none();
 
-  private static Variable clone(Variable variable) throws IOException {
+  private static Variable clone(Variable variable) {
     return BatfishObjectMapper.clone(variable, Variable.class);
   }
 
   @Test
-  public void testEquals() throws IOException {
+  public void testEquals() {
     Variable variable = new Variable();
     variable.setType(Type.INTEGER);
     Variable initialInstance = clone(variable);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/AllExtendedCommunitiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/AllExtendedCommunitiesTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -13,7 +12,7 @@ import org.junit.Test;
 public final class AllExtendedCommunitiesTest {
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(AllExtendedCommunities.instance(), AllExtendedCommunities.class),
         equalTo(AllExtendedCommunities.instance()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/AllLargeCommunitiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/AllLargeCommunitiesTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -13,7 +12,7 @@ import org.junit.Test;
 public final class AllLargeCommunitiesTest {
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(AllLargeCommunities.instance(), AllLargeCommunities.class),
         equalTo(AllLargeCommunities.instance()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/AllStandardCommunitiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/AllStandardCommunitiesTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -13,7 +12,7 @@ import org.junit.Test;
 public final class AllStandardCommunitiesTest {
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(AllStandardCommunities.instance(), AllStandardCommunities.class),
         equalTo(AllStandardCommunities.instance()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/ColonSeparatedRenderingTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/ColonSeparatedRenderingTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -13,7 +12,7 @@ import org.junit.Test;
 public final class ColonSeparatedRenderingTest {
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(
             ColonSeparatedRendering.instance(), ColonSeparatedRendering.class),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityAclLineTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityAclLineTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.LineAction;
@@ -17,7 +16,7 @@ public final class CommunityAclLineTest {
       new CommunityAclLine(LineAction.PERMIT, AllStandardCommunities.instance());
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(LINE, CommunityAclLine.class), equalTo(LINE));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityAclTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityAclTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.LineAction;
@@ -17,7 +16,7 @@ public final class CommunityAclTest {
   private static final CommunityAcl ACL = new CommunityAcl(ImmutableList.of());
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(ACL, CommunityAcl.class), equalTo(ACL));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityExprsSetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityExprsSetTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
@@ -18,7 +17,7 @@ public final class CommunityExprsSetTest {
       CommunityExprsSet.of(new StandardCommunityHighLowExprs(new LiteralInt(1), new LiteralInt(1)));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, CommunityExprsSet.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityInTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityInTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -15,7 +14,7 @@ public final class CommunityInTest {
   private static final CommunityIn EXPR = new CommunityIn(new CommunitySetReference("a"));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunityIn.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityIsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityIsTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
@@ -16,7 +15,7 @@ public final class CommunityIsTest {
   private static final CommunityIs EXPR = new CommunityIs(StandardCommunity.of(1L));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunityIs.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchAllTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchAllTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public final class CommunityMatchAllTest {
   private static final CommunityMatchAll EXPR = new CommunityMatchAll(ImmutableList.of());
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunityMatchAll.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchAnyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchAnyTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public final class CommunityMatchAnyTest {
   private static final CommunityMatchAny EXPR = new CommunityMatchAny(ImmutableList.of());
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunityMatchAny.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprReferenceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprReferenceTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -15,7 +14,7 @@ public final class CommunityMatchExprReferenceTest {
   private static final CommunityMatchExprReference EXPR = new CommunityMatchExprReference("a");
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunityMatchExprReference.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchRegexTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchRegexTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public final class CommunityMatchRegexTest {
       new CommunityMatchRegex(IntegerValueRendering.instance(), "a");
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunityMatchRegex.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityNotTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunityNotTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -15,7 +14,7 @@ public final class CommunityNotTest {
   private static final CommunityNot EXPR = new CommunityNot(AllStandardCommunities.instance());
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunityNot.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetAclLineTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetAclLineTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.LineAction;
@@ -17,7 +16,7 @@ public final class CommunitySetAclLineTest {
       new CommunitySetAclLine(LineAction.PERMIT, new CommunitySetMatchExprReference("a"));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(LINE, CommunitySetAclLine.class), equalTo(LINE));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetAclTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetAclTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.LineAction;
@@ -17,7 +16,7 @@ public final class CommunitySetAclTest {
   private static final CommunitySetAcl ACL = new CommunitySetAcl(ImmutableList.of());
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(ACL, CommunitySetAcl.class), equalTo(ACL));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetDifferenceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetDifferenceTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -17,7 +16,7 @@ public final class CommunitySetDifferenceTest {
           new CommunitySetExprReference("a"), new CommunityMatchExprReference("a"));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunitySetDifference.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetExprReferenceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetExprReferenceTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -15,7 +14,7 @@ public final class CommunitySetExprReferenceTest {
   private static final CommunitySetExprReference EXPR = new CommunitySetExprReference("a");
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunitySetExprReference.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetMatchAllTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetMatchAllTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public final class CommunitySetMatchAllTest {
   private static final CommunitySetMatchAll EXPR = new CommunitySetMatchAll(ImmutableList.of());
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunitySetMatchAll.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetMatchAnyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetMatchAnyTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public final class CommunitySetMatchAnyTest {
   private static final CommunitySetMatchAny EXPR = new CommunitySetMatchAny(ImmutableList.of());
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunitySetMatchAny.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetMatchExprReferenceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetMatchExprReferenceTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public final class CommunitySetMatchExprReferenceTest {
       new CommunitySetMatchExprReference("a");
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(EXPR, CommunitySetMatchExprReference.class), equalTo(EXPR));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetMatchRegexTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetMatchRegexTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -17,7 +16,7 @@ public final class CommunitySetMatchRegexTest {
           new TypesFirstAscendingSpaceSeparated(IntegerValueRendering.instance()), "a");
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunitySetMatchRegex.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetNotTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetNotTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public final class CommunitySetNotTest {
       new CommunitySetNot(new CommunitySetMatchExprReference("a"));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunitySetNot.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetReferenceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetReferenceTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -15,7 +14,7 @@ public final class CommunitySetReferenceTest {
   private static final CommunitySetReference EXPR = new CommunitySetReference("a");
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, CommunitySetReference.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
@@ -20,7 +19,7 @@ public final class CommunitySetTest {
   private static final CommunitySet SET = CommunitySet.of();
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(SET, CommunitySet.class), equalTo(SET));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetUnionTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/CommunitySetUnionTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public final class CommunitySetUnionTest {
       CommunitySetUnion.of(new CommunitySetExprReference("a"), new CommunitySetExprReference("a"));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, CommunitySetUnion.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/ExtendedCommunityGlobalAdministratorHighMatchTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/ExtendedCommunityGlobalAdministratorHighMatchTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.routing_policy.expr.IntComparator;
@@ -20,7 +19,7 @@ public final class ExtendedCommunityGlobalAdministratorHighMatchTest {
           new IntComparison(IntComparator.EQ, new LiteralInt(1)));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(OBJ, ExtendedCommunityGlobalAdministratorHighMatch.class),
         equalTo(OBJ));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/ExtendedCommunityGlobalAdministratorLowMatchTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/ExtendedCommunityGlobalAdministratorLowMatchTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.routing_policy.expr.IntComparator;
@@ -20,7 +19,7 @@ public final class ExtendedCommunityGlobalAdministratorLowMatchTest {
           new IntComparison(IntComparator.EQ, new LiteralInt(1)));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(OBJ, ExtendedCommunityGlobalAdministratorLowMatch.class),
         equalTo(OBJ));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/ExtendedCommunityGlobalAdministratorMatchTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/ExtendedCommunityGlobalAdministratorMatchTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.routing_policy.expr.IntComparator;
@@ -20,7 +19,7 @@ public final class ExtendedCommunityGlobalAdministratorMatchTest {
           new LongComparison(IntComparator.EQ, new LiteralLong(1L)));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(OBJ, ExtendedCommunityGlobalAdministratorMatch.class),
         equalTo(OBJ));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/ExtendedCommunityLocalAdministratorMatchTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/ExtendedCommunityLocalAdministratorMatchTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.routing_policy.expr.IntComparator;
@@ -20,7 +19,7 @@ public final class ExtendedCommunityLocalAdministratorMatchTest {
           new IntComparison(IntComparator.EQ, new LiteralInt(1)));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(OBJ, ExtendedCommunityLocalAdministratorMatch.class),
         equalTo(OBJ));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/HasCommunityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/HasCommunityTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -15,7 +14,7 @@ public final class HasCommunityTest {
   private static final HasCommunity EXPR = new HasCommunity(AllStandardCommunities.instance());
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, HasCommunity.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/InputCommunitiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/InputCommunitiesTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -13,7 +12,7 @@ import org.junit.Test;
 public final class InputCommunitiesTest {
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(InputCommunities.instance(), InputCommunities.class),
         equalTo(InputCommunities.instance()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/IntegerValueRenderingTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/IntegerValueRenderingTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -13,7 +12,7 @@ import org.junit.Test;
 public final class IntegerValueRenderingTest {
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(IntegerValueRendering.instance(), IntegerValueRendering.class),
         equalTo(IntegerValueRendering.instance()));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/LiteralCommunitySetTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/LiteralCommunitySetTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
@@ -16,7 +15,7 @@ public final class LiteralCommunitySetTest {
   private static final LiteralCommunitySet OBJ = new LiteralCommunitySet(CommunitySet.empty());
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, LiteralCommunitySet.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/MatchCommunitiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/MatchCommunitiesTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Configuration;
@@ -24,7 +23,7 @@ public final class MatchCommunitiesTest {
           new CommunitySetExprReference("a"), new CommunitySetMatchExprReference("a"));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(EXPR, MatchCommunities.class), equalTo(EXPR));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/RouteTargetExtendedCommunitiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/RouteTargetExtendedCommunitiesTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -13,7 +12,7 @@ import org.junit.Test;
 public final class RouteTargetExtendedCommunitiesTest {
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(
             RouteTargetExtendedCommunities.instance(), RouteTargetExtendedCommunities.class),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/RouteTargetExtendedCommunityExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/RouteTargetExtendedCommunityExprTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
@@ -18,7 +17,7 @@ public final class RouteTargetExtendedCommunityExprTest {
       new RouteTargetExtendedCommunityExpr(new LiteralLong(1L), new LiteralInt(1));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(OBJ, RouteTargetExtendedCommunityExpr.class), equalTo(OBJ));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/SetCommunitiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/SetCommunitiesTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -34,7 +33,7 @@ public final class SetCommunitiesTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, SetCommunities.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/SiteOfOriginExtendedCommunitiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/SiteOfOriginExtendedCommunitiesTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -13,7 +12,7 @@ import org.junit.Test;
 public final class SiteOfOriginExtendedCommunitiesTest {
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(
             SiteOfOriginExtendedCommunities.instance(), SiteOfOriginExtendedCommunities.class),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/StandardCommunityHighLowExprsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/StandardCommunityHighLowExprsTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
@@ -17,7 +16,7 @@ public final class StandardCommunityHighLowExprsTest {
       new StandardCommunityHighLowExprs(new LiteralInt(1), new LiteralInt(1));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, StandardCommunityHighLowExprs.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/StandardCommunityHighMatchTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/StandardCommunityHighMatchTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.routing_policy.expr.IntComparator;
@@ -19,7 +18,7 @@ public final class StandardCommunityHighMatchTest {
       new StandardCommunityHighMatch(new IntComparison(IntComparator.EQ, new LiteralInt(1)));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, StandardCommunityHighMatch.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/StandardCommunityLowMatchTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/StandardCommunityLowMatchTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.routing_policy.expr.IntComparator;
@@ -19,7 +18,7 @@ public final class StandardCommunityLowMatchTest {
       new StandardCommunityLowMatch(new IntComparison(IntComparator.EQ, new LiteralInt(1)));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, StandardCommunityLowMatch.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/TypesFirstAscendingSpaceSeparatedTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/TypesFirstAscendingSpaceSeparatedTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public final class TypesFirstAscendingSpaceSeparatedTest {
       new TypesFirstAscendingSpaceSeparated(IntegerValueRendering.instance());
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(EXPR, TypesFirstAscendingSpaceSeparated.class), equalTo(EXPR));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/VpnDistinguisherExtendedCommunitiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/VpnDistinguisherExtendedCommunitiesTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -13,7 +12,7 @@ import org.junit.Test;
 public final class VpnDistinguisherExtendedCommunitiesTest {
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(
         BatfishObjectMapper.clone(
             VpnDistinguisherExtendedCommunities.instance(),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/AsnValueTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/AsnValueTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.BgpSessionProperties;
@@ -23,7 +22,7 @@ public class AsnValueTest {
   }
 
   @Test
-  public void testEquals() throws IOException {
+  public void testEquals() {
     AsnValue tester = AsnValue.of(RemoteAs.instance());
     new EqualsTester()
         .addEqualityGroup(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChainTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/ConjunctionChainTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.NavigableMap;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -112,7 +111,7 @@ public class ConjunctionChainTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     ConjunctionChain cc = new ConjunctionChain(ImmutableList.of(BooleanExprs.TRUE));
     assertThat(BatfishObjectMapper.clone(cc, ConjunctionChain.class), equalTo(cc));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChainTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/FirstMatchChainTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.NavigableMap;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -93,7 +92,7 @@ public class FirstMatchChainTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     FirstMatchChain fmc = new FirstMatchChain(ImmutableList.of(BooleanExprs.TRUE));
     assertThat(BatfishObjectMapper.clone(fmc, FirstMatchChain.class), equalTo(fmc));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/IntComparisonTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/IntComparisonTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -15,7 +14,7 @@ public final class IntComparisonTest {
   private static final IntComparison OBJ = new IntComparison(IntComparator.EQ, new LiteralInt(1));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, IntComparison.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/IntMatchAllTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/IntMatchAllTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -17,7 +16,7 @@ public final class IntMatchAllTest {
       IntMatchAll.of(new IntComparison(IntComparator.EQ, new LiteralInt(1)));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, IntMatchAll.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/LiteralIntTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/LiteralIntTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -15,7 +14,7 @@ public final class LiteralIntTest {
   private static final LiteralInt OBJ = new LiteralInt(1);
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, LiteralInt.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/LocalAsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/LocalAsTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.BgpSessionProperties;
@@ -24,7 +23,7 @@ public class LocalAsTest {
   }
 
   @Test
-  public void testEquals() throws IOException {
+  public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
             LocalAs.instance(),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/LongComparisonTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/LongComparisonTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public final class LongComparisonTest {
       new LongComparison(IntComparator.EQ, new LiteralLong(1L));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, LongComparison.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/LongMatchAllTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/LongMatchAllTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -17,7 +16,7 @@ public final class LongMatchAllTest {
       LongMatchAll.of(new LongComparison(IntComparator.EQ, new LiteralLong(1L)));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, LongMatchAll.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchProtocolTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchProtocolTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Configuration;
@@ -40,7 +39,7 @@ public class MatchProtocolTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     MatchProtocol mp = new MatchProtocol(RoutingProtocol.STATIC);
     assertThat(BatfishObjectMapper.clone(mp, BooleanExpr.class), equalTo(mp));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchSourceVrfTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/MatchSourceVrfTest.java
@@ -3,14 +3,13 @@ package org.batfish.datamodel.routing_policy.expr;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 /** Tests of {@link MatchSourceVrf} */
 public class MatchSourceVrfTest {
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     MatchSourceVrf m = new MatchSourceVrf("vrfName");
     assertThat(BatfishObjectMapper.clone(m, MatchSourceVrf.class), equalTo(m));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/RemoteAsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/RemoteAsTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.BgpSessionProperties;
@@ -24,7 +23,7 @@ public class RemoteAsTest {
   }
 
   @Test
-  public void testEquals() throws IOException {
+  public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
             RemoteAs.instance(),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/Uint32HighLowExprTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/Uint32HighLowExprTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public final class Uint32HighLowExprTest {
       new Uint32HighLowExpr(new LiteralInt(1), new LiteralInt(1));
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, Uint32HighLowExpr.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/VarIntTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/VarIntTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -15,7 +14,7 @@ public final class VarIntTest {
   private static final VarInt OBJ = new VarInt("a");
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertThat(BatfishObjectMapper.clone(OBJ, VarInt.class), equalTo(OBJ));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/AddCommunityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/AddCommunityTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Bgpv4Route;
@@ -37,7 +36,7 @@ public class AddCommunityTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     AddCommunity ac = new AddCommunity(new LiteralCommunity(StandardCommunity.of(1L)));
     assertThat(BatfishObjectMapper.clone(ac, AddCommunity.class), equalTo(ac));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/SetOriginTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/statement/SetOriginTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Configuration;
@@ -35,7 +34,7 @@ public class SetOriginTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     SetOrigin so = new SetOrigin(new LiteralOrigin(OriginType.INCOMPLETE, 1L));
     assertThat(BatfishObjectMapper.clone(so, SetOrigin.class), equalTo(so));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/TableViewTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/table/TableViewTest.java
@@ -3,11 +3,8 @@ package org.batfish.datamodel.table;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import java.io.IOException;
 import org.batfish.common.AnswerRowsOptions;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.answers.Schema;
@@ -23,7 +20,7 @@ public final class TableViewTest {
       new TableMetadata(ImmutableList.of(new ColumnMetadata("c1", Schema.STRING, "desc")));
 
   @Test
-  public void testSerialization() throws JsonParseException, JsonMappingException, IOException {
+  public void testSerialization() {
     Row row1 = Row.builder().put("key1", "v1").build();
     Row row2 = Row.builder().put("key1", "v2").build();
     TableView tableView =

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/trace/TraceTreeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/trace/TraceTreeTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import java.util.List;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.TraceElement;
@@ -27,7 +26,7 @@ public final class TraceTreeTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     TraceTree traceTree =
         new TraceTree(
             TraceElement.of("a"),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/ApplyAllTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/ApplyAllTest.java
@@ -2,7 +2,6 @@ package org.batfish.datamodel.transformation;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -20,7 +19,7 @@ public final class ApplyAllTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     ApplyAll applyAll = new ApplyAll(Noop.NOOP_DEST_NAT);
 
     assertEquals(applyAll, BatfishObjectMapper.clone(applyAll, ApplyAll.class));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/ApplyAnyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/ApplyAnyTest.java
@@ -2,7 +2,6 @@ package org.batfish.datamodel.transformation;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -20,7 +19,7 @@ public final class ApplyAnyTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     ApplyAny applyAll = new ApplyAny(Noop.NOOP_DEST_NAT);
 
     assertEquals(applyAll, BatfishObjectMapper.clone(applyAll, ApplyAny.class));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/AssignIpAddressFromPoolTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/transformation/AssignIpAddressFromPoolTest.java
@@ -7,7 +7,6 @@ import static org.batfish.datamodel.transformation.IpField.SOURCE;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
 import org.junit.Test;
@@ -30,7 +29,7 @@ public class AssignIpAddressFromPoolTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     AssignIpAddressFromPool assignIpAddressFromPool =
         new AssignIpAddressFromPool(
             DEST_NAT, DESTINATION, Ip.parse("1.1.1.1"), Ip.parse("2.2.2.2"));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vendor_family/cumulus/BridgeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vendor_family/cumulus/BridgeTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.IntegerSpace;
@@ -33,7 +32,7 @@ public final class BridgeTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     Bridge bridge =
         Bridge.builder()
             .setPorts(ImmutableSet.of("a"))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vendor_family/cumulus/CumulusFamilyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vendor_family/cumulus/CumulusFamilyTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.IntegerSpace;
@@ -36,7 +35,7 @@ public final class CumulusFamilyTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     CumulusFamily c =
         CumulusFamily.builder()
             .setBridge(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vendor_family/cumulus/InterfaceClagSettingsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vendor_family/cumulus/InterfaceClagSettingsTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Ip;
@@ -37,7 +36,7 @@ public final class InterfaceClagSettingsTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     InterfaceClagSettings c =
         InterfaceClagSettings.builder()
             .setBackupIp(Ip.ZERO)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.MutableGraph;
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import javax.annotation.Nonnull;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
@@ -33,7 +32,7 @@ public final class VxlanTopologyTest {
   }
 
   @Test
-  public void testJacksonSerialization() throws IOException {
+  public void testJacksonSerialization() {
     assertEquals(
         nonTrivialTopology(), BatfishObjectMapper.clone(nonTrivialTopology(), VxlanTopology.class));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/role/InferRolesTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -86,7 +85,7 @@ public class InferRolesTest {
               Edge.of("host2", "eth0", "as2dept1", "GigabitEthernet3/0")));
 
   @Test
-  public void inferRolesOnExampleTopology() throws JsonProcessingException {
+  public void inferRolesOnExampleTopology() {
     Optional<RoleMapping> roleMappingOpt =
         new InferRoles(EXAMPLE_NODES, EXAMPLE_TOPOLOGY).inferRoles();
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/InterfaceLocationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/InterfaceLocationTest.java
@@ -4,13 +4,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 public class InterfaceLocationTest {
   @Test
-  public void testClone() throws IOException {
+  public void testClone() {
     InterfaceLocation orig = new InterfaceLocation("foo", "bar");
     assertThat(orig, equalTo(BatfishObjectMapper.clone(orig, new TypeReference<Location>() {})));
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/vendor/VendorStructureIdTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/vendor/VendorStructureIdTest.java
@@ -3,7 +3,6 @@ package org.batfish.vendor;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.testing.EqualsTester;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
@@ -21,7 +20,7 @@ public final class VendorStructureIdTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     VendorStructureId vendorStructureId = new VendorStructureId("f", "t", "n");
     assertEquals(
         vendorStructureId, BatfishObjectMapper.clone(vendorStructureId, VendorStructureId.class));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/topology/OspfTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/topology/OspfTopologyTest.java
@@ -231,7 +231,7 @@ public class OspfTopologyTest {
   }
 
   @Test
-  public void testEdgeIdJsonSerialization() throws IOException {
+  public void testEdgeIdJsonSerialization() {
     final OspfNeighborConfigId r1i13 =
         new OspfNeighborConfigId(
             "r1",

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -172,11 +172,7 @@ public class TracerouteEngineImplTest {
             .getTracerouteEngine(snapshot)
             .computeTraces(ImmutableSet.of(flow), ignoreFilters)
             .get(flow);
-    try {
-      return BatfishObjectMapper.clone(traces, new TypeReference<List<Trace>>() {});
-    } catch (IOException e) {
-      throw new AssertionError("Could not clone traces", e);
-    }
+    return BatfishObjectMapper.clone(traces, new TypeReference<List<Trace>>() {});
   }
 
   /*

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -3729,7 +3729,7 @@ public final class CiscoGrammarTest {
 
   /** Tests that we can append more BGP config at the bottom of a file. */
   @Test
-  public void testBgpReentrantVrf() throws IOException {
+  public void testBgpReentrantVrf() {
     CiscoConfiguration c = parseCiscoConfig("ios-bgp-reentrant-vrf", ConfigurationFormat.CISCO_IOS);
     // Simple test that default VRF was parsed
     org.batfish.representation.cisco.BgpProcess defBgp = c.getDefaultVrf().getBgpProcess();
@@ -4309,7 +4309,7 @@ public final class CiscoGrammarTest {
   }
 
   @Test
-  public void testEosMlagExtraction() throws IOException {
+  public void testEosMlagExtraction() {
     CiscoConfiguration c = parseCiscoConfig("eos-mlag", ConfigurationFormat.ARISTA);
     MlagConfiguration mlag = c.getEosMlagConfiguration();
     assertThat(mlag, notNullValue());

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -473,7 +473,7 @@ public final class XrGrammarTest {
   }
 
   @Test
-  public void testExtcommunitySetRtConversion() throws IOException {
+  public void testExtcommunitySetRtConversion() {
     Configuration c = parseConfig("ios-xr-extcommunity-set-rt");
     CommunityContext ctx = CommunityContext.builder().build();
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5550,7 +5550,7 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
-  public void testRethConversion() throws IOException {
+  public void testRethConversion() {
     Configuration config = parseConfig("juniper-reth");
 
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/grammar/host/HostInterfaceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/host/HostInterfaceTest.java
@@ -117,7 +117,7 @@ public class HostInterfaceTest {
   }
 
   @Test
-  public void testEncapsulationVlan() throws IOException {
+  public void testEncapsulationVlan() {
     Integer encapsulationVlan = 5;
     HostInterface hi = new HostInterface("e0");
     hi.setEncapsulationVlan(encapsulationVlan);

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1901,7 +1901,7 @@ public final class PaloAltoGrammarTest {
   }
 
   @Test
-  public void testNatRulesAndReferences() throws IOException {
+  public void testNatRulesAndReferences() {
     String hostname = "rulebase-nat";
 
     // Check VS model

--- a/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationJobTest.java
+++ b/projects/batfish/src/test/java/org/batfish/job/ParseVendorConfigurationJobTest.java
@@ -34,14 +34,14 @@ public class ParseVendorConfigurationJobTest {
   }
 
   @Test
-  public void testHost() throws Exception {
+  public void testHost() {
     ParseVendorConfigurationResult result = parseHost(HOST_TESTCONFIGS_PREFIX + "host.json");
     // Confirm a good host file results in no failure cause
     assertThat(result.getFailureCause(), equalTo(null));
   }
 
   @Test
-  public void testHostInvalid() throws Exception {
+  public void testHostInvalid() {
     ParseVendorConfigurationResult result = parseHost(HOST_TESTCONFIGS_PREFIX + "hostInvalid.json");
     // Confirm a bad host file does not cause a crash but results in failure cause
     assertThat(result.getFailureCause(), not(equalTo(null)));

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceV2Test.java
@@ -44,7 +44,7 @@ public class WorkMgrServiceV2Test extends WorkMgrServiceV2TestBase {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -151,7 +151,7 @@ public final class WorkMgrTest {
   private IdManager _idManager;
 
   @Before
-  public void initManager() throws Exception {
+  public void initManager() {
     WorkMgrTestUtils.initWorkManager(_folder);
     _manager = Main.getWorkMgr();
     _idManager = _manager.getIdManager();
@@ -1420,7 +1420,7 @@ public final class WorkMgrTest {
   }
 
   @Test
-  public void testGetAnalysisAnswers() throws JsonProcessingException, FileNotFoundException {
+  public void testGetAnalysisAnswers() throws JsonProcessingException {
     String containerName = "container1";
     String testrigName = "testrig1";
     String analysisName = "analysis1";
@@ -1494,8 +1494,7 @@ public final class WorkMgrTest {
 
   /** Test that we return good answers when some questions are bad */
   @Test
-  public void testGetAnalysisAnswersAndMetadataPartial()
-      throws JsonProcessingException, FileNotFoundException {
+  public void testGetAnalysisAnswersAndMetadataPartial() throws JsonProcessingException {
     String containerName = "container1";
     String testrigName = "testrig1";
     String analysisName = "analysis1";
@@ -1608,8 +1607,7 @@ public final class WorkMgrTest {
   }
 
   @Test
-  public void testGetAnswerMetadataAnalysisSuccess()
-      throws JsonProcessingException, FileNotFoundException {
+  public void testGetAnswerMetadataAnalysisSuccess() throws JsonProcessingException {
     String networkName = "network1";
     String snapshotName = "snapshot1";
     String analysisName = "analysis1";
@@ -1652,8 +1650,7 @@ public final class WorkMgrTest {
   }
 
   @Test
-  public void testGetAnswerMetadataAnalysisMissingQuestion()
-      throws JsonProcessingException, FileNotFoundException {
+  public void testGetAnswerMetadataAnalysisMissingQuestion() {
     String networkName = "network1";
     String snapshotName = "snapshot1";
     String analysisName = "analysis1";
@@ -1719,8 +1716,7 @@ public final class WorkMgrTest {
   }
 
   @Test
-  public void testGetAnswerMetadataAnalysisMissingAnalysis()
-      throws JsonProcessingException, FileNotFoundException {
+  public void testGetAnswerMetadataAnalysisMissingAnalysis() {
     String networkName = "network1";
     String snapshotName = "snapshot1";
     String analysisName = "analysis1";
@@ -1740,8 +1736,7 @@ public final class WorkMgrTest {
   }
 
   @Test
-  public void testGetAnswerMetadataAdHocSuccess()
-      throws JsonProcessingException, FileNotFoundException {
+  public void testGetAnswerMetadataAdHocSuccess() throws JsonProcessingException {
     String networkName = "network1";
     String snapshotName = "snapshot1";
     Question question = new TestQuestion();
@@ -1813,8 +1808,7 @@ public final class WorkMgrTest {
   }
 
   @Test
-  public void testGetAnswerMetadataAdHocMissingQuestion()
-      throws JsonProcessingException, FileNotFoundException {
+  public void testGetAnswerMetadataAdHocMissingQuestion() throws JsonProcessingException {
     String networkName = "network1";
     String snapshotName = "snapshot1";
     Question question = new TestQuestion();

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
@@ -135,7 +135,7 @@ public final class WorkQueueMgrTest {
   private IdManager _idManager;
 
   @Before
-  public void init() throws Exception {
+  public void init() {
     Main.mainInit(new String[0]);
     Main.setLogger(new BatfishLogger("debug", false));
     _workQueueMgr = new WorkQueueMgr(Type.memory, Main.getLogger());

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/AnalysesResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/AnalysesResourceTest.java
@@ -38,7 +38,7 @@ public final class AnalysesResourceTest extends WorkMgrServiceV2TestBase {
   }
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/AnalysisResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/AnalysisResourceTest.java
@@ -36,7 +36,7 @@ public final class AnalysisResourceTest extends WorkMgrServiceV2TestBase {
   }
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/AnswerResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/AnswerResourceTest.java
@@ -98,7 +98,7 @@ public class AnswerResourceTest extends WorkMgrServiceV2TestBase {
   }
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/IssueConfigResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/IssueConfigResourceTest.java
@@ -31,7 +31,7 @@ public class IssueConfigResourceTest extends WorkMgrServiceV2TestBase {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/IssueSettingsResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/IssueSettingsResourceTest.java
@@ -33,7 +33,7 @@ public class IssueSettingsResourceTest extends WorkMgrServiceV2TestBase {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkNodeRoleDimensionResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkNodeRoleDimensionResourceTest.java
@@ -41,7 +41,7 @@ public final class NetworkNodeRoleDimensionResourceTest extends WorkMgrServiceV2
   }
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkNodeRolesResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkNodeRolesResourceTest.java
@@ -43,7 +43,7 @@ public final class NetworkNodeRolesResourceTest extends WorkMgrServiceV2TestBase
   }
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkObjectsResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkObjectsResourceTest.java
@@ -44,7 +44,7 @@ public final class NetworkObjectsResourceTest extends WorkMgrServiceV2TestBase {
   }
 
   @Before
-  public void initNetworkEnvironment() throws Exception {
+  public void initNetworkEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NetworkResourceTest.java
@@ -31,7 +31,7 @@ public final class NetworkResourceTest extends WorkMgrServiceV2TestBase {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   @Before
-  public void initContainer() throws Exception {
+  public void initContainer() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRoleDimensionBeanTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/NodeRoleDimensionBeanTest.java
@@ -18,7 +18,7 @@ public class NodeRoleDimensionBeanTest extends WorkMgrServiceV2TestBase {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/QuestionsResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/QuestionsResourceTest.java
@@ -81,7 +81,7 @@ public final class QuestionsResourceTest extends WorkMgrServiceV2TestBase {
   }
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/ReferenceBookResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/ReferenceBookResourceTest.java
@@ -32,7 +32,7 @@ public class ReferenceBookResourceTest extends WorkMgrServiceV2TestBase {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/ReferenceLibraryResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/ReferenceLibraryResourceTest.java
@@ -29,7 +29,7 @@ public class ReferenceLibraryResourceTest extends WorkMgrServiceV2TestBase {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotInputObjectsResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotInputObjectsResourceTest.java
@@ -57,7 +57,7 @@ public final class SnapshotInputObjectsResourceTest extends WorkMgrServiceV2Test
   }
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotNodeRolesResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotNodeRolesResourceTest.java
@@ -38,7 +38,7 @@ public final class SnapshotNodeRolesResourceTest extends WorkMgrServiceV2TestBas
   }
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotObjectsResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotObjectsResourceTest.java
@@ -64,7 +64,7 @@ public final class SnapshotObjectsResourceTest extends WorkMgrServiceV2TestBase 
   }
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotResourceTest.java
@@ -93,7 +93,7 @@ public final class SnapshotResourceTest extends WorkMgrServiceV2TestBase {
   }
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotsResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotsResourceTest.java
@@ -41,7 +41,7 @@ public final class SnapshotsResourceTest extends WorkMgrServiceV2TestBase {
   }
 
   @Before
-  public void setup() throws Exception {
+  public void setup() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/WorkResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/WorkResourceTest.java
@@ -41,7 +41,7 @@ public final class WorkResourceTest extends WorkMgrServiceV2TestBase {
   }
 
   @Before
-  public void initTestEnvironment() throws Exception {
+  public void initTestEnvironment() {
     WorkMgrTestUtils.initWorkManager(_folder);
   }
 

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPeerConfigurationQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpPeerConfigurationQuestionTest.java
@@ -3,7 +3,6 @@ package org.batfish.question.bgpproperties;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.questions.BgpPeerPropertySpecifier;
 import org.junit.Test;
@@ -12,7 +11,7 @@ import org.junit.Test;
 public class BgpPeerConfigurationQuestionTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     BgpPeerConfigurationQuestion q =
         new BgpPeerConfigurationQuestion("nodes", BgpPeerPropertySpecifier.LOCAL_IP);
     assertThat(BatfishObjectMapper.clone(q, BgpPeerConfigurationQuestion.class), equalTo(q));

--- a/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpProcessConfigurationQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpproperties/BgpProcessConfigurationQuestionTest.java
@@ -3,7 +3,6 @@ package org.batfish.question.bgpproperties;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.questions.BgpProcessPropertySpecifier;
 import org.junit.Test;
@@ -12,7 +11,7 @@ import org.junit.Test;
 public class BgpProcessConfigurationQuestionTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     BgpProcessConfigurationQuestion q =
         new BgpProcessConfigurationQuestion("nodes", BgpProcessPropertySpecifier.MULTIPATH_EBGP);
     assertThat(BatfishObjectMapper.clone(q, BgpProcessConfigurationQuestion.class), equalTo(q));

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionCompatibilityQuestionTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.BgpSessionProperties.SessionType;
 import org.batfish.datamodel.questions.ConfiguredSessionStatus;
@@ -26,7 +25,7 @@ public class BgpSessionCompatibilityQuestionTest {
   }
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     BgpSessionCompatibilityQuestion q =
         new BgpSessionCompatibilityQuestion(
             "nodes",

--- a/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/bgpsessionstatus/BgpSessionStatusQuestionTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.BgpSessionProperties.SessionType;
 import org.batfish.datamodel.questions.BgpSessionStatus;
@@ -15,7 +14,7 @@ import org.junit.Test;
 public class BgpSessionStatusQuestionTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     BgpSessionStatusQuestion q =
         new BgpSessionStatusQuestion(
             "nodes",

--- a/projects/question/src/test/java/org/batfish/question/findmatchingfilterlines/FindMatchingFilterLinesQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/findmatchingfilterlines/FindMatchingFilterLinesQuestionTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.collect.ImmutableSet;
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.PacketHeaderConstraints;
@@ -14,7 +13,7 @@ import org.junit.Test;
 public class FindMatchingFilterLinesQuestionTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     // Default parameters
     FindMatchingFilterLinesQuestion q =
         new FindMatchingFilterLinesQuestion(null, null, null, null, null);

--- a/projects/question/src/test/java/org/batfish/question/interfaceproperties/InterfacePropertiesQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/interfaceproperties/InterfacePropertiesQuestionTest.java
@@ -3,7 +3,6 @@ package org.batfish.question.interfaceproperties;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.questions.InterfacePropertySpecifier;
 import org.junit.Test;
@@ -12,7 +11,7 @@ import org.junit.Test;
 public class InterfacePropertiesQuestionTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     InterfacePropertiesQuestion q =
         new InterfacePropertiesQuestion(
             "nodes", "interfaces", InterfacePropertySpecifier.ACCESS_VLAN, false);

--- a/projects/question/src/test/java/org/batfish/question/mlag/MlagPropertiesQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/mlag/MlagPropertiesQuestionTest.java
@@ -3,14 +3,13 @@ package org.batfish.question.mlag;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 /** Tests of {@link org.batfish.question.mlag.MlagPropertiesQuestion} */
 public final class MlagPropertiesQuestionTest {
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     MlagPropertiesQuestion q = new MlagPropertiesQuestion("nodes", "mlags");
     assertThat(BatfishObjectMapper.clone(q, MlagPropertiesQuestion.class), equalTo(q));
   }

--- a/projects/question/src/test/java/org/batfish/question/namedstructures/NamedStructuresQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/namedstructures/NamedStructuresQuestionTest.java
@@ -3,7 +3,6 @@ package org.batfish.question.namedstructures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.questions.NamedStructurePropertySpecifier;
 import org.junit.Test;
@@ -12,7 +11,7 @@ import org.junit.Test;
 public class NamedStructuresQuestionTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     NamedStructuresQuestion q =
         new NamedStructuresQuestion(
             "nodes",

--- a/projects/question/src/test/java/org/batfish/question/nodeproperties/NodePropertiesQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/nodeproperties/NodePropertiesQuestionTest.java
@@ -3,7 +3,6 @@ package org.batfish.question.nodeproperties;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.questions.NodePropertySpecifier;
 import org.junit.Test;
@@ -12,7 +11,7 @@ import org.junit.Test;
 public class NodePropertiesQuestionTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     NodePropertiesQuestion q =
         new NodePropertiesQuestion("nodes", NodePropertySpecifier.NTP_SERVERS);
     assertThat(BatfishObjectMapper.clone(q, NodePropertiesQuestion.class), equalTo(q));

--- a/projects/question/src/test/java/org/batfish/question/ospfinterface/OspfInterfaceConfigurationQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfinterface/OspfInterfaceConfigurationQuestionTest.java
@@ -3,7 +3,6 @@ package org.batfish.question.ospfinterface;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.questions.InterfacePropertySpecifier;
 import org.junit.Test;
@@ -12,7 +11,7 @@ import org.junit.Test;
 public class OspfInterfaceConfigurationQuestionTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     OspfInterfaceConfigurationQuestion q =
         new OspfInterfaceConfigurationQuestion("nodes", InterfacePropertySpecifier.ACCESS_VLAN);
     assertThat(BatfishObjectMapper.clone(q, OspfInterfaceConfigurationQuestion.class), equalTo(q));

--- a/projects/question/src/test/java/org/batfish/question/ospfprocess/OspfProcessConfigurationQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/ospfprocess/OspfProcessConfigurationQuestionTest.java
@@ -3,7 +3,6 @@ package org.batfish.question.ospfprocess;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.questions.OspfProcessPropertySpecifier;
 import org.junit.Test;
@@ -12,7 +11,7 @@ import org.junit.Test;
 public class OspfProcessConfigurationQuestionTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     OspfProcessConfigurationQuestion q =
         new OspfProcessConfigurationQuestion("nodes", OspfProcessPropertySpecifier.AREAS);
     assertThat(BatfishObjectMapper.clone(q, OspfProcessConfigurationQuestion.class), equalTo(q));

--- a/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/searchfilters/SearchFiltersQuestionTest.java
@@ -37,7 +37,7 @@ public class SearchFiltersQuestionTest {
   @Rule public ExpectedException exception = ExpectedException.none();
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     SearchFiltersQuestion q =
         SearchFiltersQuestion.builder()
             .setAction("deny")
@@ -109,7 +109,7 @@ public class SearchFiltersQuestionTest {
   }
 
   @Test
-  public void testIpProtocols() throws IOException {
+  public void testIpProtocols() {
     ImmutableSortedSet<IpProtocol> ipProtocols =
         ImmutableSortedSet.of(IpProtocol.TCP, IpProtocol.ICMP);
     SearchFiltersQuestion question =

--- a/projects/question/src/test/java/org/batfish/question/vxlanproperties/VxlanVniPropertiesQuestionTest.java
+++ b/projects/question/src/test/java/org/batfish/question/vxlanproperties/VxlanVniPropertiesQuestionTest.java
@@ -3,7 +3,6 @@ package org.batfish.question.vxlanproperties;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.questions.VxlanVniPropertySpecifier;
 import org.junit.Test;
@@ -12,7 +11,7 @@ import org.junit.Test;
 public class VxlanVniPropertiesQuestionTest {
 
   @Test
-  public void testJsonSerialization() throws IOException {
+  public void testJsonSerialization() {
     VxlanVniPropertiesQuestion q =
         new VxlanVniPropertiesQuestion("nodes", VxlanVniPropertySpecifier.VXLAN_PORT);
     assertThat(BatfishObjectMapper.clone(q, VxlanVniPropertiesQuestion.class), equalTo(q));


### PR DESCRIPTION
Add @VisibleForTesting annotation, then remove unnecessary throws from callers.

IntelliJ did the removing part in an automated way.