### PR TITLE
PAN: avoid NPEs in template ref tracking

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -532,7 +532,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   private void referenceService(Variable_list_itemContext var, PaloAltoStructureUsage usage) {
     String serviceName = getText(var);
     // Use constructed object name so same-named refs across vsys are unique
-    String uniqueName = computeObjectName(_currentVsys.getName(), serviceName);
+    String uniqueName = computeObjectName(getCurrentVsysName(), serviceName);
 
     if (Arrays.stream(ServiceBuiltIn.values()).anyMatch(n -> serviceName.equals(n.getName()))) {
       // Built-in services can be overridden, so add optional object reference
@@ -1326,7 +1326,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
           _currentVsys.getAddressObjects().computeIfAbsent(name, AddressObject::new);
 
       // Use constructed name so same-named defs across vsys are unique
-      String uniqueName = computeObjectName(_currentVsys.getName(), name);
+      String uniqueName = computeObjectName(getCurrentVsysName(), name);
       defineFlattenedStructure(ADDRESS_OBJECT, uniqueName, ctx, _parser);
     }
   }
@@ -1388,7 +1388,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
           _currentVsys.getAddressGroups().computeIfAbsent(name, AddressGroup::new);
 
       // Use constructed name so same-named defs across vsys are unique
-      String uniqueName = computeObjectName(_currentVsys.getName(), name);
+      String uniqueName = computeObjectName(getCurrentVsysName(), name);
       defineFlattenedStructure(ADDRESS_GROUP, uniqueName, ctx, _parser);
     }
   }
@@ -1406,7 +1406,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
             .getApplications()
             .computeIfAbsent(name, n -> Application.builder(name).build());
     // Use constructed name so same-named defs across vsys are unique
-    String uniqueName = computeObjectName(_currentVsys.getName(), name);
+    String uniqueName = computeObjectName(getCurrentVsysName(), name);
     defineFlattenedStructure(APPLICATION, uniqueName, ctx, _parser);
   }
 
@@ -1421,7 +1421,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentApplicationGroup =
         _currentVsys.getApplicationGroups().computeIfAbsent(name, ApplicationGroup::new);
     // Use constructed name so same-named defs across vsys are unique
-    String uniqueName = computeObjectName(_currentVsys.getName(), name);
+    String uniqueName = computeObjectName(getCurrentVsysName(), name);
     defineFlattenedStructure(APPLICATION_GROUP, uniqueName, ctx, _parser);
   }
 
@@ -1435,7 +1435,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     for (Variable_list_itemContext var : variables(ctx.variable_list())) {
       String name = getText(var);
       _currentApplicationGroup.getMembers().add(name);
-      String uniqueName = computeObjectName(_currentVsys.getName(), name);
+      String uniqueName = computeObjectName(getCurrentVsysName(), name);
       referenceApplicationLike(name, uniqueName, APPLICATION_GROUP_MEMBERS, var);
     }
   }
@@ -1451,7 +1451,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentZone = _currentVsys.getZones().computeIfAbsent(name, n -> new Zone(n, _currentVsys));
 
     // Use constructed zone name so same-named zone defs across vsys are unique
-    String uniqueName = computeObjectName(_currentVsys.getName(), name);
+    String uniqueName = computeObjectName(getCurrentVsysName(), name);
     defineFlattenedStructure(ZONE, uniqueName, ctx, _parser);
   }
 
@@ -1502,7 +1502,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
         _currentAddressGroup.addMember(objectName);
 
         // Use constructed name so same-named defs across vsys are unique
-        String uniqueName = computeObjectName(_currentVsys.getName(), objectName);
+        String uniqueName = computeObjectName(getCurrentVsysName(), objectName);
         referenceStructure(ADDRESS_LIKE, uniqueName, ADDRESS_GROUP_STATIC, getLine(var.start));
       }
     }
@@ -1564,7 +1564,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitSelt_ip(Selt_ipContext ctx) {
     defineStructure(
-        EXTERNAL_LIST, computeObjectName(_currentVsys.getName(), _currentExternalListName), ctx);
+        EXTERNAL_LIST, computeObjectName(getCurrentVsysName(), _currentExternalListName), ctx);
   }
 
   @Override
