### PR TITLE
Clean up reachability tests

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/bddreachability/EdgeMatchers.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/EdgeMatchers.java
@@ -12,26 +12,14 @@ import org.hamcrest.Matcher;
 
 /** {@link Matcher Matchers} for {@link Edge Edges}. */
 public final class EdgeMatchers {
-  /** Matches {@link Edge#getPostState}. */
-  public static Matcher<Edge> hasPostState(StateExpr expr) {
-    return new HasPostState(equalTo(expr));
-  }
-
-  /** Matches {@link Edge#getPreState}. */
-  public static Matcher<Edge> hasPreState(StateExpr expr) {
-    return new HasPreState(equalTo(expr));
-  }
-
-  /** Matches {@link Edge#getTransition()}. */
-  public static Matcher<Edge> hasTransition(Matcher<Transition> matcher) {
-    return new HasTransition(matcher);
-  }
-
   /**
-   * Matches {@link Edge#getPostState}, {@link Edge#getPreState}, and {@link Edge#getTransition}.
+   * Matches {@link Edge#getPreState}, {@link Edge#getPostState}, and {@link Edge#getTransition}.
    */
   public static Matcher<Edge> edge(
       StateExpr preState, StateExpr postState, Matcher<Transition> transitionMatcher) {
-    return allOf(hasPreState(preState), hasPostState(postState), hasTransition(transitionMatcher));
+    return allOf(
+        new HasPreState(equalTo(preState)),
+        new HasPostState(equalTo(postState)),
+        new HasTransition(transitionMatcher));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
@@ -1,9 +1,7 @@
 package org.batfish.bddreachability;
 
 import static org.batfish.bddreachability.BDDOutgoingOriginalFlowFilterManager.forNetwork;
-import static org.batfish.bddreachability.EdgeMatchers.hasPostState;
-import static org.batfish.bddreachability.EdgeMatchers.hasPreState;
-import static org.batfish.bddreachability.EdgeMatchers.hasTransition;
+import static org.batfish.bddreachability.EdgeMatchers.edge;
 import static org.batfish.bddreachability.LastHopOutgoingInterfaceManager.NO_LAST_HOP;
 import static org.batfish.bddreachability.TransitionMatchers.mapsBackward;
 import static org.batfish.bddreachability.TransitionMatchers.mapsForward;
@@ -232,15 +230,14 @@ public final class SessionInstrumentationTest {
     assertThat(
         nodeAcceptEdges(sessionInfo),
         contains(
-            allOf(
-                hasPreState(new PreInInterface(FW, FW_I1)),
-                hasPostState(new NodeAccept(FW)),
-                hasTransition(
-                    allOf(
-                        mapsForward(srcFwI1, sessionHeaders),
-                        mapsForward(srcFwI1.and(noLastHop), sessionHeaders),
-                        mapsForward(srcFwI1.and(lastHop1), sessionHeaders),
-                        mapsBackward(ONE, validSrc.and(sessionHeaders)))))));
+            edge(
+                new PreInInterface(FW, FW_I1),
+                new NodeAccept(FW),
+                allOf(
+                    mapsForward(srcFwI1, sessionHeaders),
+                    mapsForward(srcFwI1.and(noLastHop), sessionHeaders),
+                    mapsForward(srcFwI1.and(lastHop1), sessionHeaders),
+                    mapsBackward(ONE, validSrc.and(sessionHeaders))))));
 
     // FW_I1 has an incoming session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
@@ -248,15 +245,14 @@ public final class SessionInstrumentationTest {
     assertThat(
         nodeAcceptEdges(sessionInfo),
         contains(
-            allOf(
-                hasPreState(new PreInInterface(FW, FW_I1)),
-                hasPostState(new NodeAccept(FW)),
-                hasTransition(
-                    allOf(
-                        mapsForward(srcFwI1, sessionHeaders.and(_permitTcpBdd)),
-                        mapsForward(srcFwI1.and(noLastHop), sessionHeaders.and(_permitTcpBdd)),
-                        mapsForward(srcFwI1.and(lastHop1), sessionHeaders.and(_permitTcpBdd)),
-                        mapsBackward(ONE, validSrc.and(sessionHeaders).and(_permitTcpBdd)))))));
+            edge(
+                new PreInInterface(FW, FW_I1),
+                new NodeAccept(FW),
+                allOf(
+                    mapsForward(srcFwI1, sessionHeaders.and(_permitTcpBdd)),
+                    mapsForward(srcFwI1.and(noLastHop), sessionHeaders.and(_permitTcpBdd)),
+                    mapsForward(srcFwI1.and(lastHop1), sessionHeaders.and(_permitTcpBdd)),
+                    mapsBackward(ONE, validSrc.and(sessionHeaders).and(_permitTcpBdd))))));
     _fwI1.setFirewallSessionInterfaceInfo(null);
 
     // Session has a transformation
