### PR TITLE
PAN: handle more 'empty' syntax

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -22,6 +22,8 @@ import
     PaloAlto_template,
     PaloAlto_template_stack,
     PaloAlto_virtual_router,
+    PaloAlto_virtual_wire,
+    PaloAlto_vlan,
     PaloAlto_vsys,
     PaloAlto_zone;
 
@@ -113,6 +115,8 @@ statement_template_config_devices
     | s_network
     | s_shared
     | s_vsys
+    // Ignore irrelevant syntax
+    | s_null
 ;
 
 statement_template_stack

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_network.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_network.g4
@@ -88,6 +88,8 @@ s_network
         | sn_qos
         | sn_shared_gateway
         | sn_virtual_router
+        | sn_virtual_wire
+        | sn_vlan
     )
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_shared.g4
@@ -14,10 +14,7 @@ options {
 
 s_shared
 :
-    SHARED
-    (
-        ss_common
-    )
+    SHARED ss_common?
 ;
 
 // Common syntax between vsys, panorama, and other shared contexts

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_virtual_wire.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_virtual_wire.g4
@@ -1,0 +1,12 @@
+parser grammar PaloAlto_virtual_wire;
+
+import PaloAlto_common;
+
+options {
+    tokenVocab = PaloAltoLexer;
+}
+
+sn_virtual_wire
+:
+    VIRTUAL_WIRE
+;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_vlan.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_vlan.g4
@@ -1,0 +1,12 @@
+parser grammar PaloAlto_vlan;
+
+import PaloAlto_common;
+
+options {
+    tokenVocab = PaloAltoLexer;
+}
+
+sn_vlan
+:
+    VLAN
+;

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -86,3 +86,8 @@ set vsys vsys1 log-settings syslog NAME server NAME transport UDP
 set vsys vsys1 log-settings profiles NAME match-list ML_NAME log-type foo
 set vsys vsys1 profiles dos-protection
 set vsys vsys1 profile-group NAME
+# Misc "empty" definitions
+set template T1 config mgt-config users
+set template T1 config shared
+set template T1 config devices localhost.localdomain network vlan
+set template T1 config devices localhost.localdomain network virtual-wire


### PR DESCRIPTION
Handle some more Palo Alto "empty" structure syntax
