### PR TITLE
Adding next-hop interface support to static routes for FRR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ coverage*
 # Ignore python cache files
 __pycache__
 .pytest_cache/
+
+# Ignore Tokens
+*.tokens

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,3 @@ coverage*
 # Ignore python cache files
 __pycache__
 .pytest_cache/
-
-# Ignore Tokens
-*.tokens

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -117,11 +117,6 @@ BGP
   'bgp'
 ;
 
-BLACKHOLE
-:
-  'blackhole'
-;
-
 CALL
 :
   'call' -> pushMode(M_Word)
@@ -601,7 +596,7 @@ ROUTE_MAP
 
 ROUTE
 :
-  'route'
+  'route' -> pushMode(M_Static_Route_Next_Hop)
 ;
 
 ROUTER
@@ -1018,6 +1013,29 @@ M_Expanded4_REMARK_TEXT
   ~["\r\n] F_NonWhitespace* (F_Whitespace+ F_NonWhitespace+)* -> type(REMARK_TEXT), popMode
 ;
 
+
+mode M_Static_Route_Next_Hop;
+// Parsing for static routes in the format of 'ip route 1.1.1.1/32 (eth0|2.2.2.2)
+
+M_Static_Route_IP_Prefix
+:
+  F_IpPrefix -> type(IP_PREFIX)
+;
+
+M_Static_Route_IP_Address
+:
+  F_IpAddress -> type(IP_ADDRESS) , popMode
+;
+
+M_Static_Route_Word
+:
+  F_Word -> type(WORD) , popMode
+;
+
+M_Static_Route_WS
+:
+  F_Whitespace+ -> channel ( HIDDEN )
+;
 
 
 mode M_Neighbor;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrParser.g4
@@ -104,7 +104,10 @@ s_ip
 
 ip_route
 :
-  ROUTE network = prefix next_hop_ip = ip_address (VRF vrf = word)? NEWLINE
+  ROUTE network = prefix (next_hop_ip = ip_address | next_hop_interface = word)
+    (
+      VRF vrf = word
+    )? NEWLINE
 ;
 
 s_line

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_vrf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_vrf.g4
@@ -18,12 +18,7 @@ s_vrf
 
 sv_route
 :
-  IP ROUTE prefix
-  (
-     BLACKHOLE
-     | ip_address
-  )
-  NEWLINE
+  IP ROUTE network = prefix (next_hop_ip = ip_address | next_hop_interface = word) NEWLINE
 ;
 
 sv_vni

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -876,7 +876,8 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   @Override
   public void exitSv_route(Sv_routeContext ctx) {
     // If an interface name is parsed, use it.
-    final String next_hop_interface = ctx.next_hop_interface != null ? ctx.next_hop_interface.getText() : null;
+    final String next_hop_interface =
+        ctx.next_hop_interface != null ? ctx.next_hop_interface.getText() : null;
     // If user provides an IP next-hop instead of an interface, use that
     final Ip next_hop_ip = ctx.next_hop_ip != null ? Ip.parse(ctx.next_hop_ip.getText()) : null;
     Prefix network = Prefix.parse(ctx.prefix().getText());
@@ -1192,13 +1193,13 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   @Override
   public void exitIp_route(Ip_routeContext ctx) {
     // If an interface name is parsed, use it.
-    final String next_hop_interface = ctx.next_hop_interface != null ? ctx.next_hop_interface.getText() : null;
+    final String next_hop_interface =
+        ctx.next_hop_interface != null ? ctx.next_hop_interface.getText() : null;
     // If user provides an IP next-hop instead of an interface, use that
     final Ip next_hop_ip = ctx.next_hop_ip != null ? Ip.parse(ctx.next_hop_ip.getText()) : null;
 
     StaticRoute route =
-        new StaticRoute(
-            Prefix.parse(ctx.network.getText()), next_hop_ip, next_hop_interface);
+        new StaticRoute(Prefix.parse(ctx.network.getText()), next_hop_ip, next_hop_interface);
     if (ctx.vrf == null) {
       _frr.getStaticRoutes().add(route);
     } else {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/Interface.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -13,7 +14,8 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 @ParametersAreNonnullByDefault
 public class Interface implements Serializable {
 
-  static final String NULL_INTERFACE_NAME = "null0";
+  static final Pattern NULL_INTERFACE_PATTERN = Pattern.compile("Null0|blackhole|reject",
+      Pattern.CASE_INSENSITIVE);
 
   private @Nullable String _alias;
   private @Nullable InterfaceBridgeSettings _bridge;

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/Interface.java
@@ -14,8 +14,8 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 @ParametersAreNonnullByDefault
 public class Interface implements Serializable {
 
-  static final Pattern NULL_INTERFACE_PATTERN = Pattern.compile("Null0|blackhole|reject",
-      Pattern.CASE_INSENSITIVE);
+  static final Pattern NULL_INTERFACE_PATTERN =
+      Pattern.compile("Null0|blackhole|reject", Pattern.CASE_INSENSITIVE);
 
   private @Nullable String _alias;
   private @Nullable InterfaceBridgeSettings _bridge;

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/StaticRoute.java
@@ -2,11 +2,12 @@ package org.batfish.representation.cumulus;
 
 import static org.batfish.representation.cumulus.CumulusConversions.DEFAULT_STATIC_ROUTE_ADMINISTRATIVE_DISTANCE;
 import static org.batfish.representation.cumulus.CumulusConversions.DEFAULT_STATIC_ROUTE_METRIC;
-import static org.batfish.representation.cumulus.Interface.NULL_INTERFACE_NAME;
+import static org.batfish.representation.cumulus.Interface.NULL_INTERFACE_PATTERN;
 
 import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.regex.Matcher;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
@@ -67,11 +68,20 @@ public class StaticRoute implements Serializable {
         .setNetwork(_network)
         .setNextHopIp(_nextHopIp)
         .setNextHopInterface(
-            // canonicalize null interface name if needed
-            NULL_INTERFACE_NAME.equalsIgnoreCase(_nextHopInterface)
-                ? org.batfish.datamodel.Interface.NULL_INTERFACE_NAME
-                : _nextHopInterface)
+            _nextHopInterface != null ? CanonicalizeInterfaceName(_nextHopInterface) : null)
         .build();
+  }
+
+  /**
+   * Canonicalizes the many FRR discard interface names into just the standard one
+   * supported by the Batfish VI model - "null_interface"
+   */
+  public String CanonicalizeInterfaceName(String nextHopInterface) {
+    Matcher matcher = NULL_INTERFACE_PATTERN.matcher(nextHopInterface);
+    if (matcher.matches()) {
+      return org.batfish.datamodel.Interface.NULL_INTERFACE_NAME;
+    }
+    return nextHopInterface;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/StaticRoute.java
@@ -68,7 +68,7 @@ public class StaticRoute implements Serializable {
         .setNetwork(_network)
         .setNextHopIp(_nextHopIp)
         .setNextHopInterface(
-            _nextHopInterface != null ? CanonicalizeInterfaceName(_nextHopInterface) : null)
+            _nextHopInterface != null ? canonicalizeInterfaceName(_nextHopInterface) : null)
         .build();
   }
 
@@ -76,7 +76,7 @@ public class StaticRoute implements Serializable {
    * Canonicalizes the many FRR discard interface names into just the standard one
    * supported by the Batfish VI model - "null_interface"
    */
-  public String CanonicalizeInterfaceName(String nextHopInterface) {
+  private String canonicalizeInterfaceName(String nextHopInterface) {
     Matcher matcher = NULL_INTERFACE_PATTERN.matcher(nextHopInterface);
     if (matcher.matches()) {
       return org.batfish.datamodel.Interface.NULL_INTERFACE_NAME;

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/StaticRoute.java
@@ -73,8 +73,8 @@ public class StaticRoute implements Serializable {
   }
 
   /**
-   * Canonicalizes the many FRR discard interface names into just the standard one
-   * supported by the Batfish VI model - "null_interface"
+   * Canonicalizes the many FRR discard interface names into just the standard one supported by the
+   * Batfish VI model - "null_interface"
    */
   private String canonicalizeInterfaceName(String nextHopInterface) {
     Matcher matcher = NULL_INTERFACE_PATTERN.matcher(nextHopInterface);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
@@ -293,8 +293,7 @@ public class CumulusConcatenatedGrammarTest {
                     .setNetwork(Prefix.parse("7.7.7.7/24"))
                     .setNextHopInterface("null_interface")
                     .setAdministrativeCost(1)
-                    .build()
-            )));
+                    .build())));
     assertThat(
         viConfig.getVrfs().get("VRF").getStaticRoutes(),
         equalTo(
@@ -308,8 +307,7 @@ public class CumulusConcatenatedGrammarTest {
                     .setNetwork(Prefix.parse("5.5.5.5/24"))
                     .setNextHopInterface("eth0-1")
                     .setAdministrativeCost(1)
-                    .build()
-            )));
+                    .build())));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
@@ -273,7 +273,28 @@ public class CumulusConcatenatedGrammarTest {
                     .setNetwork(Prefix.parse("1.1.1.1/24"))
                     .setNextHopIp(Ip.parse("10.0.0.1"))
                     .setAdministrativeCost(1)
-                    .build())));
+                    .build(),
+                StaticRoute.builder()
+                    .setNetwork(Prefix.parse("3.3.3.3/24"))
+                    .setNextHopInterface("null_interface")
+                    .setAdministrativeCost(1)
+                    .build(),
+                StaticRoute.builder()
+                    .setNetwork(Prefix.parse("4.4.4.4/24"))
+                    .setNextHopInterface("Eth0")
+                    .setAdministrativeCost(1)
+                    .build(),
+                StaticRoute.builder()
+                    .setNetwork(Prefix.parse("6.6.6.6/24"))
+                    .setNextHopInterface("null_interface")
+                    .setAdministrativeCost(1)
+                    .build(),
+                StaticRoute.builder()
+                    .setNetwork(Prefix.parse("7.7.7.7/24"))
+                    .setNextHopInterface("null_interface")
+                    .setAdministrativeCost(1)
+                    .build()
+            )));
     assertThat(
         viConfig.getVrfs().get("VRF").getStaticRoutes(),
         equalTo(
@@ -282,7 +303,13 @@ public class CumulusConcatenatedGrammarTest {
                     .setNetwork(Prefix.parse("2.2.2.2/24"))
                     .setNextHopIp(Ip.parse("10.0.0.2"))
                     .setAdministrativeCost(1)
-                    .build())));
+                    .build(),
+                StaticRoute.builder()
+                    .setNetwork(Prefix.parse("5.5.5.5/24"))
+                    .setNextHopInterface("eth0-1")
+                    .setAdministrativeCost(1)
+                    .build()
+            )));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -1,7 +1,6 @@
 package org.batfish.grammar.cumulus_frr;
 
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
-import static org.batfish.datamodel.Interface.NULL_INTERFACE_NAME;
 import static org.batfish.datamodel.routing_policy.Environment.Direction.OUT;
 import static org.batfish.grammar.cumulus_frr.CumulusFrrConfigurationBuilder.nextMultipleOfFive;
 import static org.batfish.representation.cumulus.CumulusRoutingProtocol.CONNECTED;