@@ -269,16 +265,15 @@ public final class SessionInstrumentationTest {
       assertThat(
           nodeAcceptEdges(natSessionInfo),
           contains(
-              allOf(
-                  hasPreState(new PreInInterface(FW, FW_I1)),
-                  hasPostState(new NodeAccept(FW)),
-                  hasTransition(
-                      allOf(
-                          mapsForward(srcFwI1, sessionHeaders.and(poolBdd)),
-                          mapsForward(srcFwI1.and(noLastHop), sessionHeaders.and(poolBdd)),
-                          mapsForward(srcFwI1.and(lastHop1), sessionHeaders.and(poolBdd)),
-                          mapsBackward(ONE, validSrc.and(sessionHeaders)),
-                          mapsBackward(poolBdd.not(), ZERO))))));
+              edge(
+                  new PreInInterface(FW, FW_I1),
+                  new NodeAccept(FW),
+                  allOf(
+                      mapsForward(srcFwI1, sessionHeaders.and(poolBdd)),
+                      mapsForward(srcFwI1.and(noLastHop), sessionHeaders.and(poolBdd)),
+                      mapsForward(srcFwI1.and(lastHop1), sessionHeaders.and(poolBdd)),
+                      mapsBackward(ONE, validSrc.and(sessionHeaders)),
+                      mapsBackward(poolBdd.not(), ZERO)))));
     }
   }
 
@@ -292,14 +287,12 @@ public final class SessionInstrumentationTest {
     assertThat(
         fibLookupSessionEdges(sessionInfo),
         contains(
-            allOf(
-                hasPreState(new PreInInterface(FW, FW_I1)),
-                hasPostState(new PostInVrfSession(FW, FW_VRF)),
-                hasTransition(
-                    allOf(
-                        mapsForward(
-                            ONE, sessionHeaders.and(_fwSrcMgr.getSourceInterfaceBDD(FW_I1))),
-                        mapsBackward(ONE, sessionHeaders))))));
+            edge(
+                new PreInInterface(FW, FW_I1),
+                new PostInVrfSession(FW, FW_VRF),
+                allOf(
+                    mapsForward(ONE, sessionHeaders.and(_fwSrcMgr.getSourceInterfaceBDD(FW_I1))),
+                    mapsBackward(ONE, sessionHeaders)))));
   }
 
   @Test
@@ -314,17 +307,14 @@ public final class SessionInstrumentationTest {
     assertThat(
         fibLookupSessionEdges(sessionInfo),
         contains(
-            allOf(
-                hasPreState(new PreInInterface(FW, FW_I1)),
-                hasPostState(new PostInVrfSession(FW, FW_VRF)),
-                hasTransition(
-                    allOf(
-                        mapsForward(
-                            ONE,
-                            sessionHeaders
-                                .and(poolBdd)
-                                .and(_fwSrcMgr.getSourceInterfaceBDD(FW_I1))),
-                        mapsBackward(ONE, sessionHeaders))))));
+            edge(
+                new PreInInterface(FW, FW_I1),
+                new PostInVrfSession(FW, FW_VRF),
+                allOf(
+                    mapsForward(
+                        ONE,
+                        sessionHeaders.and(poolBdd).and(_fwSrcMgr.getSourceInterfaceBDD(FW_I1))),
+                    mapsBackward(ONE, sessionHeaders)))));
   }
 
   @Test
@@ -340,14 +330,14 @@ public final class SessionInstrumentationTest {
     assertThat(
         fibLookupSessionEdges(sessionInfo),
         containsInAnyOrder(
-            allOf(
-                hasPreState(new OriginateInterface(FW, FW_I1)),
-                hasPostState(new PostInVrfSession(FW, FW_VRF)),
-                hasTransition(expectedTransition)),
-            allOf(
-                hasPreState(new OriginateVrf(FW, FW_VRF)),
-                hasPostState(new PostInVrfSession(FW, FW_VRF)),
-                hasTransition(expectedTransition))));
+            edge(
+                new OriginateInterface(FW, FW_I1),
+                new PostInVrfSession(FW, FW_VRF),
+                expectedTransition),
+            edge(
+                new OriginateVrf(FW, FW_VRF),
+                new PostInVrfSession(FW, FW_VRF),
+                expectedTransition)));
   }
 
   @Test
