### PR TITLE
AWS: split match ICMP type and code

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/MatchHeaderSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/MatchHeaderSpace.java
@@ -51,6 +51,10 @@ public class MatchHeaderSpace extends AclLineMatchExpr {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(getClass()).add(PROP_HEADER_SPACE, _headerSpace).toString();
+    return MoreObjects.toStringHelper(getClass())
+        .omitNullValues()
+        .add(PROP_HEADER_SPACE, _headerSpace)
+        .add(PROP_TRACE_ELEMENT, getTraceElement())
+        .toString();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -541,14 +541,14 @@ final class Utils {
     return TraceElement.of(String.format("Matched instance %s", instanceName));
   }
 
-  static TraceElement traceElementForIcmp(int type, int code) {
+  static TraceElement traceElementForIcmpType(int type) {
     assert type != -1;
-    TraceElement.Builder treBuilder =
-        TraceElement.builder().add(String.format("Matched ICMP type %s", type));
-    if (code != -1) {
-      treBuilder.add(String.format("Matched ICMP code %s", code));
-    }
-    return treBuilder.build();
+    return TraceElement.of(String.format("Matched ICMP type %s", type));
+  }
+
+  static TraceElement traceElementForIcmpCode(int code) {
+    assert code != -1;
+    return TraceElement.of(String.format("Matched ICMP code %s", code));
   }
 
   private Utils() {}

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -9,7 +9,8 @@ import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_SECURITY_GROU
 import static org.batfish.representation.aws.Utils.getTraceElementForRule;
 import static org.batfish.representation.aws.Utils.traceElementForAddress;
 import static org.batfish.representation.aws.Utils.traceElementForDstPorts;
-import static org.batfish.representation.aws.Utils.traceElementForIcmp;
+import static org.batfish.representation.aws.Utils.traceElementForIcmpCode;
+import static org.batfish.representation.aws.Utils.traceElementForIcmpType;
 import static org.batfish.representation.aws.Utils.traceElementForProtocol;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -81,15 +82,6 @@ public class SecurityGroupsTest {
     return new MatchHeaderSpace(
         HeaderSpace.builder().setDstPorts(new SubRange(fromPort, toPort)).build(),
         traceElementForDstPorts(fromPort, toPort));
-  }
-
-  private static MatchHeaderSpace matchIcmpTypeCode(int type, int code) {
-    HeaderSpace.Builder hsBuilder = HeaderSpace.builder();
-    hsBuilder.setIcmpTypes(type);
-    if (code != -1) {
-      hsBuilder.setIcmpCodes(code);
-    }
-    return new MatchHeaderSpace(hsBuilder.build(), traceElementForIcmp(type, code));
   }
 
   @Before
@@ -197,7 +189,12 @@ public class SecurityGroupsTest {
     assertThat(
         line,
         isExprAclLineThat(
-            hasMatchCondition(and(matchIcmp, matchIcmpTypeCode(8, -1), matchUniverse))));
+            hasMatchCondition(
+                and(
+                    matchIcmp,
+                    new MatchHeaderSpace(
+                        HeaderSpace.builder().setIcmpTypes(8).build(), traceElementForIcmpType(8)),
+                    matchUniverse))));
   }
 
   @Test
@@ -207,7 +204,14 @@ public class SecurityGroupsTest {
     assertThat(
         line,
         isExprAclLineThat(
-            hasMatchCondition(and(matchIcmp, matchIcmpTypeCode(8, 9), matchUniverse))));
+            hasMatchCondition(
+                and(
+                    matchIcmp,
+                    new MatchHeaderSpace(
+                        HeaderSpace.builder().setIcmpTypes(8).build(), traceElementForIcmpType(8)),
+                    new MatchHeaderSpace(
+                        HeaderSpace.builder().setIcmpCodes(9).build(), traceElementForIcmpCode(9)),
+                    matchUniverse))));
   }
 
   @Test


### PR DESCRIPTION
Before they would just be squished together:

   * Matched ICMP type 8 Matched ICMP Code 0

Now they are separate.