### PR TITLE
Move all ReferenceLibrary IO to StorageProvider

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -84,6 +84,7 @@ import org.batfish.identifiers.NodeRolesId;
 import org.batfish.identifiers.QuestionId;
 import org.batfish.identifiers.QuestionSettingsId;
 import org.batfish.identifiers.SnapshotId;
+import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRolesData;
 
 /** A utility class that abstracts the underlying file system storage used by Batfish. */
@@ -1306,6 +1307,30 @@ public final class FileBasedStorage implements StorageProvider {
     } catch (IOException e) {
       throw new IOException("Could not list files in '" + idsDir + "'", e);
     }
+  }
+
+  @Nonnull
+  @Override
+  public Optional<ReferenceLibrary> loadReferenceLibrary(NetworkId network) throws IOException {
+    Path path = getReferenceLibraryPath(network);
+    if (!Files.exists(path)) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        BatfishObjectMapper.mapper()
+            .readValue(
+                readFileToString(getReferenceLibraryPath(network), UTF_8), ReferenceLibrary.class));
+  }
+
+  @Override
+  public void storeReferenceLibrary(ReferenceLibrary referenceLibrary, NetworkId network)
+      throws IOException {
+    writeStringToFile(
+        getReferenceLibraryPath(network), BatfishObjectMapper.writeString(referenceLibrary), UTF_8);
+  }
+
+  private @Nonnull Path getReferenceLibraryPath(NetworkId network) {
+    return _d.getNetworkDir(network).resolve(BfConsts.RELPATH_REFERENCE_LIBRARY_PATH);
   }
 
   private static String toIdDirName(Class<? extends Id> type) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -40,6 +40,7 @@ import org.batfish.identifiers.NodeRolesId;
 import org.batfish.identifiers.QuestionId;
 import org.batfish.identifiers.QuestionSettingsId;
 import org.batfish.identifiers.SnapshotId;
+import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRolesData;
 
 /** Storage backend for loading and storing persistent data used by Batfish */
