### PR TITLE
ISP Modeling: use Configuration#humanName instead of #hostname for name

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspModel.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/isp/IspModel.java
@@ -24,10 +24,10 @@ import org.batfish.datamodel.isp_configuration.traffic_filtering.IspTrafficFilte
 /** Contains the information required to model one ISP node */
 @ParametersAreNonnullByDefault
 final class IspModel {
+
   static final class Builder {
     IspModel build() {
       checkArgument(_asn != null, "Missing ASN");
-      checkArgument(_name != null, "Missing name");
       return new IspModel(
           _asn,
           firstNonNull(_remotes, ImmutableList.of()),
@@ -166,7 +166,7 @@ final class IspModel {
   }
 
   private final long _asn;
-  private final @Nonnull String _name;
+  private final @Nullable String _name;
   private @Nonnull List<Remote> _remotes;
   private final @Nonnull Set<Prefix> _additionalPrefixesToInternet;
   private final @Nonnull IspTrafficFiltering _trafficFiltering;
@@ -174,7 +174,7 @@ final class IspModel {
   private IspModel(
       long asn,
       List<Remote> remotes,
-      String name,
+      @Nullable String name,
       Set<Prefix> additionalPrefixesToInternet,
       IspTrafficFiltering trafficFiltering) {
     _asn = asn;
@@ -200,6 +200,7 @@ final class IspModel {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
+        .omitNullValues()
         .add("asn", _asn)
         .add("name", _name)
         .add("neighbors", _remotes)
@@ -219,7 +220,7 @@ final class IspModel {
     IspModel ispInfo = (IspModel) o;
     return _asn == ispInfo._asn
         && _remotes.equals(ispInfo._remotes)
-        && _name.equals(ispInfo._name)
+        && Objects.equals(_name, ispInfo._name)
         && _additionalPrefixesToInternet.equals(ispInfo._additionalPrefixesToInternet)
         && _trafficFiltering.equals(ispInfo._trafficFiltering);
   }
@@ -234,6 +235,11 @@ final class IspModel {
   }
 
   @Nonnull
+  public String getHostname() {
+    return IspModelingUtils.getDefaultIspNodeName(_asn);
+  }
+
+  @Nullable
   public String getName() {
     return _name;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -1,7 +1,7 @@
 package org.batfish.representation.aws;
 
 import static org.batfish.representation.aws.InternetGateway.AWS_BACKBONE_ASN;
-import static org.batfish.representation.aws.InternetGateway.AWS_BACKBONE_NODE_NAME;
+import static org.batfish.representation.aws.InternetGateway.AWS_BACKBONE_HUMAN_NAME;
 import static org.batfish.representation.aws.InternetGateway.BACKBONE_INTERFACE_NAME;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -153,7 +153,7 @@ public class AwsConfiguration extends VendorConfiguration {
         ImmutableList.of(
             new IspNodeInfo(
                 AWS_BACKBONE_ASN,
-                AWS_BACKBONE_NODE_NAME,
+                AWS_BACKBONE_HUMAN_NAME,
                 AwsPrefixes.getPrefixes().stream()
                     .map(IspAnnouncement::new)
                     .collect(ImmutableList.toImmutableList()))));

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/InternetGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/InternetGateway.java
@@ -60,8 +60,8 @@ final class InternetGateway implements AwsVpcEntity, Serializable {
   /** ASN to use for AWS backbone */
   static final long AWS_BACKBONE_ASN = 16509L;
 
-  /** Name to use for AWS backbone */
-  static final String AWS_BACKBONE_NODE_NAME = "aws-backbone";
+  /** Human name to use for AWS backbone */
+  static final String AWS_BACKBONE_HUMAN_NAME = "aws-backbone";
 
   /** ASN to use for AWS internet gateways */
   static final long AWS_INTERNET_GATEWAY_AS = 65534L;

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationNatGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationNatGatewayTest.java
@@ -4,12 +4,13 @@ import static org.batfish.common.util.isp.IspModelingUtils.INTERNET_HOST_NAME;
 import static org.batfish.representation.aws.AwsConfigurationTestUtils.getTcpFlow;
 import static org.batfish.representation.aws.AwsConfigurationTestUtils.testSetup;
 import static org.batfish.representation.aws.AwsConfigurationTestUtils.testTrace;
-import static org.batfish.representation.aws.InternetGateway.AWS_BACKBONE_NODE_NAME;
+import static org.batfish.representation.aws.InternetGateway.AWS_BACKBONE_ASN;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
 import org.batfish.common.plugin.IBatfish;
+import org.batfish.common.util.isp.IspModelingUtils;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.Ip;
@@ -31,6 +32,9 @@ import org.junit.rules.TemporaryFolder;
  * the tests below but were part of the definition file (and pulled data) for manual testing.
  */
 public class AwsConfigurationNatGatewayTest {
+
+  private static final String AWS_BACKBONE_HOSTNAME =
+      IspModelingUtils.getDefaultIspNodeName(AWS_BACKBONE_ASN);
 
   private static final String TESTCONFIGS_DIR = "org/batfish/representation/aws/test-nat-gateway";
 
@@ -81,11 +85,11 @@ public class AwsConfigurationNatGatewayTest {
             _subnetNat,
             _vpc,
             _internetGateway,
-            AWS_BACKBONE_NODE_NAME,
+            AWS_BACKBONE_HOSTNAME,
             INTERNET_HOST_NAME),
         ImmutableList.of(
             INTERNET_HOST_NAME,
-            AWS_BACKBONE_NODE_NAME,
+            AWS_BACKBONE_HOSTNAME,
             _internetGateway,
             _vpc,
             _subnetNat,
@@ -122,7 +126,7 @@ public class AwsConfigurationNatGatewayTest {
         FlowDisposition.DENIED_IN,
         ImmutableList.of(
             INTERNET_HOST_NAME,
-            AWS_BACKBONE_NODE_NAME,
+            AWS_BACKBONE_HOSTNAME,
             _internetGateway,
             _vpc,
             _subnetNat,

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicPrivateSubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicPrivateSubnetTest.java
@@ -5,7 +5,7 @@ import static org.batfish.representation.aws.AwsConfigurationTestUtils.getAnyFlo
 import static org.batfish.representation.aws.AwsConfigurationTestUtils.getTraces;
 import static org.batfish.representation.aws.AwsConfigurationTestUtils.testSetup;
 import static org.batfish.representation.aws.AwsConfigurationTestUtils.testTrace;
-import static org.batfish.representation.aws.InternetGateway.AWS_BACKBONE_NODE_NAME;
+import static org.batfish.representation.aws.InternetGateway.AWS_BACKBONE_ASN;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -32,6 +32,9 @@ import org.junit.rules.TemporaryFolder;
  * manually.
  */
 public class AwsConfigurationPublicPrivateSubnetTest {
+
+  private static final String AWS_BACKBONE_HOSTNAME =
+      IspModelingUtils.getDefaultIspNodeName(AWS_BACKBONE_ASN);
 
   private static final String TESTCONFIGS_DIR =
       "org/batfish/representation/aws/test-public-private-subnet";
@@ -119,7 +122,7 @@ public class AwsConfigurationPublicPrivateSubnetTest {
         FlowDisposition.DENIED_IN, // be the default security setting
         ImmutableList.of(
             IspModelingUtils.INTERNET_HOST_NAME,
-            AWS_BACKBONE_NODE_NAME,
+            AWS_BACKBONE_HOSTNAME,
             _igw,
             _vpc,
             _publicSubnet,
@@ -143,7 +146,7 @@ public class AwsConfigurationPublicPrivateSubnetTest {
             _publicSubnet,
             _vpc,
             _igw,
-            AWS_BACKBONE_NODE_NAME,
+            AWS_BACKBONE_HOSTNAME,
             IspModelingUtils.INTERNET_HOST_NAME),
         _batfish);
 
@@ -161,7 +164,7 @@ public class AwsConfigurationPublicPrivateSubnetTest {
         getAnyFlow(_publicInstance, _sitePrefix.getStartIp(), _batfish),
         FlowDisposition.EXITS_NETWORK,
         ImmutableList.of(
-            _publicInstance, _publicSubnet, _vpc, _igw, AWS_BACKBONE_NODE_NAME, INTERNET_HOST_NAME),
+            _publicInstance, _publicSubnet, _vpc, _igw, AWS_BACKBONE_HOSTNAME, INTERNET_HOST_NAME),
         _batfish);
 
     // private instance should send site traffic to VGW

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicSubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationPublicSubnetTest.java
@@ -7,7 +7,7 @@ import static org.batfish.representation.aws.AwsConfigurationTestUtils.getAnyFlo
 import static org.batfish.representation.aws.AwsConfigurationTestUtils.getTcpFlow;
 import static org.batfish.representation.aws.AwsConfigurationTestUtils.testSetup;
 import static org.batfish.representation.aws.AwsConfigurationTestUtils.testTrace;
-import static org.batfish.representation.aws.InternetGateway.AWS_BACKBONE_NODE_NAME;
+import static org.batfish.representation.aws.InternetGateway.AWS_BACKBONE_ASN;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
@@ -66,6 +66,9 @@ public class AwsConfigurationPublicSubnetTest {
   private static Ip _publicIp = Ip.parse("18.216.80.133");
   private static Ip _privateIp = Ip.parse("10.0.0.91");
 
+  private static final String AWS_BACKBONE_HOSTNAME =
+      IspModelingUtils.getDefaultIspNodeName(AWS_BACKBONE_ASN);
+
   @ClassRule public static TemporaryFolder _folder = new TemporaryFolder();
 
   private static IBatfish _batfish;
@@ -89,7 +92,7 @@ public class AwsConfigurationPublicSubnetTest {
             FlowDisposition.DENIED_IN, // by the default security settings
             ImmutableList.of(
                 IspModelingUtils.INTERNET_HOST_NAME,
-                AWS_BACKBONE_NODE_NAME,
+                AWS_BACKBONE_HOSTNAME,
                 _igw,
                 _vpc,
                 _subnet,
@@ -118,7 +121,7 @@ public class AwsConfigurationPublicSubnetTest {
     testTrace(
         flowFromInternet,
         FlowDisposition.NULL_ROUTED,
-        ImmutableList.of(IspModelingUtils.INTERNET_HOST_NAME, AWS_BACKBONE_NODE_NAME),
+        ImmutableList.of(IspModelingUtils.INTERNET_HOST_NAME, AWS_BACKBONE_HOSTNAME),
         _batfish);
   }
 
@@ -150,7 +153,7 @@ public class AwsConfigurationPublicSubnetTest {
                 _subnet,
                 _vpc,
                 _igw,
-                AWS_BACKBONE_NODE_NAME,
+                AWS_BACKBONE_HOSTNAME,
                 IspModelingUtils.INTERNET_HOST_NAME),
             _batfish);
 

--- a/tests/aws/topology-example-aws.ref
+++ b/tests/aws/topology-example-aws.ref
@@ -210,9 +210,9 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-aws-backbone-To-igw-068fee63",
-      "name" : "To-igw-068fee63",
-      "nodeId" : "node-aws-backbone",
+      "id" : "interface-node-isp_16509-To-igw-9b93ddfc",
+      "name" : "To-igw-9b93ddfc",
+      "nodeId" : "node-isp_16509",
       "type" : "UNKNOWN",
       "properties" : null
     },
@@ -315,13 +315,6 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-aws-backbone-To-igw-9b93ddfc",
-      "name" : "To-igw-9b93ddfc",
-      "nodeId" : "node-aws-backbone",
-      "type" : "UNKNOWN",
-      "properties" : null
-    },
-    {
       "id" : "interface-node-subnet-7044ff16-vpc-b390fad5-vrf-igw-9b93ddfc",
       "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
       "nodeId" : "node-subnet-7044ff16",
@@ -371,13 +364,6 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-aws-backbone-To-igw-fac5839d",
-      "name" : "To-igw-fac5839d",
-      "nodeId" : "node-aws-backbone",
-      "type" : "UNKNOWN",
-      "properties" : null
-    },
-    {
       "id" : "interface-node-vpc-925131f4-subnet-62f14104-vrf-igw-fac5839d",
       "name" : "subnet-62f14104-vrf-igw-fac5839d",
       "nodeId" : "node-vpc-925131f4",
@@ -392,6 +378,13 @@
       "properties" : null
     },
     {
+      "id" : "interface-node-isp_16509-To-igw-fac5839d",
+      "name" : "To-igw-fac5839d",
+      "nodeId" : "node-isp_16509",
+      "type" : "UNKNOWN",
+      "properties" : null
+    },
+    {
       "id" : "interface-node-subnet-7044ff16-to-instances",
       "name" : "to-instances",
       "nodeId" : "node-subnet-7044ff16",
@@ -403,6 +396,13 @@
       "name" : "subnet-30398256-vrf-igw-9b93ddfc",
       "nodeId" : "node-vpc-b390fad5",
       "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "id" : "interface-node-internet-To-isp_16509",
+      "name" : "To-isp_16509",
+      "nodeId" : "node-internet",
+      "type" : "UNKNOWN",
       "properties" : null
     },
     {
@@ -525,9 +525,9 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-internet-To-aws-backbone",
-      "name" : "To-aws-backbone",
-      "nodeId" : "node-internet",
+      "id" : "interface-node-isp_16509-To-igw-068fee63",
+      "name" : "To-igw-068fee63",
+      "nodeId" : "node-isp_16509",
       "type" : "UNKNOWN",
       "properties" : null
     },
@@ -546,17 +546,17 @@
       "properties" : null
     },
     {
+      "id" : "interface-node-isp_16509-To-Internet",
+      "name" : "To-Internet",
+      "nodeId" : "node-isp_16509",
+      "type" : "UNKNOWN",
+      "properties" : null
+    },
+    {
       "id" : "interface-node-subnet-30398256-vpc-b390fad5-vrf-igw-9b93ddfc",
       "name" : "vpc-b390fad5-vrf-igw-9b93ddfc",
       "nodeId" : "node-subnet-30398256",
       "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "id" : "interface-node-aws-backbone-To-Internet",
-      "name" : "To-Internet",
-      "nodeId" : "node-aws-backbone",
-      "type" : "UNKNOWN",
       "properties" : null
     },
     {
@@ -611,13 +611,6 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-aws-backbone-To-Internet",
-      "id" : "link-interface-node-internet-To-aws-backbone-interface-node-aws-backbone-To-Internet",
-      "srcId" : "interface-node-internet-To-aws-backbone",
-      "type" : "UNKNOWN",
-      "properties" : null
-    },
-    {
       "dstId" : "interface-node-subnet-1641fa70-vpc-b390fad5-vrf-igw-9b93ddfc",
       "id" : "link-interface-node-vpc-b390fad5-subnet-1641fa70-vrf-igw-9b93ddfc-interface-node-subnet-1641fa70-vpc-b390fad5-vrf-igw-9b93ddfc",
       "srcId" : "interface-node-vpc-b390fad5-subnet-1641fa70-vrf-igw-9b93ddfc",
@@ -639,6 +632,13 @@
       "properties" : null
     },
     {
+      "dstId" : "interface-node-igw-9b93ddfc-backbone",
+      "id" : "link-interface-node-isp_16509-To-igw-9b93ddfc-interface-node-igw-9b93ddfc-backbone",
+      "srcId" : "interface-node-isp_16509-To-igw-9b93ddfc",
+      "type" : "UNKNOWN",
+      "properties" : null
+    },
+    {
       "dstId" : "interface-node-subnet-30398256-vpc-b390fad5",
       "id" : "link-interface-node-vpc-b390fad5-subnet-30398256-interface-node-subnet-30398256-vpc-b390fad5",
       "srcId" : "interface-node-vpc-b390fad5-subnet-30398256",
@@ -650,20 +650,6 @@
       "id" : "link-interface-node-subnet-1f315846-vpc-f8fad69d-vrf-igw-068fee63-interface-node-vpc-f8fad69d-subnet-1f315846-vrf-igw-068fee63",
       "srcId" : "interface-node-subnet-1f315846-vpc-f8fad69d-vrf-igw-068fee63",
       "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-igw-9b93ddfc-backbone",
-      "id" : "link-interface-node-aws-backbone-To-igw-9b93ddfc-interface-node-igw-9b93ddfc-backbone",
-      "srcId" : "interface-node-aws-backbone-To-igw-9b93ddfc",
-      "type" : "UNKNOWN",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-aws-backbone-To-igw-fac5839d",
-      "id" : "link-interface-node-igw-fac5839d-backbone-interface-node-aws-backbone-To-igw-fac5839d",
-      "srcId" : "interface-node-igw-fac5839d-backbone",
-      "type" : "UNKNOWN",
       "properties" : null
     },
     {
@@ -716,6 +702,13 @@
       "properties" : null
     },
     {
+      "dstId" : "interface-node-isp_16509-To-igw-068fee63",
+      "id" : "link-interface-node-igw-068fee63-backbone-interface-node-isp_16509-To-igw-068fee63",
+      "srcId" : "interface-node-igw-068fee63-backbone",
+      "type" : "UNKNOWN",
+      "properties" : null
+    },
+    {
       "dstId" : "interface-node-subnet-7044ff16-vpc-b390fad5-vrf-igw-9b93ddfc",
       "id" : "link-interface-node-vpc-b390fad5-subnet-7044ff16-vrf-igw-9b93ddfc-interface-node-subnet-7044ff16-vpc-b390fad5-vrf-igw-9b93ddfc",
       "srcId" : "interface-node-vpc-b390fad5-subnet-7044ff16-vrf-igw-9b93ddfc",
@@ -737,10 +730,24 @@
       "properties" : null
     },
     {
+      "dstId" : "interface-node-igw-fac5839d-backbone",
+      "id" : "link-interface-node-isp_16509-To-igw-fac5839d-interface-node-igw-fac5839d-backbone",
+      "srcId" : "interface-node-isp_16509-To-igw-fac5839d",
+      "type" : "UNKNOWN",
+      "properties" : null
+    },
+    {
       "dstId" : "interface-node-subnet-8d0cbdeb-vpc-925131f4-vrf-igw-fac5839d",
       "id" : "link-interface-node-vpc-925131f4-subnet-8d0cbdeb-vrf-igw-fac5839d-interface-node-subnet-8d0cbdeb-vpc-925131f4-vrf-igw-fac5839d",
       "srcId" : "interface-node-vpc-925131f4-subnet-8d0cbdeb-vrf-igw-fac5839d",
       "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-isp_16509-To-Internet",
+      "id" : "link-interface-node-internet-To-isp_16509-interface-node-isp_16509-To-Internet",
+      "srcId" : "interface-node-internet-To-isp_16509",
+      "type" : "UNKNOWN",
       "properties" : null
     },
     {
@@ -772,6 +779,13 @@
       "properties" : null
     },
     {
+      "dstId" : "interface-node-igw-068fee63-backbone",
+      "id" : "link-interface-node-isp_16509-To-igw-068fee63-interface-node-igw-068fee63-backbone",
+      "srcId" : "interface-node-isp_16509-To-igw-068fee63",
+      "type" : "UNKNOWN",
+      "properties" : null
+    },
+    {
       "dstId" : "interface-node-subnet-8d0cbdeb-vpc-925131f4",
       "id" : "link-interface-node-vpc-925131f4-subnet-8d0cbdeb-interface-node-subnet-8d0cbdeb-vpc-925131f4",
       "srcId" : "interface-node-vpc-925131f4-subnet-8d0cbdeb",
@@ -793,6 +807,13 @@
       "properties" : null
     },
     {
+      "dstId" : "interface-node-isp_16509-To-igw-9b93ddfc",
+      "id" : "link-interface-node-igw-9b93ddfc-backbone-interface-node-isp_16509-To-igw-9b93ddfc",
+      "srcId" : "interface-node-igw-9b93ddfc-backbone",
+      "type" : "UNKNOWN",
+      "properties" : null
+    },
+    {
       "dstId" : "interface-node-vpc-b390fad5-subnet-073b8061",
       "id" : "link-interface-node-subnet-073b8061-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-073b8061",
       "srcId" : "interface-node-subnet-073b8061-vpc-b390fad5",
@@ -804,13 +825,6 @@
       "id" : "link-interface-node-subnet-30398256-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-30398256",
       "srcId" : "interface-node-subnet-30398256-vpc-b390fad5",
       "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-igw-068fee63-backbone",
-      "id" : "link-interface-node-aws-backbone-To-igw-068fee63-interface-node-igw-068fee63-backbone",
-      "srcId" : "interface-node-aws-backbone-To-igw-068fee63",
-      "type" : "UNKNOWN",
       "properties" : null
     },
     {
@@ -846,13 +860,6 @@
       "id" : "link-interface-node-vgw-81fd279f-vpc-815775e7-interface-node-vpc-815775e7-vgw-81fd279f",
       "srcId" : "interface-node-vgw-81fd279f-vpc-815775e7",
       "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-internet-To-aws-backbone",
-      "id" : "link-interface-node-aws-backbone-To-Internet-interface-node-internet-To-aws-backbone",
-      "srcId" : "interface-node-aws-backbone-To-Internet",
-      "type" : "UNKNOWN",
       "properties" : null
     },
     {
@@ -905,17 +912,17 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-aws-backbone-To-igw-068fee63",
-      "id" : "link-interface-node-igw-068fee63-backbone-interface-node-aws-backbone-To-igw-068fee63",
-      "srcId" : "interface-node-igw-068fee63-backbone",
-      "type" : "UNKNOWN",
-      "properties" : null
-    },
-    {
       "dstId" : "interface-node-subnet-30398256-vpc-b390fad5-vrf-igw-9b93ddfc",
       "id" : "link-interface-node-vpc-b390fad5-subnet-30398256-vrf-igw-9b93ddfc-interface-node-subnet-30398256-vpc-b390fad5-vrf-igw-9b93ddfc",
       "srcId" : "interface-node-vpc-b390fad5-subnet-30398256-vrf-igw-9b93ddfc",
       "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-internet-To-isp_16509",
+      "id" : "link-interface-node-isp_16509-To-Internet-interface-node-internet-To-isp_16509",
+      "srcId" : "interface-node-isp_16509-To-Internet",
+      "type" : "UNKNOWN",
       "properties" : null
     },
     {
@@ -961,17 +968,17 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-aws-backbone-To-igw-9b93ddfc",
-      "id" : "link-interface-node-igw-9b93ddfc-backbone-interface-node-aws-backbone-To-igw-9b93ddfc",
-      "srcId" : "interface-node-igw-9b93ddfc-backbone",
-      "type" : "UNKNOWN",
-      "properties" : null
-    },
-    {
       "dstId" : "interface-node-vpc-b390fad5-igw-9b93ddfc",
       "id" : "link-interface-node-igw-9b93ddfc-vpc-b390fad5-interface-node-vpc-b390fad5-igw-9b93ddfc",
       "srcId" : "interface-node-igw-9b93ddfc-vpc-b390fad5",
       "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-isp_16509-To-igw-fac5839d",
+      "id" : "link-interface-node-igw-fac5839d-backbone-interface-node-isp_16509-To-igw-fac5839d",
+      "srcId" : "interface-node-igw-fac5839d-backbone",
+      "type" : "UNKNOWN",
       "properties" : null
     },
     {
@@ -1000,13 +1007,6 @@
       "id" : "link-interface-node-subnet-f73a8191-vpc-b390fad5-vrf-igw-9b93ddfc-interface-node-vpc-b390fad5-subnet-f73a8191-vrf-igw-9b93ddfc",
       "srcId" : "interface-node-subnet-f73a8191-vpc-b390fad5-vrf-igw-9b93ddfc",
       "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-igw-fac5839d-backbone",
-      "id" : "link-interface-node-aws-backbone-To-igw-fac5839d-interface-node-igw-fac5839d-backbone",
-      "srcId" : "interface-node-aws-backbone-To-igw-fac5839d",
-      "type" : "UNKNOWN",
       "properties" : null
     },
     {
@@ -1075,6 +1075,13 @@
       "properties" : null
     },
     {
+      "id" : "node-isp_16509",
+      "model" : "BATFISH_ISP",
+      "name" : "isp_16509",
+      "type" : "ISP",
+      "properties" : null
+    },
+    {
       "id" : "node-subnet-30398256",
       "model" : "AWS_SUBNET_PUBLIC",
       "name" : "subnet-30398256",
@@ -1114,13 +1121,6 @@
       "model" : null,
       "name" : "lhr-border-02",
       "type" : "ROUTER",
-      "properties" : null
-    },
-    {
-      "id" : "node-aws-backbone",
-      "model" : "BATFISH_ISP",
-      "name" : "aws-backbone",
-      "type" : "ISP",
       "properties" : null
     },
     {

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -2,11 +2,1103 @@
   {
     "class" : "org.batfish.question.VIModelQuestionPlugin$VIModelAnswerElement",
     "nodes" : {
-      "aws-backbone" : {
+      "es-domain" : {
+        "configurationFormat" : "AWS",
+        "name" : "es-domain",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceModel" : "AWS_ELASTICSEARCH_DOMAIN",
+        "deviceType" : "HOST",
+        "domainName" : "aws",
+        "interfaces" : {
+          "es-domain-subnet-1641fa70" : {
+            "name" : "es-domain-subnet-1641fa70",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allPrefixes" : [
+              "192.168.1.2/24"
+            ],
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "description" : "To subnet subnet-1641fa70",
+            "firewallSessionInterfaceInfo" : {
+              "fibLookup" : false,
+              "sessionInterfaces" : [
+                "es-domain-subnet-1641fa70"
+              ]
+            },
+            "incomingFilter" : "~SECURITY_GROUP_INGRESS_ACL~",
+            "mtu" : 1500,
+            "outgoingFilter" : "~EGRESS_ACL~es-domain-subnet-1641fa70",
+            "prefix" : "192.168.1.2/24",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "es-domain-subnet-7044ff16" : {
+            "name" : "es-domain-subnet-7044ff16",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allPrefixes" : [
+              "192.168.2.2/28"
+            ],
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "description" : "To subnet subnet-7044ff16",
+            "firewallSessionInterfaceInfo" : {
+              "fibLookup" : false,
+              "sessionInterfaces" : [
+                "es-domain-subnet-7044ff16"
+              ]
+            },
+            "incomingFilter" : "~SECURITY_GROUP_INGRESS_ACL~",
+            "mtu" : 1500,
+            "outgoingFilter" : "~EGRESS_ACL~es-domain-subnet-7044ff16",
+            "prefix" : "192.168.2.2/28",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "~EGRESS_ACL~es-domain-subnet-1641fa70" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.NotMatchExpr",
+                  "operand" : {
+                    "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                    "headerSpace" : {
+                      "negate" : false,
+                      "srcIps" : {
+                        "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
+                        "whitelist" : [
+                          "192.168.1.2"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Deny spoofed source IPs"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~EGRESS_ACL~es-domain-subnet-1641fa70"
+          },
+          "~EGRESS_ACL~es-domain-subnet-7044ff16" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.NotMatchExpr",
+                  "operand" : {
+                    "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                    "headerSpace" : {
+                      "negate" : false,
+                      "srcIps" : {
+                        "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
+                        "whitelist" : [
+                          "192.168.2.2"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Deny spoofed source IPs"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~EGRESS_ACL~es-domain-subnet-7044ff16"
+          },
+          "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.UniverseIpSpace"
+                    },
+                    "negate" : false
+                  },
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched destination address CIDR IP 0.0.0.0/0"
+                      }
+                    ]
+                  }
+                },
+                "name" : "sg-3dfb3140 - default [egress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule with no description"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
+          },
+          "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.OrMatchExpr",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "negate" : false,
+                        "srcIps" : {
+                          "class" : "org.batfish.datamodel.IpIpSpace",
+                          "ip" : "192.168.1.3"
+                        }
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched instance test-rds"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched source address Security Group default"
+                      }
+                    ]
+                  }
+                },
+                "name" : "sg-3dfb3140 - default [ingress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule with no description"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
+          },
+          "~SECURITY_GROUP_INGRESS_ACL~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~SECURITY_GROUP_INGRESS_ACL~"
+          }
+        },
+        "vendorFamily" : {
+          "aws" : {
+            "region" : "us-west-2",
+            "vpcId" : "vpc-b390fad5"
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "hasOriginatingSessions" : true,
+            "staticRoutes" : [
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "0.0.0.0/0",
+                "nextHopInterface" : "dynamic",
+                "nextHopIp" : "192.168.1.1",
+                "tag" : -1
+              },
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "0.0.0.0/0",
+                "nextHopInterface" : "dynamic",
+                "nextHopIp" : "192.168.2.1",
+                "tag" : -1
+              }
+            ]
+          }
+        }
+      },
+      "igw-068fee63" : {
+        "configurationFormat" : "AWS",
+        "name" : "igw-068fee63",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceModel" : "AWS_INTERNET_GATEWAY",
+        "deviceType" : "ROUTER",
+        "domainName" : "aws",
+        "interfaces" : {
+          "backbone" : {
+            "name" : "backbone",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "description" : "To AWS backbone",
+            "mtu" : 1500,
+            "prefix" : "link-local:169.254.0.1",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vpc-f8fad69d" : {
+            "name" : "vpc-f8fad69d",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "description" : "To vpc-f8fad69d",
+            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
+            "mtu" : 1500,
+            "prefix" : "link-local:169.254.0.1",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "~DENY~UNASSOCIATED~PRIVATE~IPs~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace"
+                    }
+                  }
+                },
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Allowed private instance IPs associated with a public IP"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Denied private instance IPs NOT associated with a public IP"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~DENY~UNASSOCIATED~PRIVATE~IPs~"
+          }
+        },
+        "routingPolicies" : {
+          "AwsInternetGatewayExportPolicy" : {
+            "name" : "AwsInternetGatewayExportPolicy",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocols" : [
+                        "static"
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                        "prefixSpace" : [ ]
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                    "originType" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                      "originType" : "incomplete"
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "aws" : {
+            "region" : "us-west-2"
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
+              "routerId" : "169.254.0.1",
+              "interfaceNeighbors" : {
+                "backbone" : {
+                  "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "ipv4UnicastAddressFamily" : {
+                    "addressFamilyCapabilities" : {
+                      "additionalPathsReceive" : false,
+                      "additionalPathsSelectAll" : false,
+                      "additionalPathsSend" : false,
+                      "advertiseExternal" : false,
+                      "advertiseInactive" : false,
+                      "allowLocalAsIn" : false,
+                      "allowRemoteAsOut" : false,
+                      "sendCommunity" : false,
+                      "sendExtendedCommunity" : false
+                    },
+                    "exportPolicy" : "AwsInternetGatewayExportPolicy",
+                    "exportPolicySources" : [
+                      "AwsInternetGatewayExportPolicy"
+                    ],
+                    "routeReflectorClient" : false
+                  },
+                  "localAs" : 65534,
+                  "localIp" : "169.254.0.1",
+                  "peerInterface" : "backbone",
+                  "remoteAsns" : "16509"
+                }
+              },
+              "multipathEbgp" : false,
+              "multipathIbgp" : false,
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "hasOriginatingSessions" : false,
+            "staticRoutes" : [
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "172.31.0.0/16",
+                "nextHopInterface" : "vpc-f8fad69d",
+                "nextHopIp" : "169.254.0.1",
+                "tag" : -1
+              }
+            ]
+          }
+        }
+      },
+      "igw-9b93ddfc" : {
+        "configurationFormat" : "AWS",
+        "name" : "igw-9b93ddfc",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceModel" : "AWS_INTERNET_GATEWAY",
+        "deviceType" : "ROUTER",
+        "domainName" : "aws",
+        "humanName" : "Arista Demo",
+        "interfaces" : {
+          "backbone" : {
+            "name" : "backbone",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "description" : "To AWS backbone",
+            "mtu" : 1500,
+            "prefix" : "link-local:169.254.0.1",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vpc-b390fad5" : {
+            "name" : "vpc-b390fad5",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "description" : "To vpc-b390fad5",
+            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
+            "mtu" : 1500,
+            "prefix" : "link-local:169.254.0.1",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "~DENY~UNASSOCIATED~PRIVATE~IPs~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace"
+                    }
+                  }
+                },
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Allowed private instance IPs associated with a public IP"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Denied private instance IPs NOT associated with a public IP"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~DENY~UNASSOCIATED~PRIVATE~IPs~"
+          }
+        },
+        "routingPolicies" : {
+          "AwsInternetGatewayExportPolicy" : {
+            "name" : "AwsInternetGatewayExportPolicy",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocols" : [
+                        "static"
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                        "prefixSpace" : [ ]
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                    "originType" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                      "originType" : "incomplete"
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "aws" : {
+            "region" : "us-west-2"
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
+              "routerId" : "169.254.0.1",
+              "interfaceNeighbors" : {
+                "backbone" : {
+                  "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "ipv4UnicastAddressFamily" : {
+                    "addressFamilyCapabilities" : {
+                      "additionalPathsReceive" : false,
+                      "additionalPathsSelectAll" : false,
+                      "additionalPathsSend" : false,
+                      "advertiseExternal" : false,
+                      "advertiseInactive" : false,
+                      "allowLocalAsIn" : false,
+                      "allowRemoteAsOut" : false,
+                      "sendCommunity" : false,
+                      "sendExtendedCommunity" : false
+                    },
+                    "exportPolicy" : "AwsInternetGatewayExportPolicy",
+                    "exportPolicySources" : [
+                      "AwsInternetGatewayExportPolicy"
+                    ],
+                    "routeReflectorClient" : false
+                  },
+                  "localAs" : 65534,
+                  "localIp" : "169.254.0.1",
+                  "peerInterface" : "backbone",
+                  "remoteAsns" : "16509"
+                }
+              },
+              "multipathEbgp" : false,
+              "multipathIbgp" : false,
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "hasOriginatingSessions" : false,
+            "staticRoutes" : [
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "192.168.0.0/16",
+                "nextHopInterface" : "vpc-b390fad5",
+                "nextHopIp" : "169.254.0.1",
+                "tag" : -1
+              }
+            ]
+          }
+        }
+      },
+      "igw-fac5839d" : {
+        "configurationFormat" : "AWS",
+        "name" : "igw-fac5839d",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceModel" : "AWS_INTERNET_GATEWAY",
+        "deviceType" : "ROUTER",
+        "domainName" : "aws",
+        "interfaces" : {
+          "backbone" : {
+            "name" : "backbone",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "description" : "To AWS backbone",
+            "mtu" : 1500,
+            "prefix" : "link-local:169.254.0.1",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "vpc-925131f4" : {
+            "name" : "vpc-925131f4",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "description" : "To vpc-925131f4",
+            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
+            "mtu" : 1500,
+            "prefix" : "link-local:169.254.0.1",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "~DENY~UNASSOCIATED~PRIVATE~IPs~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "negate" : false,
+                    "srcIps" : {
+                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace"
+                    }
+                  }
+                },
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Allowed private instance IPs associated with a public IP"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Denied private instance IPs NOT associated with a public IP"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~DENY~UNASSOCIATED~PRIVATE~IPs~"
+          }
+        },
+        "routingPolicies" : {
+          "AwsInternetGatewayExportPolicy" : {
+            "name" : "AwsInternetGatewayExportPolicy",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocols" : [
+                        "static"
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                        "prefixSpace" : [ ]
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                    "originType" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                      "originType" : "incomplete"
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "aws" : {
+            "region" : "us-west-2"
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
+              "routerId" : "169.254.0.1",
+              "interfaceNeighbors" : {
+                "backbone" : {
+                  "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "ipv4UnicastAddressFamily" : {
+                    "addressFamilyCapabilities" : {
+                      "additionalPathsReceive" : false,
+                      "additionalPathsSelectAll" : false,
+                      "additionalPathsSend" : false,
+                      "advertiseExternal" : false,
+                      "advertiseInactive" : false,
+                      "allowLocalAsIn" : false,
+                      "allowRemoteAsOut" : false,
+                      "sendCommunity" : false,
+                      "sendExtendedCommunity" : false
+                    },
+                    "exportPolicy" : "AwsInternetGatewayExportPolicy",
+                    "exportPolicySources" : [
+                      "AwsInternetGatewayExportPolicy"
+                    ],
+                    "routeReflectorClient" : false
+                  },
+                  "localAs" : 65534,
+                  "localIp" : "169.254.0.1",
+                  "peerInterface" : "backbone",
+                  "remoteAsns" : "16509"
+                }
+              },
+              "multipathEbgp" : false,
+              "multipathIbgp" : false,
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "hasOriginatingSessions" : false,
+            "staticRoutes" : [
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "10.0.0.0/16",
+                "nextHopInterface" : "vpc-925131f4",
+                "nextHopIp" : "169.254.0.1",
+                "tag" : -1
+              }
+            ]
+          }
+        }
+      },
+      "internet" : {
         "configurationFormat" : "CISCO_IOS",
-        "name" : "aws-backbone",
+        "name" : "internet",
+        "deviceModel" : "BATFISH_INTERNET",
+        "deviceType" : "INTERNET",
+        "interfaces" : {
+          "To-isp_16509" : {
+            "name" : "To-isp_16509",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "mtu" : 1500,
+            "prefix" : "link-local:169.254.0.1",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "UNKNOWN",
+            "vrf" : "default"
+          },
+          "out" : {
+            "name" : "out",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allPrefixes" : [
+              "240.254.254.1/30"
+            ],
+            "allowedVlans" : "",
+            "autostate" : true,
+            "mtu" : 1500,
+            "prefix" : "240.254.254.1/30",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "UNKNOWN",
+            "vrf" : "default"
+          }
+        },
+        "routingPolicies" : {
+          "exportPolicyOnInternet" : {
+            "name" : "exportPolicyOnInternet",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                      "protocols" : [
+                        "static"
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                      "prefix" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                      },
+                      "prefixSet" : {
+                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                        "prefixSpace" : [
+                          "0.0.0.0/0"
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
+                    "originType" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
+                      "originType" : "incomplete"
+                    }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ExitAccept"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "vendorFamily" : { },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
+              "routerId" : "240.254.254.1",
+              "interfaceNeighbors" : {
+                "To-isp_16509" : {
+                  "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
+                  "defaultMetric" : 0,
+                  "ebgpMultihop" : false,
+                  "enforceFirstAs" : false,
+                  "ipv4UnicastAddressFamily" : {
+                    "addressFamilyCapabilities" : {
+                      "additionalPathsReceive" : false,
+                      "additionalPathsSelectAll" : false,
+                      "additionalPathsSend" : false,
+                      "advertiseExternal" : false,
+                      "advertiseInactive" : false,
+                      "allowLocalAsIn" : false,
+                      "allowRemoteAsOut" : false,
+                      "sendCommunity" : false,
+                      "sendExtendedCommunity" : false
+                    },
+                    "exportPolicy" : "exportPolicyOnInternet",
+                    "routeReflectorClient" : false
+                  },
+                  "localAs" : 65537,
+                  "localIp" : "169.254.0.1",
+                  "peerInterface" : "To-isp_16509",
+                  "remoteAsns" : "16509"
+                }
+              },
+              "multipathEbgp" : true,
+              "multipathEquivalentAsPathMatchMode" : "PATH_LENGTH",
+              "multipathIbgp" : false,
+              "tieBreaker" : "ARRIVAL_ORDER"
+            },
+            "hasOriginatingSessions" : false,
+            "staticRoutes" : [
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "0.0.0.0/0",
+                "nextHopInterface" : "out",
+                "nextHopIp" : "AUTO/NONE(-1l)",
+                "tag" : -1
+              },
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "10.0.0.0/8",
+                "nextHopInterface" : "null_interface",
+                "nextHopIp" : "AUTO/NONE(-1l)",
+                "tag" : -1
+              },
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "172.16.0.0/12",
+                "nextHopInterface" : "null_interface",
+                "nextHopIp" : "AUTO/NONE(-1l)",
+                "tag" : -1
+              },
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "192.168.0.0/16",
+                "nextHopInterface" : "null_interface",
+                "nextHopIp" : "AUTO/NONE(-1l)",
+                "tag" : -1
+              }
+            ]
+          }
+        }
+      },
+      "isp_16509" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "isp_16509",
         "deviceModel" : "BATFISH_ISP",
         "deviceType" : "ISP",