@@ -367,14 +357,14 @@ public final class SessionInstrumentationTest {
     assertThat(
         fibLookupSessionEdges(natSessionInfo),
         containsInAnyOrder(
-            allOf(
-                hasPreState(new OriginateInterface(FW, FW_I1)),
-                hasPostState(new PostInVrfSession(FW, FW_VRF)),
-                hasTransition(expectedTransition)),
-            allOf(
-                hasPreState(new OriginateVrf(FW, FW_VRF)),
-                hasPostState(new PostInVrfSession(FW, FW_VRF)),
-                hasTransition(expectedTransition))));
+            edge(
+                new OriginateInterface(FW, FW_I1),
+                new PostInVrfSession(FW, FW_VRF),
+                expectedTransition),
+            edge(
+                new OriginateVrf(FW, FW_VRF),
+                new PostInVrfSession(FW, FW_VRF),
+                expectedTransition)));
   }
 
   @Test
@@ -400,16 +390,15 @@ public final class SessionInstrumentationTest {
     assertThat(
         preInInterfaceEdges(sessionInfo),
         contains(
-            allOf(
-                hasPreState(new PreInInterface(FW, FW_I1)),
-                hasPostState(new PreInInterface(SOURCE1, SOURCE1_IFACE)),
-                hasTransition(
-                    allOf(
-                        mapsForward(srcFwI1, sessionHeaders.and(source1Iface)),
-                        mapsForward(srcFwI1.and(noLastHop), sessionHeaders.and(source1Iface)),
-                        mapsForward(srcFwI1.and(lastHop1), sessionHeaders.and(source1Iface)),
-                        mapsBackward(source1Iface, validSrc.and(sessionHeaders)),
-                        mapsBackward(fakeIface, ZERO))))));
+            edge(
+                new PreInInterface(FW, FW_I1),
+                new PreInInterface(SOURCE1, SOURCE1_IFACE),
+                allOf(
+                    mapsForward(srcFwI1, sessionHeaders.and(source1Iface)),
+                    mapsForward(srcFwI1.and(noLastHop), sessionHeaders.and(source1Iface)),
+                    mapsForward(srcFwI1.and(lastHop1), sessionHeaders.and(source1Iface)),
+                    mapsBackward(source1Iface, validSrc.and(sessionHeaders)),
+                    mapsBackward(fakeIface, ZERO)))));
 
     // FW_I1 has an incoming session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
@@ -417,20 +406,18 @@ public final class SessionInstrumentationTest {
     assertThat(
         preInInterfaceEdges(sessionInfo),
         contains(
-            allOf(
-                hasPreState(new PreInInterface(FW, FW_I1)),
-                hasPostState(new PreInInterface(SOURCE1, SOURCE1_IFACE)),
-                hasTransition(
-                    allOf(
-                        mapsForward(srcFwI1, sessionHeaders.and(_permitTcpBdd).and(source1Iface)),
-                        mapsForward(
-                            srcFwI1.and(noLastHop),
-                            sessionHeaders.and(_permitTcpBdd).and(source1Iface)),
-                        mapsForward(
-                            srcFwI1.and(lastHop1),
-                            sessionHeaders.and(_permitTcpBdd).and(source1Iface)),
-                        mapsBackward(source1Iface, validSrc.and(sessionHeaders).and(_permitTcpBdd)),
-                        mapsBackward(fakeIface, ZERO))))));
+            edge(
+                new PreInInterface(FW, FW_I1),
+                new PreInInterface(SOURCE1, SOURCE1_IFACE),
+                allOf(
+                    mapsForward(srcFwI1, sessionHeaders.and(_permitTcpBdd).and(source1Iface)),
+                    mapsForward(
+                        srcFwI1.and(noLastHop),
+                        sessionHeaders.and(_permitTcpBdd).and(source1Iface)),
+                    mapsForward(
+                        srcFwI1.and(lastHop1), sessionHeaders.and(_permitTcpBdd).and(source1Iface)),
+                    mapsBackward(source1Iface, validSrc.and(sessionHeaders).and(_permitTcpBdd)),
+                    mapsBackward(fakeIface, ZERO)))));
     _fwI1.setFirewallSessionInterfaceInfo(null);
 
     // FW_I1 has an outgoing session ACL
