### PR TITLE
Juniper: add support for more characters in GroupWildcard

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/GroupWildcard.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/GroupWildcard.java
@@ -73,10 +73,14 @@ public class GroupWildcard extends BaseParser<String> {
   @SuppressSubnodes
   Rule AllLiterals() {
     // Skipping special characters until proven otherwise
-    Rule base = FirstOf(ClassLiterals(), Dot());
+    Rule base = FirstOf(ClassLiterals(), NonClassLiterals(), Dot());
     return Sequence(
         base, // pop()
         ZeroOrMore(base, push(pop(1) + pop())));
+  }
+
+  Rule NonClassLiterals() {
+    return Sequence(Ch('/'), push(match()));
   }
 
   Rule Dot() {

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/GroupWildcardTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/GroupWildcardTest.java
@@ -32,6 +32,8 @@ public class GroupWildcardTest {
     assertThat(toJavaRegex("[0-9]"), equalTo("[0-9]"));
     assertThat(toJavaRegex("[A-D]"), equalTo("[A-D]"));
     assertThat(toJavaRegex("border-[0-9]-DC?-*"), equalTo("border-[0-9]-DC\\w-.*"));
+    assertThat(toJavaRegex("ge-1/2/[5-8]"), equalTo("ge-1/2/[5-8]"));
+    assertThat(toJavaRegex("12.1[23]4.*.*/2[89]"), equalTo("12\\.1[23]4\\..*\\..*/2[89]"));
   }
 
   @Test


### PR DESCRIPTION
Juniper example:

  interfaces {
    "<ge-1/2/[5-8]>" {
      description "These interfaces reserved for Customer ABC";
    }
  }

Siva example on Batfish SLack: dd.d[dd]d.*.*/d[dd] where d is a digit