### PR TITLE
AWS TGW: add enum for peering resource type

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayAttachment.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayAttachment.java
@@ -20,6 +20,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 final class TransitGatewayAttachment implements AwsVpcEntity, Serializable {
 
   enum ResourceType {
+    PEERING,
     VPC,
     VPN
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayAttachment.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayAttachment.java
@@ -19,6 +19,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 final class TransitGatewayAttachment implements AwsVpcEntity, Serializable {
 
+  /** Different types of TGW attachments */
   enum ResourceType {
     PEERING,
     VPC,


### PR DESCRIPTION
Leads to a slightly better error message. 