### PR TITLE
Apply transformation in FibLookup incoming session edges

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/SessionScopeFibLookupSessionEdges.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/SessionScopeFibLookupSessionEdges.java
@@ -1,6 +1,7 @@
 package org.batfish.bddreachability;
 
 import static org.batfish.bddreachability.transition.Transitions.addOriginatingFromDeviceConstraint;
+import static org.batfish.bddreachability.transition.Transitions.addSourceInterfaceConstraint;
 import static org.batfish.bddreachability.transition.Transitions.compose;
 import static org.batfish.bddreachability.transition.Transitions.constraint;
 
@@ -61,7 +62,10 @@ public class SessionScopeFibLookupSessionEdges implements SessionScopeVisitor<St
                     new PreInInterface(_hostname, incomingInterface),
                     new PostInVrfSession(
                         _hostname, _ifaces.get(incomingInterface).getVrf().getName()),
-                    compose(constraint(_sessionFlows), _transformation)));
+                    compose(
+                        constraint(_sessionFlows),
+                        _transformation,
+                        addSourceInterfaceConstraint(_srcMgr, incomingInterface))));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/SessionScopeFibLookupSessionEdges.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/SessionScopeFibLookupSessionEdges.java
@@ -61,8 +61,7 @@ public class SessionScopeFibLookupSessionEdges implements SessionScopeVisitor<St
                     new PreInInterface(_hostname, incomingInterface),
                     new PostInVrfSession(
                         _hostname, _ifaces.get(incomingInterface).getVrf().getName()),
-                    // TODO Should this edge apply _transformation?
-                    _sessionFlows));
+                    compose(constraint(_sessionFlows), _transformation)));
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
@@ -286,7 +286,10 @@ public final class SessionInstrumentationTest {
                 hasPreState(new PreInInterface(FW, FW_I1)),
                 hasPostState(new PostInVrfSession(FW, FW_VRF)),
                 hasTransition(
-                    allOf(mapsForward(ONE, sessionHeaders), mapsBackward(ONE, sessionHeaders))))));
+                    allOf(
+                        mapsForward(
+                            ONE, sessionHeaders.and(_fwSrcMgr.getSourceInterfaceBDD(FW_I1))),
+                        mapsBackward(ONE, sessionHeaders))))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionScopeFibLookupSessionEdgesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionScopeFibLookupSessionEdgesTest.java
@@ -60,13 +60,18 @@ public class SessionScopeFibLookupSessionEdgesTest {
     // PreInInterface to PostInVrf
     IncomingSessionScope scope = new IncomingSessionScope(ImmutableSet.of(IFACE_NAME));
     List<Edge> actualEdges = scope.accept(VISITOR).collect(ImmutableList.toImmutableList());
+    BDD expectedForwardFlows =
+        SESSION_HEADERS.and(POOL_BDD).and(SRC_MGR.getSourceInterfaceBDD(IFACE_NAME));
     assertThat(
         actualEdges,
         contains(
             allOf(
                 hasPreState(new PreInInterface(HOSTNAME, IFACE_NAME)),
                 hasPostState(new PostInVrfSession(HOSTNAME, VRF_NAME)),
-                hasTransition(mapsForward(ONE, SESSION_HEADERS.and(POOL_BDD))))));
+                hasTransition(
+                    allOf(
+                        mapsForward(ONE, expectedForwardFlows),
+                        mapsBackward(ONE, SESSION_HEADERS))))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionScopeFibLookupSessionEdgesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionScopeFibLookupSessionEdgesTest.java
@@ -59,14 +59,14 @@ public class SessionScopeFibLookupSessionEdgesTest {
     // Applying visitor to IncomingSessionScope for the known interface should give edge from
     // PreInInterface to PostInVrf
     IncomingSessionScope scope = new IncomingSessionScope(ImmutableSet.of(IFACE_NAME));
-    Edge expectedEdge =
-        new Edge(
-            new PreInInterface(HOSTNAME, IFACE_NAME),
-            new PostInVrfSession(HOSTNAME, VRF_NAME),
-            // TODO Currently no source or transformation constraint here, but there should be.
-            SESSION_HEADERS);
     List<Edge> actualEdges = scope.accept(VISITOR).collect(ImmutableList.toImmutableList());
-    assertThat(actualEdges, contains(expectedEdge));
+    assertThat(
+        actualEdges,
+        contains(
+            allOf(
+                hasPreState(new PreInInterface(HOSTNAME, IFACE_NAME)),
+                hasPostState(new PostInVrfSession(HOSTNAME, VRF_NAME)),
+                hasTransition(mapsForward(ONE, SESSION_HEADERS.and(POOL_BDD))))));
   }
 
   @Test


### PR DESCRIPTION
`PreInInterface` -> `PostInVrfSession` edges, which represent matching a firewall session with action `FibLookup`, now apply the transformation for that session. This won't change behavior because none of the currently-supported types of firewall sessions do a FibLookup with a transformation.