### PR TITLE
PAN: support interface address from objects

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
@@ -21,6 +21,13 @@ interface_address
     | addr_with_mask = ip_prefix
 ;
 
+interface_address_or_reference
+:
+    addr = ip_address
+    | addr_with_mask = IP_PREFIX
+    | reference = variable
+;
+
 ip_address
 :
     IP_ADDRESS

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
@@ -24,7 +24,7 @@ interface_address
 interface_address_or_reference
 :
     addr = ip_address
-    | addr_with_mask = IP_PREFIX
+    | addr_with_mask = ip_prefix
     | reference = variable
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
@@ -192,7 +192,7 @@ sniel3_common
 
 sniel3_ip
 :
-    IP address = interface_address
+    IP address = interface_address_or_reference
 ;
 
 sniel3_mtu
@@ -227,7 +227,7 @@ sniel3_units
 
 snil_ip
 :
-    IP address = interface_address
+    IP address = interface_address_or_reference
 ;
 
 snil_unit

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -150,6 +150,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Cp_lifetimeContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.If_commentContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.If_tagContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Interface_addressContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Interface_address_or_referenceContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ip_addressContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ip_address_or_slash32Context;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Ip_prefixContext;
@@ -352,6 +353,7 @@ import org.batfish.representation.palo_alto.EbgpPeerGroupType;
 import org.batfish.representation.palo_alto.EbgpPeerGroupType.ExportNexthopMode;
 import org.batfish.representation.palo_alto.EbgpPeerGroupType.ImportNexthopMode;
 import org.batfish.representation.palo_alto.Interface;
+import org.batfish.representation.palo_alto.InterfaceAddress;
 import org.batfish.representation.palo_alto.IpPrefix;
 import org.batfish.representation.palo_alto.NatRule;
 import org.batfish.representation.palo_alto.OspfArea;
@@ -615,6 +617,17 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     return convProblem(IpsecAuthenticationAlgorithm.class, ctx, null);
   }
 
