### PR TITLE
Reachability: Let PBR flows get accepted

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/VrfExprNameExtractor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/packet_policy/VrfExprNameExtractor.java
@@ -1,0 +1,25 @@
+package org.batfish.datamodel.packet_policy;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Interface;
+
+/** {@link VrfExprVisitor} that provides the name of the specified VRF. */
+@ParametersAreNonnullByDefault
+public class VrfExprNameExtractor implements VrfExprVisitor<String> {
+  @Nonnull private final Interface _ingressIface;
+
+  public VrfExprNameExtractor(Interface ingressIface) {
+    _ingressIface = ingressIface;
+  }
+
+  @Override
+  public String visitLiteralVrfName(LiteralVrfName expr) {
+    return expr.getVrfName();
+  }
+
+  @Override
+  public String visitIngressInterfaceVrf(IngressInterfaceVrf expr) {
+    return _ingressIface.getVrfName();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDFibGenerator.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDFibGenerator.java
@@ -1,13 +1,8 @@
 package org.batfish.bddreachability;
 
-import static org.batfish.common.util.CollectionUtil.toImmutableMap;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Streams;
-import java.util.Collection;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -72,38 +67,21 @@ public final class BDDFibGenerator {
       Map<String, Map<String, Map<String, BDD>>> exitsNetworkBDDs,
       Map<String, Map<String, Map<String, BDD>>> insufficientInfoBDDs,
       Map<String, Map<String, Map<String, BDD>>> ifaceAcceptBDDs,
+      Map<String, Map<String, BDD>> vrfAcceptBDDs,
       Map<String, Map<String, BDD>> routableBDDs,
       Map<String, Map<String, Map<String, BDD>>> nextVrfBDDs,
-      Map<String, Map<String, BDD>> nullRoutedBDDs,
-      Function<Collection<BDD>, BDD> orAll) {
+      Map<String, Map<String, BDD>> nullRoutedBDDs) {
     _arpTrueEdgeBDDs = arpTrueEdgeBDDs;
     _neighborUnreachableBDDs = neighborUnreachableBDDs;
     _deliveredToSubnetBDDs = deliveredToSubnetBDDs;
     _exitsNetworkBDDs = exitsNetworkBDDs;
     _insufficientInfoBDDs = insufficientInfoBDDs;
     _ifaceAcceptBDDs = ifaceAcceptBDDs;
-    _vrfAcceptBDDs = computeVrfAcceptBDDs(_ifaceAcceptBDDs, orAll);
     _routableBDDs = routableBDDs;
     _nextVrfBDDs = nextVrfBDDs;
     _nullRoutedBDDs = nullRoutedBDDs;
-  }
-
-  /**
-   * Given a mapping of interface accept BDDs (node -&gt; vrf -&gt; interface -&gt; accept BDD),
-   * returns a mapping of node -&gt; vrf -&gt; accept BDD where each VRF's accept BDD is the union
-   * of its interfaces' accept BDDs.
-   */
-  private static Map<String, Map<String, BDD>> computeVrfAcceptBDDs(
-      Map<String, Map<String, Map<String, BDD>>> ifaceAcceptBdds,
-      Function<Collection<BDD>, BDD> orAll) {
-    return toImmutableMap(
-        ifaceAcceptBdds,
-        Entry::getKey, // node name
-        nodeEntry ->
-            toImmutableMap(
-                nodeEntry.getValue(),
-                Entry::getKey, // vrf name
-                vrfEntry -> orAll.apply(vrfEntry.getValue().values()))); // vrf's accept BDD
+    // fully determined by ifaceAcceptBdds, but already computed in BDDReachabilityAnalysisFactory
+    _vrfAcceptBDDs = vrfAcceptBDDs;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateExprToLocation.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateExprToLocation.java
@@ -17,6 +17,7 @@ import org.batfish.symbolic.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.symbolic.state.OriginateInterface;
 import org.batfish.symbolic.state.OriginateInterfaceLink;
 import org.batfish.symbolic.state.OriginateVrf;
+import org.batfish.symbolic.state.PbrFibLookup;
 import org.batfish.symbolic.state.PostInInterface;
 import org.batfish.symbolic.state.PostInInterfacePostNat;
 import org.batfish.symbolic.state.PostInVrf;
@@ -162,6 +163,11 @@ public final class OriginationStateExprToLocation implements StateExprVisitor<Op
 
   @Override
   public Optional<Location> visitOriginateVrf(OriginateVrf originateVrf) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Location> visitPbrFibLookup(PbrFibLookup pbrFibLookup) {
     return Optional.empty();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateToTerminationState.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateToTerminationState.java
@@ -16,6 +16,7 @@ import org.batfish.symbolic.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.symbolic.state.OriginateInterface;
 import org.batfish.symbolic.state.OriginateInterfaceLink;
 import org.batfish.symbolic.state.OriginateVrf;
+import org.batfish.symbolic.state.PbrFibLookup;
 import org.batfish.symbolic.state.PostInInterface;
 import org.batfish.symbolic.state.PostInInterfacePostNat;
 import org.batfish.symbolic.state.PostInVrf;
@@ -166,6 +167,11 @@ public class OriginationStateToTerminationState implements StateExprVisitor<List
   @Override
   public List<StateExpr> visitOriginateVrf(OriginateVrf originateVrf) {
     return ImmutableList.of(new VrfAccept(originateVrf.getHostname(), originateVrf.getVrf()));
+  }
+
+  @Override
+  public List<StateExpr> visitPbrFibLookup(PbrFibLookup pbrFibLookup) {
+    return null;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/PreOutgoingTransformationNodeVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/PreOutgoingTransformationNodeVisitor.java
@@ -14,6 +14,7 @@ import org.batfish.symbolic.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.symbolic.state.OriginateInterface;
 import org.batfish.symbolic.state.OriginateInterfaceLink;
 import org.batfish.symbolic.state.OriginateVrf;
+import org.batfish.symbolic.state.PbrFibLookup;
 import org.batfish.symbolic.state.PostInInterface;
 import org.batfish.symbolic.state.PostInInterfacePostNat;
 import org.batfish.symbolic.state.PostInVrf;
@@ -152,6 +153,11 @@ public class PreOutgoingTransformationNodeVisitor implements StateExprVisitor<No
 
   @Override
   public NodeInterfacePair visitOriginateVrf(OriginateVrf originateVrf) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitPbrFibLookup(PbrFibLookup pbrFibLookup) {
     return null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/ReversePassOriginationState.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/ReversePassOriginationState.java
@@ -15,6 +15,7 @@ import org.batfish.symbolic.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.symbolic.state.OriginateInterface;
 import org.batfish.symbolic.state.OriginateInterfaceLink;
 import org.batfish.symbolic.state.OriginateVrf;
+import org.batfish.symbolic.state.PbrFibLookup;
 import org.batfish.symbolic.state.PostInInterface;
 import org.batfish.symbolic.state.PostInInterfacePostNat;
 import org.batfish.symbolic.state.PostInVrf;
@@ -174,6 +175,11 @@ public class ReversePassOriginationState implements StateExprVisitor<StateExpr> 
 
   @Override
   public StateExpr visitOriginateVrf(OriginateVrf originateVrf) {
+    return null;
+  }
+
+  @Override
+  public StateExpr visitPbrFibLookup(PbrFibLookup pbrFibLookup) {
     return null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/SessionCreationNodeVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/SessionCreationNodeVisitor.java
@@ -14,6 +14,7 @@ import org.batfish.symbolic.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.symbolic.state.OriginateInterface;
 import org.batfish.symbolic.state.OriginateInterfaceLink;
 import org.batfish.symbolic.state.OriginateVrf;
+import org.batfish.symbolic.state.PbrFibLookup;
 import org.batfish.symbolic.state.PostInInterface;
 import org.batfish.symbolic.state.PostInInterfacePostNat;
 import org.batfish.symbolic.state.PostInVrf;
@@ -157,6 +158,11 @@ final class SessionCreationNodeVisitor implements StateExprVisitor<NodeInterface
 
   @Override
   public NodeInterfacePair visitOriginateVrf(OriginateVrf originateVrf) {
+    return null;
+  }
+
+  @Override
+  public NodeInterfacePair visitPbrFibLookup(PbrFibLookup pbrFibLookup) {
     return null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -108,10 +108,8 @@ import org.batfish.datamodel.packet_policy.FibLookup;
 import org.batfish.datamodel.packet_policy.FibLookupOverrideLookupIp;
 import org.batfish.datamodel.packet_policy.FlowEvaluator;
 import org.batfish.datamodel.packet_policy.FlowEvaluator.FlowResult;
-import org.batfish.datamodel.packet_policy.IngressInterfaceVrf;
-import org.batfish.datamodel.packet_policy.LiteralVrfName;
 import org.batfish.datamodel.packet_policy.PacketPolicy;
-import org.batfish.datamodel.packet_policy.VrfExprVisitor;
+import org.batfish.datamodel.packet_policy.VrfExprNameExtractor;
 import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.TransformationEvaluator;
@@ -528,18 +526,7 @@ class FlowTracer {
     return new ActionVisitor<Boolean>() {
 
       /** Helper visitor to figure out in which VRF we need to do the FIB lookup */
-      private VrfExprVisitor<String> _vrfExprVisitor =
-          new VrfExprVisitor<String>() {
-            @Override
-            public String visitLiteralVrfName(@Nonnull LiteralVrfName expr) {
-              return expr.getVrfName();
-            }
-
-            @Override
-            public String visitIngressInterfaceVrf(@Nonnull IngressInterfaceVrf expr) {
-              return incomingInterface.getVrfName();
-            }
-          };
+      private VrfExprNameExtractor _vrfExprVisitor = new VrfExprNameExtractor(incomingInterface);
 
       @Override
       public Boolean visitDrop(@Nonnull Drop drop) {

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDFibGeneratorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDFibGeneratorTest.java
@@ -1,5 +1,6 @@
 package org.batfish.bddreachability;
 
+import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItem;
@@ -9,6 +10,7 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
 import org.batfish.common.bdd.BDDPacket;
@@ -141,10 +143,10 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ifaceAcceptBDDs,
+            toVrfAcceptBdds(ifaceAcceptBDDs),
             routableBDDs,
             ImmutableMap.of(),
-            ImmutableMap.of(),
-            PKT.getFactory()::orAll);
+            ImmutableMap.of());
     Edge expectedEdge =
         new Edge(
             new InterfaceAccept(NODE1, IFACE1), new VrfAccept(NODE1, VRF1), PKT.getFactory().one());
@@ -189,10 +191,10 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ifaceAcceptBDDs,
+            toVrfAcceptBdds(ifaceAcceptBDDs),
             routableBDDs,
             ImmutableMap.of(),
-            ImmutableMap.of(),
-            PKT.getFactory()::orAll);
+            ImmutableMap.of());
     Edge expectedEdge =
         new Edge(new TestPostInVrf(NODE1, VRF1), new InterfaceAccept(NODE1, IFACE1), DSTIP1);
 
@@ -235,10 +237,10 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ifaceAcceptBdds,
+            toVrfAcceptBdds(ifaceAcceptBdds),
             routableBDDs,
             ImmutableMap.of(),
-            ImmutableMap.of(),
-            PKT.getFactory()::orAll);
+            ImmutableMap.of());
     Edge expectedEdge =
         new Edge(new TestPostInVrf(NODE1, VRF1), new NodeDropNoRoute(NODE1), DSTIP1.nor(DSTIP2));
 
@@ -280,9 +282,9 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of(),
-            nextVrfBDDs,
             ImmutableMap.of(),
-            PKT.getFactory()::orAll);
+            nextVrfBDDs,
+            ImmutableMap.of());
     Edge expectedEdge =
         new Edge(new TestPostInVrf(NODE1, VRF1), new TestPostInVrf(NODE1, VRF2), DSTIP1);
 
@@ -329,10 +331,10 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ifaceAcceptBdds,
+            toVrfAcceptBdds(ifaceAcceptBdds),
             routableBDDs,
             ImmutableMap.of(),
-            ImmutableMap.of(),
-            PKT.getFactory()::orAll);
+            ImmutableMap.of());
     Edge expectedEdge =
         new Edge(new TestPostInVrf(NODE1, VRF1), new TestPreOutVrf(NODE1, VRF1), DSTIP2);
 
@@ -372,8 +374,8 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of(),
-            nullRoutedBDDs,
-            PKT.getFactory()::orAll);
+            ImmutableMap.of(),
+            nullRoutedBDDs);
     Edge expectedEdge =
         new Edge(new TestPreOutVrf(NODE1, VRF1), new NodeDropNullRoute(NODE1), DSTIP1);
 