@@ -439,20 +426,18 @@ public final class SessionInstrumentationTest {
     assertThat(
         preInInterfaceEdges(sessionInfo),
         contains(
-            allOf(
-                hasPreState(new PreInInterface(FW, FW_I1)),
-                hasPostState(new PreInInterface(SOURCE1, SOURCE1_IFACE)),
-                hasTransition(
-                    allOf(
-                        mapsForward(srcFwI1, sessionHeaders.and(_permitTcpBdd).and(source1Iface)),
-                        mapsForward(
-                            srcFwI1.and(noLastHop),
-                            sessionHeaders.and(_permitTcpBdd).and(source1Iface)),
-                        mapsForward(
-                            srcFwI1.and(lastHop1),
-                            sessionHeaders.and(_permitTcpBdd).and(source1Iface)),
-                        mapsBackward(source1Iface, validSrc.and(sessionHeaders).and(_permitTcpBdd)),
-                        mapsBackward(fakeIface, ZERO))))));
+            edge(
+                new PreInInterface(FW, FW_I1),
+                new PreInInterface(SOURCE1, SOURCE1_IFACE),
+                allOf(
+                    mapsForward(srcFwI1, sessionHeaders.and(_permitTcpBdd).and(source1Iface)),
+                    mapsForward(
+                        srcFwI1.and(noLastHop),
+                        sessionHeaders.and(_permitTcpBdd).and(source1Iface)),
+                    mapsForward(
+                        srcFwI1.and(lastHop1), sessionHeaders.and(_permitTcpBdd).and(source1Iface)),
+                    mapsBackward(source1Iface, validSrc.and(sessionHeaders).and(_permitTcpBdd)),
+                    mapsBackward(fakeIface, ZERO)))));
     _fwI1.setFirewallSessionInterfaceInfo(null);
 
     // Session has a transformation
@@ -469,20 +454,18 @@ public final class SessionInstrumentationTest {
       assertThat(
           preInInterfaceEdges(natSessionInfo),
           contains(
-              allOf(
-                  hasPreState(new PreInInterface(FW, FW_I1)),
-                  hasPostState(new PreInInterface(SOURCE1, SOURCE1_IFACE)),
-                  hasTransition(
-                      allOf(
-                          mapsForward(srcFwI1, sessionHeaders.and(poolBdd).and(source1Iface)),
-                          mapsForward(
-                              srcFwI1.and(noLastHop),
-                              sessionHeaders.and(poolBdd).and(source1Iface)),
-                          mapsForward(
-                              srcFwI1.and(lastHop1), sessionHeaders.and(poolBdd).and(source1Iface)),
-                          mapsBackward(source1Iface, validSrc.and(sessionHeaders)),
-                          mapsBackward(source1Iface.and(poolBdd.not()), ZERO),
-                          mapsBackward(fakeIface, ZERO))))));
+              edge(
+                  new PreInInterface(FW, FW_I1),
+                  new PreInInterface(SOURCE1, SOURCE1_IFACE),
+                  allOf(
+                      mapsForward(srcFwI1, sessionHeaders.and(poolBdd).and(source1Iface)),
+                      mapsForward(
+                          srcFwI1.and(noLastHop), sessionHeaders.and(poolBdd).and(source1Iface)),
+                      mapsForward(
+                          srcFwI1.and(lastHop1), sessionHeaders.and(poolBdd).and(source1Iface)),
+                      mapsBackward(source1Iface, validSrc.and(sessionHeaders)),
+                      mapsBackward(source1Iface.and(poolBdd.not()), ZERO),
+                      mapsBackward(fakeIface, ZERO)))));
     }
   }
 
