### PR TITLE
More traceroute tests for PBR

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java
@@ -1,36 +1,40 @@
 package org.batfish.question.traceroute;
 
 import static org.batfish.common.util.TracePruner.DEFAULT_MAX_TRACES;
+import static org.batfish.datamodel.matchers.HopMatchers.hasAcceptingInterface;
 import static org.batfish.datamodel.matchers.HopMatchers.hasOutputInterface;
-import static org.batfish.datamodel.matchers.RowMatchers.hasColumn;
 import static org.batfish.datamodel.matchers.TraceMatchers.hasDisposition;
-import static org.batfish.datamodel.matchers.TraceMatchers.hasLastHop;
-import static org.batfish.question.traceroute.TracerouteAnswerer.COL_TRACES;
-import static org.hamcrest.Matchers.everyItem;
+import static org.batfish.datamodel.matchers.TraceMatchers.hasHop;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.IOException;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.PacketHeaderConstraints;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
-import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.packet_policy.Drop;
 import org.batfish.datamodel.packet_policy.FibLookup;
 import org.batfish.datamodel.packet_policy.If;
@@ -38,7 +42,6 @@ import org.batfish.datamodel.packet_policy.LiteralVrfName;
 import org.batfish.datamodel.packet_policy.PacketMatchExpr;
 import org.batfish.datamodel.packet_policy.PacketPolicy;
 import org.batfish.datamodel.packet_policy.Return;
