### PR TITLE
syntactic sugar for the internet source location

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/IspModelingUtils.java
@@ -93,7 +93,7 @@ public final class IspModelingUtils {
   static final long INTERNET_AS = 65537L;
   public static final String INTERNET_HOST_NAME = "internet";
   static final Ip INTERNET_OUT_ADDRESS = INTERNET_OUT_SUBNET.getFirstHostIp();
-  static final String INTERNET_OUT_INTERFACE = "out";
+  public static final String INTERNET_OUT_INTERFACE = "out";
   static final Ip LINK_LOCAL_IP = Ip.parse("169.254.0.1");
   static final LinkLocalAddress LINK_LOCAL_ADDRESS = LinkLocalAddress.of(LINK_LOCAL_IP);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ToSpecifierString.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ToSpecifierString.java
@@ -14,7 +14,8 @@ public final class ToSpecifierString implements LocationVisitor<String> {
 
   @Override
   public String visitInterfaceLinkLocation(InterfaceLinkLocation interfaceLinkLocation) {
-    // special-case for traffic originating from the internet
+    // special-case for traffic originating from the internet.
+    // TODO check the device type to be completely consistent with the location specifier
     if (interfaceLinkLocation.getNodeName().equals(IspModelingUtils.INTERNET_HOST_NAME)
         && interfaceLinkLocation
             .getInterfaceName()

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ToSpecifierString.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/ToSpecifierString.java
@@ -1,5 +1,7 @@
 package org.batfish.specifier;
 
+import org.batfish.common.util.IspModelingUtils;
+
 /** Converts a {@link Location} to its specifier string */
 public final class ToSpecifierString implements LocationVisitor<String> {
   private static final ToSpecifierString INSTANCE = new ToSpecifierString();
@@ -12,6 +14,13 @@ public final class ToSpecifierString implements LocationVisitor<String> {
 
   @Override
   public String visitInterfaceLinkLocation(InterfaceLinkLocation interfaceLinkLocation) {
+    // special-case for traffic originating from the internet
+    if (interfaceLinkLocation.getNodeName().equals(IspModelingUtils.INTERNET_HOST_NAME)
+        && interfaceLinkLocation
+            .getInterfaceName()
+            .equals(IspModelingUtils.INTERNET_OUT_INTERFACE)) {
+      return IspModelingUtils.INTERNET_HOST_NAME;
+    }
     return String.format(
         "@enter(%s[%s])",
         interfaceLinkLocation.getNodeName(), interfaceLinkLocation.getInterfaceName());

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Anchor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Anchor.java
@@ -163,6 +163,7 @@ import org.batfish.datamodel.answers.AutocompleteSuggestion.SuggestionType;
         "Packets entering interface",
         "locationInterface)",
         SuggestionType.FUNCTION),
+    LOCATION_INTERNET("LOCATION_INTERNET", "The Internet", null, SuggestionType.NAME_LITERAL),
     /** For a rule that denotes locationSpec can be parenthetical */
     LOCATION_PARENS(
         "LOCATION_PARENS", "Location specifier", "locationSpec)", SuggestionType.OPEN_PARENS),

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Anchor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Anchor.java
@@ -96,6 +96,11 @@ import org.batfish.datamodel.answers.AutocompleteSuggestion.SuggestionType;
      * ParboiledAutoCompleteSuggestion#completeDescriptionIfNeeded}.
      */
     FILTER_SET_OP("FILTER_SET_OP", " of filters", "filterSpec", SuggestionType.SET_OPERATOR),
+    /**
+     * Rules tagged as HIDDEN and their children will not be used for autocompletion. The behavior
+     * is similar to DEPRECATED rules, but HIDDEN rules are still supported.
+     */
+    HIDDEN("HIDDEN", null, null, SuggestionType.UNKNOWN),
     /** Rules tagged as IGNORE and their children will not be used for autocompletion */
     IGNORE("IGNORE", null, null, SuggestionType.UNKNOWN),
     /** connectedTo() function for interfaces */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Anchor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Anchor.java
@@ -163,7 +163,6 @@ import org.batfish.datamodel.answers.AutocompleteSuggestion.SuggestionType;
         "Packets entering interface",
         "locationInterface)",
         SuggestionType.FUNCTION),
-    LOCATION_INTERNET("LOCATION_INTERNET", "The Internet", null, SuggestionType.NAME_LITERAL),
     /** For a rule that denotes locationSpec can be parenthetical */
     LOCATION_PARENS(
         "LOCATION_PARENS", "Location specifier", "locationSpec)", SuggestionType.OPEN_PARENS),

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/AstNodeVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/AstNodeVisitor.java
@@ -125,6 +125,8 @@ interface AstNodeVisitor<T> {
 
   T visitIcmpAllAppAstNode(IcmpAllAppAstNode icmpAllAppAstNode);
 
+  T visitInternetLocationAstNode();
+
   T visitNameAppAstNode(NameAppAstNode nameAppAstNode);
 
   T visitTcpAppAstNode(PortAppAstNode tcpAppAstNode);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/InternetLocationAstNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/InternetLocationAstNode.java
@@ -1,0 +1,23 @@
+package org.batfish.specifier.parboiled;
+
+import org.batfish.common.util.IspModelingUtils;
+import org.batfish.specifier.InterfaceLinkLocation;
+import org.batfish.specifier.Location;
+
+public class InternetLocationAstNode implements LocationAstNode {
+  public static final InternetLocationAstNode INSTANCE = new InternetLocationAstNode();
+
+  public static final Location INTERNET_LOCATION =
+      new InterfaceLinkLocation(
+          IspModelingUtils.INTERNET_HOST_NAME, IspModelingUtils.INTERNET_OUT_INTERFACE);
+
+  @Override
+  public <T> T accept(LocationAstNodeVisitor<T> visitor) {
+    return visitor.visitInternetLocationAstNode();
+  }
+
+  @Override
+  public <T> T accept(AstNodeVisitor<T> visitor) {
+    return visitor.visitInternetLocationAstNode();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/InternetLocationAstNode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/InternetLocationAstNode.java
@@ -2,12 +2,11 @@ package org.batfish.specifier.parboiled;
 
 import org.batfish.common.util.IspModelingUtils;
 import org.batfish.specifier.InterfaceLinkLocation;
-import org.batfish.specifier.Location;
 
 public class InternetLocationAstNode implements LocationAstNode {
   public static final InternetLocationAstNode INSTANCE = new InternetLocationAstNode();
 
-  public static final Location INTERNET_LOCATION =
+  public static final InterfaceLinkLocation INTERNET_LOCATION =
       new InterfaceLinkLocation(
           IspModelingUtils.INTERNET_HOST_NAME, IspModelingUtils.INTERNET_OUT_INTERFACE);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/LocationAstNodeVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/LocationAstNodeVisitor.java
@@ -9,5 +9,7 @@ interface LocationAstNodeVisitor<T> {
 
   T visitInterfaceLocationAstNode(InterfaceLocationAstNode interfaceLocationAstNode);
 
+  T visitInternetLocationAstNode();
+
   T visitEnterLocationAstNode(EnterLocationAstNode enterLocationAstNode);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledLocationSpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledLocationSpecifier.java
@@ -1,7 +1,9 @@
 package org.batfish.specifier.parboiled;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.specifier.parboiled.InternetLocationAstNode.INTERNET_LOCATION;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.Objects;
 import java.util.Set;
@@ -67,6 +69,11 @@ public final class ParboiledLocationSpecifier implements LocationSpecifier {
       return new IntersectionLocationSpecifier(
               new NodeSpecifierInterfaceLocationSpecifier(nodes), interfaceLocations)
           .resolve(_ctxt);
+    }
+
+    @Override
+    public Set<Location> visitInternetLocationAstNode() {
+      return ImmutableSet.of(INTERNET_LOCATION);
     }
 
     @Nonnull

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -43,7 +43,6 @@ import static org.batfish.specifier.parboiled.Anchor.Type.IP_SPACE_PARENS;
 import static org.batfish.specifier.parboiled.Anchor.Type.IP_SPACE_SET_OP;
 import static org.batfish.specifier.parboiled.Anchor.Type.IP_WILDCARD;
 import static org.batfish.specifier.parboiled.Anchor.Type.LOCATION_ENTER;
-import static org.batfish.specifier.parboiled.Anchor.Type.LOCATION_INTERNET;
 import static org.batfish.specifier.parboiled.Anchor.Type.LOCATION_PARENS;
 import static org.batfish.specifier.parboiled.Anchor.Type.LOCATION_SET_OP;
 import static org.batfish.specifier.parboiled.Anchor.Type.NAME_SET_NAME;
@@ -1055,7 +1054,6 @@ public class Parser extends CommonParser {
         LocationParens());
   }
 
-  @Anchor(LOCATION_INTERNET)
   public Rule LocationInternet() {
     return Sequence(
         IgnoreCase(IspModelingUtils.INTERNET_HOST_NAME), push(InternetLocationAstNode.INSTANCE));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -22,6 +22,7 @@ import static org.batfish.specifier.parboiled.Anchor.Type.FILTER_NAME;
 import static org.batfish.specifier.parboiled.Anchor.Type.FILTER_NAME_REGEX;
 import static org.batfish.specifier.parboiled.Anchor.Type.FILTER_PARENS;
 import static org.batfish.specifier.parboiled.Anchor.Type.FILTER_SET_OP;
+import static org.batfish.specifier.parboiled.Anchor.Type.HIDDEN;
 import static org.batfish.specifier.parboiled.Anchor.Type.INTERFACE_CONNECTED_TO;
 import static org.batfish.specifier.parboiled.Anchor.Type.INTERFACE_GROUP_NAME;
 import static org.batfish.specifier.parboiled.Anchor.Type.INTERFACE_NAME;
@@ -1054,6 +1055,7 @@ public class Parser extends CommonParser {
         LocationParens());
   }
 
+  @Anchor(HIDDEN)
   public Rule LocationInternet() {
     return Sequence(
         IgnoreCase(IspModelingUtils.INTERNET_HOST_NAME), push(InternetLocationAstNode.INSTANCE));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -43,6 +43,7 @@ import static org.batfish.specifier.parboiled.Anchor.Type.IP_SPACE_PARENS;
 import static org.batfish.specifier.parboiled.Anchor.Type.IP_SPACE_SET_OP;
 import static org.batfish.specifier.parboiled.Anchor.Type.IP_WILDCARD;
 import static org.batfish.specifier.parboiled.Anchor.Type.LOCATION_ENTER;
+import static org.batfish.specifier.parboiled.Anchor.Type.LOCATION_INTERNET;
 import static org.batfish.specifier.parboiled.Anchor.Type.LOCATION_PARENS;
 import static org.batfish.specifier.parboiled.Anchor.Type.LOCATION_SET_OP;
 import static org.batfish.specifier.parboiled.Anchor.Type.NAME_SET_NAME;
@@ -76,6 +77,7 @@ import static org.batfish.specifier.parboiled.Anchor.Type.ZONE_NAME;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import org.batfish.common.util.IspModelingUtils;
 import org.batfish.datamodel.DeviceType;
 import org.batfish.datamodel.InterfaceType;
 import org.parboiled.Parboiled;
@@ -1045,11 +1047,18 @@ public class Parser extends CommonParser {
 
   public Rule LocationTerm() {
     return FirstOf(
+        LocationInternet(),
         LocationEnterDeprecated(),
         LocationEnter(),
         LocationInterfaceDeprecated(),
         LocationInterface(),
         LocationParens());
+  }
+
+  @Anchor(LOCATION_INTERNET)
+  public Rule LocationInternet() {
+    return Sequence(
+        IgnoreCase(IspModelingUtils.INTERNET_HOST_NAME), push(InternetLocationAstNode.INSTANCE));
   }
 
   @Anchor(LOCATION_ENTER)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParserUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParserUtils.java
@@ -113,8 +113,12 @@ final class ParserUtils {
         throw new IllegalStateException(String.format("No anchor found for path %s", path));
       }
 
-      // Do not consider DEPRECATED paths
-      if (pathElements.stream().anyMatch(e -> e.getAnchorType() == Anchor.Type.DEPRECATED)) {
+      // Do not consider IGNORE or DEPRECATED paths
+      if (pathElements.stream()
+          .anyMatch(
+              e ->
+                  e.getAnchorType() == Anchor.Type.DEPRECATED
+                      || e.getAnchorType() == Anchor.Type.HIDDEN)) {
         continue;
       }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/ToSpecifierStringTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/ToSpecifierStringTest.java
@@ -3,6 +3,8 @@ package org.batfish.specifier;
 import static org.batfish.specifier.ToSpecifierString.toSpecifierString;
 import static org.junit.Assert.assertEquals;
 
+import org.batfish.common.util.IspModelingUtils;
+import org.batfish.specifier.parboiled.InternetLocationAstNode;
 import org.junit.Test;
 
 /** Test for {@link ToSpecifierString}. */
@@ -15,5 +17,13 @@ public final class ToSpecifierStringTest {
   @Test
   public void testInterfaceLinkLocation() {
     assertEquals("@enter(n[i])", toSpecifierString(new InterfaceLinkLocation("n", "i")));
+  }
+
+  @Test
+  public void testInternet() {
+    // special case for the internet source location
+    assertEquals(
+        IspModelingUtils.INTERNET_HOST_NAME,
+        toSpecifierString(InternetLocationAstNode.INTERNET_LOCATION));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledLocationSpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledLocationSpecifierTest.java
@@ -1,13 +1,20 @@
 package org.batfish.specifier.parboiled;
 
+import static org.batfish.specifier.Location.interfaceLinkLocation;
+import static org.batfish.specifier.Location.interfaceLocation;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.batfish.common.util.IspModelingUtils;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.DeviceModel;
+import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.specifier.InterfaceLocation;
 import org.batfish.specifier.MockSpecifierContext;
@@ -129,5 +136,64 @@ public class ParboiledLocationSpecifierTest {
     assertThat(
         ParboiledLocationSpecifier.parse("node0"),
         equalTo(new ParboiledLocationSpecifier(InterfaceLocationAstNode.createFromNode("node0"))));
+  }
+
+  @Test
+  public void testParseInternet() {
+    assertThat(
+        ParboiledLocationSpecifier.parse("internet"),
+        equalTo(new ParboiledLocationSpecifier(InternetLocationAstNode.INSTANCE)));
+  }
+
+  @Test
+  public void testParseInternet_noInternet() {
+    assertThat(ParboiledLocationSpecifier.parse("internet").resolve(_ctxt), empty());
+  }
+
+  @Test
+  public void testParseInternet_batfishInternet() {
+    NetworkFactory nf = new NetworkFactory();
+
+    Configuration inet =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname(IspModelingUtils.INTERNET_HOST_NAME)
+            .setDeviceModel(DeviceModel.BATFISH_INTERNET)
+            .build();
+    Interface i1 =
+        nf.interfaceBuilder()
+            .setOwner(inet)
+            .setName(IspModelingUtils.INTERNET_OUT_INTERFACE)
+            .build();
+
+    MockSpecifierContext ctxt =
+        MockSpecifierContext.builder()
+            .setConfigs(ImmutableMap.of(inet.getHostname(), inet))
+            .build();
+
+    assertThat(
+        ParboiledLocationSpecifier.parse("internet").resolve(ctxt),
+        contains(interfaceLinkLocation(i1)));
+  }
+
+  @Test
+  public void testParseInternet_nonBatfishInternet() {
+    NetworkFactory nf = new NetworkFactory();
+
+    Configuration inet =
+        nf.configurationBuilder()
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .setHostname(IspModelingUtils.INTERNET_HOST_NAME)
+            .build();
+    Interface i1 = nf.interfaceBuilder().setOwner(inet).setName(_iface1).build();
+
+    MockSpecifierContext ctxt =
+        MockSpecifierContext.builder()
+            .setConfigs(ImmutableMap.of(inet.getHostname(), inet))
+            .build();
+
+    assertThat(
+        ParboiledLocationSpecifier.parse("internet").resolve(ctxt),
+        contains(interfaceLocation(i1)));
   }
 }


### PR DESCRIPTION
add `internet` as a shorthand for `@enter(internet[out])` to the location specifier grammar.

no tests yet -- seeking feedback on this approach first