### PR TITLE
ISP modeling: Use LLA for Internet-ISP edges

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModel.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModel.java
@@ -1,0 +1,158 @@
+package org.batfish.common.util;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.Prefix;
+
+/** Contains the information required to model one ISP node */
+@ParametersAreNonnullByDefault
+final class IspModel {
+
+  /** Represents one remote end of the ISP node */
+  static final class Remote {
+
+    private @Nonnull final String _remoteHostname;
+    private @Nonnull final String _remoteIfaceName;
+    private @Nonnull final ConcreteInterfaceAddress _ispIfaceAddress;
+    private @Nonnull final BgpActivePeerConfig _remoteBgpActivePeerConfig;
+
+    Remote(
+        String remoteHostname,
+        String remoteIfaceName,
+        ConcreteInterfaceAddress ispIfaceAddress,
+        BgpActivePeerConfig remoteBgpActivePeerConfig) {
+      _remoteHostname = remoteHostname;
+      _remoteIfaceName = remoteIfaceName;
+      _ispIfaceAddress = ispIfaceAddress;
+      _remoteBgpActivePeerConfig = remoteBgpActivePeerConfig;
+    }
+
+    @Nonnull
+    public ConcreteInterfaceAddress getIspIfaceAddress() {
+      return _ispIfaceAddress;
+    }
+
+    @Nonnull
+    public BgpActivePeerConfig getRemoteBgpActivePeerConfig() {
+      return _remoteBgpActivePeerConfig;
+    }
+
+    @Nonnull
+    public String getRemoteHostname() {
+      return _remoteHostname;
+    }
+
+    @Nonnull
+    public String getRemoteIfaceName() {
+      return _remoteIfaceName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Remote)) {
+        return false;
+      }
+      Remote neighbor = (Remote) o;
+      return _ispIfaceAddress.equals(neighbor._ispIfaceAddress)
+          && _remoteBgpActivePeerConfig.equals(neighbor._remoteBgpActivePeerConfig);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_ispIfaceAddress, _remoteBgpActivePeerConfig);
+    }
+  }
+
+  private long _asn;
+  private @Nonnull String _name;
+  private @Nonnull List<Remote> _remotes;
+  private @Nonnull Set<Prefix> _additionalPrefixesToInternet;
+
+  IspModel(long asn, String name) {
+    this(asn, new ArrayList<>(), name, ImmutableSet.of());
+  }
+
+  IspModel(long asn, String name, Set<Prefix> additionalPrefixesToInternet) {
+    this(asn, new ArrayList<>(), name, additionalPrefixesToInternet);
+  }
+
+  IspModel(long asn, List<Remote> remotes, String name) {
+    this(asn, remotes, name, ImmutableSet.of());
+  }
+
+  IspModel(long asn, List<Remote> remotes, String name, Set<Prefix> additionalPrefixesToInternet) {
+    _asn = asn;
+    _remotes = remotes;
+    _name = name;
+    _additionalPrefixesToInternet = ImmutableSet.copyOf(additionalPrefixesToInternet);
+  }
+
+  void addNeighbor(Remote neighbor) {
+    _remotes.add(neighbor);
+  }
+
+  @Nonnull
+  List<Remote> getRemotes() {
+    return ImmutableList.copyOf(_remotes);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("asn", _asn)
+        .add("name", _name)
+        .add("neighbors", _remotes)
+        .add("additionalPrefixes", _additionalPrefixesToInternet)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof IspModel)) {
+      return false;
+    }
+    IspModel ispInfo = (IspModel) o;
+    return _asn == ispInfo._asn
+        && _remotes.equals(ispInfo._remotes)
+        && _name.equals(ispInfo._name)
+        && _additionalPrefixesToInternet.equals(ispInfo._additionalPrefixesToInternet);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_asn, _remotes, _name, _additionalPrefixesToInternet);
+  }
+
+  public long getAsn() {
+    return _asn;
+  }
+
+  @Nonnull
+  public String getName() {
+    return _name;
+  }
+
+  /**
+   * Returns the prefixes that the ISP should announce to the Internet over the BGP connection
+   * (beyond just passing along what it hears from other connected nodes)
+   */
+  @Nonnull
+  public Set<Prefix> getAdditionalPrefixesToInternet() {
+    return _additionalPrefixesToInternet;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModel.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModel.java
@@ -76,6 +76,16 @@ final class IspModel {
       return Objects.hash(
           _remoteHostname, _remoteIfaceName, _ispIfaceAddress, _remoteBgpActivePeerConfig);
     }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("remoteHostname", _remoteHostname)
+          .add("remoteIfaceName", _remoteIfaceName)
+          .add("ispIfaceAddress", _ispIfaceAddress)
+          .add("remoteBgpActivePeerConfig", _remoteBgpActivePeerConfig)
+          .toString();
+    }
   }
 
   private long _asn;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModel.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModel.java
