### PR TITLE
FirewallSessionInterfaceInfo: fix deserialization of empty interfaces

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
@@ -1,9 +1,10 @@
 package org.batfish.datamodel;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
 import java.util.Objects;
@@ -46,9 +47,11 @@ public final class FirewallSessionInterfaceInfo implements Serializable {
       @JsonProperty(PROP_SESSION_INTERFACES) @Nullable Set<String> sessionInterfaces,
       @JsonProperty(PROP_INCOMING_ACL_NAME) @Nullable String incomingAclName,
       @JsonProperty(PROP_OUTGOING_ACL_NAME) @Nullable String outgoingAclName) {
-    checkNotNull(sessionInterfaces, PROP_SESSION_INTERFACES + " cannot be null");
     return new FirewallSessionInterfaceInfo(
-        fibLookup, sessionInterfaces, incomingAclName, outgoingAclName);
+        fibLookup,
+        firstNonNull(sessionInterfaces, ImmutableList.of()),
+        incomingAclName,
+        outgoingAclName);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FirewallSessionInterfaceInfoTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FirewallSessionInterfaceInfoTest.java
@@ -1,7 +1,12 @@
 package org.batfish.datamodel;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
 /** Tests for {@link FirewallSessionInterfaceInfo}. */
@@ -19,5 +24,18 @@ public final class FirewallSessionInterfaceInfoTest {
         .addEqualityGroup(
             new FirewallSessionInterfaceInfo(false, ImmutableSet.of("B"), "IN_ACL", "OUT_ACL"))
         .testEquals();
+  }
+
+  @Test
+  public void testJson() {
+    FirewallSessionInterfaceInfo info1 =
+        new FirewallSessionInterfaceInfo(true, ImmutableList.of(), null, null);
+    assertThat(
+        info1, equalTo(BatfishObjectMapper.clone(info1, FirewallSessionInterfaceInfo.class)));
+
+    FirewallSessionInterfaceInfo info2 =
+        new FirewallSessionInterfaceInfo(false, ImmutableList.of("a"), "b", "c");
+    assertThat(
+        info2, equalTo(BatfishObjectMapper.clone(info2, FirewallSessionInterfaceInfo.class)));
   }
 }


### PR DESCRIPTION
It may round-trip through json as null instead of empty.