@@ -423,7 +425,7 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of(),
-            PKT.getFactory()::orAll);
+            ImmutableMap.of());
     Edge expectedEdge =
         new Edge(
             new TestPreOutVrf(NODE1, VRF1),
@@ -489,7 +491,7 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of(),
-            PKT.getFactory()::orAll);
+            ImmutableMap.of());
     Edge expectedEdgeNeighborUnreachable =
         new Edge(
             new TestPreOutVrf(NODE1, VRF1),
@@ -567,5 +569,18 @@ public final class BDDFibGeneratorTest {
                 new TestPreOutVrf(NODE1, VRF1),
                 new TestPreOutInterfaceExitsNetwork(NODE1, IFACE1),
                 DSTIP1)));
+  }
+
+  private static Map<String, Map<String, BDD>> toVrfAcceptBdds(
+      Map<String, Map<String, Map<String, BDD>>> ifaceAcceptBdds) {
+    return toImmutableMap(
+        ifaceAcceptBdds,
+        Entry::getKey, // node name
+        nodeEntry ->
+            toImmutableMap(
+                nodeEntry.getValue(),
+                Entry::getKey, // vrf name
+                vrfEntry ->
+                    PKT.getFactory().orAll(vrfEntry.getValue().values()))); // vrf's accept BDD}
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -125,6 +125,7 @@ import org.batfish.symbolic.state.NodeInterfaceNeighborUnreachable;
 import org.batfish.symbolic.state.OriginateInterface;
 import org.batfish.symbolic.state.OriginateInterfaceLink;
 import org.batfish.symbolic.state.OriginateVrf;
+import org.batfish.symbolic.state.PbrFibLookup;
 import org.batfish.symbolic.state.PostInInterface;
 import org.batfish.symbolic.state.PostInVrf;
 import org.batfish.symbolic.state.PreInInterface;
@@ -1580,17 +1581,19 @@ public final class BDDReachabilityAnalysisFactoryTest {
             ImmutableSet.of(hostname),
             ImmutableSet.of(EXITS_NETWORK));
 
-    // Check state edge presence
+    // Check state edge presence (note, INGRESS_IFACE is in vrf1, not INGRESS_VRF)
+    PbrFibLookup pbrFibLookup = new PbrFibLookup(hostname, "vrf1", "vrf2");
+    PreOutVrf preOutVrf2 = new PreOutVrf(hostname, "vrf2");
     assertThat(
         analysis.getForwardEdgeMap(),
         hasEntry(
-            equalTo(new PreInInterface(hostname, INGRESS_IFACE)),
-            hasKey(equalTo(new PostInVrf(hostname, "vrf2")))));
+            equalTo(new PreInInterface(hostname, INGRESS_IFACE)), hasKey(equalTo(pbrFibLookup))));
+    assertThat(
+        analysis.getForwardEdgeMap(), hasEntry(equalTo(pbrFibLookup), hasKey(equalTo(preOutVrf2))));
     assertThat(
         analysis.getForwardEdgeMap(),
         hasEntry(
-            equalTo(new PreOutVrf(hostname, "vrf2")),
-            hasKey(equalTo(new PreOutInterfaceExitsNetwork(hostname, "i1")))));
+            equalTo(preOutVrf2), hasKey(equalTo(new PreOutInterfaceExitsNetwork(hostname, "i1")))));
 
     // End-to-end reachability based on reachable ingress locations
     Map<IngressLocation, BDD> bdds = analysis.getIngressLocationReachableBDDs();
