### PR TITLE
WorkMgr snapshot initialization move persistent I/O to StorageProvider

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/UnzipUtility.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/UnzipUtility.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -51,53 +52,58 @@ public final class UnzipUtility {
   }
 
   /**
-   * Extracts a zip file specified by the zipFilePath to a directory specified by {@code
-   * destDirectory} (will be created if does not exists)
+   * Extracts {@code zipStream} to a directory specified by {@code destDirectory} (will be created
+   * if does not exists).
    *
-   * @param zipFile The path to the input zip file
-   * @param destDirectory The output directory in which to extract the zip
+   * @throws IOException if there is an error
    */
-  public static void unzip(Path zipFile, Path destDirectory) {
+  public static void unzip(InputStream zipStream, Path destDirectory) throws IOException {
     if (!Files.exists(destDirectory) && !destDirectory.toFile().mkdirs()) {
-      throw new BatfishException("Could not create zip output directory " + destDirectory);
+      throw new IOException("Could not create zip output directory " + destDirectory);
     }
 
-    try {
-      // :ratul:
-      // this lets us check if the zip file is proper
-      // for bad zip files this will throw an exception
-      ZipFile zipTest = new ZipFile(zipFile.toFile());
-      zipTest.close();
+    try (ZipInputStream zipIn = new ZipInputStream(zipStream)) {
 
-      try (FileInputStream fis = new FileInputStream(zipFile.toFile());
-          ZipInputStream zipIn = new ZipInputStream(fis)) {
-
-        for (ZipEntry entry = zipIn.getNextEntry(); entry != null; entry = zipIn.getNextEntry()) {
-          Path outputPath =
-              validatePath(
-                  Paths.get(destDirectory + File.separator + entry.getName()), destDirectory);
-          if (entry.isDirectory()) {
-            // Make the directory, including parent dirs.
-            if (!outputPath.toFile().mkdirs()) {
-              throw new IOException("Unable to make directory " + outputPath);
-            }
-          } else {
-            // Make sure parent directories exist, in case the zip does not contain dir entries
-            File parentDir = outputPath.toFile().getParentFile();
-            if (!parentDir.exists()) {
-              if (!parentDir.mkdirs()) {
-                throw new IOException("Unable to make directory " + parentDir.getPath());
-              }
-            }
-            // Extract the file.
-            extractFile(zipIn, outputPath);
+      for (ZipEntry entry = zipIn.getNextEntry(); entry != null; entry = zipIn.getNextEntry()) {
+        Path outputPath =
+            validatePath(
+                Paths.get(destDirectory + File.separator + entry.getName()), destDirectory);
+        if (entry.isDirectory()) {
+          // Make the directory, including parent dirs.
+          if (!outputPath.toFile().mkdirs()) {
+            throw new IOException("Unable to make directory " + outputPath);
           }
-          zipIn.closeEntry();
+        } else {
+          // Make sure parent directories exist, in case the zip does not contain dir entries
+          File parentDir = outputPath.toFile().getParentFile();
+          if (!parentDir.exists()) {
+            if (!parentDir.mkdirs()) {
+              throw new IOException("Unable to make directory " + parentDir.getPath());
+            }
+          }
+          // Extract the file.
+          extractFile(zipIn, outputPath);
         }
+        zipIn.closeEntry();
       }
-    } catch (IOException e) {
-      throw new BatfishException(
-          "Could not unzip: '" + zipFile + "' into: '" + destDirectory + "'", e);
+    }
+  }
+
+  /**
+   * Extracts {@code zipFile} to a directory specified by {@code destDirectory} (will be created if
+   * does not exists).
+   *
+   * @throws IOException if there is an error
+   */
+  public static void unzip(Path zipFile, Path destDirectory) throws IOException {
+    // :ratul:
+    // this lets us check if the zip file is proper
+    // for bad zip files this will throw an exception
+    ZipFile zipTest = new ZipFile(zipFile.toFile());
+    zipTest.close();
+
+    try (FileInputStream fis = new FileInputStream(zipFile.toFile())) {
+      unzip(fis, destDirectory);
     }
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/UnzipUtility.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/UnzipUtility.java
@@ -3,6 +3,7 @@ package org.batfish.common.util;
 import com.google.common.io.ByteStreams;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,18 +53,17 @@ public final class UnzipUtility {
   }
 
   /**
-   * Extracts {@code zipStream} to a directory specified by {@code destDirectory} (will be created
-   * if does not exists).
+   * Extracts {@code zipStream} to a directory specified by {@code destDirectory}, which must
+   * already exist.
    *
-   * @throws IOException if there is an error
+   * @throws IOException if {@code destDirectory} does not exist or there is any other errror
    */
   public static void unzip(InputStream zipStream, Path destDirectory) throws IOException {
-    if (!Files.exists(destDirectory) && !destDirectory.toFile().mkdirs()) {
-      throw new IOException("Could not create zip output directory " + destDirectory);
+    if (!Files.exists(destDirectory)) {
+      throw new FileNotFoundException(
+          String.format("Output directory does not exist exists: %s", destDirectory));
     }
-
     try (ZipInputStream zipIn = new ZipInputStream(zipStream)) {
-
       for (ZipEntry entry = zipIn.getNextEntry(); entry != null; entry = zipIn.getNextEntry()) {
         Path outputPath =
             validatePath(
@@ -75,12 +75,7 @@ public final class UnzipUtility {
           }
         } else {
           // Make sure parent directories exist, in case the zip does not contain dir entries
-          File parentDir = outputPath.toFile().getParentFile();
-          if (!parentDir.exists()) {
-            if (!parentDir.mkdirs()) {
-              throw new IOException("Unable to make directory " + parentDir.getPath());
-            }
-          }
+          com.google.common.io.Files.createParentDirs(outputPath.toFile());
           // Extract the file.
           extractFile(zipIn, outputPath);
         }
@@ -90,10 +85,10 @@ public final class UnzipUtility {
   }
 
   /**
-   * Extracts {@code zipFile} to a directory specified by {@code destDirectory} (will be created if
-   * does not exists).
+   * Extracts {@code zipFile} to a directory specified by {@code destDirectory}, which must already
+   * exist.
    *
-   * @throws IOException if there is an error
+   * @throws IOException if {@code destDirectory} does not exist or there is any other errror
    */
   public static void unzip(Path zipFile, Path destDirectory) throws IOException {
     // :ratul:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -15,6 +15,7 @@ import com.google.common.io.Closer;
 import com.google.errorprone.annotations.MustBeClosed;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -1126,6 +1127,17 @@ public final class FileBasedStorage implements StorageProvider {
     }
   }
 
+  private void writeStreamToFile(InputStream inputStream, Path outputFile) throws IOException {
+    mkdirs(outputFile.getParent());
+    try (OutputStream fileOutputStream = new FileOutputStream(outputFile.toFile())) {
+      int read = 0;
+      final byte[] bytes = new byte[STREAMED_FILE_BUFFER_SIZE];
+      while ((read = inputStream.read(bytes)) != -1) {
+        fileOutputStream.write(bytes, 0, read);
+      }
+    }
+  }
+
   private static void writeStringToFile(Path file, String data, Charset charset)
       throws IOException {
     Path tmpFile = Files.createTempFile(null, null);
@@ -1327,6 +1339,33 @@ public final class FileBasedStorage implements StorageProvider {
       throws IOException {
     writeStringToFile(
         getReferenceLibraryPath(network), BatfishObjectMapper.writeString(referenceLibrary), UTF_8);
+  }
+
+  @Override
+  public void storeUploadSnapshotZip(InputStream inputStream, String key, NetworkId network)
+      throws IOException {
+    writeStreamToFile(inputStream, getUploadSnapshotZipPath(key, network));
+  }
+
+  private @Nonnull Path getUploadSnapshotZipPath(String key, NetworkId network) {
+    return _d.getOriginalDir(network).resolve(toBase64(key));
+  }
+
+  private static final int STREAMED_FILE_BUFFER_SIZE = 1024;
+
+  @MustBeClosed
+  @Nonnull
+  @Override
+  public InputStream loadUploadSnapshotZip(String key, NetworkId network) throws IOException {
+    return Files.newInputStream(getUploadSnapshotZipPath(key, network));
+  }
+
+  @Override
+  public void storeSnapshotInputObject(
+      InputStream inputStream, String key, NetworkSnapshot snapshot) throws IOException {
+    writeStreamToFile(
+        inputStream,
+        getSnapshotInputObjectPath(snapshot.getNetwork(), snapshot.getSnapshot(), key));
   }
 
   private @Nonnull Path getReferenceLibraryPath(NetworkId network) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -1348,7 +1348,7 @@ public final class FileBasedStorage implements StorageProvider {
   }
 
   private @Nonnull Path getUploadSnapshotZipPath(String key, NetworkId network) {
-    return _d.getOriginalDir(network).resolve(toBase64(key));
+    return _d.getOriginalDir(key, network).resolve(BfConsts.RELPATH_SNAPSHOT_ZIP_FILE);
   }
 
   private static final int STREAMED_FILE_BUFFER_SIZE = 1024;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorageDirectoryProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorageDirectoryProvider.java
@@ -62,6 +62,12 @@ public class FileBasedStorageDirectoryProvider {
     return _baseDir.resolve(network.getId());
   }
 
+  /** Directory where original initialization or fork requests are stored */
+  @Nonnull
+  Path getOriginalDir(NetworkId network) {
+    return getNetworkDir(network).resolve(BfConsts.RELPATH_ORIGINAL_DIR);
+  }
+
   public @Nonnull Path getNetworkSettingsDir(NetworkId network) {
     return getNetworkDir(network).resolve(BfConsts.RELPATH_CONTAINER_SETTINGS);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorageDirectoryProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorageDirectoryProvider.java
@@ -1,5 +1,7 @@
 package org.batfish.storage;
 
+import static org.batfish.storage.FileBasedStorage.toBase64;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import javax.annotation.Nonnull;
@@ -64,8 +66,8 @@ public class FileBasedStorageDirectoryProvider {
 
   /** Directory where original initialization or fork requests are stored */
   @Nonnull
-  Path getOriginalDir(NetworkId network) {
-    return getNetworkDir(network).resolve(BfConsts.RELPATH_ORIGINAL_DIR);
+  Path getOriginalDir(String key, NetworkId network) {
+    return getNetworkDir(network).resolve(BfConsts.RELPATH_ORIGINAL_DIR).resolve(toBase64(key));
   }
 
   public @Nonnull Path getNetworkSettingsDir(NetworkId network) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -702,4 +702,31 @@ public interface StorageProvider {
    */
   void storeReferenceLibrary(ReferenceLibrary referenceLibrary, NetworkId network)
       throws IOException;
+
+  /**
+   * Stores the original zip for a snapshot upload request for the given network, associating it
+   * with the given key.
+   *
+   * @throws IOException if there is an error
+   */
+  void storeUploadSnapshotZip(InputStream inputStream, String key, NetworkId network)
+      throws IOException;
+
+  /**
+   * Loads the original zip for a snapshot upload request associated with the given key.
+   *
+   * @throws IOException if there is an error
+   */
+  @MustBeClosed
+  @Nonnull
+  InputStream loadUploadSnapshotZip(String key, NetworkId network) throws IOException;
+
+  /**
+   * Stores an input object with the given key whose contents are accessible via the given
+   * inputStream for the given snapshot.
+   *
+   * @throws IOException if there is an error
+   */
+  void storeSnapshotInputObject(InputStream inputStream, String key, NetworkSnapshot snapshot)
+      throws IOException;
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/UnzipUtilityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/UnzipUtilityTest.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-import org.batfish.common.BatfishException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -71,8 +70,7 @@ public class UnzipUtilityTest {
     }
 
     File dest = _folder.newFolder("dest");
-    _thrown.expect(BatfishException.class);
-    _thrown.expectCause(instanceOf(IOException.class));
+    _thrown.expect(instanceOf(IOException.class));
     UnzipUtility.unzip(pathViolation.toPath(), dest.toPath());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -363,6 +363,7 @@ public final class FileBasedStorageTest {
     }
 
     Path unzipDir = _folder.getRoot().toPath().resolve("tmp");
+    unzipDir.toFile().mkdirs();
     UnzipUtility.unzip(tmpzip, unzipDir);
 
     // the top level entry in the zip should be testkey

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
@@ -441,4 +441,22 @@ public class TestStorageProvider implements StorageProvider {
       throws IOException {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public void storeUploadSnapshotZip(InputStream inputStream, String key, NetworkId network)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public InputStream loadUploadSnapshotZip(String key, NetworkId network) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void storeSnapshotInputObject(
+      InputStream inputStream, String key, NetworkSnapshot snapshot) throws IOException {
+    throw new UnsupportedOperationException();
+  }
 }


### PR DESCRIPTION
- Add StorageProvider methods for:
  - loading and storing original snapshot zip
  - storing individual snapshot input objects
- Update UnzipUtility to support unzipping from streams
- Follow-on work: similarly update forkSnapshot