### PR TITLE
AWS NLB: Fix the type in the constructor of default action

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancerListener.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancerListener.java
@@ -56,7 +56,7 @@ final class LoadBalancerListener implements AwsVpcEntity, Serializable {
           order, targetGroupArn, ActionType.valueOf(type.toUpperCase().replace('-', '_')));
     }
 
-    DefaultAction(int order, String targetGroupArn, ActionType type) {
+    DefaultAction(@Nullable Integer order, String targetGroupArn, ActionType type) {
       _order = order;
       _targetGroupArn = targetGroupArn;
       _type = type;

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerListenerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerListenerTest.java
@@ -44,4 +44,18 @@ public class LoadBalancerListenerTest {
                             Protocol.TCP,
                             80))))));
   }
+
+  @Test
+  public void testDeserializationDefaultAction_nullOrder() throws IOException {
+    String text = CommonUtil.readResource("org/batfish/representation/aws/DefaultAction.json");
+
+    DefaultAction defaultAction = BatfishObjectMapper.mapper().readValue(text, DefaultAction.class);
+    assertThat(
+        defaultAction,
+        equalTo(
+            new DefaultAction(
+                null,
+                "arn:aws:elasticloadbalancing:us-east-2:554773406868:targetgroup/target1/10b6be82e58c40a8",
+                ActionType.FORWARD)));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/DefaultAction.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/DefaultAction.json
@@ -1,0 +1,4 @@
+{
+  "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-2:554773406868:targetgroup/target1/10b6be82e58c40a8",
+  "Type": "forward"
+}


### PR DESCRIPTION
This fixes a bug introduced in #5756 