@@ -506,17 +489,14 @@ public final class SessionInstrumentationTest {
     assertThat(
         actual,
         contains(
-            allOf(
-                hasPreState(new PreInInterface(FW, FW_I1)),
-                hasPostState(new NodeInterfaceDeliveredToSubnet(FW, FW_I1)),
-                hasTransition(
-                    allOf(
-                        mapsForward(srcFwI1, sessionHeaders.and(srcFwI1)),
-                        mapsForward(
-                            srcFwI1.and(noLastHop), sessionHeaders.and(srcFwI1).and(noLastHop)),
-                        mapsForward(
-                            srcFwI1.and(lastHop1), sessionHeaders.and(srcFwI1).and(lastHop1)),
-                        mapsBackward(ONE, sessionHeaders))))));
+            edge(
+                new PreInInterface(FW, FW_I1),
+                new NodeInterfaceDeliveredToSubnet(FW, FW_I1),
+                allOf(
+                    mapsForward(srcFwI1, sessionHeaders.and(srcFwI1)),
+                    mapsForward(srcFwI1.and(noLastHop), sessionHeaders.and(srcFwI1).and(noLastHop)),
+                    mapsForward(srcFwI1.and(lastHop1), sessionHeaders.and(srcFwI1).and(lastHop1)),
+                    mapsBackward(ONE, sessionHeaders)))));
 
     // FW_I1 has an incoming session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
@@ -524,13 +504,12 @@ public final class SessionInstrumentationTest {
     assertThat(
         deliveredToSubnetEdges(sessionInfo),
         contains(
-            allOf(
-                hasPreState(new PreInInterface(FW, FW_I1)),
-                hasPostState(new NodeInterfaceDeliveredToSubnet(FW, FW_I1)),
-                hasTransition(
-                    allOf(
-                        mapsForward(ONE, sessionHeaders.and(_permitTcpBdd)),
-                        mapsBackward(ONE, sessionHeaders.and(_permitTcpBdd)))))));
+            edge(
+                new PreInInterface(FW, FW_I1),
+                new NodeInterfaceDeliveredToSubnet(FW, FW_I1),
+                allOf(
+                    mapsForward(ONE, sessionHeaders.and(_permitTcpBdd)),
+                    mapsBackward(ONE, sessionHeaders.and(_permitTcpBdd))))));
     _fwI1.setFirewallSessionInterfaceInfo(null);
 
     // FW_I1 has an outgoing session ACL
@@ -539,13 +518,12 @@ public final class SessionInstrumentationTest {
     assertThat(
         deliveredToSubnetEdges(sessionInfo),
         contains(
-            allOf(
-                hasPreState(new PreInInterface(FW, FW_I1)),
-                hasPostState(new NodeInterfaceDeliveredToSubnet(FW, FW_I1)),
-                hasTransition(
-                    allOf(
-                        mapsForward(ONE, sessionHeaders.and(_permitTcpBdd)),
-                        mapsBackward(ONE, sessionHeaders.and(_permitTcpBdd)))))));
+            edge(
+                new PreInInterface(FW, FW_I1),
+                new NodeInterfaceDeliveredToSubnet(FW, FW_I1),
+                allOf(
+                    mapsForward(ONE, sessionHeaders.and(_permitTcpBdd)),
+                    mapsBackward(ONE, sessionHeaders.and(_permitTcpBdd))))));
     _fwI1.setFirewallSessionInterfaceInfo(null);
 
     // Session has a transformation
@@ -562,15 +540,14 @@ public final class SessionInstrumentationTest {
       assertThat(
           deliveredToSubnetEdges(natSessionInfo),
           contains(
-              allOf(
-                  hasPreState(new PreInInterface(FW, FW_I1)),
-                  hasPostState(new NodeInterfaceDeliveredToSubnet(FW, FW_I1)),
-                  hasTransition(
-                      allOf(
-                          mapsForward(ONE, sessionHeaders.and(poolBdd)),
-                          mapsForward(poolBdd.not(), sessionHeaders.and(poolBdd)),
-                          mapsBackward(ONE, sessionHeaders),
-                          mapsBackward(poolBdd.not(), ZERO))))));
+              edge(
+                  new PreInInterface(FW, FW_I1),
+                  new NodeInterfaceDeliveredToSubnet(FW, FW_I1),
+                  allOf(
+                      mapsForward(ONE, sessionHeaders.and(poolBdd)),
+                      mapsForward(poolBdd.not(), sessionHeaders.and(poolBdd)),
+                      mapsBackward(ONE, sessionHeaders),
+                      mapsBackward(poolBdd.not(), ZERO)))));
     }
   }
 
