### PR TITLE
TGW static routes don't need an attachment

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayRoute.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.aws;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_DESTINATION_CIDR_BLOCK;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_DESTINATION_IPV6_CIDR_BLOCK;
@@ -13,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
+import java.util.LinkedList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -53,14 +55,13 @@ abstract class TransitGatewayRoute implements Serializable {
         "Only one of v4 or v6 destination CIDR block must be present for a transit gateway static route");
     checkArgument(state != null, "State cannot be null for transit gateway attachment");
     checkArgument(type != null, "Type cannot be null for transit gateway attachment");
-    checkArgument(attachments != null, "Attachments cannot be null for transit gateway attachment");
 
     if (destinationCidrBlock != null) {
       return new TransitGatewayRouteV4(
           destinationCidrBlock,
           State.valueOf(state.toUpperCase()),
           Type.valueOf(type.toUpperCase()),
-          attachments.stream()
+          firstNonNull(attachments, new LinkedList<Attachment>()).stream()
               .map(Attachment::getAttachmentId)
               .collect(ImmutableList.toImmutableList()));
     } else {
@@ -68,7 +69,7 @@ abstract class TransitGatewayRoute implements Serializable {
           destinationIpv6CidrBlock,
           State.valueOf(state.toUpperCase()),
           Type.valueOf(type.toUpperCase()),
-          attachments.stream()
+          firstNonNull(attachments, new LinkedList<Attachment>()).stream()
               .map(Attachment::getAttachmentId)
               .collect(ImmutableList.toImmutableList()));
     }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayStaticRoutesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayStaticRoutesTest.java
@@ -42,7 +42,12 @@ public class TransitGatewayStaticRoutesTest {
                             Prefix.parse("1.1.1.1/32"),
                             State.ACTIVE,
                             Type.STATIC,
-                            ImmutableList.of("tgw-attach-07f5ec59e9f540021")))),
+                            ImmutableList.of("tgw-attach-07f5ec59e9f540021")),
+                        new TransitGatewayRouteV4(
+                            Prefix.parse("192.168.0.0/16"),
+                            State.BLACKHOLE,
+                            Type.STATIC,
+                            ImmutableList.of()))),
                 "tgw-rtb-0fa40c8df355dce6e",
                 new TransitGatewayStaticRoutes("tgw-rtb-0fa40c8df355dce6e", ImmutableList.of()))));
   }

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/TransitGatewayStaticRoutesTest.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/TransitGatewayStaticRoutesTest.json
@@ -14,6 +14,11 @@
             }
           ],
           "Type": "static"
+        },
+        {
+          "DestinationCidrBlock": "192.168.0.0/16",
+          "State": "blackhole",
+          "Type": "static"
         }
       ],
       "TransitGatewayRouteTableId": "tgw-rtb-08262a9ed03306288"


### PR DESCRIPTION
TGW static routes are valid without defined attachments