### PR TITLE
sanitize id paths via base64 encoding

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -841,11 +841,11 @@ public final class FileBasedStorage implements StorageProvider {
     return _d.getSnapshotObjectsDir(networkId, snapshotId).resolve(encodedKey);
   }
 
-  private static @Nonnull String toBase64(String key) {
+  public static @Nonnull String toBase64(String key) {
     return Base64.getUrlEncoder().encodeToString(key.getBytes(StandardCharsets.UTF_8));
   }
 
-  private static @Nonnull String fromBase64(String key) {
+  public static @Nonnull String fromBase64(String key) {
     return new String(Base64.getUrlDecoder().decode(key), StandardCharsets.UTF_8);
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/identifiers/BUILD
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/identifiers/BUILD
@@ -1,0 +1,45 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+load("@batfish//skylark:junit.bzl", "junit_tests")
+load("@batfish//skylark:pmd_test.bzl", "pmd_test")
+
+java_library(
+    name = "identifiers",
+    srcs = glob(
+        ["*.java"],
+        exclude = ["*Test.java"],
+    ),
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "@maven//:com_google_code_findbugs_jsr305",
+    ],
+)
+
+pmd_test(
+    name = "pmd",
+    lib = ":identifiers",
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob(
+        ["*.java"],
+        exclude = ["Test*.java"],
+
+    ),
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:junit_junit",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)
+
+

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/identifiers/FileBasedIdResolverTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/identifiers/FileBasedIdResolverTest.java
@@ -1,0 +1,86 @@
+package org.batfish.identifiers;
+
+import static org.batfish.identifiers.FileBasedIdResolver.listResolvableNames;
+import static org.batfish.storage.FileBasedStorage.fromBase64;
+import static org.batfish.storage.FileBasedStorage.toBase64;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Test of {@link FileBasedIdResolver}. */
+public final class FileBasedIdResolverTest {
+
+  private FileBasedIdResolver _resolver;
+
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  @Before
+  public void setup() {
+    _resolver = new FileBasedIdResolver(_folder.getRoot().toPath());
+  }
+
+  private static void assertLastComponentBase64Encoded(Path idPath) {
+    assertNotNull(fromBase64(idPath.getFileName().toString()));
+  }
+
+  @Test
+  public void testListResolvableNames() throws IOException {
+    Path root = _folder.getRoot().toPath();
+    Files.createFile(root.resolve(toBase64("foo.id")));
+    Files.createFile(root.resolve(toBase64("bar.id")));
+    Files.createFile(root.resolve("baz.id")); // should be excluded because it is not base64-encoded
+    Files.createFile(
+        root.resolve(toBase64("bath"))); // should be excluded because it doesn't end in ID
+
+    assertThat(listResolvableNames(root), containsInAnyOrder("foo", "bar"));
+  }
+
+  @Test
+  public void testGetAnalysisIdPath() {
+    assertLastComponentBase64Encoded(
+        _resolver.getAnalysisIdPath("analysis1", new NetworkId("net1_id")));
+  }
+
+  @Test
+  public void testGetIssueSettingsIdPath() {
+    assertLastComponentBase64Encoded(
+        _resolver.getIssueSettingsIdPath("majorIssueType1", new NetworkId("net1_id")));
+  }
+
+  @Test
+  public void testGetNetworkIdPath() {
+    assertLastComponentBase64Encoded(_resolver.getNetworkIdPath("net1"));
+  }
+
+  @Test
+  public void testGetQuestionIdPath() {
+    // with analysis
+    assertLastComponentBase64Encoded(
+        _resolver.getQuestionIdPath(
+            "question1", new NetworkId("net1_id"), new AnalysisId("analysis1_id")));
+
+    // without analysis
+    assertLastComponentBase64Encoded(
+        _resolver.getQuestionIdPath("question1", new NetworkId("net1_id"), null));
+  }
+
+  @Test
+  public void testGetQuestionSettingsIdPath() {
+    assertLastComponentBase64Encoded(
+        _resolver.getQuestionSettingsIdPath("questionClassId1", new NetworkId("net1_id")));
+  }
+
+  @Test
+  public void testGetSnapshotIdPath() {
+    assertLastComponentBase64Encoded(
+        _resolver.getSnapshotIdPath("snapshot1", new NetworkId("net1_id")));
+  }
+}

--- a/projects/batfish/BUILD
+++ b/projects/batfish/BUILD
@@ -115,6 +115,7 @@ junit_tests(
         "//projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd:matchers",
         "//projects/batfish-common-protocol/src/test/java/org/batfish/common/matchers",
         "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/identifiers",
         "//projects/bdd",
         "//projects/symbolic",
         "@maven//:com_google_code_findbugs_jsr305",


### PR DESCRIPTION
- supports relaxed restrictions on entity names
- prevents malicious path injection