@@ -1599,7 +1599,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentZone = _currentVsys.getZones().computeIfAbsent(name, n -> new Zone(n, _currentVsys));
 
     // Use constructed zone name so same-named zone defs across vsys are unique
-    String uniqueName = computeObjectName(_currentVsys.getName(), name);
+    String uniqueName = computeObjectName(getCurrentVsysName(), name);
     defineFlattenedStructure(ZONE, uniqueName, ctx, _parser);
   }
 
@@ -1621,7 +1621,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       // Mark reference to zone when it has an interface in it (since the zone if effectively used
       // at this point)
       // Use constructed object name so same-named refs across vsys are unique
-      String zoneName = computeObjectName(_currentVsys.getName(), _currentZone.getName());
+      String zoneName = computeObjectName(getCurrentVsysName(), _currentZone.getName());
       referenceStructure(ZONE, zoneName, LAYER3_INTERFACE_ZONE, getLine(var.start));
     }
   }
@@ -1680,7 +1680,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     defineFlattenedStructure(TEMPLATE, templateName, ctx, _parser);
     _currentTemplate = _mainConfiguration.getOrCreateTemplate(templateName);
     _currentConfiguration = _currentTemplate;
-    _currentVsys = null;
+    _currentVsys = _defaultVsys;
   }
 
   @Override
@@ -2195,7 +2195,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentNatRule = rulebase.getNatRules().computeIfAbsent(name, NatRule::new);
 
     // Use constructed name so same-named defs across vsys are unique
-    String uniqueName = computeObjectName(_currentVsys.getName(), name);
+    String uniqueName = computeObjectName(getCurrentVsysName(), name);
     defineFlattenedStructure(NAT_RULE, uniqueName, ctx, _parser);
     referenceStructure(NAT_RULE, uniqueName, NAT_RULE_SELF_REF, getLine(ctx.name.start));
   }
@@ -2211,7 +2211,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentNatRule.setDestinationTranslation(new DestinationTranslation(translatedAddress));
 
     // Add reference
-    String uniqueName = computeObjectName(_currentVsys.getName(), translatedAddress.getValue());
+    String uniqueName = computeObjectName(getCurrentVsysName(), translatedAddress.getValue());
     // At this time, don't know if something that looks like a constant (e.g. IP address) is a
     // reference or not.  So mark a reference to a very permissive abstract structure type.
     PaloAltoStructureType type = ADDRESS_LIKE_OR_NONE;
@@ -2241,7 +2241,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       dynamicIpAndPort.addTranslatedAddress(translatedAddress);
 
       // Add reference
-      String uniqueName = computeObjectName(_currentVsys.getName(), translatedAddress.getValue());
+      String uniqueName = computeObjectName(getCurrentVsysName(), translatedAddress.getValue());
       // At this time, don't know if something that looks like a constant (e.g. IP address) is a
       // reference or not.  So mark a reference to a very permissive abstract structure type.
       PaloAltoStructureType type = ADDRESS_LIKE_OR_NONE;
@@ -2261,7 +2261,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       _currentNatRule.getDestination().add(endpoint);
 
       // Use constructed object name so same-named refs across vsys are unique
-      String uniqueName = computeObjectName(_currentVsys.getName(), endpoint.getValue());
+      String uniqueName = computeObjectName(getCurrentVsysName(), endpoint.getValue());
 
       // At this time, don't know if something that looks like a constant (e.g. IP address) is a
       // reference or not.  So mark a reference to a very permissive abstract structure type.
@@ -2281,7 +2281,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       RuleEndpoint endpoint = toRuleEndpoint(var);
       _currentNatRule.getSource().add(endpoint);
       // Use constructed object name so same-named refs across vsys are unique
-      String uniqueName = computeObjectName(_currentVsys.getName(), endpoint.getValue());
+      String uniqueName = computeObjectName(getCurrentVsysName(), endpoint.getValue());
 
       // At this time, don't know if something that looks like a constant (e.g. IP address) is a
       // reference or not.  So mark a reference to a very permissive abstract structure type.
