### PR TITLE
UnzipUtility: do not assume specific order of zip entries

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/UnzipUtility.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/UnzipUtility.java
@@ -74,8 +74,10 @@ public final class UnzipUtility {
                 destDirectory);
         if (entry.isDirectory()) {
           // Make the directory, including parent dirs.
-          if (!outputPath.toFile().mkdirs()) {
-            throw new IOException("Unable to make directory " + outputPath);
+          if (!outputPath.toFile().exists()) {
+            if (!outputPath.toFile().mkdirs()) {
+              throw new IOException("Unable to make directory " + outputPath);
+            }
           }
         } else {
           // Make sure parent directories exist, in case the zip does not contain dir entries

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/UnzipUtilityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/UnzipUtilityTest.java
@@ -73,4 +73,24 @@ public class UnzipUtilityTest {
     _thrown.expect(instanceOf(IOException.class));
     UnzipUtility.unzip(pathViolation.toPath(), dest.toPath());
   }
+
+  /**
+   * Test that unzipping does not assume a specific order of zip entries. In particular that entries
+   * for parent directories appear before file entries.
+   */
+  @Test
+  public void testUnzipEntriesOutOfOrder() throws IOException {
+    byte[] contents = "contents of file.txt".getBytes();
+    File notOrdered = _folder.newFile("not_ordered");
+    try (FileOutputStream fos = new FileOutputStream(notOrdered);
+        ZipOutputStream out = new ZipOutputStream(fos)) {
+      out.putNextEntry(new ZipEntry("dir/file.txt"));
+      out.write(contents);
+      out.putNextEntry(new ZipEntry("dir/"));
+    }
+
+    File dest = _folder.newFolder("dest");
+    // Don't crash
+    UnzipUtility.unzip(notOrdered.toPath(), dest.toPath());
+  }
 }


### PR DESCRIPTION
If file entries appeared before directory entries, we would crash claiming we cannot make a directory.
This fixes that by only creating parent directories if they don't
already exist.

Note there is nothing in zip spec that says entries need to be ordered
in any way.