@@ -744,7 +743,7 @@ public class CumulusFrrGrammarTest {
         vrf.getStaticRoutes(),
         equalTo(
             ImmutableSet.of(
-                new StaticRoute(Prefix.parse("1.0.0.0/8"), null, NULL_INTERFACE_NAME))));
+                new StaticRoute(Prefix.parse("1.0.0.0/8"), null, "blackhole"))));
   }
 
   @Test
@@ -1624,4 +1623,35 @@ public class CumulusFrrGrammarTest {
         _frr.getBgpProcess().getDefaultVrf().getNeighbors().get("1.1.1.1").getBgpNeighborSource(),
         equalTo(new BgpNeighborSourceInterface("lo")));
   }
+
+  @Test
+  public void testStaticRouteNull0_defaultVrf() {
+    parseLines("ip route 1.2.3.4/24 Null0");
+    assertThat(
+        _frr.getStaticRoutes(),
+        equalTo(
+            ImmutableSet.of(
+                new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "Null0"))));
+  }
+
+  @Test
+  public void testStaticRouteReject_defaultVrf() {
+    parseLines("ip route 1.2.3.4/24 reject");
+    assertThat(
+        _frr.getStaticRoutes(),
+        equalTo(
+            ImmutableSet.of(
+                new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "reject"))));
+  }
+
+  @Test
+  public void testStaticRouteBlackhole_defaultVrf() {
+    parseLines("ip route 1.2.3.4/24 blackhole");
+    assertThat(
+        _frr.getStaticRoutes(),
+        equalTo(
+            ImmutableSet.of(
+                new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "blackhole"))));
+  }
+
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -1654,4 +1654,27 @@ public class CumulusFrrGrammarTest {
                 new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "blackhole"))));
   }
 
