### PR TITLE
Move vendor configuration parsing I/O to StorageProvider

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -127,7 +127,6 @@ public class BfConsts {
   public static final String PROP_VALUES = "values";
   public static final String PROP_VARIABLES = "variables";
 
-  public static final String RELPATH_AWS_ACCOUNTS_DIR = "accounts";
   public static final String RELPATH_AWS_CONFIGS_DIR = "aws_configs";
   public static final String RELPATH_AWS_CONFIGS_FILE = "aws_configs";
   public static final String RELPATH_CONFIGURATIONS_DIR = "configs";
@@ -144,7 +143,6 @@ public class BfConsts {
   public static final String RELPATH_RUNTIME_DATA_FILE = "runtime_data.json";
   public static final String RELPATH_QUESTION_FILE = "question.json";
   public static final String RELPATH_SNAPSHOTS_DIR = "snapshots";
-  public static final String RELPATH_VENDOR_SPECIFIC_CONFIG_DIR = "vendor";
 
   public static final String SVC_BASE_RSC = "/batfishservice";
   public static final String SVC_FAILURE_KEY = "failure";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -47,6 +47,7 @@ import org.batfish.identifiers.QuestionSettingsId;
 import org.batfish.identifiers.SnapshotId;
 import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRolesData;
+import org.batfish.vendor.VendorConfiguration;
 
 /** Storage backend for loading and storing persistent data used by Batfish */
 @ParametersAreNonnullByDefault
@@ -452,6 +453,8 @@ public interface StorageProvider {
   @MustBeClosed
   InputStream loadSnapshotInputObject(NetworkId networkId, SnapshotId snapshotId, String key)
       throws FileNotFoundException, IOException;
+
+  boolean hasSnapshotInputObject(String key, NetworkSnapshot snapshot) throws IOException;
 
   /**
    * Fetch the list of keys in the given snapshot's input directory
@@ -889,4 +892,69 @@ public interface StorageProvider {
    * @throws IOException if there is an error
    */
   void deleteParseVendorConfigurationAnswerElement(NetworkSnapshot snapshot) throws IOException;
+
+  /**
+   * Loads the compiled vendor configurations for the given snapshot if they exist. Returns an empty
+   * map if none were compiled.
+   *
+   * @throws IOException if there is an error
+   */
+  @Nonnull
+  Map<String, VendorConfiguration> loadVendorConfigurations(NetworkSnapshot snapshot)
+      throws IOException;
+
+  /**
+   * Stores the compiled vendor configurations for the given snapshot if they exist. Merges with any
+   * existing stored vendor configurations.
+   *
+   * @throws IOException if there is an error
+   */
+  void storeVendorConfigurations(
+      Map<String, VendorConfiguration> vendorConfigurations, NetworkSnapshot snapshot)
+      throws IOException;
+
+  /**
+   * Deletes the compiled vendor configurations for the given snapshot if they exist.
+   *
+   * @throws IOException if there is an error
+   */
+  void deleteVendorConfigurations(NetworkSnapshot snapshot) throws IOException;
+
+  /**
+   * Returns a list of snapshot input object keys corresponding to host configurations.
+   *
+   * @throws IOException if there is an error
+   */
+  @MustBeClosed
+  @Nonnull
+  Stream<String> listInputHostConfigurationsKeys(NetworkSnapshot snapshot) throws IOException;
+
+  /**
+   * Returns a list of snapshot input object keys corresponding to network configurations.
+   *
+   * @throws IOException if there is an error
+   */
+  @MustBeClosed
+  @Nonnull
+  Stream<String> listInputNetworkConfigurationsKeys(NetworkSnapshot snapshot) throws IOException;
+
+  /**
+   * Returns a list of snapshot input object keys corresponding to AWS multi-account configuration
+   * data.
+   *
+   * @throws IOException if there is an error
+   */
+  @MustBeClosed
+  @Nonnull
+  Stream<String> listInputAwsMultiAccountKeys(NetworkSnapshot snapshot) throws IOException;
+
+  /**
+   * Returns a list of snapshot input object keys corresponding to AWS single-account configuration
+   * data.
+   *
+   * @throws IOException if there is an error
+   */
+  @MustBeClosed
+  @Nonnull
+  Stream<String> listInputAwsSingleAccountKeys(NetworkSnapshot snapshot) throws IOException;
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
@@ -44,6 +44,7 @@ import org.batfish.identifiers.QuestionSettingsId;
 import org.batfish.identifiers.SnapshotId;
 import org.batfish.referencelibrary.ReferenceLibrary;
 import org.batfish.role.NodeRolesData;
+import org.batfish.vendor.VendorConfiguration;
 
 public class TestStorageProvider implements StorageProvider {
 
@@ -282,6 +283,11 @@ public class TestStorageProvider implements StorageProvider {
   public InputStream loadSnapshotInputObject(
       NetworkId networkId, SnapshotId snapshotId, String key) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean hasSnapshotInputObject(String key, NetworkSnapshot snapshot) throws IOException {
+    return false;
   }
 
   @Override
@@ -577,6 +583,49 @@ public class TestStorageProvider implements StorageProvider {
   @Override
   public void deleteParseVendorConfigurationAnswerElement(NetworkSnapshot snapshot)
       throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public Map<String, VendorConfiguration> loadVendorConfigurations(NetworkSnapshot snapshot)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void storeVendorConfigurations(
+      Map<String, VendorConfiguration> vendorConfigurations, NetworkSnapshot snapshot)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void deleteVendorConfigurations(NetworkSnapshot snapshot) throws IOException {}
+
+  @Nonnull
+  @Override
+  public Stream<String> listInputHostConfigurationsKeys(NetworkSnapshot snapshot)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public Stream<String> listInputNetworkConfigurationsKeys(NetworkSnapshot snapshot)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public Stream<String> listInputAwsMultiAccountKeys(NetworkSnapshot snapshot) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public Stream<String> listInputAwsSingleAccountKeys(NetworkSnapshot snapshot) throws IOException {
     throw new UnsupportedOperationException();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -36,6 +36,7 @@ import org.batfish.vendor.VendorConfiguration;
 @ParametersAreNonnullByDefault
 public class AwsConfiguration extends VendorConfiguration {
 
+  public static final String DEFAULT_REGION_NAME = "us-west-2";
   static final Ip LINK_LOCAL_IP = Ip.parse("169.254.0.1");
   public static final String DEFAULT_ACCOUNT_NAME = "default";
 

--- a/projects/batfish/src/test/java/org/batfish/main/AwsParseWarningsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/AwsParseWarningsTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.batfish.common.BfConsts;
 import org.batfish.common.Warning;
@@ -16,7 +15,8 @@ import org.junit.Test;
 public class AwsParseWarningsTest {
 
   private ParseVendorConfigurationAnswerElement _pvcae;
-  private Path _path = Paths.get(BfConsts.RELPATH_AWS_CONFIGS_DIR, "region", "file.json");
+  private String _key =
+      Paths.get(BfConsts.RELPATH_AWS_CONFIGS_DIR, "region", "file.json").toString();
 
   @Before
   public void initializeAnswerElement() {
@@ -25,22 +25,19 @@ public class AwsParseWarningsTest {
 
   @Test
   public void testBadJsonWarning() {
-    Batfish.parseAwsConfigurations(ImmutableMap.of(_path, "{"), _pvcae);
+    Batfish.parseAwsConfigurations(ImmutableMap.of(_key, "{"), _pvcae);
     assertThat(
         _pvcae.getWarnings().get(RELPATH_AWS_CONFIGS_FILE).getRedFlagWarnings(),
-        contains(
-            new Warning(
-                String.format("Unexpected content in AWS file %s", _path.toString()), "AWS")));
+        contains(new Warning(String.format("Unexpected content in AWS file %s", _key), "AWS")));
   }
 
   @Test
   public void testInvalidKeyWarning() {
-    Batfish.parseAwsConfigurations(ImmutableMap.of(_path, "{ \"invalidKey\": [1] }"), _pvcae);
+    Batfish.parseAwsConfigurations(ImmutableMap.of(_key, "{ \"invalidKey\": [1] }"), _pvcae);
     assertThat(
         _pvcae.getWarnings().get(RELPATH_AWS_CONFIGS_FILE).getUnimplementedWarnings(),
         contains(
             new Warning(
-                String.format("Unrecognized element 'invalidKey' in AWS file %s", _path.toString()),
-                "AWS")));
+                String.format("Unrecognized element 'invalidKey' in AWS file %s", _key), "AWS")));
   }
 }

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -30605,7 +30605,7 @@
         "domainName" : "aws",
         "vendorFamily" : {
           "aws" : {
-            "region" : "aws_configs",
+            "region" : "us-west-2",
             "subnetId" : "subnet-a9660ce1",
             "vpcId" : "vpc-50fffd36"
           }
@@ -30627,7 +30627,7 @@
         "domainName" : "aws",
         "vendorFamily" : {
           "aws" : {
-            "region" : "aws_configs",
+            "region" : "us-west-2",
             "subnetId" : "subnet-3e7e3458",
             "vpcId" : "vpc-50fffd36"
           }


### PR DESCRIPTION
- remove poorly structured AWS tests
- pick a default region when AWS files provided in flat structure
- fix bug treating arbitrary path data as region name
- fix AWS test refs
- move related constants to FileBasedStorage