### PR TITLE
improved autocomplete suggestions for single-application specifier

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Anchor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Anchor.java
@@ -242,13 +242,15 @@ import org.batfish.datamodel.answers.AutocompleteSuggestion.SuggestionType;
     /** Denotes an operator that ends an expression, e.g., ], ) */
     OPERATOR_END("OPERATOR_END", null, null, SuggestionType.OPERATOR_END),
     /** Denotes a single application */
-    ONE_APP("ONE_APP", "Single application", null, SuggestionType.UNKNOWN),
+    ONE_APP("ONE_APP", "Application", null, SuggestionType.UNKNOWN),
     /** Denotes a single ICMP application */
-    ONE_APP_ICMP("ONE_APP_ICMP", "Single ICMP application", null, SuggestionType.UNKNOWN),
+    ONE_APP_ICMP("ONE_APP_ICMP", "ICMP application", "type/code", SuggestionType.CONSTANT),
+    /** Denotes a single ICMP application with the type specified */
+    ONE_APP_ICMP_TYPE("ONE_APP_ICMP_TYPE", "ICMP application", "code", SuggestionType.CONSTANT),
     /** Denotes a single TCP application */
-    ONE_APP_TCP("ONE_APP_TCP", "Single TCP application", null, SuggestionType.UNKNOWN),
+    ONE_APP_TCP("ONE_APP_TCP", "TCP application", "port number", SuggestionType.CONSTANT),
     /** Denotes a single UDP application */
-    ONE_APP_UDP("ONE_APP_UDP", "Single UDP application", null, SuggestionType.UNKNOWN),
+    ONE_APP_UDP("ONE_APP_UDP", "UDP application", "port number", SuggestionType.CONSTANT),
     /** Rule for @addressGroup(book, group) */
     REFERENCE_BOOK_AND_ADDRESS_GROUP(
         "REFERENCE_BOOK_AND_ADDRESS_GROUP",

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
@@ -191,6 +191,7 @@ public final class ParboiledAutoComplete {
       case ADDRESS_GROUP_NAME:
         return autoCompleteReferenceBookEntity(pm);
       case ONE_APP_ICMP:
+      case ONE_APP_ICMP_TYPE:
       case APP_ICMP_TYPE:
       case APP_ICMP_TYPE_CODE:
         // don't help with numbers

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/Parser.java
@@ -64,6 +64,7 @@ import static org.batfish.specifier.parboiled.Anchor.Type.NODE_SET_OP;
 import static org.batfish.specifier.parboiled.Anchor.Type.NODE_TYPE;
 import static org.batfish.specifier.parboiled.Anchor.Type.ONE_APP;
 import static org.batfish.specifier.parboiled.Anchor.Type.ONE_APP_ICMP;
+import static org.batfish.specifier.parboiled.Anchor.Type.ONE_APP_ICMP_TYPE;
 import static org.batfish.specifier.parboiled.Anchor.Type.ONE_APP_TCP;
 import static org.batfish.specifier.parboiled.Anchor.Type.ONE_APP_UDP;
 import static org.batfish.specifier.parboiled.Anchor.Type.REFERENCE_BOOK_AND_ADDRESS_GROUP;
@@ -191,25 +192,26 @@ public class Parser extends CommonParser {
   @Anchor(ONE_APP_ICMP)
   public Rule OneAppIcmp() {
     return Sequence(
-        IgnoreCase("icmp"),
-        WhiteSpace(),
-        "/ ",
+        IgnoreCase("icmp/"),
         Number(),
         push(new IcmpTypeAppAstNode(Integer.parseInt(match()))),
-        WhiteSpace(),
-        "/ ",
-        Number(),
-        push(IcmpTypeCodeAppAstNode.create(pop(), Integer.parseInt(match()))));
+        OneAppIcmpType());
+  }
+
+  @Anchor(ONE_APP_ICMP_TYPE)
+  public Rule OneAppIcmpType() {
+    return Sequence(
+        "/ ", Number(), push(IcmpTypeCodeAppAstNode.create(pop(), Integer.parseInt(match()))));
   }
 
   @Anchor(ONE_APP_TCP)
   public Rule OneAppTcp() {
-    return Sequence(IgnoreCase("tcp"), WhiteSpace(), push(new TcpAppAstNode()), "/ ", AppPort());
+    return Sequence(IgnoreCase("tcp/"), push(new TcpAppAstNode()), AppPort());
   }
 
   @Anchor(ONE_APP_UDP)
   public Rule OneAppUdp() {
-    return Sequence(IgnoreCase("udp"), WhiteSpace(), push(new UdpAppAstNode()), "/ ", AppPort());
+    return Sequence(IgnoreCase("udp/"), push(new UdpAppAstNode()), AppPort());
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserOneAppTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParserOneAppTest.java
@@ -2,6 +2,7 @@ package org.batfish.specifier.parboiled;
 
 import static org.batfish.specifier.parboiled.Anchor.Type.APP_NAME;
 import static org.batfish.specifier.parboiled.Anchor.Type.ONE_APP_ICMP;
+import static org.batfish.specifier.parboiled.Anchor.Type.ONE_APP_ICMP_TYPE;
 import static org.batfish.specifier.parboiled.Anchor.Type.ONE_APP_TCP;
 import static org.batfish.specifier.parboiled.Anchor.Type.ONE_APP_UDP;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -56,9 +57,9 @@ public class ParserOneAppTest {
             CommonParser.namedApplications.stream()
                 .map(app -> new ParboiledAutoCompleteSuggestion(app, insertionIndex, APP_NAME))
                 .collect(ImmutableSet.toImmutableSet()))
-        .add(new ParboiledAutoCompleteSuggestion("icmp", insertionIndex, ONE_APP_ICMP))
-        .add(new ParboiledAutoCompleteSuggestion("tcp", insertionIndex, ONE_APP_TCP))
-        .add(new ParboiledAutoCompleteSuggestion("udp", insertionIndex, ONE_APP_UDP))
+        .add(new ParboiledAutoCompleteSuggestion("icmp/", insertionIndex, ONE_APP_ICMP))
+        .add(new ParboiledAutoCompleteSuggestion("tcp/", insertionIndex, ONE_APP_TCP))
+        .add(new ParboiledAutoCompleteSuggestion("udp/", insertionIndex, ONE_APP_UDP))
         .build();
   }
 
@@ -108,25 +109,25 @@ public class ParserOneAppTest {
   public void testCompletionPartialProtocolName() {
     assertThat(
         getPAC("ud").run(),
-        containsInAnyOrder(new ParboiledAutoCompleteSuggestion("udp", 0, ONE_APP_UDP)));
+        containsInAnyOrder(new ParboiledAutoCompleteSuggestion("udp/", 0, ONE_APP_UDP)));
   }
 
   @Test
   public void testCompletionFullProtocolName() {
     assertThat(
         getPAC("udp").run(),
-        equalTo(ImmutableSet.of(new ParboiledAutoCompleteSuggestion("/", 3, ONE_APP_UDP))));
+        equalTo(ImmutableSet.of(new ParboiledAutoCompleteSuggestion("udp/", 0, ONE_APP_UDP))));
   }
 
   @Test
   public void testCompletionPortProtocolName() {
     // nothing to autocomplete since we don't have useful suggestions for port numbers
-    assertThat(getPAC("udp / ").run(), equalTo(ImmutableSet.of()));
+    assertThat(getPAC("udp/").run(), equalTo(ImmutableSet.of()));
   }
 
   @Test
   public void testCompletionProtocolPort() {
-    String query = "udp / 2";
+    String query = "udp/2";
     assertThat(getPAC(query).run(), equalTo(ImmutableSet.of()));
   }
 
@@ -135,7 +136,7 @@ public class ParserOneAppTest {
     String query = "icmp";
     assertThat(
         getPAC(query).run(),
-        equalTo(ImmutableSet.of(new ParboiledAutoCompleteSuggestion("/", 4, ONE_APP_ICMP))));
+        equalTo(ImmutableSet.of(new ParboiledAutoCompleteSuggestion("icmp/", 0, ONE_APP_ICMP))));
   }
 
   @Test
