### PR TITLE
AWS: handle the case where vpc is in a different account

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -87,8 +87,7 @@ public class AwsConfiguration extends VendorConfiguration {
         _regions.values().stream()
             .flatMap(r -> r.getVpcPeeringConnections().values().stream())
             .collect(ImmutableSet.toImmutableSet());
-    vpcPeeringConnections.forEach(
-        c -> c.createConnection(_regions, _convertedConfiguration, getWarnings()));
+    vpcPeeringConnections.forEach(c -> c.createConnection(_convertedConfiguration, getWarnings()));
   }
 
   @Override


### PR DESCRIPTION
Fixes a crash when peering VPCs across accounts. The original root cause was
using _accepterVpcId instead of _requesterVpcId in a check, but the check was also
checking the wrong property (VS checked, VI used). I rewrote the code entirely and
added a test.