### PR TITLE
VI infrastructure to filter on original flow

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -70,6 +70,7 @@ public final class Interface extends ComparableStructure<String> {
     private @Nullable Integer _nativeVlan;
     private OspfInterfaceSettings _ospfSettings;
     private IpAccessList _outgoingFilter;
+    @Nullable private IpAccessList _outgoingOriginalFlowFilter;
     private Transformation _outgoingTransformation;
     private Configuration _owner;
     private String _routingPolicy;
@@ -152,6 +153,7 @@ public final class Interface extends ComparableStructure<String> {
         iface.setNativeVlan(_nativeVlan);
       }
       iface.setOutgoingFilter(_outgoingFilter);
+      iface.setOutgoingOriginalFlowFilter(_outgoingOriginalFlowFilter);
       iface.setOutgoingTransformation(_outgoingTransformation);
       iface.setOwner(_owner);
       if (_owner != null) {
@@ -377,6 +379,11 @@ public final class Interface extends ComparableStructure<String> {
       return this;
     }
 
+    public Builder setOutgoingOriginalFlowFilter(IpAccessList outgoingOriginalFlowFilter) {
+      _outgoingOriginalFlowFilter = outgoingOriginalFlowFilter;
+      return this;
+    }
+
     public Builder setOutgoingTransformation(Transformation outgoingTransformation) {
       _outgoingTransformation = outgoingTransformation;
       return this;
@@ -573,6 +580,7 @@ public final class Interface extends ComparableStructure<String> {
   private static final String PROP_NATIVE_VLAN = "nativeVlan";
   private static final String PROP_OSPF_SETTINGS = "ospfSettings";
   private static final String PROP_OUTGOING_FILTER = "outgoingFilter";
+  private static final String PROP_OUTGOING_ORIGINAL_FLOW_FILTER = "outgoingOriginalFlowFilter";
   private static final String PROP_OUTGOING_TRANSFORMATION = "outgoingTransformation";
   private static final String PROP_POST_TRANSFORMATION_INCOMING_FILTER =
       "postTransformationIncomingFilter";
@@ -845,6 +853,8 @@ public final class Interface extends ComparableStructure<String> {
   @Nullable private OspfInterfaceSettings _ospfSettings;
   private IpAccessList _outgoingFilter;
   private transient String _outgoingFilterName;
+  @Nullable private IpAccessList _outgoingOriginalFlowFilter;
+  @Nullable private transient String _outgoingOriginalFlowFilterName;
   private Transformation _outgoingTransformation;
   private Configuration _owner;
   private InterfaceAddress _address;
@@ -973,6 +983,10 @@ public final class Interface extends ComparableStructure<String> {
     }
     // TODO: check OSPF settings for equality.
     if (!IpAccessList.bothNullOrSameName(_outgoingFilter, other._outgoingFilter)) {
+      return false;
+    }
+    if (!IpAccessList.bothNullOrSameName(
+        _outgoingOriginalFlowFilter, other._outgoingOriginalFlowFilter)) {
       return false;
     }
     if (!_proxyArp == other._proxyArp) {
@@ -1289,6 +1303,12 @@ public final class Interface extends ComparableStructure<String> {
     return _outgoingFilter;
   }
 
+  @Nullable
+  @JsonIgnore
+  public IpAccessList getOutgoingOriginalFlowFilter() {
+    return _outgoingOriginalFlowFilter;
+  }
+
   /** The IPV4 access-list used to filter traffic that is sent out this interface. Stored as @id. */
   @JsonProperty(PROP_OUTGOING_FILTER)
   public String getOutgoingFilterName() {
@@ -1297,6 +1317,17 @@ public final class Interface extends ComparableStructure<String> {
     } else {
       return _outgoingFilterName;
     }
+  }
+
+  /**
+   * The IPV4 access-list used to filter traffic sent out this interface matching on the original
+   * flow that entered the node (before any transformations).
+   */
+  @JsonProperty(PROP_OUTGOING_ORIGINAL_FLOW_FILTER)
+  private String getOutgoingOriginalFlowFilterName() {
+    return _outgoingOriginalFlowFilter != null
+        ? _outgoingOriginalFlowFilter.getName()
+        : _outgoingOriginalFlowFilterName;
   }
 
   @JsonProperty(PROP_OUTGOING_TRANSFORMATION)
@@ -1659,6 +1690,16 @@ public final class Interface extends ComparableStructure<String> {
   @JsonProperty(PROP_OUTGOING_FILTER)
   public void setOutgoingFilter(String outgoingFilterName) {
     _outgoingFilterName = outgoingFilterName;
+  }
+
+  @JsonIgnore
+  public void setOutgoingOriginalFlowFilter(@Nullable IpAccessList outgoingOriginalFlowFilter) {
+    _outgoingOriginalFlowFilter = outgoingOriginalFlowFilter;
+  }
+
+  @JsonProperty(PROP_OUTGOING_ORIGINAL_FLOW_FILTER)
+  private void setOutgoingOriginalFlowFilter(String outgoingOriginalFlowFilterName) {
+    _outgoingOriginalFlowFilterName = outgoingOriginalFlowFilterName;
   }
 
   @JsonProperty(PROP_OUTGOING_TRANSFORMATION)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FilterStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FilterStep.java
@@ -33,6 +33,7 @@ public class FilterStep extends Step<FilterStepDetail> {
         case POST_TRANSFORMATION_INGRESS_FILTER:
           return FlowDisposition.DENIED_IN;
         case EGRESS_FILTER:
+        case EGRESS_ORIGINAL_FLOW_FILTER:
         case PRE_TRANSFORMATION_EGRESS_FILTER:
           return FlowDisposition.DENIED_OUT;
         default:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FilterStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/FilterStep.java
@@ -20,6 +20,8 @@ public class FilterStep extends Step<FilterStepDetail> {
     INGRESS_FILTER,
     /** egress filter */
     EGRESS_FILTER,
+    /** egress filter matching on original (pre-transformation) flow */
+    EGRESS_ORIGINAL_FLOW_FILTER,
     /** post-transformation ingress filter */
     POST_TRANSFORMATION_INGRESS_FILTER,
     /** pre-transformation egress filter */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -891,14 +891,6 @@ class FlowTracer {
                     return null;
                   }
 
-                  // apply outgoing filter matching original flow
-                  if (applyFilterToOriginalFlow(
-                          outgoingInterface.getOutgoingOriginalFlowFilter(),
-                          EGRESS_ORIGINAL_FLOW_FILTER)
-                      == DENIED) {
-                    return null;
-                  }
-
                   // add ExitOutIfaceStep
                   _steps.add(buildExitOutputIfaceStep(outgoingInterfaceName));
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -891,6 +891,14 @@ class FlowTracer {
                     return null;
                   }
 
+                  // apply outgoing filter matching original flow
+                  if (applyFilterToOriginalFlow(
+                          outgoingInterface.getOutgoingOriginalFlowFilter(),
+                          EGRESS_ORIGINAL_FLOW_FILTER)
+                      == DENIED) {
+                    return null;
+                  }
+
                   // add ExitOutIfaceStep
                   _steps.add(buildExitOutputIfaceStep(outgoingInterfaceName));
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -8,6 +8,7 @@ import static java.util.Comparator.comparing;
 import static org.batfish.datamodel.FlowDiff.flowDiffs;
 import static org.batfish.datamodel.FlowDiff.returnFlowDiffs;
 import static org.batfish.datamodel.flow.FilterStep.FilterType.EGRESS_FILTER;
+import static org.batfish.datamodel.flow.FilterStep.FilterType.EGRESS_ORIGINAL_FLOW_FILTER;
 import static org.batfish.datamodel.flow.FilterStep.FilterType.INGRESS_FILTER;
 import static org.batfish.datamodel.flow.FilterStep.FilterType.POST_TRANSFORMATION_INGRESS_FILTER;
 import static org.batfish.datamodel.flow.FilterStep.FilterType.PRE_TRANSFORMATION_EGRESS_FILTER;
@@ -978,7 +979,7 @@ class FlowTracer {
 
     // apply outgoing filter matching original flow
     if (applyFilterToOriginalFlow(
-            outgoingInterface.getOutgoingOriginalFlowFilter(), PRE_TRANSFORMATION_EGRESS_FILTER)
+            outgoingInterface.getOutgoingOriginalFlowFilter(), EGRESS_ORIGINAL_FLOW_FILTER)
         == DENIED) {
       return;
     }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -289,7 +289,7 @@ class FlowTracer {
     return vrfName;
   }
 
-  /** Construct a {@link FlowTracer} with expliclty-provided fields. */
+  /** Construct a {@link FlowTracer} with explicitly-provided fields. */
   @VisibleForTesting
   FlowTracer(
       TracerouteEngineImplContext tracerouteContext,
@@ -596,7 +596,7 @@ class FlowTracer {
 
         Fib fib = _tracerouteContext.getFib(currentNodeName, incomingInterface.getVrfName()).get();
         // Re-resolve and send out using FIB lookup part of the pipeline.
-        // Call the version of fibLookup that keeps track of overriden nextHopIp
+        // Call the version of fibLookup that keeps track of overridden nextHopIp
         Ip dstIp = result.getFinalFlow().getDstIp();
         fibLookup(dstIp, lookupIp, currentNodeName, fib);
         return true;
@@ -658,7 +658,7 @@ class FlowTracer {
   private void fibLookup(
       Ip dstIp, @Nullable Ip overrideNextHopIp, String currentNodeName, Fib fib) {
     fibLookup(
-        // Intentionally looking up the overriden NH
+        // Intentionally looking up the overridden NH
         firstNonNull(overrideNextHopIp, dstIp),
         currentNodeName,
         fib,
@@ -955,11 +955,12 @@ class FlowTracer {
    *
    * @param outgoingInterface the interface out of which the packet is being sent
    * @param nextHopIp the next hop IP (a.k.a ARP IP) <emph>as far as the FIB is concerned</emph>
-   * @param overridenNextHopIp not {@code null} if the next hop was overriden outside of the FIB
+   * @param overriddenNextHopIp not {@code null} if the next hop was overridden outside of the FIB
    *     (e.g., in PBR)
    */
-  private void forwardOutInterface(
-      Interface outgoingInterface, Ip nextHopIp, @Nullable Ip overridenNextHopIp) {
+  @VisibleForTesting
+  void forwardOutInterface(
+      Interface outgoingInterface, Ip nextHopIp, @Nullable Ip overriddenNextHopIp) {
     // Apply preSourceNatOutgoingFilter
     if (applyFilter(
             outgoingInterface.getPreTransformationOutgoingFilter(),
@@ -972,6 +973,13 @@ class FlowTracer {
 
     // apply outgoing filter
     if (applyFilter(outgoingInterface.getOutgoingFilter(), EGRESS_FILTER) == DENIED) {
+      return;
+    }
+
+    // apply outgoing filter matching original flow
+    if (applyFilterToOriginalFlow(
+            outgoingInterface.getOutgoingOriginalFlowFilter(), PRE_TRANSFORMATION_EGRESS_FILTER)
+        == DENIED) {
       return;
     }
 
@@ -1004,8 +1012,8 @@ class FlowTracer {
     SortedSet<NodeInterfacePair> neighborIfaces =
         _tracerouteContext.getInterfaceNeighbors(currentNodeName, outgoingIfaceName);
     /*
-    Special handling is necessary if ARP IP was overriden.
-    Consider the following: dst IP: 2.2.2.2, NH was overriden to 1.1.1.1 and matched a connected route 1.1.1.0/24, for "iface0"
+    Special handling is necessary if ARP IP was overridden.
+    Consider the following: dst IP: 2.2.2.2, NH was overridden to 1.1.1.1 and matched a connected route 1.1.1.0/24, for "iface0"
     Since the FIB entry has no ARP IP (because connected route) we'd normally compute disposition for the dest IP (2.2.2.2)
     However, nothing in forwarding analysis says 2.2.2.2 has a valid disposition for "iface0":
       - there is no route for 2.2.2.2 there,
@@ -1014,13 +1022,13 @@ class FlowTracer {
     To simplify our life, just compute disposition for 1.1.1.1, at least that's guaranteed to give us a disposition
     */
     if (neighborIfaces.isEmpty()) {
-      Ip arpIp = firstNonNull(overridenNextHopIp, _currentFlow.getDstIp());
+      Ip arpIp = firstNonNull(overriddenNextHopIp, _currentFlow.getDstIp());
       FlowDisposition disposition =
           _tracerouteContext.computeDisposition(currentNodeName, outgoingIfaceName, arpIp);
       buildArpFailureTrace(outgoingIfaceName, arpIp, disposition);
     } else {
       processOutgoingInterfaceEdges(
-          outgoingIfaceName, firstNonNull(overridenNextHopIp, nextHopIp), neighborIfaces);
+          outgoingIfaceName, firstNonNull(overriddenNextHopIp, nextHopIp), neighborIfaces);
     }
   }
 
@@ -1148,17 +1156,32 @@ class FlowTracer {
   }
 
   /**
-   * Apply a filter, and create the corresponding step. If the filter DENIED the flow, then create a
-   * trace ending in the denial. Return the action if the filter is non-null. If the filter is null,
-   * return null.
+   * Apply a filter to the current flow, and create the corresponding step. If the filter DENIED the
+   * flow, then create a trace ending in the denial. Return the action if the filter is non-null. If
+   * the filter is null, return null.
    */
   private @Nullable StepAction applyFilter(@Nullable IpAccessList filter, FilterType filterType) {
+    return applyFilter(filter, filterType, _currentFlow);
+  }
+
+  /**
+   * Apply a filter to the original flow, and create the corresponding step. If the filter DENIED
+   * the flow, then create a trace ending in the denial. Return the action if the filter is
+   * non-null. If the filter is null, return null.
+   */
+  private @Nullable StepAction applyFilterToOriginalFlow(
+      @Nullable IpAccessList filter, FilterType filterType) {
+    return applyFilter(filter, filterType, _originalFlow);
+  }
+
+  private @Nullable StepAction applyFilter(
+      @Nullable IpAccessList filter, FilterType filterType, @Nonnull Flow flow) {
     if (filter == null) {
       return null;
     }
     FilterStep filterStep =
         createFilterStep(
-            _currentFlow,
+            flow,
             _ingressInterface,
             filter,
             filterType,


### PR DESCRIPTION
New VI filter is applied to outgoing flows, but matches on the original flow even if a transformation has occurred.