### PR TITLE
PAN: add panorama convert warnings

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1994,6 +1994,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
                                     name, deviceGroupEntry.getKey()));
                           } else {
                             PaloAltoConfiguration c = new PaloAltoConfiguration();
+                            c.setWarnings(_w);
                             // This may not actually be the device's hostname
                             // but this is all we know at this point
                             c.setHostname(name);
@@ -2015,6 +2016,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
                           // Create new managed config if one doesn't already exist for this device
                           if (c == null) {
                             c = new PaloAltoConfiguration();
+                            c.setWarnings(_w);
                             // This may not actually be the device's hostname
                             // but this is all we know at this point
                             c.setHostname(name);

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -126,6 +126,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warning;
 import org.batfish.common.Warnings;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.IpSpaceToBDD;
@@ -3025,5 +3026,22 @@ public final class PaloAltoGrammarTest {
     // device-group overwrite shared object definition
     assertIpSpacesEqual(
         firewall1.getIpSpaces().get(addressObject2Name), Ip.parse("192.168.1.2").toIpSpace());
+  }
+
+  @Test
+  public void testPanoramaWarning() throws IOException {
+    String panoramaHostname = "panorama-warning";
+    String firewallId = "00000001";
+
+    Batfish batfish = getBatfishForConfigurationNames(panoramaHostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Should have a warning about an unknown application associated with the firewall
+    assertThat(ccae.getWarnings().keySet(), hasItem(equalTo(firewallId)));
+    Warnings warn = ccae.getWarnings().get(firewallId);
+    assertThat(
+        warn.getRedFlagWarnings().stream().map(Warning::getText).collect(Collectors.toSet()),
+        contains("Unable to identify application undefined_app in vsys RULE1 rule panorama"));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-warning
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-warning
@@ -1,0 +1,23 @@
+set deviceconfig system hostname panorama-warning
+
+# Setup objects in device-group
+set device-group DG1 post-rulebase security rules RULE1 to any
+set device-group DG1 post-rulebase security rules RULE1 from any
+set device-group DG1 post-rulebase security rules RULE1 source any
+set device-group DG1 post-rulebase security rules RULE1 destination any
+# Undefined app should generate a warning
+set device-group DG1 post-rulebase security rules RULE1 application undefined_app
+set device-group DG1 post-rulebase security rules RULE1 service application-default
+set device-group DG1 post-rulebase security rules RULE1 action allow
+set device-group DG1 devices 00000001
+
+# Setup networking in template
+set template T1 config deviceconfig system ip-address 10.1.10.1
+set template T1 config vsys vsys1 zone Z1 network layer3 ethernet1/1
+set template T1 config vsys vsys1 zone Z3 network layer3 ethernet1/3
+set template T1 config vsys vsys1 import network interface [ ethernet1/1 ethernet1/3 ]
+set template T1 config network interface ethernet ethernet1/1 layer3 ip 10.1.41.1/30
+set template T1 config network interface ethernet ethernet1/3 layer3 ip 10.1.43.1/30
+set template T1 config network virtual-router default interface [ ethernet1/1 ethernet1/3 ]
+set template-stack TS1 templates [ T1 ]
+set template-stack TS1 devices 00000001


### PR DESCRIPTION
For now, add panorama conversion warnings to main warnings object.

Note: we will likely need to rethink how we process conversion warnings for single-config-multi-device configs in the near future.
