### PR TITLE
Create VRF-scoped BDD firewall sessions

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactory.java
@@ -16,6 +16,8 @@ import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.SOURCE_
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -33,12 +35,15 @@ import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Accept;
 import org.batfish.datamodel.flow.FibLookup;
 import org.batfish.datamodel.flow.ForwardOutInterface;
+import org.batfish.datamodel.flow.OriginatingSessionScope;
 import org.batfish.datamodel.flow.SessionAction;
 import org.batfish.symbolic.state.StateExpr;
+import org.batfish.symbolic.state.VrfAccept;
 
 /**
  * Factory for creating {@link BDDFirewallSessionTraceInfo} objects for bidirectional reachability
@@ -61,7 +66,8 @@ final class BDDReachabilityAnalysisSessionFactory {
   private final Map<String, Configuration> _configs;
   private final Map<String, BDDSourceManager> _srcManagers;
   private final LastHopOutgoingInterfaceManager _lastHopManager;
-  private final Map<NodeInterfacePair, BDD> _sessionBdds;
+  private final Map<NodeInterfacePair, BDD> _incomingSessionBdds;
+  private final Map<String, Map<String, BDD>> _originatingSessionBdds;
   private final BDDReverseFlowTransformationFactory _reverseFlowTransformationFactory;
   private final BDDReverseTransformationRanges _reverseTransformationRanges;
 
@@ -81,8 +87,12 @@ final class BDDReachabilityAnalysisSessionFactory {
         IpProtocol.IP_PROTOCOLS_WITH_SESSIONS.stream()
             .map(bddPacket.getIpProtocol()::value)
             .reduce(bddPacket.getFactory().one(), BDD::or);
-    _sessionBdds =
-        reachableSessionCreationBdds(configs, forwardReachableBdds, ipProtocolsWithSessionsBdd);
+    _incomingSessionBdds =
+        reachableIncomingSessionCreationBdds(
+            configs, forwardReachableBdds, ipProtocolsWithSessionsBdd);
+    _originatingSessionBdds =
+        reachableOriginatingSessionCreationBdds(
+            configs, forwardReachableBdds, ipProtocolsWithSessionsBdd);
     _reverseFlowTransformationFactory = transformationFactory;
     _reverseTransformationRanges = reverseTransformationRanges;
   }
@@ -130,12 +140,18 @@ final class BDDReachabilityAnalysisSessionFactory {
   private List<BDDFirewallSessionTraceInfo> computeInitializedSessions(Configuration config) {
     String hostname = config.getHostname();
 
+    List<String> sessionOriginateVrfs =
+        config.getVrfs().values().stream()
+            .filter(Vrf::hasOriginatingSessions)
+            .map(Vrf::getName)
+            .collect(ImmutableList.toImmutableList());
+
     List<Interface> sessionExitInterfaces =
         config.getAllInterfaces().values().stream()
             .filter(iface -> iface.getActive() && iface.getFirewallSessionInterfaceInfo() != null)
             .collect(ImmutableList.toImmutableList());
 
-    if (sessionExitInterfaces.isEmpty()) {
+    if (sessionOriginateVrfs.isEmpty() && sessionExitInterfaces.isEmpty()) {
       // No sessions to create (and won't have any entries in _lastHopManager), so return now
       return ImmutableList.of();
     }
@@ -152,28 +168,45 @@ final class BDDReachabilityAnalysisSessionFactory {
                     .map(BDDFiniteDomain::getValueBdds)
                     .orElse(ImmutableMap.of()));
 
-    return sessionExitInterfaces.stream()
-        .flatMap(
-            iface -> {
-              BDD exitIfaceBdd = _sessionBdds.get(NodeInterfacePair.of(hostname, iface.getName()));
-              return exitIfaceBdd == null || exitIfaceBdd.isZero()
-                  ? Stream.of()
-                  : computeInitializedSessions(iface, lastHopOutgoingInterfaceBdds, exitIfaceBdd)
-                      .stream();
-            })
+    Stream<BDDFirewallSessionTraceInfo> originatingSessions =
+        sessionOriginateVrfs.stream()
+            .flatMap(
+                vrf -> {
+                  BDD originateBdd =
+                      _originatingSessionBdds.getOrDefault(hostname, ImmutableMap.of()).get(vrf);
+                  return originateBdd == null || originateBdd.isZero()
+                      ? Stream.of()
+                      : computeInitializedOriginatingSessions(
+                          hostname, vrf, lastHopOutgoingInterfaceBdds, originateBdd)
+                          .stream();
+                });
+    Stream<BDDFirewallSessionTraceInfo> incomingSessions =
+        sessionExitInterfaces.stream()
+            .flatMap(
+                iface -> {
+                  BDD exitIfaceBdd =
+                      _incomingSessionBdds.get(NodeInterfacePair.of(hostname, iface.getName()));
+                  return exitIfaceBdd == null || exitIfaceBdd.isZero()
+                      ? Stream.of()
+                      : computeInitializedIncomingSessions(
+                          iface, lastHopOutgoingInterfaceBdds, exitIfaceBdd)
+                          .stream();
+                });
+
+    return Stream.concat(originatingSessions, incomingSessions)
         .collect(ImmutableList.toImmutableList());
   }
 
   /**
-   * Compute initialized sessions for an outgoing interface (that has a {@link
-   * org.batfish.datamodel.FirewallSessionInterfaceInfo} object).
+   * Compute initialized sessions for flows exiting an outgoing interface that has a {@link
+   * org.batfish.datamodel.FirewallSessionInterfaceInfo} object.
    *
-   * @param outIface this nodes' egress iface
+   * @param outIface this node's egress iface; a session is set up when a flow leaves this iface
    * @param lastHopOutIfaceBdds this node's ingress iface -> (last hop, out iface) -> constraint
    * @param outIfaceBdd BDD representing the set of packets for which sessions can be initiated
    *     exiting outIface.
    */
