### PR TITLE
PAN: ignore device-group profiles

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -171,6 +171,7 @@ statement_device_group
     | s_pre_rulebase
     | sdg_description
     | sdg_devices
+    | sdg_profiles
 ;
 
 set_line_tail

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_device_group.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_device_group.g4
@@ -16,6 +16,11 @@ sdg_devices
     DEVICES device = variable sdgd_vsys?
 ;
 
+sdg_profiles
+:
+    PROFILES null_rest_of_line
+;
+
 sdgd_vsys
 :
     VSYS name = variable

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -101,3 +101,6 @@ set template T1 config mgt-config users
 set template T1 config shared
 set template T1 config devices localhost.localdomain network vlan
 set template T1 config devices localhost.localdomain network virtual-wire
+
+set device-group DGNAME profiles spyware NAME rules NAME2 packet-capture disable
+set device-group DGNAME profiles vulnerability NAME rules NAME2 action alert


### PR DESCRIPTION
Ignore profiles within device-groups on Palo Alto devices.
