### PR TITLE
FlowTracer: forkTracerFollowEdge should use currentFlow as next-hop's  originalFlow

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationStep.java
@@ -23,6 +23,10 @@ public interface TransformationStep {
 
   <T> T accept(TransformationStepVisitor<T> visitor);
 
+  static AssignIpAddressFromPool assignDestinationIp(Ip poolStart) {
+    return new AssignIpAddressFromPool(DEST_NAT, DESTINATION, poolStart, poolStart);
+  }
+
   static AssignIpAddressFromPool assignDestinationIp(Ip poolStart, Ip poolEnd) {
     return new AssignIpAddressFromPool(DEST_NAT, DESTINATION, poolStart, poolEnd);
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -358,7 +358,8 @@ class FlowTracer {
 
   /** Return forked {@link FlowTracer} on same node and VRF. Used for taking ECMP actions. */
   @VisibleForTesting
-  @Nonnull FlowTracer forkTracerSameNode() {
+  @Nonnull
+  FlowTracer forkTracerSameNode() {
     return forkTracerSameNode(_vrfName);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -306,8 +306,9 @@ class FlowTracer {
       Stack<Breadcrumb> breadcrumbs,
       Flow currentFlow) {
     assert originalFlow.equals(currentFlow)
-            || steps.stream().anyMatch(TransformationStep.class::isInstance)
-        : "Original flow and current flow must be equal unless there's a transformation step";
+            || steps.stream()
+                .anyMatch(step -> step instanceof TransformationStep || step instanceof PolicyStep)
+        : "Original flow and current flow must be equal unless there's a transformation step or a policy step";
     _tracerouteContext = tracerouteContext;
     _currentConfig = currentConfig;
     _ingressInterface = ingressInterface;


### PR DESCRIPTION
FlowTracer's originalFlow field is used to compute FlowDiffs and set up sessions
after transformations.  "Original" should mean "the flow that entered the hop".
Previously it meant "the flow at the beginning of the trace", which caused
incorrect diffs and sessions when there are more than one transformation in the
trace.