### PR TITLE
IOS-XR: work around a crash in route policy evaluation

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_rpl.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_rpl.g4
@@ -353,8 +353,8 @@ set_extcommunity_rp_stanza
   SET EXTCOMMUNITY
   (
     set_extcommunity_rt
-    // TODO all the other extended community types
-  )
+    // TODO all the other extended community types. Until then, the ? prevents NPE on recovery.
+  )?
 ;
 
 set_extcommunity_rt


### PR DESCRIPTION
The code needs reworking: it's never safe for a parent to recurse into its child's context
if recovery is enabled.

For now, this works around a crash when recovery kicked in.

See https://github.com/batfish/batfish/issues/5625