@@ -1639,16 +1642,19 @@ public final class BDDReachabilityAnalysisFactoryTest {
             ImmutableSet.of(neighborHostname),
             ImmutableSet.of(ACCEPTED));
 
-    // Check state edge presence
+    // Check state edge presence (note, INGRESS_IFACE is in vrf1, not INGRESS_VRF)
+    PbrFibLookup pbrFibLookup = new PbrFibLookup(hostname, "vrf1", "vrf2");
+    PreOutVrf preOutVrf2 = new PreOutVrf(hostname, "vrf2");
     assertThat(
         analysis.getForwardEdgeMap(),
         hasEntry(
-            equalTo(new PreInInterface(hostname, INGRESS_IFACE)),
-            hasKey(equalTo(new PostInVrf(hostname, "vrf2")))));
+            equalTo(new PreInInterface(hostname, INGRESS_IFACE)), hasKey(equalTo(pbrFibLookup))));
+    assertThat(
+        analysis.getForwardEdgeMap(), hasEntry(equalTo(pbrFibLookup), hasKey(equalTo(preOutVrf2))));
     assertThat(
         analysis.getForwardEdgeMap(),
         hasEntry(
-            equalTo(new PreOutVrf(hostname, "vrf2")),
+            equalTo(preOutVrf2),
             hasKey(equalTo(new PreOutEdge(hostname, "i1", neighborHostname, neighborIface)))));
   }
 

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/PbrFibLookup.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/PbrFibLookup.java
@@ -1,0 +1,63 @@
+package org.batfish.symbolic.state;
+
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * Represents state when the flow has matched a FIB lookup rule in a packet policy. At this point,
+ * if the flow's dst IP is owned by the VRF where it arrived, it is accepted (represented by edges
+ * to {@link InterfaceAccept}). Otherwise, it is forwarded based on the lookup VRF's FIB
+ * (represented by edge to {@link PreOutVrf}).
+ */
+@ParametersAreNonnullByDefault
+public final class PbrFibLookup implements StateExpr {
+  @Nonnull private final String _hostname;
+  @Nonnull private final String _ingressVrf;
+  @Nonnull private final String _lookupVrf;
+
+  public PbrFibLookup(String hostname, String ingressVrf, String lookupVrf) {
+    _hostname = hostname;
+    _ingressVrf = ingressVrf;
+    _lookupVrf = lookupVrf;
+  }
+
+  @Nonnull
+  public String getHostname() {
+    return _hostname;
+  }
+
+  @Nonnull
+  public String getIngressVrf() {
+    return _ingressVrf;
+  }
+
+  @Nonnull
+  public String getLookupVrf() {
+    return _lookupVrf;
+  }
+
+  @Override
+  public <R> R accept(StateExprVisitor<R> visitor) {
+    return visitor.visitPbrFibLookup(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof PbrFibLookup)) {
+      return false;
+    }
+    PbrFibLookup o = (PbrFibLookup) obj;
+    return _hostname.equals(o._hostname)
+        && _ingressVrf.equals(o._ingressVrf)
+        && _lookupVrf.equals(o._lookupVrf);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_hostname, _ingressVrf, _lookupVrf);
+  }
+}

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/StateExprVisitor.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/StateExprVisitor.java
@@ -48,6 +48,8 @@ public interface StateExprVisitor<R> {
 
   R visitOriginateVrf(OriginateVrf originateVrf);
 
+  R visitPbrFibLookup(PbrFibLookup pbrFibLookup);
+
   R visitPostInInterface(PostInInterface postInInterface);
 
   R visitPostInInterfacePostNat(PostInInterfacePostNat postInInterfacePostNat);


### PR DESCRIPTION
Replaces `PreInInterface -> PostInVrf` PBR edge with three new edges including a new state:
- `PreInInterface -> PbrFibLookup`
- `PbrFibLookup -> InterfaceAccept`, one per interface in the ingress VRF
- `PbrFibLookup -> PreOutVrf`, where the `PreOutVrf` VRF is the one referred to by the PBR FIB lookup

This setup allows flows destined for the ingress VRF to get accepted in that VRF after matching the PBR policy.