@@ -2301,7 +2301,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
       if (!zoneName.equals(CATCHALL_ZONE_NAME)) {
         // Use constructed object name so same-named refs across vsys are unique
-        String uniqueName = computeObjectName(_currentVsys.getName(), zoneName);
+        String uniqueName = computeObjectName(getCurrentVsysName(), zoneName);
         referenceStructure(ZONE, uniqueName, NAT_RULE_FROM_ZONE, getLine(var.start));
       }
     }
@@ -2314,7 +2314,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
     if (!zoneName.equals(CATCHALL_ZONE_NAME)) {
       // Use constructed object name so same-named refs across vsys are unique
-      String uniqueName = computeObjectName(_currentVsys.getName(), zoneName);
+      String uniqueName = computeObjectName(getCurrentVsysName(), zoneName);
       referenceStructure(ZONE, uniqueName, NAT_RULE_TO_ZONE, getLine(ctx.zone.start));
     }
   }
@@ -2335,7 +2335,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
         rulebase.getSecurityRules().computeIfAbsent(name, n -> new SecurityRule(n, _currentVsys));
 
     // Use constructed name so same-named defs across vsys are unique
-    String uniqueName = computeObjectName(_currentVsys.getName(), name);
+    String uniqueName = computeObjectName(getCurrentVsysName(), name);
     defineFlattenedStructure(SECURITY_RULE, uniqueName, ctx, _parser);
     referenceStructure(SECURITY_RULE, uniqueName, SECURITY_RULE_SELF_REF, getLine(ctx.name.start));
   }
@@ -2375,7 +2375,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       String name = getText(var);
       _currentSecurityRule.getApplications().add(name);
       // Use constructed object name so same-named refs across vsys are unique
-      String uniqueName = computeObjectName(_currentVsys.getName(), name);
+      String uniqueName = computeObjectName(getCurrentVsysName(), name);
       referenceApplicationLike(name, uniqueName, SECURITY_RULE_APPLICATION, var);
     }
   }
@@ -2392,7 +2392,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       _currentSecurityRule.getDestination().add(endpoint);
 
       // Use constructed object name so same-named refs across vsys are unique
-      String uniqueName = computeObjectName(_currentVsys.getName(), endpoint.getValue());
+      String uniqueName = computeObjectName(getCurrentVsysName(), endpoint.getValue());
 
       // At this time, don't know if something that looks like a constant (e.g. IP address) is a
       // reference or not.  So mark a reference to a very permissive abstract structure type.
@@ -2419,7 +2419,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
       if (!zoneName.equals(CATCHALL_ZONE_NAME)) {
         // Use constructed object name so same-named refs across vsys are unique
-        String uniqueName = computeObjectName(_currentVsys.getName(), zoneName);
+        String uniqueName = computeObjectName(getCurrentVsysName(), zoneName);
         referenceStructure(ZONE, uniqueName, SECURITY_RULE_FROM_ZONE, getLine(var.start));
       }
     }
@@ -2450,7 +2450,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       RuleEndpoint endpoint = toRuleEndpoint(var);
       _currentSecurityRule.getSource().add(endpoint);
       // Use constructed object name so same-named refs across vsys are unique
-      String uniqueName = computeObjectName(_currentVsys.getName(), endpoint.getValue());
+      String uniqueName = computeObjectName(getCurrentVsysName(), endpoint.getValue());
 
       // At this time, don't know if something that looks like a constant (e.g. IP address) is a
       // reference or not.  So mark a reference to a very permissive abstract structure type.
@@ -2470,7 +2470,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
       if (!zoneName.equals(CATCHALL_ZONE_NAME)) {
         // Use constructed object name so same-named refs across vsys are unique
-        String uniqueName = computeObjectName(_currentVsys.getName(), zoneName);
+        String uniqueName = computeObjectName(getCurrentVsysName(), zoneName);
         referenceStructure(ZONE, uniqueName, SECURITY_RULE_TO_ZONE, getLine(var.start));
       }
     }
