### PR TITLE
Mitigate TOCTOU bugs related to IDs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/identifiers/IdResolver.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/identifiers/IdResolver.java
@@ -1,5 +1,6 @@
 package org.batfish.identifiers;
 
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -10,12 +11,11 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public interface IdResolver {
 
   /**
-   * Retrieve the {@link AnalysisId} assigned to {@code analysis} under {@code networkId}.
-   *
-   * @throws IllegalArgumentException if none assigned
+   * Retrieve the {@link AnalysisId} assigned to {@code analysis} under {@code networkId}. Returns
+   * {@link Optional#empty} if none assigned.
    */
   @Nonnull
-  AnalysisId getAnalysisId(String analysis, NetworkId networkId);
+  Optional<AnalysisId> getAnalysisId(String analysis, NetworkId networkId);
 
   /** Retrieve the {@link AnswerId} corresponding to the provided input IDs. */
   @Nonnull
@@ -34,50 +34,47 @@ public interface IdResolver {
 
   /**
    * Retrieve the {@link IssueSettingsId} assigned to {@code majorIssueType} under {@code
-   * networkId}.
-   *
-   * @throws IllegalArgumentException if none assigned
+   * networkId}. Returns {@link Optional#empty} if none assigned.
    */
   @Nonnull
-  IssueSettingsId getIssueSettingsId(String majorIssueType, NetworkId networkId);
+  Optional<IssueSettingsId> getIssueSettingsId(String majorIssueType, NetworkId networkId);
 
   /**
-   * Retrieve the {@link NetworkId} assigned to {@code network}.
-   *
-   * @throws IllegalArgumentException if none assigned
+   * Retrieve the {@link NetworkId} assigned to {@code network}. Returns {@link Optional#empty} if
+   * none assigned.
    */
   @Nonnull
-  NetworkId getNetworkId(String network);
+  Optional<NetworkId> getNetworkId(String network);
 
-  /** Retrieve the current {@link NodeRolesId} for {@code networkId}. */
+  /**
+   * Retrieve the current {@link NodeRolesId} for {@code networkId}. Returns {@link Optional#empty}
+   * if none assigned.
+   */
   @Nonnull
-  NodeRolesId getNetworkNodeRolesId(NetworkId networkId);
+  Optional<NodeRolesId> getNetworkNodeRolesId(NetworkId networkId);
 
   /**
    * Retrieve the {@link QuestionId} assigned to {@code question} under {@code networkId} and {@code
    * analysisId}. If {@code analysisId} is {@code null}, returns the mapping for an ad-hoc question.
-   *
-   * @throws IllegalArgumentException if none assigned
+   * Returns {@link Optional#empty} if none assigned.
    */
   @Nonnull
-  QuestionId getQuestionId(String question, NetworkId networkId, @Nullable AnalysisId analysisId);
+  Optional<QuestionId> getQuestionId(
+      String question, NetworkId networkId, @Nullable AnalysisId analysisId);
 
   /**
    * Retrieve the {@link QuestionSettingsId} assigned to {@code questionClassId} under {@code
-   * networkId}.
-   *
-   * @throws IllegalArgumentException if none assigned
+   * networkId}. Returns {@link Optional#empty} if none assigned.
    */
   @Nonnull
-  QuestionSettingsId getQuestionSettingsId(String questionClassId, NetworkId networkId);
+  Optional<QuestionSettingsId> getQuestionSettingsId(String questionClassId, NetworkId networkId);
 
   /**
-   * Retrieve the {@link SnapshotId} assigned to {@code snapshot} under {@code networkId}.
-   *
-   * @throws IllegalArgumentException if none assigned
+   * Retrieve the {@link SnapshotId} assigned to {@code snapshot} under {@code networkId}. Returns
+   * {@link Optional#empty} if none assigned.
    */
   @Nonnull
-  SnapshotId getSnapshotId(String snapshot, NetworkId networkId);
+  Optional<SnapshotId> getSnapshotId(String snapshot, NetworkId networkId);
 
   /** Retrieve the {@link NodeRolesId} corresponding to the provided input IDs. */
   @Nonnull

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/identifiers/StorageBasedIdResolver.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/identifiers/StorageBasedIdResolver.java
@@ -9,6 +9,7 @@ import com.google.common.hash.Hashing;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -33,7 +34,8 @@ public class StorageBasedIdResolver implements IdResolver {
     }
   }
 
-  private @Nonnull String readId(Class<? extends Id> idType, String name, Id... ancestors) {
+  private @Nonnull Optional<String> readId(
+      Class<? extends Id> idType, String name, Id... ancestors) {
     try {
       return _s.readId(idType, name, ancestors);
     } catch (IOException e) {
@@ -48,12 +50,8 @@ public class StorageBasedIdResolver implements IdResolver {
   }
 
   @Override
-  public @Nonnull AnalysisId getAnalysisId(String analysis, NetworkId networkId) {
-    if (!hasAnalysisId(analysis, networkId)) {
-      throw new IllegalArgumentException(
-          String.format("No ID assigned to non-existent analysis %s", analysis));
-    }
-    return new AnalysisId(readId(AnalysisId.class, analysis, networkId));
+  public @Nonnull Optional<AnalysisId> getAnalysisId(String analysis, NetworkId networkId) {
+    return readId(AnalysisId.class, analysis, networkId).map(AnalysisId::new);
   }
 
   @Override
@@ -91,59 +89,38 @@ public class StorageBasedIdResolver implements IdResolver {
   }
 
   @Override
-  public @Nonnull IssueSettingsId getIssueSettingsId(String majorIssueType, NetworkId networkId) {
-    if (!hasIssueSettingsId(majorIssueType, networkId)) {
-      throw new IllegalArgumentException(
-          String.format("No ID assigned to non-configured majorIssueType %s", majorIssueType));
-    }
-    return new IssueSettingsId(readId(IssueSettingsId.class, majorIssueType, networkId));
+  public @Nonnull Optional<IssueSettingsId> getIssueSettingsId(
+      String majorIssueType, NetworkId networkId) {
+    return readId(IssueSettingsId.class, majorIssueType, networkId).map(IssueSettingsId::new);
   }
 
   @Override
-  public @Nonnull NetworkId getNetworkId(String network) {
-    if (!hasNetworkId(network)) {
-      throw new IllegalArgumentException(
-          String.format("No ID assigned to non-existent network %s", network));
-    }
-    return new NetworkId(readId(NetworkId.class, network));
+  public @Nonnull Optional<NetworkId> getNetworkId(String network) {
+    return readId(NetworkId.class, network).map(NetworkId::new);
   }
 
   @Override
-  public NodeRolesId getNetworkNodeRolesId(NetworkId networkId) {
-    if (!hasNetworkNodeRolesId(networkId)) {
-      throw new IllegalArgumentException("No assigned node-roles ID");
-    }
-    return new NodeRolesId(readId(NodeRolesId.class, NETWORK_NODE_ROLES, networkId));
+  public Optional<NodeRolesId> getNetworkNodeRolesId(NetworkId networkId) {
+    return readId(NodeRolesId.class, NETWORK_NODE_ROLES, networkId).map(NodeRolesId::new);
   }
 
   @Override
-  public @Nonnull QuestionId getQuestionId(
+  public @Nonnull Optional<QuestionId> getQuestionId(
       String question, NetworkId networkId, @Nullable AnalysisId analysisId) {
-    if (!hasQuestionId(question, networkId, analysisId)) {
-      throw new IllegalArgumentException(
-          String.format("No ID assigned to non-existent question '%s'", question));
-    }
     Id[] ancestors = analysisId != null ? new Id[] {networkId, analysisId} : new Id[] {networkId};
-    return new QuestionId(readId(QuestionId.class, question, ancestors));
+    return readId(QuestionId.class, question, ancestors).map(QuestionId::new);
   }
 
   @Override
-  public @Nonnull QuestionSettingsId getQuestionSettingsId(
+  public @Nonnull Optional<QuestionSettingsId> getQuestionSettingsId(
       String questionClassId, NetworkId networkId) {
-    if (!hasQuestionSettingsId(questionClassId, networkId)) {
-      throw new IllegalArgumentException(
-          String.format("No ID assigned to non-configured questionClassId '%s'", questionClassId));
-    }
-    return new QuestionSettingsId(readId(QuestionSettingsId.class, questionClassId, networkId));
+    return readId(QuestionSettingsId.class, questionClassId, networkId)
+        .map(QuestionSettingsId::new);
   }
 
   @Override
-  public @Nonnull SnapshotId getSnapshotId(String snapshot, NetworkId networkId) {
-    if (!hasSnapshotId(snapshot, networkId)) {
-      throw new IllegalArgumentException(
-          String.format("No ID assigned to non-existent snapshot '%s'", snapshot));
-    }
-    return new SnapshotId(readId(SnapshotId.class, snapshot, networkId));
+  public @Nonnull Optional<SnapshotId> getSnapshotId(String snapshot, NetworkId networkId) {
+    return readId(SnapshotId.class, snapshot, networkId).map(SnapshotId::new);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -658,11 +658,13 @@ public interface StorageProvider {
 
   /**
    * Read the value of an ID corresponding to given ancestor IDs, ID type, and user-provided name.
+   * Returns {@link Optional#empty} if there is no such ID.
    *
    * @throws IOException if there is an error
    */
   @Nonnull
-  String readId(Class<? extends Id> idType, String name, Id... ancestors) throws IOException;
+  Optional<String> readId(Class<? extends Id> idType, String name, Id... ancestors)
+      throws IOException;
 
   /**
    * Write an name-ID mapping corresponding to given ancestor IDs and user-provided name.
@@ -673,11 +675,11 @@ public interface StorageProvider {
 
   /**
    * Delete the name-ID mapping corresponding to the given ancestor IDs, ID type, and user-provided
-   * name.
+   * name. Returns {@code true} iff a mapping for the provided name was successfully deleted.
    *
    * @throws IOException if there is an error
    */
-  void deleteNameIdMapping(Class<? extends Id> idType, String name, Id... ancestors)
+  boolean deleteNameIdMapping(Class<? extends Id> idType, String name, Id... ancestors)
       throws IOException;
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/identifiers/TestIdResolver.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/identifiers/TestIdResolver.java
@@ -1,11 +1,12 @@
 package org.batfish.identifiers;
 
+import java.util.Optional;
 import java.util.Set;
 
 public class TestIdResolver implements IdResolver {
 
   @Override
-  public AnalysisId getAnalysisId(String analysis, NetworkId networkId) {
+  public Optional<AnalysisId> getAnalysisId(String analysis, NetworkId networkId) {
     throw new UnsupportedOperationException();
   }
 
@@ -27,32 +28,34 @@ public class TestIdResolver implements IdResolver {
   }
 
   @Override
-  public IssueSettingsId getIssueSettingsId(String majorIssueType, NetworkId networkId) {
+  public Optional<IssueSettingsId> getIssueSettingsId(String majorIssueType, NetworkId networkId) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public NetworkId getNetworkId(String network) {
+  public Optional<NetworkId> getNetworkId(String network) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public NodeRolesId getNetworkNodeRolesId(NetworkId networkId) {
+  public Optional<NodeRolesId> getNetworkNodeRolesId(NetworkId networkId) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public QuestionId getQuestionId(String question, NetworkId networkId, AnalysisId analysisId) {
+  public Optional<QuestionId> getQuestionId(
+      String question, NetworkId networkId, AnalysisId analysisId) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public QuestionSettingsId getQuestionSettingsId(String questionClassId, NetworkId networkId) {
+  public Optional<QuestionSettingsId> getQuestionSettingsId(
+      String questionClassId, NetworkId networkId) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public SnapshotId getSnapshotId(String snapshot, NetworkId networkId) {
+  public Optional<SnapshotId> getSnapshotId(String snapshot, NetworkId networkId) {
     throw new UnsupportedOperationException();
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -534,10 +534,9 @@ public final class FileBasedStorageTest {
   @Test
   public void testReadId() throws IOException {
     _storage.writeId(new NetworkId("network1_id"), "network1");
-    assertThat(_storage.readId(NetworkId.class, "network1"), equalTo("network1_id"));
+    assertThat(_storage.readId(NetworkId.class, "network1"), equalTo(Optional.of("network1_id")));
 
-    _thrown.expect(IOException.class);
-    _storage.readId(NetworkId.class, "network2");
+    assertThat(_storage.readId(NetworkId.class, "network2"), equalTo(Optional.empty()));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
@@ -414,7 +414,8 @@ public class TestStorageProvider implements StorageProvider {
 
   @Nonnull
   @Override
-  public String readId(Class<? extends Id> type, String name, Id... ancestors) throws IOException {
+  public Optional<String> readId(Class<? extends Id> type, String name, Id... ancestors)
+      throws IOException {
     throw new UnsupportedOperationException();
   }
 
@@ -424,7 +425,7 @@ public class TestStorageProvider implements StorageProvider {
   }
 
   @Override
-  public void deleteNameIdMapping(Class<? extends Id> type, String name, Id... ancestors)
+  public boolean deleteNameIdMapping(Class<? extends Id> type, String name, Id... ancestors)
       throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -497,10 +497,15 @@ public class Batfish extends PluginConsumer implements IBatfish {
           .listQuestions(containerName, analysisName)
           .forEach(
               questionName -> {
-                QuestionId questionId =
+                Optional<QuestionId> questionIdOpt =
                     _idResolver.getQuestionId(questionName, containerName, analysisName);
-                _settings.setQuestionName(questionId);
-
+                checkArgument(
+                    questionIdOpt.isPresent(),
+                    "Question '%s' for analysis '%s' for network '%s' was deleted in the middle of this operation",
+                    questionName,
+                    containerName,
+                    analysisName);
+                _settings.setQuestionName(questionIdOpt.get());
                 Answer currentAnswer;
                 Span span =
                     GlobalTracer.get().buildSpan("Getting answer to analysis question").start();
@@ -951,12 +956,12 @@ public class Batfish extends PluginConsumer implements IBatfish {
   public NodeRolesData getNodeRolesData() {
     try {
       NetworkId networkId = _settings.getContainer();
-      if (!_idResolver.hasNetworkNodeRolesId(networkId)) {
+      Optional<NodeRolesId> networkNodeRolesIdOpt = _idResolver.getNetworkNodeRolesId(networkId);
+      if (!networkNodeRolesIdOpt.isPresent()) {
         return null;
       }
-      NodeRolesId nodeRolesId = _idResolver.getNetworkNodeRolesId(networkId);
       return BatfishObjectMapper.mapper()
-          .readValue(_storage.loadNodeRoles(nodeRolesId), NodeRolesData.class);
+          .readValue(_storage.loadNodeRoles(networkNodeRolesIdOpt.get()), NodeRolesData.class);
     } catch (IOException e) {
       _logger.errorf("Could not read roles data: %s", e);
       return null;
@@ -983,11 +988,13 @@ public class Batfish extends PluginConsumer implements IBatfish {
    */
   @Override
   public MajorIssueConfig getMajorIssueConfig(String majorIssueType) {
-    IssueSettingsId id = _idResolver.getIssueSettingsId(majorIssueType, _settings.getContainer());
-    if (id == null) {
+    Optional<IssueSettingsId> issueSetingsIdOpt =
+        _idResolver.getIssueSettingsId(majorIssueType, _settings.getContainer());
+    if (!issueSetingsIdOpt.isPresent()) {
       return new MajorIssueConfig(majorIssueType, ImmutableMap.of());
     }
-    MajorIssueConfig loaded = _storage.loadMajorIssueConfig(_settings.getContainer(), id);
+    MajorIssueConfig loaded =
+        _storage.loadMajorIssueConfig(_settings.getContainer(), issueSetingsIdOpt.get());
     return loaded != null ? loaded : new MajorIssueConfig(majorIssueType, ImmutableMap.of());
   }
 
@@ -1414,18 +1421,17 @@ public class Batfish extends PluginConsumer implements IBatfish {
     QuestionSettingsId questionSettingsId;
     try {
       String questionClassId = _storage.loadQuestionClassId(networkId, questionId, analysisId);
-      if (_idResolver.hasQuestionSettingsId(questionClassId, networkId)) {
-        questionSettingsId = _idResolver.getQuestionSettingsId(questionClassId, networkId);
-      } else {
-        questionSettingsId = QuestionSettingsId.DEFAULT_QUESTION_SETTINGS_ID;
-      }
+      questionSettingsId =
+          _idResolver
+              .getQuestionSettingsId(questionClassId, networkId)
+              .orElse(QuestionSettingsId.DEFAULT_QUESTION_SETTINGS_ID);
     } catch (IOException e) {
       throw new IOException("Failed to retrieve question settings ID", e);
     }
     NodeRolesId networkNodeRolesId =
-        _idResolver.hasNetworkNodeRolesId(networkId)
-            ? _idResolver.getNetworkNodeRolesId(networkId)
-            : NodeRolesId.DEFAULT_NETWORK_NODE_ROLES_ID;
+        _idResolver
+            .getNetworkNodeRolesId(networkId)
+            .orElse(NodeRolesId.DEFAULT_NETWORK_NODE_ROLES_ID);
     AnswerId baseAnswerId =
         _idResolver.getBaseAnswerId(
             networkId,
@@ -3123,18 +3129,17 @@ public class Batfish extends PluginConsumer implements IBatfish {
     QuestionSettingsId questionSettingsId;
     try {
       String questionClassId = _storage.loadQuestionClassId(networkId, questionId, analysisId);
-      if (_idResolver.hasQuestionSettingsId(questionClassId, networkId)) {
-        questionSettingsId = _idResolver.getQuestionSettingsId(questionClassId, networkId);
-      } else {
-        questionSettingsId = QuestionSettingsId.DEFAULT_QUESTION_SETTINGS_ID;
-      }
+      questionSettingsId =
+          _idResolver
+              .getQuestionSettingsId(questionClassId, networkId)
+              .orElse(QuestionSettingsId.DEFAULT_QUESTION_SETTINGS_ID);
     } catch (IOException e) {
       throw new BatfishException("Failed to retrieve question settings ID", e);
     }
     NodeRolesId networkNodeRolesId =
-        _idResolver.hasNetworkNodeRolesId(networkId)
-            ? _idResolver.getNetworkNodeRolesId(networkId)
-            : NodeRolesId.DEFAULT_NETWORK_NODE_ROLES_ID;
+        _idResolver
+            .getNetworkNodeRolesId(networkId)
+            .orElse(NodeRolesId.DEFAULT_NETWORK_NODE_ROLES_ID);
     AnswerId baseAnswerId =
         _idResolver.getBaseAnswerId(
             networkId,
@@ -3164,13 +3169,13 @@ public class Batfish extends PluginConsumer implements IBatfish {
   public @Nullable String loadQuestionSettings(@Nonnull Question question) {
     String questionClassId = question.getName();
     NetworkId networkId = _settings.getContainer();
-    if (!_idResolver.hasQuestionSettingsId(questionClassId, networkId)) {
+    Optional<QuestionSettingsId> questionSettingsIdOpt =
+        _idResolver.getQuestionSettingsId(questionClassId, networkId);
+    if (!questionSettingsIdOpt.isPresent()) {
       return null;
     }
     try {
-      QuestionSettingsId questionSettingsId =
-          _idResolver.getQuestionSettingsId(questionClassId, networkId);
-      return _storage.loadQuestionSettings(_settings.getContainer(), questionSettingsId);
+      return _storage.loadQuestionSettings(_settings.getContainer(), questionSettingsIdOpt.get());
     } catch (IOException e) {
       throw new BatfishException(
           String.format("Failed to read question settings for question: '%s'", questionClassId), e);

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -467,9 +468,9 @@ public class BatfishTest {
               }
 
               @Override
-              public QuestionSettingsId getQuestionSettingsId(
+              public Optional<QuestionSettingsId> getQuestionSettingsId(
                   String questionClassId, NetworkId networkId) {
-                return new QuestionSettingsId("blah");
+                return Optional.of(new QuestionSettingsId("blah"));
               }
             });
 
@@ -489,8 +490,9 @@ public class BatfishTest {
             },
             new TestIdResolver() {
               @Override
-              public boolean hasQuestionSettingsId(String questionClassId, NetworkId networkId) {
-                return false;
+              public Optional<QuestionSettingsId> getQuestionSettingsId(
+                  String questionClassId, NetworkId networkId) {
+                return Optional.empty();
               }
             });
 
@@ -510,9 +512,9 @@ public class BatfishTest {
             },
             new TestIdResolver() {
               @Override
-              public QuestionSettingsId getQuestionSettingsId(
+              public Optional<QuestionSettingsId> getQuestionSettingsId(
                   String questionClassId, NetworkId networkId) {
-                return new QuestionSettingsId("foo");
+                return Optional.of(new QuestionSettingsId("foo"));
               }
 
               @Override

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgrService.java
@@ -1345,7 +1345,12 @@ public class WorkMgrService {
       NetworkId networkId = work.getDetails().getNetworkId();
       Optional<String> networkOpt =
           Main.getWorkMgr().getNetworkNames().stream()
-              .filter(n -> Main.getWorkMgr().getIdManager().getNetworkId(n).equals(networkId))
+              .filter(
+                  n ->
+                      Main.getWorkMgr()
+                          .getIdManager()
+                          .getNetworkId(n)
+                          .equals(Optional.of(networkId)))
               .findFirst();
       checkArgument(networkOpt.isPresent(), "Invalid network ID: %s", networkId);
 

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/id/IdManager.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/id/IdManager.java
@@ -43,20 +43,30 @@ public interface IdManager extends IdResolver {
   /** Assign {@code snapshot} under {@code networkId} to {@code snapshotId}. */
   void assignSnapshot(String snapshot, NetworkId networkId, SnapshotId snapshotId);
 
-  /** Delete any mapping for {@code analysis} under {@code network} */
-  void deleteAnalysis(String analysis, NetworkId networkId);
+  /**
+   * Delete any mapping for {@code analysis} under {@code network}. Returns {@code true} iff a
+   * mapping for the provided name was successfully deleted.
+   */
+  boolean deleteAnalysis(String analysis, NetworkId networkId);
 
-  /** Delete any mapping for {@code network} */
-  void deleteNetwork(String network);
+  /**
+   * Delete any mapping for {@code network}. Returns {@code true} iff a mapping for the provided
+   * name was successfully deleted.
+   */
+  boolean deleteNetwork(String network);
 
   /**
    * Delete any mapping for {@code question} under {@code networkId}, {@code analysisId}. If {@code
-   * analysisId} is {@code null}, the mapping to remove is for an ad-hoc question.
+   * analysisId} is {@code null}, the mapping to remove is for an ad-hoc question. Returns {@code
+   * true} iff a mapping for the provided name was successfully deleted.
    */
-  void deleteQuestion(String question, NetworkId networkId, @Nullable AnalysisId analysisId);
+  boolean deleteQuestion(String question, NetworkId networkId, @Nullable AnalysisId analysisId);
 
-  /** Delete any mapping for {@code snapshot} under {@code networkId} */
-  void deleteSnapshot(String snapshot, NetworkId networkId);
+  /**
+   * Delete any mapping for {@code snapshot} under {@code networkId}. Returns {@code true} iff a
+   * mapping for the provided name was successfully deleted.
+   */
+  boolean deleteSnapshot(String snapshot, NetworkId networkId);
 
   /** Generate a new {@link AnalysisId} suitable for assignment */
   @Nonnull

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/id/StorageBasedIdManager.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/id/StorageBasedIdManager.java
@@ -33,9 +33,9 @@ public class StorageBasedIdManager extends StorageBasedIdResolver implements IdM
     super(s);
   }
 
-  private void deleteNameIdMapping(Class<? extends Id> type, String name, Id... ancestors) {
+  private boolean deleteNameIdMapping(Class<? extends Id> type, String name, Id... ancestors) {
     try {
-      _s.deleteNameIdMapping(type, name, ancestors);
+      return _s.deleteNameIdMapping(type, name, ancestors);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -92,25 +92,25 @@ public class StorageBasedIdManager extends StorageBasedIdResolver implements IdM
   }
 
   @Override
-  public void deleteAnalysis(String analysis, NetworkId networkId) {
-    deleteNameIdMapping(AnalysisId.class, analysis, networkId);
+  public boolean deleteAnalysis(String analysis, NetworkId networkId) {
+    return deleteNameIdMapping(AnalysisId.class, analysis, networkId);
   }
 
   @Override
-  public void deleteNetwork(String network) {
-    deleteNameIdMapping(NetworkId.class, network);
+  public boolean deleteNetwork(String network) {
+    return deleteNameIdMapping(NetworkId.class, network);
   }
 
   @Override
-  public void deleteQuestion(
+  public boolean deleteQuestion(
       String question, NetworkId networkId, @Nullable AnalysisId analysisId) {
     Id[] ancestors = analysisId != null ? new Id[] {networkId, analysisId} : new Id[] {networkId};
-    deleteNameIdMapping(QuestionId.class, question, ancestors);
+    return deleteNameIdMapping(QuestionId.class, question, ancestors);
   }
 
   @Override
-  public void deleteSnapshot(String snapshot, NetworkId networkId) {
-    deleteNameIdMapping(SnapshotId.class, snapshot, networkId);
+  public boolean deleteSnapshot(String snapshot, NetworkId networkId) {
+    return deleteNameIdMapping(SnapshotId.class, snapshot, networkId);
   }
 
   @Override

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrServiceTest.java
@@ -163,7 +163,7 @@ public class WorkMgrServiceTest {
         new FileInputStream(analysisFile),
         "",
         null);
-    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId);
+    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId).get();
     assertTrue(idm().hasQuestionId(questionName, _networkId, analysisId));
     // test delete questions
     String questionsToDelete = String.format("[%s]", questionName);
@@ -213,8 +213,8 @@ public class WorkMgrServiceTest {
         new FileInputStream(analysisFile),
         "",
         null);
-    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId);
-    QuestionId questionId = idm().getQuestionId(questionName, _networkId, analysisId);
+    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId).get();
+    QuestionId questionId = idm().getQuestionId(questionName, _networkId, analysisId).get();
     AnswerId answerId =
         idm()
             .getBaseAnswerId(
@@ -401,7 +401,7 @@ public class WorkMgrServiceTest {
         new FileInputStream(analysisFile),
         "",
         null);
-    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId);
+    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId).get();
     assertTrue(idm().hasQuestionId(questionName, _networkId, analysisId));
     // test delete questions
     String questionsToDelete = String.format("[%s]", questionName);
@@ -451,8 +451,8 @@ public class WorkMgrServiceTest {
         new FileInputStream(analysisFile),
         "",
         null);
-    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId);
-    QuestionId questionId = idm().getQuestionId(questionName, _networkId, analysisId);
+    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId).get();
+    QuestionId questionId = idm().getQuestionId(questionName, _networkId, analysisId).get();
     AnswerId answerId =
         idm()
             .getBaseAnswerId(
@@ -532,8 +532,8 @@ public class WorkMgrServiceTest {
         new FileInputStream(analysisFile),
         "",
         null);
-    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId);
-    QuestionId questionId = idm().getQuestionId(questionName, _networkId, analysisId);
+    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId).get();
+    QuestionId questionId = idm().getQuestionId(questionName, _networkId, analysisId).get();
     AnswerId answerId =
         idm()
             .getBaseAnswerId(
@@ -613,8 +613,8 @@ public class WorkMgrServiceTest {
         new FileInputStream(analysisFile),
         "",
         null);
-    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId);
-    QuestionId questionId = idm().getQuestionId(questionName, _networkId, analysisId);
+    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId).get();
+    QuestionId questionId = idm().getQuestionId(questionName, _networkId, analysisId).get();
     AnswerId answerId =
         idm()
             .getBaseAnswerId(
@@ -689,8 +689,8 @@ public class WorkMgrServiceTest {
         new FileInputStream(analysisFile),
         "",
         null);
-    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId);
-    QuestionId questionId = idm().getQuestionId(questionName, _networkId, analysisId);
+    AnalysisId analysisId = idm().getAnalysisId(analysisName, _networkId).get();
+    QuestionId questionId = idm().getQuestionId(questionName, _networkId, analysisId).get();
     AnswerId answerId =
         idm()
             .getBaseAnswerId(
@@ -740,7 +740,7 @@ public class WorkMgrServiceTest {
     String questionContent = BatfishObjectMapper.writeString(questionObj);
 
     Main.getWorkMgr().uploadQuestion(_networkName, question, questionContent);
-    QuestionId questionId = idm().getQuestionId(question, _networkId, null);
+    QuestionId questionId = idm().getQuestionId(question, _networkId, null).get();
     AnswerId answerId =
         idm()
             .getBaseAnswerId(
@@ -823,8 +823,8 @@ public class WorkMgrServiceTest {
         new FileInputStream(analysisFile),
         "",
         null);
-    AnalysisId analysisId = idm().getAnalysisId(analysis, _networkId);
-    QuestionId questionId = idm().getQuestionId(question, _networkId, analysisId);
+    AnalysisId analysisId = idm().getAnalysisId(analysis, _networkId).get();
+    QuestionId questionId = idm().getQuestionId(question, _networkId, analysisId).get();
     AnswerId answerId =
         idm()
             .getBaseAnswerId(
@@ -986,8 +986,8 @@ public class WorkMgrServiceTest {
         new FileInputStream(analysisFile),
         "",
         null);
-    AnalysisId analysisId = idm().getAnalysisId(analysis, _networkId);
-    QuestionId questionId = idm().getQuestionId(question, _networkId, analysisId);
+    AnalysisId analysisId = idm().getAnalysisId(analysis, _networkId).get();
+    QuestionId questionId = idm().getQuestionId(question, _networkId, analysisId).get();
     AnswerId answerId =
         idm()
             .getBaseAnswerId(

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -159,7 +159,7 @@ public final class WorkMgrTest {
   }
 
   private void createSnapshotWithMetadata(String network, String snapshot) throws IOException {
-    NetworkId networkId = _idManager.getNetworkId(network);
+    NetworkId networkId = _idManager.getNetworkId(network).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(snapshot, networkId, snapshotId);
     _snapshotMetadataManager.writeMetadata(
@@ -626,7 +626,7 @@ public final class WorkMgrTest {
     String internalQuestionName = "__internalquestion";
     String network = "container";
     _manager.initNetwork(network, null);
-    NetworkId networkId = _idManager.getNetworkId(network);
+    NetworkId networkId = _idManager.getNetworkId(network).get();
     // Make sure the questions are assigned
     _idManager.assignQuestion(questionName, networkId, _idManager.generateQuestionId(), null);
     _idManager.assignQuestion(
@@ -651,7 +651,7 @@ public final class WorkMgrTest {
   public void listSortedQuestionNames() {
     String network = "container";
     _manager.initNetwork(network, null);
-    NetworkId networkId = _idManager.getNetworkId(network);
+    NetworkId networkId = _idManager.getNetworkId(network).get();
     _idManager.assignQuestion("nodes", networkId, _idManager.generateQuestionId(), null);
     _idManager.assignQuestion("access", networkId, _idManager.generateQuestionId(), null);
     _idManager.assignQuestion("initinfo", networkId, _idManager.generateQuestionId(), null);
@@ -688,11 +688,11 @@ public final class WorkMgrTest {
     String network = "network1";
     String snapshot = "snapshot1";
     _manager.initNetwork(network, null);
-    NetworkId networkId = _idManager.getNetworkId(network);
+    NetworkId networkId = _idManager.getNetworkId(network).get();
 
     // create a snapshot and write a topology object for it
     createSnapshotWithMetadata(network, snapshot);
-    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, networkId);
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, networkId).get();
     Topology topology = new Topology(snapshot);
     topology.setNodes(ImmutableSet.of(new Node("a1"), new Node("b1")));
     _storage.storePojoTopology(topology, networkId, snapshotId);
@@ -706,7 +706,7 @@ public final class WorkMgrTest {
     String network = "container";
     String snapshot = "testrig";
     _manager.initNetwork(network, null);
-    NetworkId networkId = _idManager.getNetworkId(network);
+    NetworkId networkId = _idManager.getNetworkId(network).get();
     _idManager.assignSnapshot(snapshot, networkId, _idManager.generateSnapshotId());
     Container container = _manager.getContainer(network);
     assertThat(
@@ -757,10 +757,10 @@ public final class WorkMgrTest {
         ImmutableMap.of("question2", "question2Content", "question3", "question3Content");
     _manager.configureAnalysis(
         containerName, false, analysisName, questionsToAdd, Lists.newArrayList(), null);
-    NetworkId networkId = _idManager.getNetworkId(containerName);
-    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId);
-    QuestionId q1Id = _idManager.getQuestionId("question1", networkId, analysisId);
-    QuestionId q2Id = _idManager.getQuestionId("question2", networkId, analysisId);
+    NetworkId networkId = _idManager.getNetworkId(containerName).get();
+    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId).get();
+    QuestionId q1Id = _idManager.getQuestionId("question1", networkId, analysisId).get();
+    QuestionId q2Id = _idManager.getQuestionId("question2", networkId, analysisId).get();
     String actual = _storage.loadQuestion(networkId, q1Id, analysisId);
     assertThat(actual, equalTo("question1Content"));
     actual = _storage.loadQuestion(networkId, q2Id, analysisId);
@@ -859,8 +859,8 @@ public final class WorkMgrTest {
         networkName,
         new ForkSnapshotBean(
             snapshotBaseName, snapshotNewName1, interfaces, links, nodes, null, null, null, null));
-    NetworkId networkId = _idManager.getNetworkId(networkName);
-    SnapshotId snapshotId1 = _idManager.getSnapshotId(snapshotNewName1, networkId);
+    NetworkId networkId = _idManager.getNetworkId(networkName).get();
+    SnapshotId snapshotId1 = _idManager.getSnapshotId(snapshotNewName1, networkId).get();
 
     // Confirm the forked snapshot exists
     assertThat(_manager.getLatestSnapshot(networkName), equalTo(Optional.of(snapshotNewName1)));
@@ -878,7 +878,7 @@ public final class WorkMgrTest {
         networkName,
         new ForkSnapshotBean(
             snapshotNewName1, snapshotNewName2, null, null, null, interfaces, links, nodes, null));
-    SnapshotId snapshotId2 = _idManager.getSnapshotId(snapshotNewName2, networkId);
+    SnapshotId snapshotId2 = _idManager.getSnapshotId(snapshotNewName2, networkId).get();
 
     // Confirm the forked snapshot exists
     assertThat(_manager.getLatestSnapshot(networkName), equalTo(Optional.of(snapshotNewName2)));
@@ -970,8 +970,8 @@ public final class WorkMgrTest {
         networkName,
         new ForkSnapshotBean(
             baseSnapshotName, forkName, deactivate, null, null, activate, null, null, null));
-    NetworkId networkId = _idManager.getNetworkId(networkName);
-    SnapshotId forkId = _idManager.getSnapshotId(forkName, networkId);
+    NetworkId networkId = _idManager.getNetworkId(networkName).get();
+    SnapshotId forkId = _idManager.getSnapshotId(forkName, networkId).get();
 
     // Interface blacklist should not exist in fork
     assertNull(_storage.loadInterfaceBlacklist(networkId, forkId));
@@ -1050,8 +1050,8 @@ public final class WorkMgrTest {
         networkName,
         new ForkSnapshotBean(
             baseSnapshotName, forkName, deactivate, null, null, activate, null, null, null));
-    NetworkId networkId = _idManager.getNetworkId(networkName);
-    SnapshotId forkId = _idManager.getSnapshotId(forkName, networkId);
+    NetworkId networkId = _idManager.getNetworkId(networkName).get();
+    SnapshotId forkId = _idManager.getSnapshotId(forkName, networkId).get();
 
     // Interface blacklist should not exist in fork
     assertNull(_storage.loadInterfaceBlacklist(networkId, forkId));
@@ -1302,7 +1302,9 @@ public final class WorkMgrTest {
     // Confirm we get an illegal arg exception calling getAnswer with a bad reference snapshot
     _thrown.expect(IllegalArgumentException.class);
     _thrown.expectMessage(
-        containsString(String.format("non-existent snapshot '%s'", bogusReferenceSnapshot)));
+        containsString(
+            String.format(
+                "Missing snapshot '%s' for network '%s'", bogusReferenceSnapshot, network)));
     _manager.getAnswer(network, snapshot, questionName, bogusReferenceSnapshot, null);
   }
 
@@ -1346,12 +1348,12 @@ public final class WorkMgrTest {
 
     _manager.configureAnalysis(
         containerName, true, analysisName, questionsToAdd, Lists.newArrayList(), null);
-    NetworkId networkId = _idManager.getNetworkId(containerName);
+    NetworkId networkId = _idManager.getNetworkId(containerName).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(testrigName, networkId, snapshotId);
-    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId);
-    QuestionId questionId1 = _idManager.getQuestionId(question1Name, networkId, analysisId);
-    QuestionId questionId2 = _idManager.getQuestionId(question2Name, networkId, analysisId);
+    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId).get();
+    QuestionId questionId1 = _idManager.getQuestionId(question1Name, networkId, analysisId).get();
+    QuestionId questionId2 = _idManager.getQuestionId(question2Name, networkId, analysisId).get();
 
     AnswerId baseAnswerId1 =
         _idManager.getBaseAnswerId(
@@ -1434,12 +1436,12 @@ public final class WorkMgrTest {
 
     _manager.configureAnalysis(
         containerName, true, analysisName, questionsToAdd, Lists.newArrayList(), null);
-    NetworkId networkId = _idManager.getNetworkId(containerName);
+    NetworkId networkId = _idManager.getNetworkId(containerName).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(testrigName, networkId, snapshotId);
-    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId);
-    QuestionId questionId1 = _idManager.getQuestionId(question1Name, networkId, analysisId);
-    QuestionId questionId2 = _idManager.getQuestionId(question2Name, networkId, analysisId);
+    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId).get();
+    QuestionId questionId1 = _idManager.getQuestionId(question1Name, networkId, analysisId).get();
+    QuestionId questionId2 = _idManager.getQuestionId(question2Name, networkId, analysisId).get();
 
     AnswerId baseAnswerId1 =
         _idManager.getBaseAnswerId(
@@ -1510,12 +1512,12 @@ public final class WorkMgrTest {
 
     _manager.configureAnalysis(
         containerName, true, analysisName, questionsToAdd, Lists.newArrayList(), null);
-    NetworkId networkId = _idManager.getNetworkId(containerName);
+    NetworkId networkId = _idManager.getNetworkId(containerName).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(testrigName, networkId, snapshotId);
-    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId);
-    QuestionId questionId1 = _idManager.getQuestionId(question1Name, networkId, analysisId);
-    QuestionId questionId2 = _idManager.getQuestionId(question2Name, networkId, analysisId);
+    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId).get();
+    QuestionId questionId1 = _idManager.getQuestionId(question1Name, networkId, analysisId).get();
+    QuestionId questionId2 = _idManager.getQuestionId(question2Name, networkId, analysisId).get();
 
     AnswerId baseAnswerId1 =
         _idManager.getBaseAnswerId(
@@ -1621,11 +1623,11 @@ public final class WorkMgrTest {
         ImmutableMap.of(questionName, questionContent),
         ImmutableList.of(),
         null);
-    NetworkId networkId = _idManager.getNetworkId(networkName);
+    NetworkId networkId = _idManager.getNetworkId(networkName).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(snapshotName, networkId, snapshotId);
-    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId);
-    QuestionId questionId = _idManager.getQuestionId(questionName, networkId, analysisId);
+    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId).get();
+    QuestionId questionId = _idManager.getQuestionId(questionName, networkId, analysisId).get();
     AnswerId baseAnswerId =
         _idManager.getBaseAnswerId(
             networkId,
@@ -1658,7 +1660,7 @@ public final class WorkMgrTest {
     _manager.initNetwork(networkName, null);
     _manager.configureAnalysis(
         networkName, true, analysisName, ImmutableMap.of(), ImmutableList.of(), null);
-    NetworkId networkId = _idManager.getNetworkId(networkName);
+    NetworkId networkId = _idManager.getNetworkId(networkName).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(snapshotName, networkId, snapshotId);
     QuestionSettingsId questionSettingsId = new QuestionSettingsId("blah");
@@ -1685,11 +1687,11 @@ public final class WorkMgrTest {
         ImmutableMap.of(questionName, questionContent),
         ImmutableList.of(),
         null);
-    NetworkId networkId = _idManager.getNetworkId(networkName);
-    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId);
+    NetworkId networkId = _idManager.getNetworkId(networkName).get();
+    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(snapshotName, networkId, snapshotId);
-    QuestionId questionId = _idManager.getQuestionId(questionName, networkId, analysisId);
+    QuestionId questionId = _idManager.getQuestionId(questionName, networkId, analysisId).get();
     AnswerId baseAnswerId =
         _idManager.getBaseAnswerId(
             networkId,
@@ -1722,7 +1724,7 @@ public final class WorkMgrTest {
     Question question = new TestQuestion();
     String questionName = "question1";
     _manager.initNetwork(networkName, null);
-    NetworkId networkId = _idManager.getNetworkId(networkName);
+    NetworkId networkId = _idManager.getNetworkId(networkName).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(snapshotName, networkId, snapshotId);
     // the analysis id is not assigned, so the analysis is effectively missing
@@ -1743,10 +1745,10 @@ public final class WorkMgrTest {
     String questionName = "question2Name";
     _manager.initNetwork(networkName, null);
     _manager.uploadQuestion(networkName, questionName, questionContent, false);
-    NetworkId networkId = _idManager.getNetworkId(networkName);
+    NetworkId networkId = _idManager.getNetworkId(networkName).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(snapshotName, networkId, snapshotId);
-    QuestionId questionId = _idManager.getQuestionId(questionName, networkId, null);
+    QuestionId questionId = _idManager.getQuestionId(questionName, networkId, null).get();
     AnswerId baseAnswerId =
         _idManager.getBaseAnswerId(
             networkId,
@@ -1778,10 +1780,10 @@ public final class WorkMgrTest {
     String questionName = "question2Name";
     _manager.initNetwork(networkName, null);
     _manager.uploadQuestion(networkName, questionName, questionContent, false);
-    NetworkId networkId = _idManager.getNetworkId(networkName);
+    NetworkId networkId = _idManager.getNetworkId(networkName).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(snapshotName, networkId, snapshotId);
-    QuestionId questionId = _idManager.getQuestionId(questionName, networkId, null);
+    QuestionId questionId = _idManager.getQuestionId(questionName, networkId, null).get();
     AnswerId baseAnswerId =
         _idManager.getBaseAnswerId(
             networkId,
@@ -1815,10 +1817,10 @@ public final class WorkMgrTest {
     String questionName = "question2Name";
     _manager.initNetwork(networkName, null);
     _manager.uploadQuestion(networkName, questionName, questionContent, false);
-    NetworkId networkId = _idManager.getNetworkId(networkName);
+    NetworkId networkId = _idManager.getNetworkId(networkName).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(snapshotName, networkId, snapshotId);
-    QuestionId questionId = _idManager.getQuestionId(questionName, networkId, null);
+    QuestionId questionId = _idManager.getQuestionId(questionName, networkId, null).get();
     QuestionSettingsId questionSettingsId = new QuestionSettingsId("blah");
     _idManager.assignQuestionSettingsId(question.getName(), networkId, questionSettingsId);
     AnswerId baseAnswerId =
@@ -1875,8 +1877,8 @@ public final class WorkMgrTest {
   }
 
   private boolean getMetadataSuggested(String containerName, String analysisName) {
-    NetworkId networkId = _idManager.getNetworkId(containerName);
-    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId);
+    NetworkId networkId = _idManager.getNetworkId(containerName).get();
+    AnalysisId analysisId = _idManager.getAnalysisId(analysisName, networkId).get();
     try {
       return AnalysisMetadataMgr.readMetadata(networkId, analysisId).getSuggested();
     } catch (IOException e) {
@@ -1969,8 +1971,8 @@ public final class WorkMgrTest {
     _manager.initSnapshot(networkName, snapshotName, srcDir, false);
 
     // Interface blacklist should not exist in new snapshot
-    NetworkId networkId = _idManager.getNetworkId(networkName);
-    SnapshotId snapshotId = _idManager.getSnapshotId(snapshotName, networkId);
+    NetworkId networkId = _idManager.getNetworkId(networkName).get();
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshotName, networkId).get();
     assertNull(_storage.loadInterfaceBlacklist(networkId, snapshotId));
     assertThat(
         _storage.loadRuntimeData(networkId, snapshotId),
@@ -3022,7 +3024,7 @@ public final class WorkMgrTest {
                         .build()))
             .build();
     _manager.getStorage().storeNodeRoles(networkNodeRoles, networkNodeRolesId);
-    _idManager.assignNetworkNodeRolesId(_idManager.getNetworkId(network), networkNodeRolesId);
+    _idManager.assignNetworkNodeRolesId(_idManager.getNetworkId(network).get(), networkNodeRolesId);
 
     // inferred roles for first snapshot should have been set network-wide
     assertThat(_manager.getNetworkNodeRoles(network), equalTo(networkNodeRoles));
@@ -3056,7 +3058,7 @@ public final class WorkMgrTest {
     String network = "network1";
     String questionClassId = "foo";
     _manager.initNetwork(network, null);
-    NetworkId networkId = _idManager.getNetworkId(network);
+    NetworkId networkId = _idManager.getNetworkId(network).get();
 
     // no QuestionSettingsId for questionClassId at first
     assertFalse(_idManager.hasQuestionSettingsId(questionClassId, networkId));
@@ -3068,7 +3070,7 @@ public final class WorkMgrTest {
     assertTrue(_idManager.hasQuestionSettingsId(questionClassId, networkId));
 
     QuestionSettingsId questionSettingsId =
-        _idManager.getQuestionSettingsId(questionClassId, networkId);
+        _idManager.getQuestionSettingsId(questionClassId, networkId).get();
     _manager.writeQuestionSettings(
         network, questionClassId, ImmutableList.of(), BatfishObjectMapper.mapper().readTree("{}"));
 
@@ -3097,7 +3099,7 @@ public final class WorkMgrTest {
     String network = "network1";
     String majorIssueType = "type1";
     _manager.initNetwork(network, null);
-    NetworkId networkId = _idManager.getNetworkId(network);
+    NetworkId networkId = _idManager.getNetworkId(network).get();
 
     // no ID should exist at first
     assertFalse(_idManager.hasIssueSettingsId(majorIssueType, networkId));
@@ -3108,7 +3110,8 @@ public final class WorkMgrTest {
     // There should be an ID now
     assertTrue(_idManager.hasIssueSettingsId(majorIssueType, networkId));
 
-    IssueSettingsId issueSettingsId = _idManager.getIssueSettingsId(majorIssueType, networkId);
+    IssueSettingsId issueSettingsId =
+        _idManager.getIssueSettingsId(majorIssueType, networkId).get();
 
     _manager.putMajorIssueConfig(
         network,
@@ -3152,7 +3155,7 @@ public final class WorkMgrTest {
 
     assertThat(
         workDetails.getSnapshotId(),
-        equalTo(_idManager.getSnapshotId(snapshot, _idManager.getNetworkId(network))));
+        equalTo(_idManager.getSnapshotId(snapshot, _idManager.getNetworkId(network).get()).get()));
     assertThat(workDetails.getWorkType(), equalTo(WorkType.PARSING_DEPENDENT_ANSWERING));
   }
 
@@ -3174,7 +3177,7 @@ public final class WorkMgrTest {
 
     assertThat(
         workDetails.getSnapshotId(),
-        equalTo(_idManager.getSnapshotId(snapshot, _idManager.getNetworkId(network))));
+        equalTo(_idManager.getSnapshotId(snapshot, _idManager.getNetworkId(network).get()).get()));
     assertThat(workDetails.getWorkType(), equalTo(WorkType.PARSING_DEPENDENT_ANSWERING));
   }
 
@@ -3187,10 +3190,10 @@ public final class WorkMgrTest {
     String questionName = "question2Name";
     _manager.initNetwork(networkName, null);
     _manager.uploadQuestion(networkName, questionName, questionContent, false);
-    NetworkId networkId = _idManager.getNetworkId(networkName);
+    NetworkId networkId = _idManager.getNetworkId(networkName).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(snapshotName, networkId, snapshotId);
-    QuestionId questionId = _idManager.getQuestionId(questionName, networkId, null);
+    QuestionId questionId = _idManager.getQuestionId(questionName, networkId, null).get();
     AnswerId baseAnswerId =
         _idManager.getBaseAnswerId(
             networkId,
@@ -3392,7 +3395,7 @@ public final class WorkMgrTest {
     // No question should result in questionExists being false
     assertFalse(_manager.checkQuestionExists(network, question, null));
 
-    NetworkId networkId = _idManager.getNetworkId(network);
+    NetworkId networkId = _idManager.getNetworkId(network).get();
     _idManager.assignQuestion(question, networkId, _idManager.generateQuestionId(), null);
     // After creating both network and question, questionExists should be true
     assertTrue(_manager.checkQuestionExists(network, question, null));
@@ -3417,8 +3420,8 @@ public final class WorkMgrTest {
     assertFalse(_manager.checkQuestionExists(network, question, analysis));
 
     // After creating network, analysis, and question, check should finally be true
-    NetworkId networkId = _idManager.getNetworkId(network);
-    AnalysisId analysisId = _idManager.getAnalysisId(analysis, networkId);
+    NetworkId networkId = _idManager.getNetworkId(network).get();
+    AnalysisId analysisId = _idManager.getAnalysisId(analysis, networkId).get();
     _idManager.assignQuestion(question, networkId, _idManager.generateQuestionId(), analysisId);
     assertTrue(_manager.checkQuestionExists(network, question, analysis));
   }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTestUtils.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTestUtils.java
@@ -59,10 +59,10 @@ public final class WorkMgrTestUtils {
       throws IOException {
     IdManager idManager = Main.getWorkMgr().getIdManager();
     SnapshotMetadataMgr ssmManager = Main.getWorkMgr().getSnapshotMetadataManager();
-    NetworkId networkId = idManager.getNetworkId(network);
+    NetworkId networkId = idManager.getNetworkId(network).get();
     SnapshotId snapshotId =
         idManager.hasSnapshotId(snapshot, networkId)
-            ? idManager.getSnapshotId(snapshot, networkId)
+            ? idManager.getSnapshotId(snapshot, networkId).get()
             : idManager.generateSnapshotId();
     idManager.assignSnapshot(snapshot, networkId, snapshotId);
     ssmManager.writeMetadata(
@@ -78,8 +78,8 @@ public final class WorkMgrTestUtils {
   public static void setSnapshotNodeRoles(
       NodeRolesData nodeRolesData, String network, String snapshot) throws IOException {
     IdManager idManager = Main.getWorkMgr().getIdManager();
-    NetworkId networkId = idManager.getNetworkId(network);
-    SnapshotId snapshotId = idManager.getSnapshotId(snapshot, networkId);
+    NetworkId networkId = idManager.getNetworkId(network).get();
+    SnapshotId snapshotId = idManager.getSnapshotId(snapshot, networkId).get();
     NodeRolesId snapshotNodeRolesId = idManager.getSnapshotNodeRolesId(networkId, snapshotId);
     Main.getWorkMgr().getStorage().storeNodeRoles(nodeRolesData, snapshotNodeRolesId);
   }
@@ -159,8 +159,8 @@ public final class WorkMgrTestUtils {
     IdManager idManager = manager.getIdManager();
     StorageProvider storage = manager.getStorage();
     Question question = new TestQuestion();
-    NetworkId networkId = idManager.getNetworkId(network);
-    SnapshotId snapshotId = idManager.getSnapshotId(snapshot, networkId);
+    NetworkId networkId = idManager.getNetworkId(network).get();
+    SnapshotId snapshotId = idManager.getSnapshotId(snapshot, networkId).get();
     AnalysisId analysisId = null;
 
     // Setup question
@@ -172,18 +172,20 @@ public final class WorkMgrTestUtils {
           ImmutableMap.of(questionName, BatfishObjectMapper.writeString(question)),
           Lists.newArrayList(),
           null);
-      analysisId = idManager.getAnalysisId(analysis, networkId);
+      analysisId = idManager.getAnalysisId(analysis, networkId).get();
     } else {
       idManager.assignQuestion(questionName, networkId, idManager.generateQuestionId(), null);
     }
-    QuestionId questionId = idManager.getQuestionId(questionName, networkId, analysisId);
+    QuestionId questionId = idManager.getQuestionId(questionName, networkId, analysisId).get();
     storage.storeQuestion(
         BatfishObjectMapper.writeString(question), networkId, questionId, analysisId);
 
     // Setup answer iff one was passed in
     if (answer != null) {
       SnapshotId referenceSnapshotId =
-          referenceSnapshot == null ? null : idManager.getSnapshotId(referenceSnapshot, networkId);
+          referenceSnapshot == null
+              ? null
+              : idManager.getSnapshotId(referenceSnapshot, networkId).get();
       AnswerId answerId =
           idManager.getBaseAnswerId(
               networkId,

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkQueueMgrTest.java
@@ -142,7 +142,7 @@ public final class WorkQueueMgrTest {
     Main.getWorkMgr().initNetwork(NETWORK, null);
     _idManager = Main.getWorkMgr().getIdManager();
     _snapshotMetadataManager = Main.getWorkMgr().getSnapshotMetadataManager();
-    _networkId = _idManager.getNetworkId(NETWORK);
+    _networkId = _idManager.getNetworkId(NETWORK).get();
     _workQueueMgr = new WorkQueueMgr(Type.memory, Main.getLogger(), _snapshotMetadataManager);
   }
 
@@ -153,8 +153,8 @@ public final class WorkQueueMgrTest {
   private void initSnapshotMetadata(String network, String snapshot, ProcessingStatus status)
       throws IOException {
     WorkMgrTestUtils.initSnapshotWithTopology(NETWORK, snapshot, ImmutableSet.of());
-    NetworkId networkId = _idManager.getNetworkId(network);
-    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, networkId);
+    NetworkId networkId = _idManager.getNetworkId(network).get();
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, networkId).get();
     _snapshotMetadataManager.writeMetadata(
         new SnapshotMetadata(Instant.now(), null).updateStatus(status, null),
         networkId,
@@ -168,7 +168,7 @@ public final class WorkQueueMgrTest {
             WorkDetails.builder()
                 .setWorkType(wType)
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get())
                 .build());
     _workQueueMgr.queueUnassignedWork(work);
   }
@@ -181,8 +181,9 @@ public final class WorkQueueMgrTest {
             WorkDetails.builder()
                 .setWorkType(wType)
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
-                .setReferenceSnapshotId(_idManager.getSnapshotId(referenceSnapshot, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get())
+                .setReferenceSnapshotId(
+                    _idManager.getSnapshotId(referenceSnapshot, _networkId).get())
                 .setIsDifferential(true)
                 .build());
     _workQueueMgr.queueUnassignedWork(work);
@@ -195,7 +196,7 @@ public final class WorkQueueMgrTest {
             new WorkItem(NETWORK, SNAPSHOT),
             WorkDetails.builder()
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(SNAPSHOT, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(SNAPSHOT, _networkId).get())
                 .setWorkType(wType)
                 .build());
     _thrown.expect(BatfishException.class);
@@ -213,8 +214,9 @@ public final class WorkQueueMgrTest {
             new WorkItem(NETWORK, SNAPSHOT),
             WorkDetails.builder()
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(SNAPSHOT, _networkId))
-                .setReferenceSnapshotId(_idManager.getSnapshotId(REFERENCE_SNAPSHOT, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(SNAPSHOT, _networkId).get())
+                .setReferenceSnapshotId(
+                    _idManager.getSnapshotId(REFERENCE_SNAPSHOT, _networkId).get())
                 .setIsDifferential(true)
                 .setWorkType(wType)
                 .build());
@@ -232,7 +234,7 @@ public final class WorkQueueMgrTest {
             new WorkItem(NETWORK, SNAPSHOT),
             WorkDetails.builder()
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(SNAPSHOT, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(SNAPSHOT, _networkId).get())
                 .setWorkType(wType)
                 .build());
     doAction(new Action(ActionType.QUEUE, work));
@@ -254,8 +256,9 @@ public final class WorkQueueMgrTest {
             new WorkItem(NETWORK, SNAPSHOT),
             WorkDetails.builder()
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(SNAPSHOT, _networkId))
-                .setReferenceSnapshotId(_idManager.getSnapshotId(REFERENCE_SNAPSHOT, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(SNAPSHOT, _networkId).get())
+                .setReferenceSnapshotId(
+                    _idManager.getSnapshotId(REFERENCE_SNAPSHOT, _networkId).get())
                 .setIsDifferential(true)
                 .setWorkType(wType)
                 .build());
@@ -268,7 +271,7 @@ public final class WorkQueueMgrTest {
   public void getCompletedWork() throws Exception {
     String snapshot = "snapshot";
     WorkMgrTestUtils.initSnapshotWithTopology(NETWORK, snapshot, ImmutableSet.of());
-    SnapshotId snapshot1Id = _idManager.getSnapshotId(snapshot, _networkId);
+    SnapshotId snapshot1Id = _idManager.getSnapshotId(snapshot, _networkId).get();
 
     WorkDetails.Builder builder =
         WorkDetails.builder()
@@ -326,9 +329,9 @@ public final class WorkQueueMgrTest {
     WorkMgrTestUtils.initSnapshotWithTopology(network1, snapshot2, ImmutableSet.of());
     WorkMgrTestUtils.initSnapshotWithTopology(network2, snapshot1, ImmutableSet.of());
 
-    NetworkId network1Id = _idManager.getNetworkId(network1);
-    NetworkId network2Id = _idManager.getNetworkId(network2);
-    SnapshotId network1Snapshot1Id = _idManager.getSnapshotId(snapshot1, network1Id);
+    NetworkId network1Id = _idManager.getNetworkId(network1).get();
+    NetworkId network2Id = _idManager.getNetworkId(network2).get();
+    SnapshotId network1Snapshot1Id = _idManager.getSnapshotId(snapshot1, network1Id).get();
 
     WorkDetails.Builder builder = WorkDetails.builder().setWorkType(WorkType.UNKNOWN);
     QueuedWork network1Snapshot1Work1 =
@@ -340,14 +343,14 @@ public final class WorkQueueMgrTest {
             new WorkItem(network1, snapshot2),
             builder
                 .setNetworkId(network1Id)
-                .setSnapshotId(_idManager.getSnapshotId(snapshot2, network1Id))
+                .setSnapshotId(_idManager.getSnapshotId(snapshot2, network1Id).get())
                 .build());
     QueuedWork network2Snapshot1Work =
         new QueuedWork(
             new WorkItem(network2, snapshot1),
             builder
                 .setNetworkId(network2Id)
-                .setSnapshotId(_idManager.getSnapshotId(snapshot1, network2Id))
+                .setSnapshotId(_idManager.getSnapshotId(snapshot1, network2Id).get())
                 .build());
     _workQueueMgr.queueUnassignedWork(network1Snapshot1Work1);
     _workQueueMgr.queueUnassignedWork(network1Snapshot2Work);
@@ -381,7 +384,7 @@ public final class WorkQueueMgrTest {
         WorkDetails.builder()
             .setWorkType(WorkType.UNKNOWN)
             .setNetworkId(_networkId)
-            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId));
+            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get());
     QueuedWork work1 = new QueuedWork(wItem1, builder.build());
     QueuedWork work2 = new QueuedWork(new WorkItem(NETWORK, snapshot), builder.build());
     _workQueueMgr.queueUnassignedWork(work1);
@@ -402,7 +405,7 @@ public final class WorkQueueMgrTest {
         WorkDetails.builder()
             .setWorkType(WorkType.UNKNOWN)
             .setNetworkId(_networkId)
-            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId));
+            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get());
     QueuedWork work1 = new QueuedWork(wItem1, builder.build());
     QueuedWork work2 = new QueuedWork(new WorkItem(NETWORK, snapshot), builder.build());
     _workQueueMgr.queueUnassignedWork(work1);
@@ -425,21 +428,21 @@ public final class WorkQueueMgrTest {
     Main.getWorkMgr().initNetwork(otherNetwork, null);
     WorkMgrTestUtils.initSnapshotWithTopology(otherNetwork, snapshot, ImmutableSet.of());
     initSnapshotMetadata(otherNetwork, snapshot, ProcessingStatus.UNINITIALIZED);
-    NetworkId otherNetworkId = _idManager.getNetworkId(otherNetwork);
+    NetworkId otherNetworkId = _idManager.getNetworkId(otherNetwork).get();
     WorkDetails.Builder builder = WorkDetails.builder().setWorkType(WorkType.UNKNOWN);
     QueuedWork work1 =
         new QueuedWork(
             new WorkItem(NETWORK, snapshot),
             builder
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get())
                 .build());
     QueuedWork work2 =
         new QueuedWork(
             new WorkItem(otherNetwork, snapshot),
             builder
                 .setNetworkId(otherNetworkId)
-                .setSnapshotId(_idManager.getSnapshotId(snapshot, otherNetworkId))
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, otherNetworkId).get())
                 .build());
     _workQueueMgr.queueUnassignedWork(work1);
     _workQueueMgr.queueUnassignedWork(work2);
@@ -456,7 +459,7 @@ public final class WorkQueueMgrTest {
     WorkDetails.Builder builder =
         WorkDetails.builder()
             .setNetworkId(_networkId)
-            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId));
+            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get());
     QueuedWork work1 =
         new QueuedWork(
             new WorkItem(NETWORK, snapshot), builder.setWorkType(WorkType.PARSING).build());
@@ -483,15 +486,15 @@ public final class WorkQueueMgrTest {
     QueuedWork work1 =
         new QueuedWork(
             new WorkItem(NETWORK, snapshot1),
-            builder.setSnapshotId(_idManager.getSnapshotId(snapshot1, _networkId)).build());
+            builder.setSnapshotId(_idManager.getSnapshotId(snapshot1, _networkId).get()).build());
     QueuedWork work2 =
         new QueuedWork(
             new WorkItem(NETWORK, snapshot1),
-            builder.setSnapshotId(_idManager.getSnapshotId(snapshot2, _networkId)).build());
+            builder.setSnapshotId(_idManager.getSnapshotId(snapshot2, _networkId).get()).build());
     _workQueueMgr.queueUnassignedWork(work1);
     _workQueueMgr.queueUnassignedWork(work2);
 
-    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot1, _networkId);
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot1, _networkId).get();
     List<QueuedWork> parsingWorks = _workQueueMgr.listIncompleteWork(_networkId, snapshotId, null);
 
     assertThat(parsingWorks, equalTo(Collections.singletonList(work1)));
@@ -1160,7 +1163,7 @@ public final class WorkQueueMgrTest {
   public void dataplaningAfterParsingFailure() throws Exception {
     String snapshot = "snapshot1";
     initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
-    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId);
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId).get();
     WorkDetails.Builder builder =
         WorkDetails.builder().setNetworkId(_networkId).setSnapshotId(snapshotId);
     QueuedWork work1 =
@@ -1194,7 +1197,7 @@ public final class WorkQueueMgrTest {
     WorkDetails.Builder builder =
         WorkDetails.builder()
             .setNetworkId(_networkId)
-            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId));
+            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get());
     QueuedWork work1 =
         new QueuedWork(
             new WorkItem(NETWORK, snapshot), builder.setWorkType(WorkType.PARSING).build());
@@ -1218,7 +1221,7 @@ public final class WorkQueueMgrTest {
             WorkDetails.builder()
                 .setWorkType(WorkType.UNKNOWN)
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get())
                 .build());
     _workQueueMgr.queueUnassignedWork(work1);
     assertThat(_workQueueMgr.getLength(QueueType.INCOMPLETE), equalTo(1L));
@@ -1236,7 +1239,7 @@ public final class WorkQueueMgrTest {
     WorkDetails.Builder builder =
         WorkDetails.builder()
             .setNetworkId(_networkId)
-            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+            .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get())
             .setWorkType(WorkType.UNKNOWN);
     QueuedWork work1 = new QueuedWork(new WorkItem(NETWORK, snapshot), builder.build());
     QueuedWork work2 = new QueuedWork(new WorkItem(NETWORK, snapshot), builder.build());
@@ -1284,7 +1287,7 @@ public final class WorkQueueMgrTest {
             WorkDetails.builder()
                 .setWorkType(WorkType.UNKNOWN)
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get())
                 .build());
     _workQueueMgr.queueUnassignedWork(work1);
 
@@ -1299,7 +1302,7 @@ public final class WorkQueueMgrTest {
     String snapshot = "snapshot1";
     initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
 
-    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId);
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId).get();
     WorkDetails.Builder builder =
         WorkDetails.builder().setNetworkId(_networkId).setSnapshotId(snapshotId);
     QueuedWork work1 =
@@ -1347,7 +1350,7 @@ public final class WorkQueueMgrTest {
     String snapshot = "snapshot1";
     initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
 
-    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId);
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId).get();
     WorkDetails.Builder builder =
         WorkDetails.builder().setNetworkId(_networkId).setSnapshotId(snapshotId);
     QueuedWork work1 =
@@ -1401,7 +1404,7 @@ public final class WorkQueueMgrTest {
             WorkDetails.builder()
                 .setWorkType(WorkType.PARSING)
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get())
                 .build());
 
     doAction(new Action(ActionType.QUEUE, work1));
@@ -1420,7 +1423,7 @@ public final class WorkQueueMgrTest {
   public void testProcessTaskCheckResultPromoteSuccessfulParse() throws Exception {
     String snapshot = "snapshot1";
     initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
-    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId);
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId).get();
     NodeRolesId snapshotNodeRolesId = _idManager.getSnapshotNodeRolesId(_networkId, snapshotId);
     Main.getWorkMgr()
         .getStorage()
@@ -1434,20 +1437,20 @@ public final class WorkQueueMgrTest {
             WorkDetails.builder()
                 .setWorkType(WorkType.PARSING)
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get())
                 .build());
 
     doAction(new Action(ActionType.QUEUE, work1));
     _workQueueMgr.processTaskCheckResult(work1, new Task(TaskStatus.TerminatedNormally, "Fake"));
 
-    assertThat(_idManager.getNetworkNodeRolesId(_networkId), equalTo(snapshotNodeRolesId));
+    assertThat(_idManager.getNetworkNodeRolesId(_networkId).get(), equalTo(snapshotNodeRolesId));
   }
 
   @Test
   public void testProcessTaskCheckResultPromoteUnsuccessfulParse() throws Exception {
     String snapshot = "snapshot1";
     initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
-    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId);
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId).get();
     NodeRolesId snapshotNodeRolesId = _idManager.getSnapshotNodeRolesId(_networkId, snapshotId);
     Main.getWorkMgr()
         .getStorage()
@@ -1461,7 +1464,7 @@ public final class WorkQueueMgrTest {
             WorkDetails.builder()
                 .setWorkType(WorkType.PARSING)
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get())
                 .build());
 
     doAction(new Action(ActionType.QUEUE, work1));
@@ -1474,7 +1477,7 @@ public final class WorkQueueMgrTest {
   public void testProcessTaskCheckResultPromoteNoChange() throws Exception {
     String snapshot = "snapshot1";
     initSnapshotMetadata(snapshot, ProcessingStatus.UNINITIALIZED);
-    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId);
+    SnapshotId snapshotId = _idManager.getSnapshotId(snapshot, _networkId).get();
     NodeRolesId snapshotNodeRolesId = _idManager.getSnapshotNodeRolesId(_networkId, snapshotId);
     Main.getWorkMgr()
         .getStorage()
@@ -1488,12 +1491,12 @@ public final class WorkQueueMgrTest {
             WorkDetails.builder()
                 .setWorkType(WorkType.PARSING)
                 .setNetworkId(_networkId)
-                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId))
+                .setSnapshotId(_idManager.getSnapshotId(snapshot, _networkId).get())
                 .build());
 
     doAction(new Action(ActionType.QUEUE, work1));
     _workQueueMgr.processTaskCheckResult(work1, new Task(TaskStatus.TerminatedNormally, "Fake"));
 
-    assertThat(_idManager.getNetworkNodeRolesId(_networkId), equalTo(oldNodeRolesId));
+    assertThat(_idManager.getNetworkNodeRolesId(_networkId).get(), equalTo(oldNodeRolesId));
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/QuestionSettingsJsonPathResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/QuestionSettingsJsonPathResourceTest.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.util.Optional;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.core.MediaType;
@@ -103,10 +104,10 @@ public final class QuestionSettingsJsonPathResourceTest extends WorkMgrServiceV2
     _idManager =
         new LocalIdManager() {
           @Override
-          public QuestionSettingsId getQuestionSettingsId(
+          public Optional<QuestionSettingsId> getQuestionSettingsId(
               String questionClassId, NetworkId networkId) {
             if (questionClassId.equals(BAD_QUESTION)) {
-              return BAD_QUESTION_SETTINGS_ID;
+              return Optional.of(BAD_QUESTION_SETTINGS_ID);
             }
             return super.getQuestionSettingsId(questionClassId, networkId);
           }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/QuestionSettingsResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/QuestionSettingsResourceTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
+import java.util.Optional;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.core.MediaType;
@@ -93,10 +94,10 @@ public final class QuestionSettingsResourceTest extends WorkMgrServiceV2TestBase
     _idManager =
         new LocalIdManager() {
           @Override
-          public QuestionSettingsId getQuestionSettingsId(
+          public Optional<QuestionSettingsId> getQuestionSettingsId(
               String questionClassId, NetworkId networkId) {
             if (questionClassId.equals(BAD_QUESTION)) {
-              return BAD_QUESTION_SETTINGS_ID;
+              return Optional.of(BAD_QUESTION_SETTINGS_ID);
             }
             return super.getQuestionSettingsId(questionClassId, networkId);
           }
@@ -135,7 +136,7 @@ public final class QuestionSettingsResourceTest extends WorkMgrServiceV2TestBase
     _storage._questionSettings = settings;
     QuestionSettingsId questionSettingsId = _idManager.generateQuestionSettingsId();
     _idManager.assignQuestionSettingsId(
-        QUESTION, _idManager.getNetworkId(NETWORK), questionSettingsId);
+        QUESTION, _idManager.getNetworkId(NETWORK).get(), questionSettingsId);
     try (Response response = getQuestionSettingsTarget(QUESTION).get()) {
       assertThat(response.getStatus(), equalTo(OK.getStatusCode()));
       assertThat(response.readEntity(String.class), equalTo(settings));

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotResourceTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/resources/SnapshotResourceTest.java
@@ -299,8 +299,8 @@ public final class SnapshotResourceTest extends WorkMgrServiceV2TestBase {
     Main.getWorkMgr().initNetwork(network, null);
     WorkMgrTestUtils.uploadTestSnapshot(network, snapshot, _folder);
     IdManager idm = Main.getWorkMgr().getIdManager();
-    NetworkId networkId = idm.getNetworkId(network);
-    SnapshotId snapshotId = idm.getSnapshotId(snapshot, networkId);
+    NetworkId networkId = idm.getNetworkId(network).get();
+    SnapshotId snapshotId = idm.getSnapshotId(snapshot, networkId).get();
     Main.getWorkMgr().getStorage().storeWorkLog("logoutput", networkId, snapshotId, "workid");
 
     Builder target = getWorkLogTarget(network, snapshot, "workid");


### PR DESCRIPTION
- rewrite `getXXXId` APIs to return `Optional<XXXId>`
  - return `Optional.empty()` instead of throwing when ID does not exist
  - replace pairs of calls to `hasXXX`+`getXXXId` with single call to `getXXXId`
  - add a ton of `checkArgument` calls to result of `getXXXId` to provide better error traces
- rewrite `deleteXXX` (mapping of name to ID) APIs to return boolean
indicating whether name was previously mapped (and successfully deleted)
  - replace pairs of calls to `hasXXX`+`deleteXXX` with single call to `deleteXXX`