+  @Test
+  public void testStaticRouteInterface_defaultVrf() {
+    parseLines("ip route 1.2.3.4/24 eth0");
+    assertThat(
+        _frr.getStaticRoutes(),
+        equalTo(
+            ImmutableSet.of(
+                new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "eth0"))));
+  }
+
+  @Test
+  public void testStaticRouteInterface_vrf_withDefinition() {
+    _warnings = new Warnings(false, true, false);
+
+    _frr.getVrfs().put("VRF", new Vrf("VRF"));
+    parseLines("ip route 1.2.3.0/24 eth0 vrf VRF");
+
+    assertThat(_warnings.getRedFlagWarnings(), empty());
+
+    assertThat(
+        _frr.getVrfs().get("VRF").getStaticRoutes(),
+        contains(new StaticRoute(Prefix.parse("1.2.3.0/24"), null, "eth0")));
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -741,9 +741,7 @@ public class CumulusFrrGrammarTest {
     parse("vrf NAME\n ip route 1.0.0.0/8 blackhole\n exit-vrf\n");
     assertThat(
         vrf.getStaticRoutes(),
-        equalTo(
-            ImmutableSet.of(
-                new StaticRoute(Prefix.parse("1.0.0.0/8"), null, "blackhole"))));
+        equalTo(ImmutableSet.of(new StaticRoute(Prefix.parse("1.0.0.0/8"), null, "blackhole"))));
   }
 
   @Test
