### PR TITLE
AWS tgw: parse owner id

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsVpcEntity.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsVpcEntity.java
@@ -90,6 +90,7 @@ public interface AwsVpcEntity {
   String JSON_KEY_OPTIONS = "Options";
   String JSON_KEY_ORDER = "Order";
   String JSON_KEY_OUTSIDE_IP_ADDRESS = "OutsideIpAddress";
+  String JSON_KEY_OWNER_ID = "OwnerId";
   String JSON_KEY_PLACEMENT = "Placement";
   String JSON_KEY_PLACEMENT_GROUPS = "PlacementGroups";
   String JSON_KEY_PORT = "Port";

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGateway.java
@@ -213,29 +213,33 @@ final class TransitGateway implements AwsVpcEntity, Serializable {
   }
 
   @Nonnull private final String _gatewayId;
-
   @Nonnull private final TransitGatewayOptions _options;
-
+  @Nonnull private final String _ownerId;
   @Nonnull private final Map<String, String> _tags;
 
   @JsonCreator
   private static TransitGateway create(
       @Nullable @JsonProperty(JSON_KEY_TRANSIT_GATEWAY_ID) String gatewayId,
       @Nullable @JsonProperty(JSON_KEY_OPTIONS) TransitGatewayOptions options,
+      @Nullable @JsonProperty(JSON_KEY_OWNER_ID) String ownerId,
       @Nullable @JsonProperty(JSON_KEY_TAGS) List<Tag> tags) {
     checkArgument(gatewayId != null, "Transit Gateway Id cannot be null");
     checkArgument(options != null, "Transit Gateway Options cannot be null");
+    checkArgument(ownerId != null, "Transit Gateway owner ID cannot be null");
 
     return new TransitGateway(
         gatewayId,
         options,
+        ownerId,
         firstNonNull(tags, ImmutableList.<Tag>of()).stream()
             .collect(ImmutableMap.toImmutableMap(Tag::getKey, Tag::getValue)));
   }
 
-  public TransitGateway(String gatewayId, TransitGatewayOptions options, Map<String, String> tags) {
+  public TransitGateway(
+      String gatewayId, TransitGatewayOptions options, String ownerId, Map<String, String> tags) {
     _gatewayId = gatewayId;
     _options = options;
+    _ownerId = ownerId;
     _tags = tags;
   }
 
@@ -747,8 +751,13 @@ final class TransitGateway implements AwsVpcEntity, Serializable {
     return _gatewayId;
   }
 
+  @Nonnull
+  public String getOwnerId() {
+    return _ownerId;
+  }
+
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayTest.java
@@ -93,6 +93,7 @@ public class TransitGatewayTest {
                         true,
                         "tgw-rtb-0fa40c8df355dce6e",
                         true),
+                    "554773406868",
                     ImmutableMap.of(TAG_NAME, "transit-test")))));
   }
 
@@ -103,6 +104,7 @@ public class TransitGatewayTest {
         new TransitGateway(
             "tgw",
             new TransitGatewayOptions(0L, true, routeTableId, true, "tgw-rtb", true),
+            "123456789012",
             ImmutableMap.of());
 
     Prefix vpcPrefix = Prefix.parse("3.3.3.0/24");
@@ -303,6 +305,7 @@ public class TransitGatewayTest {
         new TransitGateway(
             "tgw",
             new TransitGatewayOptions(0L, true, routeTableId, true, "tgw-rtb", true),
+            "123456789012",
             ImmutableMap.of());
 
     VpnConnection vpnConnection =
@@ -361,6 +364,7 @@ public class TransitGatewayTest {
         new TransitGateway(
             "tgw",
             new TransitGatewayOptions(0L, true, routeTableId, true, "tgw-rtb", true),
+            "123456789012",
             ImmutableMap.of(TAG_NAME, "tgw-name"));
 
     VpnConnection vpnConnection =
@@ -448,6 +452,7 @@ public class TransitGatewayTest {
         new TransitGateway(
             "tgw",
             new TransitGatewayOptions(0L, true, routeTableId, true, "tgw-rtb", true),
+            "123456789012",
             ImmutableMap.of());
 
     Prefix vpcPrefix = Prefix.parse("2.2.2.2/32");
@@ -522,6 +527,7 @@ public class TransitGatewayTest {
         new TransitGateway(
             "tgw",
             new TransitGatewayOptions(0L, true, routeTableId, true, "tgw-rtb", true),
+            "123456789012",
             ImmutableMap.of());
 
     Vpc vpc = new Vpc("vpc", ImmutableSet.of(), ImmutableMap.of()); // no prefix
@@ -601,6 +607,7 @@ public class TransitGatewayTest {
         new TransitGateway(
             "tgw",
             new TransitGatewayOptions(0L, true, routeTableId, true, "tgw-rtb", true),
+            "123456789012",
             ImmutableMap.of());
 
     VpnConnection vpnConnection =


### PR DESCRIPTION
This will help choose an "authoritative" TGW in the future when we correctly convert 1-out-of-many TGWs when they are shared across accounts. 