### PR TITLE
BDDFlowConstraintGenerator: use flow constraints

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFlowConstraintGenerator.java
@@ -180,18 +180,6 @@ public final class BDDFlowConstraintGenerator {
         .build();
   }
 
-  private List<BDD> computeTraceroutePrefs() {
-    BDDInteger srcPort = _bddPacket.getSrcPort();
-    BDD tcp = _bddPacket.getIpProtocol().value(IpProtocol.TCP);
-
-    return ImmutableList.<BDD>builder()
-        .add(emphemeralPort(srcPort))
-        .add(_defaultPacketLength)
-        .add(_udpTraceroute)
-        .add(tcp.and(_bddPacket.getTcpSyn()))
-        .build();
-  }
-
   @VisibleForTesting
   static BDD isPrivateIp(IpSpaceToBDD ip) {
     return BDDOps.orNull(
@@ -255,7 +243,13 @@ public final class BDDFlowConstraintGenerator {
             .addAll(_ipConstraints)
             .build();
       case TRACEROUTE:
-        return computeTraceroutePrefs();
+        return ImmutableList.<BDD>builder()
+            .addAll(_udpConstraints)
+            .addAll(_tcpConstraints)
+            .addAll(_icmpConstraints)
+            .add(_defaultPacketLength)
+            .addAll(_ipConstraints)
+            .build();
       default:
         throw new BatfishException("Not supported flow preference");
     }


### PR DESCRIPTION
Reorder UDP (which includes UDP traceroute to the top) when in traceroute mode,
but otherwise continue to use flow constraints. This restores ICMP defaulting to
ECHO_REQUEST, and a few other similar improvements.