### PR TITLE
Cisco IOS line parsing improvements

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -1788,6 +1788,11 @@ BUCKETS
    'buckets'
 ;
 
+BUFFER_LENGTH
+:
+  'buffer-length'
+;
+
 BUFFER_LIMIT
 :
    'buffer-limit'
@@ -5475,6 +5480,11 @@ HIGH_RESOLUTION
 HISTORY
 :
    'history'
+;
+
+HOLD_CHARACTER
+:
+  'hold-character'
 ;
 
 HOLD_TIME
@@ -12407,6 +12417,11 @@ STICKY_ARP
 STOP
 :
    'stop'
+;
+
+STOP_CHARACTER
+:
+  'stop-character'
 ;
 
 STOP_ONLY

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_line.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_line.g4
@@ -100,12 +100,14 @@ l_null
       | AUTHORIZATION
       | AUTOHANGUP
       | AUTOSELECT
+      | BUFFER_LENGTH
       | DATABITS
       | ESCAPE_CHARACTER
       | EXEC
       | FLOWCONTROL
       | FLUSH_AT_ACTIVATION
       | HISTORY
+      | HOLD_CHARACTER
       | IPV6
       | LOCATION
       | LOGGING
@@ -120,6 +122,7 @@ l_null
       | SESSION_LIMIT
       | SESSION_TIMEOUT
       | SPEED
+      | STOP_CHARACTER
       | STOPBITS
       | TERMINAL_TYPE
       | TIMEOUT

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1269,6 +1269,11 @@ public final class CiscoGrammarTest {
   }
 
   @Test
+  public void testIosLineParsing() {
+    assertNotNull(parseCiscoConfig("ios-line", null));
+  }
+
+  @Test
   public void testIosLoggingOnDefault() throws IOException {
     Configuration loggingOnOmitted = parseConfig("iosLoggingOnOmitted");
     assertThat(loggingOnOmitted, hasVendorFamily(hasCisco(hasLogging(isOn()))));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-line
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-line
@@ -1,0 +1,78 @@
+!
+!RANCID-CONTENT-TYPE: cisco
+!
+hostname ios-line
+!
+!
+line con 0
+ exec-timeout 9 0
+ password 7 0123456789ABCDEF0123456789ABCDEF01
+ transport output telnet ssh
+line aux 0
+line 2
+ exec-timeout 0 0
+ no activation-character
+ no exec
+ transport preferred none
+ transport output all
+ stopbits 1
+line 0/0/0 0/0/12
+ exec-timeout 0 0
+ no exec
+ transport preferred none
+ transport input all
+ transport output all
+line 0/0/13
+ exec-timeout 0 0
+ buffer-length 1
+ logging synchronous level all limit 0
+ no exec
+ transport preferred none
+ transport input all
+ transport output all
+ hold-character 47
+ stopbits 1
+ stop-character 47
+line 0/0/14
+ exec-timeout 0 0
+ logging synchronous level all
+ no exec
+ transport preferred none
+ transport input all
+ transport output all
+ stopbits 1
+ stop-character 47
+line 0/0/15 0/1/5
+ exec-timeout 0 0
+ no exec
+ transport preferred none
+ transport input all
+ transport output all
+line 0/1/6 0/1/7
+ exec-timeout 0 0
+ no exec
+ transport preferred none
+ transport input all
+ transport output all
+ stopbits 1
+line vty 0 4
+ access-class foo_acl in
+ exec-timeout 9 0
+ password 7 0123456789ABCDEF0123456789ABCDEF01
+ transport input ssh
+ transport output all
+line vty 5 14
+ access-class foo_acl in
+ exec-timeout 9 0
+ password 7 0123456789ABCDEF0123456789ABCDEF01
+ transport input ssh
+ transport output all
+line vty 15
+ access-class foo_acl in
+ exec-timeout 9 0
+ password 7 0123456789ABCDEF0123456789ABCDEF01
+ rotary 23
+ transport input ssh
+ transport output all
+!
+end


### PR DESCRIPTION
- fix batfish/batfish#5831
- warn instead of crash for unsupported line ranges, i.e. where last
number of range end is smaller than last number of range start
- parse and ignore some other constructs