### PR TITLE
AWS: catch transit gateway conversion errors

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -118,8 +118,12 @@ public class AwsConfiguration extends VendorConfiguration {
     // Vpc peerings can be both cross-region and cross-account, so we handle them here
     processVpcPeerings();
     // Transit gateways can be cross-account so we handle them here
-    TransitGatewayConverter.convertTransitGateways(this, _convertedConfiguration)
-        .forEach(_convertedConfiguration::addNode);
+    try {
+      TransitGatewayConverter.convertTransitGateways(this, _convertedConfiguration)
+          .forEach(_convertedConfiguration::addNode);
+    } catch (Exception e) {
+      getWarnings().redFlag(String.format("Failed to convert transit gateways %s", e));
+    }
   }
 
   private void processVpcPeerings() {


### PR DESCRIPTION
Do not crash conversion entirely if TGWs can't be converted. Missed this earlier.