@@ -2492,7 +2492,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentService = _currentVsys.getServices().computeIfAbsent(name, Service::new);
 
     // Use constructed service name so same-named defs across vsys are unique
-    String uniqueName = computeObjectName(_currentVsys.getName(), name);
+    String uniqueName = computeObjectName(getCurrentVsysName(), name);
     defineFlattenedStructure(PaloAltoStructureType.SERVICE, uniqueName, ctx, _parser);
   }
 
@@ -2547,7 +2547,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentServiceGroup = _currentVsys.getServiceGroups().computeIfAbsent(name, ServiceGroup::new);
 
     // Use constructed service-group name so same-named defs across vsys are unique
-    String uniqueName = computeObjectName(_currentVsys.getName(), name);
+    String uniqueName = computeObjectName(getCurrentVsysName(), name);
     defineFlattenedStructure(SERVICE_GROUP, uniqueName, ctx, _parser);
   }
 
@@ -2652,7 +2652,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       // Mark reference to zone when it has an interface in it (since the zone if effectively used
       // at this point)
       // Use constructed object name so same-named refs across vsys are unique
-      String zoneName = computeObjectName(_currentVsys.getName(), _currentZone.getName());
+      String zoneName = computeObjectName(getCurrentVsysName(), _currentZone.getName());
       referenceStructure(ZONE, zoneName, LAYER2_INTERFACE_ZONE, getLine(var.start));
     }
   }
@@ -2667,7 +2667,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       // Mark reference to zone when it has an interface in it (since the zone if effectively used
       // at this point)
       // Use constructed object name so same-named refs across vsys are unique
-      String zoneName = computeObjectName(_currentVsys.getName(), _currentZone.getName());
+      String zoneName = computeObjectName(getCurrentVsysName(), _currentZone.getName());
       referenceStructure(ZONE, zoneName, LAYER3_INTERFACE_ZONE, getLine(var.start));
     }
   }
@@ -2682,7 +2682,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       // Mark reference to zone when it has an interface in it (since the zone if effectively used
       // at this point)
       // Use constructed object name so same-named refs across vsys are unique
-      String zoneName = computeObjectName(_currentVsys.getName(), _currentZone.getName());
+      String zoneName = computeObjectName(getCurrentVsysName(), _currentZone.getName());
       referenceStructure(ZONE, zoneName, TAP_INTERFACE_ZONE, getLine(var.start));
     }
   }
@@ -2697,7 +2697,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       // Mark reference to zone when it has an interface in it (since the zone if effectively used
       // at this point)
       // Use constructed object name so same-named refs across vsys are unique
-      String zoneName = computeObjectName(_currentVsys.getName(), _currentZone.getName());
+      String zoneName = computeObjectName(getCurrentVsysName(), _currentZone.getName());
       referenceStructure(ZONE, zoneName, VIRTUAL_WIRE_INTERFACE_ZONE, getLine(var.start));
     }
   }
@@ -2714,6 +2714,13 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       _currentConfiguration.setPanorama(panorama);
     }
     return panorama;
