### PR TITLE
Support runtime data for multi-device configs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/runtime/SnapshotRuntimeData.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/runtime/SnapshotRuntimeData.java
@@ -137,7 +137,10 @@ public final class SnapshotRuntimeData {
 
   @JsonIgnore
   @Nonnull
-  public RuntimeData getRuntimeData(String hostname) {
+  public RuntimeData getRuntimeData(@Nullable String hostname) {
+    if (hostname == null) {
+      return RuntimeData.EMPTY_RUNTIME_DATA;
+    }
     assert hostname.equals(hostname.toLowerCase());
     return _runtimeData.getOrDefault(hostname, RuntimeData.EMPTY_RUNTIME_DATA);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -27,7 +27,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.Warnings;
-import org.batfish.common.runtime.RuntimeData;
+import org.batfish.common.runtime.SnapshotRuntimeData;
 import org.batfish.common.topology.Layer1Edge;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -42,7 +42,7 @@ public abstract class VendorConfiguration implements Serializable {
 
   protected String _filename;
 
-  @Nonnull protected transient RuntimeData _runtimeData;
+  @Nonnull protected transient SnapshotRuntimeData _runtimeData;
 
   private VendorConfiguration _overlayConfiguration;
 
@@ -57,7 +57,7 @@ public abstract class VendorConfiguration implements Serializable {
   protected transient Warnings _w;
 
   public VendorConfiguration() {
-    _runtimeData = RuntimeData.EMPTY_RUNTIME_DATA;
+    _runtimeData = SnapshotRuntimeData.EMPTY_SNAPSHOT_RUNTIME_DATA;
     _structureDefinitions = new TreeMap<>();
     _structureReferences = new TreeMap<>();
   }
@@ -197,7 +197,7 @@ public abstract class VendorConfiguration implements Serializable {
   public abstract void setHostname(String hostname);
 
   @JsonIgnore
-  public void setRuntimeData(@Nonnull RuntimeData runtimeData) {
+  public void setRuntimeData(@Nonnull SnapshotRuntimeData runtimeData) {
     _runtimeData = runtimeData;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/runtime/SnapshotRuntimeDataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/runtime/SnapshotRuntimeDataTest.java
@@ -63,6 +63,9 @@ public class SnapshotRuntimeDataTest {
     // Non-existent hostname: should return empty runtime data
     assertThat(srd.getRuntimeData("other"), equalTo(RuntimeData.EMPTY_RUNTIME_DATA));
 
+    // Null hostname: should return empty runtime data
+    assertThat(srd.getRuntimeData(null), equalTo(RuntimeData.EMPTY_RUNTIME_DATA));
+
     // Non-canonical hostname: should throw
     _thrown.expect(AssertionError.class);
     srd.getRuntimeData(hostname.toUpperCase());

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.common.Warnings;
-import org.batfish.common.runtime.RuntimeData;
+import org.batfish.common.runtime.SnapshotRuntimeData;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.AsPathAccessList;
 import org.batfish.datamodel.CommunityList;
@@ -40,14 +40,17 @@ import org.batfish.vendor.VendorConfiguration;
 public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResult> {
 
   private Object _configObject;
-  @Nonnull private final RuntimeData _runtimeData;
+  @Nonnull private final SnapshotRuntimeData _runtimeData;
   private String _name;
 
   public ConvertConfigurationJob(
-      Settings settings, @Nullable RuntimeData runtimeData, Object configObject, String name) {
+      Settings settings,
+      @Nullable SnapshotRuntimeData runtimeData,
+      Object configObject,
+      String name) {
     super(settings);
     _configObject = configObject;
-    _runtimeData = firstNonNull(runtimeData, RuntimeData.EMPTY_RUNTIME_DATA);
+    _runtimeData = firstNonNull(runtimeData, SnapshotRuntimeData.EMPTY_SNAPSHOT_RUNTIME_DATA);
     _name = name;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -776,8 +776,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
     for (Entry<String, VendorConfiguration> config : vendorConfigurations.entrySet()) {
       VendorConfiguration vc = config.getValue();
       ConvertConfigurationJob job =
-          new ConvertConfigurationJob(
-              _settings, runtimeData.getRuntimeData(config.getKey()), vc, config.getKey());
+          new ConvertConfigurationJob(_settings, runtimeData, vc, config.getKey());
       jobs.add(job);
     }
     BatfishJobExecutor.runJobsInExecutor(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -67,7 +67,6 @@ import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.runtime.InterfaceRuntimeData;
-import org.batfish.common.runtime.RuntimeData;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AsPathAccessList;
 import org.batfish.datamodel.AsPathAccessListLine;
@@ -1784,14 +1783,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     CiscoNxosInterfaceType type = iface.getType();
     newIfaceBuilder.setType(toInterfaceType(type, parent != null));
 
-    RuntimeData hostRuntimeData =
-        firstNonNull(
-            (_hostname == null)
-                ? RuntimeData.EMPTY_RUNTIME_DATA
-                : _runtimeData.getRuntimeData(_hostname),
-            RuntimeData.EMPTY_RUNTIME_DATA);
     Optional<InterfaceRuntimeData> runtimeData =
-        Optional.ofNullable(hostRuntimeData.getInterface(ifaceName));
+        Optional.ofNullable(_runtimeData.getRuntimeData(_hostname).getInterface(ifaceName));
     Double runtimeBandwidth = runtimeData.map(InterfaceRuntimeData::getBandwidth).orElse(null);
     Double runtimeSpeed = runtimeData.map(InterfaceRuntimeData::getSpeed).orElse(null);
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -67,6 +67,7 @@ import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.runtime.InterfaceRuntimeData;
+import org.batfish.common.runtime.RuntimeData;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AsPathAccessList;
 import org.batfish.datamodel.AsPathAccessListLine;
@@ -1783,8 +1784,14 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     CiscoNxosInterfaceType type = iface.getType();
     newIfaceBuilder.setType(toInterfaceType(type, parent != null));
 
+    RuntimeData hostRuntimeData =
+        firstNonNull(
+            (_hostname == null)
+                ? RuntimeData.EMPTY_RUNTIME_DATA
+                : _runtimeData.getRuntimeData(_hostname),
+            RuntimeData.EMPTY_RUNTIME_DATA);
     Optional<InterfaceRuntimeData> runtimeData =
-        Optional.ofNullable(_runtimeData.getInterface(ifaceName));
+        Optional.ofNullable(hostRuntimeData.getInterface(ifaceName));
     Double runtimeBandwidth = runtimeData.map(InterfaceRuntimeData::getBandwidth).orElse(null);
     Double runtimeSpeed = runtimeData.map(InterfaceRuntimeData::getSpeed).orElse(null);
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -28,7 +28,6 @@ import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.zoneToZoneRejectTraceElement;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -1264,7 +1263,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
   private org.batfish.datamodel.Interface toInterface(Interface iface) {
     String name = iface.getName();
     RuntimeData hostRuntimeData =
-        MoreObjects.firstNonNull(
+        firstNonNull(
             (_hostname == null)
                 ? RuntimeData.EMPTY_RUNTIME_DATA
                 : _runtimeData.getRuntimeData(_hostname),

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -28,6 +28,7 @@ import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.zoneToZoneRejectTraceElement;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -73,6 +74,7 @@ import javax.annotation.Nullable;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.Warnings;
 import org.batfish.common.runtime.InterfaceRuntimeData;
+import org.batfish.common.runtime.RuntimeData;
 import org.batfish.datamodel.AclAclLine;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AclLine;
@@ -1261,7 +1263,13 @@ public class PaloAltoConfiguration extends VendorConfiguration {
   /** Convert Palo Alto specific interface into vendor independent model interface */
   private org.batfish.datamodel.Interface toInterface(Interface iface) {
     String name = iface.getName();
-    InterfaceRuntimeData ifaceRuntimeData = _runtimeData.getInterface(iface.getName());
+    RuntimeData hostRuntimeData =
+        MoreObjects.firstNonNull(
+            (_hostname == null)
+                ? RuntimeData.EMPTY_RUNTIME_DATA
+                : _runtimeData.getRuntimeData(_hostname),
+            RuntimeData.EMPTY_RUNTIME_DATA);
+    InterfaceRuntimeData ifaceRuntimeData = hostRuntimeData.getInterface(iface.getName());
     Interface.Type parentType = iface.getParent() != null ? iface.getParent().getType() : null;
     org.batfish.datamodel.Interface.Builder newIface =
         org.batfish.datamodel.Interface.builder()

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -73,7 +73,6 @@ import javax.annotation.Nullable;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.Warnings;
 import org.batfish.common.runtime.InterfaceRuntimeData;
-import org.batfish.common.runtime.RuntimeData;
 import org.batfish.datamodel.AclAclLine;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AclLine;
@@ -1262,13 +1261,8 @@ public class PaloAltoConfiguration extends VendorConfiguration {
   /** Convert Palo Alto specific interface into vendor independent model interface */
   private org.batfish.datamodel.Interface toInterface(Interface iface) {
     String name = iface.getName();
-    RuntimeData hostRuntimeData =
-        firstNonNull(
-            (_hostname == null)
-                ? RuntimeData.EMPTY_RUNTIME_DATA
-                : _runtimeData.getRuntimeData(_hostname),
-            RuntimeData.EMPTY_RUNTIME_DATA);
-    InterfaceRuntimeData ifaceRuntimeData = hostRuntimeData.getInterface(iface.getName());
+    InterfaceRuntimeData ifaceRuntimeData =
+        _runtimeData.getRuntimeData(_hostname).getInterface(iface.getName());
     Interface.Type parentType = iface.getParent() != null ? iface.getParent().getType() : null;
     org.batfish.datamodel.Interface.Builder newIface =
         org.batfish.datamodel.Interface.builder()

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -133,7 +133,7 @@ import org.batfish.common.Warnings;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.IpSpaceToBDD;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.common.runtime.RuntimeData;
+import org.batfish.common.runtime.SnapshotRuntimeData;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AclLine;
@@ -289,7 +289,7 @@ public final class PaloAltoGrammarTest {
     // crash if not serializable
     pac = SerializationUtils.clone(pac);
     pac.setAnswerElement(answerElement);
-    pac.setRuntimeData(RuntimeData.EMPTY_RUNTIME_DATA);
+    pac.setRuntimeData(SnapshotRuntimeData.EMPTY_SNAPSHOT_RUNTIME_DATA);
     pac.setWarnings(new Warnings());
     return pac;
   }
@@ -3358,10 +3358,8 @@ public final class PaloAltoGrammarTest {
     assertThat(
         interfaces1.get(eth1_2).getConcreteAddress(),
         equalTo(ConcreteInterfaceAddress.parse("10.1.2.1/30")));
-    // For an interface without configured address, address should be pulled from runtime data
-    assertThat(
-        interfaces1.get(eth1_3).getConcreteAddress(),
-        equalTo(ConcreteInterfaceAddress.parse("192.168.3.1/24")));
+    // No address specified for this interface on firewall1
+    assertThat(interfaces1.get(eth1_3).getConcreteAddress(), nullValue());
 
     // Use configured interface address from config where applicable
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoSecurityRuleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoSecurityRuleTest.java
@@ -24,7 +24,7 @@ import org.batfish.common.BatfishLogger;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.Warnings;
 import org.batfish.common.plugin.IBatfish;
-import org.batfish.common.runtime.RuntimeData;
+import org.batfish.common.runtime.SnapshotRuntimeData;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -81,7 +81,7 @@ public class PaloAltoSecurityRuleTest {
     pac.setFilename(TESTCONFIGS_PREFIX + hostname);
     // crash if not serializable
     pac = SerializationUtils.clone(pac);
-    pac.setRuntimeData(RuntimeData.EMPTY_RUNTIME_DATA);
+    pac.setRuntimeData(SnapshotRuntimeData.EMPTY_SNAPSHOT_RUNTIME_DATA);
     pac.setAnswerElement(answerElement);
     return pac;
   }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/snapshots/runtime_data/runtime_data.json
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/snapshots/runtime_data/runtime_data.json
@@ -1,6 +1,6 @@
 {
   "runtimeData": {
-    "panorama": {
+    "firewall2": {
       "interfaces": {
         "ethernet1/1": {
           "address": "192.168.1.1/24"


### PR DESCRIPTION
Pass `SnapshotRuntimeData` into `VendorConfiguration` so it has access to runtime data for all devices, not just its own.

This is needed for devices like Palo Alto Panorama (which configure multiple VI devices in a single VS config) to pull in runtime data for its child devices.
