### PR TITLE
AWS: if region conversion crashes, continue processing

### DIFF
--- a/library_deps.bzl
+++ b/library_deps.bzl
@@ -54,6 +54,8 @@ BATFISH_MAVEN_ARTIFACTS = [
     "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:2.27",
     "org.hamcrest:hamcrest:2.2",
     "org.lz4:lz4-java:1.6.0",
+    "org.mockito:mockito-core:3.3.3",
+    "org.mockito:mockito-inline:3.3.3",
     "org.jgrapht:jgrapht-core:1.3.1",
     "org.jline:jline:3.13.1",
     "org.parboiled:parboiled-core:1.3.1",

--- a/maven_install.json
+++ b/maven_install.json
@@ -1796,6 +1796,62 @@
                 "sha256": "9f43fea92033ad82bcad2ae44cec5c82abc9d6ee4b095cab921d11ead98bf2ff"
             },
             {
+                "coord": "net.bytebuddy:byte-buddy-agent:1.10.5",
+                "file": "v1/https/repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.10.5/byte-buddy-agent-1.10.5.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "org.hamcrest:hamcrest-core"
+                ],
+                "url": "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.10.5/byte-buddy-agent-1.10.5.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.10.5/byte-buddy-agent-1.10.5.jar"
+                ],
+                "sha256": "290c9930965ef5810ddb15baf3b3647ce952f40fa2f0af82d5f669e04ba87e5b"
+            },
+            {
+                "coord": "net.bytebuddy:byte-buddy-agent:jar:sources:1.10.5",
+                "file": "v1/https/repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.10.5/byte-buddy-agent-1.10.5-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "org.hamcrest:hamcrest-core"
+                ],
+                "url": "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.10.5/byte-buddy-agent-1.10.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.10.5/byte-buddy-agent-1.10.5-sources.jar"
+                ],
+                "sha256": "2286a99c6043271d3efa6cd1190121fcbf8a9523169f78cc711420c95a120cfa"
+            },
+            {
+                "coord": "net.bytebuddy:byte-buddy:1.10.5",
+                "file": "v1/https/repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.10.5/byte-buddy-1.10.5.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "org.hamcrest:hamcrest-core"
+                ],
+                "url": "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.10.5/byte-buddy-1.10.5.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.10.5/byte-buddy-1.10.5.jar"
+                ],
+                "sha256": "3c9c603970bb9d68572c1aa29e9ae6b477d602922977a04bfa5f3b5465d7d1f4"
+            },
+            {
+                "coord": "net.bytebuddy:byte-buddy:jar:sources:1.10.5",
+                "file": "v1/https/repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.10.5/byte-buddy-1.10.5-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "org.hamcrest:hamcrest-core"
+                ],
+                "url": "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.10.5/byte-buddy-1.10.5-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.10.5/byte-buddy-1.10.5-sources.jar"
+                ],
+                "sha256": "4f60d54ecffa79da4e79761b7a4706e49771b0a0daf682948327a07e39b4b207"
+            },
+            {
                 "coord": "net.java.dev.javacc:javacc:5.0",
                 "file": "v1/https/repo1.maven.org/maven2/net/java/dev/javacc/javacc/5.0/javacc-5.0.jar",
                 "directDependencies": [],
@@ -3979,6 +4035,120 @@
                 "sha256": "db7727c82c150cec38a422b9692f6431150ea2c0c0d0c723bdf7fe6946149041"
             },
             {
+                "coord": "org.mockito:mockito-core:3.3.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/mockito/mockito-core/3.3.3/mockito-core-3.3.3.jar",
+                "directDependencies": [
+                    "net.bytebuddy:byte-buddy:1.10.5",
+                    "net.bytebuddy:byte-buddy-agent:1.10.5",
+                    "org.objenesis:objenesis:2.6"
+                ],
+                "dependencies": [
+                    "net.bytebuddy:byte-buddy-agent:1.10.5",
+                    "net.bytebuddy:byte-buddy:1.10.5",
+                    "org.objenesis:objenesis:2.6"
+                ],
+                "exclusions": [
+                    "org.hamcrest:hamcrest-core"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mockito/mockito-core/3.3.3/mockito-core-3.3.3.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mockito/mockito-core/3.3.3/mockito-core-3.3.3.jar"
+                ],
+                "sha256": "4be648c50456fba4686ba825000d628c1d805a3b92272ba9ad5b697dfa43036b"
+            },
+            {
+                "coord": "org.mockito:mockito-core:jar:sources:3.3.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/mockito/mockito-core/3.3.3/mockito-core-3.3.3-sources.jar",
+                "directDependencies": [
+                    "net.bytebuddy:byte-buddy:jar:sources:1.10.5",
+                    "net.bytebuddy:byte-buddy-agent:jar:sources:1.10.5",
+                    "org.objenesis:objenesis:jar:sources:2.6"
+                ],
+                "dependencies": [
+                    "org.objenesis:objenesis:jar:sources:2.6",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.10.5",
+                    "net.bytebuddy:byte-buddy-agent:jar:sources:1.10.5"
+                ],
+                "exclusions": [
+                    "org.hamcrest:hamcrest-core"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mockito/mockito-core/3.3.3/mockito-core-3.3.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mockito/mockito-core/3.3.3/mockito-core-3.3.3-sources.jar"
+                ],
+                "sha256": "b460650fbe05f5272e58df51628d3adff3dc870a3b19baf805bdea4d237aef1c"
+            },
+            {
+                "coord": "org.mockito:mockito-inline:3.3.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/mockito/mockito-inline/3.3.3/mockito-inline-3.3.3.jar",
+                "directDependencies": [
+                    "org.mockito:mockito-core:3.3.3"
+                ],
+                "dependencies": [
+                    "net.bytebuddy:byte-buddy-agent:1.10.5",
+                    "net.bytebuddy:byte-buddy:1.10.5",
+                    "org.objenesis:objenesis:2.6",
+                    "org.mockito:mockito-core:3.3.3"
+                ],
+                "exclusions": [
+                    "org.hamcrest:hamcrest-core"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mockito/mockito-inline/3.3.3/mockito-inline-3.3.3.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mockito/mockito-inline/3.3.3/mockito-inline-3.3.3.jar"
+                ],
+                "sha256": "c75391c34a1e75d1a977d82834f5736c3f64084c7389cd755434c750e2e745af"
+            },
+            {
+                "coord": "org.mockito:mockito-inline:jar:sources:3.3.3",
+                "file": "v1/https/repo1.maven.org/maven2/org/mockito/mockito-inline/3.3.3/mockito-inline-3.3.3-sources.jar",
+                "directDependencies": [
+                    "org.mockito:mockito-core:jar:sources:3.3.3"
+                ],
+                "dependencies": [
+                    "org.objenesis:objenesis:jar:sources:2.6",
+                    "net.bytebuddy:byte-buddy:jar:sources:1.10.5",
+                    "net.bytebuddy:byte-buddy-agent:jar:sources:1.10.5",
+                    "org.mockito:mockito-core:jar:sources:3.3.3"
+                ],
+                "exclusions": [
+                    "org.hamcrest:hamcrest-core"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/mockito/mockito-inline/3.3.3/mockito-inline-3.3.3-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/mockito/mockito-inline/3.3.3/mockito-inline-3.3.3-sources.jar"
+                ],
+                "sha256": "f92f632b36733f7344f2cf32aa77f2d136864f6a566f73acf59447097ee74d4d"
+            },
+            {
+                "coord": "org.objenesis:objenesis:2.6",
+                "file": "v1/https/repo1.maven.org/maven2/org/objenesis/objenesis/2.6/objenesis-2.6.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "org.hamcrest:hamcrest-core"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/objenesis/objenesis/2.6/objenesis-2.6.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/objenesis/objenesis/2.6/objenesis-2.6.jar"
+                ],
+                "sha256": "5e168368fbc250af3c79aa5fef0c3467a2d64e5a7bd74005f25d8399aeb0708d"
+            },
+            {
+                "coord": "org.objenesis:objenesis:jar:sources:2.6",
+                "file": "v1/https/repo1.maven.org/maven2/org/objenesis/objenesis/2.6/objenesis-2.6-sources.jar",
+                "directDependencies": [],
+                "dependencies": [],
+                "exclusions": [
+                    "org.hamcrest:hamcrest-core"
+                ],
+                "url": "https://repo1.maven.org/maven2/org/objenesis/objenesis/2.6/objenesis-2.6-sources.jar",
+                "mirror_urls": [
+                    "https://repo1.maven.org/maven2/org/objenesis/objenesis/2.6/objenesis-2.6-sources.jar"
+                ],
+                "sha256": "52d9f4dba531677fc074eff00ea07f22a1d42e5a97cc9e8571c4cd3d459b6be0"
+            },
+            {
                 "coord": "org.osgi:org.osgi.annotation.versioning:1.0.0",
                 "file": "v1/https/repo1.maven.org/maven2/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0.jar",
                 "directDependencies": [],
@@ -4362,6 +4532,6 @@
             }
         ],
         "version": "0.1.0",
