### PR TITLE
Add BDD::project and use it in session factory

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
@@ -97,7 +97,7 @@ public final class BDDFiniteDomain<V> {
     checkArgument(bdd.isAssignment());
 
     // Exist turns the assignment into just the finite domain.
-    V ret = _bddToValue.get(bdd.exist(_var.getOtherVars()));
+    V ret = _bddToValue.get(bdd.project(_var.getVars()));
     checkArgument(ret != null, "No value for valid assignment");
     return ret;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDFiniteDomain.java
@@ -9,7 +9,6 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.math.IntMath;
 import java.math.RoundingMode;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -37,7 +36,7 @@ public final class BDDFiniteDomain<V> {
     int size = values.size();
     BDD one = var.getFactory().one();
     _var = var;
-    _varBits = Arrays.stream(var.getBitvec()).reduce(BDD::and).orElse(null);
+    _varBits = var.getVars();
     if (size == 0) {
       _valueToBdd = ImmutableBiMap.of();
       _isValidValue = one;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -321,30 +320,6 @@ public class BDDInteger {
     BDD ret = BDDOps.andNull(_bitvec);
     assert ret != null;
     return ret;
-  }
-
-  /**
-   * Get the AND of all variables in the factory other than those that belong to this. Use with
-   * {@link BDD#exist} to project a {@link BDD} to this' variables.
-   *
-   * <p>This needs to be recomputed every time new variables are allocated in the factory, so be
-   * careful before caching this. If this is a bottleneck, probably better to implement as a method
-   * of {@link BDD}.
-   */
-  public BDD getOtherVars() {
-    BitSet bitSet = new BitSet(_factory.varNum());
-    for (BDD bit : _bitvec) {
-      bitSet.set(bit.var());
-    }
-
-    BDD result = _factory.one();
-    for (int i = _factory.varNum() - 1; i >= 0; i--) {
-      if (!bitSet.get(i)) {
-        result.andWith(_factory.ithVar(i));
-      }
-    }
-
-    return result;
   }
 
   public BDDFactory getFactory() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDInteger.java
@@ -317,6 +317,9 @@ public class BDDInteger {
 
   /** Returns a {@link BDD} containing all the variables of this {@link BDDInteger}. */
   public @Nonnull BDD getVars() {
+    if (_bitvec.length == 0) {
+      return _factory.one(); // empty set
+    }
     BDD ret = BDDOps.andNull(_bitvec);
     assert ret != null;
     return ret;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
@@ -4,14 +4,12 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Optional;
 import net.sf.javabdd.BDD;
 import net.sf.javabdd.BDDFactory;
-import net.sf.javabdd.JFactory;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -131,5 +132,12 @@ public class BDDIntegerTest {
         assertThat(range, equalTo(rangeEquiv));
       }
     }
+  }
+
+  @Test
+  public void testGetVars_emptyVar() {
+    BDDFactory factory = BDDUtils.bddFactory(10);
+    BDDInteger x = BDDInteger.makeFromIndex(factory, 0, 0, false);
+    assertEquals(factory.one(), x.getVars());
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDIntegerTest.java
@@ -134,20 +134,4 @@ public class BDDIntegerTest {
       }
     }
   }
-
-  @Test
-  public void testGetOtherVars() {
-    BDDFactory factory = JFactory.init(100, 100);
-    factory.setVarNum(10);
-    BDDInteger bddInteger = BDDInteger.makeFromIndex(factory, 5, 2, false);
-    BDD expected =
-        BDDOps.andNull(
-            factory.ithVar(0),
-            factory.ithVar(1),
-            factory.ithVar(7),
-            factory.ithVar(8),
-            factory.ithVar(9));
-    BDD actual = bddInteger.getOtherVars();
-    assertEquals(expected, actual);
-  }
 }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactory.java
@@ -279,7 +279,7 @@ final class BDDReachabilityAnalysisSessionFactory {
                     compose(outgoingTransformation, constraint(outgoingTransformationRange));
 
                 // Return flows for this session.
-                BDD sessionBdd = getSessionBdd(srcToOutIfaceBdd);
+                BDD sessionBdd = getSessionFlowMatchBdd(srcToOutIfaceBdd);
                 builder.add(
                     new BDDFirewallSessionTraceInfo(
                         hostname, sessionInterfaces, Accept.INSTANCE, sessionBdd, transformation));
@@ -308,7 +308,7 @@ final class BDDReachabilityAnalysisSessionFactory {
                           hostname,
                           sessionInterfaces,
                           action,
-                          getSessionBdd(srcToOutIfaceBdd),
+                          getSessionFlowMatchBdd(srcToOutIfaceBdd),
                           compose(
                               outgoingTransformation,
                               constraint(outgoingTransformationRange),
@@ -326,7 +326,7 @@ final class BDDReachabilityAnalysisSessionFactory {
                       }
 
                       // Return flows for this session.
-                      BDD sessionBdd = getSessionBdd(lastHopToSrcIfaceToOutIfaceBdd);
+                      BDD sessionBdd = getSessionFlowMatchBdd(lastHopToSrcIfaceToOutIfaceBdd);
 
                       // Next hop for session flows
                       NodeInterfacePair lastHop =
@@ -416,7 +416,7 @@ final class BDDReachabilityAnalysisSessionFactory {
                         new OriginatingSessionScope(vrfName),
                         // Batfish does not support VRF-originating sessions with other actions
                         FibLookup.INSTANCE,
-                        getSessionBdd(srcToAcceptBdd),
+                        getSessionFlowMatchBdd(srcToAcceptBdd),
                         compose(incomingTransformation, constraint(incomingTransformationRange))));
                 return;
               }
@@ -430,7 +430,7 @@ final class BDDReachabilityAnalysisSessionFactory {
                     }
 
                     // Return flows for this session.
-                    BDD sessionBdd = getSessionBdd(lastHopToSrcIfaceToAcceptBdd);
+                    BDD sessionBdd = getSessionFlowMatchBdd(lastHopToSrcIfaceToAcceptBdd);
 
                     // Next hop for session flows
                     NodeInterfacePair lastHop =
@@ -459,7 +459,7 @@ final class BDDReachabilityAnalysisSessionFactory {
    * @return The match constraint for the return flows that can have an established session.
    */
   @VisibleForTesting
-  BDD getSessionBdd(BDD bdd) {
+  BDD getSessionFlowMatchBdd(BDD bdd) {
     return _bddPacket.swapSourceAndDestinationFields(bdd.project(_fiveTupleBdd));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
@@ -350,7 +350,7 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
             ImmutableMap.of(),
             _reverseFlowTransformationFactory,
             TRIVIAL_REVERSE_TRANSFORMATION_RANGES);
-    assertEquals(sessionFlows, sessionFactory.getSessionBdd(outBdd));
+    assertEquals(sessionFlows, sessionFactory.getSessionFlowMatchBdd(outBdd));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -29,6 +30,7 @@ import javax.annotation.Nullable;
 import net.sf.javabdd.BDD;
 import org.batfish.bddreachability.BDDReverseTransformationRangesImpl.Key;
 import org.batfish.bddreachability.transition.Transition;
+import org.batfish.common.bdd.BDDOps;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.common.bdd.HeaderSpaceToBDD;
@@ -54,7 +56,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 /** Tests for {@link BDDReachabilityAnalysisSessionFactory}. */
-@SuppressWarnings("unchecked")
 public class BDDReachabilityAnalysisSessionFactoryTest {
   private static final String FW = "fw";
   private static final String R1 = "r1";
@@ -314,6 +315,42 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
     assertThat(fwSession, hasAction(new ForwardOutInterface(FWI1, NodeInterfacePair.of(R1, R1I1))));
     assertThat(fwSession, hasSessionFlows(sessionFlows));
     assertThat(fwSession, hasTransformation(_fwI3ToI1ReverseTransformation));
+  }
+
+  @Test
+  public void testGetSessionFlows() {
+    Prefix sourcePrefix = Prefix.parse("2.0.0.0/8");
+    Prefix destPrefix = Prefix.parse("1.0.0.0/8");
+    BDD tcp = PKT.getIpProtocol().value(IpProtocol.TCP);
+    BDD outBdd =
+        BDDOps.andNull(
+            dstBdd(destPrefix), // dst IP constraint
+            srcBdd(sourcePrefix),
+            dstPortBdd(1),
+            srcPortBdd(2),
+            tcp,
+            // everything below will be erased
+            PKT.getFactory().ithVar(0), // unallocated variable
+            _lastHopMgr.getLastHopOutgoingInterfaceBdd(R1, R1I1, FW, FWI1),
+            _fwSrcMgr.getSourceInterfaceBDD(FWI1),
+            PKT.getTcpCwr(),
+            PKT.getDscp().value(0),
+            PKT.getEcn().value(0));
+
+    BDD sessionFlows =
+        BDDOps.andNull(srcBdd(destPrefix), dstBdd(sourcePrefix), dstPortBdd(2), srcPortBdd(1), tcp);
+
+    BDDReachabilityAnalysisSessionFactory sessionFactory =
+        new BDDReachabilityAnalysisSessionFactory(
+            PKT,
+            // None of the inputs below are needed for getSessionBdd
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            _lastHopMgr,
+            ImmutableMap.of(),
+            _reverseFlowTransformationFactory,
+            TRIVIAL_REVERSE_TRANSFORMATION_RANGES);
+    assertEquals(sessionFlows, sessionFactory.getSessionBdd(outBdd));
   }
 
   @Test

--- a/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/BDD.java
@@ -502,6 +502,18 @@ public abstract class BDD {
   public abstract BDD exist(BDD var);
 
   /**
+   * Project this BDD onto the variables in the set. i.e. existentially quantify all other
+   * variables.
+   *
+   * <p>Compare to bdd_project.
+   *
+   * @param var BDD containing the variables to be projected onto
+   * @return the result of the projection
+   * @see net.sf.javabdd.BDDDomain#set()
+   */
+  public abstract BDD project(BDD var);
+
+  /**
    * Universal quantification of variables. Removes all occurrences of this BDD in variables in the
    * set var by universal quantification.
    *

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -123,6 +123,7 @@ public final class JFactory extends BDDFactory {
       return _index == BDDONE;
     }
 
+    @Override
     public boolean isAssignment() {
       return bdd_isAssignment(_index);
     }
@@ -193,6 +194,13 @@ public final class JFactory extends BDDFactory {
       int x = _index;
       int y = ((BDDImpl) var)._index;
       return makeBDD(bdd_exist(x, y));
+    }
+
+    @Override
+    public BDD project(BDD var) {
+      int x = _index;
+      int y = ((BDDImpl) var)._index;
+      return makeBDD(bdd_project(x, y));
     }
 
     @Override
@@ -2322,6 +2330,53 @@ public final class JFactory extends BDDFactory {
     return res;
   }
 
+  private int project_rec(int r) {
+    BddCacheDataI entry;
+    int res;
+
+    if (r < 2) {
+      return r;
+    }
+
+    int level = LEVEL(r);
+    if (level > quantlast) {
+      // existentially quantify all remaining variables
+      return BDDONE;
+    }
+
+    entry = BddCache_lookupI(quantcache, QUANTHASH(r));
+    if (entry.a == r && entry.c == quantid) {
+      if (CACHESTATS) {
+        cachestats.opHit++;
+      }
+      return entry.res;
+    }
+    if (CACHESTATS) {
+      cachestats.opMiss++;
+    }
+
+    int low = PUSHREF(project_rec(LOW(r)));
+    int high = PUSHREF(project_rec(HIGH(r)));
+
+    if (INVARSET(level)) {
+      res = bdd_makenode(level, low, high);
+    } else {
+      // existentially quantify
+      res = or_rec(low, high);
+    }
+
+    POPREF(2);
+
+    if (CACHESTATS && entry.a != -1) {
+      cachestats.opOverwrite++;
+    }
+    entry.a = r;
+    entry.c = quantid;
+    entry.res = res;
+
+    return res;
+  }
+
   private int bdd_constrain(int f, int c) {
     CHECK(f);
     CHECK(c);
@@ -2554,6 +2609,32 @@ public final class JFactory extends BDDFactory {
 
     INITREF();
     int res = quant_rec(r);
+    checkresize();
+
+    return res;
+  }
+
+  private int bdd_project(int r, int var) {
+    CHECK(r);
+    CHECK(var);
+
+    if (var < 2) /* Empty set */ {
+      return r;
+    }
+    if (varset2vartable(var) < 0) {
+      return BDDZERO;
+    }
+
+    if (applycache == null) {
+      applycache = BddCacheI_init(cachesize);
+    }
+    if (quantcache == null) {
+      quantcache = BddCacheI_init(cachesize);
+    }
+    quantid = (var << 3) | CACHEID_PROJECT; /* FIXME: range */
+
+    INITREF();
+    int res = project_rec(r);
     checkresize();
 
     return res;
@@ -3658,13 +3739,14 @@ public final class JFactory extends BDDFactory {
   private static final int CACHEID_VECCOMPOSE = 0x2;
   private static final int CACHEID_CORRECTIFY = 0x3;
 
-  /* Hash value modifiers for quantification */
+  /* Hash value modifiers for quantification. Max 8 values */
   private static final int CACHEID_EXIST = 0x0;
   private static final int CACHEID_FORALL = 0x1;
   private static final int CACHEID_UNIQUE = 0x2;
   private static final int CACHEID_APPEX = 0x3;
   private static final int CACHEID_APPAL = 0x4;
   private static final int CACHEID_APPUN = 0x5;
+  private static final int CACHEID_PROJECT = 0x6;
 
   /* Number of boolean operators */
   static final int OPERATOR_NUM = 11;

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -2631,7 +2631,7 @@ public final class JFactory extends BDDFactory {
     if (quantcache == null) {
       quantcache = BddCacheI_init(cachesize);
     }
-    quantid = (var << 3) | CACHEID_PROJECT; /* FIXME: range */
+    quantid = (var << 3) | CACHEID_PROJECT;
 
     INITREF();
     int res = project_rec(r);

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -2619,7 +2619,9 @@ public final class JFactory extends BDDFactory {
     CHECK(var);
 
     if (var < 2) /* Empty set */ {
-      return r;
+      // projecting onto an empty set of variables means existentially
+      // quantifying all variables.
+      return r == BDDZERO ? BDDZERO : BDDONE;
     }
     if (varset2vartable(var) < 0) {
       return BDDZERO;

--- a/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
+++ b/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
@@ -446,4 +446,25 @@ public class JFactoryTest {
     int[] a4 = {1};
     assertEquals(JFactory.dedupSorted(a4), a4);
   }
+
+  @Test
+  public void testProject() {
+    _factory.setVarNum(10);
+    BDD one = _factory.one();
+    BDD x = _factory.ithVar(0);
+    BDD y = _factory.ithVar(1);
+    BDD z = _factory.ithVar(2);
+
+    BDD ite = x.ite(y,z);
+
+    assertEquals(one,ite.project(x));
+    assertEquals(one,ite.project(y));
+    assertEquals(one,ite.project(z));
+
+    assertEquals(x.imp(y),ite.project(x.and(y)));
+    assertEquals(x.not().imp(z),ite.project(x.and(z)));
+    assertEquals(y.or(z),ite.project(y.and(z)));
+
+    assertEquals(ite, ite.project(x.and(y).and(z)));
+  }
 }

--- a/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
+++ b/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
@@ -451,20 +451,40 @@ public class JFactoryTest {
   public void testProject() {
     _factory.setVarNum(10);
     BDD one = _factory.one();
-    BDD x = _factory.ithVar(0);
-    BDD y = _factory.ithVar(1);
-    BDD z = _factory.ithVar(2);
+    BDD zero = _factory.zero();
 
-    BDD ite = x.ite(y, z);
+    // vars used for our test constraint
+    BDD v2 = _factory.ithVar(2);
+    BDD v4 = _factory.ithVar(4);
+    BDD v6 = _factory.ithVar(6);
+    BDD ite = v2.ite(v4, v6);
 
-    assertEquals(one, ite.project(x));
-    assertEquals(one, ite.project(y));
-    assertEquals(one, ite.project(z));
+    // projecting onto one of the variables in the constraint
+    assertEquals(one, ite.project(v2));
+    assertEquals(one, ite.project(v4));
+    assertEquals(one, ite.project(v6));
 
-    assertEquals(x.imp(y), ite.project(x.and(y)));
-    assertEquals(x.not().imp(z), ite.project(x.and(z)));
-    assertEquals(y.or(z), ite.project(y.and(z)));
+    // projecting onto combinations of the variables in the constraint
+    assertEquals(v2.imp(v4), ite.project(v2.and(v4)));
+    assertEquals(v2.not().imp(v6), ite.project(v2.and(v6)));
+    assertEquals(v4.or(v6), ite.project(v4.and(v6)));
 
-    assertEquals(ite, ite.project(x.and(y).and(z)));
+    // projecting onto all the variables in the constraint
+    assertEquals(ite, ite.project(v2.and(v4).and(v6)));
+
+    // projecting any satisfiable BDD to the empty set (i.e. zero or one) returns one
+    assertEquals(one, ite.project(one));
+    assertEquals(one, ite.project(zero));
+
+    // projecting the zero BDD to the empty set (i.e. zero or one) returns zero
+    assertEquals(zero, zero.project(one));
+    assertEquals(zero, zero.project(zero));
+
+    // projecting onto a variable not in the constraint
+    assertEquals(one, ite.project(_factory.ithVar(1)));
+    assertEquals(one, ite.project(_factory.ithVar(3)));
+    assertEquals(one, ite.project(_factory.ithVar(5)));
+    assertEquals(one, ite.project(_factory.ithVar(7)));
+    assertEquals(one, ite.project(_factory.ithVar(9))); // last var
   }
 }

--- a/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
+++ b/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
@@ -455,15 +455,15 @@ public class JFactoryTest {
     BDD y = _factory.ithVar(1);
     BDD z = _factory.ithVar(2);
 
-    BDD ite = x.ite(y,z);
+    BDD ite = x.ite(y, z);
 
-    assertEquals(one,ite.project(x));
-    assertEquals(one,ite.project(y));
-    assertEquals(one,ite.project(z));
+    assertEquals(one, ite.project(x));
+    assertEquals(one, ite.project(y));
+    assertEquals(one, ite.project(z));
 
-    assertEquals(x.imp(y),ite.project(x.and(y)));
-    assertEquals(x.not().imp(z),ite.project(x.and(z)));
-    assertEquals(y.or(z),ite.project(y.and(z)));
+    assertEquals(x.imp(y), ite.project(x.and(y)));
+    assertEquals(x.not().imp(z), ite.project(x.and(z)));
+    assertEquals(y.or(z), ite.project(y.and(z)));
 
     assertEquals(ite, ite.project(x.and(y).and(z)));
   }


### PR DESCRIPTION
project() is similar to exist(), but existentially quantifies all variables not in the input var set. Simpler and more maintainable when you want to project a BDD onto a set of vars.

Using project() in session factory will clear the way for @corinaminer to add support for original-flow filters in reachability. In particular, she shouldn't need to touch the session factory again.