-import org.batfish.datamodel.table.TableAnswerElement;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.junit.Rule;
@@ -51,6 +54,10 @@ public class TraceroutePolicyBasedRoutingTest {
   private static final String ROUTING_POLICY_NAME = "packetPolicy";
   private static final String SOURCE_LOCATION_STR = "enter(c1[ingressInterface])";
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  private static final Ip INGRESS_IFACE_IP = Ip.parse("1.1.1.1");
+  private static final Ip IFACE1_IP = Ip.parse("2.2.2.1");
+  private static final Ip IFACE2_IP = Ip.parse("3.3.3.1");
 
   /*
    * Build a simple 1-node network with 2 VRFs
@@ -71,7 +78,7 @@ public class TraceroutePolicyBasedRoutingTest {
 
     Interface ingressIface =
         nf.interfaceBuilder()
-            .setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/31"))
+            .setAddress(ConcreteInterfaceAddress.create(INGRESS_IFACE_IP, 31))
             .setOwner(c1)
             .setVrf(v1)
             .setName("ingressInterface")
@@ -79,7 +86,7 @@ public class TraceroutePolicyBasedRoutingTest {
 
     if (withPolicy) {
       ingressIface.setRoutingPolicy(ROUTING_POLICY_NAME);
-      // IF dst IP is 9.9.9.9 use PBR to do a lookup in V2, which will cause the packet to
+      // If IP protocol is TCP use PBR to do a lookup in V2, which will cause the packet to
       // take a different exit interface
       c1.setPacketPolicies(
           ImmutableSortedMap.of(
@@ -90,17 +97,13 @@ public class TraceroutePolicyBasedRoutingTest {
                       new If(
                           new PacketMatchExpr(
                               new MatchHeaderSpace(
-                                  HeaderSpace.builder()
-                                      .setDstIps(Ip.parse("9.9.9.9").toIpSpace())
-                                      .build())),
+                                  HeaderSpace.builder().setIpProtocols(IpProtocol.TCP).build())),
                           ImmutableList.of(
                               new Return(new FibLookup(new LiteralVrfName(v2.getName()))))),
                       new If(
                           new PacketMatchExpr(
                               new MatchHeaderSpace(
-                                  HeaderSpace.builder()
-                                      .setDstIps(Ip.parse("10.10.10.10").toIpSpace())
-                                      .build())),
+                                  HeaderSpace.builder().setIpProtocols(IpProtocol.UDP).build())),
                           ImmutableList.of(new Return(Drop.instance())))),
                   new Return(new FibLookup(new LiteralVrfName(v1.getName()))))));
       ingressIface.setRoutingPolicy(ROUTING_POLICY_NAME);
@@ -108,14 +111,14 @@ public class TraceroutePolicyBasedRoutingTest {
 
     Interface i1 =
         nf.interfaceBuilder()
-            .setAddress(ConcreteInterfaceAddress.parse("2.2.2.1/24"))
+            .setAddress(ConcreteInterfaceAddress.create(IFACE1_IP, 24))
             .setOwner(c1)
             .setVrf(v1)
             .setName("i1")
             .build();
     Interface i2 =
         nf.interfaceBuilder()
-            .setAddress(ConcreteInterfaceAddress.parse("3.3.3.1/24"))
+            .setAddress(ConcreteInterfaceAddress.create(IFACE2_IP, 24))
             .setOwner(c1)
             .setVrf(v2)
             .setName("i2")
@@ -143,93 +146,213 @@ public class TraceroutePolicyBasedRoutingTest {
 
   @Test
   public void testWithNoPolicy() throws IOException {
+    /*
+     Construct TCP flow to 9.9.9.9, but don't set up PBR. Flow should take V1's static route out i1.
+    */
     SortedMap<String, Configuration> configs = pbrNetwork(false);
     Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
     PacketHeaderConstraints header =
-        PacketHeaderConstraints.builder().setSrcIp("1.1.1.222").setDstIp("9.9.9.9").build();
+        PacketHeaderConstraints.builder()
+            .setSrcIp("1.1.1.222")
+            .setDstIp("9.9.9.9")
+            .setIpProtocols(ImmutableSet.of(IpProtocol.TCP))
+            .build();
 
     TracerouteQuestion question =
         new TracerouteQuestion(SOURCE_LOCATION_STR, header, false, DEFAULT_MAX_TRACES);
-
     TracerouteAnswerer answerer = new TracerouteAnswerer(question, batfish);
-    TableAnswerElement answer = (TableAnswerElement) answerer.answer(batfish.getSnapshot());
-    assertThat(answer.getRows().getData(), hasSize(1));
+    Map<Flow, List<Trace>> traces = answerer.getTraces(batfish.getSnapshot(), question);
+
+    assertThat(traces.entrySet(), hasSize(1));
     assertThat(
-        answer.getRows().getData(),
-        everyItem(
-            hasColumn(
-                COL_TRACES,
-                everyItem(hasLastHop(hasOutputInterface(NodeInterfacePair.of("c1", "i1")))),
-                Schema.set(Schema.TRACE))));
+        traces.values().iterator().next(),
+        contains(hasHop(hasOutputInterface(NodeInterfacePair.of("c1", "i1")))));
   }
 
   @Test
   public void testMatchesPolicyIf() throws IOException {
+    /*
+     Construct TCP flow to 9.9.9.9. This should match the first PBR rule, resulting in a FIB lookup
+     in V2, so it should take V2's static route out i2.
+    */
     SortedMap<String, Configuration> configs = pbrNetwork(true);
     Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
     PacketHeaderConstraints header =
-        PacketHeaderConstraints.builder().setSrcIp("1.1.1.222").setDstIp("9.9.9.9").build();
+        PacketHeaderConstraints.builder()
+            .setSrcIp("1.1.1.222")
+            .setDstIp("9.9.9.9")
+            .setIpProtocols(ImmutableSet.of(IpProtocol.TCP))
+            .build();
 
     TracerouteQuestion question =
         new TracerouteQuestion(SOURCE_LOCATION_STR, header, false, DEFAULT_MAX_TRACES);
-
     TracerouteAnswerer answerer = new TracerouteAnswerer(question, batfish);
-    TableAnswerElement answer = (TableAnswerElement) answerer.answer(batfish.getSnapshot());
-    assertThat(answer.getRows().getData(), hasSize(1));
+    Map<Flow, List<Trace>> traces = answerer.getTraces(batfish.getSnapshot(), question);
+
+    assertThat(traces.entrySet(), hasSize(1));
     assertThat(
-        answer.getRows().getData(),
-        everyItem(
-            hasColumn(
-                COL_TRACES,
-                everyItem(hasLastHop(hasOutputInterface(NodeInterfacePair.of("c1", "i2")))),
-                Schema.set(Schema.TRACE))));
+        traces.values().iterator().next(),
+        contains(hasHop(hasOutputInterface(NodeInterfacePair.of("c1", "i2")))));
   }
 
   @Test
   public void testMatchesPolicyIfThenDropDrop() throws IOException {
+    /*
+     Construct UDP flow to 9.9.9.9. This should match the second PBR rule and get dropped.
+    */
     SortedMap<String, Configuration> configs = pbrNetwork(true);
     Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
     PacketHeaderConstraints header =
-        PacketHeaderConstraints.builder().setSrcIp("1.1.1.222").setDstIp("10.10.10.10").build();
+        PacketHeaderConstraints.builder()
+            .setSrcIp("1.1.1.222")
+            .setDstIp("9.9.9.9")
+            .setIpProtocols(ImmutableSet.of(IpProtocol.UDP))
+            .build();
 
     TracerouteQuestion question =
         new TracerouteQuestion(SOURCE_LOCATION_STR, header, false, DEFAULT_MAX_TRACES);
-
     TracerouteAnswerer answerer = new TracerouteAnswerer(question, batfish);
-    TableAnswerElement answer = (TableAnswerElement) answerer.answer(batfish.getSnapshot());
-    assertThat(answer.getRows().getData(), hasSize(1));
+    Map<Flow, List<Trace>> traces = answerer.getTraces(batfish.getSnapshot(), question);
+
+    assertThat(traces.entrySet(), hasSize(1));
     assertThat(
-        answer.getRows().getData(),
-        everyItem(
-            hasColumn(
-                COL_TRACES,
-                everyItem(hasDisposition(FlowDisposition.DENIED_IN)),
-                Schema.set(Schema.TRACE))));
+        traces.values().iterator().next(), contains(hasDisposition(FlowDisposition.DENIED_IN)));
   }
 
   @Test
   public void testDoesNotMatchPolicyIf() throws IOException {
+    /*
+     Construct ICMP flow to 9.9.9.9. This shouldn't match either PBR rule, so should take the
+     policy's default action of FIB lookup in V1. Should take V1's static route out i1.
+    */
     SortedMap<String, Configuration> configs = pbrNetwork(true);
     Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
     batfish.computeDataPlane(batfish.getSnapshot());
     PacketHeaderConstraints header =
-        PacketHeaderConstraints.builder().setSrcIp("1.1.1.222").setDstIp("9.9.9.233").build();
+        PacketHeaderConstraints.builder()
+            .setSrcIp("1.1.1.222")
+            .setDstIp("9.9.9.9")
+            .setIpProtocols(ImmutableSet.of(IpProtocol.ICMP))
+            .build();
 
     TracerouteQuestion question =
         new TracerouteQuestion(SOURCE_LOCATION_STR, header, false, DEFAULT_MAX_TRACES);
-
     TracerouteAnswerer answerer = new TracerouteAnswerer(question, batfish);
-    TableAnswerElement answer = (TableAnswerElement) answerer.answer(batfish.getSnapshot());
-    assertThat(answer.getRows().getData(), hasSize(1));
+    Map<Flow, List<Trace>> traces = answerer.getTraces(batfish.getSnapshot(), question);
+
+    assertThat(traces.entrySet(), hasSize(1));
     assertThat(
-        answer.getRows().getData(),
-        everyItem(
-            hasColumn(
-                COL_TRACES,
-                everyItem(hasLastHop(hasOutputInterface(NodeInterfacePair.of("c1", "i1")))),
-                Schema.set(Schema.TRACE))));
+        traces.values().iterator().next(),
+        contains(hasHop(hasOutputInterface(NodeInterfacePair.of("c1", "i1")))));
+  }
+
+  @Test
+  public void testMatchesPolicyIf_destinedForFirstVrf() throws IOException {
+    /*
+     Construct TCP flow to an IP owned by V1. This should match the first PBR rule, then get
+     accepted into V1.
+    */
+    SortedMap<String, Configuration> configs = pbrNetwork(true);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    PacketHeaderConstraints header =
+        PacketHeaderConstraints.builder()
+            .setSrcIp("1.1.1.222")
+            .setDstIp(IFACE1_IP.toString())
+            .setIpProtocols(ImmutableSet.of(IpProtocol.TCP))
+            .build();
+
+    TracerouteQuestion question =
+        new TracerouteQuestion(SOURCE_LOCATION_STR, header, false, DEFAULT_MAX_TRACES);
+    TracerouteAnswerer answerer = new TracerouteAnswerer(question, batfish);
+    Map<Flow, List<Trace>> traces = answerer.getTraces(batfish.getSnapshot(), question);
+
+    assertThat(traces.entrySet(), hasSize(1));
+    assertThat(
+        traces.values().iterator().next(),
+        contains(hasHop(hasAcceptingInterface(NodeInterfacePair.of("c1", "i1")))));
+  }
+
+  @Test
+  public void testMatchesPolicyIfThenDrop_destinedForFirstVrf() throws IOException {
+    /*
+     Construct UDP flow to an IP owned by V1. This should match the second PBR rule and get dropped.
+    */
+    SortedMap<String, Configuration> configs = pbrNetwork(true);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    PacketHeaderConstraints header =
+        PacketHeaderConstraints.builder()
+            .setSrcIp("1.1.1.222")
+            .setDstIp(IFACE1_IP.toString())
+            .setIpProtocols(ImmutableSet.of(IpProtocol.UDP))
+            .build();
+
+    TracerouteQuestion question =
+        new TracerouteQuestion(SOURCE_LOCATION_STR, header, false, DEFAULT_MAX_TRACES);
+    TracerouteAnswerer answerer = new TracerouteAnswerer(question, batfish);
+    Map<Flow, List<Trace>> traces = answerer.getTraces(batfish.getSnapshot(), question);
+
+    assertThat(traces.entrySet(), hasSize(1));
+    assertThat(
+        traces.values().iterator().next(), contains(hasDisposition(FlowDisposition.DENIED_IN)));
+  }
+
+  @Test
+  public void testDoesNotMatchPolicy_destinedForFirstVrf() throws IOException {
+    /*
+     Construct ICMP flow to an IP owned by V1. This shouldn't match either PBR rule, but since the
+     policy's default action is not DROP, it should still be accepted into V1.
+    */
+    SortedMap<String, Configuration> configs = pbrNetwork(true);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    PacketHeaderConstraints header =
+        PacketHeaderConstraints.builder()
+            .setSrcIp("1.1.1.222")
+            .setDstIp(IFACE1_IP.toString())
+            .setIpProtocols(ImmutableSet.of(IpProtocol.ICMP))
+            .build();
+
+    TracerouteQuestion question =
+        new TracerouteQuestion(SOURCE_LOCATION_STR, header, false, DEFAULT_MAX_TRACES);
+    TracerouteAnswerer answerer = new TracerouteAnswerer(question, batfish);
+    Map<Flow, List<Trace>> traces = answerer.getTraces(batfish.getSnapshot(), question);
+
+    assertThat(traces.entrySet(), hasSize(1));
+    assertThat(
+        traces.values().iterator().next(),
+        contains(hasHop(hasAcceptingInterface(NodeInterfacePair.of("c1", "i1")))));
+  }
+
+  @Test
+  public void testMatchesPolicyIf_destinedForSecondVrf() throws IOException {
+    /*
+     Construct TCP flow to an IP owned by V2. This should match the first PBR rule, then should be
+     forwarded according to V2's FIB, resulting in NEIGHBOR_UNREACHABLE. There should never be an
+     opportunity for V2 to accept the flow (even though it owns the dst IP).
+    */
+    SortedMap<String, Configuration> configs = pbrNetwork(true);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _folder);
+    batfish.computeDataPlane(batfish.getSnapshot());
+    PacketHeaderConstraints header =
+        PacketHeaderConstraints.builder()
+            .setSrcIp("1.1.1.222")
+            .setDstIp(IFACE2_IP.toString())
+            .setIpProtocols(ImmutableSet.of(IpProtocol.TCP))
+            .build();
+
+    TracerouteQuestion question =
+        new TracerouteQuestion(SOURCE_LOCATION_STR, header, false, DEFAULT_MAX_TRACES);
+    TracerouteAnswerer answerer = new TracerouteAnswerer(question, batfish);
+    Map<Flow, List<Trace>> traces = answerer.getTraces(batfish.getSnapshot(), question);
+
+    assertThat(traces.entrySet(), hasSize(1));
+    assertThat(
+        traces.values().iterator().next(),
+        contains(hasDisposition(FlowDisposition.NEIGHBOR_UNREACHABLE)));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/HopMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/HopMatchers.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Hop;
 import org.batfish.datamodel.flow.Step;
