### PR TITLE
reachability: only merge RemoveSourceConstraint/AddSourceConstraint when safe

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
@@ -207,7 +207,7 @@ public final class Transitions {
       AddSourceConstraint add = (AddSourceConstraint) t2;
       BDDSourceManager mgr = remove.getSourceManager();
 
-      if(!mgr.isValidValue().isOne()) {
+      if (!mgr.isValidValue().isOne()) {
         // cannot merge, because we'd lose the isValidConstraint RemoveSourceConstraint imposes in
         // the backward direction.
         return null;

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/transition/Transitions.java
@@ -207,6 +207,12 @@ public final class Transitions {
       AddSourceConstraint add = (AddSourceConstraint) t2;
       BDDSourceManager mgr = remove.getSourceManager();
 
+      if(!mgr.isValidValue().isOne()) {
+        // cannot merge, because we'd lose the isValidConstraint RemoveSourceConstraint imposes in
+        // the backward direction.
+        return null;
+      }
+
       // each node has its own source mgr, but all mgrs are backed by a single BDDInteger
       checkState(
           mgr.getFiniteDomain().getVar() == add.getSourceManager().getFiniteDomain().getVar(),
@@ -376,8 +382,8 @@ public final class Transitions {
       BDDOutgoingOriginalFlowFilterManager originalFlowFilterMgr,
       BDDSourceManager sourceMgr) {
     return compose(
-        removeSourceConstraint(sourceMgr),
         removeLastHopConstraint(lastHopMgr, node),
+        removeSourceConstraint(sourceMgr),
         removeOutgoingInterfaceConstraints(originalFlowFilterMgr));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransitionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/TransitionsTest.java
@@ -303,10 +303,11 @@ public class TransitionsTest {
   }
 
   @Test
-  public void testMergeComposed_RemoveSourceConstraint_AddSourceConstraint() {
+  public void testMergeComposed_RemoveSourceConstraint_AddSourceConstraint_merge() {
     BDDSourceManager mgr =
         BDDSourceManager.forSources(
-            PKT, ImmutableSet.of("a", "b", "c", "d"), ImmutableSet.of("a", "b"));
+            PKT, ImmutableSet.of("a", "b", "c", "d"), ImmutableSet.of("a", "b", "c"));
+    checkState(mgr.isValidValue().isOne(), "manager needs to have isValidValue = 1");
     RemoveSourceConstraint remove = new RemoveSourceConstraint(mgr);
     AddSourceConstraint add = new AddSourceConstraint(mgr, "a");
 
@@ -314,6 +315,18 @@ public class TransitionsTest {
     Transition expected =
         eraseAndSet(mgr.getFiniteDomain().getVar(), mgr.getSourceInterfaceBDD("a"));
     assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testMergeComposed_RemoveSourceConstraint_AddSourceConstraint_no_merge() {
+    BDDSourceManager mgr =
+        BDDSourceManager.forSources(
+            PKT, ImmutableSet.of("a", "b", "c", "d"), ImmutableSet.of("a", "b"));
+    checkState(
+        !mgr.isValidValue().isOne(), "manager needs to have nontrivial isValidValue constraint");
+    RemoveSourceConstraint remove = new RemoveSourceConstraint(mgr);
+    AddSourceConstraint add = new AddSourceConstraint(mgr, "a");
+    assertNull(mergeComposed(remove, add));
   }
 
   private static List<Transition> mergeCompositeTransitions(Transition... transitions) {


### PR DESCRIPTION
If the source manager for the RemoveSourceConstraint has a nontrivial
isValueValue constraint (i.e. not the one bdd), it is not safe to merge.
Merging in that case would not impose that constraint in the reverse
direction of the edge.