### PR TITLE
Allow some ifaces on device to have null firewall info

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -34,6 +35,11 @@ public final class FirewallSessionInterfaceInfo implements Serializable {
       Iterable<String> sessionInterfaces,
       @Nullable String incomingAclName,
       @Nullable String outgoingAclName) {
+    // A FirewallSessionInterfaceInfo with no interfaces wouldn't create or match any sessions.
+    // In this case the interface should just have null FirewallSessionInterfaceInfo.
+    checkArgument(
+        sessionInterfaces.iterator().hasNext(),
+        "Cannot create FirewallSessionInterfaceInfo with zero session interfaces.");
     _sessionInterfaces = ImmutableSortedSet.copyOf(sessionInterfaces);
     _incomingAclName = incomingAclName;
     _outgoingAclName = outgoingAclName;

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpcEndpointGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpcEndpointGateway.java
@@ -22,7 +22,6 @@ import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.ExprAclLine;
-import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpAccessList;
@@ -73,11 +72,6 @@ final class VpcEndpointGateway extends VpcEndpoint {
       return cfgNode;
     }
     Utils.connect(awsConfiguration, cfgNode, servicesGatewayCfg);
-
-    Interface ifaceOnServicesGateway =
-        servicesGatewayCfg.getAllInterfaces().get(interfaceNameToRemote(cfgNode));
-    ifaceOnServicesGateway.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(), null, null));
 
     List<Prefix> servicePrefixes = getServicePrefixes(_serviceName, region, warnings);
     IpSpace servicePrefixSpace =

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BidirectionalReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BidirectionalReachabilityAnalysisTest.java
@@ -740,7 +740,8 @@ public final class BidirectionalReachabilityAnalysisTest {
     IpAccessList permitUdpAcl =
         nf.aclBuilder().setOwner(fw).setLines(ImmutableList.of(permitUdpLine)).build();
     fwI2.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(), null, permitUdpAcl.getName()));
+        new FirewallSessionInterfaceInfo(
+            false, ImmutableList.of(fwI2.getName()), null, permitUdpAcl.getName()));
 
     // transform source IP before setting up session on fwI3
     Ip poolIp = Ip.parse("5.5.5.5");

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/LastHopOutgoingInterfaceManagerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/LastHopOutgoingInterfaceManagerTest.java
@@ -63,8 +63,9 @@ public final class LastHopOutgoingInterfaceManagerTest {
     Configuration c = _cb.build();
     Vrf vrf = _vb.setOwner(c).build();
     FirewallSessionInterfaceInfo firewallSessionInterfaceInfo =
-        new FirewallSessionInterfaceInfo(false, ImmutableSet.of(), null, null);
+        new FirewallSessionInterfaceInfo(false, ImmutableSet.of("iface"), null, null);
     _ib.setActive(true)
+        .setName("iface")
         .setOwner(c)
         .setVrf(vrf)
         .setFirewallSessionInterfaceInfo(firewallSessionInterfaceInfo)

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/VpcEndpointGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/VpcEndpointGatewayTest.java
@@ -112,11 +112,6 @@ public class VpcEndpointGatewayTest {
         vpceGwConfig.getAllInterfaces().get(interfaceNameToRemote(awsServicesGatewayConfig));
     Interface vpcInterface = vpceGwConfig.getAllInterfaces().get(interfaceNameToRemote(vpcConfig));
 
-    // interface is created on the service gateway and has a firewall session
-    Interface ifaceOnServiceGateway =
-        awsServicesGatewayConfig.getAllInterfaces().get(interfaceNameToRemote(vpceGwConfig));
-    assertThat(ifaceOnServiceGateway.getFirewallSessionInterfaceInfo(), notNullValue());
-
     // static routes exist to the VPC prefix and to the service
     assertThat(
         vpceGwConfig.getDefaultVrf().getStaticRoutes(),


### PR DESCRIPTION
Until now, we've required all interfaces on a given device to have nonnull `FirewallSessionInterfaceInfo` if the device can create sessions. Now we want some interfaces to be unable to create sessions for exiting flows. This change makes that possible.

Also properly enforces the invariant that a `FirewallSessionInterfaceInfo` can't have an empty list of session interfaces, and stops creating a `FirewallSessionInterfaceInfo` for an interface on AWS service gateways that surfaced this issue.