### PR TITLE
PAN: ignore log-collector lines

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -788,6 +788,16 @@ LOCAL_PORT
     'local-port'
 ;
 
+LOG_COLLECTOR
+:
+    'log-collector'
+;
+
+LOG_COLLECTOR_GROUP
+:
+    'log-collector-group'
+;
+
 LOG_SETTINGS
 :
     'log-settings'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -49,7 +49,9 @@ newline
 s_null
 :
     (
-        MGT_CONFIG
+        LOG_COLLECTOR
+        | LOG_COLLECTOR_GROUP
+        | MGT_CONFIG
     )
     null_rest_of_line
 ;

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/ignored-lines
@@ -62,6 +62,11 @@ set policy panorama application-filter SOFTWARE-UPDATES subcategory software-upd
 set policy panorama application-filter SOFTWARE-UPDATES technology client-server
 set policy panorama profiles virus
 #
+set log-collector NAME deviceconfig system service disable-icmp no
+set log-collector NAME secure-conn-client certificate-type none
+set log-collector-group GNAME logfwd-setting collectors NAME
+set log-collector-group GNAME general-setting management quota-settings disk-quota detailed 50
+#
 set shared botnet configuration http dynamic-dns enabled yes
 set shared botnet configuration other-applications irc yes
 set shared botnet configuration unknown-applications unknown-tcp destinations-per-hour 10


### PR DESCRIPTION
Ignore log-collector configuration on Palo Alto devices.
