### PR TITLE
AWS: Cleanup ConvertedConfiguration

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -78,7 +78,7 @@ public class AwsConfiguration extends VendorConfiguration {
     if (_convertedConfiguration == null) {
       convertConfigurations();
     }
-    return ImmutableList.copyOf(_convertedConfiguration.getConfigurationNodes().values());
+    return ImmutableList.copyOf(_convertedConfiguration.getAllNodes());
   }
 
   private void convertConfigurations() {

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/ConvertedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/ConvertedConfiguration.java
@@ -2,21 +2,22 @@ package org.batfish.representation.aws;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.topology.Layer1Edge;
 import org.batfish.datamodel.Configuration;
 
 /** Represents vendor independent configuration data after conversion of native AWS data. */
 @ParametersAreNonnullByDefault
-public class ConvertedConfiguration implements Serializable {
+class ConvertedConfiguration implements Serializable {
 
   @Nonnull private final Map<String, Configuration> _configurationNodes;
-
   @Nonnull private final Set<Layer1Edge> _layer1Edges;
 
   public ConvertedConfiguration() {
@@ -35,9 +36,14 @@ public class ConvertedConfiguration implements Serializable {
     _layer1Edges = layer1Edges;
   }
 
-  @Nonnull
-  public Map<String, Configuration> getConfigurationNodes() {
-    return _configurationNodes;
+  /** Return configuration nodes across all accounts */
+  public Collection<Configuration> getAllNodes() {
+    return _configurationNodes.values();
+  }
+
+  @Nullable
+  public Configuration getNode(String hostname) {
+    return _configurationNodes.get(hostname);
   }
 
   @Nonnull
@@ -45,11 +51,12 @@ public class ConvertedConfiguration implements Serializable {
     return _layer1Edges;
   }
 
-  public void addNode(Configuration cfgNode) {
+  @VisibleForTesting
+  void addNode(Configuration cfgNode) {
     _configurationNodes.put(cfgNode.getHostname(), cfgNode);
   }
 
-  public void addEdge(String nodeName1, String ifaceName1, String nodeName2, String ifaceName2) {
+  void addEdge(String nodeName1, String ifaceName1, String nodeName2, String ifaceName2) {
     _layer1Edges.add(new Layer1Edge(nodeName1, ifaceName1, nodeName2, ifaceName2));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/ConvertedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/ConvertedConfiguration.java
@@ -51,7 +51,6 @@ class ConvertedConfiguration implements Serializable {
     return _layer1Edges;
   }
 
-  @VisibleForTesting
   void addNode(Configuration cfgNode) {
     _configurationNodes.put(cfgNode.getHostname(), cfgNode);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/NatGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/NatGateway.java
@@ -265,7 +265,7 @@ final class NatGateway implements AwsVpcEntity, Serializable {
       return null;
     }
 
-    Configuration vpcCfg = awsConfiguration.getConfigurationNodes().get(Vpc.nodeName(vpc.getId()));
+    Configuration vpcCfg = awsConfiguration.getNode(Vpc.nodeName(vpc.getId()));
     if (vpcCfg == null) {
       warnings.redFlag(
           String.format(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
@@ -201,8 +201,7 @@ public class Subnet implements AwsVpcEntity, Serializable {
         instancesIfaceName, cfgNode, instancesIfaceAddress, "To instances " + _subnetId);
 
     // connect to the VPC on each of its VRFs. add static routes on the VPC to this subnet.
-    Configuration vpcConfigNode =
-        awsConfiguration.getConfigurationNodes().get(Vpc.nodeName(_vpcId));
+    Configuration vpcConfigNode = awsConfiguration.getNode(Vpc.nodeName(_vpcId));
     vpcConfigNode
         .getVrfs()
         .values()
@@ -458,8 +457,7 @@ public class Subnet implements AwsVpcEntity, Serializable {
               cfgNode,
               sr.setNextHopIp(natGateway.getPrivateIp())
                   .setNextHopInterface(
-                      interfaceNameToRemote(
-                          awsConfiguration.getConfigurationNodes().get(natGateway.getId())))
+                      interfaceNameToRemote(awsConfiguration.getNode(natGateway.getId())))
                   .build());
         } else {
           addStaticRoute(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGateway.java
@@ -369,7 +369,7 @@ final class TransitGateway implements AwsVpcEntity, Serializable {
       return;
     }
 
-    Configuration vpcCfg = awsConfiguration.getConfigurationNodes().get(Vpc.nodeName(vpc.getId()));
+    Configuration vpcCfg = awsConfiguration.getNode(Vpc.nodeName(vpc.getId()));
     String vrfNameOnVpc = Vpc.vrfNameForLink(attachment.getId());
     if (!vpcCfg.getVrfs().containsKey(vrfNameOnVpc)) {
       warnings.redFlag(String.format("VRF %s not found on VPC %s", vrfNameOnVpc, vpc.getId()));
@@ -591,7 +591,7 @@ final class TransitGateway implements AwsVpcEntity, Serializable {
       ConvertedConfiguration awsConfiguration,
       Warnings warnings) {
 
-    Configuration vpcCfg = awsConfiguration.getConfigurationNodes().get(Vpc.nodeName(vpc.getId()));
+    Configuration vpcCfg = awsConfiguration.getNode(Vpc.nodeName(vpc.getId()));
     if (vpcCfg == null) {
       warnings.redFlag(String.format("VPC configuration node for VPC %s not found", vpc.getId()));
       return;
@@ -684,9 +684,7 @@ final class TransitGateway implements AwsVpcEntity, Serializable {
       case VPC:
         {
           Configuration vpcCfg =
-              awsConfiguration
-                  .getConfigurationNodes()
-                  .get(Vpc.nodeName(tgwAttachment.getResourceId()));
+              awsConfiguration.getNode(Vpc.nodeName(tgwAttachment.getResourceId()));
           addStaticRoute(
               vrf,
               toStaticRoute(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -331,7 +331,7 @@ final class Utils {
       return null;
     }
 
-    Configuration vpcCfg = awsConfiguration.getConfigurationNodes().get(Vpc.nodeName(vpc.getId()));
+    Configuration vpcCfg = awsConfiguration.getNode(Vpc.nodeName(vpc.getId()));
     if (vpcCfg == null) {
       warnings.redFlag(String.format("Configuration for VPC with id %s not found", vpcId));
       return null;

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpcPeeringConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpcPeeringConnection.java
@@ -130,8 +130,7 @@ final class VpcPeeringConnection implements AwsVpcEntity, Serializable {
    * routes that belong to subnets were inserted during subnet processing).
    */
   void createConnection(ConvertedConfiguration awsConfiguration, Warnings warnings) {
-    Configuration accepterCfg =
-        awsConfiguration.getConfigurationNodes().get(Vpc.nodeName(_accepterVpcId));
+    Configuration accepterCfg = awsConfiguration.getNode(Vpc.nodeName(_accepterVpcId));
     if (accepterCfg == null) {
       warnings.redFlag(
           String.format(
@@ -139,8 +138,7 @@ final class VpcPeeringConnection implements AwsVpcEntity, Serializable {
               _accepterVpcId, _vpcPeeringConnectionId));
       return;
     }
-    Configuration requesterCfg =
-        awsConfiguration.getConfigurationNodes().get(Vpc.nodeName(_requesterVpcId));
+    Configuration requesterCfg = awsConfiguration.getNode(Vpc.nodeName(_requesterVpcId));
     if (requesterCfg == null) {
       warnings.redFlag(
           String.format(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/NatGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/NatGatewayTest.java
@@ -120,7 +120,7 @@ public class NatGatewayTest {
 
     ConvertedConfiguration awsConfiguration = new ConvertedConfiguration();
     Configuration vpcCfg = vpc.toConfigurationNode(awsConfiguration, region, new Warnings());
-    awsConfiguration.getConfigurationNodes().put(vpcCfg.getHostname(), vpcCfg);
+    awsConfiguration.addNode(vpcCfg);
 
     String vrfNameOnVpc = vrfNameForLink(ngw.getId());
     vpcCfg
@@ -205,7 +205,7 @@ public class NatGatewayTest {
             .build();
     ConvertedConfiguration awsConfiguration = new ConvertedConfiguration();
     Configuration vpcCfg = vpc.toConfigurationNode(awsConfiguration, region, new Warnings());
-    awsConfiguration.getConfigurationNodes().put(vpcCfg.getHostname(), vpcCfg);
+    awsConfiguration.addNode(vpcCfg);
 
     ngw.connectToVpc(ngwConfig, awsConfiguration, region, new Warnings());
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import org.batfish.common.Warning;
 import org.batfish.common.Warnings;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -154,9 +153,10 @@ public class RegionTest {
             .setOwner(c)
             .setAddress(ConcreteInterfaceAddress.parse("12.12.12.0/24"))
             .build();
-    Map<String, Configuration> configurationMap = ImmutableMap.of(c.getHostname(), c);
+    ConvertedConfiguration cfg = new ConvertedConfiguration();
+    cfg.addNode(c);
     Region region = createTestRegion();
-    region.applyInstanceInterfaceAcls(configurationMap, new Warnings());
+    region.applyInstanceInterfaceAcls(cfg, new Warnings());
 
     // security groups sg-001 and sg-002 converted to ExprAclLines
     assertThat(c.getIpAccessLists(), hasKey("~INGRESS~SECURITY-GROUP~sg-1~sg-001~"));
@@ -196,9 +196,10 @@ public class RegionTest {
         .setOwner(c)
         .setAddress(ConcreteInterfaceAddress.parse("12.12.12.0/24"))
         .build();
-    Map<String, Configuration> configurationMap = ImmutableMap.of(c.getHostname(), c);
     Region region = createTestRegion();
-    region.applyInstanceInterfaceAcls(configurationMap, new Warnings());
+    ConvertedConfiguration cfg = new ConvertedConfiguration();
+    cfg.addNode(c);
+    region.applyInstanceInterfaceAcls(cfg, new Warnings());
     IpAccessList ingressAcl = c.getIpAccessLists().get("~SECURITY_GROUP_INGRESS_ACL~");
 
     Flow permittedFlow =


### PR DESCRIPTION
Maps are painful to work with. So cleanup to 
1. return collection of configurations, which is what we want most of the time anyway
2. Introduce `get` and `add` helpers so we can easily track read/write access.

No functionality changes