+        "humanName" : "aws-backbone",
         "interfaces" : {
           "To-Internet" : {
             "name" : "To-Internet",
@@ -14043,1097 +15135,6 @@
                 "administrativeCost" : 32767,
                 "metric" : 0,
                 "network" : "216.182.238.0/23",
-                "nextHopInterface" : "null_interface",
-                "nextHopIp" : "AUTO/NONE(-1l)",
-                "tag" : -1
-              }
-            ]
-          }
-        }
-      },
-      "es-domain" : {
-        "configurationFormat" : "AWS",
-        "name" : "es-domain",
-        "defaultCrossZoneAction" : "PERMIT",
-        "defaultInboundAction" : "PERMIT",
-        "deviceModel" : "AWS_ELASTICSEARCH_DOMAIN",
-        "deviceType" : "HOST",
-        "domainName" : "aws",
-        "interfaces" : {
-          "es-domain-subnet-1641fa70" : {
-            "name" : "es-domain-subnet-1641fa70",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allPrefixes" : [
-              "192.168.1.2/24"
-            ],
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E12,
-            "description" : "To subnet subnet-1641fa70",
-            "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
-              "sessionInterfaces" : [
-                "es-domain-subnet-1641fa70"
-              ]
-            },
-            "incomingFilter" : "~SECURITY_GROUP_INGRESS_ACL~",
-            "mtu" : 1500,
-            "outgoingFilter" : "~EGRESS_ACL~es-domain-subnet-1641fa70",
-            "prefix" : "192.168.1.2/24",
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "es-domain-subnet-7044ff16" : {
-            "name" : "es-domain-subnet-7044ff16",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allPrefixes" : [
-              "192.168.2.2/28"
-            ],
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E12,
-            "description" : "To subnet subnet-7044ff16",
-            "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
-              "sessionInterfaces" : [
-                "es-domain-subnet-7044ff16"
-              ]
-            },
-            "incomingFilter" : "~SECURITY_GROUP_INGRESS_ACL~",
-            "mtu" : 1500,
-            "outgoingFilter" : "~EGRESS_ACL~es-domain-subnet-7044ff16",
-            "prefix" : "192.168.2.2/28",
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          }
-        },
-        "ipAccessLists" : {
-          "~EGRESS_ACL~es-domain-subnet-1641fa70" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.NotMatchExpr",
-                  "operand" : {
-                    "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                    "headerSpace" : {
-                      "negate" : false,
-                      "srcIps" : {
-                        "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
-                        "whitelist" : [
-                          "192.168.1.2"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Deny spoofed source IPs"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~EGRESS_ACL~es-domain-subnet-1641fa70"
-          },
-          "~EGRESS_ACL~es-domain-subnet-7044ff16" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.NotMatchExpr",
-                  "operand" : {
-                    "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                    "headerSpace" : {
-                      "negate" : false,
-                      "srcIps" : {
-                        "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
-                        "whitelist" : [
-                          "192.168.2.2"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Deny spoofed source IPs"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~EGRESS_ACL~es-domain-subnet-7044ff16"
-          },
-          "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "PERMIT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "dstIps" : {
-                      "class" : "org.batfish.datamodel.UniverseIpSpace"
-                    },
-                    "negate" : false
-                  },
-                  "traceElement" : {
-                    "fragments" : [
-                      {
-                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched destination address CIDR IP 0.0.0.0/0"
-                      }
-                    ]
-                  }
-                },
-                "name" : "sg-3dfb3140 - default [egress] 0",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with no description"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
-          },
-          "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "PERMIT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.OrMatchExpr",
-                  "disjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "negate" : false,
-                        "srcIps" : {
-                          "class" : "org.batfish.datamodel.IpIpSpace",
-                          "ip" : "192.168.1.3"
-                        }
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched instance test-rds"
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "traceElement" : {
-                    "fragments" : [
-                      {
-                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched source address Security Group default"
-                      }
-                    ]
-                  }
-                },
-                "name" : "sg-3dfb3140 - default [ingress] 0",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with no description"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
-          },
-          "~SECURITY_GROUP_INGRESS_ACL~" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~SECURITY_GROUP_INGRESS_ACL~"
-          }
-        },
-        "vendorFamily" : {
-          "aws" : {
-            "region" : "us-west-2",
-            "vpcId" : "vpc-b390fad5"
-          }
-        },
-        "vrfs" : {
-          "default" : {
-            "name" : "default",
-            "hasOriginatingSessions" : true,
-            "staticRoutes" : [
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 1,
-                "metric" : 0,
-                "network" : "0.0.0.0/0",
-                "nextHopInterface" : "dynamic",
-                "nextHopIp" : "192.168.1.1",
-                "tag" : -1
-              },
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 1,
-                "metric" : 0,
-                "network" : "0.0.0.0/0",
-                "nextHopInterface" : "dynamic",
-                "nextHopIp" : "192.168.2.1",
-                "tag" : -1
-              }
-            ]
-          }
-        }
-      },
-      "igw-068fee63" : {
-        "configurationFormat" : "AWS",
-        "name" : "igw-068fee63",
-        "defaultCrossZoneAction" : "PERMIT",
-        "defaultInboundAction" : "PERMIT",
-        "deviceModel" : "AWS_INTERNET_GATEWAY",
-        "deviceType" : "ROUTER",
-        "domainName" : "aws",
-        "interfaces" : {
-          "backbone" : {
-            "name" : "backbone",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E12,
-            "description" : "To AWS backbone",
-            "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.1",
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vpc-f8fad69d" : {
-            "name" : "vpc-f8fad69d",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E12,
-            "description" : "To vpc-f8fad69d",
-            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
-            "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.1",
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          }
-        },
-        "ipAccessLists" : {
-          "~DENY~UNASSOCIATED~PRIVATE~IPs~" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "PERMIT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "negate" : false,
-                    "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace"
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Allowed private instance IPs associated with a public IP"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.TrueExpr"
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Denied private instance IPs NOT associated with a public IP"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~DENY~UNASSOCIATED~PRIVATE~IPs~"
-          }
-        },
-        "routingPolicies" : {
-          "AwsInternetGatewayExportPolicy" : {
-            "name" : "AwsInternetGatewayExportPolicy",
-            "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                      "protocols" : [
-                        "static"
-                      ]
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                      "prefix" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                      },
-                      "prefixSet" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                        "prefixSpace" : [ ]
-                      }
-                    }
-                  ]
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
-                    "originType" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
-                      "originType" : "incomplete"
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitAccept"
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        "vendorFamily" : {
-          "aws" : {
-            "region" : "us-west-2"
-          }
-        },
-        "vrfs" : {
-          "default" : {
-            "name" : "default",
-            "bgpProcess" : {
-              "ebgpAdminCost" : 20,
-              "ibgpAdminCost" : 200,
-              "routerId" : "169.254.0.1",
-              "interfaceNeighbors" : {
-                "backbone" : {
-                  "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
-                  "defaultMetric" : 0,
-                  "ebgpMultihop" : false,
-                  "enforceFirstAs" : false,
-                  "ipv4UnicastAddressFamily" : {
-                    "addressFamilyCapabilities" : {
-                      "additionalPathsReceive" : false,
-                      "additionalPathsSelectAll" : false,
-                      "additionalPathsSend" : false,
-                      "advertiseExternal" : false,
-                      "advertiseInactive" : false,
-                      "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
-                      "sendCommunity" : false,
-                      "sendExtendedCommunity" : false
-                    },
-                    "exportPolicy" : "AwsInternetGatewayExportPolicy",
-                    "exportPolicySources" : [
-                      "AwsInternetGatewayExportPolicy"
-                    ],
-                    "routeReflectorClient" : false
-                  },
-                  "localAs" : 65534,
-                  "localIp" : "169.254.0.1",
-                  "peerInterface" : "backbone",
-                  "remoteAsns" : "16509"
-                }
-              },
-              "multipathEbgp" : false,
-              "multipathIbgp" : false,
-              "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "hasOriginatingSessions" : false,
-            "staticRoutes" : [
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 1,
-                "metric" : 0,
-                "network" : "172.31.0.0/16",
-                "nextHopInterface" : "vpc-f8fad69d",
-                "nextHopIp" : "169.254.0.1",
-                "tag" : -1
-              }
-            ]
-          }
-        }
-      },
-      "igw-9b93ddfc" : {
-        "configurationFormat" : "AWS",
-        "name" : "igw-9b93ddfc",
-        "defaultCrossZoneAction" : "PERMIT",
-        "defaultInboundAction" : "PERMIT",
-        "deviceModel" : "AWS_INTERNET_GATEWAY",
-        "deviceType" : "ROUTER",
-        "domainName" : "aws",
-        "humanName" : "Arista Demo",
-        "interfaces" : {
-          "backbone" : {
-            "name" : "backbone",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E12,
-            "description" : "To AWS backbone",
-            "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.1",
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vpc-b390fad5" : {
-            "name" : "vpc-b390fad5",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E12,
-            "description" : "To vpc-b390fad5",
-            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
-            "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.1",
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          }
-        },
-        "ipAccessLists" : {
-          "~DENY~UNASSOCIATED~PRIVATE~IPs~" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "PERMIT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "negate" : false,
-                    "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace"
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Allowed private instance IPs associated with a public IP"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.TrueExpr"
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Denied private instance IPs NOT associated with a public IP"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~DENY~UNASSOCIATED~PRIVATE~IPs~"
-          }
-        },
-        "routingPolicies" : {
-          "AwsInternetGatewayExportPolicy" : {
-            "name" : "AwsInternetGatewayExportPolicy",
-            "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                      "protocols" : [
-                        "static"
-                      ]
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                      "prefix" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                      },
-                      "prefixSet" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                        "prefixSpace" : [ ]
-                      }
-                    }
-                  ]
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
-                    "originType" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
-                      "originType" : "incomplete"
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitAccept"
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        "vendorFamily" : {
-          "aws" : {
-            "region" : "us-west-2"
-          }
-        },
-        "vrfs" : {
-          "default" : {
-            "name" : "default",
-            "bgpProcess" : {
-              "ebgpAdminCost" : 20,
-              "ibgpAdminCost" : 200,
-              "routerId" : "169.254.0.1",
-              "interfaceNeighbors" : {
-                "backbone" : {
-                  "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
-                  "defaultMetric" : 0,
-                  "ebgpMultihop" : false,
-                  "enforceFirstAs" : false,
-                  "ipv4UnicastAddressFamily" : {
-                    "addressFamilyCapabilities" : {
-                      "additionalPathsReceive" : false,
-                      "additionalPathsSelectAll" : false,
-                      "additionalPathsSend" : false,
-                      "advertiseExternal" : false,
-                      "advertiseInactive" : false,
-                      "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
-                      "sendCommunity" : false,
-                      "sendExtendedCommunity" : false
-                    },
-                    "exportPolicy" : "AwsInternetGatewayExportPolicy",
-                    "exportPolicySources" : [
-                      "AwsInternetGatewayExportPolicy"
-                    ],
-                    "routeReflectorClient" : false
-                  },
-                  "localAs" : 65534,
-                  "localIp" : "169.254.0.1",
-                  "peerInterface" : "backbone",
-                  "remoteAsns" : "16509"
-                }
-              },
-              "multipathEbgp" : false,
-              "multipathIbgp" : false,
-              "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "hasOriginatingSessions" : false,
-            "staticRoutes" : [
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 1,
-                "metric" : 0,
-                "network" : "192.168.0.0/16",
-                "nextHopInterface" : "vpc-b390fad5",
-                "nextHopIp" : "169.254.0.1",
-                "tag" : -1
-              }
-            ]
-          }
-        }
-      },
-      "igw-fac5839d" : {
-        "configurationFormat" : "AWS",
-        "name" : "igw-fac5839d",
-        "defaultCrossZoneAction" : "PERMIT",
-        "defaultInboundAction" : "PERMIT",
-        "deviceModel" : "AWS_INTERNET_GATEWAY",
-        "deviceType" : "ROUTER",
-        "domainName" : "aws",
-        "interfaces" : {
-          "backbone" : {
-            "name" : "backbone",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E12,
-            "description" : "To AWS backbone",
-            "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.1",
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "vpc-925131f4" : {
-            "name" : "vpc-925131f4",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E12,
-            "description" : "To vpc-925131f4",
-            "incomingFilter" : "~DENY~UNASSOCIATED~PRIVATE~IPs~",
-            "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.1",
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          }
-        },
-        "ipAccessLists" : {
-          "~DENY~UNASSOCIATED~PRIVATE~IPs~" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "PERMIT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "negate" : false,
-                    "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardSetIpSpace"
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Allowed private instance IPs associated with a public IP"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.TrueExpr"
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Denied private instance IPs NOT associated with a public IP"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~DENY~UNASSOCIATED~PRIVATE~IPs~"
-          }
-        },
-        "routingPolicies" : {
-          "AwsInternetGatewayExportPolicy" : {
-            "name" : "AwsInternetGatewayExportPolicy",
-            "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                      "protocols" : [
-                        "static"
-                      ]
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                      "prefix" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                      },
-                      "prefixSet" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                        "prefixSpace" : [ ]
-                      }
-                    }
-                  ]
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
-                    "originType" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
-                      "originType" : "incomplete"
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitAccept"
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        "vendorFamily" : {
-          "aws" : {
-            "region" : "us-west-2"
-          }
-        },
-        "vrfs" : {
-          "default" : {
-            "name" : "default",
-            "bgpProcess" : {
-              "ebgpAdminCost" : 20,
-              "ibgpAdminCost" : 200,
-              "routerId" : "169.254.0.1",
-              "interfaceNeighbors" : {
-                "backbone" : {
-                  "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
-                  "defaultMetric" : 0,
-                  "ebgpMultihop" : false,
-                  "enforceFirstAs" : false,
-                  "ipv4UnicastAddressFamily" : {
-                    "addressFamilyCapabilities" : {
-                      "additionalPathsReceive" : false,
-                      "additionalPathsSelectAll" : false,
-                      "additionalPathsSend" : false,
-                      "advertiseExternal" : false,
-                      "advertiseInactive" : false,
-                      "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
-                      "sendCommunity" : false,
-                      "sendExtendedCommunity" : false
-                    },
-                    "exportPolicy" : "AwsInternetGatewayExportPolicy",
-                    "exportPolicySources" : [
-                      "AwsInternetGatewayExportPolicy"
-                    ],
-                    "routeReflectorClient" : false
-                  },
-                  "localAs" : 65534,
-                  "localIp" : "169.254.0.1",
-                  "peerInterface" : "backbone",
-                  "remoteAsns" : "16509"
-                }
-              },
-              "multipathEbgp" : false,
-              "multipathIbgp" : false,
-              "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "hasOriginatingSessions" : false,
-            "staticRoutes" : [
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 1,
-                "metric" : 0,
-                "network" : "10.0.0.0/16",
-                "nextHopInterface" : "vpc-925131f4",
-                "nextHopIp" : "169.254.0.1",
-                "tag" : -1
-              }
-            ]
-          }
-        }
-      },
-      "internet" : {
-        "configurationFormat" : "CISCO_IOS",
-        "name" : "internet",
-        "deviceModel" : "BATFISH_INTERNET",
-        "deviceType" : "INTERNET",
-        "interfaces" : {
-          "To-aws-backbone" : {
-            "name" : "To-aws-backbone",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allowedVlans" : "",
-            "autostate" : true,
-            "mtu" : 1500,
-            "prefix" : "link-local:169.254.0.1",
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
-            "vrf" : "default"
-          },
-          "out" : {
-            "name" : "out",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allPrefixes" : [
-              "240.254.254.1/30"
-            ],
-            "allowedVlans" : "",
-            "autostate" : true,
-            "mtu" : 1500,
-            "prefix" : "240.254.254.1/30",
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "UNKNOWN",
-            "vrf" : "default"
-          }
-        },
-        "routingPolicies" : {
-          "exportPolicyOnInternet" : {
-            "name" : "exportPolicyOnInternet",
-            "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Conjunction",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
-                      "protocols" : [
-                        "static"
-                      ]
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                      "prefix" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                      },
-                      "prefixSet" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
-                        "prefixSpace" : [
-                          "0.0.0.0/0"
-                        ]
-                      }
-                    }
-                  ]
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
-                    "originType" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
-                      "originType" : "incomplete"
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitAccept"
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        "vendorFamily" : { },
-        "vrfs" : {
-          "default" : {
-            "name" : "default",
-            "bgpProcess" : {
-              "ebgpAdminCost" : 20,
-              "ibgpAdminCost" : 200,
-              "routerId" : "240.254.254.1",
-              "interfaceNeighbors" : {
-                "To-aws-backbone" : {
-                  "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
-                  "defaultMetric" : 0,
-                  "ebgpMultihop" : false,
-                  "enforceFirstAs" : false,
-                  "ipv4UnicastAddressFamily" : {
-                    "addressFamilyCapabilities" : {
-                      "additionalPathsReceive" : false,
-                      "additionalPathsSelectAll" : false,
-                      "additionalPathsSend" : false,
-                      "advertiseExternal" : false,
-                      "advertiseInactive" : false,
-                      "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
-                      "sendCommunity" : false,
-                      "sendExtendedCommunity" : false
-                    },
-                    "exportPolicy" : "exportPolicyOnInternet",
-                    "routeReflectorClient" : false
-                  },
-                  "localAs" : 65537,
-                  "localIp" : "169.254.0.1",
-                  "peerInterface" : "To-aws-backbone",
-                  "remoteAsns" : "16509"
-                }
-              },
-              "multipathEbgp" : true,
-              "multipathEquivalentAsPathMatchMode" : "PATH_LENGTH",
-              "multipathIbgp" : false,
-              "tieBreaker" : "ARRIVAL_ORDER"
-            },
-            "hasOriginatingSessions" : false,
-            "staticRoutes" : [
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 1,
-                "metric" : 0,
-                "network" : "0.0.0.0/0",
-                "nextHopInterface" : "out",
-                "nextHopIp" : "AUTO/NONE(-1l)",
-                "tag" : -1
-              },
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 1,
-                "metric" : 0,
-                "network" : "10.0.0.0/8",
-                "nextHopInterface" : "null_interface",
-                "nextHopIp" : "AUTO/NONE(-1l)",
-                "tag" : -1
-              },
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 1,
-                "metric" : 0,
-                "network" : "172.16.0.0/12",
-                "nextHopInterface" : "null_interface",
-                "nextHopIp" : "AUTO/NONE(-1l)",
-                "tag" : -1
-              },
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 1,
-                "metric" : 0,
-                "network" : "192.168.0.0/16",
                 "nextHopInterface" : "null_interface",
                 "nextHopIp" : "AUTO/NONE(-1l)",
                 "tag" : -1


### PR DESCRIPTION
* Eliminates a class of ISP bugs.
* Guarantees stability of names.
* Relaxes name requirements to any valid human name.
* Changes behavior of AWS (backbone -> isp).