### PR TITLE
BDDUtils: move isAssignment internally

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
@@ -2,7 +2,6 @@ package org.batfish.common.bdd;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.batfish.common.bdd.BDDUtils.isAssignment;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 import static org.batfish.common.util.CommonUtil.forEachWithIndex;
 
@@ -95,7 +94,7 @@ public final class BDDFiniteDomain<V> {
   }
 
   public V getValueFromAssignment(BDD bdd) {
-    checkArgument(isAssignment(bdd));
+    checkArgument(bdd.isAssignment());
 
     // Exist turns the assignment into just the finite domain.
     V ret = _bddToValue.get(bdd.exist(_var.getOtherVars()));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -2,7 +2,6 @@ package org.batfish.common.bdd;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.common.bdd.BDDInteger.makeFromIndex;
-import static org.batfish.common.bdd.BDDUtils.isAssignment;
 import static org.batfish.common.bdd.BDDUtils.swapPairing;
 
 import com.google.common.base.Suppliers;
@@ -267,7 +266,7 @@ public class BDDPacket {
   }
 
   public Flow.Builder getFlowFromAssignment(BDD satAssignment) {
-    checkArgument(isAssignment(satAssignment));
+    checkArgument(satAssignment.isAssignment());
 
     Flow.Builder fb = Flow.builder();
     fb.setDstIp(Ip.create(_dstIp.satAssignmentToLong(satAssignment)));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDUtils.java
@@ -19,7 +19,7 @@ public class BDDUtils {
     return factory;
   }
 
-  /** @see BDD#isAssignment(). */
+  /** @see BDD#isAssignment() */
   public static boolean isAssignment(BDD orig) {
     return orig.isAssignment();
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDUtils.java
@@ -19,30 +19,9 @@ public class BDDUtils {
     return factory;
   }
 
-  /**
-   * Check if this BDD represents a single assignment, i.e. if each node has only 1 path to the leaf
-   * node "one" in the DAG. If this is true, either the high or low child node will be the leaf node
-   * "zero", due to reduction. Specifically, one of the children must only lead to zero, and
-   * reduction recursively removes nodes whose high and low children are the same node.
-   */
+  /** @see BDD#isAssignment(). */
   public static boolean isAssignment(BDD orig) {
-    BDD bdd = orig;
-    if (bdd.isZero()) {
-      return false;
-    }
-    while (!bdd.isOne()) {
-      if (bdd.low().isZero()) {
-        // this node looks good; check its high child.
-        bdd = bdd.high();
-      } else if (bdd.high().isZero()) {
-        // this node looks good; check its low child.
-        bdd = bdd.low();
-      } else {
-        // one of the branches must be zero. not an assignment
-        return false;
-      }
-    }
-    return true;
+    return orig.isAssignment();
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDUtilsTest.java
@@ -1,7 +1,6 @@
 package org.batfish.common.bdd;
 
 import static org.batfish.common.bdd.BDDOps.andNull;
-import static org.batfish.common.bdd.BDDUtils.isAssignment;
 import static org.batfish.common.bdd.BDDUtils.swap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -18,8 +17,8 @@ public class BDDUtilsTest {
   @Test
   public void testIsAssignment_trivial() {
     BDDFactory factory = BDDUtils.bddFactory(1);
-    assertTrue("one is an assignment (that assigns nothing)", isAssignment(factory.one()));
-    assertFalse("zero is not an assignment", isAssignment(factory.zero()));
+    assertTrue("one is an assignment (that assigns nothing)", factory.one().isAssignment());
+    assertFalse("zero is not an assignment", factory.zero().isAssignment());
   }
 
   @Test
@@ -28,8 +27,8 @@ public class BDDUtilsTest {
     BDD v0 = factory.ithVar(0);
     BDD v1 = factory.ithVar(1);
     BDD xor = v0.xor(v1);
-    assertFalse("xor is not an assignment", isAssignment(xor));
-    assertTrue("xor.fullSatOne is an assignment", isAssignment(xor.fullSatOne()));
+    assertFalse("xor is not an assignment", xor.isAssignment());
+    assertTrue("xor.fullSatOne is an assignment", xor.fullSatOne().isAssignment());
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDUtilsTest.java
@@ -4,33 +4,13 @@ import static org.batfish.common.bdd.BDDOps.andNull;
 import static org.batfish.common.bdd.BDDUtils.swap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import java.util.function.BiFunction;
 import net.sf.javabdd.BDD;
-import net.sf.javabdd.BDDFactory;
 import org.batfish.datamodel.Ip;
 import org.junit.Test;
 
 public class BDDUtilsTest {
-  @Test
-  public void testIsAssignment_trivial() {
-    BDDFactory factory = BDDUtils.bddFactory(1);
-    assertTrue("one is an assignment (that assigns nothing)", factory.one().isAssignment());
-    assertFalse("zero is not an assignment", factory.zero().isAssignment());
-  }
-
-  @Test
-  public void testIsAssignment() {
-    BDDFactory factory = BDDUtils.bddFactory(2);
-    BDD v0 = factory.ithVar(0);
-    BDD v1 = factory.ithVar(1);
-    BDD xor = v0.xor(v1);
-    assertFalse("xor is not an assignment", xor.isAssignment());
-    assertTrue("xor.fullSatOne is an assignment", xor.fullSatOne().isAssignment());
-  }
-
   @Test
   public void testSwap() {
     BDDPacket pkt = new BDDPacket();

--- a/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
@@ -66,6 +66,17 @@ public abstract class BDD {
   public abstract BDDFactory getFactory();
 
   /**
+   * Returns true if this BDD is a satsifiable assignment.
+   *
+   * <p>A BDD is an assignment if there is exactly a single path to the {@link BDDFactory#one()}
+   * BDD.
+   *
+   * <p>Note that being an assignment does not mean that there is a value assigned to every
+   * variable. See {@link #satOne()} and {@link #fullSatOne()}.
+   */
+  public abstract boolean isAssignment();
+
+  /**
    * Returns true if this BDD is the zero (false) BDD.
    *
    * @return true if this BDD is the zero (false) BDD

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -126,6 +126,10 @@ public final class JFactory extends BDDFactory {
       return _index == BDDONE;
     }
 
+    public boolean isAssignment() {
+      return bdd_isAssignment(_index);
+    }
+
     @Override
     public int var() {
       return bdd_var(_index);
@@ -917,6 +921,25 @@ public final class JFactory extends BDDFactory {
     checkresize();
 
     return res;
+  }
+
+  private boolean bdd_isAssignment(int r) {
+    CHECK(r);
+    if (r == BDDONE) {
+      return true;
+    } else if (r == BDDZERO) {
+      return false;
+    }
+
+    // If this node is an assignment, exactly one child will be zero at every level except the last,
+    // which will be one. If there are no zero children, there are two satisfying paths.
+    if (LOW(r) == BDDZERO) {
+      return bdd_isAssignment(HIGH(r));
+    } else if (HIGH(r) == BDDZERO) {
+      return bdd_isAssignment(LOW(r));
+    }
+
+    return false;
   }
 
   private int bdd_not(int r) {

--- a/projects/bdd/src/test/java/net/sf/javabdd/bdd/BasicTests.java
+++ b/projects/bdd/src/test/java/net/sf/javabdd/bdd/BasicTests.java
@@ -83,9 +83,17 @@ public class BasicTests extends BDDTestCase {
       assertTrue(b.isAssignment());
       BDD c = b.or(z);
       assertFalse(c.isAssignment());
+      // Calling satOne should always produce an assignment.
+      BDD d = c.satOne();
+      assertTrue(d.isAssignment());
+      // Calling fullSatOne should always produce an assignment.
+      BDD e = c.fullSatOne();
+      assertTrue(e.isAssignment());
       a.free();
       b.free();
       c.free();
+      d.free();
+      e.free();
       x.free();
       y.free();
       z.free();

--- a/projects/bdd/src/test/java/net/sf/javabdd/bdd/BasicTests.java
+++ b/projects/bdd/src/test/java/net/sf/javabdd/bdd/BasicTests.java
@@ -59,6 +59,39 @@ public class BasicTests extends BDDTestCase {
     junit.textui.TestRunner.run(BasicTests.class);
   }
 
+  public void testIsAssignment() {
+    reset();
+    assertTrue(hasNext());
+    while (hasNext()) {
+      BDDFactory bdd = next();
+      BDD zero = bdd.zero();
+      BDD one = bdd.one();
+      if (bdd.varNum() < 5) {
+        bdd.setVarNum(5);
+      }
+      BDD x = bdd.ithVar(1);
+      BDD y = bdd.ithVar(2);
+      BDD z = bdd.ithVar(3);
+      assertFalse(zero.isAssignment());
+      assertTrue(one.isAssignment());
+      assertTrue(x.isAssignment());
+      assertTrue(y.isAssignment());
+      assertTrue(z.isAssignment());
+      BDD a = x.or(y);
+      assertFalse(a.isAssignment());
+      BDD b = x.and(y);
+      assertTrue(b.isAssignment());
+      BDD c = b.or(z);
+      assertFalse(c.isAssignment());
+      a.free();
+      b.free();
+      c.free();
+      x.free();
+      y.free();
+      z.free();
+    }
+  }
+
   public void testIsZeroOne() {
     reset();
     assertTrue(hasNext());


### PR DESCRIPTION
No need to materialize the inner nodes as BDD objects, reducing overhead
and making free on the outer BDDs effective.