### PR TITLE
Break dependency cycle between Batfish and Driver

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/BatfishJobExecutor.java
+++ b/projects/batfish/src/main/java/org/batfish/job/BatfishJobExecutor.java
@@ -13,7 +13,7 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.answers.AnswerElement;
-import org.batfish.main.Driver;
+import org.batfish.main.BatchManager;
 
 /**
  * Class to execute a list of jobs in a thread pool of adaptable size using {@link Executors}. The
@@ -254,7 +254,7 @@ public class BatfishJobExecutor {
   <JobT> void initializeJobsStats(List<JobT> jobs, String description) {
     _finishedJobs = 0;
     _totalJobs = jobs.size();
-    _completed = Driver.newBatch(_settings, description, _totalJobs);
+    _completed = BatchManager.get().newBatch(_settings, description, _totalJobs);
     _finishedPercent = 0;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/main/BatchManager.java
+++ b/projects/batfish/src/main/java/org/batfish/main/BatchManager.java
@@ -1,0 +1,92 @@
+package org.batfish.main;
+
+import java.util.Date;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.common.BatfishException;
+import org.batfish.common.BfConsts.TaskStatus;
+import org.batfish.common.Task;
+import org.batfish.common.Task.Batch;
+import org.batfish.config.Settings;
+
+/** Helps manage task and batch creation within a Batfish worker */
+public final class BatchManager {
+
+  private final ConcurrentMap<String, Task> _taskLog;
+  @Nonnull private static BatchManager _instance = new BatchManager();
+
+  private BatchManager() {
+    _taskLog = new ConcurrentHashMap<>();
+  }
+
+  @Nonnull
+  public static BatchManager get() {
+    return _instance;
+  }
+
+  @Nullable
+  private synchronized Task getTask(Settings settings) {
+    String taskId = settings.getTaskId();
+    if (taskId == null) {
+      return null;
+    } else {
+      return _taskLog.get(taskId);
+    }
+  }
+
+  public synchronized AtomicInteger newBatch(Settings settings, String description, int jobs) {
+    Batch batch = null;
+    Task task = getTask(settings);
+    if (task != null) {
+      batch = task.newBatch(description);
+      batch.setSize(jobs);
+      return batch.getCompleted();
+    } else {
+      return new AtomicInteger();
+    }
+  }
+
+  @Nullable
+  public synchronized Task getTaskFromLog(String taskId) {
+    return _taskLog.get(taskId);
+  }
+
+  public synchronized Task killTask(String taskId) {
+    Task task = _taskLog.get(taskId);
+    if (task == null) {
+      throw new BatfishException("Task with provided id not found: " + taskId);
+    } else if (task.getStatus().isTerminated()) {
+      throw new BatfishException("Task with provided id already terminated " + taskId);
+    } else {
+      // update task details in case a new query for status check comes in
+      task.newBatch("Got kill request");
+      task.setStatus(TaskStatus.TerminatedByUser);
+      task.setTerminated(new Date());
+      task.setErrMessage("Terminated by user");
+
+      // we die after a little bit, to allow for the response making it back to the coordinator
+      new java.util.Timer()
+          .schedule(
+              new java.util.TimerTask() {
+                @Override
+                public void run() {
+                  System.exit(0);
+                }
+              },
+              3000);
+
+      return task;
+    }
+  }
+
+  synchronized void logTask(String taskId, Task task) throws Exception {
+    if (_taskLog.containsKey(taskId)) {
+      throw new Exception("duplicate UUID for task");
+    } else {
+      _taskLog.put(taskId, task);
+    }
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1009,7 +1009,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
     params.put(CoordConsts.SVC_KEY_VERSION, BatfishVersion.getVersionStatic());
     params.put(CoordConstsV2.QP_VERBOSE, String.valueOf(verbose));
 
-    JSONObject response = (JSONObject) Driver.talkToCoordinator(url, params, _logger);
+    JSONObject response =
+        (JSONObject) CoordinatorClient.talkToCoordinator(url, params, _settings, _logger);
     if (response == null) {
       throw new BatfishException("Could not get question templates: Got null response");
     }
@@ -1369,7 +1370,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
 
   @Override
   public AtomicInteger newBatch(String description, int jobs) {
-    return Driver.newBatch(_settings, description, jobs);
+    return BatchManager.get().newBatch(_settings, description, jobs);
   }
 
   private void outputAnswer(Answer answer) {

--- a/projects/batfish/src/main/java/org/batfish/main/CoordinatorClient.java
+++ b/projects/batfish/src/main/java/org/batfish/main/CoordinatorClient.java
@@ -1,0 +1,81 @@
+package org.batfish.main;
+
+import com.google.common.base.Throwables;
+import java.util.Map;
+import javax.net.ssl.SSLHandshakeException;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.batfish.common.BatfishException;
+import org.batfish.common.BatfishLogger;
+import org.batfish.common.CoordConsts;
+import org.batfish.common.util.CommonUtil;
+import org.batfish.config.Settings;
+import org.codehaus.jettison.json.JSONArray;
+
+/** Helper class that implements (some) communication between Batfish worker and coordinator */
+public final class CoordinatorClient {
+
+  public static Object talkToCoordinator(
+      String url, Map<String, String> params, Settings settings, BatfishLogger logger) {
+    Client client = null;
+    try {
+      client =
+          CommonUtil.createHttpClientBuilder(
+                  settings.getSslDisable(),
+                  settings.getSslTrustAllCerts(),
+                  settings.getSslKeystoreFile(),
+                  settings.getSslKeystorePassword(),
+                  settings.getSslTruststoreFile(),
+                  settings.getSslTruststorePassword(),
+                  true)
+              .build();
+      WebTarget webTarget = client.target(url);
+      for (Map.Entry<String, String> entry : params.entrySet()) {
+        webTarget = webTarget.queryParam(entry.getKey(), entry.getValue());
+      }
+      JSONArray array;
+      try (Response response = webTarget.request(MediaType.APPLICATION_JSON).get()) {
+
+        logger.debug(
+            "BF: " + response.getStatus() + " " + response.getStatusInfo() + " " + response + "\n");
+
+        if (response.getStatus() != Response.Status.OK.getStatusCode()) {
+          logger.error("Did not get an OK response\n");
+          return null;
+        }
+
+        String sobj = response.readEntity(String.class);
+        array = new JSONArray(sobj);
+      }
+      logger.debugf("BF: response: %s [%s] [%s]\n", array, array.get(0), array.get(1));
+
+      if (!array.get(0).equals(CoordConsts.SVC_KEY_SUCCESS)) {
+        logger.errorf(
+            "BF: got error while talking to coordinator: %s %s\n", array.get(0), array.get(1));
+        return null;
+      }
+
+      return array.get(1);
+    } catch (ProcessingException e) {
+      if (CommonUtil.causedBy(e, SSLHandshakeException.class)
+          || CommonUtil.causedByMessage(e, "Unexpected end of file from server")) {
+        throw new BatfishException("Unrecoverable connection error", e);
+      }
+      logger.errorf("BF: unable to connect to coordinator pool mgr at %s\n", url);
+      logger.debug(Throwables.getStackTraceAsString(e) + "\n");
+      return null;
+    } catch (Exception e) {
+      logger.errorf("exception: " + Throwables.getStackTraceAsString(e));
+      return null;
+    } finally {
+      if (client != null) {
+        client.close();
+      }
+    }
+  }
+
+  private CoordinatorClient() {}
+}

--- a/projects/batfish/src/main/java/org/batfish/main/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Service.java
@@ -58,7 +58,7 @@ public class Service {
         return new JSONArray(Arrays.asList(BfConsts.SVC_FAILURE_KEY, "taskid not supplied"));
       }
 
-      Task task = Driver.getTaskFromLog(taskId);
+      Task task = BatchManager.get().getTaskFromLog(taskId);
       if (task == null) {
         task = new Task(TaskStatus.Unknown);
       }
@@ -78,7 +78,7 @@ public class Service {
       if (Strings.isNullOrEmpty(taskId)) {
         return new JSONArray(Arrays.asList(BfConsts.SVC_FAILURE_KEY, "taskid not supplied"));
       }
-      Task task = Driver.killTask(taskId);
+      Task task = BatchManager.get().killTask(taskId);
       String taskStr = BatfishObjectMapper.writeString(task);
       return new JSONArray(Arrays.asList(BfConsts.SVC_SUCCESS_KEY, taskStr));
     } catch (Exception e) {


### PR DESCRIPTION
`Batfish` had pointers back to static `Driver` functions. This is a problem if there were to be another entry point that starts worker(s). Broke the cycle by factoring out helper classes that Batfish can depend on.

There is still too much `static`-ness going on (that's why `BatchManager` is a singleton) but can tackle that later if needed. 

No intended functionality changes.  