### PR TITLE
AWS: add interface name to security group ingress ACLs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -166,10 +166,22 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
       @Nonnull String purpose,
       Warnings w) {
     @Nullable IpAccessList acl = getter.get();
-    if (acl == null || acls.containsKey(acl.getName())) {
+    if (acl == null) {
       return;
     }
-    w.redFlag(String.format("The device ACL map does not contain %s %s.", acl.getName(), purpose));
+    @Nullable IpAccessList inMap = acls.get(acl.getName());
+    // Deliberate == comparison.
+    if (inMap == acl) {
+      return;
+    }
+    if (inMap == null) {
+      w.redFlag(
+          String.format("The device ACL map does not contain %s %s.", purpose, acl.getName()));
+    } else {
+      w.redFlag(
+          String.format(
+              "The device ACL map has a different version of %s %s.", purpose, acl.getName()));
+    }
     setter.accept(null);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -4,7 +4,6 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.not;
 import static org.batfish.representation.aws.AwsConfiguration.AWS_SERVICES_GATEWAY_NODE_NAME;
-import static org.batfish.representation.aws.SecurityGroup.SG_INGRESS_ACL_NAME;
 import static org.batfish.representation.aws.Utils.getTraceElementForSecurityGroup;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -66,8 +65,12 @@ public final class Region implements Serializable {
     void accept(T t) throws E, IOException;
   }
 
-  static String instanceEgressAclName(String interfaceName) {
+  static String eniEgressAclName(String interfaceName) {
     return String.format("~EGRESS_ACL~%s", interfaceName);
+  }
+
+  static String eniIngressAclName(String interfaceName) {
+    return String.format("~INGRESS_ACL~%s", interfaceName);
   }
 
   static final TraceElement DENY_SPOOFED_SOURCE_IP_TRACE_ELEMENT =
@@ -924,7 +927,7 @@ public final class Region implements Serializable {
 
     IpAccessList inAcl =
         IpAccessList.builder()
-            .setName(SG_INGRESS_ACL_NAME)
+            .setName(eniIngressAclName(i.getName()))
             .setLines(lines.build())
             .setOwner(c)
             .build();
@@ -954,7 +957,7 @@ public final class Region implements Serializable {
     // egress ACL is spoofing protection plus egress SGs
     IpAccessList outAcl =
         IpAccessList.builder()
-            .setName(instanceEgressAclName(i.getName()))
+            .setName(eniEgressAclName(i.getName()))
             .setLines(
                 ImmutableList.<AclLine>builder()
                     .add(computeAntiSpoofingFilter(i))

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -29,7 +29,6 @@ import org.batfish.datamodel.IpAccessList;
 public final class SecurityGroup implements AwsVpcEntity, Serializable {
   static final String INGRESS = "INGRESS";
   static final String EGRESS = "EGRESS";
-  static final String SG_INGRESS_ACL_NAME = "~SECURITY_GROUP_INGRESS_ACL~";
 
   @Nullable private final String _description;
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationSubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationSubnetTest.java
@@ -4,8 +4,8 @@ import static org.batfish.representation.aws.AwsConfigurationTestUtils.getAnyFlo
 import static org.batfish.representation.aws.AwsConfigurationTestUtils.testSetup;
 import static org.batfish.representation.aws.AwsConfigurationTestUtils.testTrace;
 import static org.batfish.representation.aws.NetworkAcl.getAclName;
-import static org.batfish.representation.aws.Region.instanceEgressAclName;
-import static org.batfish.representation.aws.SecurityGroup.SG_INGRESS_ACL_NAME;
+import static org.batfish.representation.aws.Region.eniEgressAclName;
+import static org.batfish.representation.aws.Region.eniIngressAclName;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -48,13 +48,14 @@ public class AwsConfigurationSubnetTest {
           "Vpcs.json");
 
   // various entities in the configs
-  private static String _instance1 = "i-08ef86e76fceabd8d";
-  private static String _instance1Iface = "eni-010f649a7fc5c1e34";
-  private static String _instance2 = "i-07519d6ba3f9497e4";
-  private static Ip _instance2Ip = Ip.parse("10.10.1.44");
-  private static String _subnet = "subnet-06c8307e34ffadb04";
-  private static String _vpc = "vpc-062867d29dbf9386f";
-  private static String _networkAcl = "acl-07102431133dec52a";
+  private static final String INSTANCE_1 = "i-08ef86e76fceabd8d";
+  private static final String INSTANCE_1_IFACE = "eni-010f649a7fc5c1e34";
+  private static final String INSTANCE_2 = "i-07519d6ba3f9497e4";
+  private static final String INSTANCE_2_IFACE = "eni-029bf1092de61fb40";
+  private static final Ip INSTANCE_2_IP = Ip.parse("10.10.1.44");
+  private static final String SUBNET = "subnet-06c8307e34ffadb04";
+  private static final String VPC = "vpc-062867d29dbf9386f";
+  private static final String NETWORK_ACL = "acl-07102431133dec52a";
 
   @ClassRule public static TemporaryFolder _folder = new TemporaryFolder();
 
@@ -79,49 +80,49 @@ public class AwsConfigurationSubnetTest {
   public void testInstanceToInstance() {
     Trace trace =
         testTrace(
-            getAnyFlow(_instance1, _instance2Ip, _batfish),
+            getAnyFlow(INSTANCE_1, INSTANCE_2_IP, _batfish),
             FlowDisposition.DENIED_IN, // denied because of security group on instance2
-            ImmutableList.of(_instance1, _instance2), // Instance to instance traffic is direct
+            ImmutableList.of(INSTANCE_1, INSTANCE_2), // Instance to instance traffic is direct
             _batfish);
 
     // security group at instance1
-    assertFilterAtHop(trace, 0, instanceEgressAclName(_instance1Iface));
+    assertFilterAtHop(trace, 0, eniEgressAclName(INSTANCE_1_IFACE));
 
     // security group at instance2
-    assertFilterAtHop(trace, 1, SG_INGRESS_ACL_NAME);
+    assertFilterAtHop(trace, 1, eniIngressAclName(INSTANCE_2_IFACE));
   }
 
   @Test
   public void testInstanceToOutsideSubnet() {
     Trace trace =
         testTrace(
-            getAnyFlow(_instance1, Ip.parse("10.10.0.1"), _batfish),
+            getAnyFlow(INSTANCE_1, Ip.parse("10.10.0.1"), _batfish),
             FlowDisposition.NULL_ROUTED,
-            ImmutableList.of(_instance1, _subnet, _vpc),
+            ImmutableList.of(INSTANCE_1, SUBNET, VPC),
             _batfish);
 
     // network acl is applied when leaving the subnet
-    assertFilterAtHop(trace, 1, getAclName(_networkAcl, true));
+    assertFilterAtHop(trace, 1, getAclName(NETWORK_ACL, true));
   }
 
   @Test
   public void testOutsideSubnetToInstance() {
     Trace trace =
         testTrace(
-            Flow.builder().setIngressNode(_vpc).setDstIp(_instance2Ip).build(),
+            Flow.builder().setIngressNode(VPC).setDstIp(INSTANCE_2_IP).build(),
             FlowDisposition.DENIED_IN, // security group
-            ImmutableList.of(_vpc, _subnet, _instance2),
+            ImmutableList.of(VPC, SUBNET, INSTANCE_2),
             _batfish);
 
     // network acl is applied when leaving the subnet
-    assertFilterAtHop(trace, 1, getAclName(_networkAcl, false));
+    assertFilterAtHop(trace, 1, getAclName(NETWORK_ACL, false));
   }
 
   @Test
   public void testInstanceHasOriginatingVrf() {
     // Instances should allow originating sessions (sessions can be established by inbound packets)
-    Configuration instance1 = _batfish.loadConfigurations(_batfish.getSnapshot()).get(_instance1);
-    Configuration instance2 = _batfish.loadConfigurations(_batfish.getSnapshot()).get(_instance2);
+    Configuration instance1 = _batfish.loadConfigurations(_batfish.getSnapshot()).get(INSTANCE_1);
+    Configuration instance2 = _batfish.loadConfigurations(_batfish.getSnapshot()).get(INSTANCE_2);
     assertTrue(instance1.getVrfs().values().stream().allMatch(Vrf::hasOriginatingSessions));
     assertTrue(instance2.getVrfs().values().stream().allMatch(Vrf::hasOriginatingSessions));
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -11,7 +11,8 @@ import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchConditi
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_DOMAIN_STATUS_LIST;
 import static org.batfish.representation.aws.Region.computeAntiSpoofingFilter;
-import static org.batfish.representation.aws.Region.instanceEgressAclName;
+import static org.batfish.representation.aws.Region.eniEgressAclName;
+import static org.batfish.representation.aws.Region.eniIngressAclName;
 import static org.batfish.representation.aws.Utils.traceElementEniPrivateIp;
 import static org.batfish.representation.aws.Utils.traceElementForAddress;
 import static org.batfish.representation.aws.Utils.traceElementForDstPorts;
@@ -234,26 +235,25 @@ public class ElasticsearchDomainTest {
                                         .build(),
                                     traceElementEniPrivateIp(
                                         "eni-05e8949c37b78cf4d on i-066b1b9957b9200e7 (Test host)")))))))));
-    assertThat(
-        esDomain.getIpAccessLists().get("~SECURITY_GROUP_INGRESS_ACL~").getLines(),
-        equalTo(
-            ImmutableList.of(
-                new AclAclLine(
-                    "Security Group Test Security Group",
-                    "~INGRESS~SECURITY-GROUP~Test Security Group~sg-0de0ddfa8a5a45810~",
-                    Utils.getTraceElementForSecurityGroup("Test Security Group")))));
     for (Interface iface : esDomain.getAllInterfaces().values()) {
-      assertThat(iface.getIncomingFilter().getName(), equalTo("~SECURITY_GROUP_INGRESS_ACL~"));
+      assertThat(iface.getIncomingFilter().getName(), equalTo(eniIngressAclName(iface.getName())));
+      assertThat(iface.getOutgoingFilter().getName(), equalTo(eniEgressAclName(iface.getName())));
       assertThat(
-          iface.getOutgoingFilter().getName(), equalTo(instanceEgressAclName(iface.getName())));
-      assertThat(
-          esDomain.getIpAccessLists().get(instanceEgressAclName(iface.getName())).getLines(),
+          esDomain.getIpAccessLists().get(eniEgressAclName(iface.getName())).getLines(),
           equalTo(
               ImmutableList.of(
                   computeAntiSpoofingFilter(iface),
                   new AclAclLine(
                       "Security Group Test Security Group",
                       "~EGRESS~SECURITY-GROUP~Test Security Group~" + "sg-0de0ddfa8a5a45810~",
+                      Utils.getTraceElementForSecurityGroup("Test Security Group")))));
+      assertThat(
+          esDomain.getIpAccessLists().get(eniIngressAclName(iface.getName())).getLines(),
+          equalTo(
+              ImmutableList.of(
+                  new AclAclLine(
+                      "Security Group Test Security Group",
+                      "~INGRESS~SECURITY-GROUP~Test Security Group~sg-0de0ddfa8a5a45810~",
                       Utils.getTraceElementForSecurityGroup("Test Security Group")))));
       assertThat(
           iface.getFirewallSessionInterfaceInfo(),

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.matchers.TraceTreeMatchers.hasChildren;
 import static org.batfish.datamodel.matchers.TraceTreeMatchers.hasTraceElement;
 import static org.batfish.representation.aws.AwsConfiguration.AWS_SERVICES_GATEWAY_NODE_NAME;
 import static org.batfish.representation.aws.Region.computeAntiSpoofingFilter;
+import static org.batfish.representation.aws.Region.eniIngressAclName;
 import static org.batfish.representation.aws.Utils.getTraceElementForRule;
 import static org.batfish.representation.aws.Utils.getTraceElementForSecurityGroup;
 import static org.batfish.representation.aws.Utils.newAwsConfiguration;
@@ -232,7 +233,7 @@ public class RegionTest {
     ConvertedConfiguration cfg = new ConvertedConfiguration();
     cfg.addNode(c);
     region.computeSecurityGroups(cfg, new Warnings());
-    IpAccessList ingressAcl = c.getIpAccessLists().get("~SECURITY_GROUP_INGRESS_ACL~");
+    IpAccessList ingressAcl = c.getIpAccessLists().get(eniIngressAclName(ni.getId()));
 
     Flow permittedFlow =
         Flow.builder()

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -7691,7 +7691,7 @@
                 "es-domain-subnet-1641fa70"
               ]
             },
-            "incomingFilter" : "~SECURITY_GROUP_INGRESS_ACL~",
+            "incomingFilter" : "~INGRESS_ACL~es-domain-subnet-1641fa70",
             "mtu" : 1500,
             "outgoingFilter" : "~EGRESS_ACL~es-domain-subnet-1641fa70",
             "prefix" : "192.168.1.2/24",
@@ -7724,7 +7724,7 @@
                 "es-domain-subnet-7044ff16"
               ]
             },
-            "incomingFilter" : "~SECURITY_GROUP_INGRESS_ACL~",
+            "incomingFilter" : "~INGRESS_ACL~es-domain-subnet-7044ff16",
             "mtu" : 1500,
             "outgoingFilter" : "~EGRESS_ACL~es-domain-subnet-7044ff16",
             "prefix" : "192.168.2.2/28",
@@ -7865,6 +7865,42 @@
             ],
             "name" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
           },