@@ -593,14 +570,12 @@ public final class SessionInstrumentationTest {
     assertThat(
         nodeDropAclInEdges(sessionInfo),
         contains(
-            allOf(
-                hasPreState(new PreInInterface(FW, FW_I1)),
-                hasPostState(new NodeDropAclIn(FW)),
-                hasTransition(
-                    allOf(
-                        mapsForward(srcFwI1, sessionHeaders.and(_permitTcpBdd.not())),
-                        mapsBackward(
-                            ONE, validSrc.and(sessionHeaders).and(_permitTcpBdd.not())))))));
+            edge(
+                new PreInInterface(FW, FW_I1),
+                new NodeDropAclIn(FW),
+                allOf(
+                    mapsForward(srcFwI1, sessionHeaders.and(_permitTcpBdd.not())),
+                    mapsBackward(ONE, validSrc.and(sessionHeaders).and(_permitTcpBdd.not()))))));
     _fwI1.setFirewallSessionInterfaceInfo(null);
   }
 
@@ -627,14 +602,12 @@ public final class SessionInstrumentationTest {
     assertThat(
         nodeDropAclOutEdges(sessionInfo),
         contains(
-            allOf(
-                hasPreState(new PreInInterface(FW, FW_I1)),
-                hasPostState(new NodeDropAclOut(FW)),
-                hasTransition(
-                    allOf(
-                        mapsForward(srcFwI1, sessionHeaders.and(_permitTcpBdd.not())),
-                        mapsBackward(
-                            ONE, validSrc.and(sessionHeaders).and(_permitTcpBdd.not())))))));
+            edge(
+                new PreInInterface(FW, FW_I1),
+                new NodeDropAclOut(FW),
+                allOf(
+                    mapsForward(srcFwI1, sessionHeaders.and(_permitTcpBdd.not())),
+                    mapsBackward(ONE, validSrc.and(sessionHeaders).and(_permitTcpBdd.not()))))));
     _fwI1.setFirewallSessionInterfaceInfo(null);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionScopeFibLookupSessionEdgesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionScopeFibLookupSessionEdgesTest.java
@@ -1,8 +1,6 @@
 package org.batfish.bddreachability;
 
-import static org.batfish.bddreachability.EdgeMatchers.hasPostState;
-import static org.batfish.bddreachability.EdgeMatchers.hasPreState;
-import static org.batfish.bddreachability.EdgeMatchers.hasTransition;
+import static org.batfish.bddreachability.EdgeMatchers.edge;
 import static org.batfish.bddreachability.TransitionMatchers.mapsBackward;
 import static org.batfish.bddreachability.TransitionMatchers.mapsForward;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -65,13 +63,11 @@ public class SessionScopeFibLookupSessionEdgesTest {
     assertThat(
         actualEdges,
         contains(
-            allOf(
-                hasPreState(new PreInInterface(HOSTNAME, IFACE_NAME)),
-                hasPostState(new PostInVrfSession(HOSTNAME, VRF_NAME)),
-                hasTransition(
-                    allOf(
-                        mapsForward(ONE, expectedForwardFlows),
-                        mapsBackward(ONE, SESSION_HEADERS))))));
+            edge(
+                new PreInInterface(HOSTNAME, IFACE_NAME),
+                new PostInVrfSession(HOSTNAME, VRF_NAME),
+                allOf(
+                    mapsForward(ONE, expectedForwardFlows), mapsBackward(ONE, SESSION_HEADERS)))));
   }
 
   @Test
@@ -89,13 +85,13 @@ public class SessionScopeFibLookupSessionEdgesTest {
     assertThat(
         edges,
         containsInAnyOrder(
-            allOf(
-                hasPreState(new OriginateInterface(HOSTNAME, IFACE_NAME)),
-                hasPostState(new PostInVrfSession(HOSTNAME, VRF_NAME)),
-                hasTransition(expectedTransition)),
-            allOf(
-                hasPreState(new OriginateVrf(HOSTNAME, VRF_NAME)),
-                hasPostState(new PostInVrfSession(HOSTNAME, VRF_NAME)),
-                hasTransition(expectedTransition))));
+            edge(
+                new OriginateInterface(HOSTNAME, IFACE_NAME),
+                new PostInVrfSession(HOSTNAME, VRF_NAME),
+                expectedTransition),
+            edge(
+                new OriginateVrf(HOSTNAME, VRF_NAME),
+                new PostInVrfSession(HOSTNAME, VRF_NAME),
+                expectedTransition)));
   }
 }


### PR DESCRIPTION
No functional changes, just cleanup from the stash.
* Factor out factory creation in BDDReachabilityAnalysisFactoryTest
* Make better use of EdgeMatchers#edge and remove other edge matchers