### PR TITLE
AWS: fix aggregate generation for VPCs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Topology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/pojo/Topology.java
@@ -4,6 +4,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -103,8 +104,8 @@ public class Topology extends BfObject {
     return pojoTopology;
   }
 
-  private static void putInAwsAggregate(
-      Topology pojoTopology, Configuration configuration, Node pojoNode) {
+  @VisibleForTesting
+  static void putInAwsAggregate(Topology pojoTopology, Configuration configuration, Node pojoNode) {
     VendorFamily vendorFamily = configuration.getVendorFamily();
     if (vendorFamily.getAws().getSubnetId() != null) {
       String subnetId = vendorFamily.getAws().getSubnetId();
@@ -122,6 +123,8 @@ public class Topology extends BfObject {
       String region = vendorFamily.getAws().getRegion();
       Aggregate regionAggregate = pojoTopology.getOrCreateAggregate(region, AggregateType.REGION);
       regionAggregate.getContents().add(vpcAggregate.getId());
+      Aggregate awsAggregate = pojoTopology.getOrCreateAggregate("aws", AggregateType.CLOUD);
+      awsAggregate.getContents().add(regionAggregate.getId());
     } else if (vendorFamily.getAws().getRegion() != null) {
       String region = vendorFamily.getAws().getRegion();
       Aggregate regionAggregate = pojoTopology.getOrCreateAggregate(region, AggregateType.REGION);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/pojo/TopologyTest.java
@@ -157,4 +157,31 @@ public class TopologyTest {
 
     assertThat(topo.getAggregates(), hasItem(expectedAgg));
   }
+
+  @Test
+  public void testPutInAwsAggregateCreatesAwsAggregateIfNeededForVpc() {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration c1 =
+        nf.configurationBuilder()
+            .setHostname("vpc-1")
+            .setConfigurationFormat(ConfigurationFormat.AWS)
+            .build();
+    VendorFamily vf = new VendorFamily();
+    AwsFamily af = new AwsFamily();
+    String regionName = "us-west-1";
+    af.setRegion(regionName);
+    af.setVpcId("vpc-1");
+    vf.setAws(af);
+    c1.setVendorFamily(vf);
+    Topology topo = new Topology("ss");
+    Node topoNode = new Node(c1.getHostname());
+
+    Topology.putInAwsAggregate(topo, c1, topoNode);
+
+    // AWS aggregate is present and contains region of the node c1
+    Aggregate expectedAgg = new Aggregate("aws", AggregateType.CLOUD);
+    expectedAgg.setContents(ImmutableSet.of("aggregate-us-west-1"));
+
+    assertThat(topo.getAggregates(), hasItem(expectedAgg));
+  }
 }


### PR DESCRIPTION
Fixes bug where for regions with only VPCs present (but no gateways, for example) we missed the correct placement of region into AWS aggregate