### PR TITLE
Reachability: Outgoing original flow filter fixes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDOutgoingOriginalFlowFilterManager.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDOutgoingOriginalFlowFilterManager.java
@@ -207,6 +207,11 @@ public final class BDDOutgoingOriginalFlowFilterManager {
    * BDD, but if the BDD is later constrained to a specific egress interface, this constraint will
    * cause {@link #_permitVar} to be true iff the original flow was permitted by that interface's
    * outgoingOriginalFlowFilter.
+   *
+   * <p>Always use {@link
+   * org.batfish.bddreachability.transition.Transitions#addOutgoingOriginalFlowFiltersConstraint(BDDOutgoingOriginalFlowFilterManager)
+   * addOutgoingOriginalFlowFiltersConstraint} to apply this constraint to edges; otherwise
+   * backwards transition will not erase vars.
    */
   public BDD outgoingOriginalFlowFiltersConstraint() {
     return getInterfaceBDDs().keySet().stream()

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -675,7 +675,8 @@ public final class BDDReachabilityAnalysisFactory {
             });
   }
 
-  private Stream<Edge> generateRootEdges_OriginateVrf_PostInVrf(Map<StateExpr, BDD> rootBdds) {
+  @VisibleForTesting
+  Stream<Edge> generateRootEdges_OriginateVrf_PostInVrf(Map<StateExpr, BDD> rootBdds) {
     return rootBdds.entrySet().stream()
         .filter(entry -> entry.getKey() instanceof OriginateVrf)
         .map(
@@ -692,6 +693,8 @@ public final class BDDReachabilityAnalysisFactory {
                   postInVrf,
                   compose(
                       addOriginatingFromDeviceConstraint(_bddSourceManagers.get(hostname)),
+                      addOutgoingOriginalFlowFiltersConstraint(
+                          _bddOutgoingOriginalFlowFilterManagers.get(hostname)),
                       constraint(rootBdd)));
             });
   }
@@ -705,12 +708,14 @@ public final class BDDReachabilityAnalysisFactory {
               OriginateInterface state = (OriginateInterface) e.getKey();
               String vrf = _interfacesToVrfsMap.get(state.getHostname()).get(state.getInterface());
               PostInVrf postInVrf = new PostInVrf(state.getHostname(), vrf);
+              String hostname = state.getHostname();
               return new Edge(
                   state,
                   postInVrf,
                   compose(
-                      addOriginatingFromDeviceConstraint(
-                          _bddSourceManagers.get(state.getHostname())),
+                      addOriginatingFromDeviceConstraint(_bddSourceManagers.get(hostname)),
+                      addOutgoingOriginalFlowFiltersConstraint(
+                          _bddOutgoingOriginalFlowFilterManagers.get(hostname)),
                       constraint(e.getValue())));
             });
   }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -1,6 +1,7 @@
 package org.batfish.bddreachability;
 
 import static org.batfish.bddreachability.EdgeMatchers.edge;
+import static org.batfish.bddreachability.TransitionMatchers.mapsBackward;
 import static org.batfish.bddreachability.TransitionMatchers.mapsForward;
 import static org.batfish.bddreachability.transition.Transitions.addOriginatingFromDeviceConstraint;
 import static org.batfish.bddreachability.transition.Transitions.compose;
@@ -31,6 +32,7 @@ import static org.batfish.datamodel.transformation.TransformationStep.assignDest
 import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationPort;
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourcePort;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -57,6 +59,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import net.sf.javabdd.BDD;
 import org.batfish.bddreachability.transition.Transition;