@@ -65,13 +65,16 @@ final class IspModel {
         return false;
       }
       Remote neighbor = (Remote) o;
-      return _ispIfaceAddress.equals(neighbor._ispIfaceAddress)
+      return _remoteHostname.equals(neighbor._remoteHostname)
+          && _remoteIfaceName.equals(neighbor._remoteIfaceName)
+          && _ispIfaceAddress.equals(neighbor._ispIfaceAddress)
           && _remoteBgpActivePeerConfig.equals(neighbor._remoteBgpActivePeerConfig);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(_ispIfaceAddress, _remoteBgpActivePeerConfig);
+      return Objects.hash(
+          _remoteHostname, _remoteIfaceName, _ispIfaceAddress, _remoteBgpActivePeerConfig);
     }
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
@@ -92,6 +92,7 @@ public final class IspModelingUtils {
   static final Ip INTERNET_OUT_ADDRESS = INTERNET_OUT_SUBNET.getFirstHostIp();
   static final String INTERNET_OUT_INTERFACE = "out";
   static final Ip LINK_LOCAL_IP = Ip.parse("169.254.0.1");
+  static final LinkLocalAddress LINK_LOCAL_ADDRESS = LinkLocalAddress.of(LINK_LOCAL_IP);
 
   // null routing private address space at the internet prevents "INSUFFICIENT_INFO" for networks
   // that use this space internally
@@ -119,13 +120,18 @@ public final class IspModelingUtils {
       _layer1Edgesdges = new HashSet<>();
     }
 
-    void addConfiguration(Configuration configuration) {
+    public void addConfiguration(Configuration configuration) {
       _configurations.put(configuration.getHostname(), configuration);
     }
 
-    void addLayer1Edge(String node1, String node1Iface, String node2, String node2Iface) {
-      _layer1Edgesdges.add(new Layer1Edge(node1, node1Iface, node2, node2Iface));
-      _layer1Edgesdges.add(new Layer1Edge(node2, node2Iface, node1, node1Iface));
+    /** Add both directions of the node/interface pairs as layer 1 edges */
+    public void addLayer1Edge(String node1, String node1Iface, String node2, String node2Iface) {
+      addLayer1Edge(new Layer1Edge(node1, node1Iface, node2, node2Iface));
+      addLayer1Edge(new Layer1Edge(node2, node2Iface, node1, node1Iface));
+    }
+
+    public void addLayer1Edge(Layer1Edge edge) {
+      _layer1Edgesdges.add(edge);
     }
 
     @Nonnull
@@ -344,13 +350,13 @@ public final class IspModelingUtils {
           nf.interfaceBuilder()
               .setOwner(internet)
               .setVrf(internet.getDefaultVrf())
-              .setAddress(LinkLocalAddress.of(LINK_LOCAL_IP))
+              .setAddress(LINK_LOCAL_ADDRESS)
               .build();
       Interface ispIface =
           nf.interfaceBuilder()
               .setOwner(ispConfiguration)
               .setVrf(ispConfiguration.getDefaultVrf())
-              .setAddress(LinkLocalAddress.of(LINK_LOCAL_IP))
+              .setAddress(LINK_LOCAL_ADDRESS)
               .build();
 
       BgpUnnumberedPeerConfig.builder()

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
@@ -135,7 +135,7 @@ public final class IspModelingUtils {
     }
 
     @Nonnull
-    public Set<Layer1Edge> getLayer1Edgesdges() {
+    public Set<Layer1Edge> getLayer1Edges() {
       return ImmutableSet.copyOf(_layer1Edgesdges);
     }
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.common.topology.Layer1Edge;
@@ -259,6 +258,7 @@ public final class IspModelingUtils {
     return modeledNodes;
   }
 
+  /** Creates the modeled Internet node and inserts it into {@code modeledNodes} */
   @VisibleForTesting
   static void createInternetNode(ModeledNodes modeledNodes) {
     Configuration.Builder cb = Configuration.builder();
@@ -487,16 +487,15 @@ public final class IspModelingUtils {
   }
 
   /**
-   * Creates and returns the {@link Configuration} for the ISP node given an ASN and {@link
-   * IspModel}
+   * Creates the {@link Configuration} for the ISP node given an ASN and {@link IspModel}. Inserts
+   * that node and its layer1 edges to the Internet into {@code modeledNodes}.
    */
   @VisibleForTesting
-  @Nullable
-  static Configuration createIspNode(
+  static void createIspNode(
       ModeledNodes modeledNodes, IspModel ispInfo, NetworkFactory nf, BatfishLogger logger) {
     if (ispInfo.getRemotes().isEmpty()) {
       logger.warnf("ISP information for ASN '%s' is not correct", ispInfo.getAsn());
-      return null;
+      return;
     }
 
     Configuration ispConfiguration =
@@ -584,8 +583,6 @@ public final class IspModelingUtils {
                     .build());
 
     modeledNodes.addConfiguration(ispConfiguration);
-
-    return ispConfiguration;
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -1175,10 +1175,11 @@ public final class TopologyUtilTest {
             new IspFilter(ImmutableList.of(), ImmutableList.of()));
     Map<String, Configuration> ispConfigurations =
         IspModelingUtils.getInternetAndIspNodes(
-            explicitConfigurations,
-            ImmutableList.of(ispConfiguration),
-            new BatfishLogger(BatfishLogger.LEVELSTR_ERROR, false),
-            new Warnings());
+                explicitConfigurations,
+                ImmutableList.of(ispConfiguration),
+                new BatfishLogger(BatfishLogger.LEVELSTR_ERROR, false),
+                new Warnings())
+            .getConfigurations();
     Map<String, Configuration> configurations =
         ImmutableMap.<String, Configuration>builder()
             .putAll(explicitConfigurations)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.common.util.IspModelingUtils;
+import org.batfish.common.util.IspModelingUtils.ModeledNodes;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
@@ -1173,47 +1174,52 @@ public final class TopologyUtilTest {
                 new BorderInterfaceInfo(NodeInterfacePair.of(b1Name, i2Name)),
                 new BorderInterfaceInfo(NodeInterfacePair.of(b2Name, i2Name))),
             new IspFilter(ImmutableList.of(), ImmutableList.of()));
-    Map<String, Configuration> ispConfigurations =
+    ModeledNodes modeledNodes =
         IspModelingUtils.getInternetAndIspNodes(
-                explicitConfigurations,
-                ImmutableList.of(ispConfiguration),
-                new BatfishLogger(BatfishLogger.LEVELSTR_ERROR, false),
-                new Warnings())
-            .getConfigurations();
+            explicitConfigurations,
+            ImmutableList.of(ispConfiguration),
+            new BatfishLogger(BatfishLogger.LEVELSTR_ERROR, false),
+            new Warnings());
     Map<String, Configuration> configurations =
         ImmutableMap.<String, Configuration>builder()
             .putAll(explicitConfigurations)
-            .putAll(ispConfigurations)
+            .putAll(modeledNodes.getConfigurations())
             .build();
 
-    Layer1Topology layer1PhysicalTopology =
-        cleanLayer1PhysicalTopology(rawLayer1Topology, configurations);
-
-    // Layer-1 physical topology should include edges in each direction between each border router
+    // Layer-1 raw topology should include edges in each direction between each border router
     // and corresponding host
     assertThat(
-        layer1PhysicalTopology.getGraph().edges(),
+        cleanLayer1PhysicalTopology(rawLayer1Topology, configurations).getGraph().edges(),
         containsInAnyOrder(
             new Layer1Edge(l1B1, l1H1),
             new Layer1Edge(l1H1, l1B1),
             new Layer1Edge(l1B2, l1H2),
             new Layer1Edge(l1H2, l1B2)));
 
+    Layer1Topology layer1SynthesizedTopology = new Layer1Topology(modeledNodes.getLayer1Edges());
+
+    // merge the raw and synthesized layer1 topologies
+    Layer1Topology layer1PhysicalTopology =
+        unionLayer1PhysicalTopologies(
+                Optional.of(cleanLayer1PhysicalTopology(rawLayer1Topology, configurations)),
+                Optional.of(layer1SynthesizedTopology))
+            .get();
+
+    Layer1Topology layer1LogicalTopology =
+        computeLayer1LogicalTopology(layer1PhysicalTopology, configurations);
+
     Topology layer3Topology =
         computeRawLayer3Topology(
             rawLayer1Topology,
-            Layer1Topology.EMPTY,
-            computeLayer2Topology(
-                computeLayer1LogicalTopology(layer1PhysicalTopology, configurations),
-                VxlanTopology.EMPTY,
-                configurations),
+            layer1LogicalTopology,
+            computeLayer2Topology(layer1LogicalTopology, VxlanTopology.EMPTY, configurations),
             configurations);
 
     NodeInterfacePair l3B1 = NodeInterfacePair.of(b1Name, i2Name);
     NodeInterfacePair l3B2 = NodeInterfacePair.of(b2Name, i2Name);
 
     Set<String> explicitNodes = explicitConfigurations.keySet();
-    Set<String> ispNodes = ispConfigurations.keySet();
+    Set<String> ispNodes = modeledNodes.getConfigurations().keySet();
 
     // Layer-3 topology should include edges in each direction between each border router and
     // generated ISP node

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelTest.java
@@ -1,0 +1,79 @@
+package org.batfish.common.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.testing.EqualsTester;
+import org.batfish.common.util.IspModel.Remote;
+import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.Prefix;
+import org.junit.Test;
+
+public class IspModelTest {
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new IspModel(1L, ImmutableList.of(), "name", ImmutableSet.of()),
+            new IspModel(1L, ImmutableList.of(), "name", ImmutableSet.of()))
+        .addEqualityGroup(new IspModel(2L, ImmutableList.of(), "name", ImmutableSet.of()))
+        .addEqualityGroup(
+            new IspModel(
+                1L,
+                ImmutableList.of(
+                    new Remote(
+                        "a",
+                        "b",
+                        ConcreteInterfaceAddress.parse("1.1.1.1/32"),
+                        BgpActivePeerConfig.builder().build())),
+                "name",
+                ImmutableSet.of()))
+        .addEqualityGroup(new IspModel(1L, ImmutableList.of(), "other", ImmutableSet.of()))
+        .addEqualityGroup(
+            new IspModel(
+                1L, ImmutableList.of(), "name", ImmutableSet.of(Prefix.parse("1.1.1.1/32"))))
+        .testEquals();
+  }
+
+  @Test
+  public void testEqualsRemote() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new Remote(
+                "a",
+                "b",
+                ConcreteInterfaceAddress.parse("1.1.1.1/32"),
+                BgpActivePeerConfig.builder().build()),
+            new Remote(
+                "a",
+                "b",
+                ConcreteInterfaceAddress.parse("1.1.1.1/32"),
+                BgpActivePeerConfig.builder().build()))
+        .addEqualityGroup(
+            new Remote(
+                "other",
+                "b",
+                ConcreteInterfaceAddress.parse("1.1.1.1/32"),
+                BgpActivePeerConfig.builder().build()))
+        .addEqualityGroup(
+            new Remote(
+                "a",
+                "other",
+                ConcreteInterfaceAddress.parse("1.1.1.1/32"),
+                BgpActivePeerConfig.builder().build()))
+        .addEqualityGroup(
+            new Remote(
+                "a",
+                "b",
+                ConcreteInterfaceAddress.parse("2.2.2.2/32"),
+                BgpActivePeerConfig.builder().build()))
+        .addEqualityGroup(
+            new Remote(
+                "other",
+                "b",
+                ConcreteInterfaceAddress.parse("1.1.1.1/32"),
+                BgpActivePeerConfig.builder().setDescription("other").build()))
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
@@ -305,18 +305,6 @@ public class IspModelingUtilsTest {
 
   @Test
   public void testGetIspConfigurationNodeInvalid() {
-    ConcreteInterfaceAddress interfaceAddress =
-        ConcreteInterfaceAddress.create(Ip.parse("2.2.2.2"), 30);
-    ConcreteInterfaceAddress interfaceAddress2 =
-        ConcreteInterfaceAddress.create(Ip.parse("3.3.3.3"), 30);
-    BgpActivePeerConfig peer =
-        BgpActivePeerConfig.builder()
-            .setPeerAddress(Ip.parse("1.1.1.1"))
-            .setRemoteAs(1L)
-            .setLocalIp(Ip.parse("2.2.2.2"))
-            .setLocalAs(2L)
-            .setIpv4UnicastAddressFamily(Ipv4UnicastAddressFamily.builder().build())
-            .build();
     long asn = 2L;
     IspModel ispInfo = new IspModel(asn, ImmutableList.of(), getDefaultIspNodeName(asn));
     BatfishLogger logger = new BatfishLogger("debug", false);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IspModelingUtilsTest.java
@@ -550,14 +550,15 @@ public class IspModelingUtilsTest {
 
     Map<String, Configuration> internetAndIsps =
         IspModelingUtils.getInternetAndIspNodes(
-            ImmutableMap.of(configuration.getHostname(), configuration),
-            ImmutableList.of(
-                new IspConfiguration(
-                    ImmutableList.of(
-                        new BorderInterfaceInfo(NodeInterfacePair.of("CoNf", "InTeRfAcE"))),
-                    IspFilter.ALLOW_ALL)),
-            new BatfishLogger("output", false),
-            new Warnings());
+                ImmutableMap.of(configuration.getHostname(), configuration),
+                ImmutableList.of(
+                    new IspConfiguration(
+                        ImmutableList.of(
+                            new BorderInterfaceInfo(NodeInterfacePair.of("CoNf", "InTeRfAcE"))),
+                        IspFilter.ALLOW_ALL)),
+                new BatfishLogger("output", false),
+                new Warnings())
+            .getConfigurations();
 
     // Isp and Internet nodes should be created irrespective of case used in Isp configuration
     assertThat(internetAndIsps, hasKey("isp_1"));
@@ -591,14 +592,15 @@ public class IspModelingUtilsTest {
 
     Map<String, Configuration> internetAndIsps =
         IspModelingUtils.getInternetAndIspNodes(
-            ImmutableMap.of(configuration.getHostname(), configuration),
-            ImmutableList.of(
-                new IspConfiguration(
-                    ImmutableList.of(
-                        new BorderInterfaceInfo(NodeInterfacePair.of("conf", "interface"))),
-                    IspFilter.ALLOW_ALL)),
-            new BatfishLogger("output", false),
-            new Warnings());
+                ImmutableMap.of(configuration.getHostname(), configuration),
+                ImmutableList.of(
+                    new IspConfiguration(
+                        ImmutableList.of(
+                            new BorderInterfaceInfo(NodeInterfacePair.of("conf", "interface"))),
+                        IspFilter.ALLOW_ALL)),
+                new BatfishLogger("output", false),
+                new Warnings())
+            .getConfigurations();
 
     assertThat(internetAndIsps, hasKey(IspModelingUtils.INTERNET_HOST_NAME));
     Configuration internetNode = internetAndIsps.get(IspModelingUtils.INTERNET_HOST_NAME);
@@ -806,19 +808,20 @@ public class IspModelingUtilsTest {
 
     Map<String, Configuration> internetAndIsps =
         IspModelingUtils.getInternetAndIspNodes(
-            ImmutableMap.of(
-                configuration1.getHostname(),
-                configuration1,
-                configuration2.getHostname(),
-                configuration2),
-            ImmutableList.of(
-                new IspConfiguration(
-                    ImmutableList.of(
-                        new BorderInterfaceInfo(NodeInterfacePair.of("conf1", "interface1")),
-                        new BorderInterfaceInfo(NodeInterfacePair.of("conf2", "interface2"))),
-                    IspFilter.ALLOW_ALL)),
-            new BatfishLogger("output", false),
-            new Warnings());
+                ImmutableMap.of(
+                    configuration1.getHostname(),
+                    configuration1,
+                    configuration2.getHostname(),
+                    configuration2),
+                ImmutableList.of(
+                    new IspConfiguration(
+                        ImmutableList.of(
+                            new BorderInterfaceInfo(NodeInterfacePair.of("conf1", "interface1")),
+                            new BorderInterfaceInfo(NodeInterfacePair.of("conf2", "interface2"))),
+                        IspFilter.ALLOW_ALL)),
+                new BatfishLogger("output", false),
+                new Warnings())
+            .getConfigurations();
 
     assertThat(internetAndIsps, hasKey("isp_1234"));
 
@@ -863,15 +866,16 @@ public class IspModelingUtilsTest {
     // passing non-existent border interfaces
     Map<String, Configuration> internetAndIsps =
         IspModelingUtils.getInternetAndIspNodes(
-            ImmutableMap.of(configuration1.getHostname(), configuration1),
-            ImmutableList.of(
-                new IspConfiguration(
-                    ImmutableList.of(
-                        new BorderInterfaceInfo(NodeInterfacePair.of("conf2", "interface2")),
-                        new BorderInterfaceInfo(NodeInterfacePair.of("conf2", "interface2"))),
-                    IspFilter.ALLOW_ALL)),
-            new BatfishLogger("output", false),
-            new Warnings());
+                ImmutableMap.of(configuration1.getHostname(), configuration1),
+                ImmutableList.of(
+                    new IspConfiguration(
+                        ImmutableList.of(
+                            new BorderInterfaceInfo(NodeInterfacePair.of("conf2", "interface2")),
+                            new BorderInterfaceInfo(NodeInterfacePair.of("conf2", "interface2"))),
+                        IspFilter.ALLOW_ALL)),
+                new BatfishLogger("output", false),
+                new Warnings())
+            .getConfigurations();
 
     // no ISPs and no Internet
     assertThat(internetAndIsps, anEmptyMap());

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -120,6 +120,7 @@ import org.batfish.common.topology.TopologyContainer;
 import org.batfish.common.topology.TopologyProvider;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.common.util.CommonUtil;
+import org.batfish.common.util.IspModelingUtils.ModeledNodes;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.Configuration;
@@ -2537,9 +2538,11 @@ public class Batfish extends PluginConsumer implements IBatfish {
         .filter(Objects::nonNull)
         .forEach(ispConfigurations::add);
 
-    Map<String, Configuration> additionalConfigs =
+    ModeledNodes nodes =
         getInternetAndIspNodes(
             configurations, ispConfigurations.build(), _logger, internetWarnings);
+
+    Map<String, Configuration> additionalConfigs = nodes.getConfigurations();
 
     Set<String> commonNodes =
         Sets.intersection(configurations.keySet(), additionalConfigs.keySet());

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2505,7 +2505,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
               vendorConfigs.values().stream()
                   .flatMap(vc -> vc.getLayer1Edges().stream())
                   .collect(Collectors.toSet()),
-              modeledNodes.getLayer1Edgesdges());
+              modeledNodes.getLayer1Edges());
 
       try (ActiveSpan storeSpan =
           GlobalTracer.get().buildSpan("Store vendor-independent configs").startActive()) {

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -4,6 +4,7 @@ import static org.batfish.common.BfConsts.RELPATH_AWS_CONFIGS_FILE;
 import static org.batfish.common.matchers.ThrowableMatchers.hasStackTrace;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasName;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.isActive;
+import static org.batfish.main.Batfish.mergeInternetAndIspNodes;
 import static org.batfish.main.Batfish.postProcessInterfaceDependencies;
 import static org.batfish.main.Batfish.readAllFiles;
 import static org.hamcrest.Matchers.allOf;
@@ -45,12 +46,14 @@ import org.batfish.common.Answerer;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.NetworkSnapshot;
+import org.batfish.common.Warnings;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.topology.IpOwners;
 import org.batfish.common.topology.Layer1Edge;
 import org.batfish.common.topology.Layer1Node;
 import org.batfish.common.topology.Layer1Topology;
 import org.batfish.common.util.CommonUtil;
+import org.batfish.common.util.IspModelingUtils.ModeledNodes;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Edge;
@@ -849,5 +852,47 @@ public class BatfishTest {
     // should throw FileNotFoundException if file not found
     _thrown.expect(FileNotFoundException.class);
     batfish.getSnapshotInputObject(batfish.getSnapshot(), "missing file");
+  }
+
+  @Test
+  public void testMergeInternetAndIspNodes() {
+    Map<String, Configuration> snapshotConfigs = new HashMap<>();
+    Configuration config = new Configuration("node1", ConfigurationFormat.CISCO_IOS);
+    snapshotConfigs.put(config.getHostname(), config);
+
+    Set<Layer1Edge> snapshotEdges = new HashSet<>();
+    Layer1Edge edge = new Layer1Edge("n1", "i1", "n2", "i2");
+    snapshotEdges.add(edge);
+
+    ModeledNodes modeledNodes = new ModeledNodes();
+    Layer1Edge modeledEdge = new Layer1Edge("m1", "i1", "m2", "i2");
+    Configuration modeledConfig = new Configuration("model1", ConfigurationFormat.AWS);
+    modeledNodes.addConfiguration(modeledConfig);
+    modeledNodes.addLayer1Edge(modeledEdge);
+
+    Warnings warnings = new Warnings(true, true, true);
+    mergeInternetAndIspNodes(modeledNodes, snapshotConfigs, snapshotEdges, warnings);
+
+    assertThat(
+        snapshotConfigs,
+        equalTo(
+            ImmutableMap.of(
+                config.getHostname(), config, modeledConfig.getHostname(), modeledConfig)));
+    assertThat(snapshotEdges, equalTo(ImmutableSet.of(edge, modeledEdge)));
+    assertTrue(warnings.isEmpty());
+
+    // merging again should be a no-op (even if the modeled nodes contain new information)
+    modeledNodes.addConfiguration(new Configuration("model2", ConfigurationFormat.AWS));
+
+    mergeInternetAndIspNodes(modeledNodes, snapshotConfigs, snapshotEdges, warnings);
+    assertThat(
+        snapshotConfigs,
+        equalTo(
+            ImmutableMap.of(
+                config.getHostname(), config, modeledConfig.getHostname(), modeledConfig)));
+    assertThat(snapshotEdges, equalTo(ImmutableSet.of(edge, modeledEdge)));
+    assertThat(
+        warnings.getRedFlagWarnings().get(0).getText(),
+        containsString("Cannot add internet and ISP nodes"));
   }
 }

--- a/tests/aws/init-example-aws.ref
+++ b/tests/aws/init-example-aws.ref
@@ -560,7 +560,10 @@
         }
       }
     },
-    "version" : "0.36.0"
+    "version" : "0.36.0",
+    "warnings" : {
+      "internet" : { }
+    }
   },
   {
     "class" : "org.batfish.datamodel.answers.InitInfoAnswerElement",

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -83,13 +83,10 @@
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
-            "allPrefixes" : [
-              "240.1.1.3/31"
-            ],
             "allowedVlans" : "",
             "autostate" : true,
             "mtu" : 1500,
-            "prefix" : "240.1.1.3/31",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -1530,6 +1527,33 @@
               "ebgpAdminCost" : 20,
               "ibgpAdminCost" : 200,
               "routerId" : "240.0.0.1",
+              "interfaceNeighbors" : {
+                "~Interface_4~" : {
+                  "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "ipv4UnicastAddressFamily" : {
+                    "addressFamilyCapabilities" : {
+                      "additionalPathsReceive" : false,
+                      "additionalPathsSelectAll" : false,
+                      "additionalPathsSend" : false,
+                      "advertiseExternal" : false,
+                      "advertiseInactive" : false,
+                      "allowLocalAsIn" : false,
+                      "allowRemoteAsOut" : false,
+                      "sendCommunity" : false,
+                      "sendExtendedCommunity" : false
+                    },
+                    "exportPolicy" : "exportPolicyOnIspToInternet",
+                    "routeReflectorClient" : false
+                  },
+                  "localAs" : 16509,
+                  "localIp" : "169.254.0.1",
+                  "peerInterface" : "~Interface_4~",
+                  "remoteAsns" : "65537"
+                }
+              },
               "multipathEbgp" : true,
               "multipathIbgp" : false,
               "neighbors" : {
@@ -1607,31 +1631,6 @@
                   "localIp" : "240.0.0.5",
                   "peerAddress" : "240.0.0.4",
                   "remoteAsns" : "65534"
-                },
-                "240.1.1.2/32" : {
-                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
-                  "defaultMetric" : 0,
-                  "ebgpMultihop" : false,
-                  "enforceFirstAs" : false,
-                  "ipv4UnicastAddressFamily" : {
-                    "addressFamilyCapabilities" : {
-                      "additionalPathsReceive" : false,
-                      "additionalPathsSelectAll" : false,
-                      "additionalPathsSend" : false,
-                      "advertiseExternal" : false,
-                      "advertiseInactive" : false,
-                      "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
-                      "sendCommunity" : false,
-                      "sendExtendedCommunity" : false
-                    },
-                    "exportPolicy" : "exportPolicyOnIspToInternet",
-                    "routeReflectorClient" : false
-                  },
-                  "localAs" : 16509,
-                  "localIp" : "240.1.1.3",
-                  "peerAddress" : "240.1.1.2",
-                  "remoteAsns" : "65537"
                 }
               },
               "tieBreaker" : "ARRIVAL_ORDER"
