### PR TITLE
AWS interfaces without valid address in the subnet

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
@@ -315,21 +315,23 @@ final class LoadBalancer implements AwsVpcEntity, Serializable {
       List<Listener> listeners,
       Region region,
       Warnings warnings) {
-    List<LoadBalancerTransformation> listenerTransformations =
-        listeners.stream()
-            .map(
-                listener ->
-                    computeListenerTransformation(
-                        listener,
-                        lbAvailabilityZoneName,
-                        viIface.getConcreteAddress().getIp(),
-                        crossZoneLoadBalancing,
-                        region,
-                        warnings))
-            .filter(Objects::nonNull)
-            .collect(ImmutableList.toImmutableList());
+    if (viIface.getConcreteAddress() != null) { // May be null if we couldn't find a usable address
+      List<LoadBalancerTransformation> listenerTransformations =
+          listeners.stream()
+              .map(
+                  listener ->
+                      computeListenerTransformation(
+                          listener,
+                          lbAvailabilityZoneName,
+                          viIface.getConcreteAddress().getIp(),
+                          crossZoneLoadBalancing,
+                          region,
+                          warnings))
+              .filter(Objects::nonNull)
+              .collect(ImmutableList.toImmutableList());
 
-    viIface.setIncomingTransformation(chainListenerTransformations(listenerTransformations));
+      viIface.setIncomingTransformation(chainListenerTransformations(listenerTransformations));
+    }
     viIface.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(false, ImmutableList.of(viIface.getName()), null, null));
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/NatGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/NatGateway.java
@@ -197,8 +197,7 @@ final class NatGateway implements AwsVpcEntity, Serializable {
 
     // post transformation filter on the interface to the subnet
     IpAccessList postTransformationFilter =
-        computePostTransformationIllegalPacketFilter(
-            getPrivateIp(), ifaceToSubnet.getPrimaryNetwork());
+        computePostTransformationIllegalPacketFilter(getPrivateIp(), subnet.getCidrBlock());
     cfgNode.getIpAccessLists().put(postTransformationFilter.getName(), postTransformationFilter);
     ifaceToSubnet.setPostTransformationIncomingFilter(postTransformationFilter);
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -138,7 +138,7 @@ final class Utils {
 
   /** Creates a new interface on {@code c} with the provided name, address, and description. */
   static Interface newInterface(
-      String name, Configuration c, InterfaceAddress primaryAddress, String description) {
+      String name, Configuration c, @Nullable InterfaceAddress primaryAddress, String description) {
     return newInterface(name, c, c.getDefaultVrf().getName(), primaryAddress, description);
   }
 
@@ -150,7 +150,7 @@ final class Utils {
       String name,
       Configuration c,
       String vrfName,
-      InterfaceAddress primaryAddress,
+      @Nullable InterfaceAddress primaryAddress,
       String description) {
     checkArgument(
         c.getVrfs().containsKey(vrfName), "VRF %s does not exist on %s", vrfName, c.getHostname());
@@ -458,6 +458,11 @@ final class Utils {
       ifaceAddressesBuilder.add(address);
     }
     Set<ConcreteInterfaceAddress> ifaceAddresses = ifaceAddressesBuilder.build();
+    if (ifaceAddresses.isEmpty()) {
+      warnings.redFlag(
+          String.format("No valid address found for interface '%s'", netInterface.getId()));
+    }
+    @Nullable
     ConcreteInterfaceAddress primaryAddress =
         ifaceAddresses.stream()
             .filter(addr -> addr.getIp().equals(netInterface.getPrimaryPrivateIp().getPrivateIp()))
@@ -468,8 +473,7 @@ final class Utils {
                       String.format(
                           "Primary address not found for interface '%s'. Using lowest address as primary",
                           netInterface.getId()));
-                  // get() is safe here: ifaceAddresses cannot be empty
-                  return ifaceAddresses.stream().min(naturalOrder()).get();
+                  return ifaceAddresses.stream().min(naturalOrder()).orElse(null);
                 });
 
     Interface iface =


### PR DESCRIPTION
Instead of crashing, log a warning and create an interface with no address