### PR TITLE
Cleanup after #5953

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/runtime/SnapshotRuntimeData.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/runtime/SnapshotRuntimeData.java
@@ -137,10 +137,7 @@ public final class SnapshotRuntimeData {
 
   @JsonIgnore
   @Nonnull
-  public RuntimeData getRuntimeData(@Nullable String hostname) {
-    if (hostname == null) {
-      return RuntimeData.EMPTY_RUNTIME_DATA;
-    }
+  public RuntimeData getRuntimeData(String hostname) {
     assert hostname.equals(hostname.toLowerCase());
     return _runtimeData.getOrDefault(hostname, RuntimeData.EMPTY_RUNTIME_DATA);
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/runtime/SnapshotRuntimeDataTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/runtime/SnapshotRuntimeDataTest.java
@@ -63,9 +63,6 @@ public class SnapshotRuntimeDataTest {
     // Non-existent hostname: should return empty runtime data
     assertThat(srd.getRuntimeData("other"), equalTo(RuntimeData.EMPTY_RUNTIME_DATA));
 
-    // Null hostname: should return empty runtime data
-    assertThat(srd.getRuntimeData(null), equalTo(RuntimeData.EMPTY_RUNTIME_DATA));
-
     // Non-canonical hostname: should throw
     _thrown.expect(AssertionError.class);
     srd.getRuntimeData(hostname.toUpperCase());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1784,7 +1784,9 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     newIfaceBuilder.setType(toInterfaceType(type, parent != null));
 
     Optional<InterfaceRuntimeData> runtimeData =
-        Optional.ofNullable(_runtimeData.getRuntimeData(_hostname).getInterface(ifaceName));
+        Optional.ofNullable(_hostname)
+            .map(h -> _runtimeData.getRuntimeData(h))
+            .map(d -> d.getInterface(ifaceName));
     Double runtimeBandwidth = runtimeData.map(InterfaceRuntimeData::getBandwidth).orElse(null);
     Double runtimeSpeed = runtimeData.map(InterfaceRuntimeData::getSpeed).orElse(null);
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1261,8 +1261,10 @@ public class PaloAltoConfiguration extends VendorConfiguration {
   /** Convert Palo Alto specific interface into vendor independent model interface */
   private org.batfish.datamodel.Interface toInterface(Interface iface) {
     String name = iface.getName();
-    InterfaceRuntimeData ifaceRuntimeData =
-        _runtimeData.getRuntimeData(_hostname).getInterface(iface.getName());
+    Optional<InterfaceRuntimeData> ifaceRuntimeData =
+        Optional.ofNullable(_hostname)
+            .map(h -> _runtimeData.getRuntimeData(h))
+            .map(d -> d.getInterface(name));
     Interface.Type parentType = iface.getParent() != null ? iface.getParent().getType() : null;
     org.batfish.datamodel.Interface.Builder newIface =
         org.batfish.datamodel.Interface.builder()
@@ -1282,8 +1284,8 @@ public class PaloAltoConfiguration extends VendorConfiguration {
         interfaceAddressToConcreteInterfaceAddress(
             iface.getAddress(), _virtualSystems.get(DEFAULT_VSYS_NAME), _w);
     // No explicit address detected, fallback to runtime data
-    if (interfaceAddress == null && ifaceRuntimeData != null) {
-      interfaceAddress = ifaceRuntimeData.getAddress();
+    if (interfaceAddress == null) {
+      interfaceAddress = ifaceRuntimeData.map(InterfaceRuntimeData::getAddress).orElse(null);
     }
 
     if (interfaceAddress != null) {


### PR DESCRIPTION
Enforce non-null hostname again for `getRuntimeData`, improve calling code.