+  }
+
+  /**
+   * Get name for the currently active vsys. If no vsys is active, falls back to default vsys name.
+   */
+  private String getCurrentVsysName() {
+    return (_currentVsys != null) ? _currentVsys.getName() : DEFAULT_VSYS_NAME;
   }
 
   private static boolean toBoolean(Yes_or_noContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -450,6 +450,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   private TemplateStack _currentTemplateStack;
   private VirtualRouter _currentVirtualRouter;
   private Vsys _currentVsys;
+  private Vsys _dummyVsys;
   private Zone _currentZone;
 
   public PaloAltoConfigurationBuilder(
@@ -532,7 +533,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   private void referenceService(Variable_list_itemContext var, PaloAltoStructureUsage usage) {
     String serviceName = getText(var);
     // Use constructed object name so same-named refs across vsys are unique
-    String uniqueName = computeObjectName(getCurrentVsysName(), serviceName);
+    String uniqueName = computeObjectName(_currentVsys.getName(), serviceName);
 
     if (Arrays.stream(ServiceBuiltIn.values()).anyMatch(n -> serviceName.equals(n.getName()))) {
       // Built-in services can be overridden, so add optional object reference
@@ -1287,6 +1288,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentConfiguration = _mainConfiguration;
     _defaultVsys =
         _mainConfiguration.getVirtualSystems().computeIfAbsent(DEFAULT_VSYS_NAME, Vsys::new);
+    _dummyVsys = new Vsys(DEFAULT_VSYS_NAME);
     _currentVsys = _defaultVsys;
     _currentDeviceGroup = null;
   }
@@ -1326,7 +1328,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
           _currentVsys.getAddressObjects().computeIfAbsent(name, AddressObject::new);
 
       // Use constructed name so same-named defs across vsys are unique
-      String uniqueName = computeObjectName(getCurrentVsysName(), name);
+      String uniqueName = computeObjectName(_currentVsys.getName(), name);
       defineFlattenedStructure(ADDRESS_OBJECT, uniqueName, ctx, _parser);
     }
   }
@@ -1388,7 +1390,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
           _currentVsys.getAddressGroups().computeIfAbsent(name, AddressGroup::new);
 
       // Use constructed name so same-named defs across vsys are unique
-      String uniqueName = computeObjectName(getCurrentVsysName(), name);
+      String uniqueName = computeObjectName(_currentVsys.getName(), name);
       defineFlattenedStructure(ADDRESS_GROUP, uniqueName, ctx, _parser);
     }
   }
@@ -1406,7 +1408,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
             .getApplications()
             .computeIfAbsent(name, n -> Application.builder(name).build());
     // Use constructed name so same-named defs across vsys are unique
-    String uniqueName = computeObjectName(getCurrentVsysName(), name);
+    String uniqueName = computeObjectName(_currentVsys.getName(), name);
     defineFlattenedStructure(APPLICATION, uniqueName, ctx, _parser);
   }
 
@@ -1421,7 +1423,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentApplicationGroup =
         _currentVsys.getApplicationGroups().computeIfAbsent(name, ApplicationGroup::new);
     // Use constructed name so same-named defs across vsys are unique
-    String uniqueName = computeObjectName(getCurrentVsysName(), name);
+    String uniqueName = computeObjectName(_currentVsys.getName(), name);
     defineFlattenedStructure(APPLICATION_GROUP, uniqueName, ctx, _parser);
   }
 
@@ -1435,7 +1437,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     for (Variable_list_itemContext var : variables(ctx.variable_list())) {
       String name = getText(var);
       _currentApplicationGroup.getMembers().add(name);
-      String uniqueName = computeObjectName(getCurrentVsysName(), name);
+      String uniqueName = computeObjectName(_currentVsys.getName(), name);
       referenceApplicationLike(name, uniqueName, APPLICATION_GROUP_MEMBERS, var);
     }
   }
@@ -1451,7 +1453,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentZone = _currentVsys.getZones().computeIfAbsent(name, n -> new Zone(n, _currentVsys));
 
     // Use constructed zone name so same-named zone defs across vsys are unique
-    String uniqueName = computeObjectName(getCurrentVsysName(), name);
+    String uniqueName = computeObjectName(_currentVsys.getName(), name);
     defineFlattenedStructure(ZONE, uniqueName, ctx, _parser);
   }
 
@@ -1502,7 +1504,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
         _currentAddressGroup.addMember(objectName);
 
         // Use constructed name so same-named defs across vsys are unique
-        String uniqueName = computeObjectName(getCurrentVsysName(), objectName);
+        String uniqueName = computeObjectName(_currentVsys.getName(), objectName);
         referenceStructure(ADDRESS_LIKE, uniqueName, ADDRESS_GROUP_STATIC, getLine(var.start));
       }
     }
@@ -1564,7 +1566,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitSelt_ip(Selt_ipContext ctx) {
     defineStructure(
-        EXTERNAL_LIST, computeObjectName(getCurrentVsysName(), _currentExternalListName), ctx);
+        EXTERNAL_LIST, computeObjectName(_currentVsys.getName(), _currentExternalListName), ctx);
   }
 
   @Override
