### PR TITLE
PAN: ignore device-group profile-group

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -172,6 +172,7 @@ statement_device_group
     | sdg_description
     | sdg_devices
     | sdg_profiles
+    | sdg_profile_group
 ;
 
 set_line_tail

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_device_group.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_device_group.g4
@@ -16,6 +16,11 @@ sdg_devices
     DEVICES device = variable sdgd_vsys?
 ;
 
+sdg_profile_group
+:
+    PROFILE_GROUP null_rest_of_line
+;
+
 sdg_profiles
 :
     PROFILES null_rest_of_line

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -104,3 +104,5 @@ set template T1 config devices localhost.localdomain network virtual-wire
 
 set device-group DGNAME profiles spyware NAME rules NAME2 packet-capture disable
 set device-group DGNAME profiles vulnerability NAME rules NAME2 action alert
+set device-group DGNAME profile-group GROUPNAME spyware NAME2
+set device-group DGNAME profile-group GROUPNAME vulnerability NAME2


### PR DESCRIPTION
Similar to https://github.com/batfish/batfish/pull/5961, ignore profile-groups within device-groups on Palo Alto devices.