@@ -14663,13 +14662,10 @@
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
             },
-            "allPrefixes" : [
-              "240.1.1.2/31"
-            ],
             "allowedVlans" : "",
             "autostate" : true,
             "mtu" : 1500,
-            "prefix" : "240.1.1.2/31",
+            "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
             "ripEnabled" : false,
             "ripPassive" : false,
@@ -14735,12 +14731,9 @@
               "ebgpAdminCost" : 20,
               "ibgpAdminCost" : 200,
               "routerId" : "240.254.254.1",
-              "multipathEbgp" : true,
-              "multipathEquivalentAsPathMatchMode" : "PATH_LENGTH",
-              "multipathIbgp" : false,
-              "neighbors" : {
-                "240.1.1.3/32" : {
-                  "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+              "interfaceNeighbors" : {
+                "~Interface_3~" : {
+                  "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
                   "enforceFirstAs" : false,
@@ -14760,11 +14753,14 @@
                     "routeReflectorClient" : false
                   },
                   "localAs" : 65537,
-                  "localIp" : "240.1.1.2",
-                  "peerAddress" : "240.1.1.3",
+                  "localIp" : "169.254.0.1",
+                  "peerInterface" : "~Interface_3~",
                   "remoteAsns" : "16509"
                 }
               },
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "PATH_LENGTH",
+              "multipathIbgp" : false,
               "tieBreaker" : "ARRIVAL_ORDER"
             },
             "staticRoutes" : [

--- a/tests/basic/example-iptables-init.ref
+++ b/tests/basic/example-iptables-init.ref
@@ -357,7 +357,10 @@
           }
         }
       },
