### PR TITLE
Add v2 call to get work json answer file

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
@@ -517,6 +517,53 @@ public class BfCoordWorkHelper {
     }
   }
 
+  @Nullable
+  public String getWorkJson(String networkName, String snapshotName, UUID workId) {
+    try {
+      WebTarget webTarget =
+          getTargetV2(
+              Arrays.asList(
+                  CoordConstsV2.RSC_NETWORKS,
+                  networkName,
+                  CoordConstsV2.RSC_SNAPSHOTS,
+                  snapshotName,
+                  CoordConstsV2.RSC_WORK_JSON,
+                  workId.toString()));
+
+      Response response =
+          webTarget
+              .request(MediaType.TEXT_PLAIN)
+              .header(CoordConstsV2.HTTP_HEADER_BATFISH_APIKEY, _settings.getApiKey())
+              .header(CoordConstsV2.HTTP_HEADER_BATFISH_VERSION, BatfishVersion.getVersionStatic())
+              .get();
+
+      _logger.debug(response.getStatus() + " " + response.getStatusInfo() + " " + response + "\n");
+
+      if (response.getStatusInfo().getFamily() != Status.Family.SUCCESSFUL) {
+        _logger.debugf(
+            "getWorkJson: Did not get an OK response for %s -> %s->%s\n",
+            networkName, snapshotName, workId);
+        return null;
+      }
+
+      File inFile = response.readEntity(File.class);
+
+      File tmpOutFile = Files.createTempFile("batfish_client", null).toFile();
+      tmpOutFile.deleteOnExit();
+
+      FileUtils.copyFile(inFile, tmpOutFile);
+      if (!inFile.delete()) {
+        throw new BatfishException("Failed to delete temporary file: " + inFile.getAbsolutePath());
+      }
+      return tmpOutFile.getAbsolutePath();
+    } catch (Exception e) {
+      _logger.errorf(
+          "Exception in getWorkJson from %s using (%s, %s)\n", _coordWorkMgr, snapshotName, workId);
+      _logger.error(Throwables.getStackTraceAsString(e) + "\n");
+      return null;
+    }
+  }
+
   /**
    * Gets the questions configured at the coordinator
    *

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -2058,11 +2058,11 @@ public class Client extends AbstractClient implements IClient {
       return false;
     }
     // get the answer
-    String ansFileName = wItem.getId() + BfConsts.SUFFIX_ANSWER_JSON_FILE;
     String downloadedAnsFile =
-        _workHelper.getObject(wItem.getNetwork(), wItem.getSnapshot(), ansFileName);
+        _workHelper.getWorkJson(wItem.getNetwork(), wItem.getSnapshot(), wItem.getId());
     if (downloadedAnsFile == null) {
-      _logger.errorf("Failed to get answer file %s. (Was work killed?)\n", ansFileName);
+      _logger.errorf(
+          "Failed to get answer file for work ID %s. (Was work killed?)\n", wItem.getId());
     } else {
       String answerString = CommonUtil.readFile(Paths.get(downloadedAnsFile));
 

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -2057,14 +2057,13 @@ public class Client extends AbstractClient implements IClient {
     if (!pollResult) {
       return false;
     }
-    // get the answer
-    String downloadedAnsFile =
+    // get the JSON log of the work performed
+    String answerString =
         _workHelper.getWorkJson(wItem.getNetwork(), wItem.getSnapshot(), wItem.getId());
-    if (downloadedAnsFile == null) {
+    if (answerString == null) {
       _logger.errorf(
-          "Failed to get answer file for work ID %s. (Was work killed?)\n", wItem.getId());
+          "Failed to get JSON answer for work ID %s. (Was work killed?)\n", wItem.getId());
     } else {
-      String answerString = CommonUtil.readFile(Paths.get(downloadedAnsFile));
 
       logOutput(outWriter, answerString);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConstsV2.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/CoordConstsV2.java
@@ -36,4 +36,5 @@ public class CoordConstsV2 {
   public static final String RSC_VERSION = "version";
   public static final String RSC_WORK = "work";
   public static final String RSC_WORK_LOG = "worklog";
+  public static final String RSC_WORK_JSON = "workjson";
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -1009,13 +1009,13 @@ public final class FileBasedStorage implements StorageProvider {
   @Nonnull
   private Path getWorkLogPath(NetworkId network, SnapshotId snapshot, String workId) {
     return _d.getSnapshotOutputDir(network, snapshot)
-        .resolve(toBase64(workId) + BfConsts.SUFFIX_LOG_FILE);
+        .resolve(toBase64(workId + BfConsts.SUFFIX_LOG_FILE));
   }
 
   @Nonnull
   private Path getWorkJsonPath(NetworkId network, SnapshotId snapshot, String workId) {
     return _d.getSnapshotOutputDir(network, snapshot)
-        .resolve(toBase64(workId) + BfConsts.SUFFIX_ANSWER_JSON_FILE);
+        .resolve(toBase64(workId + BfConsts.SUFFIX_ANSWER_JSON_FILE));
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -328,6 +328,18 @@ public final class FileBasedStorage implements StorageProvider {
   }
 
   @Override
+  @Nonnull
+  public String loadWorkJson(NetworkId network, SnapshotId snapshot, String workId)
+      throws IOException {
+    Path filePath = getWorkJsonPath(network, snapshot, workId);
+    if (!Files.exists(filePath)) {
+      throw new FileNotFoundException(
+          String.format("Could not find work json for work ID: %s", workId));
+    }
+    return readFileToString(filePath, UTF_8);
+  }
+
+  @Override
   public @Nullable MajorIssueConfig loadMajorIssueConfig(
       NetworkId network, IssueSettingsId majorIssueType) {
     Path path = _d.getMajorIssueConfigDir(network, majorIssueType);
@@ -1000,6 +1012,12 @@ public final class FileBasedStorage implements StorageProvider {
         .resolve(toBase64(workId) + BfConsts.SUFFIX_LOG_FILE);
   }
 
+  @Nonnull
+  private Path getWorkJsonPath(NetworkId network, SnapshotId snapshot, String workId) {
+    return _d.getSnapshotOutputDir(network, snapshot)
+        .resolve(toBase64(workId) + BfConsts.SUFFIX_ANSWER_JSON_FILE);
+  }
+
   @Override
   public @Nonnull String loadInitialTopology(NetworkId networkId, SnapshotId snapshotId)
       throws IOException {
@@ -1034,6 +1052,12 @@ public final class FileBasedStorage implements StorageProvider {
   public void storeWorkLog(String logOutput, NetworkId network, SnapshotId snapshot, String workId)
       throws IOException {
     writeStringToFile(getWorkLogPath(network, snapshot, workId), logOutput, UTF_8);
+  }
+
+  @Override
+  public void storeWorkJson(
+      String jsonOutput, NetworkId network, SnapshotId snapshot, String workId) throws IOException {
+    writeStringToFile(getWorkJsonPath(network, snapshot, workId), jsonOutput, UTF_8);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -124,6 +124,15 @@ public interface StorageProvider {
   String loadWorkLog(NetworkId network, SnapshotId snapshot, String workId) throws IOException;
 
   /**
+   * Load the answer JSON file for a given work item ID.
+   *
+   * @throws FileNotFoundException if the log file is not found.
+   * @throws IOException if there is an error reading the log file.
+   */
+  @Nonnull
+  String loadWorkJson(NetworkId network, SnapshotId snapshot, String workId) throws IOException;
+
+  /**
    * Stores the {@link MajorIssueConfig} into the given network. Will replace any previously-stored
    * {@link MajorIssueConfig}s
    *
@@ -489,6 +498,10 @@ public interface StorageProvider {
 
   /** Store a given string as a log file for a given work item ID. */
   void storeWorkLog(String logOutput, NetworkId network, SnapshotId snapshot, String workId)
