### PR TITLE
AWS: support multi-account transit gateways

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -101,6 +101,9 @@ public class AwsConfiguration extends VendorConfiguration {
     }
     // Vpc peerings can be both cross-region and cross-account, so we handle them here
     processVpcPeerings();
+    // Transit gateways can be both cross-account so we handle them here:
+    TransitGatewayConverter.convertTransitGateways(this, _convertedConfiguration)
+        .forEach(_convertedConfiguration::addNode);
   }
 
   private void processVpcPeerings() {

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -116,7 +116,7 @@ public class AwsConfiguration extends VendorConfiguration {
     }
     // Vpc peerings can be both cross-region and cross-account, so we handle them here
     processVpcPeerings();
-    // Transit gateways can be both cross-account so we handle them here:
+    // Transit gateways can be cross-account so we handle them here
     TransitGatewayConverter.convertTransitGateways(this, _convertedConfiguration)
         .forEach(_convertedConfiguration::addNode);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -51,6 +52,20 @@ public class AwsConfiguration extends VendorConfiguration {
 
   public Collection<Account> getAccounts() {
     return _accounts.values();
+  }
+
+  /** Return a stream of all VPCs, across all accounts */
+  @Nonnull
+  public Stream<Vpc> getAllVpc() {
+    return getAccounts().stream()
+        .flatMap(a -> a.getRegions().stream())
+        .flatMap(r -> r.getVpcs().values().stream());
+  }
+
+  /** Return a VPC with a given ID (in any account/region) if it exists, or {@code null} */
+  @Nullable
+  public Vpc getVpc(String vpcId) {
+    return getAllVpc().filter(v -> vpcId.equals(v.getId())).findFirst().orElse(null);
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -741,7 +741,8 @@ public final class Region implements Serializable {
       awsConfiguration.addNode(cfgNode);
     }
 
-    // VpcPeeringConnections and TransitGateways are processed in AwsConfiguration since they can be cross region (or cross-account)
+    // VpcPeeringConnections and TransitGateways are processed in AwsConfiguration since they can be
+    // cross region (or cross-account)
 
     applyInstanceInterfaceAcls(awsConfiguration, warnings);
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -741,12 +741,7 @@ public final class Region implements Serializable {
       awsConfiguration.addNode(cfgNode);
     }
 
-    for (TransitGateway tgw : getTransitGateways().values()) {
-      Configuration cfgNode = tgw.toConfigurationNode(awsConfiguration, this, warnings);
-      awsConfiguration.addNode(cfgNode);
-    }
-
-    // VpcPeeringConnections are processed in AwsConfiguration since they can be cross region
+    // VpcPeeringConnections and TransitGateways are processed in AwsConfiguration since they can be cross region (or cross-account)
 
     applyInstanceInterfaceAcls(awsConfiguration, warnings);
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayConverter.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayConverter.java
@@ -67,7 +67,8 @@ public final class TransitGatewayConverter {
         .map(
             tgw ->
                 tgw.getGateway()
-                    .toConfigurationNode(configs, tgw.getRegion(), awsConfiguration.getWarnings()))
+                    .toConfigurationNode(
+                        awsConfiguration, configs, tgw.getRegion(), awsConfiguration.getWarnings()))
         .collect(ImmutableList.toImmutableList());
   }
 
@@ -121,7 +122,8 @@ public final class TransitGatewayConverter {
   static TransitGatewayWithMetadata findOriginalGateway(
       Collection<TransitGatewayWithMetadata> tgws) {
     checkArgument(!tgws.isEmpty());
-    checkArgument(tgws.stream().map(TransitGatewayWithMetadata::getTransitGatewayId).distinct().count() == 1);
+    checkArgument(
+        tgws.stream().map(TransitGatewayWithMetadata::getTransitGatewayId).distinct().count() == 1);
     if (tgws.size() == 1) {
       // Short circuit if there is no de-duplication to do.
       return tgws.iterator().next();

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayConverter.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayConverter.java
@@ -1,0 +1,134 @@
+package org.batfish.representation.aws;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.Sets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+
+@ParametersAreNonnullByDefault
+public final class TransitGatewayConverter {
+
+  /* Transit Gateway with metadata about which account and region it came from. Required for conversion */
+  @VisibleForTesting
+  static final class TransitGatewayWithMetadata {
+    @Nonnull private TransitGateway _gateway;
+    @Nonnull private Region _region;
+    @Nonnull private String _accountId;
+
+    @VisibleForTesting
+    TransitGatewayWithMetadata(TransitGateway gateway, Region region, String accountId) {
+      _gateway = gateway;
+      _region = region;
+      _accountId = accountId;
+    }
+
+    boolean isOriginal() {
+      return _accountId.equals(_gateway.getOwnerId());
+    }
+
+    String getTransitGatewayId() {
+      return _gateway.getId();
+    }
+
+    @Nonnull
+    public TransitGateway getGateway() {
+      return _gateway;
+    }
+
+    @Nonnull
+    public Region getRegion() {
+      return _region;
+    }
+  }
+
+  /**
+   * Convert transit gateways in a way that keeps them unique, with one hostname per gateway, even
+   * if they appear in multiple accounts. For each tgw, determine the account that owns it, use that
+   * VS representation.
+   */
+  public static List<Configuration> convertTransitGateways(
+      AwsConfiguration awsConfiguration, ConvertedConfiguration configs) {
+    return getUniqueTransitGateways(
+            collectGateways(awsConfiguration), awsConfiguration.getWarnings())
+        .stream()
+        .map(
+            tgw ->
+                tgw.getGateway()
+                    .toConfigurationNode(configs, tgw.getRegion(), awsConfiguration.getWarnings()))
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  @VisibleForTesting
+  static Collection<TransitGatewayWithMetadata> getUniqueTransitGateways(
+      Collection<TransitGatewayWithMetadata> gateways, Warnings warnings) {
+    // Break into groups (by ID). Attempt to find an original gateway for each ID.
+    // If we didn't get correct account from snapshot packaging, bail converting (for that one TGW).
+    Map<String, List<TransitGatewayWithMetadata>> byId =
+        gateways.stream()
+            .collect(
+                Collectors.groupingBy(
+                    TransitGatewayWithMetadata::getTransitGatewayId, Collectors.toList()));
+    List<TransitGatewayWithMetadata> result =
+        byId.values().stream()
+            .map(TransitGatewayConverter::findOriginalGateway)
+            .filter(Objects::nonNull)
+            .collect(ImmutableList.toImmutableList());
+    // If we couldn't find some authoritative TGWs, log a warning
+    if (result.size() < byId.size()) {
+      Set<String> missing =
+          Sets.difference(
+              byId.keySet(),
+              result.stream()
+                  .map(TransitGatewayWithMetadata::getTransitGatewayId)
+                  .collect(Collectors.toSet()));
+      warnings.redFlag(
+          String.format(
+              "Could not find authoritative representation for transit gateways: %s",
+              String.join(" ", missing)));
+    }
+    return result;
+  }
+
+  /** Collect all transit gateways across regions and accounts */
+  private static ImmutableList<TransitGatewayWithMetadata> collectGateways(
+      AwsConfiguration awsConfiguration) {
+    Builder<TransitGatewayWithMetadata> builder = ImmutableList.builder();
+    for (Account account : awsConfiguration.getAccounts()) {
+      for (Region region : account.getRegions()) {
+        for (TransitGateway tgw : region.getTransitGateways().values()) {
+          builder.add(new TransitGatewayWithMetadata(tgw, region, account.getId()));
+        }
+      }
+    }
+    return builder.build();
+  }
+
+  @VisibleForTesting
+  @Nullable
+  static TransitGatewayWithMetadata findOriginalGateway(
+      Collection<TransitGatewayWithMetadata> tgws) {
+    checkArgument(!tgws.isEmpty());
+    checkArgument(tgws.stream().map(TransitGatewayWithMetadata::getTransitGatewayId).distinct().count() == 1);
+    if (tgws.size() == 1) {
+      // Short circuit if there is no de-duplication to do.
+      return tgws.iterator().next();
+    }
+    return tgws.stream().filter(TransitGatewayWithMetadata::isOriginal).findFirst().orElse(null);
+  }
+
+  // prevent initialization
+  private TransitGatewayConverter() {}
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationTransitGatewayMultiAccountTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationTransitGatewayMultiAccountTest.java
@@ -1,0 +1,99 @@
+package org.batfish.representation.aws;
+
+import static org.batfish.representation.aws.AwsConfigurationTestUtils.getTcpFlow;
+import static org.batfish.representation.aws.AwsConfigurationTestUtils.testSetup;
+import static org.batfish.representation.aws.AwsConfigurationTestUtils.testTrace;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.NamedPort;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * E2e tests for transit gateway. The configuration was pulled after creating two VPCs A and B and
+ * connecting them via a transit gateway. VPC A has two subnets in different availability zones; the
+ * routing table of only of those points to the transit gateway attachment. VPC B has only one
+ * subnet, which is connected to the attachment.
+ */
+public class AwsConfigurationTransitGatewayMultiAccountTest {
+
+  private static final String TESTCONFIGS_DIR =
+      "org/batfish/representation/aws/test-transit-gateway-multi-account";
+
+  private static final List<String> fileNames =
+      ImmutableList.of(
+          "accounts/028403472736/us-east-1/NetworkInterfaces.json",
+          "accounts/028403472736/us-east-1/Reservations.json",
+          "accounts/028403472736/us-east-1/RouteTables.json",
+          "accounts/028403472736/us-east-1/SecurityGroups.json",
+          "accounts/028403472736/us-east-1/Subnets.json",
+          "accounts/028403472736/us-east-1/TransitGatewayAttachments.json",
+          "accounts/028403472736/us-east-1/TransitGatewayPropagations.json",
+          "accounts/028403472736/us-east-1/TransitGatewayRouteTables.json",
+          "accounts/028403472736/us-east-1/TransitGateways.json",
+          "accounts/028403472736/us-east-1/TransitGatewayStaticRoutes.json",
+          "accounts/028403472736/us-east-1/TransitGatewayVpcAttachments.json",
+          "accounts/028403472736/us-east-1/Vpcs.json",
+          "accounts/951601349076/us-east-1/NetworkInterfaces.json",
+          "accounts/951601349076/us-east-1/Reservations.json",
+          "accounts/951601349076/us-east-1/RouteTables.json",
+          "accounts/951601349076/us-east-1/SecurityGroups.json",
+          "accounts/951601349076/us-east-1/Subnets.json",
+          "accounts/951601349076/us-east-1/TransitGatewayAttachments.json",
+          "accounts/951601349076/us-east-1/TransitGatewayPropagations.json",
+          "accounts/951601349076/us-east-1/TransitGatewayRouteTables.json",
+          "accounts/951601349076/us-east-1/TransitGateways.json",
+          "accounts/951601349076/us-east-1/TransitGatewayStaticRoutes.json",
+          "accounts/951601349076/us-east-1/TransitGatewayVpcAttachments.json",
+          "accounts/951601349076/us-east-1/Vpcs.json");
+
+  // various entities in the configs
+  private static String _tgw = "tgw-0efdeab79e9a8e490";
+  private static String _vpcA = "vpc-04048d4bfba9c2289";
+  private static String _vpcB = "vpc-08287a9084472b276";
+
+  private static String _subnetA = "subnet-0a68915f31d3ca69f";
+  private static String _subnetB = "subnet-0c2cb08833b3c9921";
+
+  private static String _instanceA = "i-0bdf35d561be3d962";
+  private static String _instanceB = "i-03df168b3f73cc262";
+
+  private static Ip _instanceAIp = Ip.parse("10.1.1.100");
+  private static Ip _instanceBIp = Ip.parse("10.2.1.183");
+
+  @ClassRule public static TemporaryFolder _folder = new TemporaryFolder();
+
+  private static IBatfish _batfish;
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    _batfish = testSetup(TESTCONFIGS_DIR, fileNames, _folder);
+  }
+
+  /** Test connectivity from A to B */
+  @Test
+  public void testFromAtoB() {
+    testTrace(
+        getTcpFlow(_instanceA, _instanceBIp, NamedPort.SSH.number(), _batfish),
+        FlowDisposition.ACCEPTED,
+        ImmutableList.of(_instanceA, _subnetA, _vpcA, _tgw, _vpcB, _subnetB, _instanceB),
+        _batfish);
+  }
+
+  /** Test connectivity from B to A */
+  @Test
+  public void testFromBtoA() {
+    testTrace(
+        getTcpFlow(_instanceB, _instanceAIp, NamedPort.SSH.number(), _batfish),
+        FlowDisposition.ACCEPTED,
+        ImmutableList.of(_instanceB, _subnetB, _vpcB, _tgw, _vpcA, _subnetA, _instanceA),
+        _batfish);
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayConverterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayConverterTest.java
@@ -1,0 +1,134 @@
+package org.batfish.representation.aws;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import org.batfish.common.Warning;
+import org.batfish.common.Warnings;
+import org.batfish.representation.aws.TransitGatewayConverter.TransitGatewayWithMetadata;
+import org.junit.Test;
+
+public class TransitGatewayConverterTest {
+
+  @Test
+  public void testFindOriginalGateway() {
+    TransitGateway tgw1 = mock(TransitGateway.class);
+    when(tgw1.getId()).thenReturn("id1");
+    when(tgw1.getOwnerId()).thenReturn("account1");
+    TransitGateway tgw2 = mock(TransitGateway.class);
+    when(tgw2.getId()).thenReturn("id1");
+    when(tgw2.getOwnerId()).thenReturn("account1");
+    TransitGatewayWithMetadata t1 =
+        new TransitGatewayWithMetadata(tgw1, new Region("r1"), "account1");
+    TransitGatewayWithMetadata t2 =
+        new TransitGatewayWithMetadata(tgw2, new Region("r1"), "account2");
+    assertThat(
+        TransitGatewayConverter.findOriginalGateway(ImmutableList.of(t1, t2)), sameInstance(t1));
+  }
+
+  @Test
+  public void testFindOriginalGatewayNonAmbiguous() {
+    TransitGateway tgw1 = mock(TransitGateway.class);
+    when(tgw1.getId()).thenReturn("id1");
+    when(tgw1.getOwnerId()).thenReturn("account1");
+    // Note account mismatch
+    TransitGatewayWithMetadata t1 =
+        new TransitGatewayWithMetadata(tgw1, new Region("r1"), "wrong_account");
+    assertThat(TransitGatewayConverter.findOriginalGateway(ImmutableList.of(t1)), sameInstance(t1));
+  }
+
+  @Test
+  public void testFindOriginalGatewayFailure() {
+    TransitGateway tgw1 = mock(TransitGateway.class);
+    when(tgw1.getId()).thenReturn("id1");
+    when(tgw1.getOwnerId()).thenReturn("account1");
+    TransitGateway tgw2 = mock(TransitGateway.class);
+    when(tgw2.getId()).thenReturn("id1");
+    when(tgw2.getOwnerId()).thenReturn("account1");
+    // Note account mismatch
+    TransitGatewayWithMetadata t1 =
+        new TransitGatewayWithMetadata(tgw1, new Region("r1"), "wrong_account");
+    TransitGatewayWithMetadata t2 =
+        new TransitGatewayWithMetadata(tgw1, new Region("r1"), "wrong_account_2");
+    assertThat(TransitGatewayConverter.findOriginalGateway(ImmutableList.of(t1, t2)), nullValue());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFindOriginalGatewayEmpty() {
+    TransitGatewayConverter.findOriginalGateway(ImmutableList.of());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFindOriginalGatewayNotAllSameId() {
+    TransitGateway tgw1 = mock(TransitGateway.class);
+    when(tgw1.getId()).thenReturn("id1");
+    TransitGateway tgw2 = mock(TransitGateway.class);
+    when(tgw2.getId()).thenReturn("id2");
+    TransitGatewayWithMetadata t1 =
+        new TransitGatewayWithMetadata(tgw1, new Region("r1"), "account1");
+    TransitGatewayWithMetadata t2 =
+        new TransitGatewayWithMetadata(tgw2, new Region("r1"), "account1");
+    TransitGatewayConverter.findOriginalGateway(ImmutableList.of(t1, t2));
+  }
+
+  @Test
+  public void testGetUniqueTransitGateways() {
+    TransitGateway tgw1 = mock(TransitGateway.class);
+    when(tgw1.getId()).thenReturn("id1");
+    when(tgw1.getOwnerId()).thenReturn("account1");
+    TransitGateway tgw2 = mock(TransitGateway.class);
+    when(tgw2.getId()).thenReturn("id1");
+    when(tgw2.getOwnerId()).thenReturn("account1");
+
+    TransitGateway tgw3 = mock(TransitGateway.class);
+    when(tgw3.getId()).thenReturn("id2");
+    when(tgw3.getOwnerId()).thenReturn("account3");
+
+    TransitGatewayWithMetadata t1 =
+        new TransitGatewayWithMetadata(tgw1, new Region("r1"), "account1");
+    TransitGatewayWithMetadata t2 =
+        new TransitGatewayWithMetadata(tgw2, new Region("r1"), "account2");
+    TransitGatewayWithMetadata t3 =
+        new TransitGatewayWithMetadata(tgw3, new Region("r1"), "account3");
+    assertThat(
+        TransitGatewayConverter.getUniqueTransitGateways(
+            ImmutableList.of(t1, t2, t3), new Warnings()), containsInAnyOrder(t1, t3));
+  }
+
+  @Test
+  public void testGetUniqueTransitGatewaysLogFailure() {
+    TransitGateway tgw1 = mock(TransitGateway.class);
+    when(tgw1.getId()).thenReturn("id1");
+    when(tgw1.getOwnerId()).thenReturn("account1");
+    TransitGateway tgw2 = mock(TransitGateway.class);
+    when(tgw2.getId()).thenReturn("id1");
+    when(tgw2.getOwnerId()).thenReturn("account1");
+
+    TransitGateway tgw3 = mock(TransitGateway.class);
+    when(tgw3.getId()).thenReturn("id2");
+    when(tgw3.getOwnerId()).thenReturn("account3");
+
+    TransitGatewayWithMetadata t1 =
+        new TransitGatewayWithMetadata(tgw1, new Region("r1"), "wrong_account");
+    TransitGatewayWithMetadata t2 =
+        new TransitGatewayWithMetadata(tgw2, new Region("r1"), "wrong_account_2");
+    TransitGatewayWithMetadata t3 =
+        new TransitGatewayWithMetadata(tgw3, new Region("r1"), "account3");
+    Warnings w = new Warnings(true, true, true);
+    assertThat(
+        TransitGatewayConverter.getUniqueTransitGateways(ImmutableList.of(t1, t2, t3), w),
+        contains(t3));
+    assertThat(
+        w.getRedFlagWarnings(),
+        contains(
+            new Warning(
+                "Could not find authoritative representation for transit gateways: id1",
+                Warnings.TAG_RED_FLAG)));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayConverterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayConverterTest.java
@@ -98,7 +98,8 @@ public class TransitGatewayConverterTest {
         new TransitGatewayWithMetadata(tgw3, new Region("r1"), "account3");
     assertThat(
         TransitGatewayConverter.getUniqueTransitGateways(
-            ImmutableList.of(t1, t2, t3), new Warnings()), containsInAnyOrder(t1, t3));
+            ImmutableList.of(t1, t2, t3), new Warnings()),
+        containsInAnyOrder(t1, t3));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayTest.java
@@ -137,11 +137,13 @@ public class TransitGatewayTest {
     Configuration vpcCfg =
         vpc.toConfigurationNode(new ConvertedConfiguration(), region, new Warnings());
 
+    AwsConfiguration vsConfig = new AwsConfiguration();
+    vsConfig.addOrGetAccount("acc").addRegion(region);
     ConvertedConfiguration awsConfiguration =
         new ConvertedConfiguration(ImmutableMap.of(vpcCfg.getHostname(), vpcCfg));
 
     Warnings warnings = new Warnings(true, true, true);
-    Configuration tgwCfg = tgw.toConfigurationNode(awsConfiguration, region, warnings);
+    Configuration tgwCfg = tgw.toConfigurationNode(vsConfig, awsConfiguration, region, warnings);
     assertThat(tgwCfg, hasDeviceModel(DeviceModel.AWS_TRANSIT_GATEWAY));
 
     // check that vrfs exist
@@ -200,13 +202,15 @@ public class TransitGatewayTest {
                 ImmutableMap.of(
                     routeTableId, new TransitGatewayRouteTable(routeTableId, tgwId, true, true)))
             .build();
+    AwsConfiguration vsConfig = new AwsConfiguration();
+    vsConfig.addOrGetAccount("acc").addRegion(region);
 
     Vrf.builder().setName(vrfNameForRouteTable(routeTableId)).setOwner(tgwCfg).build();
     Vrf.builder().setOwner(vpcCfg).setName(vrfNameForLink(tgwAttachment.getId())).build();
 
     ConvertedConfiguration awsConfiguration =
         new ConvertedConfiguration(ImmutableMap.of(vpcCfg.getHostname(), vpcCfg));
-    connectVpc(tgwCfg, tgwAttachment, awsConfiguration, region, new Warnings());
+    connectVpc(tgwCfg, tgwAttachment, vsConfig, awsConfiguration, region, new Warnings());
 
     // check that interfaces are created in the right VRFs
     Interface tgwInterface =
@@ -272,6 +276,8 @@ public class TransitGatewayTest {
                             new Propagation(
                                 tgwAttachment.getId(), ResourceType.VPC, vpc.getId(), true)))))
             .build();
+    AwsConfiguration vsConfig = new AwsConfiguration();
+    vsConfig.addOrGetAccount("acc").addRegion(region);
 
     Vrf.builder().setName(vrfNameForRouteTable(routeTableId1)).setOwner(tgwCfg).build();
     Vrf.builder().setName(vrfNameForRouteTable(routeTableId2)).setOwner(tgwCfg).build();
@@ -279,7 +285,7 @@ public class TransitGatewayTest {
 
     ConvertedConfiguration awsConfiguration =
         new ConvertedConfiguration(ImmutableMap.of(vpcCfg.getHostname(), vpcCfg));
-    connectVpc(tgwCfg, tgwAttachment, awsConfiguration, region, new Warnings());
+    connectVpc(tgwCfg, tgwAttachment, vsConfig, awsConfiguration, region, new Warnings());
 
     // check that interfaces are created and in the right VRFs
     assertThat(
@@ -339,10 +345,13 @@ public class TransitGatewayTest {
                     new TransitGatewayRouteTable(routeTableId, tgw.getId(), true, true)))
             .build();
 
+    AwsConfiguration vsConfig = new AwsConfiguration();
+    vsConfig.addOrGetAccount("acc").addRegion(region);
+
     ConvertedConfiguration awsConfiguration = new ConvertedConfiguration();
 
     Warnings warnings = new Warnings(true, true, true);
-    Configuration tgwCfg = tgw.toConfigurationNode(awsConfiguration, region, warnings);
+    Configuration tgwCfg = tgw.toConfigurationNode(vsConfig, awsConfiguration, region, warnings);
     assertThat(tgwCfg, hasDeviceModel(DeviceModel.AWS_TRANSIT_GATEWAY));
 
     // check that the vrf exists
@@ -405,11 +414,12 @@ public class TransitGatewayTest {
                     routeTableId,
                     new TransitGatewayRouteTable(routeTableId, tgw.getId(), true, true)))
             .build();
-
+    AwsConfiguration vsConfig = new AwsConfiguration();
+    vsConfig.addOrGetAccount("acc").addRegion(region);
     ConvertedConfiguration awsConfiguration = new ConvertedConfiguration();
 
     Warnings warnings = new Warnings(true, true, true);
-    Configuration tgwCfg = tgw.toConfigurationNode(awsConfiguration, region, warnings);
+    Configuration tgwCfg = tgw.toConfigurationNode(vsConfig, awsConfiguration, region, warnings);
     assertThat(tgwCfg.getHumanName(), equalTo("tgw-name"));
     assertThat(tgwCfg, hasDeviceModel(DeviceModel.AWS_TRANSIT_GATEWAY));
 
@@ -492,11 +502,14 @@ public class TransitGatewayTest {
 
     Configuration vpcCfg =
         vpc.toConfigurationNode(new ConvertedConfiguration(), region, new Warnings());
+    AwsConfiguration vsConfig = new AwsConfiguration();
+    vsConfig.addOrGetAccount("acc").addRegion(region);
     ConvertedConfiguration awsConfiguration =
         new ConvertedConfiguration(ImmutableMap.of(vpcCfg.getHostname(), vpcCfg));
 
     Warnings warnings = new Warnings(true, true, true);
-    Configuration tgwCfg = tgw.toConfigurationNode(awsConfiguration, region, warnings);
+
+    Configuration tgwCfg = tgw.toConfigurationNode(vsConfig, awsConfiguration, region, warnings);
     assertThat(tgwCfg, hasDeviceModel(DeviceModel.AWS_TRANSIT_GATEWAY));
 
     // check that vrf exists
@@ -576,11 +589,13 @@ public class TransitGatewayTest {
 
     Configuration vpcCfg =
         vpc.toConfigurationNode(new ConvertedConfiguration(), region, new Warnings());
+    AwsConfiguration vsConfig = new AwsConfiguration();
+    vsConfig.addOrGetAccount("acc").addRegion(region);
     ConvertedConfiguration awsConfiguration =
         new ConvertedConfiguration(ImmutableMap.of(vpcCfg.getHostname(), vpcCfg));
 
     Warnings warnings = new Warnings(true, true, true);
-    Configuration tgwCfg = tgw.toConfigurationNode(awsConfiguration, region, warnings);
+    Configuration tgwCfg = tgw.toConfigurationNode(vsConfig, awsConfiguration, region, warnings);
     assertThat(tgwCfg, hasDeviceModel(DeviceModel.AWS_TRANSIT_GATEWAY));
 
     // check that vrf exists
@@ -654,9 +669,11 @@ public class TransitGatewayTest {
             .build();
 
     ConvertedConfiguration awsConfiguration = new ConvertedConfiguration();
-
+    AwsConfiguration vsConfig = new AwsConfiguration();
+    vsConfig.addOrGetAccount("acc").addRegion(region);
     Warnings warnings = new Warnings(true, true, true);
-    Configuration tgwCfg = tgw.toConfigurationNode(awsConfiguration, region, warnings);
+
+    Configuration tgwCfg = tgw.toConfigurationNode(vsConfig, awsConfiguration, region, warnings);
     assertThat(tgwCfg, hasDeviceModel(DeviceModel.AWS_TRANSIT_GATEWAY));
 
     // check that the vrf exists

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/NetworkInterfaces.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/NetworkInterfaces.json
@@ -1,0 +1,86 @@
+{
+ "NetworkInterfaces": [
+  {
+   "Attachment": {
+    "AttachmentId": "ela-attach-12923018",
+    "DeleteOnTermination": false,
+    "DeviceIndex": 1,
+    "InstanceOwnerId": "amazon-aws",
+    "Status": "attached"
+   },
+   "AvailabilityZone": "us-east-1a",
+   "Description": "Network Interface for Transit Gateway Attachment tgw-attach-0f832eb2ca4a975a4",
+   "Groups": [],
+   "InterfaceType": "transit_gateway",
+   "Ipv6Addresses": [],
+   "MacAddress": "12:c4:eb:8c:6a:a1",
+   "NetworkInterfaceId": "eni-0e151815b7108dfc4",
+   "OwnerId": "028403472736",
+   "PrivateDnsName": "ip-10-1-250-80.ec2.internal",
+   "PrivateIpAddress": "10.1.250.80",
+   "PrivateIpAddresses": [
+    {
+     "Primary": true,
+     "PrivateDnsName": "ip-10-1-250-80.ec2.internal",
+     "PrivateIpAddress": "10.1.250.80"
+    }
+   ],
+   "RequesterId": "936118442230",
+   "RequesterManaged": false,
+   "SourceDestCheck": false,
+   "Status": "in-use",
+   "SubnetId": "subnet-03b8a36729c9da776",
+   "TagSet": [],
+   "VpcId": "vpc-04048d4bfba9c2289"
+  },
+  {
+   "Association": {
+    "IpOwnerId": "amazon",
+    "PublicDnsName": "ec2-18-212-39-59.compute-1.amazonaws.com",
+    "PublicIp": "18.212.39.59"
+   },
+   "Attachment": {
+    "AttachTime": "2020-04-28 22:36:30+00:00",
+    "AttachmentId": "eni-attach-0475a7681bf0f8651",
+    "DeleteOnTermination": true,
+    "DeviceIndex": 0,
+    "InstanceId": "i-0bdf35d561be3d962",
+    "InstanceOwnerId": "028403472736",
+    "Status": "attached"
+   },
+   "AvailabilityZone": "us-east-1a",
+   "Description": "",
+   "Groups": [
+    {
+     "GroupId": "sg-0749b241c02b9bb8c",
+     "GroupName": "bat_sg"
+    }
+   ],
+   "InterfaceType": "interface",
+   "Ipv6Addresses": [],
+   "MacAddress": "12:b2:3c:29:13:9d",
+   "NetworkInterfaceId": "eni-0206afdbeb82fcedf",
+   "OwnerId": "028403472736",
+   "PrivateDnsName": "ip-10-1-1-100.ec2.internal",
+   "PrivateIpAddress": "10.1.1.100",
+   "PrivateIpAddresses": [
+    {
+     "Association": {
+      "IpOwnerId": "amazon",
+      "PublicDnsName": "ec2-18-212-39-59.compute-1.amazonaws.com",
+      "PublicIp": "18.212.39.59"
+     },
+     "Primary": true,
+     "PrivateDnsName": "ip-10-1-1-100.ec2.internal",
+     "PrivateIpAddress": "10.1.1.100"
+    }
+   ],
+   "RequesterManaged": false,
+   "SourceDestCheck": true,
+   "Status": "in-use",
+   "SubnetId": "subnet-0a68915f31d3ca69f",
+   "TagSet": [],
+   "VpcId": "vpc-04048d4bfba9c2289"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/Reservations.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/Reservations.json
@@ -1,0 +1,201 @@
+{
+ "Reservations": [
+  {
+   "Groups": [],
+   "Instances": [
+    {
+     "AmiLaunchIndex": 0,
+     "Architecture": "x86_64",
+     "BlockDeviceMappings": [],
+     "CapacityReservationSpecification": {
+      "CapacityReservationPreference": "open"
+     },
+     "ClientToken": "",
+     "CpuOptions": {
+      "CoreCount": 1,
+      "ThreadsPerCore": 1
+     },
+     "EbsOptimized": false,
+     "EnaSupport": true,
+     "HibernationOptions": {
+      "Configured": false
+     },
+     "Hypervisor": "xen",
+     "ImageId": "ami-0fc61db8544a617ed",
+     "InstanceId": "i-04f03d526c63297ae",
+     "InstanceType": "t2.micro",
+     "KeyName": "publicKey",
+     "LaunchTime": "2020-04-28 22:05:15+00:00",
+     "MetadataOptions": {
+      "HttpEndpoint": "enabled",
+      "HttpPutResponseHopLimit": 1,
+      "HttpTokens": "optional",
+      "State": "pending"
+     },
+     "Monitoring": {
+      "State": "disabled"
+     },
+     "NetworkInterfaces": [],
+     "Placement": {
+      "AvailabilityZone": "us-east-1a",
+      "GroupName": "",
+      "Tenancy": "default"
+     },
+     "PrivateDnsName": "",
+     "ProductCodes": [],
+     "PublicDnsName": "",
+     "RootDeviceName": "/dev/xvda",
+     "RootDeviceType": "ebs",
+     "SecurityGroups": [],
+     "State": {
+      "Code": 48,
+      "Name": "terminated"
+     },
+     "StateReason": {
+      "Code": "Client.UserInitiatedShutdown",
+      "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+     },
+     "StateTransitionReason": "User initiated (2020-04-28 22:35:24 GMT)",
+     "Tags": [
+      {
+       "Key": "Name",
+       "Value": "bat-web01"
+      }
+     ],
+     "VirtualizationType": "hvm"
+    }
+   ],
+   "OwnerId": "028403472736",
+   "ReservationId": "r-0bc349bf02bbf34e0"
+  },
+  {
+   "Groups": [],
+   "Instances": [
+    {
+     "AmiLaunchIndex": 0,
+     "Architecture": "x86_64",
+     "BlockDeviceMappings": [
+      {
+       "DeviceName": "/dev/xvda",
+       "Ebs": {
+        "AttachTime": "2020-04-28 22:36:30+00:00",
+        "DeleteOnTermination": true,
+        "Status": "attached",
+        "VolumeId": "vol-066fa6058be1773ab"
+       }
+      }
+     ],
+     "CapacityReservationSpecification": {
+      "CapacityReservationPreference": "open"
+     },
+     "ClientToken": "",
+     "CpuOptions": {
+      "CoreCount": 1,
+      "ThreadsPerCore": 1
+     },
+     "EbsOptimized": false,
+     "EnaSupport": true,
+     "HibernationOptions": {
+      "Configured": false
+     },
+     "Hypervisor": "xen",
+     "ImageId": "ami-0fc61db8544a617ed",
+     "InstanceId": "i-0bdf35d561be3d962",
+     "InstanceType": "t2.micro",
+     "KeyName": "publicKey",
+     "LaunchTime": "2020-04-28 22:36:30+00:00",
+     "MetadataOptions": {
+      "HttpEndpoint": "enabled",
+      "HttpPutResponseHopLimit": 1,
+      "HttpTokens": "optional",
+      "State": "applied"
+     },
+     "Monitoring": {
+      "State": "disabled"
+     },
+     "NetworkInterfaces": [
+      {
+       "Association": {
+        "IpOwnerId": "amazon",
+        "PublicDnsName": "ec2-18-212-39-59.compute-1.amazonaws.com",
+        "PublicIp": "18.212.39.59"
+       },
+       "Attachment": {
+        "AttachTime": "2020-04-28 22:36:30+00:00",
+        "AttachmentId": "eni-attach-0475a7681bf0f8651",
+        "DeleteOnTermination": true,
+        "DeviceIndex": 0,
+        "Status": "attached"
+       },
+       "Description": "",
+       "Groups": [
+        {
+         "GroupId": "sg-0749b241c02b9bb8c",
+         "GroupName": "bat_sg"
+        }
+       ],
+       "InterfaceType": "interface",
+       "Ipv6Addresses": [],
+       "MacAddress": "12:b2:3c:29:13:9d",
+       "NetworkInterfaceId": "eni-0206afdbeb82fcedf",
+       "OwnerId": "028403472736",
+       "PrivateDnsName": "ip-10-1-1-100.ec2.internal",
+       "PrivateIpAddress": "10.1.1.100",
+       "PrivateIpAddresses": [
+        {
+         "Association": {
+          "IpOwnerId": "amazon",
+          "PublicDnsName": "ec2-18-212-39-59.compute-1.amazonaws.com",
+          "PublicIp": "18.212.39.59"
+         },
+         "Primary": true,
+         "PrivateDnsName": "ip-10-1-1-100.ec2.internal",
+         "PrivateIpAddress": "10.1.1.100"
+        }
+       ],
+       "SourceDestCheck": true,
+       "Status": "in-use",
+       "SubnetId": "subnet-0a68915f31d3ca69f",
+       "VpcId": "vpc-04048d4bfba9c2289"
+      }
+     ],
+     "Placement": {
+      "AvailabilityZone": "us-east-1a",
+      "GroupName": "",
+      "Tenancy": "default"
+     },
+     "PrivateDnsName": "ip-10-1-1-100.ec2.internal",
+     "PrivateIpAddress": "10.1.1.100",
+     "ProductCodes": [],
+     "PublicDnsName": "ec2-18-212-39-59.compute-1.amazonaws.com",
+     "PublicIpAddress": "18.212.39.59",
+     "RootDeviceName": "/dev/xvda",
+     "RootDeviceType": "ebs",
+     "SecurityGroups": [
+      {
+       "GroupId": "sg-0749b241c02b9bb8c",
+       "GroupName": "bat_sg"
+      }
+     ],
+     "SourceDestCheck": true,
+     "State": {
+      "Code": 16,
+      "Name": "running"
+     },
+     "StateTransitionReason": "",
+     "SubnetId": "subnet-0a68915f31d3ca69f",
+     "Tags": [
+      {
+       "Key": "Name",
+       "Value": "bat-web01"
+      }
+     ],
+     "VirtualizationType": "hvm",
+     "VpcId": "vpc-04048d4bfba9c2289"
+    }
+   ],
+   "OwnerId": "028403472736",
+   "ReservationId": "r-0154599dfa271b7d4"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/RouteTables.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/RouteTables.json
@@ -1,0 +1,81 @@
+{
+ "RouteTables": [
+  {
+   "Associations": [
+    {
+     "AssociationState": {
+      "State": "associated"
+     },
+     "Main": false,
+     "RouteTableAssociationId": "rtbassoc-01b6234db1d391ea6",
+     "RouteTableId": "rtb-0fef69d4490091932",
+     "SubnetId": "subnet-0a68915f31d3ca69f"
+    },
+    {
+     "AssociationState": {
+      "State": "associated"
+     },
+     "Main": false,
+     "RouteTableAssociationId": "rtbassoc-069910cbc121afb03",
+     "RouteTableId": "rtb-0fef69d4490091932",
+     "SubnetId": "subnet-03b8a36729c9da776"
+    }
+   ],
+   "OwnerId": "028403472736",
+   "PropagatingVgws": [],
+   "RouteTableId": "rtb-0fef69d4490091932",
+   "Routes": [
+    {
+     "DestinationCidrBlock": "10.1.0.0/16",
+     "GatewayId": "local",
+     "Origin": "CreateRouteTable",
+     "State": "active"
+    },
+    {
+     "DestinationCidrBlock": "10.2.0.0/16",
+     "Origin": "CreateRoute",
+     "State": "active",
+     "TransitGatewayId": "tgw-0efdeab79e9a8e490"
+    },
+    {
+     "DestinationCidrBlock": "0.0.0.0/0",
+     "GatewayId": "igw-06754039f5006fdfe",
+     "Origin": "CreateRoute",
+     "State": "active"
+    }
+   ],
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "bat-igw"
+    }
+   ],
+   "VpcId": "vpc-04048d4bfba9c2289"
+  },
+  {
+   "Associations": [
+    {
+     "AssociationState": {
+      "State": "associated"
+     },
+     "Main": true,
+     "RouteTableAssociationId": "rtbassoc-0c01aaf221589a976",
+     "RouteTableId": "rtb-077a9c73d8e1008c5"
+    }
+   ],
+   "OwnerId": "028403472736",
+   "PropagatingVgws": [],
+   "RouteTableId": "rtb-077a9c73d8e1008c5",
+   "Routes": [
+    {
+     "DestinationCidrBlock": "10.1.0.0/16",
+     "GatewayId": "local",
+     "Origin": "CreateRouteTable",
+     "State": "active"
+    }
+   ],
+   "Tags": [],
+   "VpcId": "vpc-04048d4bfba9c2289"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/SecurityGroups.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/SecurityGroups.json
@@ -1,0 +1,109 @@
+{
+ "SecurityGroups": [
+  {
+   "Description": "Managed by Terraform",
+   "GroupId": "sg-0749b241c02b9bb8c",
+   "GroupName": "bat_sg",
+   "IpPermissions": [
+    {
+     "FromPort": 33434,
+     "IpProtocol": "udp",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "Traceroute Access"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "ToPort": 33534,
+     "UserIdGroupPairs": []
+    },
+    {
+     "FromPort": 22,
+     "IpProtocol": "tcp",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "SSH Access"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "ToPort": 22,
+     "UserIdGroupPairs": []
+    },
+    {
+     "FromPort": 8,
+     "IpProtocol": "icmp",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "ICMP Access"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "ToPort": 0,
+     "UserIdGroupPairs": []
+    }
+   ],
+   "IpPermissionsEgress": [
+    {
+     "IpProtocol": "-1",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "Allow all"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "UserIdGroupPairs": []
+    }
+   ],
+   "OwnerId": "028403472736",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "bat-general"
+    }
+   ],
+   "VpcId": "vpc-04048d4bfba9c2289"
+  },
+  {
+   "Description": "default VPC security group",
+   "GroupId": "sg-0d99230b0dd8c9ce4",
+   "GroupName": "default",
+   "IpPermissions": [
+    {
+     "IpProtocol": "-1",
+     "IpRanges": [],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "UserIdGroupPairs": [
+      {
+       "GroupId": "sg-0d99230b0dd8c9ce4",
+       "UserId": "028403472736"
+      }
+     ]
+    }
+   ],
+   "IpPermissionsEgress": [
+    {
+     "IpProtocol": "-1",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "UserIdGroupPairs": []
+    }
+   ],
+   "OwnerId": "028403472736",
+   "VpcId": "vpc-04048d4bfba9c2289"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/Subnets.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/Subnets.json
@@ -1,0 +1,46 @@
+{
+ "Subnets": [
+  {
+   "AssignIpv6AddressOnCreation": false,
+   "AvailabilityZone": "us-east-1a",
+   "AvailabilityZoneId": "use1-az2",
+   "AvailableIpAddressCount": 250,
+   "CidrBlock": "10.1.250.0/24",
+   "DefaultForAz": false,
+   "Ipv6CidrBlockAssociationSet": [],
+   "MapPublicIpOnLaunch": false,
+   "OwnerId": "028403472736",
+   "State": "available",
+   "SubnetArn": "arn:aws:ec2:us-east-1:028403472736:subnet/subnet-03b8a36729c9da776",
+   "SubnetId": "subnet-03b8a36729c9da776",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "bat_10.1.250.0/24"
+    }
+   ],
+   "VpcId": "vpc-04048d4bfba9c2289"
+  },
+  {
+   "AssignIpv6AddressOnCreation": false,
+   "AvailabilityZone": "us-east-1a",
+   "AvailabilityZoneId": "use1-az2",
+   "AvailableIpAddressCount": 250,
+   "CidrBlock": "10.1.1.0/24",
+   "DefaultForAz": false,
+   "Ipv6CidrBlockAssociationSet": [],
+   "MapPublicIpOnLaunch": true,
+   "OwnerId": "028403472736",
+   "State": "available",
+   "SubnetArn": "arn:aws:ec2:us-east-1:028403472736:subnet/subnet-0a68915f31d3ca69f",
+   "SubnetId": "subnet-0a68915f31d3ca69f",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "bat_10.1.1.0/24"
+    }
+   ],
+   "VpcId": "vpc-04048d4bfba9c2289"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/TransitGatewayAttachments.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/TransitGatewayAttachments.json
@@ -1,0 +1,39 @@
+{
+ "TransitGatewayAttachments": [
+  {
+   "Association": {
+    "State": "associated",
+    "TransitGatewayRouteTableId": "tgw-rtb-0b2c8eeefcf19371b"
+   },
+   "CreationTime": "2020-04-28 22:12:29+00:00",
+   "ResourceId": "vpc-04048d4bfba9c2289",
+   "ResourceOwnerId": "028403472736",
+   "ResourceType": "vpc",
+   "State": "available",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "tgw-att-bat"
+    }
+   ],
+   "TransitGatewayAttachmentId": "tgw-attach-0f832eb2ca4a975a4",
+   "TransitGatewayId": "tgw-0efdeab79e9a8e490",
+   "TransitGatewayOwnerId": "028403472736"
+  },
+  {
+   "Association": {
+    "State": "associated",
+    "TransitGatewayRouteTableId": "tgw-rtb-0b2c8eeefcf19371b"
+   },
+   "CreationTime": "2020-04-28 22:22:25+00:00",
+   "ResourceId": "vpc-08287a9084472b276",
+   "ResourceOwnerId": "951601349076",
+   "ResourceType": "vpc",
+   "State": "available",
+   "Tags": [],
+   "TransitGatewayAttachmentId": "tgw-attach-0f8397dbb9b9bce0d",
+   "TransitGatewayId": "tgw-0efdeab79e9a8e490",
+   "TransitGatewayOwnerId": "028403472736"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/TransitGatewayPropagations.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/TransitGatewayPropagations.json
@@ -1,0 +1,21 @@
+{
+ "TransitGatewayPropagations": [
+  {
+   "TransitGatewayRouteTableId": "tgw-rtb-0b2c8eeefcf19371b",
+   "TransitGatewayRouteTablePropagations": [
+    {
+     "ResourceId": "vpc-04048d4bfba9c2289",
+     "ResourceType": "vpc",
+     "State": "enabled",
+     "TransitGatewayAttachmentId": "tgw-attach-0f832eb2ca4a975a4"
+    },
+    {
+     "ResourceId": "vpc-08287a9084472b276",
+     "ResourceType": "vpc",
+     "State": "enabled",
+     "TransitGatewayAttachmentId": "tgw-attach-0f8397dbb9b9bce0d"
+    }
+   ]
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/TransitGatewayRouteTables.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/TransitGatewayRouteTables.json
@@ -1,0 +1,13 @@
+{
+ "TransitGatewayRouteTables": [
+  {
+   "CreationTime": "2020-04-28 21:38:43+00:00",
+   "DefaultAssociationRouteTable": true,
+   "DefaultPropagationRouteTable": true,
+   "State": "available",
+   "Tags": [],
+   "TransitGatewayId": "tgw-0efdeab79e9a8e490",
+   "TransitGatewayRouteTableId": "tgw-rtb-0b2c8eeefcf19371b"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/TransitGatewayStaticRoutes.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/TransitGatewayStaticRoutes.json
@@ -1,0 +1,9 @@
+{
+ "TransitGatewayStaticRoutes": [
+  {
+   "AdditionalRoutesAvailable": false,
+   "Routes": [],
+   "TransitGatewayRouteTableId": "tgw-rtb-0b2c8eeefcf19371b"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/TransitGatewayVpcAttachments.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/TransitGatewayVpcAttachments.json
@@ -1,0 +1,41 @@
+{
+ "TransitGatewayVpcAttachments": [
+  {
+   "CreationTime": "2020-04-28 22:12:29+00:00",
+   "Options": {
+    "DnsSupport": "enable",
+    "Ipv6Support": "disable"
+   },
+   "State": "available",
+   "SubnetIds": [
+    "subnet-03b8a36729c9da776"
+   ],
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "tgw-att-bat"
+    }
+   ],
+   "TransitGatewayAttachmentId": "tgw-attach-0f832eb2ca4a975a4",
+   "TransitGatewayId": "tgw-0efdeab79e9a8e490",
+   "VpcId": "vpc-04048d4bfba9c2289",
+   "VpcOwnerId": "028403472736"
+  },
+  {
+   "CreationTime": "2020-04-28 22:22:25+00:00",
+   "Options": {
+    "DnsSupport": "enable",
+    "Ipv6Support": "disable"
+   },
+   "State": "available",
+   "SubnetIds": [
+    "subnet-0ffa87ae0b553703e"
+   ],
+   "Tags": [],
+   "TransitGatewayAttachmentId": "tgw-attach-0f8397dbb9b9bce0d",
+   "TransitGatewayId": "tgw-0efdeab79e9a8e490",
+   "VpcId": "vpc-08287a9084472b276",
+   "VpcOwnerId": "951601349076"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/TransitGateways.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/TransitGateways.json
@@ -1,0 +1,28 @@
+{
+ "TransitGateways": [
+  {
+   "CreationTime": "2020-04-28 21:38:18+00:00",
+   "Options": {
+    "AmazonSideAsn": 64512,
+    "AssociationDefaultRouteTableId": "tgw-rtb-0b2c8eeefcf19371b",
+    "AutoAcceptSharedAttachments": "enable",
+    "DefaultRouteTableAssociation": "enable",
+    "DefaultRouteTablePropagation": "enable",
+    "DnsSupport": "enable",
+    "MulticastSupport": "disable",
+    "PropagationDefaultRouteTableId": "tgw-rtb-0b2c8eeefcf19371b",
+    "VpnEcmpSupport": "enable"
+   },
+   "OwnerId": "028403472736",
+   "State": "available",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "tgw-batfish"
+    }
+   ],
+   "TransitGatewayArn": "arn:aws:ec2:us-east-1:028403472736:transit-gateway/tgw-0efdeab79e9a8e490",
+   "TransitGatewayId": "tgw-0efdeab79e9a8e490"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/Vpcs.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/028403472736/us-east-1/Vpcs.json
@@ -1,0 +1,28 @@
+{
+ "Vpcs": [
+  {
+   "CidrBlock": "10.1.0.0/16",
+   "CidrBlockAssociationSet": [
+    {
+     "AssociationId": "vpc-cidr-assoc-03b0df824e8e0b644",
+     "CidrBlock": "10.1.0.0/16",
+     "CidrBlockState": {
+      "State": "associated"
+     }
+    }
+   ],
+   "DhcpOptionsId": "dopt-3bb56641",
+   "InstanceTenancy": "default",
+   "IsDefault": false,
+   "OwnerId": "028403472736",
+   "State": "available",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "bat"
+    }
+   ],
+   "VpcId": "vpc-04048d4bfba9c2289"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/NetworkInterfaces.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/NetworkInterfaces.json
@@ -1,0 +1,86 @@
+{
+ "NetworkInterfaces": [
+  {
+   "Attachment": {
+    "AttachmentId": "ela-attach-c9d18bf7",
+    "DeleteOnTermination": false,
+    "DeviceIndex": 1,
+    "InstanceOwnerId": "amazon-aws",
+    "Status": "attached"
+   },
+   "AvailabilityZone": "us-east-1a",
+   "Description": "Network Interface for Transit Gateway Attachment tgw-attach-0f8397dbb9b9bce0d",
+   "Groups": [],
+   "InterfaceType": "transit_gateway",
+   "Ipv6Addresses": [],
+   "MacAddress": "0a:97:10:8f:47:29",
+   "NetworkInterfaceId": "eni-02c0a3e91d5705a3f",
+   "OwnerId": "951601349076",
+   "PrivateDnsName": "ip-10-2-250-249.ec2.internal",
+   "PrivateIpAddress": "10.2.250.249",
+   "PrivateIpAddresses": [
+    {
+     "Primary": true,
+     "PrivateDnsName": "ip-10-2-250-249.ec2.internal",
+     "PrivateIpAddress": "10.2.250.249"
+    }
+   ],
+   "RequesterId": "936118442230",
+   "RequesterManaged": false,
+   "SourceDestCheck": false,
+   "Status": "in-use",
+   "SubnetId": "subnet-0ffa87ae0b553703e",
+   "TagSet": [],
+   "VpcId": "vpc-08287a9084472b276"
+  },
+  {
+   "Association": {
+    "IpOwnerId": "amazon",
+    "PublicDnsName": "ec2-52-201-239-254.compute-1.amazonaws.com",
+    "PublicIp": "52.201.239.254"
+   },
+   "Attachment": {
+    "AttachTime": "2020-04-28 22:36:30+00:00",
+    "AttachmentId": "eni-attach-07f9c77f893278245",
+    "DeleteOnTermination": true,
+    "DeviceIndex": 0,
+    "InstanceId": "i-03df168b3f73cc262",
+    "InstanceOwnerId": "951601349076",
+    "Status": "attached"
+   },
+   "AvailabilityZone": "us-east-1a",
+   "Description": "",
+   "Groups": [
+    {
+     "GroupId": "sg-081797c4fc92bb8ec",
+     "GroupName": "fish_sg"
+    }
+   ],
+   "InterfaceType": "interface",
+   "Ipv6Addresses": [],
+   "MacAddress": "0a:01:3e:6a:e0:97",
+   "NetworkInterfaceId": "eni-0d1a34edceb1e9c42",
+   "OwnerId": "951601349076",
+   "PrivateDnsName": "ip-10-2-1-183.ec2.internal",
+   "PrivateIpAddress": "10.2.1.183",
+   "PrivateIpAddresses": [
+    {
+     "Association": {
+      "IpOwnerId": "amazon",
+      "PublicDnsName": "ec2-52-201-239-254.compute-1.amazonaws.com",
+      "PublicIp": "52.201.239.254"
+     },
+     "Primary": true,
+     "PrivateDnsName": "ip-10-2-1-183.ec2.internal",
+     "PrivateIpAddress": "10.2.1.183"
+    }
+   ],
+   "RequesterManaged": false,
+   "SourceDestCheck": true,
+   "Status": "in-use",
+   "SubnetId": "subnet-0c2cb08833b3c9921",
+   "TagSet": [],
+   "VpcId": "vpc-08287a9084472b276"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/Reservations.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/Reservations.json
@@ -1,0 +1,201 @@
+{
+ "Reservations": [
+  {
+   "Groups": [],
+   "Instances": [
+    {
+     "AmiLaunchIndex": 0,
+     "Architecture": "x86_64",
+     "BlockDeviceMappings": [],
+     "CapacityReservationSpecification": {
+      "CapacityReservationPreference": "open"
+     },
+     "ClientToken": "",
+     "CpuOptions": {
+      "CoreCount": 1,
+      "ThreadsPerCore": 1
+     },
+     "EbsOptimized": false,
+     "EnaSupport": true,
+     "HibernationOptions": {
+      "Configured": false
+     },
+     "Hypervisor": "xen",
+     "ImageId": "ami-0fc61db8544a617ed",
+     "InstanceId": "i-0a5efcfa80eacffe4",
+     "InstanceType": "t2.micro",
+     "KeyName": "publicKey",
+     "LaunchTime": "2020-04-28 21:38:46+00:00",
+     "MetadataOptions": {
+      "HttpEndpoint": "enabled",
+      "HttpPutResponseHopLimit": 1,
+      "HttpTokens": "optional",
+      "State": "pending"
+     },
+     "Monitoring": {
+      "State": "disabled"
+     },
+     "NetworkInterfaces": [],
+     "Placement": {
+      "AvailabilityZone": "us-east-1a",
+      "GroupName": "",
+      "Tenancy": "default"
+     },
+     "PrivateDnsName": "",
+     "ProductCodes": [],
+     "PublicDnsName": "",
+     "RootDeviceName": "/dev/xvda",
+     "RootDeviceType": "ebs",
+     "SecurityGroups": [],
+     "State": {
+      "Code": 48,
+      "Name": "terminated"
+     },
+     "StateReason": {
+      "Code": "Client.UserInitiatedShutdown",
+      "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+     },
+     "StateTransitionReason": "User initiated (2020-04-28 22:33:07 GMT)",
+     "Tags": [
+      {
+       "Key": "Name",
+       "Value": "fish-web01"
+      }
+     ],
+     "VirtualizationType": "hvm"
+    }
+   ],
+   "OwnerId": "951601349076",
+   "ReservationId": "r-0a432769cca6ca1ed"
+  },
+  {
+   "Groups": [],
+   "Instances": [
+    {
+     "AmiLaunchIndex": 0,
+     "Architecture": "x86_64",
+     "BlockDeviceMappings": [
+      {
+       "DeviceName": "/dev/xvda",
+       "Ebs": {
+        "AttachTime": "2020-04-28 22:36:30+00:00",
+        "DeleteOnTermination": true,
+        "Status": "attached",
+        "VolumeId": "vol-0112f0d4c4a34f0d5"
+       }
+      }
+     ],
+     "CapacityReservationSpecification": {
+      "CapacityReservationPreference": "open"
+     },
+     "ClientToken": "",
+     "CpuOptions": {
+      "CoreCount": 1,
+      "ThreadsPerCore": 1
+     },
+     "EbsOptimized": false,
+     "EnaSupport": true,
+     "HibernationOptions": {
+      "Configured": false
+     },
+     "Hypervisor": "xen",
+     "ImageId": "ami-0fc61db8544a617ed",
+     "InstanceId": "i-03df168b3f73cc262",
+     "InstanceType": "t2.micro",
+     "KeyName": "publicKey",
+     "LaunchTime": "2020-04-28 22:36:30+00:00",
+     "MetadataOptions": {
+      "HttpEndpoint": "enabled",
+      "HttpPutResponseHopLimit": 1,
+      "HttpTokens": "optional",
+      "State": "applied"
+     },
+     "Monitoring": {
+      "State": "disabled"
+     },
+     "NetworkInterfaces": [
+      {
+       "Association": {
+        "IpOwnerId": "amazon",
+        "PublicDnsName": "ec2-52-201-239-254.compute-1.amazonaws.com",
+        "PublicIp": "52.201.239.254"
+       },
+       "Attachment": {
+        "AttachTime": "2020-04-28 22:36:30+00:00",
+        "AttachmentId": "eni-attach-07f9c77f893278245",
+        "DeleteOnTermination": true,
+        "DeviceIndex": 0,
+        "Status": "attached"
+       },
+       "Description": "",
+       "Groups": [
+        {
+         "GroupId": "sg-081797c4fc92bb8ec",
+         "GroupName": "fish_sg"
+        }
+       ],
+       "InterfaceType": "interface",
+       "Ipv6Addresses": [],
+       "MacAddress": "0a:01:3e:6a:e0:97",
+       "NetworkInterfaceId": "eni-0d1a34edceb1e9c42",
+       "OwnerId": "951601349076",
+       "PrivateDnsName": "ip-10-2-1-183.ec2.internal",
+       "PrivateIpAddress": "10.2.1.183",
+       "PrivateIpAddresses": [
+        {
+         "Association": {
+          "IpOwnerId": "amazon",
+          "PublicDnsName": "ec2-52-201-239-254.compute-1.amazonaws.com",
+          "PublicIp": "52.201.239.254"
+         },
+         "Primary": true,
+         "PrivateDnsName": "ip-10-2-1-183.ec2.internal",
+         "PrivateIpAddress": "10.2.1.183"
+        }
+       ],
+       "SourceDestCheck": true,
+       "Status": "in-use",
+       "SubnetId": "subnet-0c2cb08833b3c9921",
+       "VpcId": "vpc-08287a9084472b276"
+      }
+     ],
+     "Placement": {
+      "AvailabilityZone": "us-east-1a",
+      "GroupName": "",
+      "Tenancy": "default"
+     },
+     "PrivateDnsName": "ip-10-2-1-183.ec2.internal",
+     "PrivateIpAddress": "10.2.1.183",
+     "ProductCodes": [],
+     "PublicDnsName": "ec2-52-201-239-254.compute-1.amazonaws.com",
+     "PublicIpAddress": "52.201.239.254",
+     "RootDeviceName": "/dev/xvda",
+     "RootDeviceType": "ebs",
+     "SecurityGroups": [
+      {
+       "GroupId": "sg-081797c4fc92bb8ec",
+       "GroupName": "fish_sg"
+      }
+     ],
+     "SourceDestCheck": true,
+     "State": {
+      "Code": 16,
+      "Name": "running"
+     },
+     "StateTransitionReason": "",
+     "SubnetId": "subnet-0c2cb08833b3c9921",
+     "Tags": [
+      {
+       "Key": "Name",
+       "Value": "fish-web01"
+      }
+     ],
+     "VirtualizationType": "hvm",
+     "VpcId": "vpc-08287a9084472b276"
+    }
+   ],
+   "OwnerId": "951601349076",
+   "ReservationId": "r-07ed417d4b7036755"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/RouteTables.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/RouteTables.json
@@ -1,0 +1,81 @@
+{
+ "RouteTables": [
+  {
+   "Associations": [
+    {
+     "AssociationState": {
+      "State": "associated"
+     },
+     "Main": false,
+     "RouteTableAssociationId": "rtbassoc-08eb50f012eda765a",
+     "RouteTableId": "rtb-0b064b1571221e230",
+     "SubnetId": "subnet-0ffa87ae0b553703e"
+    },
+    {
+     "AssociationState": {
+      "State": "associated"
+     },
+     "Main": false,
+     "RouteTableAssociationId": "rtbassoc-0d262e78e7d4f746f",
+     "RouteTableId": "rtb-0b064b1571221e230",
+     "SubnetId": "subnet-0c2cb08833b3c9921"
+    }
+   ],
+   "OwnerId": "951601349076",
+   "PropagatingVgws": [],
+   "RouteTableId": "rtb-0b064b1571221e230",
+   "Routes": [
+    {
+     "DestinationCidrBlock": "10.1.0.0/16",
+     "Origin": "CreateRoute",
+     "State": "active",
+     "TransitGatewayId": "tgw-0efdeab79e9a8e490"
+    },
+    {
+     "DestinationCidrBlock": "10.2.0.0/16",
+     "GatewayId": "local",
+     "Origin": "CreateRouteTable",
+     "State": "active"
+    },
+    {
+     "DestinationCidrBlock": "0.0.0.0/0",
+     "GatewayId": "igw-01cc5d1eeebd9a80f",
+     "Origin": "CreateRoute",
+     "State": "active"
+    }
+   ],
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "fish-igw"
+    }
+   ],
+   "VpcId": "vpc-08287a9084472b276"
+  },
+  {
+   "Associations": [
+    {
+     "AssociationState": {
+      "State": "associated"
+     },
+     "Main": true,
+     "RouteTableAssociationId": "rtbassoc-0665c5f497d15d0e4",
+     "RouteTableId": "rtb-0fc15f74e220648e7"
+    }
+   ],
+   "OwnerId": "951601349076",
+   "PropagatingVgws": [],
+   "RouteTableId": "rtb-0fc15f74e220648e7",
+   "Routes": [
+    {
+     "DestinationCidrBlock": "10.2.0.0/16",
+     "GatewayId": "local",
+     "Origin": "CreateRouteTable",
+     "State": "active"
+    }
+   ],
+   "Tags": [],
+   "VpcId": "vpc-08287a9084472b276"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/SecurityGroups.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/SecurityGroups.json
@@ -1,0 +1,109 @@
+{
+ "SecurityGroups": [
+  {
+   "Description": "Managed by Terraform",
+   "GroupId": "sg-081797c4fc92bb8ec",
+   "GroupName": "fish_sg",
+   "IpPermissions": [
+    {
+     "FromPort": 33434,
+     "IpProtocol": "udp",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "Traceroute Access"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "ToPort": 33534,
+     "UserIdGroupPairs": []
+    },
+    {
+     "FromPort": 22,
+     "IpProtocol": "tcp",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "SSH Access"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "ToPort": 22,
+     "UserIdGroupPairs": []
+    },
+    {
+     "FromPort": 8,
+     "IpProtocol": "icmp",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "ICMP Access"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "ToPort": 0,
+     "UserIdGroupPairs": []
+    }
+   ],
+   "IpPermissionsEgress": [
+    {
+     "IpProtocol": "-1",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0",
+       "Description": "Allow all"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "UserIdGroupPairs": []
+    }
+   ],
+   "OwnerId": "951601349076",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "fish-general"
+    }
+   ],
+   "VpcId": "vpc-08287a9084472b276"
+  },
+  {
+   "Description": "default VPC security group",
+   "GroupId": "sg-0a769a1647a9ddb29",
+   "GroupName": "default",
+   "IpPermissions": [
+    {
+     "IpProtocol": "-1",
+     "IpRanges": [],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "UserIdGroupPairs": [
+      {
+       "GroupId": "sg-0a769a1647a9ddb29",
+       "UserId": "951601349076"
+      }
+     ]
+    }
+   ],
+   "IpPermissionsEgress": [
+    {
+     "IpProtocol": "-1",
+     "IpRanges": [
+      {
+       "CidrIp": "0.0.0.0/0"
+      }
+     ],
+     "Ipv6Ranges": [],
+     "PrefixListIds": [],
+     "UserIdGroupPairs": []
+    }
+   ],
+   "OwnerId": "951601349076",
+   "VpcId": "vpc-08287a9084472b276"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/Subnets.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/Subnets.json
@@ -1,0 +1,46 @@
+{
+ "Subnets": [
+  {
+   "AssignIpv6AddressOnCreation": false,
+   "AvailabilityZone": "us-east-1a",
+   "AvailabilityZoneId": "use1-az4",
+   "AvailableIpAddressCount": 250,
+   "CidrBlock": "10.2.250.0/24",
+   "DefaultForAz": false,
+   "Ipv6CidrBlockAssociationSet": [],
+   "MapPublicIpOnLaunch": false,
+   "OwnerId": "951601349076",
+   "State": "available",
+   "SubnetArn": "arn:aws:ec2:us-east-1:951601349076:subnet/subnet-0ffa87ae0b553703e",
+   "SubnetId": "subnet-0ffa87ae0b553703e",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "fish_10.2.250.0/24"
+    }
+   ],
+   "VpcId": "vpc-08287a9084472b276"
+  },
+  {
+   "AssignIpv6AddressOnCreation": false,
+   "AvailabilityZone": "us-east-1a",
+   "AvailabilityZoneId": "use1-az4",
+   "AvailableIpAddressCount": 250,
+   "CidrBlock": "10.2.1.0/24",
+   "DefaultForAz": false,
+   "Ipv6CidrBlockAssociationSet": [],
+   "MapPublicIpOnLaunch": true,
+   "OwnerId": "951601349076",
+   "State": "available",
+   "SubnetArn": "arn:aws:ec2:us-east-1:951601349076:subnet/subnet-0c2cb08833b3c9921",
+   "SubnetId": "subnet-0c2cb08833b3c9921",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "fish_10.2.1.0/24"
+    }
+   ],
+   "VpcId": "vpc-08287a9084472b276"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/TransitGatewayAttachments.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/TransitGatewayAttachments.json
@@ -1,0 +1,24 @@
+{
+ "TransitGatewayAttachments": [
+  {
+   "Association": {
+    "State": "associated",
+    "TransitGatewayRouteTableId": "tgw-rtb-0b2c8eeefcf19371b"
+   },
+   "CreationTime": "2020-04-28 22:22:25+00:00",
+   "ResourceId": "vpc-08287a9084472b276",
+   "ResourceOwnerId": "951601349076",
+   "ResourceType": "vpc",
+   "State": "available",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "tgw-att-fish"
+    }
+   ],
+   "TransitGatewayAttachmentId": "tgw-attach-0f8397dbb9b9bce0d",
+   "TransitGatewayId": "tgw-0efdeab79e9a8e490",
+   "TransitGatewayOwnerId": "028403472736"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/TransitGatewayPropagations.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/TransitGatewayPropagations.json
@@ -1,0 +1,3 @@
+{
+ "TransitGatewayPropagations": []
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/TransitGatewayRouteTables.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/TransitGatewayRouteTables.json
@@ -1,0 +1,3 @@
+{
+ "TransitGatewayRouteTables": []
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/TransitGatewayStaticRoutes.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/TransitGatewayStaticRoutes.json
@@ -1,0 +1,3 @@
+{
+ "TransitGatewayStaticRoutes": []
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/TransitGatewayVpcAttachments.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/TransitGatewayVpcAttachments.json
@@ -1,0 +1,25 @@
+{
+ "TransitGatewayVpcAttachments": [
+  {
+   "CreationTime": "2020-04-28 22:22:25+00:00",
+   "Options": {
+    "DnsSupport": "enable",
+    "Ipv6Support": "disable"
+   },
+   "State": "available",
+   "SubnetIds": [
+    "subnet-0ffa87ae0b553703e"
+   ],
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "tgw-att-fish"
+    }
+   ],
+   "TransitGatewayAttachmentId": "tgw-attach-0f8397dbb9b9bce0d",
+   "TransitGatewayId": "tgw-0efdeab79e9a8e490",
+   "VpcId": "vpc-08287a9084472b276",
+   "VpcOwnerId": "951601349076"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/TransitGateways.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/TransitGateways.json
@@ -1,0 +1,23 @@
+{
+ "TransitGateways": [
+  {
+   "CreationTime": "2020-04-28 21:38:18+00:00",
+   "Options": {
+    "AmazonSideAsn": 64512,
+    "AssociationDefaultRouteTableId": "tgw-rtb-0b2c8eeefcf19371b",
+    "AutoAcceptSharedAttachments": "enable",
+    "DefaultRouteTableAssociation": "enable",
+    "DefaultRouteTablePropagation": "enable",
+    "DnsSupport": "enable",
+    "MulticastSupport": "disable",
+    "PropagationDefaultRouteTableId": "tgw-rtb-0b2c8eeefcf19371b",
+    "VpnEcmpSupport": "enable"
+   },
+   "OwnerId": "028403472736",
+   "State": "available",
+   "Tags": [],
+   "TransitGatewayArn": "arn:aws:ec2:us-east-1:028403472736:transit-gateway/tgw-0efdeab79e9a8e490",
+   "TransitGatewayId": "tgw-0efdeab79e9a8e490"
+  }
+ ]
+}

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/Vpcs.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/test-transit-gateway-multi-account/aws_configs/accounts/951601349076/us-east-1/Vpcs.json
@@ -1,0 +1,28 @@
+{
+ "Vpcs": [
+  {
+   "CidrBlock": "10.2.0.0/16",
+   "CidrBlockAssociationSet": [
+    {
+     "AssociationId": "vpc-cidr-assoc-0e110c8a9c7c21ab5",
+     "CidrBlock": "10.2.0.0/16",
+     "CidrBlockState": {
+      "State": "associated"
+     }
+    }
+   ],
+   "DhcpOptionsId": "dopt-aa2d83d0",
+   "InstanceTenancy": "default",
+   "IsDefault": false,
+   "OwnerId": "951601349076",
+   "State": "available",
+   "Tags": [
+    {
+     "Key": "Name",
+     "Value": "fish"
+    }
+   ],
+   "VpcId": "vpc-08287a9084472b276"
+  }
+ ]
+}


### PR DESCRIPTION
Change summary:
1. Convert only one, authoritative TGW from the account that owns it.
2. For attachment connections, allow lookups in all VPCs, not just region VPCs

Suggested review: commit-by-commit:
deduping, attachments, e2e test.

cc @ratulm please skim to ensure I changed to the correct attachment code in r2.