+  /** Convert address or reference into an InterfaceAddress */
+  private InterfaceAddress toInterfaceAddress(Interface_address_or_referenceContext ctx) {
+    String text = getText(ctx);
+    if (ctx.addr != null) {
+      return new InterfaceAddress(InterfaceAddress.Type.IP_ADDRESS, text);
+    } else if (ctx.addr_with_mask != null) {
+      return new InterfaceAddress(InterfaceAddress.Type.IP_PREFIX, text);
+    }
+    return new InterfaceAddress(InterfaceAddress.Type.REFERENCE, text);
+  }
+
   /** Convert source or destination list item into an appropriate IpSpace */
   private RuleEndpoint toRuleEndpoint(Src_or_dst_list_itemContext ctx) {
     String text = getText(ctx);
@@ -836,7 +849,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void exitBgppgp_la_ip(Bgppgp_la_ipContext ctx) {
-    ConcreteInterfaceAddress address = toInterfaceAddress(ctx.interface_address());
+    ConcreteInterfaceAddress address = toConcreteInterfaceAddress(ctx.interface_address());
     _currentBgpPeer.setLocalAddress(address.getIp());
   }
 
@@ -1906,7 +1919,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void exitSniel3_ip(Sniel3_ipContext ctx) {
-    ConcreteInterfaceAddress address = toInterfaceAddress(ctx.address);
+    InterfaceAddress address = toInterfaceAddress(ctx.address);
     _currentInterface.addAddress(address);
   }
 
@@ -1933,10 +1946,13 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void exitSnil_ip(Snil_ipContext ctx) {
-    ConcreteInterfaceAddress address = toInterfaceAddress(ctx.address);
-    if (address.getPrefix().getPrefixLength() != Prefix.MAX_PREFIX_LENGTH) {
-      warn(ctx, ctx.address, "Loopback ip address must be /32 or without mask");
-      return;
+    InterfaceAddress address = toInterfaceAddress(ctx.address);
+    if (ctx.address.addr_with_mask != null) {
+      if (Prefix.parse(getText(ctx.address.addr_with_mask)).getPrefixLength()
+          != Prefix.MAX_PREFIX_LENGTH) {
+        warn(ctx, ctx.address, "Loopback ip address must be /32 or without mask");
+        return;
+      }
     }
     _currentInterface.addAddress(address);
   }
@@ -2724,7 +2740,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     return false;
   }
 
-  private static @Nonnull ConcreteInterfaceAddress toInterfaceAddress(
+  private static @Nonnull ConcreteInterfaceAddress toConcreteInterfaceAddress(
       Interface_addressContext ctx) {
     if (ctx.addr != null) {
       // PAN allows implicit /32 in lots of places.
@@ -2747,7 +2763,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   private @Nonnull Optional<Ip> toIp(
       ParserRuleContext ctx, Ip_address_or_slash32Context addr, String ipType) {
-    ConcreteInterfaceAddress ip = toInterfaceAddress(addr.addr);
+    ConcreteInterfaceAddress ip = toConcreteInterfaceAddress(addr.addr);
     if (ip.getNetworkBits() != Prefix.MAX_PREFIX_LENGTH) {
       warn(ctx, addr, String.format("Expecting 32-bit mask for %s, ignoring", ipType));
       return Optional.empty();

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -1947,13 +1947,6 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitSnil_ip(Snil_ipContext ctx) {
     InterfaceAddress address = toInterfaceAddress(ctx.address);
-    if (ctx.address.addr_with_mask != null) {
-      if (Prefix.parse(getText(ctx.address.addr_with_mask)).getPrefixLength()
-          != Prefix.MAX_PREFIX_LENGTH) {
-        warn(ctx, ctx.address, "Loopback ip address must be /32 or without mask");
-        return;
-      }
-    }
     _currentInterface.addAddress(address);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
@@ -9,10 +9,12 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpRange;
 import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.Prefix;
 
 /** Represents a Palo Alto address object */
 @ParametersAreNonnullByDefault
@@ -60,6 +62,22 @@ public final class AddressObject implements Serializable {
       return IpRange.range(_ipRange.lowerEndpoint(), _ipRange.upperEndpoint());
     }
     return EmptyIpSpace.INSTANCE;
+  }
+
+  /**
+   * Convert this address object into a {@link ConcreteInterfaceAddress} if possible. For some types
+   * of address objects this is not possible and returns {@code null} instead.
+   */
+  @Nullable
+  public ConcreteInterfaceAddress toConcreteInterfaceAddress() {
+    if (_ip != null) {
+      return ConcreteInterfaceAddress.create(_ip, Prefix.MAX_PREFIX_LENGTH);
+    } else if (_prefix != null) {
+      return ConcreteInterfaceAddress.create(
+          _prefix.getIp(), _prefix.getPrefix().getPrefixLength());
+    }
+    // Cannot convert ambiguous address objects like ip-range objects to concrete iface address
+    return null;
   }
 
   /** Returns all addresses owned by this address object as an IP {@link RangeSet}. */

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
@@ -79,7 +79,8 @@ public final class AddressObject implements Serializable {
     }
     // Cannot convert ambiguous address objects like ip-range objects to concrete iface address
     w.redFlag(
-        String.format("Could not convert %s AddressObject to ConcreteInterfaceAddress.", _type));
+        String.format(
+            "Could not convert %s AddressObject '%s' to ConcreteInterfaceAddress.", _type, _name));
     return null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/AddressObject.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.Ip;
@@ -69,7 +70,7 @@ public final class AddressObject implements Serializable {
    * of address objects this is not possible and returns {@code null} instead.
    */
   @Nullable
-  public ConcreteInterfaceAddress toConcreteInterfaceAddress() {
+  public ConcreteInterfaceAddress toConcreteInterfaceAddress(Warnings w) {
     if (_ip != null) {
       return ConcreteInterfaceAddress.create(_ip, Prefix.MAX_PREFIX_LENGTH);
     } else if (_prefix != null) {
@@ -77,6 +78,8 @@ public final class AddressObject implements Serializable {
           _prefix.getIp(), _prefix.getPrefix().getPrefixLength());
     }
     // Cannot convert ambiguous address objects like ip-range objects to concrete iface address
+    w.redFlag(
+        String.format("Could not convert %s AddressObject to ConcreteInterfaceAddress.", _type));
     return null;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Interface.java
@@ -9,7 +9,6 @@ import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.ConcreteInterfaceAddress;
 
 /** PAN datamodel component containing interface configuration */
 @ParametersAreNonnullByDefault
@@ -27,9 +26,9 @@ public final class Interface implements Serializable {
   public static final int DEFAULT_INTERFACE_MTU = 1500;
 
   private boolean _active;
-  @Nullable private ConcreteInterfaceAddress _address;
+  @Nullable private InterfaceAddress _address;
   @Nullable private String _aggregateGroup;
-  @Nonnull private final Set<ConcreteInterfaceAddress> _allAddresses;
+  @Nonnull private final Set<InterfaceAddress> _allAddresses;
   @Nullable private String _comment;
   @Nullable private Boolean _ha;
   @Nullable private Integer _mtu;
@@ -53,7 +52,7 @@ public final class Interface implements Serializable {
     return _active;
   }
 
-  public void addAddress(ConcreteInterfaceAddress address) {
+  public void addAddress(InterfaceAddress address) {
     if (_address == null) {
       _address = address;
     }
@@ -61,7 +60,7 @@ public final class Interface implements Serializable {
   }
 
   @Nullable
-  public ConcreteInterfaceAddress getAddress() {
+  public InterfaceAddress getAddress() {
     return _address;
   }
 
@@ -75,7 +74,7 @@ public final class Interface implements Serializable {
   }
 
   @Nonnull
-  public Set<ConcreteInterfaceAddress> getAllAddresses() {
+  public Set<InterfaceAddress> getAllAddresses() {
     return Collections.unmodifiableSet(_allAddresses);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/InterfaceAddress.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/InterfaceAddress.java
@@ -49,7 +49,7 @@ public final class InterfaceAddress implements Serializable {
       return false;
     }
     InterfaceAddress o = (InterfaceAddress) obj;
-    return _type == o._type && Objects.equals(_value, o._value);
+    return _type == o._type && _value.equals(o._value);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/InterfaceAddress.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/InterfaceAddress.java
@@ -1,0 +1,59 @@
+package org.batfish.representation.palo_alto;
+
+import com.google.common.base.MoreObjects;
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/** PAN datamodel component containing an address specifier for an interface. */
+public final class InterfaceAddress implements Serializable {
+
+  public enum Type {
+    IP_ADDRESS,
+    IP_PREFIX,
+    REFERENCE
+  }
+
+  private final Type _type;
+
+  private final String _value;
+
+  public InterfaceAddress(Type type, String value) {
+    _type = type;
+    _value = value;
+  }
+
+  /** Type hint from lexer */
+  public Type getType() {
+    return _type;
+  }
+
+  public String getValue() {
+    return _value;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(getClass())
+        .add("type", _type)
+        .add("value", _value)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof InterfaceAddress)) {
+      return false;
+    }
+    InterfaceAddress o = (InterfaceAddress) obj;
+    return _type == o._type && Objects.equals(_value, o._value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_type.ordinal(), _value);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1083,6 +1083,55 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     return ret.build();
   }
 
+  /** Converts interface address {@code String} to {@link IpSpace} */
+  @Nullable
+  @SuppressWarnings("fallthrough")
+  private ConcreteInterfaceAddress interfaceAddressToConcreteInterfaceAddress(
+      @Nullable InterfaceAddress address, Vsys vsys, Warnings w) {
+    if (address == null) {
+      return null;
+    }
+    String addressText = address.getValue();
+    // Palo Alto allows object references that look like IP addresses etc.
+    // Devices use objects over constants when possible, so, check to see if there is a matching
+    // object regardless of the type of interface address we're expecting.
+    if (vsys.getAddressObjects().containsKey(addressText)) {
+      AddressObject addrObject = vsys.getAddressObjects().get(addressText);
+      ConcreteInterfaceAddress concreteIfaceAddr = addrObject.toConcreteInterfaceAddress();
+      if (concreteIfaceAddr != null) {
+        return concreteIfaceAddr;
+      }
+      // If we cannot build a concrete interface address from the address object, assume we're
+      // referencing some object in a different namespace
+    }
+    switch (vsys.getNamespaceType()) {
+      case LEAF:
+        if (_shared != null) {
+          return interfaceAddressToConcreteInterfaceAddress(address, _shared, w);
+        }
+        // fall-through
+      case SHARED:
+        if (_panorama != null) {
+          return interfaceAddressToConcreteInterfaceAddress(address, _panorama, w);
+        }
+        // fall-through
+      default:
+        // No named object found matching this value, so parse the value as is
+        switch (address.getType()) {
+          case IP_ADDRESS:
+            return ConcreteInterfaceAddress.create(Ip.parse(addressText), Prefix.MAX_PREFIX_LENGTH);
+          case IP_PREFIX:
+            return ConcreteInterfaceAddress.parse(addressText);
+          case REFERENCE:
+          default:
+            w.redFlag(
+                String.format(
+                    "Could not convert InterfaceAddress to ConcreteInterfaceAddress: %s", address));
+            return null;
+        }
+    }
+  }
+
   /** Converts {@link RuleEndpoint} to {@code IpSpace} */
   @Nonnull
   @SuppressWarnings("fallthrough")
@@ -1220,10 +1269,20 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     if (mtu != null) {
       newIface.setMtu(mtu);
     }
-    newIface.setAddress(iface.getAddress());
-    if (iface.getAddress() != null) {
+    ConcreteInterfaceAddress concreteAddress =
+        interfaceAddressToConcreteInterfaceAddress(
+            iface.getAddress(), _virtualSystems.get(DEFAULT_VSYS_NAME), _w);
+    if (concreteAddress != null) {
+      newIface.setAddress(concreteAddress);
       newIface.setSecondaryAddresses(
-          Sets.difference(iface.getAllAddresses(), ImmutableSet.of(iface.getAddress())));
+          Sets.difference(
+              iface.getAllAddresses().stream()
+                  .map(
+                      a ->
+                          interfaceAddressToConcreteInterfaceAddress(
+                              a, _virtualSystems.get(DEFAULT_VSYS_NAME), _w))
+                  .collect(Collectors.toSet()),
+              ImmutableSet.of(concreteAddress)));
     }
     newIface.setActive(iface.getActive());
     newIface.setDescription(iface.getComment());
@@ -1535,6 +1594,10 @@ public class PaloAltoConfiguration extends VendorConfiguration {
       Optional.ofNullable(peer.getLocalInterface())
           .map(_interfaces::get)
           .map(Interface::getAddress)
+          .map(
+              a ->
+                  interfaceAddressToConcreteInterfaceAddress(
+                      a, _virtualSystems.get(DEFAULT_VSYS_NAME), _w))
           .map(ConcreteInterfaceAddress::getIp)
           .ifPresent(peerB::setLocalIp);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1279,22 +1279,21 @@ public class PaloAltoConfiguration extends VendorConfiguration {
         interfaceAddressToConcreteInterfaceAddress(
             iface.getAddress(), _virtualSystems.get(DEFAULT_VSYS_NAME), _w);
     if (concreteAddress != null) {
-      if (iface.getType() == Interface.Type.LOOPBACK) {
-        if (concreteAddress.getPrefix().getPrefixLength() != Prefix.MAX_PREFIX_LENGTH) {
-          _w.redFlag("Loopback ip address must be /32 or without mask");
-        }
+      if (iface.getType() == Interface.Type.LOOPBACK
+          && concreteAddress.getPrefix().getPrefixLength() != Prefix.MAX_PREFIX_LENGTH) {
+        _w.redFlag("Loopback ip address must be /32 or without mask");
+      } else {
+        newIface.setAddress(concreteAddress);
+        newIface.setSecondaryAddresses(
+            Sets.difference(
+                iface.getAllAddresses().stream()
+                    .map(
+                        a ->
+                            interfaceAddressToConcreteInterfaceAddress(
+                                a, _virtualSystems.get(DEFAULT_VSYS_NAME), _w))
+                    .collect(Collectors.toSet()),
+                ImmutableSet.of(concreteAddress)));
       }
-
-      newIface.setAddress(concreteAddress);
-      newIface.setSecondaryAddresses(
-          Sets.difference(
-              iface.getAllAddresses().stream()
-                  .map(
-                      a ->
-                          interfaceAddressToConcreteInterfaceAddress(
-                              a, _virtualSystems.get(DEFAULT_VSYS_NAME), _w))
-                  .collect(Collectors.toSet()),
-              ImmutableSet.of(concreteAddress)));
     }
     newIface.setActive(iface.getActive());
     newIface.setDescription(iface.getComment());

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1269,6 +1269,10 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     if (mtu != null) {
       newIface.setMtu(mtu);
     }
+
+    // It is unclear which vsys is used to start the object lookup process on multi-vsys systems,
+    // since interfaces are not associated with particular vsys.
+    // Assuming default vsys is good enough for now (this is the behavior for single-vsys systems).
     ConcreteInterfaceAddress concreteAddress =
         interfaceAddressToConcreteInterfaceAddress(
             iface.getAddress(), _virtualSystems.get(DEFAULT_VSYS_NAME), _w);

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1245,8 +1245,8 @@ public final class PaloAltoGrammarTest {
                 "Interface %s is not in a virtual-router, placing in %s and shutting it down.",
                 "ethernet1/3.11", NULL_VRF_NAME),
             String.format(
-                "Could not convert %s AddressObject to ConcreteInterfaceAddress.",
-                AddressObject.Type.IP_RANGE)));
+                "Could not convert %s AddressObject '%s' to ConcreteInterfaceAddress.",
+                AddressObject.Type.IP_RANGE, "ADDR3")));
 
     // Should see a warning about the loopback having a non /32 address
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1251,6 +1251,7 @@ public final class PaloAltoGrammarTest {
     Interface e1_1 = c.getInterfaces().get("ethernet1/1");
     Interface e1_4 = c.getInterfaces().get("ethernet1/4");
     Interface e1_5 = c.getInterfaces().get("ethernet1/5");
+    Interface e1_7 = c.getInterfaces().get("ethernet1/7");
 
     assertThat(e1_1, notNullValue());
     InterfaceAddress e1_1_addr = e1_1.getAddress();
@@ -1266,6 +1267,13 @@ public final class PaloAltoGrammarTest {
     assertThat(e1_5_addr, notNullValue());
     assertThat(e1_5_addr.getType(), equalTo(InterfaceAddress.Type.REFERENCE));
     assertThat(e1_5_addr.getValue(), equalTo("ADDR2"));
+
+    assertThat(e1_7, notNullValue());
+    InterfaceAddress e1_7_addr = e1_7.getAddress();
+    assertThat(e1_7_addr, notNullValue());
+    // Object reference that looks like an IP address
+    assertThat(e1_7_addr.getType(), equalTo(InterfaceAddress.Type.IP_ADDRESS));
+    assertThat(e1_7_addr.getValue(), equalTo("10.100.100.100"));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1292,6 +1292,7 @@ public final class PaloAltoGrammarTest {
     String hostname = "interface";
     String hostnameLoopbackRef = "interface-loopback-ref";
     String hostnameLoopbackRefInvalid = "interface-loopback-ref-invalid";
+    String hostnameLoopbackRefInvalidRange = "interface-loopback-ref-invalid-range";
     String eth1_1 = "ethernet1/1";
     String eth1_2 = "ethernet1/2";
     String eth1_3 = "ethernet1/3";
@@ -1300,18 +1301,22 @@ public final class PaloAltoGrammarTest {
     String eth1_5 = "ethernet1/5";
     String eth1_6 = "ethernet1/6";
     String eth1_7 = "ethernet1/7";
+    String eth1_8 = "ethernet1/8";
     String eth1_21 = "ethernet1/21";
     String loopback = "loopback";
     Configuration c = parseConfig(hostname);
     Configuration cLoopbackRef = parseConfig(hostnameLoopbackRef);
     Configuration cLoopbackRefInvalid = parseConfig(hostnameLoopbackRefInvalid);
+    Configuration cLoopbackRefInvalidRange = parseConfig(hostnameLoopbackRefInvalidRange);
 
     assertThat(
         c.getAllInterfaces().keySet(),
         containsInAnyOrder(
-            eth1_1, eth1_2, eth1_3, eth1_3_11, eth1_4, eth1_5, eth1_6, eth1_7, eth1_21, loopback));
+            eth1_1, eth1_2, eth1_3, eth1_3_11, eth1_4, eth1_5, eth1_6, eth1_7, eth1_8, eth1_21,
+            loopback));
     assertThat(cLoopbackRef.getAllInterfaces().keySet(), contains(loopback));
     assertThat(cLoopbackRefInvalid.getAllInterfaces().keySet(), contains(loopback));
+    assertThat(cLoopbackRefInvalidRange.getAllInterfaces().keySet(), contains(loopback));
 
     // Confirm interface MTU is extracted
     assertThat(c, hasInterface(eth1_1, hasMtu(9001)));
@@ -1333,6 +1338,8 @@ public final class PaloAltoGrammarTest {
         c,
         hasInterface(
             eth1_7, hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.10.11.10/32")))));
+    // Address-group object reference is not allowed
+    assertThat(c, hasInterface(eth1_8, hasAllAddresses(emptyIterable())));
     assertThat(
         c,
         hasInterface(
@@ -1351,8 +1358,9 @@ public final class PaloAltoGrammarTest {
         cLoopbackRef,
         hasInterface(
             loopback, hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.10.10.10/32")))));
-    // Bad address object reference
+    // Bad address object references
     assertThat(cLoopbackRefInvalid, hasInterface(loopback, hasAllAddresses(emptyIterable())));
+    assertThat(cLoopbackRefInvalidRange, hasInterface(loopback, hasAllAddresses(emptyIterable())));
 
     // Confirm comments are extracted
     assertThat(c, hasInterface(eth1_1, hasDescription("description")));

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressObjectTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressObjectTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNull;
 
 import com.google.common.collect.Range;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.representation.palo_alto.AddressObject.Type;
@@ -17,20 +18,21 @@ public class AddressObjectTest {
   @Test
   public void testGetConcreteInterfaceAddress() {
     AddressObject a = new AddressObject("name");
+    Warnings w = new Warnings();
 
     a.setPrefix(IpPrefix.parse("1.2.3.4/24"));
     assertThat(
-        a.toConcreteInterfaceAddress(), equalTo(ConcreteInterfaceAddress.parse("1.2.3.4/24")));
+        a.toConcreteInterfaceAddress(w), equalTo(ConcreteInterfaceAddress.parse("1.2.3.4/24")));
 
     // Implied /32
     a.setIp(Ip.parse("1.2.3.4"));
     assertThat(
-        a.toConcreteInterfaceAddress(), equalTo(ConcreteInterfaceAddress.parse("1.2.3.4/32")));
+        a.toConcreteInterfaceAddress(w), equalTo(ConcreteInterfaceAddress.parse("1.2.3.4/32")));
 
     // Cannot convert ip range to concrete interface address
     Range<Ip> range = Range.closed(Ip.ZERO, Ip.parse("1.1.1.1"));
     a.setIpRange(range);
-    assertThat(a.toConcreteInterfaceAddress(), nullValue());
+    assertThat(a.toConcreteInterfaceAddress(w), nullValue());
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressObjectTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/AddressObjectTest.java
@@ -2,15 +2,36 @@ package org.batfish.representation.palo_alto;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNull;
 
 import com.google.common.collect.Range;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.representation.palo_alto.AddressObject.Type;
 import org.junit.Test;
 
 /** Tests of {@link AddressObject} */
 public class AddressObjectTest {
+
+  @Test
+  public void testGetConcreteInterfaceAddress() {
+    AddressObject a = new AddressObject("name");
+
+    a.setPrefix(IpPrefix.parse("1.2.3.4/24"));
+    assertThat(
+        a.toConcreteInterfaceAddress(), equalTo(ConcreteInterfaceAddress.parse("1.2.3.4/24")));
+
+    // Implied /32
+    a.setIp(Ip.parse("1.2.3.4"));
+    assertThat(
+        a.toConcreteInterfaceAddress(), equalTo(ConcreteInterfaceAddress.parse("1.2.3.4/32")));
+
+    // Cannot convert ip range to concrete interface address
+    Range<Ip> range = Range.closed(Ip.ZERO, Ip.parse("1.1.1.1"));
+    a.setIpRange(range);
+    assertThat(a.toConcreteInterfaceAddress(), nullValue());
+  }
 
   @Test
   public void testSetClearsTypeAndMembers() {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-objects
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/address-objects
@@ -10,3 +10,11 @@ set address addr2 ip-netmask 10.1.1.2
 set address addr2 tag [ tag2 "tag with spaces"]
 
 set address addr3 ip-range 1.1.1.1-1.1.1.2
+
+set address addr4 ip-netmask 10.1.1.1/32
+set address 4.3.2.1 ip-netmask 44.33.22.11/32
+set network interface ethernet ethernet1/1 layer3 ip addr4
+set network interface ethernet ethernet1/2 layer3 ip 1.2.3.4
+set network interface ethernet ethernet1/3 layer3 ip 4.3.2.1
+set network interface ethernet ethernet1/4 layer3 ip addr_undef
+set network interface loopback ip addr4

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface
@@ -1,4 +1,8 @@
 set deviceconfig system hostname interface
+set address ADDR1 ip-netmask 10.10.11.10
+set address ADDR2 ip-netmask 10.10.12.10/24
+set address ADDR3 ip-range 10.10.13.13-10.10.13.15
+set address 10.100.100.100 ip-netmask 10.10.11.10
 set network interface ethernet ethernet1/1 layer3 mtu 9001
 set network interface ethernet ethernet1/1 layer3 ip 1.1.1.1/24
 set network interface ethernet ethernet1/1 comment description
@@ -10,8 +14,14 @@ set network interface ethernet ethernet1/3 comment 'single quoted description'
 set network interface ethernet ethernet1/3 layer3 units ethernet1/3.11 comment 'unit description'
 set network interface ethernet ethernet1/3 layer3 units ethernet1/3.11 tag 11
 set network interface ethernet ethernet1/4 ha
+# Address object w/ explicit /24
+set network interface ethernet ethernet1/5 layer3 ip ADDR2
+# Valid object name, but address range cannot be used for interface address
+set network interface ethernet ethernet1/6 layer3 ip ADDR3
+# Refer to ambiguously named address object w/ implicit /32
+set network interface ethernet ethernet1/7 layer3 ip 10.100.100.100
 set network interface ethernet ethernet1/21 link-state down
 set network interface loopback ip 7.7.7.7/32
 set network interface loopback ip 7.7.7.8
 # Interfaces are not functionally active unless they are in a virtual-router
-set network virtual-router default interface [ ethernet1/1 ethernet1/2 ethernet1/3 loopback ]
+set network virtual-router default interface [ ethernet1/1 ethernet1/2 ethernet1/3 ethernet1/5 ethernet1/6 ethernet1/7 loopback ]

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface
@@ -3,6 +3,7 @@ set address ADDR1 ip-netmask 10.10.11.10
 set address ADDR2 ip-netmask 10.10.12.10/24
 set address ADDR3 ip-range 10.10.13.13-10.10.13.15
 set address 10.100.100.100 ip-netmask 10.10.11.10
+set address-group GRP1 static ADDR1
 set network interface ethernet ethernet1/1 layer3 mtu 9001
 set network interface ethernet ethernet1/1 layer3 ip 1.1.1.1/24
 set network interface ethernet ethernet1/1 comment description
@@ -20,6 +21,8 @@ set network interface ethernet ethernet1/5 layer3 ip ADDR2
 set network interface ethernet ethernet1/6 layer3 ip ADDR3
 # Refer to ambiguously named address object w/ implicit /32
 set network interface ethernet ethernet1/7 layer3 ip 10.100.100.100
+# Valid object name, but address-groups cannot be used for interface addresses
+set network interface ethernet ethernet1/8 layer3 ip GRP1
 set network interface ethernet ethernet1/21 link-state down
 set network interface loopback ip 7.7.7.7/32
 set network interface loopback ip 7.7.7.8

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-bad-loopback-addr
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-bad-loopback-addr
@@ -1,0 +1,5 @@
+set deviceconfig system hostname interface-bad-loopback-addr
+set address ADDR1 ip-netmask 10.10.10.10/24
+set network interface loopback ip ADDR1
+# Interfaces are not functionally active unless they are in a virtual-router
+set network virtual-router default interface loopback

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-loopback-ref
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-loopback-ref
@@ -1,0 +1,5 @@
+set deviceconfig system hostname interface-loopback-ref
+set address ADDR1 ip-netmask 10.10.10.10
+set network interface loopback ip ADDR1
+# Interfaces are not functionally active unless they are in a virtual-router
+set network virtual-router default interface loopback

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-loopback-ref-invalid
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-loopback-ref-invalid
@@ -1,0 +1,5 @@
+set deviceconfig system hostname interface-loopback-ref-invalid
+set address ADDR1 ip-range 10.10.13.13-10.10.13.15
+set network interface loopback ip ADDR1
+# Interfaces are not functionally active unless they are in a virtual-router
+set network virtual-router default interface loopback

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-loopback-ref-invalid
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-loopback-ref-invalid
@@ -1,5 +1,6 @@
 set deviceconfig system hostname interface-loopback-ref-invalid
-set address ADDR1 ip-range 10.10.13.13-10.10.13.15
+# This is not a valid loopback address, cannot be associated w/ loopback iface
+set address ADDR1 ip-netmask 10.10.13.13/24
 set network interface loopback ip ADDR1
 # Interfaces are not functionally active unless they are in a virtual-router
 set network virtual-router default interface loopback

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-loopback-ref-invalid-range
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface-loopback-ref-invalid-range
@@ -1,0 +1,5 @@
+set deviceconfig system hostname interface-loopback-ref-invalid-range
+set address ADDR1 ip-range 10.10.13.13-10.10.13.15
+set network interface loopback ip ADDR1
+# Interfaces are not functionally active unless they are in a virtual-router
+set network virtual-router default interface loopback


### PR DESCRIPTION
Palo Alto devices let you specify a named address object instead of explicitly specifying an address for an L3 ethernet interface. This PR adds support for that.

Reference tracking PR will follow.