-      "version" : "0.36.0"
+      "version" : "0.36.0",
+      "warnings" : {
+        "internet" : { }
+      }
     },
     {
       "class" : "org.batfish.datamodel.answers.InitInfoAnswerElement",

--- a/tests/basic/init-candidate.ref
+++ b/tests/basic/init-candidate.ref
@@ -2887,7 +2887,8 @@
               "text" : "Could not determine update source for BGP neighbor: '5.6.7.8'"
             }
           ]
-        }
+        },
+        "internet" : { }
       }
     },
     {

--- a/tests/basic/init-with-ba.ref
+++ b/tests/basic/init-with-ba.ref
@@ -2887,7 +2887,8 @@
               "text" : "Could not determine update source for BGP neighbor: '5.6.7.8'"
             }
           ]
-        }
+        },
+        "internet" : { }
       }
     },
     {

--- a/tests/basic/init.ref
+++ b/tests/basic/init.ref
@@ -2877,7 +2877,8 @@
               "text" : "Could not determine update source for BGP neighbor: '5.6.7.8'"
             }
           ]
-        }
+        },
+        "internet" : { }
       }
     },
     {

--- a/tests/parsing-errors-tests/invalid-ip-no-verbose.ref
+++ b/tests/parsing-errors-tests/invalid-ip-no-verbose.ref
@@ -6,6 +6,9 @@
         "configs/as1r1.cfg" : "PASSED",
         "hosts/host1.json" : "PASSED",
         "iptables/host1.iptables" : "FAILED"
+      },
+      "warnings" : {
+        "internet" : { }
       }
     }
   ],