@@ -684,4 +685,21 @@ public interface StorageProvider {
    */
   @Nonnull
   Set<String> listResolvableNames(Class<? extends Id> idType, Id... ancestors) throws IOException;
+
+  /**
+   * Loads the network-wide reference library for the given network if it exists, or else returns
+   * {@link Optional#empty}.
+   *
+   * @throws IOException if there is an error
+   */
+  @Nonnull
+  Optional<ReferenceLibrary> loadReferenceLibrary(NetworkId network) throws IOException;
+
+  /**
+   * Stores the network-wide reference library for the given network
+   *
+   * @throws IOException if there is an error
+   */
+  void storeReferenceLibrary(ReferenceLibrary referenceLibrary, NetworkId network)
+      throws IOException;
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/referencelibrary/ReferenceLibraryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/referencelibrary/ReferenceLibraryTest.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.SortedSet;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.common.util.CommonUtil;
@@ -66,12 +65,10 @@ public class ReferenceLibraryTest {
   /** check that merger of reference books is proper */
   @Test
   public void testMergeReferenceBooks() throws IOException {
-    Path tempPath = CommonUtil.createTempFile("referencelibrary", "tmp");
     ReferenceLibrary library =
         new ReferenceLibrary(
             ImmutableList.of(
                 ReferenceBook.builder("book1").build(), ReferenceBook.builder("book2").build()));
-    ReferenceLibrary.write(library, tempPath);
 
     SortedSet<ReferenceBook> newBooks =
         ImmutableSortedSet.of(
@@ -81,10 +78,10 @@ public class ReferenceLibraryTest {
                 .build(),
             ReferenceBook.builder("book3").build());
 
-    ReferenceLibrary.mergeReferenceBooks(tempPath, newBooks);
+    ReferenceLibrary merged = library.mergeReferenceBooks(newBooks);
 
     assertThat(
-        ReferenceLibrary.read(tempPath).getReferenceBooks(),
+        merged.getReferenceBooks(),
         equalTo(
             ImmutableSortedSet.of(
                 ReferenceBook.builder("book1")

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
@@ -37,6 +37,7 @@ import org.batfish.identifiers.NodeRolesId;
 import org.batfish.identifiers.QuestionId;
 import org.batfish.identifiers.QuestionSettingsId;
 import org.batfish.identifiers.SnapshotId;
+import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRolesData;
 
 public class TestStorageProvider implements StorageProvider {
@@ -425,6 +426,18 @@ public class TestStorageProvider implements StorageProvider {
   @Nonnull
   @Override
   public Set<String> listResolvableNames(Class<? extends Id> type, Id... ancestors)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public Optional<ReferenceLibrary> loadReferenceLibrary(NetworkId network) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void storeReferenceLibrary(ReferenceLibrary referenceLibrary, NetworkId network)
       throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1243,16 +1243,14 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   /** Gets the {@link ReferenceLibrary} for the network */
   @Override
-  public ReferenceLibrary getReferenceLibraryData() {
-    Path libraryPath =
-        _settings
-            .getStorageBase()
-            .resolve(_settings.getContainer().getId())
-            .resolve(BfConsts.RELPATH_REFERENCE_LIBRARY_PATH);
+  public @Nullable ReferenceLibrary getReferenceLibraryData() {
     try {
-      return ReferenceLibrary.read(libraryPath);
+      return _storage
+          .loadReferenceLibrary(_settings.getContainer())
+          .orElse(new ReferenceLibrary(null));
     } catch (IOException e) {
-      _logger.errorf("Could not read reference library data from %s: %s", libraryPath, e);
+      _logger.errorf(
+          "Could not read reference library data for network %s: %s", _settings.getContainer(), e);
       return null;
     }
   }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/ReferenceBookResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/ReferenceBookResource.java
@@ -45,7 +45,7 @@ public class ReferenceBookResource {
     try {
       ReferenceLibrary library = Main.getWorkMgr().getReferenceLibrary(_network);
       library.delAddressBook(_bookName);
-      ReferenceLibrary.write(library, Main.getWorkMgr().getReferenceLibraryPath(_network));
+      Main.getWorkMgr().putReferenceLibrary(library, _network);
       return Response.ok().build();
     } catch (IOException e) {
       throw new InternalServerErrorException("Reference library is corrupted");
@@ -82,9 +82,12 @@ public class ReferenceBookResource {
     _logger.infof("WMS2: putReferenceBook '%s'\n", _network);
     checkClientArgument(referenceBookBean.name != null, "Reference book must have a name");
     try {
-      ReferenceLibrary.mergeReferenceBooks(
-          Main.getWorkMgr().getReferenceLibraryPath(_network),
-          ImmutableSortedSet.of(referenceBookBean.toAddressBook()));
+      Main.getWorkMgr()
+          .putReferenceLibrary(
+              Main.getWorkMgr()
+                  .getReferenceLibrary(_network)
+                  .mergeReferenceBooks(ImmutableSortedSet.of(referenceBookBean.toAddressBook())),
+              _network);
       return Response.ok().build();
     } catch (IOException e) {
       throw new InternalServerErrorException("ReferenceLibrary resource is corrupted");

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/resources/ReferenceLibraryResource.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/resources/ReferenceLibraryResource.java
@@ -46,9 +46,12 @@ public class ReferenceLibraryResource {
       if (library.getReferenceBook(referenceBookBean.name).isPresent()) {
         throw new BadRequestException("Duplicate bookname: " + referenceBookBean.name);
       }
-      ReferenceLibrary.mergeReferenceBooks(
-          Main.getWorkMgr().getReferenceLibraryPath(_network),
-          ImmutableSortedSet.of(referenceBookBean.toAddressBook()));
+      Main.getWorkMgr()
+          .putReferenceLibrary(
+              Main.getWorkMgr()
+                  .getReferenceLibrary(_network)
+                  .mergeReferenceBooks(ImmutableSortedSet.of(referenceBookBean.toAddressBook())),
+              _network);
       return Response.ok().build();
     } catch (IOException e) {
       throw new InternalServerErrorException("ReferenceLibrary resource is corrupted");

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/ReferenceBookResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/ReferenceBookResourceTest.java
@@ -5,7 +5,6 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -52,10 +51,11 @@ public class ReferenceBookResourceTest extends WorkMgrServiceV2TestBase {
     String container = "someContainer";
     Main.getWorkMgr().initNetwork(container, null);
 
-    // write a library to the right place
-    ReferenceLibrary.write(
-        new ReferenceLibrary(ImmutableList.of(ReferenceBook.builder("book1").build())),
-        Main.getWorkMgr().getReferenceLibraryPath(container));
+    // write a library
+    Main.getWorkMgr()
+        .putReferenceLibrary(
+            new ReferenceLibrary(ImmutableList.of(ReferenceBook.builder("book1").build())),
+            container);
 
     Response response = getReferenceBookTarget(container, "book1").delete();
 
@@ -71,14 +71,15 @@ public class ReferenceBookResourceTest extends WorkMgrServiceV2TestBase {
   }
 
   @Test
-  public void getReferenceBook() throws JsonProcessingException {
+  public void getReferenceBook() throws IOException {
     String container = "someContainer";
     Main.getWorkMgr().initNetwork(container, null);
 
     // write a library to the right place
-    ReferenceLibrary.write(
-        new ReferenceLibrary(ImmutableList.of(ReferenceBook.builder("book1").build())),
-        Main.getWorkMgr().getReferenceLibraryPath(container));
+    Main.getWorkMgr()
+        .putReferenceLibrary(
+            new ReferenceLibrary(ImmutableList.of(ReferenceBook.builder("book1").build())),
+            container);
 
     // we only check that the right type of object is returned at the expected URL target
     // we rely on ReferenceBookBean to have created the object with the right content


### PR DESCRIPTION
- remove IO from ReferenceLibrary class
- add load and store methods for ReferenceLibrary to StorageProvider
- update callers