+import org.batfish.datamodel.matchers.HopMatchersImpl.HasAcceptingInterface;
 import org.batfish.datamodel.matchers.HopMatchersImpl.HasEnterInputInterface;
 import org.batfish.datamodel.matchers.HopMatchersImpl.HasExitOutputInterface;
 import org.batfish.datamodel.matchers.HopMatchersImpl.HasNodeName;
@@ -17,6 +18,10 @@ import org.hamcrest.Matcher;
 public final class HopMatchers {
   public static HasNodeName hasNodeName(String nodeName) {
     return new HasNodeName(equalTo(nodeName));
+  }
+
+  public static Matcher<Hop> hasAcceptingInterface(NodeInterfacePair iface) {
+    return new HasAcceptingInterface(is(iface));
   }
 
   public static HasEnterInputInterface hasInputInterface(NodeInterfacePair iface) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/HopMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/HopMatchersImpl.java
@@ -12,6 +12,7 @@ import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.EnterInputIfaceStep;
 import org.batfish.datamodel.flow.ExitOutputIfaceStep;
 import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.InboundStep;
 import org.batfish.datamodel.flow.Step;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -27,6 +28,24 @@ final class HopMatchersImpl {
     @Override
     protected String featureValueOf(Hop hop) {
       return hop.getNode().getName();
+    }
+  }
+
+  static class HasAcceptingInterface extends FeatureMatcher<Hop, NodeInterfacePair> {
+    HasAcceptingInterface(Matcher<? super NodeInterfacePair> subMatcher) {
+      super(subMatcher, "a Hop with accepting interface:", "accepting interface");
+    }
+
+    @Override
+    protected NodeInterfacePair featureValueOf(Hop hop) {
+      List<Step<?>> steps =
+          hop.getSteps().stream()
+              .filter(step -> step instanceof InboundStep)
+              .collect(ImmutableList.toImmutableList());
+      assertThat(steps, hasSize(1));
+
+      InboundStep lastStep = (InboundStep) steps.get(0);
+      return NodeInterfacePair.of(hop.getNode().getName(), lastStep.getDetail().getInterface());
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/TraceMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/TraceMatchers.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel.matchers;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.List;
@@ -36,6 +37,11 @@ public final class TraceMatchers {
   /** A {@link Matcher} for {@link Trace} {@link Hop hops}. */
   public static HasHops hasHops(Matcher<? super List<? extends Hop>> hopsMatcher) {
     return new HasHops(hopsMatcher);
+  }
+
+  /** A {@link Matcher} for a {@link Trace} with a single {@link Hop}. */
+  public static HasHops hasHop(Matcher<? super Hop> hopMatcher) {
+    return hasHops(contains(hopMatcher));
   }
 
   /** A {@link Matcher} for the last hop in a {@link Trace}. */

--- a/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/traceroute/TracerouteAnswerer.java
@@ -2,6 +2,7 @@ package org.batfish.question.traceroute;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedHashMultiset;
 import com.google.common.collect.Multiset;
@@ -39,7 +40,8 @@ public final class TracerouteAnswerer extends Answerer {
     super(question, batfish);
   }
 
-  private SortedMap<Flow, List<Trace>> getTraces(NetworkSnapshot snapshot, TracerouteQuestion q) {
+  @VisibleForTesting
+  SortedMap<Flow, List<Trace>> getTraces(NetworkSnapshot snapshot, TracerouteQuestion q) {
     TracerouteAnswererHelper helper =
         new TracerouteAnswererHelper(
             q.getHeaderConstraints(),


### PR DESCRIPTION
Adds tests that:
- Flows destined for the ingress VRF will be accepted iff the packet policy does not reject them
- Flows that match a packet policy rule to do a FIB lookup in a second VRF won't be *accepted* into that second VRF, even if it owns their dst IP

Also refactored the test a bit:
- The test PBR policy's rules now match on protocols instead of dst IPs (specifically, TCP instead of 9.9.9.9 and UDP instead of 10.10.10.10). This was necessary to experiment with flows with different dst IPs.
- The `TracerouteAnswerer` method `getTraces` is now visible for testing, so this test doesn't have to extract traces from tables. The `TracerouteAnswerer` infrastructure that converts the result of `getTraces` into table answers is already tested separately.