+          "~INGRESS_ACL~es-domain-subnet-1641fa70" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~INGRESS_ACL~es-domain-subnet-1641fa70"
+          },
+          "~INGRESS_ACL~es-domain-subnet-7044ff16" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~INGRESS_ACL~es-domain-subnet-7044ff16"
+          },
           "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
             "lines" : [
               {
@@ -7913,24 +7949,6 @@
               }
             ],
             "name" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
-          },
-          "~SECURITY_GROUP_INGRESS_ACL~" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~SECURITY_GROUP_INGRESS_ACL~"
           }
         },
         "vendorFamily" : {
@@ -24867,7 +24885,7 @@
                 "test-rds-subnet-1641fa70"
               ]
             },
-            "incomingFilter" : "~SECURITY_GROUP_INGRESS_ACL~",
+            "incomingFilter" : "~INGRESS_ACL~test-rds-subnet-1641fa70",
             "mtu" : 1500,
             "outgoingFilter" : "~EGRESS_ACL~test-rds-subnet-1641fa70",
             "prefix" : "192.168.1.3/24",
@@ -24962,6 +24980,24 @@
               }
             ],
             "name" : "~EGRESS~SECURITY-GROUP~default~sg-55510831~"
+          },
+          "~INGRESS_ACL~test-rds-subnet-1641fa70" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-55510831~",
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~INGRESS_ACL~test-rds-subnet-1641fa70"
           },
           "~INGRESS~SECURITY-GROUP~default~sg-55510831~" : {
             "lines" : [
@@ -25317,24 +25353,6 @@
               }
             ],
             "name" : "~INGRESS~SECURITY-GROUP~default~sg-55510831~"
-          },
-          "~SECURITY_GROUP_INGRESS_ACL~" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-55510831~",
-                "name" : "Security Group default",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~SECURITY_GROUP_INGRESS_ACL~"
           }
         },
         "vendorFamily" : {


### PR DESCRIPTION
Missed in #5902.

Also fix the conversion finalization code to have caught this bug retroactively.