### PR TITLE
Frr: correctly extract text from parser context for warnings/todos

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedControlPlaneExtractor.java
@@ -87,7 +87,7 @@ public class CumulusConcatenatedControlPlaneExtractor implements ControlPlaneExt
     checkErrors(parser);
     ParseTreeWalker walker = new BatfishParseTreeWalker(parser);
     CumulusFrrConfigurationBuilder cb =
-        new CumulusFrrConfigurationBuilder(_configuration, parser, _w);
+        new CumulusFrrConfigurationBuilder(_configuration, parser, _w, _text);
     walker.walk(cb, ctxt);
     mergeParseTree(ctxt, parser);
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -191,6 +191,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   private final CumulusFrrConfiguration _frr;
   private final CumulusFrrCombinedParser _parser;
   private final Warnings _w;
+  private final String _text;
 
   private @Nullable Vrf _currentVrf;
   private @Nullable RouteMapEntry _currentRouteMapEntry;
@@ -202,11 +203,15 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   private @Nullable FrrInterface _currentInterface;
 
   public CumulusFrrConfigurationBuilder(
-      CumulusConcatenatedConfiguration configuration, CumulusFrrCombinedParser parser, Warnings w) {
+      CumulusConcatenatedConfiguration configuration,
+      CumulusFrrCombinedParser parser,
+      Warnings w,
+      String fullText) {
     _c = configuration;
     _frr = configuration.getFrrConfiguration();
     _parser = parser;
     _w = w;
+    _text = fullText;
   }
 
   CumulusConcatenatedConfiguration getVendorConfiguration() {
@@ -268,12 +273,20 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     }
   }
 
+  /** Return the text of a given rule context */
+  @Nonnull
+  String getFullText(ParserRuleContext ctx) {
+    int start = ctx.getStart().getStartIndex();
+    int end = ctx.getStop().getStopIndex();
+    return _text.substring(start, end + 1);
+  }
+
   private void todo(ParserRuleContext ctx) {
-    _w.todo(ctx, ctx.getText(), _parser);
+    _w.todo(ctx, getFullText(ctx), _parser);
   }
 
   private void warn(ParserRuleContext ctx, String message) {
-    _w.addWarning(ctx, ctx.getText(), _parser, message);
+    _w.addWarning(ctx, getFullText(ctx), _parser, message);
   }
 
   private LongExpr toMetricLongExpr(Int_exprContext ctx) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -169,7 +169,7 @@ public class CumulusFrrGrammarTest {
         Batfish.parse(parser, new BatfishLogger(BatfishLogger.LEVELSTR_FATAL, false), settings);
     ParseTreeWalker walker = new BatfishParseTreeWalker(parser);
     CumulusFrrConfigurationBuilder cb =
-        new CumulusFrrConfigurationBuilder(_config, parser, _warnings);
+        new CumulusFrrConfigurationBuilder(_config, parser, _warnings, src);
     walker.walk(cb, tree);
     _config = SerializationUtils.clone(_config);
   }


### PR DESCRIPTION
This follows our usual pattern that lets us preserve spaces/hidden chars.