### PR TITLE
Granular filters for AWS LB

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
@@ -84,7 +84,7 @@ final class LoadBalancer implements AwsVpcEntity, Serializable {
 
   /** Regex for load balancer ARN. Used to find the interface in {@link #findMyInterface}. */
   static final Pattern LOAD_BALANCER_ARN_PATTERN =
-      Pattern.compile("^arn:aws:elasticloadbalancing:[^:]+:[0-9]+:loadbalancer/(.+)$");
+      Pattern.compile("^arn:aws:elasticloadbalancing:[^:]+:[0-9]+:loadbalancer\\/(.+)$");
 
   /** The prefix is that used for interfaces that belong to load balancer */
   static final String LOAD_BALANCER_INTERFACE_DESCRIPTION_PREFIX = "ELB ";
@@ -267,13 +267,13 @@ final class LoadBalancer implements AwsVpcEntity, Serializable {
     boolean crossZoneLoadBalancing =
         loadBalancerAttributes != null && loadBalancerAttributes.getCrossZoneLoadBalancing();
 
-    List<Listener> listeners;
-    if (region.getLoadBalancerListeners().containsKey(_arn)) {
-      listeners = region.getLoadBalancerListeners().get(_arn).getListeners();
+    List<Listener> listeners = ImmutableList.of();
+    LoadBalancerListener lbListener = region.getLoadBalancerListeners().get(_arn);
+    if (lbListener != null) {
+      listeners = lbListener.getListeners();
     } else {
       warnings.redFlag(
           String.format("Listeners not found for load balancer %s (%s).", _name, _arn));
-      listeners = ImmutableList.of();
     }
 
     IpAccessList incomingFilter = computeListenerFilter(listeners);

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerTest.java
@@ -3,6 +3,7 @@ package org.batfish.representation.aws;
 import static com.google.common.collect.Iterators.getOnlyElement;
 import static org.batfish.datamodel.NamedPort.EPHEMERAL_HIGHEST;
 import static org.batfish.datamodel.NamedPort.EPHEMERAL_LOWEST;
+import static org.batfish.datamodel.matchers.TraceTreeMatchers.hasTraceElement;
 import static org.batfish.representation.aws.AwsLocationInfoUtils.INFRASTRUCTURE_LOCATION_INFO;
 import static org.batfish.representation.aws.LoadBalancer.FINAL_TRANSFORMATION;
 import static org.batfish.representation.aws.LoadBalancer.LISTENER_FILTER_NAME;
@@ -13,12 +14,17 @@ import static org.batfish.representation.aws.LoadBalancer.computeTargetGroupTran
 import static org.batfish.representation.aws.LoadBalancer.computeTargetTransformationStep;
 import static org.batfish.representation.aws.LoadBalancer.computeUntransformedFilter;
 import static org.batfish.representation.aws.LoadBalancer.getNodeId;
+import static org.batfish.representation.aws.LoadBalancer.getTraceElementForMatchedListener;
+import static org.batfish.representation.aws.LoadBalancer.getTraceElementForNoMatchedListener;
+import static org.batfish.representation.aws.LoadBalancer.getTraceElementForTransformedPackets;
+import static org.batfish.representation.aws.LoadBalancer.getTraceElementForUntransformedPackets;
 import static org.batfish.representation.aws.LoadBalancer.isValidTarget;
 import static org.batfish.representation.aws.Utils.publicIpAddressGroupName;
 import static org.batfish.specifier.Location.interfaceLinkLocation;
 import static org.batfish.specifier.Location.interfaceLocation;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -48,6 +54,7 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclTracer;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.transformation.ApplyAll;
 import org.batfish.datamodel.transformation.ApplyAny;
@@ -697,27 +704,40 @@ public class LoadBalancerTest {
     IpAccessList ipAccessList = computeListenerFilter(listeners);
 
     // TCP tp port 80 -- allowed
+    Flow allowedFlow = getTcpFlow(Ip.parse("1.1.1.1"));
     assertThat(
-        ipAccessList
-            .filter(getTcpFlow(Ip.parse("1.1.1.1")), null, ImmutableMap.of(), ImmutableMap.of())
-            .getAction(),
+        ipAccessList.filter(allowedFlow, null, ImmutableMap.of(), ImmutableMap.of()).getAction(),
         equalTo(LineAction.PERMIT));
+    assertThat(
+        AclTracer.trace(
+            ipAccessList,
+            allowedFlow,
+            null,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of()),
+        contains(hasTraceElement(getTraceElementForMatchedListener("listener1Arn"))));
 
     // TCP to port 81 -- dropped
+    Flow deniedTcpFlow =
+        Flow.builder()
+            .setIngressNode("a")
+            .setSrcPort(89)
+            .setDstPort(81)
+            .setIpProtocol(IpProtocol.TCP)
+            .build();
     assertThat(
-        ipAccessList
-            .filter(
-                Flow.builder()
-                    .setIngressNode("a")
-                    .setSrcPort(89)
-                    .setDstPort(81)
-                    .setIpProtocol(IpProtocol.TCP)
-                    .build(),
-                null,
-                ImmutableMap.of(),
-                ImmutableMap.of())
-            .getAction(),
+        ipAccessList.filter(deniedTcpFlow, null, ImmutableMap.of(), ImmutableMap.of()).getAction(),
         equalTo(LineAction.DENY));
+    assertThat(
+        AclTracer.trace(
+            ipAccessList,
+            deniedTcpFlow,
+            null,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of()),
+        contains(hasTraceElement(getTraceElementForNoMatchedListener())));
 
     // UDP to port 80 -- dropped
     assertThat(
@@ -744,17 +764,33 @@ public class LoadBalancerTest {
             ImmutableList.of(new PrivateIpAddress(true, loadBalancerIp, null)));
 
     // not transformed
+    Flow deniedFlow = getTcpFlow(loadBalancerIp);
     assertThat(
-        ipAccessList
-            .filter(getTcpFlow(loadBalancerIp), null, ImmutableMap.of(), ImmutableMap.of())
-            .getAction(),
+        ipAccessList.filter(deniedFlow, null, ImmutableMap.of(), ImmutableMap.of()).getAction(),
         equalTo(LineAction.DENY));
+    assertThat(
+        AclTracer.trace(
+            ipAccessList,
+            deniedFlow,
+            null,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of()),
+        contains(hasTraceElement(getTraceElementForUntransformedPackets())));
 
     // transformed
+    Flow allowedFlow = getTcpFlow(Ip.parse("1.1.1.1"));
     assertThat(
-        ipAccessList
-            .filter(getTcpFlow(Ip.parse("1.1.1.1")), null, ImmutableMap.of(), ImmutableMap.of())
-            .getAction(),
+        ipAccessList.filter(allowedFlow, null, ImmutableMap.of(), ImmutableMap.of()).getAction(),
         equalTo(LineAction.PERMIT));
+    assertThat(
+        AclTracer.trace(
+            ipAccessList,
+            allowedFlow,
+            null,
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of()),
+        contains(hasTraceElement(getTraceElementForTransformedPackets())));
   }
 }


### PR DESCRIPTION
Earlier, we had a binary filter that dropped all untransformed packets for any reason. So, it was hard for users to tell why the packet got dropped. Now, they can tell if the packet got dropped because it didn't match a configured listener or because no valid target was found behind the listener. 