### PR TITLE
BDDFlowConstraintGenerator: change the algorithm

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
@@ -3,12 +3,9 @@ package org.batfish.common.bdd;
 import static org.batfish.datamodel.PacketHeaderConstraintsUtil.DEFAULT_PACKET_LENGTH;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 import io.opentracing.ActiveSpan;
 import io.opentracing.util.GlobalTracer;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import net.sf.javabdd.BDD;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.IcmpType;
@@ -18,23 +15,26 @@ import org.batfish.datamodel.NamedPort;
 
 /** This class generates common useful flow constraints as BDDs. */
 public final class BDDFlowConstraintGenerator {
-  /**
-   * Difference preferences of flow constraints: DEBUGGING: 1. ICMP 2. UDP 3. TCP APPLICATION : 1.
-   * TCP 2. UDP 3. ICMP
-   */
+  /** Allows a caller to express preferences on how packets should be retrieved. */
   public enum FlowPreference {
+    /** Prefers ICMP over UDP over TCP. */
     DEBUGGING,
+    /** Prefers TCP over UDP over ICMP. */
     APPLICATION,
+    /**
+     * Prefers TCP over UDP over ICMP. Not currently different from {@link #APPLICATION}, but may
+     * change.
+     */
     TESTFILTER
   }
 
   private final BDDPacket _bddPacket;
   private final BDDOps _bddOps;
-  private final BDD _icmpFlow;
-  private final BDD _udpFlow;
-  private final BDD _tcpFlow;
+  private final List<BDD> _icmpConstraints;
+  private final List<BDD> _udpConstraints;
+  private final List<BDD> _tcpConstraints;
   private final BDD _defaultPacketLength;
-  private final List<BDD> _testFilterPrefBdds;
+  private final List<BDD> _ipConstraints;
 
   BDDFlowConstraintGenerator(BDDPacket pkt) {
     try (ActiveSpan span =
@@ -43,109 +43,149 @@ public final class BDDFlowConstraintGenerator {
       _bddPacket = pkt;
       _bddOps = new BDDOps(pkt.getFactory());
       _defaultPacketLength = _bddPacket.getPacketLength().value(DEFAULT_PACKET_LENGTH);
-      _icmpFlow = computeICMPConstraint();
-      _udpFlow = computeUDPConstraint();
-      _tcpFlow = computeTCPConstraint();
-      _testFilterPrefBdds = computeTestFilterPreference();
+      _icmpConstraints = computeICMPConstraint();
+      _udpConstraints = computeUDPConstraints();
+      _tcpConstraints = computeTCPConstraints();
+      _ipConstraints = computeIpConstraints();
     }
   }
 
-  public BDD getUDPFlow() {
-    return _udpFlow;
+  private List<BDD> computeICMPConstraint() {
+    BDD icmp = _bddPacket.getIpProtocol().value(IpProtocol.ICMP);
+    BDDIcmpType type = _bddPacket.getIcmpType();
+    BDD codeZero = _bddPacket.getIcmpCode().value(0);
+    // Prefer ICMP Echo_Request, then anything with code 0, then anything ICMP/
+    return ImmutableList.of(
+        _bddOps.and(icmp, type.value(IcmpType.ECHO_REQUEST), codeZero),
+        _bddOps.and(icmp, codeZero),
+        icmp);
   }
 
-  public BDD getTCPFlow() {
-    return _tcpFlow;
+  private BDD emphemeralPort(BDDInteger portInteger) {
+    return portInteger.geq(NamedPort.EPHEMERAL_LOWEST.number());
   }
 
-  public BDD getICMPFlow() {
-    return _icmpFlow;
+  private List<BDD> tcpPortPreferences(BDD tcp, BDDInteger tcpPort) {
+    return ImmutableList.of(
+        _bddOps.and(tcp, tcpPort.value(NamedPort.HTTP.number())),
+        _bddOps.and(tcp, tcpPort.value(NamedPort.HTTPS.number())),
+        _bddOps.and(tcp, tcpPort.value(NamedPort.SSH.number())),
+        // at least not zero if possible
+        _bddOps.and(tcp, tcpPort.value(0).not()));
   }
 
-  // Get ICMP echo request packets
-  BDD computeICMPConstraint() {
-    return _bddOps.and(
-        _defaultPacketLength,
-        _bddPacket.getIpProtocol().value(IpProtocol.ICMP),
-        _bddPacket
-            .getIcmpType()
-            .value(IcmpType.ECHO_REQUEST)
-            .and(_bddPacket.getIcmpCode().value(0)));
-  }
-
-  // Get TCP packets with names ports:
-  // 1. Considers both directions of a TCP flow.
-  // 2. Set src (dst, respectively) port to a ephemeral port, and dst (src, respectively) port to a
-  // named port
-  BDD computeTCPConstraint() {
+  // Get TCP packets with special named ports, trying to find cases where only one side is
+  // ephemeral.
+  private List<BDD> computeTCPConstraints() {
     BDDInteger dstPort = _bddPacket.getDstPort();
     BDDInteger srcPort = _bddPacket.getSrcPort();
-    BDD bdd1 =
-        _bddPacket
-            .getFactory()
-            .orAll(
-                Arrays.stream(NamedPort.values())
-                    .map(namedPort -> dstPort.value(namedPort.number()))
-                    .collect(Collectors.toList()));
-    bdd1 = bdd1.and(srcPort.geq(NamedPort.EPHEMERAL_LOWEST.number()));
-    BDD bdd2 = _bddPacket.swapSourceAndDestinationFields(bdd1);
     BDD tcp = _bddPacket.getIpProtocol().value(IpProtocol.TCP);
-    return _bddOps.and(_defaultPacketLength, tcp, bdd1.or(bdd2));
+
+    BDD srcPortEphemeral = emphemeralPort(srcPort);
+    BDD dstPortEphemeral = emphemeralPort(dstPort);
+
+    return ImmutableList.<BDD>builder()
+        // First, try to nudge src and dst port apart. E.g., if one is ephemeral the other is not.
+        .add(_bddOps.and(tcp, srcPortEphemeral, dstPortEphemeral.not()))
+        .add(_bddOps.and(tcp, srcPortEphemeral.not(), dstPortEphemeral))
+        // Next, execute port preferences
+        .addAll(tcpPortPreferences(tcp, srcPort))
+        .addAll(tcpPortPreferences(tcp, dstPort))
+        // Anything TCP.
+        .add(tcp)
+        .build();
   }
 
-  // Get UDP packets for traceroute:
-  // 1. Considers both directions of a UDP flow.
-  // 2. Set dst (src, respectively) port to the range 33434-33534 (common ports used by traceroute),
-  // and src (dst, respectively) port to a ephemeral port
-  BDD computeUDPConstraint() {
+  private List<BDD> udpPortPreferences(BDD udp, BDDInteger tcpPort) {
+    return ImmutableList.of(
+        _bddOps.and(udp, tcpPort.value(NamedPort.DOMAIN.number())),
+        _bddOps.and(udp, tcpPort.value(NamedPort.SNMP.number())),
+        _bddOps.and(udp, tcpPort.value(NamedPort.SNMPTRAP.number())),
+        // at least not zero if possible
+        _bddOps.and(udp, tcpPort.value(0).not()));
+  }
+
+  // Get UDP packets with special named ports, trying to find cases where only one side is
+  // ephemeral.
+  private List<BDD> computeUDPConstraints() {
     BDDInteger dstPort = _bddPacket.getDstPort();
     BDDInteger srcPort = _bddPacket.getSrcPort();
-    BDD bdd1 = dstPort.range(33434, 33534).and(srcPort.geq(NamedPort.EPHEMERAL_LOWEST.number()));
-    BDD bdd2 = _bddPacket.swapSourceAndDestinationFields(bdd1);
     BDD udp = _bddPacket.getIpProtocol().value(IpProtocol.UDP);
-    return _bddOps.and(_defaultPacketLength, udp, bdd1.or(bdd2));
+
+    BDD srcPortEphemeral = emphemeralPort(srcPort);
+    BDD dstPortEphemeral = emphemeralPort(dstPort);
+
+    return ImmutableList.<BDD>builder()
+        // Try for UDP traceroute.
+        .add(
+            _bddOps.and(
+                udp,
+                dstPort.range(33434, 33534).and(srcPort.geq(NamedPort.EPHEMERAL_LOWEST.number()))))
+        // Next, try to nudge src and dst port apart. E.g., if one is ephemeral the other is not.
+        .add(_bddOps.and(udp, srcPortEphemeral, dstPortEphemeral.not()))
+        .add(_bddOps.and(udp, srcPortEphemeral.not(), dstPortEphemeral))
+        // Next, execute port preferences
+        .addAll(udpPortPreferences(udp, srcPort))
+        .addAll(udpPortPreferences(udp, dstPort))
+        // Anything UDP.
+        .add(udp)
+        .build();
   }
 
-  private List<BDD> computeTestFilterPreference() {
+  private BDD isPrivateIp(BDDInteger ipInteger) {
+    return _bddOps.or(
+        ipInteger.range(Ip.parse("10.0.0.0").asLong(), Ip.parse("10.255.255.255").asLong()),
+        ipInteger.range(Ip.parse("172.16.0.0").asLong(), Ip.parse("172.255.255.255").asLong()),
+        ipInteger.range(Ip.parse("192.168.0.0").asLong(), Ip.parse("192.168.255.255").asLong()));
+  }
+
+  private List<BDD> ipPreferences(BDDInteger ipInteger) {
+    return ImmutableList.of(
+        // First, one of the special IPs.
+        ipInteger.value(Ip.parse("8.8.8.8").asLong()),
+        ipInteger.value(Ip.parse("1.1.1.1").asLong()),
+        // Next, at least don't start with 0.
+        ipInteger.geq(Ip.parse("1.0.0.0").asLong()),
+        // Next, try to be in class A.
+        ipInteger.leq(Ip.parse("126.255.255.254").asLong()));
+  }
+
+  private List<BDD> computeIpConstraints() {
+    BDDInteger srcIp = _bddPacket.getSrcIp();
     BDDInteger dstIp = _bddPacket.getDstIp();
-    BDDInteger dstPort = _bddPacket.getDstPort();
-    BDDInteger srcPort = _bddPacket.getSrcPort();
-    BDDIpProtocol ipProtocol = _bddPacket.getIpProtocol();
+    BDD srcIpPrivate = isPrivateIp(srcIp);
+    BDD dstIpPrivate = isPrivateIp(dstIp);
 
-    BDD defaultDstIpBdd = dstIp.value(Ip.parse("8.8.8.8").asLong());
-    BDD tcpBdd = ipProtocol.value(IpProtocol.TCP);
-    BDD udpBdd = ipProtocol.value(IpProtocol.UDP);
-    BDD defaultSrcPortBdd = srcPort.value(NamedPort.EPHEMERAL_LOWEST.number());
-    BDD defaultDstPortBdd = dstPort.value(NamedPort.HTTP.number());
-
-    BDD one = _bddPacket.getFactory().one();
-    // generate all combinations in order to enforce the following logic: when a field in the input
-    // bdd contains the default value for that field, then use that value; otherwise use a value
-    // in BDD of the field.
-    Builder<BDD> builder = ImmutableList.builder();
-    for (BDD dstIpBdd : ImmutableList.of(defaultDstIpBdd, one)) {
-      for (BDD ipProtocolBdd : ImmutableList.of(tcpBdd, udpBdd)) {
-        for (BDD srcPortBdd : ImmutableList.of(defaultSrcPortBdd, one)) {
-          for (BDD dstPortBdd : ImmutableList.of(defaultDstPortBdd, one)) {
-            builder.add(
-                _bddOps.and(_defaultPacketLength, dstIpBdd, ipProtocolBdd, srcPortBdd, dstPortBdd));
-          }
-        }
-      }
-    }
-    builder.add(defaultDstIpBdd);
-    builder.add(_defaultPacketLength);
-    return builder.build();
+    return ImmutableList.<BDD>builder()
+        // First, try to nudge src and dst IP apart. E.g., if one is private the other should be
+        // public.
+        .add(_bddOps.and(srcIpPrivate, dstIpPrivate.not()))
+        .add(_bddOps.and(srcIpPrivate.not(), dstIpPrivate))
+        // Next, execute IP preferences
+        .addAll(ipPreferences(srcIp))
+        .addAll(ipPreferences(dstIp))
+        .build();
   }
 
   public List<BDD> generateFlowPreference(FlowPreference preference) {
     switch (preference) {
       case DEBUGGING:
-        return ImmutableList.of(_icmpFlow, _udpFlow, _tcpFlow, _defaultPacketLength);
+        return ImmutableList.<BDD>builder()
+            .addAll(_icmpConstraints)
+            .addAll(_udpConstraints)
+            .addAll(_tcpConstraints)
+            .add(_defaultPacketLength)
+            .addAll(_ipConstraints)
+            .build();
       case APPLICATION:
-        return ImmutableList.of(_tcpFlow, _udpFlow, _icmpFlow, _defaultPacketLength);
       case TESTFILTER:
-        return _testFilterPrefBdds;
+        return ImmutableList.<BDD>builder()
+            .addAll(_tcpConstraints)
+            .addAll(_udpConstraints)
+            .addAll(_icmpConstraints)
+            .add(_defaultPacketLength)
+            .addAll(_ipConstraints)
+            .build();
       default:
         throw new BatfishException("Not supported flow preference");
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -239,13 +239,18 @@ public class BDDPacket {
    * @return A Flow.Builder for a representative of the set, if it's non-empty
    */
   public Optional<Flow.Builder> getFlow(BDD bdd, FlowPreference preference) {
+    if (bdd.isZero()) {
+      return Optional.empty();
+    }
     BDD representativeBDD =
         BDDRepresentativePicker.pickRepresentative(
             bdd, _flowConstraintGeneratorSupplier.get().generateFlowPreference(preference));
 
     if (representativeBDD.isZero()) {
+      // Should not be possible if the preference is well-formed.
       return Optional.empty();
     }
+
     return Optional.of(getFlowFromAssignment(representativeBDD));
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDRepresentativePicker.java
@@ -1,6 +1,7 @@
 package org.batfish.common.bdd;
 
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 
@@ -11,19 +12,23 @@ import net.sf.javabdd.BDD;
 @ParametersAreNonnullByDefault
 public final class BDDRepresentativePicker {
 
-  public static BDD pickRepresentative(BDD bdd, List<BDD> preference) {
+  /** Picks a representative flow, possibly from a combination of the given preference BDDs. */
+  public static @Nonnull BDD pickRepresentative(BDD bdd, List<BDD> preference) {
     if (bdd.isZero()) {
       return bdd;
     }
 
-    for (BDD preferedBDD : preference) {
-      BDD newBDD = preferedBDD.and(bdd);
-      if (!newBDD.isZero()) {
-        return newBDD.fullSatOne();
+    BDD curBDD = bdd.id(); // clone so we can free.
+    for (BDD preferredBDD : preference) {
+      BDD newBDD = preferredBDD.and(curBDD);
+      if (newBDD.isZero()) {
+        continue;
       }
+      curBDD.free();
+      curBDD = newBDD;
     }
 
-    return bdd.fullSatOne();
+    return curBDD.fullSatOne();
   }
 
   private BDDRepresentativePicker() {}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
@@ -237,7 +237,7 @@ public class BDDPacketTest {
     assertThat(flow, hasDstIp(dstIp));
     assertThat(flow, hasSrcIp(srcIp));
     assertThat(flow, hasIpProtocol(IpProtocol.TCP));
-    assertThat(flow, hasDstPort(1));
+    assertThat(flow, hasDstPort(80));
     assertThat(flow, hasSrcPort(NamedPort.EPHEMERAL_LOWEST.number()));
   }
 
@@ -252,7 +252,7 @@ public class BDDPacketTest {
     assertTrue("Unsat", flowBuilder.isPresent());
     Flow flow = flowBuilder.get().setIngressNode("ingressNode").build();
 
-    assertThat(flow, hasDstIp(Ip.parse("8.8.8.8")));
+    assertThat(flow, hasDstIp(Ip.parse("10.0.0.0")));
     assertThat(flow, hasSrcIp(srcIp));
     assertThat(flow, hasIpProtocol(IpProtocol.TCP));
     assertThat(flow, hasDstPort(80));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/HeaderSpaceToFlowTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/HeaderSpaceToFlowTest.java
@@ -137,7 +137,7 @@ public class HeaderSpaceToFlowTest {
     assertTrue(flowBuilder.isPresent());
     assertThat(flowBuilder.get().getDstIp(), equalTo(Ip.parse("1.1.1.1")));
     assertThat(flowBuilder.get().getIpProtocol(), equalTo(IpProtocol.UDP));
-    assertThat(flowBuilder.get().getDstPort(), equalTo(NamedPort.HTTP.number()));
+    assertThat(flowBuilder.get().getDstPort(), equalTo(NamedPort.EPHEMERAL_LOWEST.number()));
     assertThat(flowBuilder.get().getSrcPort(), equalTo(2));
     assertThat(flowBuilder.get().getPacketLength(), equalTo(DEFAULT_PACKET_LENGTH));
   }


### PR DESCRIPTION
Previous algorithm: picked flows from BDDs by taking a list of constraints and
keeping the first match. The constraints were either very simple ("ICMP
echo-request") or fairly complex ("well-known source IPs to private IPs using
UDP traceroute"). After finding the first matching constraint, we'd fill in the
unconstrainted bits. For simple constraints, we ended up with a lot of "source
IP 0", "source port 0", etc. For complex constraints, the barrier was an
exponential explosion of simple constraints.

Instead, use a long list of "simple" constraints, which need not be related in
any way except that more preferred ones come earlier. This allows us to home in
on a good representative -- we can put very general nudges like "if possible,
exactly one of src and dst port should be ephemeral" without an exponential
explosion. (The cost instead is potentially many operations to compute a
representative, which has not been fully measured).