### PR TITLE
Remove TestrigSettings and clean up unnecessary Path logic

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/Answerer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/Answerer.java
@@ -56,9 +56,6 @@ public abstract class Answerer {
    * <p>Answerers that want a custom differential answer, should override this function.
    */
   public AnswerElement answerDiff(NetworkSnapshot snapshot, NetworkSnapshot reference) {
-    _batfish.checkSnapshotOutputReady(snapshot);
-    _batfish.checkSnapshotOutputReady(reference);
-
     AnswerElement baseAnswer = create(_question, _batfish).answer(snapshot);
     AnswerElement deltaAnswer = create(_question, _batfish).answer(reference);
     if (baseAnswer instanceof TableAnswerElement) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -138,11 +138,9 @@ public class BfConsts {
   public static final String RELPATH_L1_TOPOLOGY_PATH = "layer1_topology.json";
   public static final String RELPATH_NODE_BLACKLIST_FILE = "node_blacklist";
   public static final String RELPATH_NODE_ROLES_PATH = "node_roles.json";
-  public static final String RELPATH_OUTPUT = "output";
   public static final String RELPATH_REFERENCE_LIBRARY_PATH = "address_library.json";
   public static final String RELPATH_RUNTIME_DATA_FILE = "runtime_data.json";
   public static final String RELPATH_QUESTION_FILE = "question.json";
-  public static final String RELPATH_SNAPSHOTS_DIR = "snapshots";
 
   public static final String SVC_BASE_RSC = "/batfishservice";
   public static final String SVC_FAILURE_KEY = "failure";

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/IBatfish.java
@@ -63,8 +63,6 @@ public interface IBatfish extends IPluginConsumer {
   SortedMap<Flow, List<Trace>> buildFlows(
       NetworkSnapshot snapshot, Set<Flow> flows, boolean ignoreFilters);
 
-  void checkSnapshotOutputReady(NetworkSnapshot snapshot);
-
   /** Compute the dataplane for the given {@link NetworkSnapshot} */
   DataPlaneAnswerElement computeDataPlane(NetworkSnapshot snapshot);
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -137,6 +137,8 @@ public final class FileBasedStorage implements StorageProvider {
   private static final String RELPATH_PARSE_ANSWER_PATH = "parse_answer";
   private static final String RELPATH_VENDOR_SPECIFIC_CONFIG_DIR = "vendor";
   private static final String RELPATH_AWS_ACCOUNTS_DIR = "accounts";
+  private static final String RELPATH_SNAPSHOTS_DIR = "snapshots";
+  private static final String RELPATH_OUTPUT = "output";
 
   private final BatfishLogger _logger;
   private final BiFunction<String, Integer, AtomicInteger> _newBatch;
@@ -176,8 +178,7 @@ public final class FileBasedStorage implements StorageProvider {
       NetworkId network, SnapshotId snapshot) {
     Path testrigDir = getSnapshotDir(network, snapshot);
     Path indepDir =
-        testrigDir.resolve(
-            Paths.get(BfConsts.RELPATH_OUTPUT, RELPATH_VENDOR_INDEPENDENT_CONFIG_DIR));
+        testrigDir.resolve(Paths.get(RELPATH_OUTPUT, RELPATH_VENDOR_INDEPENDENT_CONFIG_DIR));
     return loadConfigurations(network, snapshot, indepDir);
   }
 
@@ -481,12 +482,12 @@ public final class FileBasedStorage implements StorageProvider {
 
   private @Nonnull Path getConvertAnswerPath(NetworkId network, SnapshotId snapshot) {
     return getSnapshotDir(network, snapshot)
-        .resolve(Paths.get(BfConsts.RELPATH_OUTPUT, RELPATH_CONVERT_ANSWER_PATH));
+        .resolve(Paths.get(RELPATH_OUTPUT, RELPATH_CONVERT_ANSWER_PATH));
   }
 
   private @Nonnull Path getSynthesizedLayer1TopologyPath(NetworkId network, SnapshotId snapshot) {
     return getSnapshotDir(network, snapshot)
-        .resolve(Paths.get(BfConsts.RELPATH_OUTPUT, RELPATH_SYNTHESIZED_LAYER1_TOPOLOGY));
+        .resolve(Paths.get(RELPATH_OUTPUT, RELPATH_SYNTHESIZED_LAYER1_TOPOLOGY));
   }
 
   private void storeConfigurations(
@@ -753,7 +754,7 @@ public final class FileBasedStorage implements StorageProvider {
 
   private @Nonnull Path getSnapshotMetadataPath(NetworkId networkId, SnapshotId snapshotId) {
     return getSnapshotDir(networkId, snapshotId)
-        .resolve(Paths.get(BfConsts.RELPATH_OUTPUT, RELPATH_METADATA_FILE));
+        .resolve(Paths.get(RELPATH_OUTPUT, RELPATH_METADATA_FILE));
   }
 
   @Override
@@ -1062,7 +1063,7 @@ public final class FileBasedStorage implements StorageProvider {
 
   private @Nonnull Path getPojoTopologyPath(NetworkId networkId, SnapshotId snapshotId) {
     return getSnapshotDir(networkId, snapshotId)
-        .resolve(BfConsts.RELPATH_OUTPUT)
+        .resolve(RELPATH_OUTPUT)
         .resolve(RELPATH_TESTRIG_POJO_TOPOLOGY_PATH);
   }
 
@@ -1095,7 +1096,7 @@ public final class FileBasedStorage implements StorageProvider {
 
   private @Nonnull Path getEnvTopologyPath(NetworkId networkId, SnapshotId snapshotId) {
     return getSnapshotDir(networkId, snapshotId)
-        .resolve(BfConsts.RELPATH_OUTPUT)
+        .resolve(RELPATH_OUTPUT)
         .resolve(RELPATH_ENV_TOPOLOGY_FILE);
   }
 
@@ -1692,7 +1693,7 @@ public final class FileBasedStorage implements StorageProvider {
   }
 
   private @Nonnull Path getSnapshotDir(NetworkId network, SnapshotId snapshot) {
-    return getNetworkDir(network).resolve(BfConsts.RELPATH_SNAPSHOTS_DIR).resolve(snapshot.getId());
+    return getNetworkDir(network).resolve(RELPATH_SNAPSHOTS_DIR).resolve(snapshot.getId());
   }
 
   private @Nonnull Path getStorageBase() {
@@ -1701,12 +1702,12 @@ public final class FileBasedStorage implements StorageProvider {
 
   private @Nonnull Path getVendorIndependentConfigDir(NetworkId network, SnapshotId snapshot) {
     return getSnapshotDir(network, snapshot)
-        .resolve(Paths.get(BfConsts.RELPATH_OUTPUT, RELPATH_VENDOR_INDEPENDENT_CONFIG_DIR));
+        .resolve(Paths.get(RELPATH_OUTPUT, RELPATH_VENDOR_INDEPENDENT_CONFIG_DIR));
   }
 
   private @Nonnull Path getVendorSpecificConfigDir(NetworkId network, SnapshotId snapshot) {
     return getSnapshotDir(network, snapshot)
-        .resolve(Paths.get(BfConsts.RELPATH_OUTPUT, RELPATH_VENDOR_SPECIFIC_CONFIG_DIR));
+        .resolve(Paths.get(RELPATH_OUTPUT, RELPATH_VENDOR_SPECIFIC_CONFIG_DIR));
   }
 
   private Path getNetworkBlobsDir(NetworkId networkId) {
@@ -1726,7 +1727,7 @@ public final class FileBasedStorage implements StorageProvider {
   }
 
   private Path getSnapshotOutputDir(NetworkId networkId, SnapshotId snapshotId) {
-    return getSnapshotDir(networkId, snapshotId).resolve(BfConsts.RELPATH_OUTPUT);
+    return getSnapshotDir(networkId, snapshotId).resolve(RELPATH_OUTPUT);
   }
 
   @Nonnull

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/plugin/IBatfishTestAdapter.java
@@ -181,11 +181,6 @@ public class IBatfishTestAdapter implements IBatfish {
   }
 
   @Override
-  public void checkSnapshotOutputReady(NetworkSnapshot snapshot) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public DataPlaneAnswerElement computeDataPlane(NetworkSnapshot snapshot) {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
- remove TestrigSettings class
- replace with SnapshotId at client sitesd, since name is only field still
used
- remove extraneous Path logic from from {I,}Batfish
  - delete checkSnapshotOutputReady
- move some constants previously used by TestrigSettings to FileBasedStorage
- use StorageProvider instead of TestrigSettings to write temporary
input files for tests