### PR TITLE
PAN: preserve ip address for prefix objects

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -352,6 +352,7 @@ import org.batfish.representation.palo_alto.EbgpPeerGroupType;
 import org.batfish.representation.palo_alto.EbgpPeerGroupType.ExportNexthopMode;
 import org.batfish.representation.palo_alto.EbgpPeerGroupType.ImportNexthopMode;
 import org.batfish.representation.palo_alto.Interface;
+import org.batfish.representation.palo_alto.IpPrefix;
 import org.batfish.representation.palo_alto.NatRule;
 import org.batfish.representation.palo_alto.OspfArea;
 import org.batfish.representation.palo_alto.OspfAreaNormal;
@@ -1475,7 +1476,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     if (ctx.ip_address() != null) {
       _currentAddressObject.setIp(toIp(ctx.ip_address()));
     } else if (ctx.ip_prefix() != null) {
-      _currentAddressObject.setPrefix(toPrefix(ctx.ip_prefix()));
+      _currentAddressObject.setPrefix(toIpPrefix(ctx.ip_prefix()));
     } else {
       warn(ctx, "Cannot understand what follows 'ip-netmask'");
     }
@@ -2735,6 +2736,10 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   private static @Nonnull Ip toIp(Ip_addressContext ctx) {
     return Ip.parse(ctx.getText());
+  }
+
+  private static @Nonnull IpPrefix toIpPrefix(Ip_prefixContext ctx) {
+    return IpPrefix.parse(ctx.getText());
   }
 
   private static @Nonnull Prefix toPrefix(Ip_prefixContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
@@ -87,7 +87,7 @@ public final class AddressObject implements Serializable {
   }
 
   /**
-   * Get {@code InterfacePrefix} for this address, if it exists. This can be used for specifying an
+   * Get {@link IpPrefix} for this address, if it exists. This can be used for specifying an
    * interface address, so it preserves the initial (not canonical) base ip address.
    */
   @Nullable

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
@@ -91,7 +91,7 @@ public final class AddressObject implements Serializable {
    * interface address, so it preserves the initial (not canonical) base ip address.
    */
   @Nullable
-  public IpPrefix getPrefix() {
+  public IpPrefix getIpPrefix() {
     return _prefix;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
@@ -13,7 +13,6 @@ import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpRange;
 import org.batfish.datamodel.IpSpace;
-import org.batfish.datamodel.Prefix;
 
 /** Represents a Palo Alto address object */
 @ParametersAreNonnullByDefault
@@ -33,7 +32,7 @@ public final class AddressObject implements Serializable {
   // Only one can be set
   @Nullable private Ip _ip;
   @Nullable private Range<Ip> _ipRange;
-  @Nullable private Prefix _prefix;
+  @Nullable private IpPrefix _prefix;
 
   public AddressObject(String name) {
     _name = name;
@@ -56,7 +55,7 @@ public final class AddressObject implements Serializable {
     if (_ip != null) {
       return _ip.toIpSpace();
     } else if (_prefix != null) {
-      return _prefix.toIpSpace();
+      return _prefix.getPrefix().toIpSpace();
     } else if (_ipRange != null) {
       return IpRange.range(_ipRange.lowerEndpoint(), _ipRange.upperEndpoint());
     }
@@ -69,7 +68,8 @@ public final class AddressObject implements Serializable {
     if (_ip != null) {
       return ImmutableRangeSet.of(Range.singleton(_ip));
     } else if (_prefix != null) {
-      return ImmutableRangeSet.of(Range.closed(_prefix.getStartIp(), _prefix.getEndIp()));
+      return ImmutableRangeSet.of(
+          Range.closed(_prefix.getPrefix().getStartIp(), _prefix.getPrefix().getEndIp()));
     } else if (_ipRange != null) {
       return ImmutableRangeSet.of(_ipRange);
     }
@@ -86,8 +86,12 @@ public final class AddressObject implements Serializable {
     return _ipRange;
   }
 
+  /**
+   * Get {@code InterfacePrefix} for this address, if it exists. This can be used for specifying an
+   * interface address, so it preserves the initial (not canonical) base ip address.
+   */
   @Nullable
-  public Prefix getPrefix() {
+  public IpPrefix getPrefix() {
     return _prefix;
   }
 
@@ -122,7 +126,7 @@ public final class AddressObject implements Serializable {
     _ipRange = ipRange;
   }
 
-  public void setPrefix(@Nullable Prefix prefix) {
+  public void setPrefix(@Nullable IpPrefix prefix) {
     _type = prefix == null ? null : Type.PREFIX;
     clearAddress();
     _prefix = prefix;

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/IpPrefix.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/IpPrefix.java
@@ -2,7 +2,6 @@ package org.batfish.representation.palo_alto;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import java.io.Serializable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -28,7 +27,6 @@ public class IpPrefix implements Serializable {
 
   /** Parse a {@link Prefix} from a string. */
   @Nonnull
-  @JsonCreator
   public static IpPrefix parse(@Nullable String text) {
     checkArgument(text != null, "Invalid IPv4 prefix %s", text);
     String[] parts = text.split("/");

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/IpPrefix.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/IpPrefix.java
@@ -1,10 +1,8 @@
 package org.batfish.representation.palo_alto;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.io.Serializable;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 
@@ -27,18 +25,10 @@ public class IpPrefix implements Serializable {
 
   /** Parse a {@link Prefix} from a string. */
   @Nonnull
-  public static IpPrefix parse(@Nullable String text) {
-    checkArgument(text != null, "Invalid IPv4 prefix %s", text);
-    String[] parts = text.split("/");
-    checkArgument(parts.length == 2, "Invalid prefix string: \"%s\"", text);
-    Ip ip = Ip.parse(parts[0]);
-    int prefixLength;
-    try {
-      prefixLength = Integer.parseInt(parts[1]);
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException("Invalid prefix length: \"" + parts[1] + "\"", e);
-    }
-    return new IpPrefix(ip, prefixLength);
+  public static IpPrefix parse(@Nonnull String text) {
+    ConcreteInterfaceAddress concreteInterfaceAddress = ConcreteInterfaceAddress.parse(text);
+    return new IpPrefix(
+        concreteInterfaceAddress.getIp(), concreteInterfaceAddress.getNetworkBits());
   }
 
   public Ip getIp() {

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/IpPrefix.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/IpPrefix.java
@@ -1,0 +1,53 @@
+package org.batfish.representation.palo_alto;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+
+/**
+ * Palo Alto ipv4 prefix structure preserving initial (not canonical) {@code Ip} in addition to a
+ * canonical {@code Prefix}.
+ */
+public class IpPrefix implements Serializable {
+
+  /** A "0.0.0.0/0" prefix */
+  public static final IpPrefix ZERO = new IpPrefix(Ip.ZERO, 0);
+
+  private Prefix _prefix;
+  private Ip _ip;
+
+  IpPrefix(Ip ip, int prefixLength) {
+    _prefix = Prefix.create(ip, prefixLength);
+    _ip = ip;
+  }
+
+  /** Parse a {@link Prefix} from a string. */
+  @Nonnull
+  @JsonCreator
+  public static IpPrefix parse(@Nullable String text) {
+    checkArgument(text != null, "Invalid IPv4 prefix %s", text);
+    String[] parts = text.split("/");
+    checkArgument(parts.length == 2, "Invalid prefix string: \"%s\"", text);
+    Ip ip = Ip.parse(parts[0]);
+    int prefixLength;
+    try {
+      prefixLength = Integer.parseInt(parts[1]);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid prefix length: \"" + parts[1] + "\"", e);
+    }
+    return new IpPrefix(ip, prefixLength);
+  }
+
+  public Ip getIp() {
+    return _ip;
+  }
+
+  public Prefix getPrefix() {
+    return _prefix;
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressGroupTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressGroupTest.java
@@ -13,7 +13,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.Prefix;
 import org.junit.Test;
 
 /** Tests for {@link AddressGroup} */
@@ -161,7 +160,7 @@ public class AddressGroupTest {
         equalTo(ImmutableRangeSet.of(Range.singleton(Ip.ZERO))));
 
     // For address object containing a prefix
-    addressObj.setPrefix(Prefix.ZERO);
+    addressObj.setPrefix(IpPrefix.ZERO);
     assertThat(
         group.getIpRangeSet(addrObjects, groupMap),
         equalTo(ImmutableRangeSet.of(Range.closed(Ip.ZERO, Ip.MAX))));

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressObjectTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressObjectTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNull;
 
 import com.google.common.collect.Range;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.Prefix;
 import org.batfish.representation.palo_alto.AddressObject.Type;
 import org.junit.Test;
 
@@ -24,9 +23,9 @@ public class AddressObjectTest {
     assertThat(a.getType(), equalTo(Type.IP));
 
     // Setting prefix clears members and updates type
-    a.setPrefix(Prefix.ZERO);
+    a.setPrefix(IpPrefix.ZERO);
     assertNull(a.getIp());
-    assertThat(a.getPrefix(), equalTo(Prefix.ZERO));
+    assertThat(a.getPrefix(), equalTo(IpPrefix.ZERO));
     assertThat(a.getType(), equalTo(Type.PREFIX));
 
     // Setting range clears members and updates type

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressObjectTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressObjectTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 
 import com.google.common.collect.Range;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
 import org.batfish.representation.palo_alto.AddressObject.Type;
 import org.junit.Test;
 
@@ -23,15 +24,17 @@ public class AddressObjectTest {
     assertThat(a.getType(), equalTo(Type.IP));
 
     // Setting prefix clears members and updates type
-    a.setPrefix(IpPrefix.ZERO);
+    a.setPrefix(IpPrefix.parse("1.2.3.4/24"));
     assertNull(a.getIp());
-    assertThat(a.getPrefix(), equalTo(IpPrefix.ZERO));
+    // Make sure we preserve pre-canonicalized form of prefix ip
+    assertThat(a.getIpPrefix().getIp(), equalTo(Ip.parse("1.2.3.4")));
+    assertThat(a.getIpPrefix().getPrefix(), equalTo(Prefix.parse("1.2.3.4/24")));
     assertThat(a.getType(), equalTo(Type.PREFIX));
 
     // Setting range clears members and updates type
     Range<Ip> range = Range.closed(Ip.ZERO, Ip.parse("1.1.1.1"));
     a.setIpRange(range);
-    assertNull(a.getPrefix());
+    assertNull(a.getIpPrefix());
     assertThat(a.getIpRange(), equalTo(range));
     assertThat(a.getType(), equalTo(Type.IP_RANGE));
 

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressObjectTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressObjectTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNull;
 
 import com.google.common.collect.Range;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.Prefix;
 import org.batfish.representation.palo_alto.AddressObject.Type;
 import org.junit.Test;
 
@@ -24,11 +23,9 @@ public class AddressObjectTest {
     assertThat(a.getType(), equalTo(Type.IP));
 
     // Setting prefix clears members and updates type
-    a.setPrefix(IpPrefix.parse("1.2.3.4/24"));
+    a.setPrefix(IpPrefix.ZERO);
     assertNull(a.getIp());
-    // Make sure we preserve pre-canonicalized form of prefix ip
-    assertThat(a.getIpPrefix().getIp(), equalTo(Ip.parse("1.2.3.4")));
-    assertThat(a.getIpPrefix().getPrefix(), equalTo(Prefix.parse("1.2.3.4/24")));
+    assertThat(a.getIpPrefix(), equalTo(IpPrefix.ZERO));
     assertThat(a.getType(), equalTo(Type.PREFIX));
 
     // Setting range clears members and updates type

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/IpPrefixTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/IpPrefixTest.java
@@ -1,0 +1,42 @@
+package org.batfish.representation.palo_alto;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Tests for {@link IpPrefix} */
+public class IpPrefixTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testParseInvalidPrefixBits() {
+    thrown.expect(IllegalArgumentException.class);
+    IpPrefix.parse("1.2.3.4/33");
+  }
+
+  @Test
+  public void testParseInvalidChars() {
+    thrown.expect(IllegalArgumentException.class);
+    IpPrefix.parse("1.A.3.4/33");
+  }
+
+  @Test
+  public void testParseInvalidHostBits() {
+    thrown.expect(IllegalArgumentException.class);
+    IpPrefix.parse("1.2.3.256/32");
+  }
+
+  @Test
+  public void testPreserveBaseIpAddress() {
+    IpPrefix ipPrefix = IpPrefix.parse("1.2.3.4/24");
+
+    // Make sure we preserve pre-canonicalized form of prefix ip
+    assertThat(ipPrefix.getIp(), equalTo(Ip.parse("1.2.3.4")));
+    assertThat(ipPrefix.getPrefix(), equalTo(Prefix.parse("1.2.3.0/24")));
+  }
+}


### PR DESCRIPTION
Palo Alto devices support setting interface addresses from `address` objects. Therefore, `address` objects need to preserve the pre-canonicalized form of the prefix (e.g. `1.2.3.4/24` needs to be stored as such and not canonicalized to `1.2.3.0/24` at configuration-build time).

This PR adds a Palo Alto-specific structure that preserves pre-canonicalized ip prefix info and updates `address` objects to use it.
