### PR TITLE
AWS aggregates: use nodes (not edges) for computation

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Topology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Topology.java
@@ -103,12 +103,12 @@ public class Topology extends BfObject {
     return pojoTopology;
   }
 
-  private static void putInAwsAggregate(Topology pojoTopology, Configuration configuration, Node pojoNode) {
+  private static void putInAwsAggregate(
+      Topology pojoTopology, Configuration configuration, Node pojoNode) {
     VendorFamily vendorFamily = configuration.getVendorFamily();
     if (vendorFamily.getAws().getSubnetId() != null) {
       String subnetId = vendorFamily.getAws().getSubnetId();
-      Aggregate subnetAggregate =
-          pojoTopology.getOrCreateAggregate(subnetId, AggregateType.SUBNET);
+      Aggregate subnetAggregate = pojoTopology.getOrCreateAggregate(subnetId, AggregateType.SUBNET);
       subnetAggregate.getContents().add(pojoNode.getId());
 
       String vpcId = vendorFamily.getAws().getVpcId();
@@ -120,13 +120,11 @@ public class Topology extends BfObject {
       vpcAggregate.getContents().add(pojoNode.getId());
 
       String region = vendorFamily.getAws().getRegion();
-      Aggregate regionAggregate =
-          pojoTopology.getOrCreateAggregate(region, AggregateType.REGION);
+      Aggregate regionAggregate = pojoTopology.getOrCreateAggregate(region, AggregateType.REGION);
       regionAggregate.getContents().add(vpcAggregate.getId());
     } else if (vendorFamily.getAws().getRegion() != null) {
       String region = vendorFamily.getAws().getRegion();
-      Aggregate regionAggregate =
-          pojoTopology.getOrCreateAggregate(region, AggregateType.REGION);
+      Aggregate regionAggregate = pojoTopology.getOrCreateAggregate(region, AggregateType.REGION);
       regionAggregate.getContents().add(pojoNode.getId());
 
       Aggregate awsAggregate = pojoTopology.getOrCreateAggregate("aws", AggregateType.CLOUD);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
@@ -152,9 +152,9 @@ public class TopologyTest {
             new org.batfish.datamodel.Topology(ImmutableSortedSet.of()));
     Node topoNode = new Node(c1.getHostname());
 
-    Aggregate expected_agg = new Aggregate(regionName, AggregateType.REGION);
-    expected_agg.setContents(ImmutableSet.of(topoNode.getId()));
+    Aggregate expectedAgg = new Aggregate(regionName, AggregateType.REGION);
+    expectedAgg.setContents(ImmutableSet.of(topoNode.getId()));
 
-    assertThat(topo.getAggregates(), hasItem(expected_agg));
+    assertThat(topo.getAggregates(), hasItem(expectedAgg));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
@@ -1,6 +1,5 @@
 package org.batfish.datamodel.pojo;
 
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
@@ -134,7 +133,11 @@ public class TopologyTest {
   @Test
   public void testAwsAggregateUsesNodes() {
     NetworkFactory nf = new NetworkFactory();
-    Configuration c1 = nf.configurationBuilder().setHostname("vpc-1").setConfigurationFormat(ConfigurationFormat.AWS).build();
+    Configuration c1 =
+        nf.configurationBuilder()
+            .setHostname("vpc-1")
+            .setConfigurationFormat(ConfigurationFormat.AWS)
+            .build();
     VendorFamily vf = new VendorFamily();
     AwsFamily af = new AwsFamily();
     String regionName = "us-west-1";

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.pojo;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
@@ -8,10 +10,13 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.pojo.Aggregate.AggregateType;
+import org.batfish.datamodel.vendor_family.AwsFamily;
+import org.batfish.datamodel.vendor_family.VendorFamily;
 import org.junit.Test;
 
 /** Tests of {@link Topology}. */
@@ -124,5 +129,29 @@ public class TopologyTest {
             ImmutableSet.of(
                 new Interface("node-c1", "to-c2", InterfaceType.VPN),
                 new Interface("node-c2", "to-c1", InterfaceType.TUNNEL))));
+  }
+
+  @Test
+  public void testAwsAggregateUsesNodes() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c1 = nf.configurationBuilder().setHostname("vpc-1").setConfigurationFormat(ConfigurationFormat.AWS).build();
+    VendorFamily vf = new VendorFamily();
+    AwsFamily af = new AwsFamily();
+    String regionName = "us-west-1";
+    af.setRegion(regionName);
+    vf.setAws(af);
+    c1.setVendorFamily(vf);
+
+    Topology topo =
+        Topology.create(
+            "ss",
+            ImmutableMap.of(c1.getHostname(), c1),
+            new org.batfish.datamodel.Topology(ImmutableSortedSet.of()));
+    Node topoNode = new Node(c1.getHostname());
+
+    Aggregate expected_agg = new Aggregate(regionName, AggregateType.REGION);
+    expected_agg.setContents(ImmutableSet.of(topoNode.getId()));
+
+    assertThat(topo.getAggregates(), hasItem(expected_agg));
   }
 }

--- a/tests/aws/topology-example-aws.ref
+++ b/tests/aws/topology-example-aws.ref
@@ -12,6 +12,14 @@
     },
     {
       "contents" : [
+        "node-vpc-815775e7"
+      ],
+      "id" : "aggregate-vpc-815775e7",
+      "name" : "vpc-815775e7",
+      "type" : "VNET"
+    },
+    {
+      "contents" : [
         "node-subnet-f73a8191"
       ],
       "id" : "aggregate-subnet-f73a8191",
@@ -91,10 +99,12 @@
       "contents" : [
         "node-igw-9b93ddfc",
         "aggregate-vpc-f8fad69d",
+        "aggregate-vpc-815775e7",
         "node-igw-068fee63",
         "aggregate-vpc-925131f4",
         "aggregate-vpc-b390fad5",
-        "node-igw-fac5839d"
+        "node-igw-fac5839d",
+        "node-vgw-81fd279f"
       ],
       "id" : "aggregate-us-west-2",
       "name" : "us-west-2",


### PR DESCRIPTION
Ensures that disconnected nodes are placed into aggregates.