### PR TITLE
BlockReservedAddressesAtInternet: allow documentation IPs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/BlockReservedAddressesAtInternet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/BlockReservedAddressesAtInternet.java
@@ -51,13 +51,18 @@ public final class BlockReservedAddressesAtInternet implements IspTrafficFilteri
           .put("10.0.0.0/8", "RFC 1918 private")
           .put("127.0.0.0/8", "Loopback")
           .put("172.16.0.0/12", "RFC 1918 private")
-          .put("192.0.2.0/24", "Documentation")
           .put("192.168.0.0/16", "RFC 1918 private")
-          .put("198.51.100.0/24", "Documentation")
-          .put("203.0.113.0/24", "Documentation")
           .put("224.0.0.0/4", "Multicast")
           .put("240.0.0.0/4", "Future use")
           .build();
+  /*
+   * Having ISPs block documentation IPs hurts our examples. TBD how we resolve this.
+   *
+   * .put("192.0.2.0/24", "Documentation")
+   * .put("198.51.100.0/24", "Documentation")
+   * .put("203.0.113.0/24", "Documentation")
+   */
+
   /*
    * Skipping these for now.
    *

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -191,28 +191,6 @@
                     "negate" : false,
                     "srcOrDstIps" : {
                       "class" : "org.batfish.datamodel.PrefixIpSpace",
-                      "prefix" : "192.0.2.0/24"
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched reserved IP address space 192.0.2.0/24 (Documentation)"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "negate" : false,
-                    "srcOrDstIps" : {
-                      "class" : "org.batfish.datamodel.PrefixIpSpace",
                       "prefix" : "192.168.0.0/16"
                     }
                   }
@@ -222,50 +200,6 @@
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
                       "text" : "Matched reserved IP address space 192.168.0.0/16 (RFC 1918 private)"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "negate" : false,
-                    "srcOrDstIps" : {
-                      "class" : "org.batfish.datamodel.PrefixIpSpace",
-                      "prefix" : "198.51.100.0/24"
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched reserved IP address space 198.51.100.0/24 (Documentation)"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "negate" : false,
-                    "srcOrDstIps" : {
-                      "class" : "org.batfish.datamodel.PrefixIpSpace",
-                      "prefix" : "203.0.113.0/24"
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched reserved IP address space 203.0.113.0/24 (Documentation)"
                     }
                   ]
                 }
@@ -431,28 +365,6 @@
                     "negate" : false,
                     "srcOrDstIps" : {
                       "class" : "org.batfish.datamodel.PrefixIpSpace",
-                      "prefix" : "192.0.2.0/24"
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched reserved IP address space 192.0.2.0/24 (Documentation)"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "negate" : false,
-                    "srcOrDstIps" : {
-                      "class" : "org.batfish.datamodel.PrefixIpSpace",
                       "prefix" : "192.168.0.0/16"
                     }
                   }
@@ -462,50 +374,6 @@
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
                       "text" : "Matched reserved IP address space 192.168.0.0/16 (RFC 1918 private)"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "negate" : false,
-                    "srcOrDstIps" : {
-                      "class" : "org.batfish.datamodel.PrefixIpSpace",
-                      "prefix" : "198.51.100.0/24"
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched reserved IP address space 198.51.100.0/24 (Documentation)"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "negate" : false,
-                    "srcOrDstIps" : {
-                      "class" : "org.batfish.datamodel.PrefixIpSpace",
-                      "prefix" : "203.0.113.0/24"
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched reserved IP address space 203.0.113.0/24 (Documentation)"
                     }
                   ]
                 }


### PR DESCRIPTION
This is crucial to keeping examples working. Instead, nudge away from the doc subnets
when picking flows. TBD how we'll resolve permanently, but this is a good middle.