-        "__AUTOGENERATED_FILE_DO_NOT_MODIFY_THIS_FILE_MANUALLY": -1845770343
+        "__AUTOGENERATED_FILE_DO_NOT_MODIFY_THIS_FILE_MANUALLY": 1799877172
     }
 }

--- a/projects/batfish/pom.xml
+++ b/projects/batfish/pom.xml
@@ -34,6 +34,8 @@
                   </ignoredUnusedDeclaredDependency>
                   <ignoredUnusedDeclaredDependency>com.google.auto.service:auto-service-annotations
                   </ignoredUnusedDeclaredDependency>
+                  <ignoredUnusedDeclaredDependency>org.mockito:mockito-inline
+                  </ignoredUnusedDeclaredDependency>
                 </ignoredUnusedDeclaredDependencies>
               </configuration>
             </execution>
@@ -453,6 +455,18 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Account.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Account.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.aws;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
@@ -26,6 +27,11 @@ public class Account implements Serializable {
   @Nonnull
   public Region addOrGetRegion(String region) {
     return _regions.computeIfAbsent(region, Region::new);
+  }
+
+  @VisibleForTesting
+  public void addRegion(Region region) {
+    _regions.put(region.getName(), region);
   }
 
   public Collection<Region> getRegions() {

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -5,6 +5,7 @@ import static org.batfish.representation.aws.InternetGateway.AWS_BACKBONE_NODE_N
 import static org.batfish.representation.aws.InternetGateway.BACKBONE_INTERFACE_NAME;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
@@ -52,8 +53,9 @@ public class AwsConfiguration extends VendorConfiguration {
     return _accounts.values();
   }
 
+  @VisibleForTesting
   @Nonnull
-  private Account addOrGetAccount(String accountId) {
+  Account addOrGetAccount(String accountId) {
     return _accounts.computeIfAbsent(accountId, Account::new);
   }
 
@@ -86,15 +88,30 @@ public class AwsConfiguration extends VendorConfiguration {
     for (Account account : getAccounts()) {
       Collection<Region> regions = account.getRegions();
       for (Region region : regions) {
-        region.toConfigurationNodes(_convertedConfiguration, getWarnings());
+        try {
+          region.toConfigurationNodes(_convertedConfiguration, getWarnings());
+        } catch (Exception e) {
+          getWarnings()
+              .redFlag(
+                  String.format(
+                      "Failed conversion for account %s, region %s\n%s",
+                      account.getId(), region.getName(), e));
+        }
       }
       // We do this de-duplication because cross-region connections will show up in both regions
       Set<VpcPeeringConnection> vpcPeeringConnections =
           regions.stream()
               .flatMap(r -> r.getVpcPeeringConnections().values().stream())
               .collect(ImmutableSet.toImmutableSet());
-      vpcPeeringConnections.forEach(
-          c -> c.createConnection(_convertedConfiguration, getWarnings()));
+      try {
+        vpcPeeringConnections.forEach(
+            c -> c.createConnection(_convertedConfiguration, getWarnings()));
+      } catch (Exception e) {
+        getWarnings()
+            .redFlag(
+                String.format(
+                    "Failed to process VPC peerings for account %s\n%s", account.getId(), e));
+      }
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationErrorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationErrorTest.java
@@ -1,0 +1,50 @@
+package org.batfish.representation.aws;
+
+import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasHostname;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.junit.Test;
+
+public class AwsConfigurationErrorTest {
+
+  /** Test that conversion doesn't return empty topology if one of the regions fails to convert */
+  @Test
+  public void toVendorIndependentConfigurations() {
+    Warnings w = new Warnings(true, true, true);
+    AwsConfiguration awsConfiguration = new AwsConfiguration();
+    awsConfiguration.setWarnings(w);
+
+    Account account = awsConfiguration.addOrGetAccount("account1");
+    account
+        .addOrGetRegion("region1")
+        .getVpcs()
+        .put("vpc1", new Vpc("vpc1", ImmutableSet.of(), ImmutableMap.of()));
+
+    Region r2_mock = mock(Region.class);
+    when(r2_mock.getName()).thenReturn("region2");
+    doThrow(new NullPointerException()).when(r2_mock).toConfigurationNodes(any(), same(w));
+    account.addRegion(r2_mock);
+
+    List<Configuration> c = awsConfiguration.toVendorIndependentConfigurations();
+
+    assertThat(c, contains(hasHostname("vpc1")));
+    assertThat(
+        w.getRedFlagWarnings().get(0).getText(),
+        allOf(
+            containsString("Failed conversion for"),
+            containsString(NullPointerException.class.getSimpleName())));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/BUILD
@@ -23,5 +23,7 @@ junit_tests(
         "@maven//:com_google_guava_guava_testlib",
         "@maven//:junit_junit",
         "@maven//:org_hamcrest_hamcrest",
+        "@maven//:org_mockito_mockito_core",
+        "@maven//:org_mockito_mockito_inline",
     ],
 )

--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -82,6 +82,7 @@
     <jsr305.version>3.0.2</jsr305.version>
     <junit.version>4.12</junit.version>
     <lz4.version>1.6.0</lz4.version>
+    <mockito.version>3.3.3</mockito.version>
     <opentracing-jaxrs2.version>1.0.0</opentracing-jaxrs2.version>
     <opentracing.version>0.33.0</opentracing.version>
     <parboiled.version>1.3.1</parboiled.version>
@@ -1030,6 +1031,18 @@
         <groupId>org.lastnpe.eea</groupId>
         <artifactId>jdk-eea</artifactId>
         <version>${jdk-eea.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <version>${mockito.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This is not perfect, but lets us crash less at, a high level (still need smaller granularity). The issues should end up in initIssues.

cc @dhalperi I've caved and decided to bring in a mocking library so I can write more concise tests. Let me know if you think this is overkill (but I do see potential uses for it in other places).