### PR TITLE
Asymmetric forwarding via VPC connections

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/NatGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/NatGateway.java
@@ -45,7 +45,6 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.TraceElement;
-import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.NotMatchExpr;
 import org.batfish.datamodel.acl.TrueExpr;
@@ -279,8 +278,8 @@ final class NatGateway implements AwsVpcEntity, Serializable {
     String vrfNameOnVpc = Vpc.vrfNameForLink(_natGatewayId);
 
     if (!vpcCfg.getVrfs().containsKey(vrfNameOnVpc)) {
-      Vrf vrf = Vrf.builder().setOwner(vpcCfg).setName(vrfNameOnVpc).build();
-      vpc.initializeVrf(vrf);
+      warnings.redFlag(String.format("VRF %s not found on VPC %s", vrfNameOnVpc, _vpcId));
+      return null;
     }
 
     connect(awsConfiguration, natGwCfg, DEFAULT_VRF_NAME, vpcCfg, vrfNameOnVpc, "");

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
@@ -208,21 +208,23 @@ public class Subnet implements AwsVpcEntity, Serializable {
         .values()
         .forEach(
             vrf -> {
+              String interfaceSuffix = vrf.getName().equals(DEFAULT_VRF_NAME) ? "" : vrf.getName();
               connect(
                   awsConfiguration,
                   cfgNode,
                   DEFAULT_VRF_NAME,
                   vpcConfigNode,
                   vrf.getName(),
-                  vrf.getName().equals(DEFAULT_VRF_NAME) ? "" : vrf.getName());
+                  interfaceSuffix);
 
               // add a static route on the vpc router for this subnet;
               addStaticRoute(
                   vrf,
                   toStaticRoute(
                       _cidrBlock,
-                      interfaceNameToRemote(cfgNode),
-                      getInterfaceLinkLocalIp(cfgNode, _vpcId)));
+                      interfaceNameToRemote(cfgNode, interfaceSuffix),
+                      getInterfaceLinkLocalIp(
+                          cfgNode, interfaceNameToRemote(vpcConfigNode, interfaceSuffix))));
             });
 
     Optional<VpnGateway> optVpnGateway = region.findVpnGateway(_vpcId);

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGateway.java
@@ -368,8 +368,8 @@ final class TransitGateway implements AwsVpcEntity, Serializable {
     String vrfNameOnTgw = vrfNameForRouteTable(attachment.getAssociation().getRouteTableId());
 
     if (!vpcCfg.getVrfs().containsKey(vrfNameOnVpc)) {
-      Vrf vrf = Vrf.builder().setOwner(vpcCfg).setName(vrfNameOnVpc).build();
-      vpc.initializeVrf(vrf);
+      warnings.redFlag(String.format("VRF %s not found on VPC %s", vrfNameOnVpc, vpc.getId()));
+      return;
     }
 
     // the VRF will exist if this routing table has been encountered before

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -339,8 +339,8 @@ final class Utils {
 
     String vrfNameOnVpc = Vpc.vrfNameForLink(gatewayId);
     if (!vpcCfg.getVrfs().containsKey(vrfNameOnVpc)) {
-      Vrf vrf = Vrf.builder().setOwner(vpcCfg).setName(vrfNameOnVpc).build();
-      vpc.initializeVrf(vrf);
+      warnings.redFlag(String.format("VRF %s not found on VPC %s", vrfNameOnVpc, vpcId));
+      return null;
     }
 
     connect(awsConfiguration, gatewayCfg, DEFAULT_VRF_NAME, vpcCfg, vrfNameOnVpc, "");

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Vpc.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Vpc.java
@@ -2,6 +2,7 @@ package org.batfish.representation.aws;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.representation.aws.Utils.checkNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -116,8 +117,8 @@ final class Vpc implements AwsVpcEntity, Serializable {
   /**
    * Returns {@link Configuration} corresponding to this VPC node.
    *
-   * <p>We only create the node here. Interfaces are added when we traverse its neighbors such as
-   * subnets and internet gateways
+   * <p>We create the VI node and VRFs here. Interfaces and links are added when we traverse its
+   * neighbors such as subnets and internet gateways
    */
   Configuration toConfigurationNode(
       ConvertedConfiguration awsConfiguration, Region region, Warnings warnings) {
@@ -126,7 +127,31 @@ final class Vpc implements AwsVpcEntity, Serializable {
     cfgNode.getVendorFamily().getAws().setRegion(region.getName());
     cfgNode.getVendorFamily().getAws().setVpcId(_vpcId);
 
-    initializeVrf(cfgNode.getDefaultVrf());
+    initializeVrf(DEFAULT_VRF_NAME, cfgNode);
+
+    region.getInternetGateways().values().stream()
+        .filter(igw -> igw.getAttachmentVpcIds().contains(_vpcId))
+        .forEach(igw -> initializeVrf(vrfNameForLink(igw.getId()), cfgNode));
+
+    region.getVpnGateways().values().stream()
+        .filter(vgw -> vgw.getAttachmentVpcIds().contains(_vpcId))
+        .forEach(vgw -> initializeVrf(vrfNameForLink(vgw.getId()), cfgNode));
+
+    region.getNatGateways().values().stream()
+        .filter(ngw -> ngw.getVpcId().equals(_vpcId))
+        .forEach(ngw -> initializeVrf(vrfNameForLink(ngw.getId()), cfgNode));
+
+    region.getTransitGatewayVpcAttachments().values().stream()
+        .filter(attachment -> attachment.getVpcId().equals(_vpcId))
+        .forEach(attachment -> initializeVrf(vrfNameForLink(attachment.getId()), cfgNode));
+
+    region.getVpcPeeringConnections().values().stream()
+        .filter(
+            connection ->
+                connection.getAccepterVpcId().equals(_vpcId)
+                    || connection.getRequesterVpcId().equals(_vpcId))
+        .forEach(connection -> initializeVrf(vrfNameForLink(connection.getId()), cfgNode));
+
     return cfgNode;
   }
 
@@ -142,7 +167,11 @@ final class Vpc implements AwsVpcEntity, Serializable {
    *       will get the traffic, rather than ECMP.
    * </ul>
    */
-  void initializeVrf(Vrf vrf) {
+  void initializeVrf(String vrfName, Configuration vpcCfg) {
+    Vrf vrf =
+        vrfName.equals(DEFAULT_VRF_NAME)
+            ? vpcCfg.getDefaultVrf()
+            : Vrf.builder().setOwner(vpcCfg).setName(vrfName).build();
     _cidrBlockAssociations.forEach(
         cb ->
             vrf.getStaticRoutes()
@@ -154,6 +183,23 @@ final class Vpc implements AwsVpcEntity, Serializable {
                         .setNextHopInterface(Interface.NULL_INTERFACE_NAME)
                         .build()));
   }
+
+  private static String subnetFacingIfaceName(String subnetId, String vrfName) {
+    return vrfName.equals(DEFAULT_VRF_NAME) ? subnetId : subnetId + "-" + vrfName;
+  }
+
+  //  void initializeVrf(Vrf vrf) {
+  //    _cidrBlockAssociations.forEach(
+  //        cb ->
+  //            vrf.getStaticRoutes()
+  //                .add(
+  //                    StaticRoute.builder()
+  //                        .setAdministrativeCost(255)
+  //                        .setMetric(Route.DEFAULT_STATIC_ROUTE_COST)
+  //                        .setNetwork(cb)
+  //                        .setNextHopInterface(Interface.NULL_INTERFACE_NAME)
+  //                        .build()));
+  //  }
 
   /** Return the hostname used for a VPC Id */
   static String nodeName(String vpcId) {

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicPrivateSubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicPrivateSubnetTest.java
@@ -192,7 +192,7 @@ public class AwsConfigurationPublicPrivateSubnetTest {
         _batfish);
 
     // The public subnet does not point to the VGW for outgoing traffic, but it's private space must
-    // still accessible via the VGW since the VPC announces the whole space
+    // still be accessible via the VGW since the VPC announces the whole space
     testTrace(
         getAnyFlow(_vgw, _publicInstancePrivateIp, _batfish),
         FlowDisposition.DENIED_IN,

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicPrivateSubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicPrivateSubnetTest.java
@@ -191,12 +191,12 @@ public class AwsConfigurationPublicPrivateSubnetTest {
         ImmutableList.of(_vgw),
         _batfish);
 
-    // The private subnet does not point to the VGW, so its (private) address space is not available
-    // via the VGW
+    // The public subnet does not point to the VGW for outgoing traffic, but it's private space must
+    // still accessible via the VGW since the VPC announces the whole space
     testTrace(
         getAnyFlow(_vgw, _publicInstancePrivateIp, _batfish),
-        FlowDisposition.NULL_ROUTED,
-        ImmutableList.of(_vgw, _vpc),
+        FlowDisposition.DENIED_IN,
+        ImmutableList.of(_vgw, _vpc, _publicSubnet, _publicInstance),
         _batfish);
 
     testTrace(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationTransitGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationTransitGatewayTest.java
@@ -17,9 +17,9 @@ import org.junit.rules.TemporaryFolder;
 
 /**
  * E2e tests for transit gateway. The configuration was pulled after creating two VPCs A and B and
- * connecting them via a transit gateway. VPC A has two subnets in different availability zones,
- * only one of which is connected to the VPC's attachment to the gateway. VPC B has only one subnet,
- * which is connected to the attachment.
+ * connecting them via a transit gateway. VPC A has two subnets in different availability zones; the
+ * routing table of only of those points to the transit gateway attachment. VPC B has only one
+ * subnet, which is connected to the attachment.
  */
 public class AwsConfigurationTransitGatewayTest {
 
@@ -51,7 +51,7 @@ public class AwsConfigurationTransitGatewayTest {
   private static String _vpcB = "vpc-00a31ce9d0c06675c";
 
   private static String _subnetA = "subnet-006a19c846f047bd7";
-  private static String _subnetA2 = "subnet-0b5b8ddd5a69fcfcd"; // not connected to the gateway
+  private static String _subnetA2 = "subnet-0b5b8ddd5a69fcfcd"; // does not point to the gateway
   private static String _subnetB = "subnet-0ebf6378a79a3e534";
 
   private static String _instanceA = "i-06ba034d88c84ef07";
@@ -101,13 +101,16 @@ public class AwsConfigurationTransitGatewayTest {
         _batfish);
   }
 
-  /** Test connectivity from B to A2 -- should die at the VPC */
+  /**
+   * Test connectivity from B to A2 -- should get to A2. A2 not pointing to the TGW only impacts
+   * outgoing traffic, not incoming traffic.
+   */
   @Test
   public void testFromBtoA2() {
     testTrace(
         getAnyFlow(_instanceB, _instanceA2Ip, _batfish),
-        FlowDisposition.NULL_ROUTED,
-        ImmutableList.of(_instanceB, _subnetB, _vpcB, _tgw, _vpcA),
+        FlowDisposition.DENIED_IN,
+        ImmutableList.of(_instanceB, _subnetB, _vpcB, _tgw, _vpcA, _subnetA2, _instanceA2),
         _batfish);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/InternetGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/InternetGatewayTest.java
@@ -22,6 +22,7 @@ import static org.batfish.representation.aws.InternetGateway.BACKBONE_INTERFACE_
 import static org.batfish.representation.aws.InternetGateway.UNASSOCIATED_PRIVATE_IP_FILTER_NAME;
 import static org.batfish.representation.aws.InternetGateway.computeUnassociatedPrivateIpFilter;
 import static org.batfish.representation.aws.InternetGateway.configureNat;
+import static org.batfish.representation.aws.Vpc.vrfNameForLink;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -52,6 +53,7 @@ import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.PrefixRange;
 import org.batfish.datamodel.PrefixSpace;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.TransformationStep;
@@ -111,6 +113,11 @@ public class InternetGatewayTest {
             .setVpcs(ImmutableMap.of(vpc.getId(), vpc))
             .setNetworkInterfaces(ImmutableMap.of(ni.getId(), ni))
             .build();
+
+    String vrfNameOnVpc = vrfNameForLink(internetGateway.getId());
+    vpcConfig
+        .getVrfs()
+        .put(vrfNameOnVpc, Vrf.builder().setName(vrfNameOnVpc).setOwner(vpcConfig).build());
 
     ConvertedConfiguration awsConfiguration =
         new ConvertedConfiguration(ImmutableMap.of(vpcConfig.getHostname(), vpcConfig));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
@@ -270,11 +270,7 @@ public class SubnetTest {
   }
 
   private static void testProcessRouteHelper(
-      RouteV4 route,
-      String linkId,
-      Configuration vpcCfg,
-      Configuration subnetCfg,
-      Prefix subnetPrefix) {
+      RouteV4 route, String linkId, Configuration vpcCfg, Configuration subnetCfg) {
     // there should be a VRF on the VPC node
     String vrfName = vrfNameForLink(linkId);
     assertThat(vpcCfg, hasVrf(vrfName, any(Vrf.class)));
@@ -334,7 +330,7 @@ public class SubnetTest {
     subnet.processRoute(
         subnetCfg, region, route, vpcCfg, igw, null, awsConfiguration, new Warnings());
 
-    testProcessRouteHelper(route, igw.getId(), vpcCfg, subnetCfg, subnet.getCidrBlock());
+    testProcessRouteHelper(route, igw.getId(), vpcCfg, subnetCfg);
   }
 
   /** Tests that we do the right thing when processing a route for an Internet gateway. */
@@ -372,7 +368,7 @@ public class SubnetTest {
     subnet.processRoute(
         subnetCfg, region, route, vpcCfg, null, vgw, awsConfiguration, new Warnings());
 
-    testProcessRouteHelper(route, vgw.getId(), vpcCfg, subnetCfg, subnet.getCidrBlock());
+    testProcessRouteHelper(route, vgw.getId(), vpcCfg, subnetCfg);
   }
 
   /** Tests that we do the right thing when processing a route for VPC peering connection. */
@@ -411,7 +407,7 @@ public class SubnetTest {
     subnet.processRoute(
         subnetCfg, region, route, vpcCfg, null, null, awsConfiguration, new Warnings());
 
-    testProcessRouteHelper(route, connectionId, vpcCfg, subnetCfg, subnetPrefix);
+    testProcessRouteHelper(route, connectionId, vpcCfg, subnetCfg);
   }
 
   /** Tests that we do the right thing when processing a route for transit gateway. */
@@ -460,7 +456,7 @@ public class SubnetTest {
     subnet.processRoute(
         subnetCfg, region, route, vpcCfg, null, null, awsConfiguration, new Warnings());
 
-    testProcessRouteHelper(route, linkId, vpcCfg, subnetCfg, subnetPrefix);
+    testProcessRouteHelper(route, linkId, vpcCfg, subnetCfg);
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayTest.java
@@ -104,7 +104,6 @@ public class TransitGatewayTest {
 
     Prefix vpcPrefix = Prefix.parse("3.3.3.0/24");
     Vpc vpc = new Vpc("vpc", ImmutableSet.of(vpcPrefix), ImmutableMap.of());
-    Configuration vpcCfg = Utils.newAwsConfiguration(Vpc.nodeName(vpc.getId()), "aws");
 
     TransitGatewayAttachment tgwAttachment =
         new TransitGatewayAttachment(
@@ -125,6 +124,9 @@ public class TransitGatewayTest {
             .setTransitGatewayVpcAttachments(ImmutableMap.of(vpcAttachment.getId(), vpcAttachment))
             .setVpcs(ImmutableMap.of(vpc.getId(), vpc))
             .build();
+
+    Configuration vpcCfg =
+        vpc.toConfigurationNode(new ConvertedConfiguration(), region, new Warnings());
 
     ConvertedConfiguration awsConfiguration =
         new ConvertedConfiguration(ImmutableMap.of(vpcCfg.getHostname(), vpcCfg));
@@ -313,7 +315,6 @@ public class TransitGatewayTest {
 
     Prefix vpcPrefix = Prefix.parse("2.2.2.2/32");
     Vpc vpc = new Vpc("vpc", ImmutableSet.of(vpcPrefix), ImmutableMap.of()); // no prefix
-    Configuration vpcCfg = Utils.newAwsConfiguration(Vpc.nodeName(vpc.getId()), "aws");
 
     TransitGatewayAttachment tgwAttachment =
         new TransitGatewayAttachment(
@@ -347,6 +348,8 @@ public class TransitGatewayTest {
             .setVpcs(ImmutableMap.of(vpc.getId(), vpc))
             .build();
 
+    Configuration vpcCfg =
+        vpc.toConfigurationNode(new ConvertedConfiguration(), region, new Warnings());
     ConvertedConfiguration awsConfiguration =
         new ConvertedConfiguration(ImmutableMap.of(vpcCfg.getHostname(), vpcCfg));
 
@@ -385,7 +388,6 @@ public class TransitGatewayTest {
             ImmutableMap.of());
 
     Vpc vpc = new Vpc("vpc", ImmutableSet.of(), ImmutableMap.of()); // no prefix
-    Configuration vpcCfg = Utils.newAwsConfiguration(Vpc.nodeName(vpc.getId()), "aws");
 
     TransitGatewayAttachment tgwAttachment =
         new TransitGatewayAttachment(
@@ -429,6 +431,8 @@ public class TransitGatewayTest {
             .setVpcs(ImmutableMap.of(vpc.getId(), vpc))
             .build();
 
+    Configuration vpcCfg =
+        vpc.toConfigurationNode(new ConvertedConfiguration(), region, new Warnings());
     ConvertedConfiguration awsConfiguration =
         new ConvertedConfiguration(ImmutableMap.of(vpcCfg.getHostname(), vpcCfg));
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/UtilsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/UtilsTest.java
@@ -1,6 +1,5 @@
 package org.batfish.representation.aws;
 
-import static org.batfish.datamodel.Interface.NULL_INTERFACE_NAME;
 import static org.batfish.representation.aws.Utils.connectGatewayToVpc;
 import static org.batfish.representation.aws.Utils.createPublicIpsRefBook;
 import static org.batfish.representation.aws.Utils.publicIpAddressGroupName;
@@ -24,6 +23,7 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LinkLocalAddress;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.Vrf;
 import org.batfish.referencelibrary.AddressGroup;
 import org.batfish.referencelibrary.GeneratedRefBookUtils;
 import org.batfish.referencelibrary.GeneratedRefBookUtils.BookType;
@@ -110,6 +110,11 @@ public class UtilsTest {
     Region region =
         Region.builder("r1").setVpcs(ImmutableMap.of(vpcCfg.getHostname(), vpc)).build();
 
+    String vrfNameOnVpc = vrfNameForLink(gatewayCfg.getHostname());
+    vpcCfg
+        .getVrfs()
+        .put(vrfNameOnVpc, Vrf.builder().setName(vrfNameOnVpc).setOwner(vpcCfg).build());
+
     ConvertedConfiguration awsConfiguration =
         new ConvertedConfiguration(ImmutableMap.of(vpcCfg.getHostname(), vpcCfg));
 
@@ -155,10 +160,6 @@ public class UtilsTest {
         vpcCfg.getVrfs().get(vrfNameForLink(gatewayCfg.getHostname())).getStaticRoutes(),
         equalTo(
             ImmutableSortedSet.of(
-                toStaticRoute(vpcPrefix, NULL_INTERFACE_NAME)
-                    .toBuilder()
-                    .setAdministrativeCost(255)
-                    .build(), // via Vpc.initializeVrf
                 toStaticRoute(
                     Prefix.ZERO,
                     vpcIface.getName(),

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/VpcTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/VpcTest.java
@@ -1,6 +1,8 @@
 package org.batfish.representation.aws;
 
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_VPCS;
+import static org.batfish.representation.aws.Vpc.vrfNameForLink;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -9,11 +11,16 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
+import org.batfish.common.Warnings;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.common.util.CommonUtil;
+import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Prefix;
 import org.junit.Test;
 
@@ -40,5 +47,168 @@ public class VpcTest {
                     "vpc-CCCCCC",
                     ImmutableSet.of(Prefix.parse("10.100.0.0/16"), Prefix.parse("10.200.0.0/16")),
                     ImmutableMap.of()))));
+  }
+
+  /** The default VRF is properly set up */
+  @Test
+  public void testToConfigurationNode_defaultVrf() {
+    Set<Prefix> prefixes = ImmutableSet.of(Prefix.parse("1.1.1.1/32"), Prefix.parse("2.2.2.2/32"));
+    Vpc vpc = new Vpc("vpc", prefixes, ImmutableMap.of());
+
+    Configuration vpcCfg =
+        vpc.toConfigurationNode(new ConvertedConfiguration(), new Region("r"), new Warnings());
+
+    assertThat(
+        vpcCfg.getDefaultVrf().getStaticRoutes(),
+        equalTo(
+            prefixes.stream()
+                .map(Vpc::staticRouteToVpcPrefix)
+                .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()))));
+  }
+
+  /** VRFs are in place for the right IGWs */
+  @Test
+  public void testToConfigurationNod_igwVrfs() {
+    Vpc vpc = new Vpc("vpc", ImmutableSet.of(), ImmutableMap.of());
+
+    String gatewayId = "gateway";
+    Region region =
+        Region.builder("r1")
+            .setInternetGateways(
+                ImmutableMap.of(
+                    gatewayId,
+                    new InternetGateway(
+                        gatewayId, ImmutableList.of(vpc.getId()), ImmutableMap.of()),
+                    "other",
+                    new InternetGateway("other", ImmutableList.of("otherVpc"), ImmutableMap.of())))
+            .build();
+
+    Configuration vpcCfg =
+        vpc.toConfigurationNode(new ConvertedConfiguration(), region, new Warnings());
+
+    assertThat(
+        vpcCfg.getVrfs().keySet(),
+        equalTo(ImmutableSet.of(DEFAULT_VRF_NAME, vrfNameForLink(gatewayId))));
+  }
+
+  /** VRFs are in place for the right VGWs */
+  @Test
+  public void testToConfigurationNod_vgwVrfs() {
+    Vpc vpc = new Vpc("vpc", ImmutableSet.of(), ImmutableMap.of());
+
+    String gatewayId = "gateway";
+    Region region =
+        Region.builder("r1")
+            .setVpnGateways(
+                ImmutableMap.of(
+                    gatewayId,
+                    new VpnGateway(gatewayId, ImmutableList.of(vpc.getId()), ImmutableMap.of()),
+                    "other",
+                    new VpnGateway("other", ImmutableList.of("otherVpc"), ImmutableMap.of())))
+            .build();
+
+    Configuration vpcCfg =
+        vpc.toConfigurationNode(new ConvertedConfiguration(), region, new Warnings());
+
+    assertThat(
+        vpcCfg.getVrfs().keySet(),
+        equalTo(ImmutableSet.of(DEFAULT_VRF_NAME, vrfNameForLink(gatewayId))));
+  }
+
+  /** VRFs are in place for the right NAT gateways */
+  @Test
+  public void testToConfigurationNod_ngwVrfs() {
+    Vpc vpc = new Vpc("vpc", ImmutableSet.of(), ImmutableMap.of());
+
+    String gatewayId = "gateway";
+    Region region =
+        Region.builder("r1")
+            .setNatGateways(
+                ImmutableMap.of(
+                    gatewayId,
+                    new NatGateway(
+                        gatewayId, "subnet", vpc.getId(), ImmutableList.of(), ImmutableMap.of()),
+                    "other",
+                    new NatGateway(
+                        "other", "subnet", "otherVpc", ImmutableList.of(), ImmutableMap.of())))
+            .build();
+
+    Configuration vpcCfg =
+        vpc.toConfigurationNode(new ConvertedConfiguration(), region, new Warnings());
+
+    assertThat(
+        vpcCfg.getVrfs().keySet(),
+        equalTo(ImmutableSet.of(DEFAULT_VRF_NAME, vrfNameForLink(gatewayId))));
+  }
+
+  /** VRFs are in place for the right TGW attachments */
+  @Test
+  public void testToConfigurationNod_tgwAttachmentVrfs() {
+    Vpc vpc = new Vpc("vpc", ImmutableSet.of(), ImmutableMap.of());
+
+    String attachment = "attachment";
+    Region region =
+        Region.builder("r1")
+            .setTransitGatewayVpcAttachments(
+                ImmutableMap.of(
+                    attachment,
+                    new TransitGatewayVpcAttachment(
+                        attachment, "tgw", vpc.getId(), ImmutableList.of()),
+                    "other",
+                    new TransitGatewayVpcAttachment(
+                        "other",
+                        "tgw", // same TGW different VPC
+                        "otherVpc",
+                        ImmutableList.of())))
+            .build();
+
+    Configuration vpcCfg =
+        vpc.toConfigurationNode(new ConvertedConfiguration(), region, new Warnings());
+
+    assertThat(
+        vpcCfg.getVrfs().keySet(),
+        equalTo(ImmutableSet.of(DEFAULT_VRF_NAME, vrfNameForLink(attachment))));
+  }
+
+  /** VRFs are in place for the right VPC peering connections */
+  @Test
+  public void testToConfigurationNod_vpcPeeringVrfs() {
+    Vpc vpc = new Vpc("vpc", ImmutableSet.of(), ImmutableMap.of());
+
+    String connectionRequester = "requester";
+    String connectionAccepter = "accepter";
+    Region region =
+        Region.builder("r1")
+            .setVpcPeerings(
+                ImmutableMap.of(
+                    connectionAccepter,
+                    new VpcPeeringConnection(
+                        connectionAccepter,
+                        vpc.getId(),
+                        ImmutableList.of(),
+                        "requester",
+                        ImmutableList.of()),
+                    connectionRequester,
+                    new VpcPeeringConnection(
+                        connectionRequester,
+                        "accepter",
+                        ImmutableList.of(),
+                        vpc.getId(),
+                        ImmutableList.of()),
+                    "other",
+                    new VpcPeeringConnection(
+                        "other", "accepter", ImmutableList.of(), "requested", ImmutableList.of())))
+            .build();
+
+    Configuration vpcCfg =
+        vpc.toConfigurationNode(new ConvertedConfiguration(), region, new Warnings());
+
+    assertThat(
+        vpcCfg.getVrfs().keySet(),
+        equalTo(
+            ImmutableSet.of(
+                DEFAULT_VRF_NAME,
+                vrfNameForLink(connectionAccepter),
+                vrfNameForLink(connectionRequester))));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/VpnGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/VpnGatewayTest.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDeviceMode
 import static org.batfish.representation.aws.AwsVpcEntity.TAG_NAME;
 import static org.batfish.representation.aws.Utils.ACCEPT_ALL_BGP;
 import static org.batfish.representation.aws.Utils.toStaticRoute;
+import static org.batfish.representation.aws.Vpc.vrfNameForLink;
 import static org.batfish.representation.aws.VpnGateway.VGW_EXPORT_POLICY_NAME;
 import static org.batfish.representation.aws.VpnGateway.VGW_IMPORT_POLICY_NAME;
 import static org.hamcrest.Matchers.equalTo;
@@ -27,6 +28,7 @@ import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.PrefixRange;
 import org.batfish.datamodel.PrefixSpace;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.representation.aws.VpnConnection.GatewayType;
 import org.junit.Test;
@@ -86,6 +88,11 @@ public class VpnGatewayTest {
     ConvertedConfiguration awsConfiguration =
         new ConvertedConfiguration(ImmutableMap.of(vpcConfig.getHostname(), vpcConfig));
 
+    String vrfNameOnVpc = vrfNameForLink(vgw.getId());
+    vpcConfig
+        .getVrfs()
+        .put(vrfNameOnVpc, Vrf.builder().setName(vrfNameOnVpc).setOwner(vpcConfig).build());
+
     Configuration vgwConfig = vgw.toConfigurationNode(awsConfiguration, region, new Warnings());
     assertThat(vgwConfig, hasDeviceModel(DeviceModel.AWS_VPN_GATEWAY));
     assertThat(vgwConfig.getHumanName(), equalTo("vgw-name"));
@@ -123,6 +130,11 @@ public class VpnGatewayTest {
             .setVpcs(ImmutableMap.of(vpc.getId(), vpc))
             .setVpnConnections(ImmutableMap.of(vpnConnection.getId(), vpnConnection))
             .build();
+
+    String vrfNameOnVpc = vrfNameForLink(vgw.getId());
+    vpcConfig
+        .getVrfs()
+        .put(vrfNameOnVpc, Vrf.builder().setName(vrfNameOnVpc).setOwner(vpcConfig).build());
 
     ConvertedConfiguration awsConfiguration =
         new ConvertedConfiguration(ImmutableMap.of(vpcConfig.getHostname(), vpcConfig));

--- a/tests/aws/topology-example-aws.ref
+++ b/tests/aws/topology-example-aws.ref
@@ -175,16 +175,23 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-vpc-b390fad5-subnet-1641fa70-igw-9b93ddfc",
-      "name" : "subnet-1641fa70-igw-9b93ddfc",
-      "nodeId" : "node-vpc-b390fad5",
+      "id" : "interface-node-vpc-925131f4-subnet-8d0cbdeb-vrf-igw-fac5839d",
+      "name" : "subnet-8d0cbdeb-vrf-igw-fac5839d",
+      "nodeId" : "node-vpc-925131f4",
       "type" : "PHYSICAL",
       "properties" : null
     },
     {
-      "id" : "interface-node-subnet-1641fa70-vpc-b390fad5-igw-9b93ddfc",
-      "name" : "vpc-b390fad5-igw-9b93ddfc",
-      "nodeId" : "node-subnet-1641fa70",
+      "id" : "interface-node-subnet-8d0cbdeb-vpc-925131f4-vrf-igw-fac5839d",
+      "name" : "vpc-925131f4-vrf-igw-fac5839d",
+      "nodeId" : "node-subnet-8d0cbdeb",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-subnet-073b8061-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
+      "nodeId" : "node-subnet-073b8061",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -196,30 +203,9 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-vpc-b390fad5-subnet-7044ff16-igw-9b93ddfc",
-      "name" : "subnet-7044ff16-igw-9b93ddfc",
-      "nodeId" : "node-vpc-b390fad5",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
       "id" : "interface-node-test-rds-test-rds-subnet-1641fa70",
       "name" : "test-rds-subnet-1641fa70",
       "nodeId" : "node-test-rds",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "id" : "interface-node-subnet-62f14104-vpc-925131f4-igw-fac5839d",
-      "name" : "vpc-925131f4-igw-fac5839d",
-      "nodeId" : "node-subnet-62f14104",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "id" : "interface-node-vpc-f8fad69d-subnet-1f315846-igw-068fee63",
-      "name" : "subnet-1f315846-igw-068fee63",
-      "nodeId" : "node-vpc-f8fad69d",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -280,6 +266,20 @@
       "properties" : null
     },
     {
+      "id" : "interface-node-subnet-d9cafabc-vpc-f8fad69d-vrf-igw-068fee63",
+      "name" : "vpc-f8fad69d-vrf-igw-068fee63",
+      "nodeId" : "node-subnet-d9cafabc",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-vpc-b390fad5-subnet-1641fa70-vrf-igw-9b93ddfc",
+      "name" : "subnet-1641fa70-vrf-igw-9b93ddfc",
+      "nodeId" : "node-vpc-b390fad5",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
       "id" : "interface-node-vpc-f8fad69d-subnet-d9cafabc",
       "name" : "subnet-d9cafabc",
       "nodeId" : "node-vpc-f8fad69d",
@@ -308,9 +308,23 @@
       "properties" : null
     },
     {
+      "id" : "interface-node-subnet-62f14104-vpc-925131f4-vrf-igw-fac5839d",
+      "name" : "vpc-925131f4-vrf-igw-fac5839d",
+      "nodeId" : "node-subnet-62f14104",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
       "id" : "interface-node-vpc-b390fad5-subnet-1641fa70",
       "name" : "subnet-1641fa70",
       "nodeId" : "node-vpc-b390fad5",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-subnet-7044ff16-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
+      "nodeId" : "node-subnet-7044ff16",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -343,13 +357,6 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-subnet-d9cafabc-vpc-f8fad69d-igw-068fee63",
-      "name" : "vpc-f8fad69d-igw-068fee63",
-      "nodeId" : "node-subnet-d9cafabc",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
       "id" : "interface-node-vgw-81fd279f-vpc-815775e7",
       "name" : "vpc-815775e7",
       "nodeId" : "node-vgw-81fd279f",
@@ -357,16 +364,16 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-vpc-b390fad5-subnet-30398256-igw-9b93ddfc",
-      "name" : "subnet-30398256-igw-9b93ddfc",
+      "id" : "interface-node-vpc-b390fad5-subnet-073b8061",
+      "name" : "subnet-073b8061",
       "nodeId" : "node-vpc-b390fad5",
       "type" : "PHYSICAL",
       "properties" : null
     },
     {
-      "id" : "interface-node-vpc-b390fad5-subnet-073b8061",
-      "name" : "subnet-073b8061",
-      "nodeId" : "node-vpc-b390fad5",
+      "id" : "interface-node-vpc-925131f4-subnet-62f14104-vrf-igw-fac5839d",
+      "name" : "subnet-62f14104-vrf-igw-fac5839d",
+      "nodeId" : "node-vpc-925131f4",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -385,36 +392,22 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-subnet-1f315846-vpc-f8fad69d-igw-068fee63",
-      "name" : "vpc-f8fad69d-igw-068fee63",
-      "nodeId" : "node-subnet-1f315846",
+      "id" : "interface-node-vpc-b390fad5-subnet-30398256-vrf-igw-9b93ddfc",
+      "name" : "subnet-30398256-vrf-igw-9b93ddfc",
+      "nodeId" : "node-vpc-b390fad5",
       "type" : "PHYSICAL",
       "properties" : null
     },
     {
-      "id" : "interface-node-vpc-f8fad69d-subnet-9c8adceb-igw-068fee63",
-      "name" : "subnet-9c8adceb-igw-068fee63",
-      "nodeId" : "node-vpc-f8fad69d",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "id" : "interface-node-subnet-9c8adceb-vpc-f8fad69d-igw-068fee63",
-      "name" : "vpc-f8fad69d-igw-068fee63",
-      "nodeId" : "node-subnet-9c8adceb",
+      "id" : "interface-node-subnet-f73a8191-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
+      "nodeId" : "node-subnet-f73a8191",
       "type" : "PHYSICAL",
       "properties" : null
     },
     {
       "id" : "interface-node-vpc-f8fad69d-subnet-9c8adceb",
       "name" : "subnet-9c8adceb",
-      "nodeId" : "node-vpc-f8fad69d",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "id" : "interface-node-vpc-f8fad69d-subnet-d9cafabc-igw-068fee63",
-      "name" : "subnet-d9cafabc-igw-068fee63",
       "nodeId" : "node-vpc-f8fad69d",
       "type" : "PHYSICAL",
       "properties" : null
@@ -441,9 +434,9 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-subnet-7044ff16-vpc-b390fad5-igw-9b93ddfc",
-      "name" : "vpc-b390fad5-igw-9b93ddfc",
-      "nodeId" : "node-subnet-7044ff16",
+      "id" : "interface-node-vpc-b390fad5-subnet-073b8061-vrf-igw-9b93ddfc",
+      "name" : "subnet-073b8061-vrf-igw-9b93ddfc",
+      "nodeId" : "node-vpc-b390fad5",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -483,30 +476,16 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-subnet-30398256-vpc-b390fad5-igw-9b93ddfc",
-      "name" : "vpc-b390fad5-igw-9b93ddfc",
-      "nodeId" : "node-subnet-30398256",
+      "id" : "interface-node-subnet-9c8adceb-vpc-f8fad69d-vrf-igw-068fee63",
+      "name" : "vpc-f8fad69d-vrf-igw-068fee63",
+      "nodeId" : "node-subnet-9c8adceb",
       "type" : "PHYSICAL",
       "properties" : null
     },
     {
-      "id" : "interface-node-subnet-073b8061-vpc-b390fad5-igw-9b93ddfc",
-      "name" : "vpc-b390fad5-igw-9b93ddfc",
-      "nodeId" : "node-subnet-073b8061",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "id" : "interface-node-vpc-925131f4-subnet-62f14104-igw-fac5839d",
-      "name" : "subnet-62f14104-igw-fac5839d",
-      "nodeId" : "node-vpc-925131f4",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "id" : "interface-node-vpc-b390fad5-subnet-073b8061-igw-9b93ddfc",
-      "name" : "subnet-073b8061-igw-9b93ddfc",
-      "nodeId" : "node-vpc-b390fad5",
+      "id" : "interface-node-vpc-f8fad69d-subnet-9c8adceb-vrf-igw-068fee63",
+      "name" : "subnet-9c8adceb-vrf-igw-068fee63",
+      "nodeId" : "node-vpc-f8fad69d",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -518,16 +497,30 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-subnet-f73a8191-vpc-b390fad5-igw-9b93ddfc",
-      "name" : "vpc-b390fad5-igw-9b93ddfc",
-      "nodeId" : "node-subnet-f73a8191",
+      "id" : "interface-node-vpc-b390fad5-igw-9b93ddfc",
+      "name" : "igw-9b93ddfc",
+      "nodeId" : "node-vpc-b390fad5",
       "type" : "PHYSICAL",
       "properties" : null
     },
     {
-      "id" : "interface-node-vpc-b390fad5-igw-9b93ddfc",
-      "name" : "igw-9b93ddfc",
-      "nodeId" : "node-vpc-b390fad5",
+      "id" : "interface-node-vpc-f8fad69d-subnet-1f315846-vrf-igw-068fee63",
+      "name" : "subnet-1f315846-vrf-igw-068fee63",
+      "nodeId" : "node-vpc-f8fad69d",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-subnet-1641fa70-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
+      "nodeId" : "node-subnet-1641fa70",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-subnet-1f315846-vpc-f8fad69d-vrf-igw-068fee63",
+      "name" : "vpc-f8fad69d-vrf-igw-068fee63",
+      "nodeId" : "node-subnet-1f315846",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -560,9 +553,9 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-vpc-b390fad5-subnet-f73a8191-igw-9b93ddfc",
-      "name" : "subnet-f73a8191-igw-9b93ddfc",
-      "nodeId" : "node-vpc-b390fad5",
+      "id" : "interface-node-subnet-30398256-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
+      "nodeId" : "node-subnet-30398256",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -570,6 +563,27 @@
       "id" : "interface-node-subnet-1f315846-vpc-f8fad69d",
       "name" : "vpc-f8fad69d",
       "nodeId" : "node-subnet-1f315846",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-vpc-f8fad69d-subnet-d9cafabc-vrf-igw-068fee63",
+      "name" : "subnet-d9cafabc-vrf-igw-068fee63",
+      "nodeId" : "node-vpc-f8fad69d",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-vpc-b390fad5-subnet-7044ff16-vrf-igw-9b93ddfc",
+      "name" : "subnet-7044ff16-vrf-igw-9b93ddfc",
+      "nodeId" : "node-vpc-b390fad5",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-vpc-b390fad5-subnet-f73a8191-vrf-igw-9b93ddfc",
+      "name" : "subnet-f73a8191-vrf-igw-9b93ddfc",
+      "nodeId" : "node-vpc-b390fad5",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -582,13 +596,6 @@
     }
   ],
   "links" : [
-    {
-      "dstId" : "interface-node-vpc-f8fad69d-subnet-1f315846-igw-068fee63",
-      "id" : "link-interface-node-subnet-1f315846-vpc-f8fad69d-igw-068fee63-interface-node-vpc-f8fad69d-subnet-1f315846-igw-068fee63",
-      "srcId" : "interface-node-subnet-1f315846-vpc-f8fad69d-igw-068fee63",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
     {
       "dstId" : "interface-node-subnet-7044ff16-to-instances",
       "id" : "link-interface-node-es-domain-es-domain-subnet-7044ff16-interface-node-subnet-7044ff16-to-instances",
@@ -611,6 +618,13 @@
       "properties" : null
     },
     {
+      "dstId" : "interface-node-subnet-1641fa70-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "id" : "link-interface-node-vpc-b390fad5-subnet-1641fa70-vrf-igw-9b93ddfc-interface-node-subnet-1641fa70-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "srcId" : "interface-node-vpc-b390fad5-subnet-1641fa70-vrf-igw-9b93ddfc",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
       "dstId" : "interface-node-vpc-f8fad69d-subnet-9c8adceb",
       "id" : "link-interface-node-subnet-9c8adceb-vpc-f8fad69d-interface-node-vpc-f8fad69d-subnet-9c8adceb",
       "srcId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d",
@@ -618,23 +632,9 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-vpc-f8fad69d-subnet-d9cafabc-igw-068fee63",
-      "id" : "link-interface-node-subnet-d9cafabc-vpc-f8fad69d-igw-068fee63-interface-node-vpc-f8fad69d-subnet-d9cafabc-igw-068fee63",
-      "srcId" : "interface-node-subnet-d9cafabc-vpc-f8fad69d-igw-068fee63",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
       "dstId" : "interface-node-subnet-62f14104-vpc-925131f4",
       "id" : "link-interface-node-vpc-925131f4-subnet-62f14104-interface-node-subnet-62f14104-vpc-925131f4",
       "srcId" : "interface-node-vpc-925131f4-subnet-62f14104",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-vpc-925131f4-subnet-62f14104-igw-fac5839d",
-      "id" : "link-interface-node-subnet-62f14104-vpc-925131f4-igw-fac5839d-interface-node-vpc-925131f4-subnet-62f14104-igw-fac5839d",
-      "srcId" : "interface-node-subnet-62f14104-vpc-925131f4-igw-fac5839d",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -653,13 +653,6 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-1641fa70-igw-9b93ddfc",
-      "id" : "link-interface-node-subnet-1641fa70-vpc-b390fad5-igw-9b93ddfc-interface-node-vpc-b390fad5-subnet-1641fa70-igw-9b93ddfc",
-      "srcId" : "interface-node-subnet-1641fa70-vpc-b390fad5-igw-9b93ddfc",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
       "dstId" : "interface-node-subnet-30398256-vpc-b390fad5",
       "id" : "link-interface-node-vpc-b390fad5-subnet-30398256-interface-node-subnet-30398256-vpc-b390fad5",
       "srcId" : "interface-node-vpc-b390fad5-subnet-30398256",
@@ -667,37 +660,23 @@
       "properties" : null
     },
     {
+      "dstId" : "interface-node-vpc-f8fad69d-subnet-1f315846-vrf-igw-068fee63",
+      "id" : "link-interface-node-subnet-1f315846-vpc-f8fad69d-vrf-igw-068fee63-interface-node-vpc-f8fad69d-subnet-1f315846-vrf-igw-068fee63",
+      "srcId" : "interface-node-subnet-1f315846-vpc-f8fad69d-vrf-igw-068fee63",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-vpc-925131f4-subnet-8d0cbdeb-vrf-igw-fac5839d",
+      "id" : "link-interface-node-subnet-8d0cbdeb-vpc-925131f4-vrf-igw-fac5839d-interface-node-vpc-925131f4-subnet-8d0cbdeb-vrf-igw-fac5839d",
+      "srcId" : "interface-node-subnet-8d0cbdeb-vpc-925131f4-vrf-igw-fac5839d",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
       "dstId" : "interface-node-vpc-f8fad69d-subnet-1f315846",
       "id" : "link-interface-node-subnet-1f315846-vpc-f8fad69d-interface-node-vpc-f8fad69d-subnet-1f315846",
       "srcId" : "interface-node-subnet-1f315846-vpc-f8fad69d",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-30398256-igw-9b93ddfc",
-      "id" : "link-interface-node-subnet-30398256-vpc-b390fad5-igw-9b93ddfc-interface-node-vpc-b390fad5-subnet-30398256-igw-9b93ddfc",
-      "srcId" : "interface-node-subnet-30398256-vpc-b390fad5-igw-9b93ddfc",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-f73a8191-igw-9b93ddfc",
-      "id" : "link-interface-node-subnet-f73a8191-vpc-b390fad5-igw-9b93ddfc-interface-node-vpc-b390fad5-subnet-f73a8191-igw-9b93ddfc",
-      "srcId" : "interface-node-subnet-f73a8191-vpc-b390fad5-igw-9b93ddfc",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-subnet-30398256-vpc-b390fad5-igw-9b93ddfc",
-      "id" : "link-interface-node-vpc-b390fad5-subnet-30398256-igw-9b93ddfc-interface-node-subnet-30398256-vpc-b390fad5-igw-9b93ddfc",
-      "srcId" : "interface-node-vpc-b390fad5-subnet-30398256-igw-9b93ddfc",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d-igw-068fee63",
-      "id" : "link-interface-node-vpc-f8fad69d-subnet-9c8adceb-igw-068fee63-interface-node-subnet-9c8adceb-vpc-f8fad69d-igw-068fee63",
-      "srcId" : "interface-node-vpc-f8fad69d-subnet-9c8adceb-igw-068fee63",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -723,13 +702,6 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-subnet-62f14104-vpc-925131f4-igw-fac5839d",
-      "id" : "link-interface-node-vpc-925131f4-subnet-62f14104-igw-fac5839d-interface-node-subnet-62f14104-vpc-925131f4-igw-fac5839d",
-      "srcId" : "interface-node-vpc-925131f4-subnet-62f14104-igw-fac5839d",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
       "dstId" : "interface-node-subnet-f73a8191-vpc-b390fad5",
       "id" : "link-interface-node-vpc-b390fad5-subnet-f73a8191-interface-node-subnet-f73a8191-vpc-b390fad5",
       "srcId" : "interface-node-vpc-b390fad5-subnet-f73a8191",
@@ -744,9 +716,16 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-subnet-1641fa70-vpc-b390fad5-igw-9b93ddfc",
-      "id" : "link-interface-node-vpc-b390fad5-subnet-1641fa70-igw-9b93ddfc-interface-node-subnet-1641fa70-vpc-b390fad5-igw-9b93ddfc",
-      "srcId" : "interface-node-vpc-b390fad5-subnet-1641fa70-igw-9b93ddfc",
+      "dstId" : "interface-node-subnet-d9cafabc-vpc-f8fad69d-vrf-igw-068fee63",
+      "id" : "link-interface-node-vpc-f8fad69d-subnet-d9cafabc-vrf-igw-068fee63-interface-node-subnet-d9cafabc-vpc-f8fad69d-vrf-igw-068fee63",
+      "srcId" : "interface-node-vpc-f8fad69d-subnet-d9cafabc-vrf-igw-068fee63",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-subnet-7044ff16-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "id" : "link-interface-node-vpc-b390fad5-subnet-7044ff16-vrf-igw-9b93ddfc-interface-node-subnet-7044ff16-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "srcId" : "interface-node-vpc-b390fad5-subnet-7044ff16-vrf-igw-9b93ddfc",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -755,20 +734,6 @@
       "id" : "link-interface-node-aws-backbone-~Interface_1~-interface-node-igw-068fee63-backbone",
       "srcId" : "interface-node-aws-backbone-~Interface_1~",
       "type" : "UNKNOWN",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-7044ff16-igw-9b93ddfc",
-      "id" : "link-interface-node-subnet-7044ff16-vpc-b390fad5-igw-9b93ddfc-interface-node-vpc-b390fad5-subnet-7044ff16-igw-9b93ddfc",
-      "srcId" : "interface-node-subnet-7044ff16-vpc-b390fad5-igw-9b93ddfc",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-vpc-f8fad69d-subnet-9c8adceb-igw-068fee63",
-      "id" : "link-interface-node-subnet-9c8adceb-vpc-f8fad69d-igw-068fee63-interface-node-vpc-f8fad69d-subnet-9c8adceb-igw-068fee63",
-      "srcId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d-igw-068fee63",
-      "type" : "PHYSICAL",
       "properties" : null
     },
     {
@@ -782,6 +747,13 @@
       "dstId" : "interface-node-subnet-7044ff16-vpc-b390fad5",
       "id" : "link-interface-node-vpc-b390fad5-subnet-7044ff16-interface-node-subnet-7044ff16-vpc-b390fad5",
       "srcId" : "interface-node-vpc-b390fad5-subnet-7044ff16",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-subnet-8d0cbdeb-vpc-925131f4-vrf-igw-fac5839d",
+      "id" : "link-interface-node-vpc-925131f4-subnet-8d0cbdeb-vrf-igw-fac5839d-interface-node-subnet-8d0cbdeb-vpc-925131f4-vrf-igw-fac5839d",
+      "srcId" : "interface-node-vpc-925131f4-subnet-8d0cbdeb-vrf-igw-fac5839d",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -821,9 +793,9 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-vpc-b390fad5-subnet-073b8061-igw-9b93ddfc",
-      "id" : "link-interface-node-subnet-073b8061-vpc-b390fad5-igw-9b93ddfc-interface-node-vpc-b390fad5-subnet-073b8061-igw-9b93ddfc",
-      "srcId" : "interface-node-subnet-073b8061-vpc-b390fad5-igw-9b93ddfc",
+      "dstId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d-vrf-igw-068fee63",
+      "id" : "link-interface-node-vpc-f8fad69d-subnet-9c8adceb-vrf-igw-068fee63-interface-node-subnet-9c8adceb-vpc-f8fad69d-vrf-igw-068fee63",
+      "srcId" : "interface-node-vpc-f8fad69d-subnet-9c8adceb-vrf-igw-068fee63",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -863,9 +835,9 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-subnet-7044ff16-vpc-b390fad5-igw-9b93ddfc",
-      "id" : "link-interface-node-vpc-b390fad5-subnet-7044ff16-igw-9b93ddfc-interface-node-subnet-7044ff16-vpc-b390fad5-igw-9b93ddfc",
-      "srcId" : "interface-node-vpc-b390fad5-subnet-7044ff16-igw-9b93ddfc",
+      "dstId" : "interface-node-vpc-b390fad5-subnet-073b8061-vrf-igw-9b93ddfc",
+      "id" : "link-interface-node-subnet-073b8061-vpc-b390fad5-vrf-igw-9b93ddfc-interface-node-vpc-b390fad5-subnet-073b8061-vrf-igw-9b93ddfc",
+      "srcId" : "interface-node-subnet-073b8061-vpc-b390fad5-vrf-igw-9b93ddfc",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -877,9 +849,37 @@
       "properties" : null
     },
     {
+      "dstId" : "interface-node-subnet-62f14104-vpc-925131f4-vrf-igw-fac5839d",
+      "id" : "link-interface-node-vpc-925131f4-subnet-62f14104-vrf-igw-fac5839d-interface-node-subnet-62f14104-vpc-925131f4-vrf-igw-fac5839d",
+      "srcId" : "interface-node-vpc-925131f4-subnet-62f14104-vrf-igw-fac5839d",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-subnet-f73a8191-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "id" : "link-interface-node-vpc-b390fad5-subnet-f73a8191-vrf-igw-9b93ddfc-interface-node-subnet-f73a8191-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "srcId" : "interface-node-vpc-b390fad5-subnet-f73a8191-vrf-igw-9b93ddfc",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
       "dstId" : "interface-node-vpc-815775e7-vgw-81fd279f",
       "id" : "link-interface-node-vgw-81fd279f-vpc-815775e7-interface-node-vpc-815775e7-vgw-81fd279f",
       "srcId" : "interface-node-vgw-81fd279f-vpc-815775e7",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-vpc-f8fad69d-subnet-9c8adceb-vrf-igw-068fee63",
+      "id" : "link-interface-node-subnet-9c8adceb-vpc-f8fad69d-vrf-igw-068fee63-interface-node-vpc-f8fad69d-subnet-9c8adceb-vrf-igw-068fee63",
+      "srcId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d-vrf-igw-068fee63",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-vpc-f8fad69d-subnet-d9cafabc-vrf-igw-068fee63",
+      "id" : "link-interface-node-subnet-d9cafabc-vpc-f8fad69d-vrf-igw-068fee63-interface-node-vpc-f8fad69d-subnet-d9cafabc-vrf-igw-068fee63",
+      "srcId" : "interface-node-subnet-d9cafabc-vpc-f8fad69d-vrf-igw-068fee63",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -919,9 +919,23 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-subnet-f73a8191-vpc-b390fad5-igw-9b93ddfc",
-      "id" : "link-interface-node-vpc-b390fad5-subnet-f73a8191-igw-9b93ddfc-interface-node-subnet-f73a8191-vpc-b390fad5-igw-9b93ddfc",
-      "srcId" : "interface-node-vpc-b390fad5-subnet-f73a8191-igw-9b93ddfc",
+      "dstId" : "interface-node-subnet-30398256-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "id" : "link-interface-node-vpc-b390fad5-subnet-30398256-vrf-igw-9b93ddfc-interface-node-subnet-30398256-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "srcId" : "interface-node-vpc-b390fad5-subnet-30398256-vrf-igw-9b93ddfc",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-subnet-073b8061-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "id" : "link-interface-node-vpc-b390fad5-subnet-073b8061-vrf-igw-9b93ddfc-interface-node-subnet-073b8061-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "srcId" : "interface-node-vpc-b390fad5-subnet-073b8061-vrf-igw-9b93ddfc",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-vpc-b390fad5-subnet-30398256-vrf-igw-9b93ddfc",
+      "id" : "link-interface-node-subnet-30398256-vpc-b390fad5-vrf-igw-9b93ddfc-interface-node-vpc-b390fad5-subnet-30398256-vrf-igw-9b93ddfc",
+      "srcId" : "interface-node-subnet-30398256-vpc-b390fad5-vrf-igw-9b93ddfc",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -929,6 +943,13 @@
       "dstId" : "interface-node-es-domain-es-domain-subnet-1641fa70",
       "id" : "link-interface-node-test-rds-test-rds-subnet-1641fa70-interface-node-es-domain-es-domain-subnet-1641fa70",
       "srcId" : "interface-node-test-rds-test-rds-subnet-1641fa70",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-vpc-b390fad5-subnet-1641fa70-vrf-igw-9b93ddfc",
+      "id" : "link-interface-node-subnet-1641fa70-vpc-b390fad5-vrf-igw-9b93ddfc-interface-node-vpc-b390fad5-subnet-1641fa70-vrf-igw-9b93ddfc",
+      "srcId" : "interface-node-subnet-1641fa70-vpc-b390fad5-vrf-igw-9b93ddfc",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -943,13 +964,6 @@
       "dstId" : "interface-node-subnet-1641fa70-vpc-b390fad5",
       "id" : "link-interface-node-vpc-b390fad5-subnet-1641fa70-interface-node-subnet-1641fa70-vpc-b390fad5",
       "srcId" : "interface-node-vpc-b390fad5-subnet-1641fa70",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-subnet-1f315846-vpc-f8fad69d-igw-068fee63",
-      "id" : "link-interface-node-vpc-f8fad69d-subnet-1f315846-igw-068fee63-interface-node-subnet-1f315846-vpc-f8fad69d-igw-068fee63",
-      "srcId" : "interface-node-vpc-f8fad69d-subnet-1f315846-igw-068fee63",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -982,6 +996,13 @@
       "properties" : null
     },
     {
+      "dstId" : "interface-node-vpc-b390fad5-subnet-f73a8191-vrf-igw-9b93ddfc",
+      "id" : "link-interface-node-subnet-f73a8191-vpc-b390fad5-vrf-igw-9b93ddfc-interface-node-vpc-b390fad5-subnet-f73a8191-vrf-igw-9b93ddfc",
+      "srcId" : "interface-node-subnet-f73a8191-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
       "dstId" : "interface-node-vpc-b390fad5-subnet-1641fa70",
       "id" : "link-interface-node-subnet-1641fa70-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-1641fa70",
       "srcId" : "interface-node-subnet-1641fa70-vpc-b390fad5",
@@ -989,9 +1010,9 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-subnet-d9cafabc-vpc-f8fad69d-igw-068fee63",
-      "id" : "link-interface-node-vpc-f8fad69d-subnet-d9cafabc-igw-068fee63-interface-node-subnet-d9cafabc-vpc-f8fad69d-igw-068fee63",
-      "srcId" : "interface-node-vpc-f8fad69d-subnet-d9cafabc-igw-068fee63",
+      "dstId" : "interface-node-vpc-925131f4-subnet-62f14104-vrf-igw-fac5839d",
+      "id" : "link-interface-node-subnet-62f14104-vpc-925131f4-vrf-igw-fac5839d-interface-node-vpc-925131f4-subnet-62f14104-vrf-igw-fac5839d",
+      "srcId" : "interface-node-subnet-62f14104-vpc-925131f4-vrf-igw-fac5839d",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -1010,9 +1031,16 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-subnet-073b8061-vpc-b390fad5-igw-9b93ddfc",
-      "id" : "link-interface-node-vpc-b390fad5-subnet-073b8061-igw-9b93ddfc-interface-node-subnet-073b8061-vpc-b390fad5-igw-9b93ddfc",
-      "srcId" : "interface-node-vpc-b390fad5-subnet-073b8061-igw-9b93ddfc",
+      "dstId" : "interface-node-vpc-b390fad5-subnet-7044ff16-vrf-igw-9b93ddfc",
+      "id" : "link-interface-node-subnet-7044ff16-vpc-b390fad5-vrf-igw-9b93ddfc-interface-node-vpc-b390fad5-subnet-7044ff16-vrf-igw-9b93ddfc",
+      "srcId" : "interface-node-subnet-7044ff16-vpc-b390fad5-vrf-igw-9b93ddfc",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-subnet-1f315846-vpc-f8fad69d-vrf-igw-068fee63",
+      "id" : "link-interface-node-vpc-f8fad69d-subnet-1f315846-vrf-igw-068fee63-interface-node-subnet-1f315846-vpc-f8fad69d-vrf-igw-068fee63",
+      "srcId" : "interface-node-vpc-f8fad69d-subnet-1f315846-vrf-igw-068fee63",
       "type" : "PHYSICAL",
       "properties" : null
     }

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -16791,8 +16791,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "vpc-b390fad5-igw-9b93ddfc" : {
-            "name" : "vpc-b390fad5-igw-9b93ddfc",
+          "vpc-b390fad5-vrf-igw-9b93ddfc" : {
+            "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -16800,7 +16800,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To vpc-b390fad5-igw-9b93ddfc",
+            "description" : "To vpc-b390fad5-vrf-igw-9b93ddfc",
             "incomingFilter" : "acl-7b78771d_ingress",
             "mtu" : 1500,
             "outgoingFilter" : "acl-7b78771d_egress",
@@ -16925,7 +16925,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
-                "nextHopInterface" : "vpc-b390fad5-igw-9b93ddfc",
+                "nextHopInterface" : "vpc-b390fad5-vrf-igw-9b93ddfc",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -17001,8 +17001,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "vpc-b390fad5-igw-9b93ddfc" : {
-            "name" : "vpc-b390fad5-igw-9b93ddfc",
+          "vpc-b390fad5-vrf-igw-9b93ddfc" : {
+            "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -17010,7 +17010,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To vpc-b390fad5-igw-9b93ddfc",
+            "description" : "To vpc-b390fad5-vrf-igw-9b93ddfc",
             "incomingFilter" : "acl-7b78771d_ingress",
             "mtu" : 1500,
             "outgoingFilter" : "acl-7b78771d_egress",
@@ -17135,7 +17135,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
-                "nextHopInterface" : "vpc-b390fad5-igw-9b93ddfc",
+                "nextHopInterface" : "vpc-b390fad5-vrf-igw-9b93ddfc",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -17210,8 +17210,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "vpc-f8fad69d-igw-068fee63" : {
-            "name" : "vpc-f8fad69d-igw-068fee63",
+          "vpc-f8fad69d-vrf-igw-068fee63" : {
+            "name" : "vpc-f8fad69d-vrf-igw-068fee63",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -17219,7 +17219,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To vpc-f8fad69d-igw-068fee63",
+            "description" : "To vpc-f8fad69d-vrf-igw-068fee63",
             "incomingFilter" : "acl-4db39c28_ingress",
             "mtu" : 1500,
             "outgoingFilter" : "acl-4db39c28_egress",
@@ -17356,7 +17356,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
-                "nextHopInterface" : "vpc-f8fad69d-igw-068fee63",
+                "nextHopInterface" : "vpc-f8fad69d-vrf-igw-068fee63",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -17432,8 +17432,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "vpc-b390fad5-igw-9b93ddfc" : {
-            "name" : "vpc-b390fad5-igw-9b93ddfc",
+          "vpc-b390fad5-vrf-igw-9b93ddfc" : {
+            "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -17441,7 +17441,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To vpc-b390fad5-igw-9b93ddfc",
+            "description" : "To vpc-b390fad5-vrf-igw-9b93ddfc",
             "incomingFilter" : "acl-7b78771d_ingress",
             "mtu" : 1500,
             "outgoingFilter" : "acl-7b78771d_egress",
@@ -17566,7 +17566,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
-                "nextHopInterface" : "vpc-b390fad5-igw-9b93ddfc",
+                "nextHopInterface" : "vpc-b390fad5-vrf-igw-9b93ddfc",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -17642,8 +17642,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "vpc-925131f4-igw-fac5839d" : {
-            "name" : "vpc-925131f4-igw-fac5839d",
+          "vpc-925131f4-vrf-igw-fac5839d" : {
+            "name" : "vpc-925131f4-vrf-igw-fac5839d",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -17651,7 +17651,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To vpc-925131f4-igw-fac5839d",
+            "description" : "To vpc-925131f4-vrf-igw-fac5839d",
             "incomingFilter" : "acl-3d4f745b_ingress",
             "mtu" : 1500,
             "outgoingFilter" : "acl-3d4f745b_egress",
@@ -17776,7 +17776,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
-                "nextHopInterface" : "vpc-925131f4-igw-fac5839d",
+                "nextHopInterface" : "vpc-925131f4-vrf-igw-fac5839d",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -17852,8 +17852,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "vpc-b390fad5-igw-9b93ddfc" : {
-            "name" : "vpc-b390fad5-igw-9b93ddfc",
+          "vpc-b390fad5-vrf-igw-9b93ddfc" : {
+            "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -17861,7 +17861,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To vpc-b390fad5-igw-9b93ddfc",
+            "description" : "To vpc-b390fad5-vrf-igw-9b93ddfc",
             "incomingFilter" : "acl-7b78771d_ingress",
             "mtu" : 1500,
             "outgoingFilter" : "acl-7b78771d_egress",
@@ -17986,7 +17986,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
-                "nextHopInterface" : "vpc-b390fad5-igw-9b93ddfc",
+                "nextHopInterface" : "vpc-b390fad5-vrf-igw-9b93ddfc",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -18048,6 +18048,30 @@
             "autostate" : true,
             "bandwidth" : 1.0E12,
             "description" : "To vpc-925131f4",
+            "incomingFilter" : "acl-3d4f745b_ingress",
+            "mtu" : 1500,
+            "outgoingFilter" : "acl-3d4f745b_egress",
+            "prefix" : "link-local:169.254.0.1",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vpc-925131f4-vrf-igw-fac5839d" : {
+            "name" : "vpc-925131f4-vrf-igw-fac5839d",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "description" : "To vpc-925131f4-vrf-igw-fac5839d",
             "incomingFilter" : "acl-3d4f745b_ingress",
             "mtu" : 1500,
             "outgoingFilter" : "acl-3d4f745b_egress",
@@ -18247,8 +18271,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "vpc-f8fad69d-igw-068fee63" : {
-            "name" : "vpc-f8fad69d-igw-068fee63",
+          "vpc-f8fad69d-vrf-igw-068fee63" : {
+            "name" : "vpc-f8fad69d-vrf-igw-068fee63",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -18256,7 +18280,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To vpc-f8fad69d-igw-068fee63",
+            "description" : "To vpc-f8fad69d-vrf-igw-068fee63",
             "incomingFilter" : "acl-4db39c28_ingress",
             "mtu" : 1500,
             "outgoingFilter" : "acl-4db39c28_egress",
@@ -18393,7 +18417,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
-                "nextHopInterface" : "vpc-f8fad69d-igw-068fee63",
+                "nextHopInterface" : "vpc-f8fad69d-vrf-igw-068fee63",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -18468,8 +18492,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "vpc-f8fad69d-igw-068fee63" : {
-            "name" : "vpc-f8fad69d-igw-068fee63",
+          "vpc-f8fad69d-vrf-igw-068fee63" : {
+            "name" : "vpc-f8fad69d-vrf-igw-068fee63",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -18477,7 +18501,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To vpc-f8fad69d-igw-068fee63",
+            "description" : "To vpc-f8fad69d-vrf-igw-068fee63",
             "incomingFilter" : "acl-4db39c28_ingress",
             "mtu" : 1500,
             "outgoingFilter" : "acl-4db39c28_egress",
@@ -18614,7 +18638,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
-                "nextHopInterface" : "vpc-f8fad69d-igw-068fee63",
+                "nextHopInterface" : "vpc-f8fad69d-vrf-igw-068fee63",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -18690,8 +18714,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "vpc-b390fad5-igw-9b93ddfc" : {
-            "name" : "vpc-b390fad5-igw-9b93ddfc",
+          "vpc-b390fad5-vrf-igw-9b93ddfc" : {
+            "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -18699,7 +18723,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To vpc-b390fad5-igw-9b93ddfc",
+            "description" : "To vpc-b390fad5-vrf-igw-9b93ddfc",
             "incomingFilter" : "acl-7b78771d_ingress",
             "mtu" : 1500,
             "outgoingFilter" : "acl-7b78771d_egress",
@@ -18824,7 +18848,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "0.0.0.0/0",
-                "nextHopInterface" : "vpc-b390fad5-igw-9b93ddfc",
+                "nextHopInterface" : "vpc-b390fad5-vrf-igw-9b93ddfc",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -19941,8 +19965,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "subnet-62f14104-igw-fac5839d" : {
-            "name" : "subnet-62f14104-igw-fac5839d",
+          "subnet-62f14104-vrf-igw-fac5839d" : {
+            "name" : "subnet-62f14104-vrf-igw-fac5839d",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -19950,7 +19974,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To subnet-62f14104-igw-fac5839d",
+            "description" : "To subnet-62f14104-vrf-igw-fac5839d",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -19984,6 +20008,28 @@
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
             "vrf" : "default"
+          },
+          "subnet-8d0cbdeb-vrf-igw-fac5839d" : {
+            "name" : "subnet-8d0cbdeb-vrf-igw-fac5839d",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "description" : "To subnet-8d0cbdeb-vrf-igw-fac5839d",
+            "mtu" : 1500,
+            "prefix" : "link-local:169.254.0.1",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "vrf-igw-fac5839d"
           }
         },
         "vendorFamily" : {
@@ -20053,7 +20099,16 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "10.0.0.0/24",
-                "nextHopInterface" : "subnet-62f14104-igw-fac5839d",
+                "nextHopInterface" : "subnet-62f14104-vrf-igw-fac5839d",
+                "nextHopIp" : "169.254.0.1",
+                "tag" : -1
+              },
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "10.0.1.0/24",
+                "nextHopInterface" : "subnet-8d0cbdeb-vrf-igw-fac5839d",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }
@@ -20115,8 +20170,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "subnet-073b8061-igw-9b93ddfc" : {
-            "name" : "subnet-073b8061-igw-9b93ddfc",
+          "subnet-073b8061-vrf-igw-9b93ddfc" : {
+            "name" : "subnet-073b8061-vrf-igw-9b93ddfc",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -20124,7 +20179,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To subnet-073b8061-igw-9b93ddfc",
+            "description" : "To subnet-073b8061-vrf-igw-9b93ddfc",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -20159,8 +20214,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "subnet-1641fa70-igw-9b93ddfc" : {
-            "name" : "subnet-1641fa70-igw-9b93ddfc",
+          "subnet-1641fa70-vrf-igw-9b93ddfc" : {
+            "name" : "subnet-1641fa70-vrf-igw-9b93ddfc",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -20168,7 +20223,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To subnet-1641fa70-igw-9b93ddfc",
+            "description" : "To subnet-1641fa70-vrf-igw-9b93ddfc",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -20203,8 +20258,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "subnet-30398256-igw-9b93ddfc" : {
-            "name" : "subnet-30398256-igw-9b93ddfc",
+          "subnet-30398256-vrf-igw-9b93ddfc" : {
+            "name" : "subnet-30398256-vrf-igw-9b93ddfc",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -20212,7 +20267,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To subnet-30398256-igw-9b93ddfc",
+            "description" : "To subnet-30398256-vrf-igw-9b93ddfc",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -20247,8 +20302,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "subnet-7044ff16-igw-9b93ddfc" : {
-            "name" : "subnet-7044ff16-igw-9b93ddfc",
+          "subnet-7044ff16-vrf-igw-9b93ddfc" : {
+            "name" : "subnet-7044ff16-vrf-igw-9b93ddfc",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -20256,7 +20311,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To subnet-7044ff16-igw-9b93ddfc",
+            "description" : "To subnet-7044ff16-vrf-igw-9b93ddfc",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -20291,8 +20346,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "subnet-f73a8191-igw-9b93ddfc" : {
-            "name" : "subnet-f73a8191-igw-9b93ddfc",
+          "subnet-f73a8191-vrf-igw-9b93ddfc" : {
+            "name" : "subnet-f73a8191-vrf-igw-9b93ddfc",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -20300,7 +20355,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To subnet-f73a8191-igw-9b93ddfc",
+            "description" : "To subnet-f73a8191-vrf-igw-9b93ddfc",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -20408,7 +20463,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "192.168.1.0/24",
-                "nextHopInterface" : "subnet-1641fa70-igw-9b93ddfc",
+                "nextHopInterface" : "subnet-1641fa70-vrf-igw-9b93ddfc",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -20417,7 +20472,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "192.168.2.0/28",
-                "nextHopInterface" : "subnet-7044ff16-igw-9b93ddfc",
+                "nextHopInterface" : "subnet-7044ff16-vrf-igw-9b93ddfc",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -20426,7 +20481,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "192.168.2.16/28",
-                "nextHopInterface" : "subnet-073b8061-igw-9b93ddfc",
+                "nextHopInterface" : "subnet-073b8061-vrf-igw-9b93ddfc",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -20435,7 +20490,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "192.168.2.32/28",
-                "nextHopInterface" : "subnet-30398256-igw-9b93ddfc",
+                "nextHopInterface" : "subnet-30398256-vrf-igw-9b93ddfc",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -20444,7 +20499,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "192.168.2.48/28",
-                "nextHopInterface" : "subnet-f73a8191-igw-9b93ddfc",
+                "nextHopInterface" : "subnet-f73a8191-vrf-igw-9b93ddfc",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }
@@ -20505,8 +20560,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "subnet-1f315846-igw-068fee63" : {
-            "name" : "subnet-1f315846-igw-068fee63",
+          "subnet-1f315846-vrf-igw-068fee63" : {
+            "name" : "subnet-1f315846-vrf-igw-068fee63",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -20514,7 +20569,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To subnet-1f315846-igw-068fee63",
+            "description" : "To subnet-1f315846-vrf-igw-068fee63",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -20549,8 +20604,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "subnet-9c8adceb-igw-068fee63" : {
-            "name" : "subnet-9c8adceb-igw-068fee63",
+          "subnet-9c8adceb-vrf-igw-068fee63" : {
+            "name" : "subnet-9c8adceb-vrf-igw-068fee63",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -20558,7 +20613,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To subnet-9c8adceb-igw-068fee63",
+            "description" : "To subnet-9c8adceb-vrf-igw-068fee63",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -20593,8 +20648,8 @@
             "type" : "PHYSICAL",
             "vrf" : "default"
           },
-          "subnet-d9cafabc-igw-068fee63" : {
-            "name" : "subnet-d9cafabc-igw-068fee63",
+          "subnet-d9cafabc-vrf-igw-068fee63" : {
+            "name" : "subnet-d9cafabc-vrf-igw-068fee63",
             "active" : true,
             "additionalArpIps" : {
               "class" : "org.batfish.datamodel.EmptyIpSpace"
@@ -20602,7 +20657,7 @@
             "allowedVlans" : "",
             "autostate" : true,
             "bandwidth" : 1.0E12,
-            "description" : "To subnet-d9cafabc-igw-068fee63",
+            "description" : "To subnet-d9cafabc-vrf-igw-068fee63",
             "mtu" : 1500,
             "prefix" : "link-local:169.254.0.1",
             "proxyArp" : false,
@@ -20692,7 +20747,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "172.31.0.0/20",
-                "nextHopInterface" : "subnet-1f315846-igw-068fee63",
+                "nextHopInterface" : "subnet-1f315846-vrf-igw-068fee63",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -20701,7 +20756,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "172.31.16.0/20",
-                "nextHopInterface" : "subnet-d9cafabc-igw-068fee63",
+                "nextHopInterface" : "subnet-d9cafabc-vrf-igw-068fee63",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               },
@@ -20710,7 +20765,7 @@
                 "administrativeCost" : 1,
                 "metric" : 0,
                 "network" : "172.31.32.0/20",
-                "nextHopInterface" : "subnet-9c8adceb-igw-068fee63",
+                "nextHopInterface" : "subnet-9c8adceb-vrf-igw-068fee63",
                 "nextHopIp" : "169.254.0.1",
                 "tag" : -1
               }


### PR DESCRIPTION
This PR fixes a behavioral bug where, for traffic coming in from entities such as TGW, VGWs, NGW, etc., VPCs would provide connectivity only to subnets that uses those entities for outgoing traffic. So, if traffic reached a VPC from a TGW for a subnet that did not use that TGW, that traffic would be dropped. Testing shows that such symmetry is not required and this PR fixes that. 

From a code perspective, two changes were made get the right behavior:
  - proactively create VRFs on the VPC node for all entities such as TGWs that it connects to. Earlier, these VRFs were being created on demand when relevant routing table entries were encountered. 
  - connect Subnets to these VRFs independent of whether they use that entity for its outgoing traffic. 