### PR TITLE
PAN: extract vsys device-group association

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_device_group.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_device_group.g4
@@ -13,5 +13,10 @@ sdg_description
 
 sdg_devices
 :
-    DEVICES device = variable
+    DEVICES device = variable sdgd_vsys?
+;
+
+sdgd_vsys
+:
+    VSYS name = variable
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -219,6 +219,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sappg_definitionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sappg_membersContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sdg_descriptionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sdg_devicesContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sdgd_vsysContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sds_default_gatewayContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sds_hostnameContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sds_ip_addressContext;
@@ -421,6 +422,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   private PaloAltoConfiguration _currentConfiguration;
   private CryptoProfile _currentCrytoProfile;
   private DeviceGroup _currentDeviceGroup;
+  private String _currentDeviceGroupVsys;
   private String _currentDeviceName;
   private String _currentExternalListName;
   private Interface _currentInterface;
@@ -1659,7 +1661,17 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void exitSdg_devices(Sdg_devicesContext ctx) {
-    _currentDeviceGroup.addDevice(getText(ctx.device));
+    if (_currentDeviceGroupVsys == null) {
+      _currentDeviceGroup.addDevice(getText(ctx.device));
+    } else {
+      _currentDeviceGroup.addVsys(getText(ctx.device), _currentDeviceGroupVsys);
+    }
+    _currentDeviceGroupVsys = null;
+  }
+
+  @Override
+  public void exitSdgd_vsys(Sdgd_vsysContext ctx) {
+    _currentDeviceGroupVsys = getText(ctx.name);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/DeviceGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/DeviceGroup.java
@@ -1,7 +1,9 @@
 package org.batfish.representation.palo_alto;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -17,16 +19,25 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public final class DeviceGroup extends PaloAltoConfiguration {
   private String _description;
   private final Set<String> _devices;
+  /** Map of Device name to set of Vsyses */
+  private final Map<String, Set<String>> _vsys;
+
   private final String _name;
 
   public DeviceGroup(String name) {
     super();
     _devices = new HashSet<>();
+    _vsys = new HashMap<>();
     _name = name;
   }
 
   public void addDevice(String device) {
     _devices.add(device);
+  }
+
+  public void addVsys(String device, String vsys) {
+    Set<String> vsysSet = _vsys.computeIfAbsent(device, d -> new HashSet<>());
+    vsysSet.add(vsys);
   }
 
   public @Nullable String getDescription() {
@@ -35,6 +46,11 @@ public final class DeviceGroup extends PaloAltoConfiguration {
 
   public @Nonnull Set<String> getDevices() {
     return ImmutableSet.copyOf(_devices);
+  }
+
+  /** Return map of device name to set of vsys names, for vsys associated with this device-group. */
+  public @Nonnull Map<String, Set<String>> getVsys() {
+    return _vsys;
   }
 
   public String getName() {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2024,16 +2024,16 @@ public class PaloAltoConfiguration extends VendorConfiguration {
                                 String.format(
                                     "Associating vsys on a managed device with different device-groups is not yet supported. Ignoring association with device-group '%s' for managed device '%s'.",
                                     deviceGroupEntry.getKey(), deviceName));
-                          } else {
-                            PaloAltoConfiguration c = new PaloAltoConfiguration();
-                            c.setWarnings(_w);
-                            c.setVendor(_vendor);
-                            // This may not actually be the device's hostname
-                            // but this is all we know at this point
-                            c.setHostname(deviceName);
-                            c.applyDeviceGroup(deviceGroupEntry.getValue(), _shared);
-                            managedConfigurations.put(deviceName, c);
+                            return;
                           }
+                          PaloAltoConfiguration c = new PaloAltoConfiguration();
+                          c.setWarnings(_w);
+                          c.setVendor(_vendor);
+                          // This may not actually be the device's hostname
+                          // but this is all we know at this point
+                          c.setHostname(deviceName);
+                          c.applyDeviceGroup(deviceGroupEntry.getValue(), _shared);
+                          managedConfigurations.put(deviceName, c);
                         }));
     // Apply template-stacks
     _templateStacks

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/device-group-attach-multi-vsys
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/device-group-attach-multi-vsys
@@ -1,0 +1,9 @@
+set deviceconfig system hostname device-group-attach-multi-vsys
+
+# Attach device-group to the first vsys on the managed device
+set device-group DG1 address ADDR1 ip-netmask 1.1.1.1
+set device-group DG1 devices 00000001 vsys vsys1
+
+# Attach a different device-group to the second vsys on the managed device
+set device-group DG2 address ADDR1 ip-netmask 2.2.2.2
+set device-group DG2 devices 00000001 vsys vsys2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/device-group-attach-vsys
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/device-group-attach-vsys
@@ -1,0 +1,5 @@
+set deviceconfig system hostname device-group-attach-vsys
+
+# Attach device-group to the first vsys on the managed device
+set device-group DG1 address ADDR1 ip-netmask 1.1.1.1
+set device-group DG1 devices 00000001 vsys vsys1


### PR DESCRIPTION
* Extract `vsys` - `device-group` association
* Handle simplest case where firewall is only associated with a single `device-group`

Cannot yet handle associating different `vsys` on the same firewall with different `device-group`s (see #5910).