@@ -1599,7 +1601,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentZone = _currentVsys.getZones().computeIfAbsent(name, n -> new Zone(n, _currentVsys));
 
     // Use constructed zone name so same-named zone defs across vsys are unique
-    String uniqueName = computeObjectName(getCurrentVsysName(), name);
+    String uniqueName = computeObjectName(_currentVsys.getName(), name);
     defineFlattenedStructure(ZONE, uniqueName, ctx, _parser);
   }
 
@@ -1621,7 +1623,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       // Mark reference to zone when it has an interface in it (since the zone if effectively used
       // at this point)
       // Use constructed object name so same-named refs across vsys are unique
-      String zoneName = computeObjectName(getCurrentVsysName(), _currentZone.getName());
+      String zoneName = computeObjectName(_currentVsys.getName(), _currentZone.getName());
       referenceStructure(ZONE, zoneName, LAYER3_INTERFACE_ZONE, getLine(var.start));
     }
   }
@@ -1680,7 +1682,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     defineFlattenedStructure(TEMPLATE, templateName, ctx, _parser);
     _currentTemplate = _mainConfiguration.getOrCreateTemplate(templateName);
     _currentConfiguration = _currentTemplate;
-    _currentVsys = _defaultVsys;
+    _currentVsys = _dummyVsys;
   }
 
   @Override
@@ -2195,7 +2197,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentNatRule = rulebase.getNatRules().computeIfAbsent(name, NatRule::new);
 
     // Use constructed name so same-named defs across vsys are unique
-    String uniqueName = computeObjectName(getCurrentVsysName(), name);
+    String uniqueName = computeObjectName(_currentVsys.getName(), name);
     defineFlattenedStructure(NAT_RULE, uniqueName, ctx, _parser);
     referenceStructure(NAT_RULE, uniqueName, NAT_RULE_SELF_REF, getLine(ctx.name.start));
   }
@@ -2211,7 +2213,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentNatRule.setDestinationTranslation(new DestinationTranslation(translatedAddress));
 
     // Add reference
-    String uniqueName = computeObjectName(getCurrentVsysName(), translatedAddress.getValue());
+    String uniqueName = computeObjectName(_currentVsys.getName(), translatedAddress.getValue());
     // At this time, don't know if something that looks like a constant (e.g. IP address) is a
     // reference or not.  So mark a reference to a very permissive abstract structure type.
     PaloAltoStructureType type = ADDRESS_LIKE_OR_NONE;
@@ -2241,7 +2243,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       dynamicIpAndPort.addTranslatedAddress(translatedAddress);
 
       // Add reference
-      String uniqueName = computeObjectName(getCurrentVsysName(), translatedAddress.getValue());
+      String uniqueName = computeObjectName(_currentVsys.getName(), translatedAddress.getValue());
       // At this time, don't know if something that looks like a constant (e.g. IP address) is a
       // reference or not.  So mark a reference to a very permissive abstract structure type.
       PaloAltoStructureType type = ADDRESS_LIKE_OR_NONE;
@@ -2261,7 +2263,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       _currentNatRule.getDestination().add(endpoint);
 
       // Use constructed object name so same-named refs across vsys are unique
-      String uniqueName = computeObjectName(getCurrentVsysName(), endpoint.getValue());
+      String uniqueName = computeObjectName(_currentVsys.getName(), endpoint.getValue());
 
       // At this time, don't know if something that looks like a constant (e.g. IP address) is a
       // reference or not.  So mark a reference to a very permissive abstract structure type.
@@ -2281,7 +2283,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       RuleEndpoint endpoint = toRuleEndpoint(var);
       _currentNatRule.getSource().add(endpoint);
       // Use constructed object name so same-named refs across vsys are unique
-      String uniqueName = computeObjectName(getCurrentVsysName(), endpoint.getValue());
+      String uniqueName = computeObjectName(_currentVsys.getName(), endpoint.getValue());
 
       // At this time, don't know if something that looks like a constant (e.g. IP address) is a
       // reference or not.  So mark a reference to a very permissive abstract structure type.
