### PR TITLE
use the name in tags as security group name

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -469,7 +469,9 @@ public final class IpPermissions implements Serializable {
     return new OrMatchExpr(
         matchExprBuilder.build(),
         traceTextForAddress(
-            ingress ? "source" : "destination", sg.getGroupName(), AddressType.SECURITY_GROUP));
+            ingress ? "source" : "destination",
+            firstNonNull(sg.getName(), sg.getId()),
+            AddressType.SECURITY_GROUP));
   }
 
   private ExprAclLine createAclLineForSg(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -788,9 +788,12 @@ public final class Region implements Serializable {
                     .map(
                         acl ->
                             new AclAclLine(
-                                String.format("Security Group %s", securityGroup.getGroupName()),
+                                String.format(
+                                    "Security Group %s",
+                                    firstNonNull(securityGroup.getName(), securityGroup.getId())),
                                 acl.getName(),
-                                getTraceElementForSecurityGroup(securityGroup.getGroupName())))
+                                getTraceElementForSecurityGroup(
+                                    firstNonNull(securityGroup.getName(), securityGroup.getId()))))
                     .orElse(null))
         .filter(Objects::nonNull)
         .collect(ImmutableList.toImmutableList());
@@ -854,11 +857,14 @@ public final class Region implements Serializable {
     if (aclLines.isEmpty()) {
       return null;
     }
+    String direction = ingress ? INGRESS : EGRESS;
     return IpAccessList.builder()
         .setName(
-            String.format(
-                "~%s~SECURITY-GROUP~%s~%s~",
-                ingress ? INGRESS : EGRESS, securityGroup.getGroupName(), securityGroup.getId()))
+            securityGroup.getName() == null
+                ? String.format("~%s~SECURITY-GROUP~%s~", direction, securityGroup.getId())
+                : String.format(
+                    "~%s~SECURITY-GROUP~%s~%s~",
+                    direction, securityGroup.getName(), securityGroup.getId()))
         .setLines(aclLines)
         .setOwner(owner)
         .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -119,6 +119,11 @@ public final class SecurityGroup implements AwsVpcEntity, Serializable {
   }
 
   @Nullable
+  public String getName() {
+    return _tags.getOrDefault(TAG_NAME, null);
+  }
+
+  @Nullable
   public String getDescription() {
     return _description;
   }

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -13806,13 +13806,13 @@
               },
               {
                 "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default",
+                "aclName" : "~EGRESS~SECURITY-GROUP~sg-3dfb3140~",
+                "name" : "Security Group sg-3dfb3140",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
+                      "text" : "Matched security group sg-3dfb3140"
                     }
                   ]
                 }
@@ -13851,13 +13851,13 @@
               },
               {
                 "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default",
+                "aclName" : "~EGRESS~SECURITY-GROUP~sg-3dfb3140~",
+                "name" : "Security Group sg-3dfb3140",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
+                      "text" : "Matched security group sg-3dfb3140"
                     }
                   ]
                 }
@@ -13865,7 +13865,7 @@
             ],
             "name" : "~EGRESS_ACL~es-domain-subnet-7044ff16"
           },
-          "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
+          "~EGRESS~SECURITY-GROUP~sg-3dfb3140~" : {
             "lines" : [
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -13898,9 +13898,9 @@
                 }
               }
             ],
-            "name" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
+            "name" : "~EGRESS~SECURITY-GROUP~sg-3dfb3140~"
           },
-          "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
+          "~INGRESS~SECURITY-GROUP~sg-3dfb3140~" : {
             "lines" : [
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -13931,7 +13931,7 @@
                     "fragments" : [
                       {
                         "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched source address Security Group default"
+                        "text" : "Matched source address Security Group Default+RDS-sg"
                       }
                     ]
                   }
@@ -13947,19 +13947,19 @@
                 }
               }
             ],
-            "name" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
+            "name" : "~INGRESS~SECURITY-GROUP~sg-3dfb3140~"
           },
           "~SECURITY_GROUP_INGRESS_ACL~" : {
             "lines" : [
               {
                 "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default",
+                "aclName" : "~INGRESS~SECURITY-GROUP~sg-3dfb3140~",
+                "name" : "Security Group sg-3dfb3140",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
+                      "text" : "Matched security group sg-3dfb3140"
                     }
                   ]
                 }
@@ -18547,13 +18547,13 @@
               },
               {
                 "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-55510831~",
-                "name" : "Security Group default",
+                "aclName" : "~EGRESS~SECURITY-GROUP~Default+RDS-sg~sg-55510831~",
+                "name" : "Security Group Default+RDS-sg",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
+                      "text" : "Matched security group Default+RDS-sg"
                     }
                   ]
                 }
@@ -18561,7 +18561,7 @@
             ],
             "name" : "~EGRESS_ACL~test-rds-subnet-1641fa70"
           },
-          "~EGRESS~SECURITY-GROUP~default~sg-55510831~" : {
+          "~EGRESS~SECURITY-GROUP~Default+RDS-sg~sg-55510831~" : {
             "lines" : [
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -18594,9 +18594,9 @@
                 }
               }
             ],
-            "name" : "~EGRESS~SECURITY-GROUP~default~sg-55510831~"
+            "name" : "~EGRESS~SECURITY-GROUP~Default+RDS-sg~sg-55510831~"
           },
-          "~INGRESS~SECURITY-GROUP~default~sg-55510831~" : {
+          "~INGRESS~SECURITY-GROUP~Default+RDS-sg~sg-55510831~" : {
             "lines" : [
               {
                 "class" : "org.batfish.datamodel.ExprAclLine",
@@ -18949,19 +18949,19 @@
                 }
               }
             ],
-            "name" : "~INGRESS~SECURITY-GROUP~default~sg-55510831~"
+            "name" : "~INGRESS~SECURITY-GROUP~Default+RDS-sg~sg-55510831~"
           },
           "~SECURITY_GROUP_INGRESS_ACL~" : {
             "lines" : [
               {
                 "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-55510831~",
-                "name" : "Security Group default",
+                "aclName" : "~INGRESS~SECURITY-GROUP~Default+RDS-sg~sg-55510831~",
+                "name" : "Security Group Default+RDS-sg",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
+                      "text" : "Matched security group Default+RDS-sg"
                     }
                   ]
                 }


### PR DESCRIPTION
before this PR, we were using GroupName -- which does not seem to be something that is actively managed by users. e.g., TF puts in a GUID there and AWS puts in 'default' there. using tag name also makes consistent with other resources. 