### PR TITLE
PAN: parse security rule log settings

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -788,9 +788,19 @@ LOCAL_PORT
     'local-port'
 ;
 
+LOG_END
+:
+    'log-end'
+;
+
 LOG_SETTINGS
 :
     'log-settings'
+;
+
+LOG_START
+:
+    'log-start'
 ;
 
 LOOPBACK

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_rulebase.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_rulebase.g4
@@ -51,6 +51,8 @@ srs_definition
         | srs_disabled
         | srs_from
         | srs_hip_profiles
+        | srs_log_end
+        | srs_log_start
         | srs_negate_destination
         | srs_negate_source
         | srs_service
@@ -107,6 +109,16 @@ srs_from
 srs_hip_profiles
 :
     HIP_PROFILES ANY // only support any
+;
+
+srs_log_end
+:
+    LOG_END yn = yes_or_no
+;
+
+srs_log_start
+:
+    LOG_START yn = yes_or_no
 ;
 
 srs_negate_destination

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -81,6 +81,8 @@ set mgt-config users admin public-key c3NoLX...
 set rulebase security rules RULE1 category streaming
 set rulebase security rules RULE1 hip-profiles any
 set rulebase security rules RULE1 source-user any
+set rulebase security rules RULE1 log-end no
+set rulebase security rules RULE1 log-start yes
 #
 set vsys vsys1 log-settings syslog NAME server NAME facility LOG_LOCAL0
 set vsys vsys1 log-settings syslog NAME server NAME format IETF


### PR DESCRIPTION
Parse and ignore security rule logging settings for Palo Alto devices.