@@ -151,7 +152,7 @@ public class ParserOneAppTest {
         getPAC(query).run(),
         equalTo(
             ImmutableSet.of(
-                new ParboiledAutoCompleteSuggestion("/", query.length(), ONE_APP_ICMP))));
+                new ParboiledAutoCompleteSuggestion("/", query.length(), ONE_APP_ICMP_TYPE))));
   }
 
   @Test
@@ -162,7 +163,7 @@ public class ParserOneAppTest {
 
   @Test
   public void testCompletionIcmpSlashTypeCode() {
-    String query = "icmp / 0 / 0 ";
+    String query = "icmp/0/0";
     assertThat(getPAC(query).run(), equalTo(ImmutableSet.of()));
   }
 
@@ -185,9 +186,7 @@ public class ParserOneAppTest {
   @Test
   public void testParseIcmpTypeCode() {
     IcmpTypeCodeAppAstNode expectedAst = new IcmpTypeCodeAppAstNode(8, 0);
-
     assertThat(ParserUtils.getAst(getRunner().run("icmp/8/0")), equalTo(expectedAst));
-    assertThat(ParserUtils.getAst(getRunner().run(" icmp / 8 / 0 ")), equalTo(expectedAst));
   }
 
   @Test
@@ -202,7 +201,7 @@ public class ParserOneAppTest {
     TcpAppAstNode expectedAst = new TcpAppAstNode(ImmutableList.of(SubRange.singleton(80)));
 
     assertThat(ParserUtils.getAst(getRunner().run("tcp/80")), equalTo(expectedAst));
-    assertThat(ParserUtils.getAst(getRunner().run(" tcp / 80 ")), equalTo(expectedAst));
+    assertThat(ParserUtils.getAst(getRunner().run(" tcp/80")), equalTo(expectedAst));
   }
 
   @Test


### PR DESCRIPTION
Now:
`tcp` suggests `tcp/port number`
`udp` suggests `udp/port number`
`icmp` suggests `icmp/type/code`
`icmp/0` suggests `.../code`

I couldn't get the trailing space to work on longer strings like "tcp/ ", so I just removed the interleaving whitespace. 

