### PR TITLE
AWS service IPs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
@@ -30,7 +30,13 @@ public final class CompletionMetadataUtils {
 
   /** We will add these well-known IPs to assist with autocompletion */
   public static Map<Ip, String> WELL_KNOWN_IPS =
-      ImmutableMap.of(Ip.parse("8.8.8.8"), "Google DNS", Ip.parse("1.1.1.1"), "Cloudflare DNS");
+      ImmutableMap.of(
+          Ip.parse("8.8.8.8"),
+          "Google DNS",
+          Ip.parse("1.1.1.1"),
+          "Cloudflare DNS",
+          Ip.parse("52.95.110.1"),
+          "AWS Route53");
 
   public static Set<String> getFilterNames(Map<String, Configuration> configurations) {
     ImmutableSet.Builder<String> filterNames = ImmutableSet.builder();
@@ -135,6 +141,10 @@ public final class CompletionMetadataUtils {
     if (bookName.equals(
         GeneratedRefBookUtils.getName(configuration.getHostname(), BookType.PublicIps))) {
       return String.format("%s public IP%s", configuration.getHostname(), suffix);
+    }
+    if (bookName.equals(
+        GeneratedRefBookUtils.getName(configuration.getHostname(), BookType.AwsSeviceIps))) {
+      return groupName;
     }
     // Don't know what type of address this is; use default value.
     return String.format(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CompletionMetadataUtils.java
@@ -156,6 +156,7 @@ public final class CompletionMetadataUtils {
                             addressGroupDisplayString(configuration, bookName, groupName),
                             configuration.getHostname(),
                             configuration.getHumanName(),
+                            bookName,
                             groupName)));
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/GeneratedRefBookUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/referencelibrary/GeneratedRefBookUtils.java
@@ -5,6 +5,7 @@ import org.batfish.datamodel.Names;
 public class GeneratedRefBookUtils {
 
   public enum BookType {
+    AwsSeviceIps,
     PoolAddresses,
     PublicIps,
     VirtualAddresses

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CompletionMetadataUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CompletionMetadataUtilsTest.java
@@ -247,6 +247,7 @@ public final class CompletionMetadataUtilsTest {
                             addressGroupDisplayString(config, book1.getName(), "ag1"),
                             config.getHostname(),
                             config.getHumanName(),
+                            "book1",
                             "ag1")))
                 .put(
                     Ip.parse("2.2.2.2"),
@@ -255,6 +256,7 @@ public final class CompletionMetadataUtilsTest {
                             addressGroupDisplayString(config, book1.getName(), "ag1"),
                             config.getHostname(),
                             config.getHumanName(),
+                            "book1",
                             "ag1")))
                 .put(
                     Ip.parse("3.3.3.3"),
@@ -264,11 +266,13 @@ public final class CompletionMetadataUtilsTest {
                                 addressGroupDisplayString(config, book1.getName(), "ag2"),
                                 config.getHostname(),
                                 config.getHumanName(),
+                                "book1",
                                 "ag2"),
                             new IpCompletionRelevance(
                                 addressGroupDisplayString(config, book2.getName(), "ag1"),
                                 config.getHostname(),
                                 config.getHumanName(),
+                                "book2",
                                 "ag1"))))
                 .put(
                     Ip.parse("4.4.4.4"),
@@ -277,6 +281,7 @@ public final class CompletionMetadataUtilsTest {
                             addressGroupDisplayString(config, book2.getName(), "ag1"),
                             config.getHostname(),
                             config.getHumanName(),
+                            "book2",
                             "ag1")))
                 .putAll(createWellKnownIpCompletion(WELL_KNOWN_IPS))
                 .build()));

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -142,6 +142,7 @@ public class AwsConfiguration extends VendorConfiguration {
       for (Region region : regions) {
         try {
           region.toConfigurationNodes(_convertedConfiguration, getWarnings());
+          region.addPrefixListReferenceBook(_convertedConfiguration, getWarnings());
         } catch (Exception e) {
           getWarnings()
               .redFlag(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -561,15 +561,18 @@ public final class Region implements Serializable {
                 })
             .collect(ImmutableList.toImmutableList());
 
-    awsServicesNode
-        .getGeneratedReferenceBooks()
-        .put(
-            bookName,
-            ReferenceBook.builder(bookName)
-                .setAddressGroups(
-                    Streams.concat(currentBook.getAddressGroups().stream(), addressGroups.stream())
-                        .collect(ImmutableList.toImmutableList()))
-                .build());
+    if (!addressGroups.isEmpty()) { // no change needed if no new address groups were produced
+      awsServicesNode
+          .getGeneratedReferenceBooks()
+          .put(
+              bookName,
+              ReferenceBook.builder(bookName)
+                  .setAddressGroups(
+                      Streams.concat(
+                              currentBook.getAddressGroups().stream(), addressGroups.stream())
+                          .collect(ImmutableList.toImmutableList()))
+                  .build());
+    }
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -3,6 +3,7 @@ package org.batfish.representation.aws;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
+import static org.batfish.representation.aws.AwsConfiguration.AWS_SERVICES_GATEWAY_NODE_NAME;
 import static org.batfish.representation.aws.SecurityGroup.SG_INGRESS_ACL_NAME;
 import static org.batfish.representation.aws.Utils.getTraceElementForSecurityGroup;
 
@@ -13,6 +14,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Streams;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
@@ -46,9 +48,14 @@ import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.IpWildcardSetIpSpace;
 import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
+import org.batfish.referencelibrary.AddressGroup;
+import org.batfish.referencelibrary.GeneratedRefBookUtils;
+import org.batfish.referencelibrary.GeneratedRefBookUtils.BookType;
+import org.batfish.referencelibrary.ReferenceBook;
 import org.batfish.representation.aws.Instance.Status;
 
 /** Represents an AWS region */
@@ -516,6 +523,53 @@ public final class Region implements Serializable {
       default:
         return null;
     }
+  }
+
+  /** Adds a generated references book for prefix lists on the AWS services gateway node */
+  void addPrefixListReferenceBook(
+      ConvertedConfiguration convertedConfiguration, Warnings warnings) {
+    Configuration awsServicesNode = convertedConfiguration.getNode(AWS_SERVICES_GATEWAY_NODE_NAME);
+    if (awsServicesNode == null) {
+      warnings.redFlag("AWS service gateway not found. Cannot generate prefix list address books");
+      return;
+    }
+    String bookName =
+        GeneratedRefBookUtils.getName(awsServicesNode.getHostname(), BookType.AwsSeviceIps);
+    final ReferenceBook currentBook =
+        awsServicesNode
+            .getGeneratedReferenceBooks()
+            .getOrDefault(bookName, ReferenceBook.builder(bookName).build());
+
+    List<AddressGroup> addressGroups =
+        _prefixLists.values().stream()
+            // prefix lists names contain region in them (e.g., "com.amazonaws.us-east-1.s3"), but
+            // address group for a prefix list may already have been created via another account in
+            // the region. we keep the original list in that case.
+            .filter(plist -> !currentBook.getAddressGroup(plist.getPrefixListName()).isPresent())
+            .filter(plist -> !plist.getCidrs().isEmpty())
+            .map(
+                plist -> {
+                  Prefix cidr = plist.getCidrs().get(0);
+                  // get a *.1 address (looks better than a *.0 address)
+                  Ip representativeIp =
+                      cidr.getPrefixLength() == Prefix.MAX_PREFIX_LENGTH
+                          ? cidr.getStartIp()
+                          : Ip.create(cidr.getStartIp().asLong() + 1);
+                  return new AddressGroup(
+                      ImmutableSortedSet.of(representativeIp.toString()),
+                      plist.getPrefixListName());
+                })
+            .collect(ImmutableList.toImmutableList());
+
+    awsServicesNode
+        .getGeneratedReferenceBooks()
+        .put(
+            bookName,
+            ReferenceBook.builder(bookName)
+                .setAddressGroups(
+                    Streams.concat(currentBook.getAddressGroups().stream(), addressGroups.stream())
+                        .collect(ImmutableList.toImmutableList()))
+                .build());
   }
 
   @Nonnull

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -10,6 +10,25 @@
         "deviceModel" : "AWS_SERVICES_GATEWAY",
         "deviceType" : "ROUTER",
         "domainName" : "aws",
+        "generatedReferenceBooks" : {
+          "AwsSeviceIps~on~__aws-services-gateway__" : {
+            "addressGroups" : [
+              {
+                "addresses" : [
+                  "52.94.28.1"
+                ],
+                "name" : "com.amazonaws.us-west-2.dynamodb"
+              },
+              {
+                "addresses" : [
+                  "54.231.160.1"
+                ],
+                "name" : "com.amazonaws.us-west-2.s3"
+              }
+            ],
+            "name" : "AwsSeviceIps~on~__aws-services-gateway__"
+          }
+        },
         "humanName" : "AWS Services Gateway",
         "interfaces" : {
           "aws-services" : {


### PR DESCRIPTION
1. Add a representative IP for Route53 that can be used by anyone to check connectivity to AWS 
2. Add generated ref books for prefix lists for AWS services that appear in snapshot data