@@ -2301,7 +2303,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
       if (!zoneName.equals(CATCHALL_ZONE_NAME)) {
         // Use constructed object name so same-named refs across vsys are unique
-        String uniqueName = computeObjectName(getCurrentVsysName(), zoneName);
+        String uniqueName = computeObjectName(_currentVsys.getName(), zoneName);
         referenceStructure(ZONE, uniqueName, NAT_RULE_FROM_ZONE, getLine(var.start));
       }
     }
@@ -2314,7 +2316,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
     if (!zoneName.equals(CATCHALL_ZONE_NAME)) {
       // Use constructed object name so same-named refs across vsys are unique
-      String uniqueName = computeObjectName(getCurrentVsysName(), zoneName);
+      String uniqueName = computeObjectName(_currentVsys.getName(), zoneName);
       referenceStructure(ZONE, uniqueName, NAT_RULE_TO_ZONE, getLine(ctx.zone.start));
     }
   }
@@ -2335,7 +2337,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
         rulebase.getSecurityRules().computeIfAbsent(name, n -> new SecurityRule(n, _currentVsys));
 
     // Use constructed name so same-named defs across vsys are unique
-    String uniqueName = computeObjectName(getCurrentVsysName(), name);
+    String uniqueName = computeObjectName(_currentVsys.getName(), name);
     defineFlattenedStructure(SECURITY_RULE, uniqueName, ctx, _parser);
     referenceStructure(SECURITY_RULE, uniqueName, SECURITY_RULE_SELF_REF, getLine(ctx.name.start));
   }
@@ -2375,7 +2377,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       String name = getText(var);
       _currentSecurityRule.getApplications().add(name);
       // Use constructed object name so same-named refs across vsys are unique
-      String uniqueName = computeObjectName(getCurrentVsysName(), name);
+      String uniqueName = computeObjectName(_currentVsys.getName(), name);
       referenceApplicationLike(name, uniqueName, SECURITY_RULE_APPLICATION, var);
     }
   }
@@ -2392,7 +2394,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       _currentSecurityRule.getDestination().add(endpoint);
 
       // Use constructed object name so same-named refs across vsys are unique
-      String uniqueName = computeObjectName(getCurrentVsysName(), endpoint.getValue());
+      String uniqueName = computeObjectName(_currentVsys.getName(), endpoint.getValue());
 
       // At this time, don't know if something that looks like a constant (e.g. IP address) is a
       // reference or not.  So mark a reference to a very permissive abstract structure type.
@@ -2419,7 +2421,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
       if (!zoneName.equals(CATCHALL_ZONE_NAME)) {
         // Use constructed object name so same-named refs across vsys are unique
-        String uniqueName = computeObjectName(getCurrentVsysName(), zoneName);
+        String uniqueName = computeObjectName(_currentVsys.getName(), zoneName);
         referenceStructure(ZONE, uniqueName, SECURITY_RULE_FROM_ZONE, getLine(var.start));
       }
     }
@@ -2450,7 +2452,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       RuleEndpoint endpoint = toRuleEndpoint(var);
       _currentSecurityRule.getSource().add(endpoint);
       // Use constructed object name so same-named refs across vsys are unique
-      String uniqueName = computeObjectName(getCurrentVsysName(), endpoint.getValue());
+      String uniqueName = computeObjectName(_currentVsys.getName(), endpoint.getValue());
 
       // At this time, don't know if something that looks like a constant (e.g. IP address) is a
       // reference or not.  So mark a reference to a very permissive abstract structure type.
@@ -2470,7 +2472,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
       if (!zoneName.equals(CATCHALL_ZONE_NAME)) {
         // Use constructed object name so same-named refs across vsys are unique
-        String uniqueName = computeObjectName(getCurrentVsysName(), zoneName);
+        String uniqueName = computeObjectName(_currentVsys.getName(), zoneName);
         referenceStructure(ZONE, uniqueName, SECURITY_RULE_TO_ZONE, getLine(var.start));
       }
     }