-  private List<BDDFirewallSessionTraceInfo> computeInitializedSessions(
+  private List<BDDFirewallSessionTraceInfo> computeInitializedIncomingSessions(
       Interface outIface,
       Map<String, Map<NodeInterfacePair, BDD>> lastHopOutIfaceBdds,
       BDD outIfaceBdd) {
@@ -313,10 +346,110 @@ final class BDDReachabilityAnalysisSessionFactory {
   }
 
   /**
+   * Compute initialized sessions for flows accepted into the VRF specified by {@code hostname} and
+   * {@code vrf}.
+   *
+   * @param lastHopOutIfaceBdds this node's ingress iface -> (last hop, out iface) -> constraint
+   * @param vrfAcceptBdd BDD representing the set of packets for which sessions can be initiated
+   *     upon being accepted into the VRF.
+   */
+  private List<BDDFirewallSessionTraceInfo> computeInitializedOriginatingSessions(
+      String hostname,
+      String vrfName,
+      Map<String, Map<NodeInterfacePair, BDD>> lastHopOutIfaceBdds,
+      BDD vrfAcceptBdd) {
+    BDDSourceManager srcMgr = _srcManagers.get(hostname);
+
+    /* In order to setup sessions correctly, we have to track all possible sources in the firewall.
+     * This means the source manager must distinguish between all sources, and the reachability
+     * graph must impose the source constraints.
+     */
+    checkArgument(srcMgr.allSourcesTracked(), "Each possible source must be tracked.");
+    checkArgument(
+        srcMgr.hasSourceConstraint(vrfAcceptBdd), "Session devices must have source constraints");
+
+    ImmutableList.Builder<BDDFirewallSessionTraceInfo> sessions = ImmutableList.builder();
+    srcMgr
+        .getSourceBDDs()
+        .forEach(
+            (src, srcBdd) -> {
+              if (src.equals(SOURCE_ORIGINATING_FROM_DEVICE)) {
+                // This assumes traffic to self can't create and match a session. See related
+                // comment in FlowTracer#buildAcceptTrace.
+                return;
+              }
+
+              // Flows that entered src (either an interface or this device) and were accepted
+              BDD srcToAcceptBdd = vrfAcceptBdd.and(srcBdd);
+              if (srcToAcceptBdd.isZero()) {
+                return;
+              }
+              Transition incomingTransformation =
+                  _reverseFlowTransformationFactory.reverseFlowIncomingTransformation(
+                      hostname, src);
+              Map<NodeInterfacePair, BDD> nextHops = lastHopOutIfaceBdds.get(src);
+              if (nextHops.isEmpty()) {
+                // The src interface has no neighbors
+                assert !_lastHopManager.hasLastHopConstraint(srcToAcceptBdd);
+
+                BDD incomingTransformationRange =
+                    _reverseTransformationRanges.reverseIncomingTransformationRange(
+                        hostname, src, src, null);
+
+                BDD sessionBdd =
+                    _bddPacket.swapSourceAndDestinationFields(srcMgr.existsSource(srcToAcceptBdd));
+                sessions.add(
+                    new BDDFirewallSessionTraceInfo(
+                        hostname,
+                        new OriginatingSessionScope(vrfName),
+                        // Batfish does not support VRF-originating sessions with other actions
+                        FibLookup.INSTANCE,
+                        sessionBdd,
+                        compose(incomingTransformation, constraint(incomingTransformationRange))));
+                return;
+              }
+
+              nextHops.forEach(
+                  (lastHopOutIface, lastHopOutIfaceBdd) -> {
+                    // Flows that came from lastHopOutIface, entered src and were accepted
+                    BDD lastHopToSrcIfaceToAcceptBdd = srcToAcceptBdd.and(lastHopOutIfaceBdd);
+                    if (lastHopToSrcIfaceToAcceptBdd.isZero()) {
+                      return;
+                    }
+
+                    // Return flows for this session.
+                    BDD sessionBdd =
+                        _bddPacket.swapSourceAndDestinationFields(
+                            srcMgr.existsSource(
+                                _lastHopManager.existsLastHop(lastHopToSrcIfaceToAcceptBdd)));
+
+                    // Next hop for session flows
+                    NodeInterfacePair lastHop =
+                        lastHopOutIface == NO_LAST_HOP ? null : lastHopOutIface;
+
+                    BDD incomingTransformationRange =
+                        _reverseTransformationRanges.reverseIncomingTransformationRange(
+                            hostname, src, src, lastHop);
+
+                    sessions.add(
+                        new BDDFirewallSessionTraceInfo(
+                            hostname,
+                            new OriginatingSessionScope(vrfName),
+                            // Batfish does not support VRF-originating sessions with other actions
+                            FibLookup.INSTANCE,
+                            sessionBdd,
+                            compose(
+                                incomingTransformation, constraint(incomingTransformationRange))));
+                  });
+            });
+    return sessions.build();
+  }
+
+  /**
    * Compute a mapping from (node,iface) to BDD representing the headers that can establish a
    * session exiting that interface.
    */
-  private static Map<NodeInterfacePair, BDD> reachableSessionCreationBdds(
+  private static Map<NodeInterfacePair, BDD> reachableIncomingSessionCreationBdds(
       Map<String, Configuration> configs,
       Map<StateExpr, BDD> reachable,
       BDD ipProtocolsWithSessionsBdd) {
@@ -344,5 +477,48 @@ final class BDDReachabilityAnalysisSessionFactory {
                     Entry::getValue,
                     collectingAndThen(
                         toList(), bdds -> ipProtocolsWithSessionsBdd.and(ops.orAll(bdds))))));
+  }
+
+  /**
+   * Compute a mapping from hostname to VRF to BDD representing the flows that can establish a
+   * session when they are accepted into that VRF.
+   */
+  private static Map<String, Map<String, BDD>> reachableOriginatingSessionCreationBdds(
+      Map<String, Configuration> configs,
+      Map<StateExpr, BDD> reachable,
+      BDD ipProtocolsWithSessionsBdd) {
+    Map<String, Map<String, List<BDD>>> reachableBdds = new HashMap<>();
+    for (Entry<StateExpr, BDD> e : reachable.entrySet()) {
+      StateExpr state = e.getKey();
+      // Not necessary to check InterfaceAccept states because all InterfaceAccept states have an
+      // unconstrained edge to a VrfAccept state.
+      // TODO: Replace with a visitor.
+      if (state instanceof VrfAccept) {
+        String hostname = ((VrfAccept) state).getHostname();
+        String vrf = ((VrfAccept) state).getVrf();
+        Configuration c = configs.get(hostname);
+        if (c.getVrfs().get(vrf).hasOriginatingSessions()) {
+          reachableBdds
+              .computeIfAbsent(hostname, k -> new HashMap<>())
+              .computeIfAbsent(vrf, k -> new ArrayList<>())
+              .add(e.getValue());
+        }
+      }
+    }
+
+    BDDOps ops = new BDDOps(ipProtocolsWithSessionsBdd.getFactory());
+    return reachableBdds.entrySet().stream()
+        .collect(
+            ImmutableMap.toImmutableMap(
+                Entry::getKey, // hostname
+                nodeEntry ->
+                    nodeEntry.getValue().entrySet().stream()
+                        .collect(
+                            ImmutableMap.toImmutableMap(
+                                Entry::getKey, // VRF name
+                                vrfEntry ->
+                                    // BDD of flows that can match originating session on VRF
+                                    ipProtocolsWithSessionsBdd.and(
+                                        ops.orAll(vrfEntry.getValue()))))));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDFirewallSessionTraceInfoMatchers.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDFirewallSessionTraceInfoMatchers.java
@@ -1,6 +1,9 @@
 package org.batfish.bddreachability;
 
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
 
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -8,11 +11,13 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 import org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchersImpl.HasAction;
 import org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchersImpl.HasHostname;
-import org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchersImpl.HasIncomingInterfaces;
 import org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchersImpl.HasSessionFlows;
+import org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchersImpl.HasSessionScope;
 import org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchersImpl.HasTransformation;
 import org.batfish.bddreachability.transition.Transition;
+import org.batfish.datamodel.flow.IncomingSessionScope;
 import org.batfish.datamodel.flow.SessionAction;
+import org.batfish.datamodel.flow.SessionScope;
 import org.hamcrest.Matcher;
 
 /** Matchers for {@link BDDFirewallSessionTraceInfo}. */
@@ -35,11 +40,20 @@ public final class BDDFirewallSessionTraceInfoMatchers {
   }
 
   /**
-   * Matches {@link BDDFirewallSessionTraceInfo} that can match flows entering a set of interfaces
-   * that match the given matcher
+   * Matches {@link BDDFirewallSessionTraceInfo} with an {@link IncomingSessionScope} whose incoming
+   * interfaces match the given matcher
    */
-  public static HasIncomingInterfaces hasIncomingInterfaces(Matcher<? super Set<String>> matcher) {
-    return new HasIncomingInterfaces(matcher);
+  public static HasSessionScope hasIncomingInterfaces(Matcher<? super Set<String>> matcher) {
+    return hasSessionScope(
+        allOf(instanceOf(IncomingSessionScope.class), hasProperty("incomingInterfaces", matcher)));
+  }
+
+  public static HasSessionScope hasSessionScope(SessionScope sessionScope) {
+    return hasSessionScope(equalTo(sessionScope));
+  }
+
+  public static HasSessionScope hasSessionScope(Matcher<? super SessionScope> matcher) {
+    return new HasSessionScope(matcher);
   }
 
   public static HasSessionFlows hasSessionFlows(BDD bdd) {

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDFirewallSessionTraceInfoMatchersImpl.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDFirewallSessionTraceInfoMatchersImpl.java
@@ -1,14 +1,10 @@
 package org.batfish.bddreachability;
 
-import com.google.common.collect.ImmutableSet;
-import java.util.Set;
 import javax.annotation.Nonnull;
 import net.sf.javabdd.BDD;
 import org.batfish.bddreachability.transition.Transition;
-import org.batfish.datamodel.flow.IncomingSessionScope;
-import org.batfish.datamodel.flow.OriginatingSessionScope;
 import org.batfish.datamodel.flow.SessionAction;
-import org.batfish.datamodel.flow.SessionScopeVisitor;
+import org.batfish.datamodel.flow.SessionScope;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
@@ -37,33 +33,15 @@ public class BDDFirewallSessionTraceInfoMatchersImpl {
     }
   }
 
-  static final class HasIncomingInterfaces
-      extends FeatureMatcher<BDDFirewallSessionTraceInfo, Set<String>> {
-    public HasIncomingInterfaces(Matcher<? super Set<String>> subMatcher) {
-      super(
-          subMatcher,
-          "A BDDFirewallSessionTraceInfo with incomingInterfaces:",
-          "incomingInterfaces");
+  static final class HasSessionScope
+      extends FeatureMatcher<BDDFirewallSessionTraceInfo, SessionScope> {
+    public HasSessionScope(Matcher<? super SessionScope> subMatcher) {
+      super(subMatcher, "A BDDFirewallSessionTraceInfo with sessionScope:", "sessionScope");
     }
 
     @Override
-    protected Set<String> featureValueOf(BDDFirewallSessionTraceInfo bddFirewallSessionTraceInfo) {
-      return bddFirewallSessionTraceInfo
-          .getSessionScope()
-          .accept(
-              new SessionScopeVisitor<Set<String>>() {
-                @Override
-                public Set<String> visitIncomingSessionScope(
-                    IncomingSessionScope incomingSessionScope) {
-                  return incomingSessionScope.getIncomingInterfaces();
-                }
-
-                @Override
-                public Set<String> visitOriginatingSessionScope(
-                    OriginatingSessionScope originatingSessionScope) {
-                  return ImmutableSet.of();
-                }
-              });
+    protected SessionScope featureValueOf(BDDFirewallSessionTraceInfo bddFirewallSessionTraceInfo) {
+      return bddFirewallSessionTraceInfo.getSessionScope();
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
@@ -4,6 +4,7 @@ import static org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchers.ha
 import static org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchers.hasHostname;
 import static org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchers.hasIncomingInterfaces;
 import static org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchers.hasSessionFlows;
+import static org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchers.hasSessionScope;
 import static org.batfish.bddreachability.BDDFirewallSessionTraceInfoMatchers.hasTransformation;
 import static org.batfish.bddreachability.BDDReachabilityAnalysisSessionFactory.computeInitializedSesssions;
 import static org.batfish.bddreachability.BDDReverseTransformationRangesImpl.TransformationType.INCOMING;
@@ -34,7 +35,6 @@ import org.batfish.common.bdd.HeaderSpaceToBDD;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
-import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.NetworkFactory;
@@ -42,11 +42,14 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Accept;
+import org.batfish.datamodel.flow.FibLookup;
 import org.batfish.datamodel.flow.ForwardOutInterface;
+import org.batfish.datamodel.flow.OriginatingSessionScope;
 import org.batfish.symbolic.state.OriginateVrf;
 import org.batfish.symbolic.state.PreInInterface;
 import org.batfish.symbolic.state.PreOutEdgePostNat;
 import org.batfish.symbolic.state.StateExpr;
+import org.batfish.symbolic.state.VrfAccept;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,11 +65,12 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
   private static final String BORDER = "border";
   private static final String BORDER_IFACE = "BORDER_IFACE";
 
-  // interface names
+  // interface/vrf names
   private static final String R1I1 = "R1I1";
   private static final String R2I1 = "R2I1";
   private static final String R3I1 = "R3I1";
 
+  private static final String FW_VRF = "FW_VRF";
   private static final String FWI1 = "FWI1";
   private static final String FWI2 = "FWI2";
   private static final String FWI3 = "FWI3";
@@ -173,7 +177,8 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
     Interface fwi1;
     Interface fwi2;
     {
-      Vrf vrf = nf.vrfBuilder().setOwner(fw).build();
+      Vrf vrf = nf.vrfBuilder().setName(FW_VRF).setOwner(fw).build();
+      vrf.setHasOriginatingSessions(true);
       ib.setOwner(fw).setVrf(vrf);
       fwi1 = ib.setName(FWI1).build();
       fwi2 = ib.setName(FWI2).build();
@@ -337,9 +342,7 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
     BDD inBdd = _fwSrcMgr.getSourceInterfaceBDD(FWI1).and(r1I1Flows.or(r2I1Flows));
 
     // Somewhere between entering and leaving the device, the traffic is constrained to TCP
-    BDD tcp =
-        TO_BDD.toBDD(
-            HeaderSpace.builder().setIpProtocols(ImmutableList.of(IpProtocol.TCP)).build());
+    BDD tcp = PKT.getIpProtocol().value(IpProtocol.TCP);
 
     BDD outBdd = inBdd.and(tcp);
 
@@ -438,9 +441,7 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
     BDD inBdd2 = _fwSrcMgr.getSourceInterfaceBDD(FWI2).and(r3I1Flows);
 
     // Somewhere between entering and leaving the device, the traffic is constrained to TCP
-    BDD tcp =
-        TO_BDD.toBDD(
-            HeaderSpace.builder().setIpProtocols(ImmutableList.of(IpProtocol.TCP)).build());
+    BDD tcp = PKT.getIpProtocol().value(IpProtocol.TCP);
     BDD outBdd = tcp.and(inBdd1.or(inBdd2));
 
     BDD r1I1SessionFlows = tcp.and(srcBdd(routePrefix1).or(srcBdd(routePrefix2)));
@@ -540,5 +541,205 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
     assertThat(fwSession, hasAction(new ForwardOutInterface(FWI1, null)));
     assertThat(fwSession, hasSessionFlows(sessionFlows));
     assertThat(fwSession, hasTransformation(_fwI3ToI1ReverseTransformation));
+  }
+
+  @Test
+  public void testSinglePath_inbound() {
+    // Path:  R1:I1 -> FW:I1 -> FW
+
+    // R1:I1 -> FW:I1
+    BDD inBdd =
+        _lastHopMgr
+            .getLastHopOutgoingInterfaceBdd(R1, R1I1, FW, FWI1)
+            .and(_fwSrcMgr.getSourceInterfaceBDD(FWI1));
+
+    Prefix routePrefix = Prefix.parse("1.0.0.0/8");
+    BDD fwdRouteBdd = dstBdd(routePrefix);
+    BDD acceptBdd = inBdd.and(fwdRouteBdd);
+
+    Map<StateExpr, BDD> forwardReachableSets =
+        ImmutableMap.of(new VrfAccept(FW, FW_VRF), acceptBdd);
+
+    Map<String, List<BDDFirewallSessionTraceInfo>> sessions =
+        computeInitializedSessions(forwardReachableSets);
+
+    assertThat(sessions.keySet(), contains(FW));
+    assertThat(
+        sessions.get(FW),
+        contains(
+            allOf(
+                hasHostname(FW),
+                hasSessionScope(new OriginatingSessionScope(FW_VRF)),
+                hasAction(FibLookup.INSTANCE),
+                hasSessionFlows(srcBdd(routePrefix)),
+                hasTransformation(FWI1_REVERSE_TRANSFORMATION))));
+  }
+
+  @Test
+  public void testDifferentLastHops_inbound() {
+    /* Two paths, different last-hops, same source interface:
+     * R1:I1 -> FW:I1 -- FW
+     * R2:I1 -> FW:I1 -- FW
+     */
+    Prefix routePrefix1 = Prefix.parse("1.0.0.0/8");
+    Prefix routePrefix2 = Prefix.parse("2.0.0.0/8");
+    Prefix routePrefix3 = Prefix.parse("3.0.0.0/8");
+    BDD fwdRouteBdd1 = dstBdd(routePrefix1);
+    BDD fwdRouteBdd2 = dstBdd(routePrefix2);
+    BDD fwdRouteBdd3 = dstBdd(routePrefix3);
+
+    BDD r1I1Flows =
+        _lastHopMgr
+            .getLastHopOutgoingInterfaceBdd(R1, R1I1, FW, FWI1)
+            .and(fwdRouteBdd1.or(fwdRouteBdd2));
+    BDD r2I1Flows =
+        _lastHopMgr
+            .getLastHopOutgoingInterfaceBdd(R2, R2I1, FW, FWI1)
+            .and(fwdRouteBdd2.or(fwdRouteBdd3));
+
+    // R1:I1 -> FW:I1  or  R2:I1 -> FW:I1; and somewhere between entering and being accepted, the
+    // traffic is constrained to TCP
+    BDD tcp = PKT.getIpProtocol().value(IpProtocol.TCP);
+    BDD acceptBdd = _fwSrcMgr.getSourceInterfaceBDD(FWI1).and(r1I1Flows.or(r2I1Flows)).and(tcp);
+
+    Map<StateExpr, BDD> forwardReachableSets =
+        ImmutableMap.of(new VrfAccept(FW, FW_VRF), acceptBdd);
+
+    BDD r1I1IncomingTransformationRange = srcPortBdd(1);
+    BDD r2I1IncomingTransformationRange = srcPortBdd(2);
+
+    BDDReverseTransformationRanges transformationRanges =
+        new MockBDDReverseTransformationRanges(
+            PKT.getFactory().zero(),
+            ImmutableMap.of(
+                // incoming transformation ranges
+                new Key(FW, FWI1, INCOMING, FWI1, NEXT_HOP_R1I1),
+                r1I1IncomingTransformationRange,
+                new Key(FW, FWI1, INCOMING, FWI1, NEXT_HOP_R2I1),
+                r2I1IncomingTransformationRange));
+
+    Map<String, List<BDDFirewallSessionTraceInfo>> sessions =
+        computeInitializedSessions(forwardReachableSets, transformationRanges);
+
+    assertThat(sessions.keySet(), contains(FW));
+    List<BDDFirewallSessionTraceInfo> fwSessions = sessions.get(FW);
+
+    BDD r1I1SessionFlows = tcp.and(srcBdd(routePrefix1).or(srcBdd(routePrefix2)));
+    BDD r2I1SessionFlows = tcp.and(srcBdd(routePrefix2).or(srcBdd(routePrefix3)));
+    assertThat(
+        fwSessions,
+        containsInAnyOrder(
+            allOf(
+                // R1:I1 -> FW:I1
+                hasHostname(FW),
+                hasSessionScope(new OriginatingSessionScope(FW_VRF)),
+                hasAction(FibLookup.INSTANCE),
+                hasSessionFlows(r1I1SessionFlows),
+                hasTransformation(
+                    compose(
+                        FWI1_REVERSE_TRANSFORMATION, constraint(r1I1IncomingTransformationRange)))),
+            allOf(
+                // R2:I1 -> FW:I1
+                hasHostname(FW),
+                hasSessionScope(new OriginatingSessionScope(FW_VRF)),
+                hasAction(FibLookup.INSTANCE),
+                hasSessionFlows(r2I1SessionFlows),
+                hasTransformation(
+                    compose(
+                        FWI1_REVERSE_TRANSFORMATION,
+                        constraint(r2I1IncomingTransformationRange))))));
+  }
+
+  @Test
+  public void testDifferentSourceInterfaces_inbound() {
+    /* two paths, different source interfaces
+     * R1:I1 -> FW:I1 -- FW
+     * R3:I1 -> FW:I2 -- FW
+     */
+    Prefix routePrefix1 = Prefix.parse("1.0.0.0/8");
+    Prefix routePrefix2 = Prefix.parse("2.0.0.0/8");
+    Prefix routePrefix3 = Prefix.parse("3.0.0.0/8");
+    BDD fwdRouteBdd1 = dstBdd(routePrefix1);
+    BDD fwdRouteBdd2 = dstBdd(routePrefix2);
+    BDD fwdRouteBdd3 = dstBdd(routePrefix3);
+
+    BDD r1I1Flows =
+        _lastHopMgr
+            .getLastHopOutgoingInterfaceBdd(R1, R1I1, FW, FWI1)
+            .and(fwdRouteBdd1.or(fwdRouteBdd2));
+    BDD r3I1Flows =
+        _lastHopMgr
+            .getLastHopOutgoingInterfaceBdd(R3, R3I1, FW, FWI2)
+            .and(fwdRouteBdd2.or(fwdRouteBdd3));
+
+    // R1:I1 -> FW:I1
+    BDD inBdd1 = _fwSrcMgr.getSourceInterfaceBDD(FWI1).and(r1I1Flows);
+
+    // R3:I1 -> FW:I2
+    BDD inBdd2 = _fwSrcMgr.getSourceInterfaceBDD(FWI2).and(r3I1Flows);
+
+    // R1:I1 -> FW:I1  or  R3:I1 -> FW:I2; and somewhere between entering and being accepted, the
+    // traffic is constrained to TCP
+    BDD tcp = PKT.getIpProtocol().value(IpProtocol.TCP);
+    BDD acceptBdd = tcp.and(inBdd1.or(inBdd2));
+
+    Map<StateExpr, BDD> forwardReachableSets =
+        ImmutableMap.of(new VrfAccept(FW, FW_VRF), acceptBdd);
+
+    Map<String, List<BDDFirewallSessionTraceInfo>> sessions =
+        computeInitializedSessions(forwardReachableSets, TRIVIAL_REVERSE_TRANSFORMATION_RANGES);
+
+    assertThat(sessions.keySet(), contains(FW));
+    List<BDDFirewallSessionTraceInfo> fwSessions = sessions.get(FW);
+
+    BDD r1I1SessionFlows = tcp.and(srcBdd(routePrefix1).or(srcBdd(routePrefix2)));
+    BDD r3I1SessionFlows = tcp.and(srcBdd(routePrefix2).or(srcBdd(routePrefix3)));
+    assertThat(
+        fwSessions,
+        containsInAnyOrder(
+            allOf(
+                // R1:I1 -> FW:I1
+                hasHostname(FW),
+                hasSessionScope(new OriginatingSessionScope(FW_VRF)),
+                hasAction(FibLookup.INSTANCE),
+                hasSessionFlows(r1I1SessionFlows),
+                hasTransformation(FWI1_REVERSE_TRANSFORMATION)),
+            allOf(
+                // R3:I1 -> FW:I2
+                hasHostname(FW),
+                hasSessionScope(new OriginatingSessionScope(FW_VRF)),
+                hasAction(FibLookup.INSTANCE),
+                hasSessionFlows(r3I1SessionFlows),
+                hasTransformation(FWI2_REVERSE_TRANSFORMATION))));
+  }
+
+  @Test
+  public void testNoLastHopOutgoingInterface_inbound() {
+    // FW:I1 -- FW
+    BDD inBdd =
+        _fwSrcMgr
+            .getSourceInterfaceBDD(FWI1)
+            .and(_lastHopMgr.getNoLastHopOutgoingInterfaceBdd(FW, FWI1));
+
+    Prefix routePrefix = Prefix.parse("1.0.0.0/8");
+    BDD fwdRouteBdd = dstBdd(routePrefix);
+    BDD acceptBdd = inBdd.and(fwdRouteBdd);
+
+    Map<StateExpr, BDD> forwardReachableSets =
+        ImmutableMap.of(new VrfAccept(FW, FW_VRF), acceptBdd);
+
+    Map<String, List<BDDFirewallSessionTraceInfo>> sessions =
+        computeInitializedSessions(forwardReachableSets, TRIVIAL_REVERSE_TRANSFORMATION_RANGES);
+
+    assertThat(sessions.keySet(), contains(FW));
+    assertThat(
+        sessions.get(FW),
+        contains(
+            allOf(
+                hasHostname(FW),
+                hasSessionScope(new OriginatingSessionScope(FW_VRF)),
+                hasAction(FibLookup.INSTANCE),
+                hasSessionFlows(srcBdd(routePrefix)),
+                hasTransformation(FWI1_REVERSE_TRANSFORMATION))));
   }
 }


### PR DESCRIPTION
After #5771. Creates VRF-scoped `BDDFirewallSessionTraceInfo` based on reachability graph. Fixes bidirectional reachability for inbound sessions.

Still to do:
- A visitor for identifying states that should cause a VRF-scoped session to be established
- Refactoring (lot of shared code between `computeInitializedIncomingSessions()` and `computeInitializedOriginatingSessions`)
- Tests