+      throws IOException;
+
+  /** Store a given string as an answer JSON file for a given work item ID. */
+  void storeWorkJson(String jsonOutput, NetworkId network, SnapshotId snapshot, String workId)
       throws IOException;
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
@@ -92,6 +92,12 @@ public class TestStorageProvider implements StorageProvider {
     throw new UnsupportedOperationException("no implementation for generated method");
   }
 
+  @Nonnull
+  @Override
+  public String loadWorkJson(NetworkId network, SnapshotId snapshot, String workId) {
+    throw new UnsupportedOperationException("no implementation for generated method");
+  }
+
   @Override
   public void storeMajorIssueConfig(
       NetworkId network, IssueSettingsId majorIssueType, MajorIssueConfig majorIssueConfig) {
@@ -306,6 +312,12 @@ public class TestStorageProvider implements StorageProvider {
   @Override
   public void storeWorkLog(
       String logOutput, NetworkId network, SnapshotId snapshot, String workId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void storeWorkJson(
+      String jsonOutput, NetworkId network, SnapshotId snapshot, String workId) {
     throw new UnsupportedOperationException();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -3323,15 +3323,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
       throws IOException {
     // Write log of WorkItem task to the configured path for logs
     if (logString != null && _settings.getTaskId() != null) {
-      Path jsonPath =
-          _settings
-              .getStorageBase()
-              .resolve(_settings.getContainer().getId())
-              .resolve(BfConsts.RELPATH_SNAPSHOTS_DIR)
-              .resolve(_settings.getTestrig().getId())
-              .resolve(BfConsts.RELPATH_OUTPUT)
-              .resolve(_settings.getTaskId() + BfConsts.SUFFIX_ANSWER_JSON_FILE);
-      CommonUtil.writeFile(jsonPath, logString);
+      _storage.storeWorkJson(
+          logString, _settings.getContainer(), _settings.getTestrig(), _settings.getTaskId());
     }
     // Write answer.json and answer-pretty.json if WorkItem was answering a question
     if (_settings.getQuestionName() != null) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -1604,6 +1604,31 @@ public class WorkMgr extends AbstractCoordinator {
     }
   }
 
+  /**
+   * Load and return the answer JSON file for a given work item ID in a given snapshot.
+   *
+   * @throws IOException if the JSON could not be read successfully.
+   * @return Content of the JSON file as a string; {@code null} if the network, snapshot or log file
+   *     is not available
+   */
+  @Nullable
+  public String getWorkJson(String networkName, String snapshotName, String workId)
+      throws IOException {
+    if (!_idManager.hasNetworkId(networkName)) {
+      return null;
+    }
+    NetworkId networkId = _idManager.getNetworkId(networkName);
+    if (!_idManager.hasSnapshotId(snapshotName, networkId)) {
+      return null;
+    }
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshotName, networkId);
+    try {
+      return _storage.loadWorkJson(networkId, snapshotId, workId);
+    } catch (FileNotFoundException e) {
+      return null;
+    }
+  }
+
   public String initNetwork(@Nullable String network, @Nullable String networkPrefix) {
     String newNetworkName =
         isNullOrEmpty(network) ? networkPrefix + "_" + UUID.randomUUID() : network;

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/SnapshotResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/SnapshotResource.java
@@ -7,6 +7,7 @@ import static org.batfish.common.CoordConstsV2.RSC_NODE_ROLES;
 import static org.batfish.common.CoordConstsV2.RSC_OBJECTS;
 import static org.batfish.common.CoordConstsV2.RSC_POJO_TOPOLOGY;
 import static org.batfish.common.CoordConstsV2.RSC_TOPOLOGY;
+import static org.batfish.common.CoordConstsV2.RSC_WORK_JSON;
 import static org.batfish.common.CoordConstsV2.RSC_WORK_LOG;
 
 import java.io.IOException;
@@ -128,5 +129,16 @@ public final class SnapshotResource {
       return Response.status(Status.NOT_FOUND).build();
     }
     return Response.status(Status.OK).entity(log).build();
+  }
+
+  @Path(RSC_WORK_JSON + "/{workid}")
+  @Produces(MediaType.TEXT_PLAIN)
+  @GET
+  public Response getWorkJson(@PathParam("workid") String workId) throws IOException {
+    String json = Main.getWorkMgr().getWorkJson(_network, _snapshot, workId);
+    if (json == null) {
+      return Response.status(Status.NOT_FOUND).build();
+    }
+    return Response.status(Status.OK).entity(json).build();
   }
 }


### PR DESCRIPTION
- switch client to use new call instead of get-object
- only store and load work json answer file through StorageProvider
- only one remaining use of v1 get-object after this