@@ -2492,7 +2494,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentService = _currentVsys.getServices().computeIfAbsent(name, Service::new);
 
     // Use constructed service name so same-named defs across vsys are unique
-    String uniqueName = computeObjectName(getCurrentVsysName(), name);
+    String uniqueName = computeObjectName(_currentVsys.getName(), name);
     defineFlattenedStructure(PaloAltoStructureType.SERVICE, uniqueName, ctx, _parser);
   }
 
@@ -2547,7 +2549,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     _currentServiceGroup = _currentVsys.getServiceGroups().computeIfAbsent(name, ServiceGroup::new);
 
     // Use constructed service-group name so same-named defs across vsys are unique
-    String uniqueName = computeObjectName(getCurrentVsysName(), name);
+    String uniqueName = computeObjectName(_currentVsys.getName(), name);
     defineFlattenedStructure(SERVICE_GROUP, uniqueName, ctx, _parser);
   }
 
@@ -2652,7 +2654,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       // Mark reference to zone when it has an interface in it (since the zone if effectively used
       // at this point)
       // Use constructed object name so same-named refs across vsys are unique
-      String zoneName = computeObjectName(getCurrentVsysName(), _currentZone.getName());
+      String zoneName = computeObjectName(_currentVsys.getName(), _currentZone.getName());
       referenceStructure(ZONE, zoneName, LAYER2_INTERFACE_ZONE, getLine(var.start));
     }
   }
@@ -2667,7 +2669,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       // Mark reference to zone when it has an interface in it (since the zone if effectively used
       // at this point)
       // Use constructed object name so same-named refs across vsys are unique
-      String zoneName = computeObjectName(getCurrentVsysName(), _currentZone.getName());
+      String zoneName = computeObjectName(_currentVsys.getName(), _currentZone.getName());
       referenceStructure(ZONE, zoneName, LAYER3_INTERFACE_ZONE, getLine(var.start));
     }
   }
@@ -2682,7 +2684,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       // Mark reference to zone when it has an interface in it (since the zone if effectively used
       // at this point)
       // Use constructed object name so same-named refs across vsys are unique
-      String zoneName = computeObjectName(getCurrentVsysName(), _currentZone.getName());
+      String zoneName = computeObjectName(_currentVsys.getName(), _currentZone.getName());
       referenceStructure(ZONE, zoneName, TAP_INTERFACE_ZONE, getLine(var.start));
     }
   }
@@ -2697,7 +2699,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       // Mark reference to zone when it has an interface in it (since the zone if effectively used
       // at this point)
       // Use constructed object name so same-named refs across vsys are unique
-      String zoneName = computeObjectName(getCurrentVsysName(), _currentZone.getName());
+      String zoneName = computeObjectName(_currentVsys.getName(), _currentZone.getName());
       referenceStructure(ZONE, zoneName, VIRTUAL_WIRE_INTERFACE_ZONE, getLine(var.start));
     }
   }
@@ -2714,13 +2716,6 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       _currentConfiguration.setPanorama(panorama);
     }
     return panorama;
-  }
-
-  /**
-   * Get name for the currently active vsys. If no vsys is active, falls back to default vsys name.
-   */
-  private String getCurrentVsysName() {
-    return (_currentVsys != null) ? _currentVsys.getName() : DEFAULT_VSYS_NAME;
   }
 
   private static boolean toBoolean(Yes_or_noContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -377,6 +377,10 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     return String.format("%s~%s", objectName, vsysName);
   }
 
+  public static String computeObjectName(@Nullable Vsys vsys, String objectName) {
+    return (vsys != null) ? computeObjectName(vsys.getName(), objectName) : objectName;
+  }
+
   /** Generate egress IpAccessList name given an interface or zone name */
   public static String computeOutgoingFilterName(String interfaceOrZoneName) {
     return String.format("~%s~OUTGOING_FILTER~", interfaceOrZoneName);


### PR DESCRIPTION
In some contexts, i.e. inside `template`s, there may not be a current vsys but there may be references to objects (not yet supported, but will be in the future).

This PR helps set up for tracking object references when there is no current vsys / avoids NPEs when there is no current vsys.