--- a/tests/parsing-errors-tests/no-verbose.ref
+++ b/tests/parsing-errors-tests/no-verbose.ref
@@ -7,6 +7,9 @@
         "configs/as1r2.cfg" : "PASSED",
         "configs/as2r1.cfg" : "PASSED",
         "configs/cumulus_nclu_range" : "FAILED"
+      },
+      "warnings" : {
+        "internet" : { }
       }
     }
   ],

--- a/tests/parsing-errors-tests/recovery-invalid-ip-no-verbose.ref
+++ b/tests/parsing-errors-tests/recovery-invalid-ip-no-verbose.ref
@@ -6,6 +6,9 @@
         "configs/as1r1.cfg" : "PASSED",
         "hosts/host1.json" : "PASSED",
         "iptables/host1.iptables" : "PASSED"
+      },
+      "warnings" : {
+        "internet" : { }
       }
     }
   ],

--- a/tests/parsing-errors-tests/recovery-no-verbose.ref
+++ b/tests/parsing-errors-tests/recovery-no-verbose.ref
@@ -36,7 +36,8 @@
               "Text" : "net add vxlan vni4294967295-4294967296 vxlan local-tunnelip 1.1.1.1"
             }
           ]
-        }
+        },
+        "internet" : { }
       }
     }
   ],

