### PR TITLE
Parboiled: convert from Function to function and update references

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/parboiled/ParboiledAutoComplete.java
@@ -58,17 +58,18 @@ public final class ParboiledAutoComplete {
 
   static final char ILLEGAL_CHAR = (char) 0x26bd;
 
-  static final Function<ReferenceBook, Set<String>> addressGroupGetter =
-      book ->
-          book.getAddressGroups().stream()
-              .map(AddressGroup::getName)
-              .collect(ImmutableSet.toImmutableSet());
+  @VisibleForTesting
+  static Set<String> addressGroupGetter(ReferenceBook book) {
+    return book.getAddressGroups().stream()
+        .map(AddressGroup::getName)
+        .collect(ImmutableSet.toImmutableSet());
+  }
 
-  static final Function<ReferenceBook, Set<String>> interfaceGroupGetter =
-      book ->
-          book.getInterfaceGroups().stream()
-              .map(InterfaceGroup::getName)
-              .collect(ImmutableSet.toImmutableSet());
+  private static Set<String> interfaceGroupGetter(ReferenceBook book) {
+    return book.getInterfaceGroups().stream()
+        .map(InterfaceGroup::getName)
+        .collect(ImmutableSet.toImmutableSet());
+  }
 
   private final Grammar _grammar;
   private final Rule _inputRule;
@@ -579,9 +580,9 @@ public final class ParboiledAutoComplete {
   private static Function<ReferenceBook, Set<String>> getEntityNameGetter(Anchor.Type anchorType) {
     switch (anchorType) {
       case ADDRESS_GROUP_NAME:
-        return addressGroupGetter;
+        return ParboiledAutoComplete::addressGroupGetter;
       case INTERFACE_GROUP_NAME:
-        return interfaceGroupGetter;
+        return ParboiledAutoComplete::interfaceGroupGetter;
       default:
         throw new IllegalArgumentException("Unexpected anchor type " + anchorType);
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteReferenceBookEntityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/specifier/parboiled/ParboiledAutoCompleteReferenceBookEntityTest.java
@@ -5,7 +5,6 @@ import static org.batfish.specifier.parboiled.Anchor.Type.INTERFACE_GROUP_NAME;
 import static org.batfish.specifier.parboiled.Anchor.Type.OPERATOR_END;
 import static org.batfish.specifier.parboiled.Anchor.Type.REFERENCE_BOOK_AND_ADDRESS_GROUP_TAIL;
 import static org.batfish.specifier.parboiled.Anchor.Type.REFERENCE_BOOK_NAME;
-import static org.batfish.specifier.parboiled.ParboiledAutoComplete.addressGroupGetter;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
@@ -86,7 +85,8 @@ public class ParboiledAutoCompleteReferenceBookEntityTest {
     PotentialMatch pm = new PotentialMatch(anchor, "", ImmutableList.of());
 
     assertThat(
-        getPAC().autoCompleteReferenceBookEntity(pm, "(b1a", addressGroupGetter),
+        getPAC()
+            .autoCompleteReferenceBookEntity(pm, "(b1a", ParboiledAutoComplete::addressGroupGetter),
         containsInAnyOrder(
             new ParboiledAutoCompleteSuggestion("g11", 42, ADDRESS_GROUP_NAME),
             new ParboiledAutoCompleteSuggestion("g12", 42, ADDRESS_GROUP_NAME)));
@@ -107,19 +107,25 @@ public class ParboiledAutoCompleteReferenceBookEntityTest {
     // should match only r11
     assertThat(
         pac.autoCompleteReferenceBookEntity(
-            new PotentialMatch(anchor, "g11", ImmutableList.of()), "(b1a", addressGroupGetter),
+            new PotentialMatch(anchor, "g11", ImmutableList.of()),
+            "(b1a",
+            ParboiledAutoComplete::addressGroupGetter),
         containsInAnyOrder(new ParboiledAutoCompleteSuggestion("g11", 42, ADDRESS_GROUP_NAME)));
 
     // should not match anything
     assertThat(
         pac.autoCompleteReferenceBookEntity(
-            new PotentialMatch(anchor, "g2", ImmutableList.of()), "(b1a", addressGroupGetter),
+            new PotentialMatch(anchor, "g2", ImmutableList.of()),
+            "(b1a",
+            ParboiledAutoComplete::addressGroupGetter),
         equalTo(ImmutableSet.of()));
 
     // should match only r11 but preserve quotes
     assertThat(
         pac.autoCompleteReferenceBookEntity(
-            new PotentialMatch(anchor, "\"g11", ImmutableList.of()), "(b1a", addressGroupGetter),
+            new PotentialMatch(anchor, "\"g11", ImmutableList.of()),
+            "(b1a",
+            ParboiledAutoComplete::addressGroupGetter),
         containsInAnyOrder(new ParboiledAutoCompleteSuggestion("\"g11\"", 42, ADDRESS_GROUP_NAME)));
   }
 


### PR DESCRIPTION
Clearer code, and eliminates a static analysis tool error about mutable final objects.
The error may have been a false positive, or you may be able to mess with
lambdas in ways you can't mess with functions.