### PR TITLE
Interface: hide the fooFilterName setters and getters

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -1181,7 +1181,7 @@ public final class Interface extends ComparableStructure<String> {
 
   /** The IPV4 access-list used to filter traffic destined for this device on this interface. */
   @JsonProperty(PROP_INBOUND_FILTER)
-  public String getInboundFilterName() {
+  private String getInboundFilterName() {
     if (_inboundFilter != null) {
       return _inboundFilter.getName();
     } else {
@@ -1196,7 +1196,7 @@ public final class Interface extends ComparableStructure<String> {
 
   /** The IPV4 access-list used to filter traffic that arrives on this interface. */
   @JsonProperty(PROP_INCOMING_FILTER)
-  public String getIncomingFilterName() {
+  private String getIncomingFilterName() {
     if (_incomingFilter != null) {
       return _incomingFilter.getName();
     } else {
@@ -1311,7 +1311,7 @@ public final class Interface extends ComparableStructure<String> {
 
   /** The IPV4 access-list used to filter traffic that is sent out this interface. Stored as @id. */
   @JsonProperty(PROP_OUTGOING_FILTER)
-  public String getOutgoingFilterName() {
+  private String getOutgoingFilterName() {
     if (_outgoingFilter != null) {
       return _outgoingFilter.getName();
     } else {
@@ -1368,7 +1368,7 @@ public final class Interface extends ComparableStructure<String> {
 
   /** The IPV4 access-list used to filter incoming traffic after applying destination NAT. */
   @JsonProperty(PROP_POST_TRANSFORMATION_INCOMING_FILTER)
-  public String getPostTransformationIncomingFilterName() {
+  private String getPostTransformationIncomingFilterName() {
     if (_postTransformationIncomingFilter != null) {
       return _postTransformationIncomingFilter.getName();
     } else {
@@ -1383,7 +1383,7 @@ public final class Interface extends ComparableStructure<String> {
 
   /** The IPV4 access-list used to filter outgoing traffic before applying source NAT. */
   @JsonProperty(PROP_PRE_TRANSFORMATION_OUTGOING_FILTER)
-  public String getPreTransformationOutgoingFilterName() {
+  private String getPreTransformationOutgoingFilterName() {
     if (_preTransformationOutgoingFilter != null) {
       return _preTransformationOutgoingFilter.getName();
     } else {
@@ -1633,7 +1633,7 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   @JsonProperty(PROP_INBOUND_FILTER)
-  public void setInboundFilterName(String inboundFilterName) {
+  private void setInboundFilterName(String inboundFilterName) {
     _inboundFilterName = inboundFilterName;
   }
 
@@ -1648,7 +1648,7 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   @JsonProperty(PROP_INCOMING_FILTER)
-  public void setIncomingFilterName(String incomingFilterName) {
+  private void setIncomingFilterName(String incomingFilterName) {
     _incomingFilterName = incomingFilterName;
   }
 
@@ -1688,7 +1688,7 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   @JsonProperty(PROP_OUTGOING_FILTER)
-  public void setOutgoingFilter(String outgoingFilterName) {
+  private void setOutgoingFilter(String outgoingFilterName) {
     _outgoingFilterName = outgoingFilterName;
   }
 
@@ -1726,7 +1726,7 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   @JsonProperty(PROP_POST_TRANSFORMATION_INCOMING_FILTER)
-  public void setPostTransformationIncomingFilter(String postTransformationIncomingFilterName) {
+  private void setPostTransformationIncomingFilter(String postTransformationIncomingFilterName) {
     _postTransformationIncomingFilterName = postTransformationIncomingFilterName;
   }
 
@@ -1736,7 +1736,7 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   @JsonProperty(PROP_PRE_TRANSFORMATION_OUTGOING_FILTER)
-  public void setPreTransformationOutgoingFilter(String preTransformationOutgoingFilterName) {
+  private void setPreTransformationOutgoingFilter(String preTransformationOutgoingFilterName) {
     _preTransformationOutgoingFilterName = preTransformationOutgoingFilterName;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
@@ -15,6 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.SwitchportEncapsulationType;
 import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.answers.Schema;
@@ -72,6 +73,22 @@ public class InterfacePropertySpecifier extends PropertySpecifier {
   public static final String VRF = "VRF";
   public static final String VRRP_GROUPS = "VRRP_Groups";
   public static final String ZONE_NAME = "Zone_Name";
+
+  private static @Nullable String getIncomingFilterName(@Nonnull Interface i) {
+    IpAccessList acl = i.getIncomingFilter();
+    if (acl == null) {
+      return null;
+    }
+    return acl.getName();
+  }
+
+  private static @Nullable String getOutgoingFilterName(@Nonnull Interface i) {
+    IpAccessList acl = i.getOutgoingFilter();
+    if (acl == null) {
+      return null;
+    }
+    return acl.getName();
+  }
 
   private static final Map<String, PropertyDescriptor<Interface>> JAVA_MAP =
       new ImmutableMap.Builder<String, PropertyDescriptor<Interface>>()
@@ -159,7 +176,9 @@ public class InterfacePropertySpecifier extends PropertySpecifier {
           .put(
               INCOMING_FILTER_NAME,
               new PropertyDescriptor<>(
-                  Interface::getIncomingFilterName, Schema.STRING, "Name of the input IPv4 filter"))
+                  InterfacePropertySpecifier::getIncomingFilterName,
+                  Schema.STRING,
+                  "Name of the input IPv4 filter"))
           // Uncomment after we've fixed interface types
           // .put(INTERFACE_TYPE, new PropertyDescriptor<>(Interface::getInterfaceType,
           // Schema.STRING))
@@ -181,7 +200,7 @@ public class InterfacePropertySpecifier extends PropertySpecifier {
           .put(
               OUTGOING_FILTER_NAME,
               new PropertyDescriptor<>(
-                  Interface::getOutgoingFilterName,
+                  InterfacePropertySpecifier::getOutgoingFilterName,
                   Schema.STRING,
                   "Name of the output IPv4 filter"))
           // skip getOwner

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/DataModelMatchers.java
@@ -110,7 +110,7 @@ public final class DataModelMatchers {
    */
   public static @Nonnull Matcher<Interface> hasOutgoingFilterName(
       @Nonnull Matcher<? super String> subMatcher) {
-    return new InterfaceMatchersImpl.HasOutgoingFilterName(subMatcher);
+    return hasOutgoingFilter(IpAccessListMatchers.hasName(subMatcher));
   }
 
   /**
@@ -118,7 +118,7 @@ public final class DataModelMatchers {
    * to {@code expectedName}.
    */
   public static @Nonnull Matcher<Interface> hasOutgoingFilterName(@Nullable String expectedName) {
-    return new InterfaceMatchersImpl.HasOutgoingFilterName(equalTo(expectedName));
+    return hasOutgoingFilter(IpAccessListMatchers.hasName(expectedName));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/InterfaceMatchersImpl.java
@@ -372,17 +372,6 @@ final class InterfaceMatchersImpl {
     }
   }
 
-  static final class HasOutgoingFilterName extends FeatureMatcher<Interface, String> {
-    HasOutgoingFilterName(@Nonnull Matcher<? super String> subMatcher) {
-      super(subMatcher, "an Interface with outgoingFilterName:", "outgoingFilterName");
-    }
-
-    @Override
-    protected String featureValueOf(Interface actual) {
-      return actual.getOutgoingFilterName();
-    }
-  }
-
   static final class HasSpeed extends FeatureMatcher<Interface, Double> {
     HasSpeed(@Nonnull Matcher<? super Double> subMatcher) {
       super(subMatcher, "an Interface with speed:", "speed");

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpAccessListMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/IpAccessListMatchers.java
@@ -70,6 +70,14 @@ public final class IpAccessListMatchers {
   }
 
   /**
+   * Provides a matcher that matches if the Ip Access List's value of {@code name} matches specified
+   * {@code subMatcher}
+   */
+  public static @Nonnull HasName hasName(Matcher<? super String> subMatcher) {
+    return new HasName(subMatcher);
+  }
+
+  /**
    * Provides a matcher that matches if the IpAccessList rejects a flow at the provided source
    * interface given the provided acl definitions.
    */

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/InterfacePropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/InterfacePropertySpecifierTest.java
@@ -67,7 +67,6 @@ public class InterfacePropertySpecifierTest {
             .setLines(ImmutableList.of(ExprAclLine.ACCEPT_ALL))
             .build();
     Interface i1 = Interface.builder().setName("i1").setIncomingFilter(acl).build();
-    i1.setInboundFilterName(acl.getName());
     assertThat(
         InterfacePropertySpecifier.getPropertyDescriptor(INCOMING_FILTER_NAME)
             .getGetter()

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -161,40 +161,60 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
   private static void removeInvalidAcls(Configuration c, Warnings w) {
     for (Interface iface : c.getAllInterfaces().values()) {
       String ifaceName = iface.getName();
-      String outName = iface.getOutgoingFilterName();
-      if (outName != null && !c.getIpAccessLists().containsKey(outName)) {
+
+      IpAccessList inboundAcl = iface.getInboundFilter();
+      if (inboundAcl != null && !c.getIpAccessLists().containsKey(inboundAcl.getName())) {
         w.redFlag(
             String.format(
-                "IpAccessList map is missing filter %s: outgoing filter for interface %s",
-                outName, ifaceName));
-        iface.setOutgoingFilter((IpAccessList) null);
+                "IpAccessList map is missing filter %s: inbound filter for interface %s",
+                inboundAcl.getName(), ifaceName));
+        iface.setInboundFilter(null);
       }
 
-      String inName = iface.getIncomingFilterName();
-      if (inName != null && !c.getIpAccessLists().containsKey(inName)) {
+      IpAccessList inAcl = iface.getIncomingFilter();
+      if (inAcl != null && !c.getIpAccessLists().containsKey(inAcl.getName())) {
         w.redFlag(
             String.format(
                 "IpAccessList map is missing filter %s: incoming filter for interface %s",
-                inName, ifaceName));
+                inAcl.getName(), ifaceName));
         iface.setIncomingFilter(null);
       }
 
-      String postTransformName = iface.getPostTransformationIncomingFilterName();
-      if (postTransformName != null && !c.getIpAccessLists().containsKey(postTransformName)) {
+      IpAccessList outAcl = iface.getOutgoingFilter();
+      if (outAcl != null && !c.getIpAccessLists().containsKey(outAcl.getName())) {
+        w.redFlag(
+            String.format(
+                "IpAccessList map is missing filter %s: outgoing filter for interface %s",
+                outAcl.getName(), ifaceName));
+        iface.setOutgoingFilter(null);
+      }
+
+      IpAccessList outOriginalAcl = iface.getOutgoingOriginalFlowFilter();
+      if (outOriginalAcl != null && !c.getIpAccessLists().containsKey(outOriginalAcl.getName())) {
+        w.redFlag(
+            String.format(
+                "IpAccessList map is missing filter %s: outgoing filter on original flow for interface %s",
+                outOriginalAcl.getName(), ifaceName));
+        iface.setOutgoingOriginalFlowFilter(null);
+      }
+
+      IpAccessList postTransformAcl = iface.getPostTransformationIncomingFilter();
+      if (postTransformAcl != null
+          && !c.getIpAccessLists().containsKey(postTransformAcl.getName())) {
         w.redFlag(
             String.format(
                 "IpAccessList map is missing filter %s: post transformation incoming filter for interface %s",
-                postTransformName, ifaceName));
-        iface.setPostTransformationIncomingFilter((IpAccessList) null);
+                postTransformAcl.getName(), ifaceName));
+        iface.setPostTransformationIncomingFilter(null);
       }
 
-      String preTransformName = iface.getPreTransformationOutgoingFilterName();
-      if (preTransformName != null && !c.getIpAccessLists().containsKey(preTransformName)) {
+      IpAccessList preTransform = iface.getPreTransformationOutgoingFilter();
+      if (preTransform != null && !c.getIpAccessLists().containsKey(preTransform.getName())) {
         w.redFlag(
             String.format(
                 "IpAccessList map is missing filter %s: pre transformation outgoing filter for interface %s",
-                preTransformName, ifaceName));
-        iface.setPreTransformationOutgoingFilter((IpAccessList) null);
+                preTransform.getName(), ifaceName));
+        iface.setPreTransformationOutgoingFilter(null);
       }
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2000,8 +2000,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
     if (zoneOutgoingAcl == null) {
       return;
     }
-    String oldOutgoingFilterName = newIface.getOutgoingFilterName();
-    if (oldOutgoingFilterName == null) {
+    IpAccessList oldOutgoingFilter = newIface.getOutgoingFilter();
+    if (oldOutgoingFilter == null) {
       // No interface outbound filter
       newIface.setOutgoingFilter(zoneOutgoingAcl);
       return;
@@ -2010,7 +2010,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
     // Construct a new ACL that combines filters, i.e. 1 AND 2
     // 1) the interface outbound filter, if it exists
     // 2) the zone filter
-
+    String oldOutgoingFilterName = oldOutgoingFilter.getName();
     IpAccessList combinedOutgoingAcl =
         IpAccessList.builder()
             .setOwner(c)
@@ -2044,7 +2044,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
     if (interSecurityLevelAcl == null) {
       return;
     }
-    String oldOutgoingFilterName = newIface.getOutgoingFilterName();
+    IpAccessList oldOutgoingFilter = newIface.getOutgoingFilter();
+    String oldOutgoingFilterName = oldOutgoingFilter == null ? null : oldOutgoingFilter.getName();
 
     // Construct a new ACL that:
     // 1) rejects if the (inter- or intra-) security-level policy rejects

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -206,6 +206,7 @@ import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.eigrp.EigrpProcess;
 import org.batfish.datamodel.matchers.HsrpGroupMatchers;
+import org.batfish.datamodel.matchers.IpAccessListMatchers;
 import org.batfish.datamodel.matchers.NssaSettingsMatchers;
 import org.batfish.datamodel.matchers.OspfAreaMatchers;
 import org.batfish.datamodel.matchers.Route6FilterListMatchers;
@@ -2412,8 +2413,8 @@ public final class CiscoNxosGrammarTest {
             hasMtu(9216)));
     assertTrue(eth11.getAutoState());
     assertThat(eth11.getDhcpRelayAddresses(), contains(Ip.parse("1.2.3.4"), Ip.parse("1.2.3.5")));
-    assertThat(eth11.getIncomingFilterName(), equalTo("acl_in"));
-    assertThat(eth11.getOutgoingFilterName(), equalTo("acl_out"));
+    assertThat(eth11.getIncomingFilter(), IpAccessListMatchers.hasName("acl_in"));
+    assertThat(eth11.getOutgoingFilter(), IpAccessListMatchers.hasName("acl_out"));
     // TODO: convert and test delay
   }
 

--- a/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/BatfishTest.java
@@ -173,8 +173,8 @@ public class BatfishTest {
             _folder);
     Map<String, Configuration> configurations = batfish.loadConfigurations(batfish.getSnapshot());
     assertThat(
-        configurations.get("host1").getAllInterfaces().get("Ethernet0").getIncomingFilterName(),
-        is(notNullValue()));
+        configurations.get("host1").getAllInterfaces().get("Ethernet0").getIncomingFilter(),
+        notNullValue());
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/InternetGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/InternetGatewayTest.java
@@ -55,6 +55,7 @@ import org.batfish.datamodel.PrefixRange;
 import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
+import org.batfish.datamodel.matchers.IpAccessListMatchers;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.TransformationStep;
 import org.junit.Test;
@@ -159,8 +160,8 @@ public class InternetGatewayTest {
         igwConfig
             .getAllInterfaces()
             .get(Utils.interfaceNameToRemote(vpcConfig))
-            .getIncomingFilterName(),
-        equalTo(UNASSOCIATED_PRIVATE_IP_FILTER_NAME));
+            .getIncomingFilter(),
+        IpAccessListMatchers.hasName(UNASSOCIATED_PRIVATE_IP_FILTER_NAME));
 
     assertThat(
         igwConfig.getRoutingPolicies().get(BACKBONE_EXPORT_POLICY_NAME).getStatements(),

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
@@ -43,6 +43,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.matchers.IpAccessListMatchers;
 import org.batfish.representation.aws.NetworkAcl.NetworkAclAssociation;
 import org.batfish.representation.aws.Route.State;
 import org.batfish.representation.aws.Route.TargetType;
@@ -559,13 +560,17 @@ public class SubnetTest {
     // NACLs are not installed on the instances-facing interface
     Interface instancesInterface =
         subnetCfg.getAllInterfaces().get(instancesInterfaceName(subnet.getId()));
-    assertThat(instancesInterface.getIncomingFilterName(), nullValue());
-    assertThat(instancesInterface.getOutgoingFilterName(), nullValue());
+    assertThat(instancesInterface.getIncomingFilter(), nullValue());
+    assertThat(instancesInterface.getOutgoingFilter(), nullValue());
 
     // NACLs are installed on the vpc-facing interface
     Interface ifaceToVpc = subnetCfg.getAllInterfaces().get(interfaceNameToRemote(vpcCfg));
-    assertThat(ifaceToVpc.getIncomingFilterName(), equalTo(getAclName(acl.getId(), false)));
-    assertThat(ifaceToVpc.getOutgoingFilterName(), equalTo(getAclName(acl.getId(), true)));
+    assertThat(
+        ifaceToVpc.getIncomingFilter(),
+        IpAccessListMatchers.hasName(getAclName(acl.getId(), false)));
+    assertThat(
+        ifaceToVpc.getOutgoingFilter(),
+        IpAccessListMatchers.hasName(getAclName(acl.getId(), true)));
   }
 
   @Test


### PR DESCRIPTION
They are for JSON only and should not be used other than implicitly by Jackson.

It wasn't hard to move all the callers off. I also added a missing convert check for the new filter.