--- a/tests/parsing-tests/example-juniper.ref
+++ b/tests/parsing-tests/example-juniper.ref
@@ -13170,7 +13170,8 @@
               "text" : "Could not determine local ip for bgp peering with neighbor ip: 5.6.7.8"
             }
           ]
-        }
+        },
+        "internet" : { }
       }
     },
     {

--- a/tests/parsing-tests/srx-testbed.ref
+++ b/tests/parsing-tests/srx-testbed.ref
@@ -7347,7 +7347,10 @@
           }
         }
       },
-      "version" : "0.36.0"
+      "version" : "0.36.0",
+      "warnings" : {
+        "internet" : { }
+      }
     },
     {
       "class" : "org.batfish.datamodel.answers.InitInfoAnswerElement",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -95643,6 +95643,7 @@
             }
           ]
         },
+        "internet" : { },
         "ios_xe_bgp" : {
           "Red flags" : [
             {


### PR DESCRIPTION
To prevent users from picking those modeled IP addresses. 

1. Moved what used to be the inner IspInfo class to its own IspModel class
2. Added an inner class (ModeledNodes) that contains both generated configs and layer1Edges.  (Earlier only configs were being generated, so we didn't a separate class.)
3. Changes to the IspModel class and ISP node generation to enable generation of Layer1 edges
4. Some variable renaming to make code easier to follow