### PR TITLE
Add another tgw attachment type (direct-connect)

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayAttachment.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayAttachment.java
@@ -21,6 +21,7 @@ final class TransitGatewayAttachment implements AwsVpcEntity, Serializable {
 
   /** Different types of TGW attachments */
   enum ResourceType {
+    DIRECT_CONNECT_GATEWAY,
     PEERING,
     VPC,
     VPN
@@ -107,7 +108,7 @@ final class TransitGatewayAttachment implements AwsVpcEntity, Serializable {
     return new TransitGatewayAttachment(
         attachmentId,
         gatewayId,
-        Enum.valueOf(ResourceType.class, resourceType.toUpperCase()),
+        Enum.valueOf(ResourceType.class, resourceType.toUpperCase().replace('-', '_')),
         resourceId,
         association);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayPropagations.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/TransitGatewayPropagations.java
@@ -52,7 +52,7 @@ final class TransitGatewayPropagations implements AwsVpcEntity, Serializable {
 
       return new Propagation(
           attachmentId,
-          ResourceType.valueOf(resourceType.toUpperCase()),
+          ResourceType.valueOf(resourceType.toUpperCase().replace('-', '_')),
           resourceId,
           state.equalsIgnoreCase("enabled"));
     }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayAttachmentTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayAttachmentTest.java
@@ -45,6 +45,13 @@ public class TransitGatewayAttachmentTest {
                     "tgw-01e19888e3ba041ac",
                     ResourceType.VPC,
                     "vpc-0de868624d5f787db",
-                    null))));
+                    null),
+                "tgw-attach-0dbe0fb191f73f405",
+                new TransitGatewayAttachment(
+                    "tgw-attach-0dbe0fb191f73f405",
+                    "tgw-0984f045a02daba60",
+                    ResourceType.DIRECT_CONNECT_GATEWAY,
+                    "a0cb33f1-da2c-4b16-94b9-09cf843d672f",
+                    new Association("tgw-rtb-0dce4e83c56c46fa9", "associated")))));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayPropagationsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/TransitGatewayPropagationsTest.java
@@ -46,6 +46,11 @@ public class TransitGatewayPropagationsTest {
                             "tgw-attach-0ae2696617bb06fb4",
                             ResourceType.VPC,
                             "vpc-00a31ce9d0c06675c",
-                            false))))));
+                            false),
+                        new Propagation(
+                            "tgw-attach-0dbe0fb191f73f405",
+                            ResourceType.DIRECT_CONNECT_GATEWAY,
+                            "a0cb33f1-da2c-4b16-94b9-09cf843d672f",
+                            true))))));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/TransitGatewayAttachmentTest.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/TransitGatewayAttachmentTest.json
@@ -55,6 +55,21 @@
       "TransitGatewayAttachmentId": "tgw-attach-0ce5cf730c95980d9",
       "TransitGatewayId": "tgw-01e19888e3ba041ac",
       "TransitGatewayOwnerId": "554773406868"
+    },
+    {
+      "Association": {
+        "State": "associated",
+        "TransitGatewayRouteTableId": "tgw-rtb-0dce4e83c56c46fa9"
+      },
+      "CreationTime": "2020-04-15 06:05:26+00:00",
+      "ResourceId": "a0cb33f1-da2c-4b16-94b9-09cf843d672f",
+      "ResourceOwnerId": "094218548868",
+      "ResourceType": "direct-connect-gateway",
+      "State": "available",
+      "Tags": [],
+      "TransitGatewayAttachmentId": "tgw-attach-0dbe0fb191f73f405",
+      "TransitGatewayId": "tgw-0984f045a02daba60",
+      "TransitGatewayOwnerId": "094218548868"
     }
   ]
 }

--- a/projects/batfish/src/test/resources/org/batfish/representation/aws/TransitGatewayPropagationsTest.json
+++ b/projects/batfish/src/test/resources/org/batfish/representation/aws/TransitGatewayPropagationsTest.json
@@ -14,6 +14,12 @@
           "ResourceType": "vpc",
           "State": "not-enabled",
           "TransitGatewayAttachmentId": "tgw-attach-0ae2696617bb06fb4"
+        },
+        {
+          "ResourceId": "a0cb33f1-da2c-4b16-94b9-09cf843d672f",
+          "ResourceType": "direct-connect-gateway",
+          "State": "enabled",
+          "TransitGatewayAttachmentId": "tgw-attach-0dbe0fb191f73f405"
         }
       ]
     }


### PR DESCRIPTION
nothing deeper than parsing. prevents deserialization from barfing. 