@@ -1953,13 +1956,22 @@ public final class BDDReachabilityAnalysisFactoryTest {
     String i2 = "i2";
     SortedMap<String, Configuration> configs = makeOutgoingFiltersNetwork(true, false);
     BDDReachabilityAnalysisFactory factory = makeBddReachabilityAnalysisFactory(configs);
-    BDD originalFlowFiltersConstraint =
-        factory
-            .getBddOutgoingOriginalFlowFilterManagers()
-            .get(c1)
-            .outgoingOriginalFlowFiltersConstraint();
+    BDDOutgoingOriginalFlowFilterManager originalFlowFilterMgr =
+        factory.getBddOutgoingOriginalFlowFilterManagers().get(c1);
+    BDD outgoingConstraint = originalFlowFilterMgr.outgoingOriginalFlowFiltersConstraint();
+    BDD permittedOutI1 = originalFlowFilterMgr.permittedByOriginalFlowEgressFilter(i1);
     // Sanity check: make sure there really is a constraint due to an outgoingOriginalFlowFilter
-    assertFalse(originalFlowFiltersConstraint.isOne());
+    assertFalse(outgoingConstraint.isOne());
+    assertFalse(permittedOutI1.isOne());
+
+    // Create BDD of header space permitted by the outgoing original flows filter, which permits
+    // flows with these three src IPs
+    BDD permittedByFilter =
+        Stream.of(Ip.parse("1.0.0.0"), Ip.parse("2.0.0.0"), Ip.parse("3.0.0.0"))
+            .map(ip -> PKT.getSrcIp().value(ip.asLong()))
+            .reduce(BDD::or)
+            .orElse(null);
+    assert permittedByFilter != null;
 
     List<Edge> edges =
         factory
@@ -1972,7 +1984,8 @@ public final class BDDReachabilityAnalysisFactoryTest {
     StateExpr postInInterface1 = new PostInInterface(c1, i1);
     StateExpr postInInterface2 = new PostInInterface(c1, i2);
     Matcher<Transition> addsOriginalFlowFiltersConstraint =
-        mapsForward(ONE, originalFlowFiltersConstraint);
+        allOf(
+            mapsForward(ONE, outgoingConstraint), mapsBackward(permittedOutI1, permittedByFilter));
     assertThat(
         edges,
         containsInAnyOrder(
@@ -1997,15 +2010,16 @@ public final class BDDReachabilityAnalysisFactoryTest {
     IpAccessList filter =
         nf.aclBuilder().setOwner(c).setLines(accepting(matchSrc(srcIp1)), REJECT_ALL).build();
     c.getAllInterfaces().get(i1).setOutgoingOriginalFlowFilter(filter);
+    BDD permittedByFilter = PKT.getSrcIp().value(srcIp1.asLong());
 
     BDDReachabilityAnalysisFactory factory = makeBddReachabilityAnalysisFactory(configs);
-    BDD originalFlowFiltersConstraint =
-        factory
-            .getBddOutgoingOriginalFlowFilterManagers()
-            .get(c1)
-            .outgoingOriginalFlowFiltersConstraint();
+    BDDOutgoingOriginalFlowFilterManager originalFlowsMgr =
+        factory.getBddOutgoingOriginalFlowFilterManagers().get(c1);
+    BDD originalFlowFiltersConstraint = originalFlowsMgr.outgoingOriginalFlowFiltersConstraint();
+    BDD permittedOutI1 = originalFlowsMgr.permittedByOriginalFlowEgressFilter(i1);
     // Sanity check: make sure there really is a constraint due to an outgoingOriginalFlowFilter
     assertFalse(originalFlowFiltersConstraint.isOne());
+    assertFalse(permittedOutI1.isOne());
 
     // Flows will also be constrained to those not dropped by the packet policy
     Prefix pbrPrefix = Prefix.parse("8.8.8.0/24");
@@ -2018,8 +2032,14 @@ public final class BDDReachabilityAnalysisFactoryTest {
 
     StateExpr preInInterface = new PreInInterface(c1, INGRESS_IFACE);
     StateExpr pbrFibLookup = new PbrFibLookup(c1, "vrf1", "vrf2"); // (see makePBRNetwork for names)
-    BDD expectedFlows = originalFlowFiltersConstraint.and(notDroppedByPbr);
     assertThat(
-        edges, contains(edge(preInInterface, pbrFibLookup, mapsForward(ONE, expectedFlows))));
+        edges,
+        contains(
+            edge(
+                preInInterface,
+                pbrFibLookup,
+                allOf(
+                    mapsForward(ONE, originalFlowFiltersConstraint.and(notDroppedByPbr)),
+                    mapsBackward(permittedOutI1, permittedByFilter.and(notDroppedByPbr))))));
   }
 }


### PR DESCRIPTION
Two fixes:
- On edges entering a node (starting at `PreInInterface`), the outgoing original flow filter constraint was added incorrectly such that transiting it backwards did not clear the outgoing interface constraint. Fixed by correctly using `Transitions.addOutgoingOriginalFlowFiltersConstraint`.
- On root edges starting with an originate state (`OriginateVrf` or `OriginateInterface`), we neglected to add the outgoing original flow filter constraint.