### PR TITLE
AWS: support cross-account VPC peerings

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationVpcPeeringCrossAccountTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationVpcPeeringCrossAccountTest.java
@@ -1,0 +1,82 @@
+package org.batfish.representation.aws;
+
+import static org.batfish.representation.aws.AwsConfigurationTestUtils.getTcpFlow;
+import static org.batfish.representation.aws.AwsConfigurationTestUtils.testSetup;
+import static org.batfish.representation.aws.AwsConfigurationTestUtils.testTrace;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NamedPort;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class AwsConfigurationVpcPeeringCrossAccountTest {
+
+  private static final String TESTCONFIGS_DIR =
+      "org/batfish/representation/aws/test-vpc-peering-multi-account";
+
+  private static final List<String> fileNames =
+      ImmutableList.of(
+          "accounts/123456789012/us-east-1/NetworkInterfaces.json",
+          "accounts/123456789012/us-east-1/Reservations.json",
+          "accounts/123456789012/us-east-1/RouteTables.json",
+          "accounts/123456789012/us-east-1/SecurityGroups.json",
+          "accounts/123456789012/us-east-1/Subnets.json",
+          "accounts/123456789012/us-east-1/VpcPeeringConnections.json",
+          "accounts/123456789012/us-east-1/Vpcs.json",
+          "accounts/123456789013/us-east-1/NetworkInterfaces.json",
+          "accounts/123456789013/us-east-1/Reservations.json",
+          "accounts/123456789013/us-east-1/RouteTables.json",
+          "accounts/123456789013/us-east-1/SecurityGroups.json",
+          "accounts/123456789013/us-east-1/Subnets.json",
+          "accounts/123456789013/us-east-1/VpcPeeringConnections.json",
+          "accounts/123456789013/us-east-1/Vpcs.json");
+
+  // various entities in the configs
+  private static String _vpcA = "vpc-0f44fae3468d2b998";
+  private static String _vpcB = "vpc-05951c91977125d2e";
+
+  private static String _subnetA = "subnet-03a80d08017ee39ef";
+  private static String _subnetB = "subnet-088d6408a3a6129fa";
+
+  private static String _instanceA = "i-07ae69cc808e8804e";
+  private static String _instanceB = "i-066ce0b1efbb5602c";
+
+  private static Ip _instanceAIp = Ip.parse("10.1.1.100");
+  private static Ip _instanceBIp = Ip.parse("10.2.1.252");
+
+  @ClassRule public static TemporaryFolder _folder = new TemporaryFolder();
+
+  private static IBatfish _batfish;
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    _batfish = testSetup(TESTCONFIGS_DIR, fileNames, _folder);
+  }
+
+  /** Test connectivity from A to B */
+  @Test
+  public void testFromAtoB() {
+    testTrace(
+        getTcpFlow(_instanceA, _instanceBIp, NamedPort.SSH.number(), _batfish),
+        FlowDisposition.ACCEPTED,
+        ImmutableList.of(_instanceA, _subnetA, _vpcA, _vpcB, _subnetB, _instanceB),
+        _batfish);
+  }
+
+  /** Test connectivity from B to A */
+  @Test
+  public void testFromBtoA() {
+    testTrace(
+        getTcpFlow(_instanceB, _instanceAIp, NamedPort.SSH.number(), _batfish),
+        FlowDisposition.ACCEPTED,
+        ImmutableList.of(_instanceB, _subnetB, _vpcB, _vpcA, _subnetA, _instanceA),
+        _batfish);
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/NetworkInterfaces.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/NetworkInterfaces.json
@@ -1,0 +1,53 @@
+{
+ "NetworkInterfaces": [
+  {
+   "Association": {
+    "IpOwnerId": "amazon",
+    "PublicDnsName": "ec2-52-90-112-181.compute-1.amazonaws.com",
+    "PublicIp": "52.90.112.181"
+   },
+   "Attachment": {
+    "AttachTime": "2020-04-28 19:04:01+00:00",
+    "AttachmentId": "eni-attach-0dd098cfa8c30c6d7",
+    "DeleteOnTermination": true,
+    "DeviceIndex": 0,
+    "InstanceId": "i-07ae69cc808e8804e",
+    "InstanceOwnerId": "028403472736",
+    "Status": "attached"
+   },
+   "AvailabilityZone": "us-east-1a",
+   "Description": "",
+   "Groups": [
+    {
+     "GroupId": "sg-06804d246c3a853bc",
+     "GroupName": "bat_sg"
+    }
+   ],
+   "InterfaceType": "interface",
+   "Ipv6Addresses": [],
+   "MacAddress": "12:9c:03:9a:a2:3d",
+   "NetworkInterfaceId": "eni-0664ca29e3153724d",
+   "OwnerId": "028403472736",
+   "PrivateDnsName": "ip-10-1-1-100.ec2.internal",
+   "PrivateIpAddress": "10.1.1.100",
+   "PrivateIpAddresses": [
+    {
+     "Association": {
+      "IpOwnerId": "amazon",
+      "PublicDnsName": "ec2-52-90-112-181.compute-1.amazonaws.com",
+      "PublicIp": "52.90.112.181"
+     },
+     "Primary": true,
+     "PrivateDnsName": "ip-10-1-1-100.ec2.internal",
+     "PrivateIpAddress": "10.1.1.100"
+    }
+   ],
+   "RequesterManaged": false,
+   "SourceDestCheck": true,
+   "Status": "in-use",
+   "SubnetId": "subnet-03a80d08017ee39ef",
+   "TagSet": [],
+   "VpcId": "vpc-0f44fae3468d2b998"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/Reservations.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/Reservations.json
@@ -1,0 +1,133 @@
+{
+ "Reservations": [
+  {
+   "Groups": [],
+   "Instances": [
+    {
+     "AmiLaunchIndex": 0,
+     "Architecture": "x86_64",
+     "BlockDeviceMappings": [
+      {
+       "DeviceName": "/dev/xvda",
+       "Ebs": {
+        "AttachTime": "2020-04-28 19:04:02+00:00",
+        "DeleteOnTermination": true,
+        "Status": "attached",
+        "VolumeId": "vol-00511e88d3216777f"
+       }
+      }
+     ],
+     "CapacityReservationSpecification": {
+      "CapacityReservationPreference": "open"
+     },
+     "ClientToken": "",
+     "CpuOptions": {
+      "CoreCount": 1,
+      "ThreadsPerCore": 1
+     },
+     "EbsOptimized": false,
+     "EnaSupport": true,
+     "HibernationOptions": {
+      "Configured": false
+     },
+     "Hypervisor": "xen",
+     "ImageId": "ami-0fc61db8544a617ed",
+     "InstanceId": "i-07ae69cc808e8804e",
+     "InstanceType": "t2.micro",
+     "KeyName": "publicKey",
+     "LaunchTime": "2020-04-28 19:04:01+00:00",
+     "MetadataOptions": {
+      "HttpEndpoint": "enabled",
+      "HttpPutResponseHopLimit": 1,
+      "HttpTokens": "optional",
+      "State": "applied"
+     },
+     "Monitoring": {
+      "State": "disabled"
+     },
+     "NetworkInterfaces": [
+      {
+       "Association": {
+        "IpOwnerId": "amazon",
+        "PublicDnsName": "ec2-52-90-112-181.compute-1.amazonaws.com",
+        "PublicIp": "52.90.112.181"
+       },
+       "Attachment": {
+        "AttachTime": "2020-04-28 19:04:01+00:00",
+        "AttachmentId": "eni-attach-0dd098cfa8c30c6d7",
+        "DeleteOnTermination": true,
+        "DeviceIndex": 0,
+        "Status": "attached"
+       },
+       "Description": "",
+       "Groups": [
+        {
+         "GroupId": "sg-06804d246c3a853bc",
+         "GroupName": "bat_sg"
+        }
+       ],
+       "InterfaceType": "interface",
+       "Ipv6Addresses": [],
+       "MacAddress": "12:9c:03:9a:a2:3d",
+       "NetworkInterfaceId": "eni-0664ca29e3153724d",
+       "OwnerId": "028403472736",
+       "PrivateDnsName": "ip-10-1-1-100.ec2.internal",
+       "PrivateIpAddress": "10.1.1.100",
+       "PrivateIpAddresses": [
+        {
+         "Association": {
+          "IpOwnerId": "amazon",
+          "PublicDnsName": "ec2-52-90-112-181.compute-1.amazonaws.com",
+          "PublicIp": "52.90.112.181"
+         },
+         "Primary": true,
+         "PrivateDnsName": "ip-10-1-1-100.ec2.internal",
+         "PrivateIpAddress": "10.1.1.100"
+        }
+       ],
+       "SourceDestCheck": true,
+       "Status": "in-use",
+       "SubnetId": "subnet-03a80d08017ee39ef",
+       "VpcId": "vpc-0f44fae3468d2b998"
+      }
+     ],
+     "Placement": {
+      "AvailabilityZone": "us-east-1a",
+      "GroupName": "",
+      "Tenancy": "default"
+     },
+     "PrivateDnsName": "ip-10-1-1-100.ec2.internal",
+     "PrivateIpAddress": "10.1.1.100",
+     "ProductCodes": [],
+     "PublicDnsName": "ec2-52-90-112-181.compute-1.amazonaws.com",
+     "PublicIpAddress": "52.90.112.181",
+     "RootDeviceName": "/dev/xvda",
+     "RootDeviceType": "ebs",
+     "SecurityGroups": [
+      {
+       "GroupId": "sg-06804d246c3a853bc",
+       "GroupName": "bat_sg"
+      }
+     ],
+     "SourceDestCheck": true,
+     "State": {
+      "Code": 16,
+      "Name": "running"
+     },
+     "StateTransitionReason": "",
+     "SubnetId": "subnet-03a80d08017ee39ef",
+     "Tags": [
+      {
+       "Key": "Name",
+       "Value": "bat-web01"
+      }
+     ],
+     "VirtualizationType": "hvm",
+     "VpcId": "vpc-0f44fae3468d2b998"
+    }
+   ],
+   "OwnerId": "028403472736",
+   "ReservationId": "r-067c33c9a790a00b7"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/RouteTables.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/RouteTables.json
@@ -1,0 +1,72 @@
+{
+ "RouteTables": [
+  {
+   "Associations": [
+    {
+     "AssociationState": {
+      "State": "associated"
+     },
+     "Main": false,
+     "RouteTableAssociationId": "rtbassoc-0998a19797a233048",
+     "RouteTableId": "rtb-0039abf2a28b091bb",
+     "SubnetId": "subnet-03a80d08017ee39ef"
+    }
+   ],
+   "OwnerId": "028403472736",
+   "PropagatingVgws": [],
+   "RouteTableId": "rtb-0039abf2a28b091bb",
+   "Routes": [
+    {
+     "DestinationCidrBlock": "10.1.0.0/16",
+     "GatewayId": "local",
+     "Origin": "CreateRouteTable",
+     "State": "active"
+    },
+    {
+     "DestinationCidrBlock": "10.2.0.0/16",
+     "Origin": "CreateRoute",
+     "State": "active",
+     "VpcPeeringConnectionId": "pcx-0040f7640e10191f4"
+    },
+    {
+     "DestinationCidrBlock": "0.0.0.0/0",
+     "GatewayId": "igw-0ccac11864b23b189",
+     "Origin": "CreateRoute",
+     "State": "active"
+    }
+   ],
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "bat-igw"
+    }
+   ],
+   "VpcId": "vpc-0f44fae3468d2b998"
+  },
+  {
+   "Associations": [
+    {
+     "AssociationState": {
+      "State": "associated"
+     },
+     "Main": true,
+     "RouteTableAssociationId": "rtbassoc-080cb11fab6f82cbd",
+     "RouteTableId": "rtb-0b373ca59442bb240"
+    }
+   ],
+   "OwnerId": "028403472736",
+   "PropagatingVgws": [],
+   "RouteTableId": "rtb-0b373ca59442bb240",
+   "Routes": [
+    {
+     "DestinationCidrBlock": "10.1.0.0/16",
+     "GatewayId": "local",
+     "Origin": "CreateRouteTable",
+     "State": "active"
+    }
+   ],
+   "Tags": [],
+   "VpcId": "vpc-0f44fae3468d2b998"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/SecurityGroups.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/SecurityGroups.json
@@ -1,0 +1,109 @@
+{
+ "SecurityGroups": [
+  {
+   "Description": "Managed by Terraform",
+   "GroupId": "sg-06804d246c3a853bc",
+   "GroupName": "bat_sg",
+   "IpPermissions": [
+    {
+     "FromPort": 33434,
+     "IpProtocol": "udp",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "Traceroute Access"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "ToPort": 33534,
+     "UserIdGroupPairs": []
+    },
+    {
+     "FromPort": 22,
+     "IpProtocol": "tcp",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "SSH Access"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "ToPort": 22,
+     "UserIdGroupPairs": []
+    },
+    {
+     "FromPort": 8,
+     "IpProtocol": "icmp",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "ICMP Access"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "ToPort": 0,
+     "UserIdGroupPairs": []
+    }
+   ],
+   "IpPermissionsEgress": [
+    {
+     "IpProtocol": "-1",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "Allow all"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "UserIdGroupPairs": []
+    }
+   ],
+   "OwnerId": "028403472736",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "bat-general"
+    }
+   ],
+   "VpcId": "vpc-0f44fae3468d2b998"
+  },
+  {
+   "Description": "default VPC security group",
+   "GroupId": "sg-0ffc7b9e504929f9b",
+   "GroupName": "default",
+   "IpPermissions": [
+    {
+     "IpProtocol": "-1",
+     "IpRanges": [],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "UserIdGroupPairs": [
+      {
+       "GroupId": "sg-0ffc7b9e504929f9b",
+       "UserId": "028403472736"
+      }
+     ]
+    }
+   ],
+   "IpPermissionsEgress": [
+    {
+     "IpProtocol": "-1",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "UserIdGroupPairs": []
+    }
+   ],
+   "OwnerId": "028403472736",
+   "VpcId": "vpc-0f44fae3468d2b998"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/Subnets.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/Subnets.json
@@ -1,0 +1,25 @@
+{
+ "Subnets": [
+  {
+   "AssignIpv6AddressOnCreation": false,
+   "AvailabilityZone": "us-east-1a",
+   "AvailabilityZoneId": "use1-az2",
+   "AvailableIpAddressCount": 250,
+   "CidrBlock": "10.1.1.0/24",
+   "DefaultForAz": false,
+   "Ipv6CidrBlockAssociationSet": [],
+   "MapPublicIpOnLaunch": true,
+   "OwnerId": "028403472736",
+   "State": "available",
+   "SubnetArn": "arn:aws:ec2:us-east-1:028403472736:subnet/subnet-03a80d08017ee39ef",
+   "SubnetId": "subnet-03a80d08017ee39ef",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "bat_10.1.1.0/24"
+    }
+   ],
+   "VpcId": "vpc-0f44fae3468d2b998"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/VpcPeeringConnections.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/VpcPeeringConnections.json
@@ -1,0 +1,67 @@
+{
+ "VpcPeeringConnections": [
+  {
+   "AccepterVpcInfo": {
+    "CidrBlock": "10.2.0.0/16",
+    "CidrBlockSet": [
+     {
+      "CidrBlock": "10.2.0.0/16"
+     }
+    ],
+    "OwnerId": "951601349076",
+    "Region": "us-east-1",
+    "VpcId": "vpc-05951c91977125d2e"
+   },
+   "RequesterVpcInfo": {
+    "CidrBlock": "10.1.0.0/16",
+    "CidrBlockSet": [
+     {
+      "CidrBlock": "10.1.0.0/16"
+     }
+    ],
+    "OwnerId": "028403472736",
+    "PeeringOptions": {
+     "AllowDnsResolutionFromRemoteVpc": false,
+     "AllowEgressFromLocalClassicLinkToRemoteVpc": false,
+     "AllowEgressFromLocalVpcToRemoteClassicLink": false
+    },
+    "Region": "us-east-1",
+    "VpcId": "vpc-0f44fae3468d2b998"
+   },
+   "Status": {
+    "Code": "active",
+    "Message": "Active"
+   },
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "pcx-bat-fish-r"
+    }
+   ],
+   "VpcPeeringConnectionId": "pcx-0040f7640e10191f4"
+  },
+  {
+   "AccepterVpcInfo": {
+    "OwnerId": "951601349076",
+    "Region": "us-east-1",
+    "VpcId": "vpc-02faa96cfaac1c17f"
+   },
+   "RequesterVpcInfo": {
+    "OwnerId": "028403472736",
+    "Region": "us-east-1",
+    "VpcId": "vpc-0fecddf1419087c57"
+   },
+   "Status": {
+    "Code": "deleted",
+    "Message": "Deleted by 028403472736"
+   },
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "pcx-bat-fish-r"
+    }
+   ],
+   "VpcPeeringConnectionId": "pcx-00eeab4f3bd2a40da"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/Vpcs.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789012/us-east-1/Vpcs.json
@@ -1,0 +1,28 @@
+{
+ "Vpcs": [
+  {
+   "CidrBlock": "10.1.0.0/16",
+   "CidrBlockAssociationSet": [
+    {
+     "AssociationId": "vpc-cidr-assoc-006d602927203f95c",
+     "CidrBlock": "10.1.0.0/16",
+     "CidrBlockState": {
+      "State": "associated"
+     }
+    }
+   ],
+   "DhcpOptionsId": "dopt-3bb56641",
+   "InstanceTenancy": "default",
+   "IsDefault": false,
+   "OwnerId": "028403472736",
+   "State": "available",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "bat"
+    }
+   ],
+   "VpcId": "vpc-0f44fae3468d2b998"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/NetworkInterfaces.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/NetworkInterfaces.json
@@ -1,0 +1,53 @@
+{
+ "NetworkInterfaces": [
+  {
+   "Association": {
+    "IpOwnerId": "amazon",
+    "PublicDnsName": "ec2-54-82-106-49.compute-1.amazonaws.com",
+    "PublicIp": "54.82.106.49"
+   },
+   "Attachment": {
+    "AttachTime": "2020-04-28 19:03:40+00:00",
+    "AttachmentId": "eni-attach-05f4821141e5f2264",
+    "DeleteOnTermination": true,
+    "DeviceIndex": 0,
+    "InstanceId": "i-066ce0b1efbb5602c",
+    "InstanceOwnerId": "951601349076",
+    "Status": "attached"
+   },
+   "AvailabilityZone": "us-east-1a",
+   "Description": "",
+   "Groups": [
+    {
+     "GroupId": "sg-0ca8413f923260084",
+     "GroupName": "fish_sg"
+    }
+   ],
+   "InterfaceType": "interface",
+   "Ipv6Addresses": [],
+   "MacAddress": "0a:bf:3c:4a:80:05",
+   "NetworkInterfaceId": "eni-0b9f8c68d6cb974a6",
+   "OwnerId": "951601349076",
+   "PrivateDnsName": "ip-10-2-1-252.ec2.internal",
+   "PrivateIpAddress": "10.2.1.252",
+   "PrivateIpAddresses": [
+    {
+     "Association": {
+      "IpOwnerId": "amazon",
+      "PublicDnsName": "ec2-54-82-106-49.compute-1.amazonaws.com",
+      "PublicIp": "54.82.106.49"
+     },
+     "Primary": true,
+     "PrivateDnsName": "ip-10-2-1-252.ec2.internal",
+     "PrivateIpAddress": "10.2.1.252"
+    }
+   ],
+   "RequesterManaged": false,
+   "SourceDestCheck": true,
+   "Status": "in-use",
+   "SubnetId": "subnet-088d6408a3a6129fa",
+   "TagSet": [],
+   "VpcId": "vpc-05951c91977125d2e"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/Reservations.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/Reservations.json
@@ -1,0 +1,201 @@
+{
+ "Reservations": [
+  {
+   "Groups": [],
+   "Instances": [
+    {
+     "AmiLaunchIndex": 0,
+     "Architecture": "x86_64",
+     "BlockDeviceMappings": [],
+     "CapacityReservationSpecification": {
+      "CapacityReservationPreference": "open"
+     },
+     "ClientToken": "",
+     "CpuOptions": {
+      "CoreCount": 1,
+      "ThreadsPerCore": 1
+     },
+     "EbsOptimized": false,
+     "EnaSupport": true,
+     "HibernationOptions": {
+      "Configured": false
+     },
+     "Hypervisor": "xen",
+     "ImageId": "ami-0fc61db8544a617ed",
+     "InstanceId": "i-022b9fb2c0a0c72c1",
+     "InstanceType": "t2.micro",
+     "KeyName": "publicKey",
+     "LaunchTime": "2020-04-28 18:55:00+00:00",
+     "MetadataOptions": {
+      "HttpEndpoint": "enabled",
+      "HttpPutResponseHopLimit": 1,
+      "HttpTokens": "optional",
+      "State": "pending"
+     },
+     "Monitoring": {
+      "State": "disabled"
+     },
+     "NetworkInterfaces": [],
+     "Placement": {
+      "AvailabilityZone": "us-east-1a",
+      "GroupName": "",
+      "Tenancy": "default"
+     },
+     "PrivateDnsName": "",
+     "ProductCodes": [],
+     "PublicDnsName": "",
+     "RootDeviceName": "/dev/xvda",
+     "RootDeviceType": "ebs",
+     "SecurityGroups": [],
+     "State": {
+      "Code": 48,
+      "Name": "terminated"
+     },
+     "StateReason": {
+      "Code": "Client.UserInitiatedShutdown",
+      "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+     },
+     "StateTransitionReason": "User initiated (2020-04-28 19:00:14 GMT)",
+     "Tags": [
+      {
+       "Key": "Name",
+       "Value": "fish-web01"
+      }
+     ],
+     "VirtualizationType": "hvm"
+    }
+   ],
+   "OwnerId": "951601349076",
+   "ReservationId": "r-081bff6b9b21f3b53"
+  },
+  {
+   "Groups": [],
+   "Instances": [
+    {
+     "AmiLaunchIndex": 0,
+     "Architecture": "x86_64",
+     "BlockDeviceMappings": [
+      {
+       "DeviceName": "/dev/xvda",
+       "Ebs": {
+        "AttachTime": "2020-04-28 19:03:41+00:00",
+        "DeleteOnTermination": true,
+        "Status": "attached",
+        "VolumeId": "vol-0c2ed5d2fe85d2040"
+       }
+      }
+     ],
+     "CapacityReservationSpecification": {
+      "CapacityReservationPreference": "open"
+     },
+     "ClientToken": "",
+     "CpuOptions": {
+      "CoreCount": 1,
+      "ThreadsPerCore": 1
+     },
+     "EbsOptimized": false,
+     "EnaSupport": true,
+     "HibernationOptions": {
+      "Configured": false
+     },
+     "Hypervisor": "xen",
+     "ImageId": "ami-0fc61db8544a617ed",
+     "InstanceId": "i-066ce0b1efbb5602c",
+     "InstanceType": "t2.micro",
+     "KeyName": "publicKey",
+     "LaunchTime": "2020-04-28 19:03:40+00:00",
+     "MetadataOptions": {
+      "HttpEndpoint": "enabled",
+      "HttpPutResponseHopLimit": 1,
+      "HttpTokens": "optional",
+      "State": "applied"
+     },
+     "Monitoring": {
+      "State": "disabled"
+     },
+     "NetworkInterfaces": [
+      {
+       "Association": {
+        "IpOwnerId": "amazon",
+        "PublicDnsName": "ec2-54-82-106-49.compute-1.amazonaws.com",
+        "PublicIp": "54.82.106.49"
+       },
+       "Attachment": {
+        "AttachTime": "2020-04-28 19:03:40+00:00",
+        "AttachmentId": "eni-attach-05f4821141e5f2264",
+        "DeleteOnTermination": true,
+        "DeviceIndex": 0,
+        "Status": "attached"
+       },
+       "Description": "",
+       "Groups": [
+        {
+         "GroupId": "sg-0ca8413f923260084",
+         "GroupName": "fish_sg"
+        }
+       ],
+       "InterfaceType": "interface",
+       "Ipv6Addresses": [],
+       "MacAddress": "0a:bf:3c:4a:80:05",
+       "NetworkInterfaceId": "eni-0b9f8c68d6cb974a6",
+       "OwnerId": "951601349076",
+       "PrivateDnsName": "ip-10-2-1-252.ec2.internal",
+       "PrivateIpAddress": "10.2.1.252",
+       "PrivateIpAddresses": [
+        {
+         "Association": {
+          "IpOwnerId": "amazon",
+          "PublicDnsName": "ec2-54-82-106-49.compute-1.amazonaws.com",
+          "PublicIp": "54.82.106.49"
+         },
+         "Primary": true,
+         "PrivateDnsName": "ip-10-2-1-252.ec2.internal",
+         "PrivateIpAddress": "10.2.1.252"
+        }
+       ],
+       "SourceDestCheck": true,
+       "Status": "in-use",
+       "SubnetId": "subnet-088d6408a3a6129fa",
+       "VpcId": "vpc-05951c91977125d2e"
+      }
+     ],
+     "Placement": {
+      "AvailabilityZone": "us-east-1a",
+      "GroupName": "",
+      "Tenancy": "default"
+     },
+     "PrivateDnsName": "ip-10-2-1-252.ec2.internal",
+     "PrivateIpAddress": "10.2.1.252",
+     "ProductCodes": [],
+     "PublicDnsName": "ec2-54-82-106-49.compute-1.amazonaws.com",
+     "PublicIpAddress": "54.82.106.49",
+     "RootDeviceName": "/dev/xvda",
+     "RootDeviceType": "ebs",
+     "SecurityGroups": [
+      {
+       "GroupId": "sg-0ca8413f923260084",
+       "GroupName": "fish_sg"
+      }
+     ],
+     "SourceDestCheck": true,
+     "State": {
+      "Code": 16,
+      "Name": "running"
+     },
+     "StateTransitionReason": "",
+     "SubnetId": "subnet-088d6408a3a6129fa",
+     "Tags": [
+      {
+       "Key": "Name",
+       "Value": "fish-web01"
+      }
+     ],
+     "VirtualizationType": "hvm",
+     "VpcId": "vpc-05951c91977125d2e"
+    }
+   ],
+   "OwnerId": "951601349076",
+   "ReservationId": "r-017e8f7de6f2d32aa"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/RouteTables.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/RouteTables.json
@@ -1,0 +1,72 @@
+{
+ "RouteTables": [
+  {
+   "Associations": [
+    {
+     "AssociationState": {
+      "State": "associated"
+     },
+     "Main": false,
+     "RouteTableAssociationId": "rtbassoc-04775398939ab07fc",
+     "RouteTableId": "rtb-00fa109c642f8c07d",
+     "SubnetId": "subnet-088d6408a3a6129fa"
+    }
+   ],
+   "OwnerId": "951601349076",
+   "PropagatingVgws": [],
+   "RouteTableId": "rtb-00fa109c642f8c07d",
+   "Routes": [
+    {
+     "DestinationCidrBlock": "10.1.0.0/16",
+     "Origin": "CreateRoute",
+     "State": "active",
+     "VpcPeeringConnectionId": "pcx-0040f7640e10191f4"
+    },
+    {
+     "DestinationCidrBlock": "10.2.0.0/16",
+     "GatewayId": "local",
+     "Origin": "CreateRouteTable",
+     "State": "active"
+    },
+    {
+     "DestinationCidrBlock": "0.0.0.0/0",
+     "GatewayId": "igw-040de946422fc9672",
+     "Origin": "CreateRoute",
+     "State": "active"
+    }
+   ],
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "fish-igw"
+    }
+   ],
+   "VpcId": "vpc-05951c91977125d2e"
+  },
+  {
+   "Associations": [
+    {
+     "AssociationState": {
+      "State": "associated"
+     },
+     "Main": true,
+     "RouteTableAssociationId": "rtbassoc-0d1f4545088632530",
+     "RouteTableId": "rtb-05a771a8b6dde18b1"
+    }
+   ],
+   "OwnerId": "951601349076",
+   "PropagatingVgws": [],
+   "RouteTableId": "rtb-05a771a8b6dde18b1",
+   "Routes": [
+    {
+     "DestinationCidrBlock": "10.2.0.0/16",
+     "GatewayId": "local",
+     "Origin": "CreateRouteTable",
+     "State": "active"
+    }
+   ],
+   "Tags": [],
+   "VpcId": "vpc-05951c91977125d2e"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/SecurityGroups.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/SecurityGroups.json
@@ -1,0 +1,109 @@
+{
+ "SecurityGroups": [
+  {
+   "Description": "Managed by Terraform",
+   "GroupId": "sg-0ca8413f923260084",
+   "GroupName": "fish_sg",
+   "IpPermissions": [
+    {
+     "FromPort": 33434,
+     "IpProtocol": "udp",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "Traceroute Access"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "ToPort": 33534,
+     "UserIdGroupPairs": []
+    },
+    {
+     "FromPort": 22,
+     "IpProtocol": "tcp",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "SSH Access"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "ToPort": 22,
+     "UserIdGroupPairs": []
+    },
+    {
+     "FromPort": 8,
+     "IpProtocol": "icmp",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "ICMP Access"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "ToPort": 0,
+     "UserIdGroupPairs": []
+    }
+   ],
+   "IpPermissionsEgress": [
+    {
+     "IpProtocol": "-1",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "Allow all"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "UserIdGroupPairs": []
+    }
+   ],
+   "OwnerId": "951601349076",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "fish-general"
+    }
+   ],
+   "VpcId": "vpc-05951c91977125d2e"
+  },
+  {
+   "Description": "default VPC security group",
+   "GroupId": "sg-0de1b8dd6b574424d",
+   "GroupName": "default",
+   "IpPermissions": [
+    {
+     "IpProtocol": "-1",
+     "IpRanges": [],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "UserIdGroupPairs": [
+      {
+       "GroupId": "sg-0de1b8dd6b574424d",
+       "UserId": "951601349076"
+      }
+     ]
+    }
+   ],
+   "IpPermissionsEgress": [
+    {
+     "IpProtocol": "-1",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "UserIdGroupPairs": []
+    }
+   ],
+   "OwnerId": "951601349076",
+   "VpcId": "vpc-05951c91977125d2e"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/Subnets.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/Subnets.json
@@ -1,0 +1,25 @@
+{
+ "Subnets": [
+  {
+   "AssignIpv6AddressOnCreation": false,
+   "AvailabilityZone": "us-east-1a",
+   "AvailabilityZoneId": "use1-az4",
+   "AvailableIpAddressCount": 250,
+   "CidrBlock": "10.2.1.0/24",
+   "DefaultForAz": false,
+   "Ipv6CidrBlockAssociationSet": [],
+   "MapPublicIpOnLaunch": true,
+   "OwnerId": "951601349076",
+   "State": "available",
+   "SubnetArn": "arn:aws:ec2:us-east-1:951601349076:subnet/subnet-088d6408a3a6129fa",
+   "SubnetId": "subnet-088d6408a3a6129fa",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "fish_10.2.1.0/24"
+    }
+   ],
+   "VpcId": "vpc-05951c91977125d2e"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/VpcPeeringConnections.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/VpcPeeringConnections.json
@@ -1,0 +1,90 @@
+{
+ "VpcPeeringConnections": [
+  {
+   "AccepterVpcInfo": {
+    "OwnerId": "951601349076",
+    "Region": "us-east-1",
+    "VpcId": "vpc-02faa96cfaac1c17f"
+   },
+   "RequesterVpcInfo": {
+    "OwnerId": "028403472736",
+    "Region": "us-east-1",
+    "VpcId": "vpc-0fecddf1419087c57"
+   },
+   "Status": {
+    "Code": "deleted",
+    "Message": "Deleted by 028403472736"
+   },
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "pcx-bat-fish-a"
+    }
+   ],
+   "VpcPeeringConnectionId": "pcx-00eeab4f3bd2a40da"
+  },
+  {
+   "AccepterVpcInfo": {
+    "CidrBlock": "10.2.0.0/16",
+    "CidrBlockSet": [
+     {
+      "CidrBlock": "10.2.0.0/16"
+     }
+    ],
+    "OwnerId": "951601349076",
+    "PeeringOptions": {
+     "AllowDnsResolutionFromRemoteVpc": false,
+     "AllowEgressFromLocalClassicLinkToRemoteVpc": false,
+     "AllowEgressFromLocalVpcToRemoteClassicLink": false
+    },
+    "Region": "us-east-1",
+    "VpcId": "vpc-05951c91977125d2e"
+   },
+   "RequesterVpcInfo": {
+    "CidrBlock": "10.1.0.0/16",
+    "CidrBlockSet": [
+     {
+      "CidrBlock": "10.1.0.0/16"
+     }
+    ],
+    "OwnerId": "028403472736",
+    "Region": "us-east-1",
+    "VpcId": "vpc-0f44fae3468d2b998"
+   },
+   "Status": {
+    "Code": "active",
+    "Message": "Active"
+   },
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "pcx-bat-fish-a"
+    }
+   ],
+   "VpcPeeringConnectionId": "pcx-0040f7640e10191f4"
+  },
+  {
+   "AccepterVpcInfo": {
+    "OwnerId": "951601349076",
+    "Region": "us-east-1",
+    "VpcId": "vpc-0b4e14880aac9155f"
+   },
+   "RequesterVpcInfo": {
+    "OwnerId": "028403472736",
+    "Region": "us-east-1",
+    "VpcId": "vpc-082cf3bfeb6d2e821"
+   },
+   "Status": {
+    "Code": "deleted",
+    "Message": "Deleted by 028403472736"
+   },
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "pcx-bat-fish-a"
+    }
+   ],
+   "VpcPeeringConnectionId": "pcx-07d8d712b329b9337"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/Vpcs.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-vpc-peering-multi-account/aws_configs/accounts/123456789013/us-east-1/Vpcs.json
@@ -1,0 +1,28 @@
+{
+ "Vpcs": [
+  {
+   "CidrBlock": "10.2.0.0/16",
+   "CidrBlockAssociationSet": [
+    {
+     "AssociationId": "vpc-cidr-assoc-061dc252477fb1d6a",
+     "CidrBlock": "10.2.0.0/16",
+     "CidrBlockState": {
+      "State": "associated"
+     }
+    }
+   ],
+   "DhcpOptionsId": "dopt-aa2d83d0",
+   "InstanceTenancy": "default",
+   "IsDefault": false,
+   "OwnerId": "951601349076",
+   "State": "available",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "fish"
+    }
+   ],
+   "VpcId": "vpc-05951c91977125d2e"
+  }
+ ]
+}


### PR DESCRIPTION
Generalize peering creation logic to be cross-account.