### PR TITLE
PAN: ignore readonly lines

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -1083,6 +1083,11 @@ QOS
     'qos'
 ;
 
+READONLY
+:
+    'readonly'
+;
+
 RECURRING
 :
     'recurring'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -142,6 +142,11 @@ set_line_device_group
     DEVICE_GROUP name = variable statement_device_group
 ;
 
+set_line_readonly
+:
+    READONLY null_rest_of_line
+;
+
 /*
  * Device-group supports a subset of device configuration (statement_config_devices)
  * plus a couple device-group / panorama specific items
@@ -168,6 +173,7 @@ set_line_tail
     set_line_config_devices
     | set_line_config_general
     | set_line_device_group
+    | set_line_readonly
     | set_line_template
     | set_line_template_stack
     | s_policy

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -86,3 +86,7 @@ set vsys vsys1 log-settings syslog NAME server NAME transport UDP
 set vsys vsys1 log-settings profiles NAME match-list ML_NAME log-type foo
 set vsys vsys1 profiles dos-protection
 set vsys vsys1 profile-group NAME
+# Readonly lines are related to firewalls managed by a panorama node
+set readonly devices localhost.localdomain device-group DG1 id 16
+set readonly devices localhost.localdomain template T1 id 12
+set readonly devices localhost.localdomain template T1 config devices localhost.localdomain vsys vsys1 zone Z1 id 14


### PR DESCRIPTION
Ignore `readonly` lines for now; these appear on Panorama devices, are related to managed firewall devices, and contain mostly redundant information we parse from the actual configuration.
