### PR TITLE
Exclude application LBs from AWS precomputed maps

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -198,6 +198,10 @@ public class AwsConfiguration extends VendorConfiguration {
                 loadBalancerAttributes != null
                     && loadBalancerAttributes.getCrossZoneLoadBalancing();
             LoadBalancer lb = region.getLoadBalancersMap().get(lbArn);
+            if (lb.getType() == LoadBalancer.Type.APPLICATION) {
+              // Application load balancers not supported
+              continue;
+            }
             Set<String> azNames =
                 lb.getAvailabilityZones().stream()
                     .map(AvailabilityZone::getZoneName)


### PR DESCRIPTION
Excludes application load balancers (which are unsupported) and their corresponding subnets, instance targets, and VPCs from the precomputed maps in AwsConfiguration. This will avoid setting up instance target interfaces/VRFs/routes for application load balancers' instance targets, subnets, and VPCs.