@@ -1629,9 +1627,7 @@ public class CumulusFrrGrammarTest {
     parseLines("ip route 1.2.3.4/24 Null0");
     assertThat(
         _frr.getStaticRoutes(),
-        equalTo(
-            ImmutableSet.of(
-                new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "Null0"))));
+        equalTo(ImmutableSet.of(new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "Null0"))));
   }
 
   @Test
@@ -1639,9 +1635,7 @@ public class CumulusFrrGrammarTest {
     parseLines("ip route 1.2.3.4/24 reject");
     assertThat(
         _frr.getStaticRoutes(),
-        equalTo(
-            ImmutableSet.of(
-                new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "reject"))));
+        equalTo(ImmutableSet.of(new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "reject"))));
   }
 
   @Test
@@ -1649,9 +1643,7 @@ public class CumulusFrrGrammarTest {
     parseLines("ip route 1.2.3.4/24 blackhole");
     assertThat(
         _frr.getStaticRoutes(),
-        equalTo(
-            ImmutableSet.of(
-                new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "blackhole"))));
+        equalTo(ImmutableSet.of(new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "blackhole"))));
   }
 
   @Test
@@ -1659,9 +1651,7 @@ public class CumulusFrrGrammarTest {
     parseLines("ip route 1.2.3.4/24 eth0");
     assertThat(
         _frr.getStaticRoutes(),
-        equalTo(
-            ImmutableSet.of(
-                new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "eth0"))));
+        equalTo(ImmutableSet.of(new StaticRoute(Prefix.parse("1.2.3.4/24"), null, "eth0"))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/static_route
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/static_route
@@ -6,3 +6,8 @@ iface VRF
 frr version test
 ip route 1.1.1.1/24 10.0.0.1
 ip route 2.2.2.2/24 10.0.0.2 vrf VRF
+ip route 3.3.3.3/24 Null0
+ip route 4.4.4.4/24 Eth0
+ip route 5.5.5.5/24 eth0-1 vrf VRF
+ip route 6.6.6.6/24 blackhole
+ip route 7.7.7.7/24 reject


### PR DESCRIPTION
Previous pull request: https://github.com/batfish/batfish/pull/5691

This adds support for syntax such as:

ip route x.x.x.x/x Null0
ip route x.x.x.x/x eth0
ip route x.x.x.x/x blackhole
ip route x.x.x.x/x Eth0

Does NOT support `ip route x.x.x.x/x y.y.y.y/y Null0` although that is valid syntax, the parser will continue to error out on that as it did previously.