### PR TITLE
PAN: handle more log-settings syntax

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -1498,6 +1498,11 @@ USED_BY_MALWARE
     'used-by-malware'
 ;
 
+USERID
+:
+    'userid'
+;
+
 USERNAME
 :
     'username'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -144,7 +144,7 @@ set_line_device_group
 
 /*
  * Device-group supports a subset of device configuration (statement_config_devices)
- * plus a couple device-group / panorama specific items
+ * plus some device-group / panorama specific items
  */
 statement_device_group
 :
@@ -157,6 +157,7 @@ statement_device_group
     | s_service_group
     | s_tag
     // Device-group / panorama specific
+    | s_log_settings
     | s_post_rulebase
     | s_pre_rulebase
     | sdg_description

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_log_settings.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_log_settings.g4
@@ -10,10 +10,17 @@ s_log_settings
 :
     LOG_SETTINGS
     (
-        sl_profiles
+        sl_config
+        | sl_profiles
         | sl_syslog
         | sl_system
+        | sl_userid
     )?
+;
+
+sl_config
+:
+    CONFIG null_rest_of_line
 ;
 
 sl_profiles
@@ -32,6 +39,11 @@ sl_syslog
 sl_system
 :
     SYSTEM null_rest_of_line
+;
+
+sl_userid
+:
+    USERID null_rest_of_line
 ;
 
 sls_server

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2868,11 +2868,14 @@ public final class PaloAltoGrammarTest {
     // Check vsys configuration is applied to the template as expected
     assertThat(t1.getVirtualSystems().keySet(), contains("vsys1"));
     Vsys vsys1 = t1.getVirtualSystems().get("vsys1");
+    Vsys shared = t1.getShared();
     assertThat(vsys1.getImportedInterfaces(), containsInAnyOrder("ethernet1/1", "ethernet1/2"));
     SortedMap<String, Zone> zones = vsys1.getZones();
     assertThat(zones.keySet(), containsInAnyOrder("ZONE1", "ZONE2"));
     assertThat(zones.get("ZONE1").getInterfaceNames(), contains("ethernet1/1"));
     assertThat(zones.get("ZONE2").getInterfaceNames(), contains("ethernet1/2"));
+    assertThat(shared, notNullValue());
+    assertThat(shared.getSyslogServer("G1", "S1").getAddress(), equalTo("10.0.0.123"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -84,5 +84,8 @@ set vsys vsys1 log-settings syslog NAME server NAME format IETF
 set vsys vsys1 log-settings syslog NAME server NAME port 65535
 set vsys vsys1 log-settings syslog NAME server NAME transport UDP
 set vsys vsys1 log-settings profiles NAME match-list ML_NAME log-type foo
+set template T1 config shared log-settings config match-list ML_NAME send-to-panorama yes
+set template T1 config shared log-settings userid match-list ML_NAME send-to-panorama yes
+set device-group DG1 log-settings profiles P1 description "long description"
 set vsys vsys1 profiles dos-protection
 set vsys vsys1 profile-group NAME

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/template
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/template
@@ -7,6 +7,7 @@ set template T1 config devices localhost.localdomain network interface ethernet 
 # Intentional use of short-hand syntax, accepted by cli
 set template T1 config network interface ethernet ethernet1/2 layer3 ip 10.0.2.1/24
 set template T1 config devices localhost.localdomain network virtual-router default interface [ ethernet1/1 ethernet1/2 ]
+set template T1 config shared log-settings syslog G1 server S1 server 10.0.0.123
 set template T2 description "template 2 description"
 # Regular, non-template config - intentionally after device-group config to confirm we pop out as expected
 set deviceconfig system hostname template


### PR DESCRIPTION
Handle more `log-settings` syntax:
* More child-syntax: `config` and `userid`
* In an additional context: under `device-group` config
