### PR TITLE
AWS ESD modeling fixes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsVpcEntity.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsVpcEntity.java
@@ -9,6 +9,7 @@ public interface AwsVpcEntity {
   String JSON_KEY_ADDRESSES = "Addresses";
   String JSON_KEY_ALLOCATION_ID = "AllocationId";
   String JSON_KEY_AMAZON_SIDE_ASN = "AmazonSideAsn";
+  String JSON_KEY_ARN = "ARN";
   String JSON_KEY_ASSOCIATION = "Association";
   String JSON_KEY_ASSOCIATION_DEFAULT_ROUTE_TABLE_ID = "AssociationDefaultRouteTableId";
   String JSON_KEY_ASSOCIATIONS = "Associations";
@@ -47,6 +48,8 @@ public interface AwsVpcEntity {
   String JSON_KEY_DOMAIN_NAME = "DomainName";
   String JSON_KEY_DOMAIN_STATUS_LIST = "DomainStatusList";
   String JSON_KEY_EGRESS = "Egress";
+  String JSON_KEY_ELASTIC_SEARCH_CLUSTER_CONFIG = "ElasticsearchClusterConfig";
+  String JSON_KEY_ENDPOINTS = "Endpoints";
   String JSON_KEY_ENTRIES = "Entries";
   String JSON_KEY_FROM = "From";
   String JSON_KEY_FROM_PORT = "FromPort";
@@ -56,6 +59,7 @@ public interface AwsVpcEntity {
   String JSON_KEY_GROUPS = "Groups";
   String JSON_KEY_ICMP_TYPE_CODE = "IcmpTypeCode";
   String JSON_KEY_ID = "Id";
+  String JSON_KEY_INSTANCE_COUNT = "InstanceCount";
   String JSON_KEY_INSTANCE_ID = "InstanceId";
   String JSON_KEY_INSTANCE_STATUSES = "InstanceStatuses";
   String JSON_KEY_INSTANCES = "Instances";

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/ElasticsearchDomain.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/ElasticsearchDomain.java
@@ -1,14 +1,18 @@
 package org.batfish.representation.aws;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.representation.aws.Utils.checkNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -24,6 +28,29 @@ import org.batfish.datamodel.StaticRoute;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ParametersAreNonnullByDefault
 public final class ElasticsearchDomain implements AwsVpcEntity, Serializable {
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @ParametersAreNonnullByDefault
+  private static final class ElasticSearchClusterConfig {
+
+    private final int _instanceCount;
+
+    @JsonCreator
+    private static ElasticSearchClusterConfig create(
+        @Nullable @JsonProperty(JSON_KEY_INSTANCE_COUNT) Integer instanceCount) {
+      checkNonNull(instanceCount, JSON_KEY_INSTANCE_COUNT, "ElasticSearchClusterConfig");
+
+      return new ElasticSearchClusterConfig(instanceCount);
+    }
+
+    private ElasticSearchClusterConfig(int instanceCount) {
+      _instanceCount = instanceCount;
+    }
+
+    public int getInstanceCount() {
+      return _instanceCount;
+    }
+  }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   @ParametersAreNonnullByDefault
@@ -69,11 +96,17 @@ public final class ElasticsearchDomain implements AwsVpcEntity, Serializable {
     }
   }
 
+  @Nonnull private final String _arn;
+
   @Nonnull private final List<String> _securityGroups;
 
   @Nonnull private final String _domainName;
 
+  @Nullable private final String _vpcEndpoint;
+
   @Nullable private final String _vpcId;
+
+  private final int _instanceCount;
 
   @Nonnull private final List<String> _subnets;
 
@@ -83,9 +116,18 @@ public final class ElasticsearchDomain implements AwsVpcEntity, Serializable {
     return _available;
   }
 
+  @Nonnull
+  public String getDomainName() {
+    return _domainName;
+  }
+
   @Override
   public String getId() {
-    return _domainName;
+    return _arn;
+  }
+
+  public int getInstanceCount() {
+    return _instanceCount;
   }
 
   @Nonnull
@@ -99,88 +141,131 @@ public final class ElasticsearchDomain implements AwsVpcEntity, Serializable {
   }
 
   @Nullable
+  public String getVpcEndpoint() {
+    return _vpcEndpoint;
+  }
+
+  @Nullable
   public String getVpcId() {
     return _vpcId;
   }
 
   @JsonCreator
   private static ElasticsearchDomain create(
+      @Nullable @JsonProperty(JSON_KEY_ARN) String arn,
       @Nullable @JsonProperty(JSON_KEY_DOMAIN_NAME) String domainName,
       @Nullable @JsonProperty(JSON_KEY_VPC_OPTIONS) VpcOptions vpcOptions,
+      @Nullable @JsonProperty(JSON_KEY_ELASTIC_SEARCH_CLUSTER_CONFIG)
+          ElasticSearchClusterConfig clusterConfig,
       @Nullable @JsonProperty(JSON_KEY_CREATED) Boolean created,
-      @Nullable @JsonProperty(JSON_KEY_DELETED) Boolean deleted) {
-    checkArgument(domainName != null, "Domain name cannot be null for elastic search domain");
-    checkArgument(created != null, "Created key must exist in elastic search domain");
-    checkArgument(deleted != null, "Deleted key must exist in elastic search domain");
+      @Nullable @JsonProperty(JSON_KEY_DELETED) Boolean deleted,
+      @Nullable @JsonProperty(JSON_KEY_ENDPOINTS) Map<String, String> endpoints) {
+    checkNonNull(arn, JSON_KEY_ARN, "ELastic search domain");
+    checkNonNull(domainName, JSON_KEY_DOMAIN_NAME, "Elastic search domain");
+    checkNonNull(clusterConfig, JSON_KEY_ELASTIC_SEARCH_CLUSTER_CONFIG, "Elastic search domain");
+    checkNonNull(created, JSON_KEY_CREATED, "Elastic search domain");
+    checkNonNull(deleted, JSON_KEY_DELETED, "Elastic search domain");
 
     return new ElasticsearchDomain(
+        arn,
         domainName,
         vpcOptions == null ? null : vpcOptions.getVpcId(),
+        endpoints == null ? null : endpoints.getOrDefault("vpc", null),
+        clusterConfig._instanceCount,
         vpcOptions == null ? ImmutableList.of() : vpcOptions.getSecurityGroupIds(),
         vpcOptions == null ? ImmutableList.of() : vpcOptions.getSubnetIds(),
         created && !deleted);
   }
 
   public ElasticsearchDomain(
+      String arn,
       String domainName,
       @Nullable String vpcId,
+      @Nullable String vpcEndpoint,
+      int instanceCount,
       List<String> securityGroups,
       List<String> subnets,
       boolean available) {
+    _arn = arn;
     _domainName = domainName;
     _vpcId = vpcId;
+    _vpcEndpoint = vpcEndpoint;
+    _instanceCount = instanceCount;
     _securityGroups = securityGroups;
     _subnets = subnets;
     _available = available;
   }
 
-  public Configuration toConfigurationNode(
+  public List<Configuration> toConfigurationNodes(
       ConvertedConfiguration awsConfiguration, Region region, Warnings warnings) {
+    return IntStream.range(0, _instanceCount)
+        .mapToObj(
+            instanceNum ->
+                toConfigurationNode(
+                    instanceNum,
+                    _subnets.get(instanceNum % _subnets.size()),
+                    awsConfiguration,
+                    region,
+                    warnings))
+        .filter(Objects::nonNull)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  @Nullable
+  @VisibleForTesting
+  Configuration toConfigurationNode(
+      int instanceNumber,
+      String subnetId,
+      ConvertedConfiguration awsConfiguration,
+      Region region,
+      Warnings warnings) {
+    Subnet subnet = region.getSubnets().get(subnetId);
+    if (subnet == null) {
+      warnings.redFlag(
+          String.format(
+              "Subnet \"%s\" for Elasticsearch domain \"%s\" not found", subnetId, _domainName));
+      return null;
+    }
     Configuration cfgNode =
-        Utils.newAwsConfiguration(_domainName, "aws", DeviceModel.AWS_ELASTICSEARCH_DOMAIN);
+        Utils.newAwsConfiguration(
+            getNodeName(instanceNumber, _arn, _vpcEndpoint),
+            "aws",
+            DeviceModel.AWS_ELASTICSEARCH_DOMAIN);
 
     cfgNode.getVendorFamily().getAws().setVpcId(_vpcId);
     cfgNode.getVendorFamily().getAws().setRegion(region.getName());
+    cfgNode.getVendorFamily().getAws().setSubnetId(subnetId);
+    cfgNode.setHumanName(_domainName);
 
-    // put the node in first subnet for topology hierarchy
-    cfgNode.getVendorFamily().getAws().setSubnetId(_subnets.isEmpty() ? null : _subnets.get(0));
+    String instancesIfaceName = subnetId;
+    Ip instancesIfaceIp = subnet.getNextIp();
+    ConcreteInterfaceAddress instancesIfaceAddress =
+        ConcreteInterfaceAddress.create(instancesIfaceIp, subnet.getCidrBlock().getPrefixLength());
+    Utils.newInterface(instancesIfaceName, cfgNode, instancesIfaceAddress, "To subnet " + subnetId);
 
-    // create an interface per subnet
-    for (String subnetId : _subnets) {
-      Subnet subnet = region.getSubnets().get(subnetId);
-      if (subnet == null) {
-        warnings.redFlag(
-            String.format(
-                "Subnet \"%s\" for Elasticsearch domain \"%s\" not found", subnetId, _domainName));
-        continue;
-      }
-      String instancesIfaceName = String.format("%s-%s", _domainName, subnetId);
-      Ip instancesIfaceIp = subnet.getNextIp();
-      ConcreteInterfaceAddress instancesIfaceAddress =
-          ConcreteInterfaceAddress.create(
-              instancesIfaceIp, subnet.getCidrBlock().getPrefixLength());
-      Utils.newInterface(
-          instancesIfaceName, cfgNode, instancesIfaceAddress, "To subnet " + subnetId);
+    Utils.addLayer1Edge(
+        awsConfiguration,
+        cfgNode.getHostname(),
+        instancesIfaceName,
+        Subnet.nodeName(subnet.getId()),
+        Subnet.instancesInterfaceName(subnet.getId()));
 
-      Utils.addLayer1Edge(
-          awsConfiguration,
-          cfgNode.getHostname(),
-          instancesIfaceName,
-          Subnet.nodeName(subnet.getId()),
-          Subnet.instancesInterfaceName(subnet.getId()));
-
-      Ip defaultGatewayAddress = subnet.computeInstancesIfaceIp();
-      StaticRoute defaultRoute =
-          StaticRoute.builder()
-              .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
-              .setMetric(Route.DEFAULT_STATIC_ROUTE_COST)
-              .setNextHopIp(defaultGatewayAddress)
-              .setNetwork(Prefix.ZERO)
-              .build();
-      cfgNode.getDefaultVrf().getStaticRoutes().add(defaultRoute);
-    }
+    Ip defaultGatewayAddress = subnet.computeInstancesIfaceIp();
+    StaticRoute defaultRoute =
+        StaticRoute.builder()
+            .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
+            .setMetric(Route.DEFAULT_STATIC_ROUTE_COST)
+            .setNextHopIp(defaultGatewayAddress)
+            .setNetwork(Prefix.ZERO)
+            .build();
+    cfgNode.getDefaultVrf().getStaticRoutes().add(defaultRoute);
 
     return cfgNode;
+  }
+
+  @Nonnull
+  static String getNodeName(int instanceNumber, String arn, @Nullable String vpcEndpoint) {
+    return String.format("%d-%s", instanceNumber, vpcEndpoint == null ? arn : vpcEndpoint);
   }
 
   @Override
@@ -192,15 +277,26 @@ public final class ElasticsearchDomain implements AwsVpcEntity, Serializable {
       return false;
     }
     ElasticsearchDomain that = (ElasticsearchDomain) o;
-    return _available == that._available
+    return _arn.equals(that._arn)
+        && _available == that._available
+        && _instanceCount == that._instanceCount
         && Objects.equals(_securityGroups, that._securityGroups)
         && Objects.equals(_domainName, that._domainName)
         && Objects.equals(_vpcId, that._vpcId)
+        && Objects.equals(_vpcEndpoint, that._vpcEndpoint)
         && Objects.equals(_subnets, that._subnets);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_securityGroups, _domainName, _vpcId, _subnets, _available);
+    return Objects.hash(
+        _arn,
+        _instanceCount,
+        _vpcEndpoint,
+        _securityGroups,
+        _domainName,
+        _vpcId,
+        _subnets,
+        _available);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/ElasticsearchDomain.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/ElasticsearchDomain.java
@@ -237,6 +237,7 @@ public final class ElasticsearchDomain implements AwsVpcEntity, Serializable {
     cfgNode.getVendorFamily().getAws().setSubnetId(subnetId);
     cfgNode.setHumanName(_domainName);
 
+    // TODO: a better way to get IPs in the subnet, use the network interface data or DNS queries
     String instancesIfaceName = subnetId;
     Ip instancesIfaceIp = subnet.getNextIp();
     ConcreteInterfaceAddress instancesIfaceAddress =

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -10,6 +10,7 @@ import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasDeviceMode
 import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchCondition;
 import static org.batfish.datamodel.matchers.IpAccessListMatchers.hasLines;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_DOMAIN_STATUS_LIST;
+import static org.batfish.representation.aws.ElasticsearchDomain.getNodeName;
 import static org.batfish.representation.aws.Region.computeAntiSpoofingFilter;
 import static org.batfish.representation.aws.Region.eniEgressAclName;
 import static org.batfish.representation.aws.Region.eniIngressAclName;
@@ -18,6 +19,7 @@ import static org.batfish.representation.aws.Utils.traceElementForAddress;
 import static org.batfish.representation.aws.Utils.traceElementForDstPorts;
 import static org.batfish.representation.aws.Utils.traceElementForProtocol;
 import static org.batfish.representation.aws.Utils.traceTextForAddress;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -28,13 +30,16 @@ import static org.junit.Assert.assertThat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.testing.EqualsTester;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.IntStream;
 import org.batfish.common.Warnings;
 import org.batfish.common.topology.TopologyUtil;
 import org.batfish.common.util.BatfishObjectMapper;
@@ -69,6 +74,9 @@ public class ElasticsearchDomainTest {
 
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
   private StaticRoute.Builder _staticRouteBuilder;
+  private Map<String, Configuration> _configurations;
+  private String _node0Name;
+  private String _node1Name;
 
   public static final MatchHeaderSpace matchTcp =
       new MatchHeaderSpace(
@@ -81,15 +89,26 @@ public class ElasticsearchDomainTest {
   }
 
   @Before
-  public void setup() {
+  public void setup() throws IOException {
     _staticRouteBuilder =
         StaticRoute.builder()
             .setAdministrativeCost(Route.DEFAULT_STATIC_ROUTE_ADMIN)
             .setMetric(Route.DEFAULT_STATIC_ROUTE_COST)
             .setNetwork(Prefix.ZERO);
+    _node0Name =
+        getNodeName(
+            0,
+            "arn:aws:es:us-west-2:118292266645:domain/es-domain",
+            "vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com");
+    _node1Name =
+        getNodeName(
+            1,
+            "arn:aws:es:us-west-2:118292266645:domain/es-domain",
+            "vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com");
+    _configurations = loadAwsConfigurations();
   }
 
-  public Map<String, Configuration> loadAwsConfigurations() throws IOException {
+  private Map<String, Configuration> loadAwsConfigurations() throws IOException {
     List<String> awsFilenames =
         ImmutableList.of(
             "ElasticsearchDomains.json",
@@ -110,8 +129,7 @@ public class ElasticsearchDomainTest {
 
   @Test
   public void testEsSubnetEdge() throws IOException {
-    Map<String, Configuration> configurations = loadAwsConfigurations();
-    Topology topology = TopologyUtil.synthesizeL3Topology(configurations);
+    Topology topology = TopologyUtil.synthesizeL3Topology(_configurations);
 
     // check that ES instance is a neighbor of both  subnets in which its interfaces are
     assertThat(
@@ -120,23 +138,21 @@ public class ElasticsearchDomainTest {
             new Edge(
                 NodeInterfacePair.of(
                     "subnet-073b8061", Subnet.instancesInterfaceName("subnet-073b8061")),
-                NodeInterfacePair.of("es-domain", "es-domain-subnet-073b8061"))));
+                NodeInterfacePair.of(_node0Name, "subnet-073b8061"))));
     assertThat(
         topology.getEdges(),
         hasItem(
             new Edge(
                 NodeInterfacePair.of(
                     "subnet-1f315846", Subnet.instancesInterfaceName("subnet-1f315846")),
-                NodeInterfacePair.of("es-domain", "es-domain-subnet-1f315846"))));
+                NodeInterfacePair.of(_node1Name, "subnet-1f315846"))));
   }
 
+  /** Check that IPs are unique for all the interfaces */
   @Test
   public void testUniqueIps() throws IOException {
-    Map<String, Configuration> configurations = loadAwsConfigurations();
-
-    // check that  IPs are unique for all the interfaces
     List<Ip> ipsAsList =
-        configurations.values().stream()
+        _configurations.values().stream()
             .map(Configuration::getAllInterfaces)
             .map(Map::values)
             .flatMap(Collection::stream)
@@ -149,16 +165,17 @@ public class ElasticsearchDomainTest {
   }
 
   @Test
-  public void testDefaultRoute() throws IOException {
-    Map<String, Configuration> configurations = loadAwsConfigurations();
+  public void testDefaultRoute() {
+    StaticRoute defaultRoute0 = _staticRouteBuilder.setNextHopIp(Ip.parse("192.168.2.17")).build();
     StaticRoute defaultRoute1 = _staticRouteBuilder.setNextHopIp(Ip.parse("172.31.0.1")).build();
-    StaticRoute defaultRoute2 = _staticRouteBuilder.setNextHopIp(Ip.parse("192.168.2.17")).build();
 
-    // checking that both default routes exist(to both the subnets) in RDS instance
-    assertThat(configurations, hasKey("es-domain"));
+    assertThat(_configurations, allOf(hasKey(_node0Name), hasKey(_node1Name)));
     assertThat(
-        configurations.get("es-domain").getDefaultVrf().getStaticRoutes(),
-        containsInAnyOrder(defaultRoute1, defaultRoute2));
+        _configurations.get(_node0Name).getDefaultVrf().getStaticRoutes(),
+        containsInAnyOrder(defaultRoute0));
+    assertThat(
+        _configurations.get(_node1Name).getDefaultVrf().getStaticRoutes(),
+        containsInAnyOrder(defaultRoute1));
   }
 
   @Test
@@ -180,23 +197,23 @@ public class ElasticsearchDomainTest {
         equalTo(
             ImmutableList.of(
                 new ElasticsearchDomain(
+                    "arn:aws:es:us-west-2:118292266645:domain/es-domain",
                     "es-domain",
                     "vpc-b390fad5",
+                    "vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
+                    2,
                     ImmutableList.of("sg-55510831"),
                     ImmutableList.of("subnet-7044ff16"),
                     true))));
   }
 
   @Test
-  public void testSecurityGroupsAcl() throws IOException {
-    Map<String, Configuration> configurations = loadAwsConfigurations();
-
-    assertThat(configurations, hasKey("es-domain"));
-    Configuration esDomain = configurations.get("es-domain");
-    assertThat(esDomain, hasDeviceModel(DeviceModel.AWS_ELASTICSEARCH_DOMAIN));
-    assertThat(esDomain.getAllInterfaces().entrySet(), hasSize(2));
+  public void testSecurityGroupsAcl() {
+    Configuration node0 = _configurations.get(_node0Name);
+    assertThat(node0, hasDeviceModel(DeviceModel.AWS_ELASTICSEARCH_DOMAIN));
+    assertThat(node0.getAllInterfaces().entrySet(), hasSize(1));
     assertThat(
-        esDomain
+        node0
             .getIpAccessLists()
             .get("~EGRESS~SECURITY-GROUP~Test Security Group~sg-0de0ddfa8a5a45810~"),
         hasLines(
@@ -207,7 +224,7 @@ public class ElasticsearchDomainTest {
                         traceElementForAddress(
                             "destination", "0.0.0.0/0", AddressType.CIDR_IP))))));
     assertThat(
-        esDomain
+        node0
             .getIpAccessLists()
             .get("~INGRESS~SECURITY-GROUP~Test Security Group~sg-0de0ddfa8a5a45810~"),
         hasLines(
@@ -237,11 +254,11 @@ public class ElasticsearchDomainTest {
                                         .build(),
                                     traceElementEniPrivateIp(
                                         "eni-05e8949c37b78cf4d on i-066b1b9957b9200e7 (Test host)")))))))));
-    for (Interface iface : esDomain.getAllInterfaces().values()) {
+    for (Interface iface : node0.getAllInterfaces().values()) {
       assertThat(iface.getIncomingFilter().getName(), equalTo(eniIngressAclName(iface.getName())));
       assertThat(iface.getOutgoingFilter().getName(), equalTo(eniEgressAclName(iface.getName())));
       assertThat(
-          esDomain.getIpAccessLists().get(eniEgressAclName(iface.getName())).getLines(),
+          node0.getIpAccessLists().get(eniEgressAclName(iface.getName())).getLines(),
           equalTo(
               ImmutableList.of(
                   computeAntiSpoofingFilter(iface),
@@ -250,7 +267,7 @@ public class ElasticsearchDomainTest {
                       "~EGRESS~SECURITY-GROUP~Test Security Group~" + "sg-0de0ddfa8a5a45810~",
                       Utils.getTraceElementForSecurityGroup("Test Security Group")))));
       assertThat(
-          esDomain.getIpAccessLists().get(eniIngressAclName(iface.getName())).getLines(),
+          node0.getIpAccessLists().get(eniIngressAclName(iface.getName())).getLines(),
           equalTo(
               ImmutableList.of(
                   new AclAclLine(
@@ -265,24 +282,119 @@ public class ElasticsearchDomainTest {
     }
   }
 
-  /** Test that the hierarchy is configured properly */
+  /** Test that the hierarchy and human name is configured properly */
   @Test
-  public void testToConfigurationNode_hierarchy() {
+  public void testToConfigurationNode() {
+    Subnet subnet =
+        new Subnet(Prefix.parse("1.1.1.0/24"), "subnet", "vpc", "az", ImmutableMap.of());
     ElasticsearchDomain esd =
         new ElasticsearchDomain(
+            "arn",
             "es-domain",
             "vpc",
-            ImmutableList.of("sg-55510831"),
-            ImmutableList.of("subnet-7", "subnet-8"),
+            "vpcEndpoint",
+            4,
+            ImmutableList.of("sg"),
+            ImmutableList.of(subnet.getId()),
             true);
 
     Configuration cfg =
         esd.toConfigurationNode(
-            new ConvertedConfiguration(), Region.builder("r1").build(), new Warnings());
+            0,
+            subnet.getId(),
+            new ConvertedConfiguration(),
+            Region.builder("r1").setSubnets(ImmutableMap.of(subnet.getId(), subnet)).build(),
+            new Warnings());
 
     AwsFamily awsFamily = cfg.getVendorFamily().getAws();
-    assertThat(awsFamily.getSubnetId(), equalTo("subnet-7"));
+    assertThat(awsFamily.getSubnetId(), equalTo(esd.getSubnets().get(0)));
     assertThat(awsFamily.getVpcId(), equalTo("vpc"));
     assertThat(awsFamily.getRegion(), equalTo("r1"));
+    assertThat(cfg.getHumanName(), equalTo(esd.getDomainName()));
+  }
+
+  /** Test that the expected set of nodes is generated by the entry function */
+  @Test
+  public void testToConfigurationNodes() {
+    Subnet subnet0 =
+        new Subnet(Prefix.parse("1.1.1.0/24"), "subnet0", "vpc", "az", ImmutableMap.of());
+    Subnet subnet1 =
+        new Subnet(Prefix.parse("1.1.1.0/24"), "subnet1", "vpc", "az", ImmutableMap.of());
+    ElasticsearchDomain esd =
+        new ElasticsearchDomain(
+            "arn",
+            "es-domain",
+            "vpc",
+            "vpcendpoint",
+            4,
+            ImmutableList.of("sg"),
+            ImmutableList.of(subnet0.getId(), subnet1.getId()),
+            true);
+
+    List<Configuration> configurations =
+        esd.toConfigurationNodes(
+            new ConvertedConfiguration(),
+            Region.builder("r1")
+                .setSubnets(ImmutableMap.of(subnet0.getId(), subnet0, subnet1.getId(), subnet1))
+                .build(),
+            new Warnings());
+
+    assertThat(
+        configurations.stream()
+            .map(Configuration::getHostname)
+            .collect(ImmutableList.toImmutableList()),
+        equalTo(
+            IntStream.range(0, esd.getInstanceCount())
+                .mapToObj(i -> getNodeName(i, esd.getId(), esd.getVpcEndpoint()))
+                .collect(ImmutableList.toImmutableList())));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new ElasticsearchDomain(
+                "arn", "domain", "vpc", "point", 1, ImmutableList.of(), ImmutableList.of(), true),
+            new ElasticsearchDomain(
+                "arn", "domain", "vpc", "point", 1, ImmutableList.of(), ImmutableList.of(), true))
+        .addEqualityGroup(
+            new ElasticsearchDomain(
+                "other", "domain", "vpc", "point", 1, ImmutableList.of(), ImmutableList.of(), true))
+        .addEqualityGroup(
+            new ElasticsearchDomain(
+                "arn", "other", "vpc", "point", 1, ImmutableList.of(), ImmutableList.of(), true))
+        .addEqualityGroup(
+            new ElasticsearchDomain(
+                "arn", "domain", "other", "point", 1, ImmutableList.of(), ImmutableList.of(), true))
+        .addEqualityGroup(
+            new ElasticsearchDomain(
+                "arn", "domain", "vpc", "other", 1, ImmutableList.of(), ImmutableList.of(), true))
+        .addEqualityGroup(
+            new ElasticsearchDomain(
+                "arn", "domain", "vpc", "point", 0, ImmutableList.of(), ImmutableList.of(), true))
+        .addEqualityGroup(
+            new ElasticsearchDomain(
+                "arn",
+                "domain",
+                "vpc",
+                "point",
+                1,
+                ImmutableList.of("other"),
+                ImmutableList.of(),
+                true))
+        .addEqualityGroup(
+            new ElasticsearchDomain(
+                "arn",
+                "domain",
+                "vpc",
+                "point",
+                1,
+                ImmutableList.of(),
+                ImmutableList.of("other"),
+                true))
+        .addEqualityGroup(
+            new ElasticsearchDomain(
+                "arn", "domain", "vpc", "point", 1, ImmutableList.of(), ImmutableList.of(), false))
+        .testEquals();
   }
 }

--- a/tests/aws/init-example-aws.ref
+++ b/tests/aws/init-example-aws.ref
@@ -350,8 +350,9 @@
     },
     "fileMap" : {
       "aws_configs" : [
+        "0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
+        "1-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
         "__aws-services-gateway__",
-        "es-domain",
         "igw-068fee63",
         "igw-9b93ddfc",
         "igw-fac5839d",

--- a/tests/aws/topology-example-aws.ref
+++ b/tests/aws/topology-example-aws.ref
@@ -56,6 +56,17 @@
     },
     {
       "contents" : [
+        "node-subnet-1641fa70",
+        "node-0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
+        "node-test-rds"
+      ],
+      "id" : "aggregate-subnet-1641fa70",
+      "name" : "subnet-1641fa70",
+      "type" : "SUBNET",
+      "properties" : null
+    },
+    {
+      "contents" : [
         "node-subnet-073b8061"
       ],
       "id" : "aggregate-subnet-073b8061",
@@ -75,6 +86,16 @@
       "id" : "aggregate-vpc-b390fad5",
       "name" : "vpc-b390fad5",
       "type" : "VNET",
+      "properties" : null
+    },
+    {
+      "contents" : [
+        "node-1-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
+        "node-subnet-7044ff16"
+      ],
+      "id" : "aggregate-subnet-7044ff16",
+      "name" : "subnet-7044ff16",
+      "type" : "SUBNET",
       "properties" : null
     },
     {
@@ -116,26 +137,6 @@
       "id" : "aggregate-vpc-f8fad69d",
       "name" : "vpc-f8fad69d",
       "type" : "VNET",
-      "properties" : null
-    },
-    {
-      "contents" : [
-        "node-subnet-7044ff16"
-      ],
-      "id" : "aggregate-subnet-7044ff16",
-      "name" : "subnet-7044ff16",
-      "type" : "SUBNET",
-      "properties" : null
-    },
-    {
-      "contents" : [
-        "node-subnet-1641fa70",
-        "node-es-domain",
-        "node-test-rds"
-      ],
-      "id" : "aggregate-subnet-1641fa70",
-      "name" : "subnet-1641fa70",
-      "type" : "SUBNET",
       "properties" : null
     },
     {
@@ -210,6 +211,13 @@
       "properties" : null
     },
     {
+      "id" : "interface-node-0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-1641fa70",
+      "name" : "subnet-1641fa70",
+      "nodeId" : "node-0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
       "id" : "interface-node-isp_16509-To-igw-9b93ddfc",
       "name" : "To-igw-9b93ddfc",
       "nodeId" : "node-isp_16509",
@@ -224,16 +232,16 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-es-domain-es-domain-subnet-7044ff16",
-      "name" : "es-domain-subnet-7044ff16",
-      "nodeId" : "node-es-domain",
+      "id" : "interface-node-vpc-b390fad5-subnet-f73a8191",
+      "name" : "subnet-f73a8191",
+      "nodeId" : "node-vpc-b390fad5",
       "type" : "PHYSICAL",
       "properties" : null
     },
     {
-      "id" : "interface-node-vpc-b390fad5-subnet-f73a8191",
-      "name" : "subnet-f73a8191",
-      "nodeId" : "node-vpc-b390fad5",
+      "id" : "interface-node-1-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-7044ff16",
+      "name" : "subnet-7044ff16",
+      "nodeId" : "node-1-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -441,13 +449,6 @@
       "properties" : null
     },
     {
-      "id" : "interface-node-es-domain-es-domain-subnet-1641fa70",
-      "name" : "es-domain-subnet-1641fa70",
-      "nodeId" : "node-es-domain",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
       "id" : "interface-node-vpc-b390fad5-subnet-073b8061-vrf-igw-9b93ddfc",
       "name" : "subnet-073b8061-vrf-igw-9b93ddfc",
       "nodeId" : "node-vpc-b390fad5",
@@ -625,20 +626,6 @@
   ],
   "links" : [
     {
-      "dstId" : "interface-node-subnet-7044ff16-to-instances",
-      "id" : "link-interface-node-es-domain-es-domain-subnet-7044ff16-interface-node-subnet-7044ff16-to-instances",
-      "srcId" : "interface-node-es-domain-es-domain-subnet-7044ff16",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-es-domain-es-domain-subnet-7044ff16",
-      "id" : "link-interface-node-subnet-7044ff16-to-instances-interface-node-es-domain-es-domain-subnet-7044ff16",
-      "srcId" : "interface-node-subnet-7044ff16-to-instances",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
       "dstId" : "interface-node-subnet-1641fa70-vpc-b390fad5-vrf-igw-9b93ddfc",
       "id" : "link-interface-node-vpc-b390fad5-subnet-1641fa70-vrf-igw-9b93ddfc-interface-node-subnet-1641fa70-vpc-b390fad5-vrf-igw-9b93ddfc",
       "srcId" : "interface-node-vpc-b390fad5-subnet-1641fa70-vrf-igw-9b93ddfc",
@@ -664,6 +651,13 @@
       "id" : "link-interface-node-isp_16509-To-igw-9b93ddfc-interface-node-igw-9b93ddfc-backbone",
       "srcId" : "interface-node-isp_16509-To-igw-9b93ddfc",
       "type" : "UNKNOWN",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-1-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-7044ff16",
+      "id" : "link-interface-node-subnet-7044ff16-to-instances-interface-node-1-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-7044ff16",
+      "srcId" : "interface-node-subnet-7044ff16-to-instances",
+      "type" : "PHYSICAL",
       "properties" : null
     },
     {
@@ -828,6 +822,13 @@
       "properties" : null
     },
     {
+      "dstId" : "interface-node-test-rds-test-rds-subnet-1641fa70",
+      "id" : "link-interface-node-0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-1641fa70-interface-node-test-rds-test-rds-subnet-1641fa70",
+      "srcId" : "interface-node-0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-1641fa70",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
       "dstId" : "interface-node-vpc-925131f4-subnet-8d0cbdeb",
       "id" : "link-interface-node-subnet-8d0cbdeb-vpc-925131f4-interface-node-vpc-925131f4-subnet-8d0cbdeb",
       "srcId" : "interface-node-subnet-8d0cbdeb-vpc-925131f4",
@@ -838,6 +839,13 @@
       "dstId" : "interface-node-igw-068fee63-vpc-f8fad69d",
       "id" : "link-interface-node-vpc-f8fad69d-igw-068fee63-interface-node-igw-068fee63-vpc-f8fad69d",
       "srcId" : "interface-node-vpc-f8fad69d-igw-068fee63",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-subnet-1641fa70-to-instances",
+      "id" : "link-interface-node-0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-1641fa70-interface-node-subnet-1641fa70-to-instances",
+      "srcId" : "interface-node-0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-1641fa70",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -898,6 +906,13 @@
       "properties" : null
     },
     {
+      "dstId" : "interface-node-0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-1641fa70",
+      "id" : "link-interface-node-subnet-1641fa70-to-instances-interface-node-0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-1641fa70",
+      "srcId" : "interface-node-subnet-1641fa70-to-instances",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
       "dstId" : "interface-node-isp_16509-To-__aws-services-gateway__",
       "id" : "link-interface-node-__aws-services-gateway__-backbone-interface-node-isp_16509-To-__aws-services-gateway__",
       "srcId" : "interface-node-__aws-services-gateway__-backbone",
@@ -908,6 +923,13 @@
       "dstId" : "interface-node-vpc-f8fad69d-subnet-9c8adceb-vrf-igw-068fee63",
       "id" : "link-interface-node-subnet-9c8adceb-vpc-f8fad69d-vrf-igw-068fee63-interface-node-vpc-f8fad69d-subnet-9c8adceb-vrf-igw-068fee63",
       "srcId" : "interface-node-subnet-9c8adceb-vpc-f8fad69d-vrf-igw-068fee63",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-subnet-7044ff16-to-instances",
+      "id" : "link-interface-node-1-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-7044ff16-interface-node-subnet-7044ff16-to-instances",
+      "srcId" : "interface-node-1-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-7044ff16",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -933,20 +955,6 @@
       "properties" : null
     },
     {
-      "dstId" : "interface-node-es-domain-es-domain-subnet-1641fa70",
-      "id" : "link-interface-node-subnet-1641fa70-to-instances-interface-node-es-domain-es-domain-subnet-1641fa70",
-      "srcId" : "interface-node-subnet-1641fa70-to-instances",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-subnet-1641fa70-to-instances",
-      "id" : "link-interface-node-es-domain-es-domain-subnet-1641fa70-interface-node-subnet-1641fa70-to-instances",
-      "srcId" : "interface-node-es-domain-es-domain-subnet-1641fa70",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
       "dstId" : "interface-node-vpc-925131f4-igw-fac5839d",
       "id" : "link-interface-node-igw-fac5839d-vpc-925131f4-interface-node-vpc-925131f4-igw-fac5839d",
       "srcId" : "interface-node-igw-fac5839d-vpc-925131f4",
@@ -957,6 +965,13 @@
       "dstId" : "interface-node-vpc-b390fad5-subnet-7044ff16",
       "id" : "link-interface-node-subnet-7044ff16-vpc-b390fad5-interface-node-vpc-b390fad5-subnet-7044ff16",
       "srcId" : "interface-node-subnet-7044ff16-vpc-b390fad5",
+      "type" : "PHYSICAL",
+      "properties" : null
+    },
+    {
+      "dstId" : "interface-node-0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-1641fa70",
+      "id" : "link-interface-node-test-rds-test-rds-subnet-1641fa70-interface-node-0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com-subnet-1641fa70",
+      "srcId" : "interface-node-test-rds-test-rds-subnet-1641fa70",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -985,13 +1000,6 @@
       "dstId" : "interface-node-vpc-b390fad5-subnet-30398256-vrf-igw-9b93ddfc",
       "id" : "link-interface-node-subnet-30398256-vpc-b390fad5-vrf-igw-9b93ddfc-interface-node-vpc-b390fad5-subnet-30398256-vrf-igw-9b93ddfc",
       "srcId" : "interface-node-subnet-30398256-vpc-b390fad5-vrf-igw-9b93ddfc",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-es-domain-es-domain-subnet-1641fa70",
-      "id" : "link-interface-node-test-rds-test-rds-subnet-1641fa70-interface-node-es-domain-es-domain-subnet-1641fa70",
-      "srcId" : "interface-node-test-rds-test-rds-subnet-1641fa70",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -1041,13 +1049,6 @@
       "dstId" : "interface-node-subnet-073b8061-vpc-b390fad5",
       "id" : "link-interface-node-vpc-b390fad5-subnet-073b8061-interface-node-subnet-073b8061-vpc-b390fad5",
       "srcId" : "interface-node-vpc-b390fad5-subnet-073b8061",
-      "type" : "PHYSICAL",
-      "properties" : null
-    },
-    {
-      "dstId" : "interface-node-test-rds-test-rds-subnet-1641fa70",
-      "id" : "link-interface-node-es-domain-es-domain-subnet-1641fa70-interface-node-test-rds-test-rds-subnet-1641fa70",
-      "srcId" : "interface-node-es-domain-es-domain-subnet-1641fa70",
       "type" : "PHYSICAL",
       "properties" : null
     },
@@ -1124,13 +1125,6 @@
       "properties" : null
     },
     {
-      "id" : "node-subnet-d9cafabc",
-      "model" : "AWS_SUBNET_PUBLIC",
-      "name" : "subnet-d9cafabc",
-      "type" : "SWITCH",
-      "properties" : null
-    },
-    {
       "id" : "node-isp_16509",
       "model" : "BATFISH_ISP",
       "name" : "isp_16509",
@@ -1145,16 +1139,79 @@
       "properties" : null
     },
     {
-      "id" : "node-es-domain",
-      "model" : "AWS_ELASTICSEARCH_DOMAIN",
-      "name" : "es-domain",
+      "id" : "node-test-rds",
+      "model" : "AWS_RDS_INSTANCE",
+      "name" : "test-rds",
       "type" : "HOST",
       "properties" : null
     },
     {
-      "id" : "node-test-rds",
-      "model" : "AWS_RDS_INSTANCE",
-      "name" : "test-rds",
+      "id" : "node-subnet-1f315846",
+      "model" : "AWS_SUBNET_PUBLIC",
+      "name" : "subnet-1f315846",
+      "type" : "SWITCH",
+      "properties" : null
+    },
+    {
+      "id" : "node-subnet-073b8061",
+      "model" : "AWS_SUBNET_PUBLIC",
+      "name" : "subnet-073b8061",
+      "type" : "SWITCH",
+      "properties" : null
+    },
+    {
+      "id" : "node-subnet-1641fa70",
+      "model" : "AWS_SUBNET_PUBLIC",
+      "name" : "subnet-1641fa70",
+      "type" : "SWITCH",
+      "properties" : null
+    },
+    {
+      "id" : "node-1-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
+      "model" : "AWS_ELASTICSEARCH_DOMAIN",
+      "name" : "1-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
+      "type" : "HOST",
+      "properties" : null
+    },
+    {
+      "id" : "node-__aws-services-gateway__",
+      "model" : "AWS_SERVICES_GATEWAY",
+      "name" : "__aws-services-gateway__",
+      "type" : "ROUTER",
+      "properties" : null
+    },
+    {
+      "id" : "node-igw-068fee63",
+      "model" : "AWS_INTERNET_GATEWAY",
+      "name" : "igw-068fee63",
+      "type" : "ROUTER",
+      "properties" : null
+    },
+    {
+      "id" : "node-subnet-8d0cbdeb",
+      "model" : "AWS_SUBNET_PRIVATE",
+      "name" : "subnet-8d0cbdeb",
+      "type" : "SWITCH",
+      "properties" : null
+    },
+    {
+      "id" : "node-vpc-925131f4",
+      "model" : "AWS_VPC",
+      "name" : "vpc-925131f4",
+      "type" : "SWITCH",
+      "properties" : null
+    },
+    {
+      "id" : "node-subnet-d9cafabc",
+      "model" : "AWS_SUBNET_PUBLIC",
+      "name" : "subnet-d9cafabc",
+      "type" : "SWITCH",
+      "properties" : null
+    },
+    {
+      "id" : "node-0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
+      "model" : "AWS_ELASTICSEARCH_DOMAIN",
+      "name" : "0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
       "type" : "HOST",
       "properties" : null
     },
@@ -1180,27 +1237,6 @@
       "properties" : null
     },
     {
-      "id" : "node-subnet-1f315846",
-      "model" : "AWS_SUBNET_PUBLIC",
-      "name" : "subnet-1f315846",
-      "type" : "SWITCH",
-      "properties" : null
-    },
-    {
-      "id" : "node-subnet-073b8061",
-      "model" : "AWS_SUBNET_PUBLIC",
-      "name" : "subnet-073b8061",
-      "type" : "SWITCH",
-      "properties" : null
-    },
-    {
-      "id" : "node-subnet-1641fa70",
-      "model" : "AWS_SUBNET_PUBLIC",
-      "name" : "subnet-1641fa70",
-      "type" : "SWITCH",
-      "properties" : null
-    },
-    {
       "id" : "node-vpc-f8fad69d",
       "model" : "AWS_VPC",
       "name" : "vpc-f8fad69d",
@@ -1208,24 +1244,10 @@
       "properties" : null
     },
     {
-      "id" : "node-__aws-services-gateway__",
-      "model" : "AWS_SERVICES_GATEWAY",
-      "name" : "__aws-services-gateway__",
-      "type" : "ROUTER",
-      "properties" : null
-    },
-    {
       "id" : "node-subnet-62f14104",
       "model" : "AWS_SUBNET_PUBLIC",
       "name" : "subnet-62f14104",
       "type" : "SWITCH",
-      "properties" : null
-    },
-    {
-      "id" : "node-igw-068fee63",
-      "model" : "AWS_INTERNET_GATEWAY",
-      "name" : "igw-068fee63",
-      "type" : "ROUTER",
       "properties" : null
     },
     {
@@ -1243,13 +1265,6 @@
       "properties" : null
     },
     {
-      "id" : "node-subnet-8d0cbdeb",
-      "model" : "AWS_SUBNET_PRIVATE",
-      "name" : "subnet-8d0cbdeb",
-      "type" : "SWITCH",
-      "properties" : null
-    },
-    {
       "id" : "node-vgw-81fd279f",
       "model" : "AWS_VPN_GATEWAY",
       "name" : "vgw-81fd279f",
@@ -1260,13 +1275,6 @@
       "id" : "node-subnet-f73a8191",
       "model" : "AWS_SUBNET_PUBLIC",
       "name" : "subnet-f73a8191",
-      "type" : "SWITCH",
-      "properties" : null
-    },
-    {
-      "id" : "node-vpc-925131f4",
-      "model" : "AWS_VPC",
-      "name" : "vpc-925131f4",
       "type" : "SWITCH",
       "properties" : null
     }

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -2,6 +2,442 @@
   {
     "class" : "org.batfish.question.VIModelQuestionPlugin$VIModelAnswerElement",
     "nodes" : {
+      "0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com" : {
+        "configurationFormat" : "AWS",
+        "name" : "0-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceModel" : "AWS_ELASTICSEARCH_DOMAIN",
+        "deviceType" : "HOST",
+        "domainName" : "aws",
+        "humanName" : "es-domain",
+        "interfaces" : {
+          "subnet-1641fa70" : {
+            "name" : "subnet-1641fa70",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allPrefixes" : [
+              "192.168.1.2/24"
+            ],
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "description" : "To subnet subnet-1641fa70",
+            "firewallSessionInterfaceInfo" : {
+              "fibLookup" : false,
+              "sessionInterfaces" : [
+                "subnet-1641fa70"
+              ]
+            },
+            "incomingFilter" : "~INGRESS_ACL~subnet-1641fa70",
+            "mtu" : 1500,
+            "outgoingFilter" : "~EGRESS_ACL~subnet-1641fa70",
+            "prefix" : "192.168.1.2/24",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "~EGRESS_ACL~subnet-1641fa70" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.NotMatchExpr",
+                  "operand" : {
+                    "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                    "headerSpace" : {
+                      "negate" : false,
+                      "srcIps" : {
+                        "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
+                        "whitelist" : [
+                          "192.168.1.2"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Deny spoofed source IPs"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~EGRESS_ACL~subnet-1641fa70"
+          },
+          "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.UniverseIpSpace"
+                    },
+                    "negate" : false
+                  },
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched destination address CIDR IP 0.0.0.0/0"
+                      }
+                    ]
+                  }
+                },
+                "name" : "sg-3dfb3140 - default [egress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule with no description"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
+          },
+          "~INGRESS_ACL~subnet-1641fa70" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~INGRESS_ACL~subnet-1641fa70"
+          },
+          "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.OrMatchExpr",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "negate" : false,
+                        "srcIps" : {
+                          "class" : "org.batfish.datamodel.IpIpSpace",
+                          "ip" : "192.168.1.3"
+                        }
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched private IP of RDS database test-rds"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched source address Security Group default"
+                      }
+                    ]
+                  }
+                },
+                "name" : "sg-3dfb3140 - default [ingress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule with no description"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
+          }
+        },
+        "vendorFamily" : {
+          "aws" : {
+            "region" : "us-west-2",
+            "subnetId" : "subnet-1641fa70",
+            "vpcId" : "vpc-b390fad5"
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "hasOriginatingSessions" : true,
+            "staticRoutes" : [
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "0.0.0.0/0",
+                "nextHopInterface" : "dynamic",
+                "nextHopIp" : "192.168.1.1",
+                "tag" : -1
+              }
+            ]
+          }
+        }
+      },
+      "1-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com" : {
+        "configurationFormat" : "AWS",
+        "name" : "1-vpc-es-domain-uiqo2tedr5ttdqrhdzcu5upaee.us-west-2.es.amazonaws.com",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceModel" : "AWS_ELASTICSEARCH_DOMAIN",
+        "deviceType" : "HOST",
+        "domainName" : "aws",
+        "humanName" : "es-domain",
+        "interfaces" : {
+          "subnet-7044ff16" : {
+            "name" : "subnet-7044ff16",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allPrefixes" : [
+              "192.168.2.2/28"
+            ],
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E12,
+            "description" : "To subnet subnet-7044ff16",
+            "firewallSessionInterfaceInfo" : {
+              "fibLookup" : false,
+              "sessionInterfaces" : [
+                "subnet-7044ff16"
+              ]
+            },
+            "incomingFilter" : "~INGRESS_ACL~subnet-7044ff16",
+            "mtu" : 1500,
+            "outgoingFilter" : "~EGRESS_ACL~subnet-7044ff16",
+            "prefix" : "192.168.2.2/28",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          }
+        },
+        "ipAccessLists" : {
+          "~EGRESS_ACL~subnet-7044ff16" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.NotMatchExpr",
+                  "operand" : {
+                    "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                    "headerSpace" : {
+                      "negate" : false,
+                      "srcIps" : {
+                        "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
+                        "whitelist" : [
+                          "192.168.2.2"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Deny spoofed source IPs"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~EGRESS_ACL~subnet-7044ff16"
+          },
+          "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                  "headerSpace" : {
+                    "dstIps" : {
+                      "class" : "org.batfish.datamodel.UniverseIpSpace"
+                    },
+                    "negate" : false
+                  },
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched destination address CIDR IP 0.0.0.0/0"
+                      }
+                    ]
+                  }
+                },
+                "name" : "sg-3dfb3140 - default [egress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule with no description"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
+          },
+          "~INGRESS_ACL~subnet-7044ff16" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
+                "name" : "Security Group default",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched security group default"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~INGRESS_ACL~subnet-7044ff16"
+          },
+          "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.OrMatchExpr",
+                  "disjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "negate" : false,
+                        "srcIps" : {
+                          "class" : "org.batfish.datamodel.IpIpSpace",
+                          "ip" : "192.168.1.3"
+                        }
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched private IP of RDS database test-rds"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "traceElement" : {
+                    "fragments" : [
+                      {
+                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                        "text" : "Matched source address Security Group default"
+                      }
+                    ]
+                  }
+                },
+                "name" : "sg-3dfb3140 - default [ingress] 0",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched rule with no description"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
+          }
+        },
+        "vendorFamily" : {
+          "aws" : {
+            "region" : "us-west-2",
+            "subnetId" : "subnet-7044ff16",
+            "vpcId" : "vpc-b390fad5"
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "hasOriginatingSessions" : true,
+            "staticRoutes" : [
+              {
+                "class" : "org.batfish.datamodel.StaticRoute",
+                "administrativeCost" : 1,
+                "metric" : 0,
+                "network" : "0.0.0.0/0",
+                "nextHopInterface" : "dynamic",
+                "nextHopIp" : "192.168.2.1",
+                "tag" : -1
+              }
+            ]
+          }
+        }
+      },
       "__aws-services-gateway__" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "__aws-services-gateway__",
@@ -12821,328 +13257,6 @@
                 "network" : "223.71.71.128/25",
                 "nextHopInterface" : "aws-services",
                 "nextHopIp" : "AUTO/NONE(-1l)",
-                "tag" : -1
-              }
-            ]
-          }
-        }
-      },
-      "es-domain" : {
-        "configurationFormat" : "AWS",
-        "name" : "es-domain",
-        "defaultCrossZoneAction" : "PERMIT",
-        "defaultInboundAction" : "PERMIT",
-        "deviceModel" : "AWS_ELASTICSEARCH_DOMAIN",
-        "deviceType" : "HOST",
-        "domainName" : "aws",
-        "interfaces" : {
-          "es-domain-subnet-1641fa70" : {
-            "name" : "es-domain-subnet-1641fa70",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allPrefixes" : [
-              "192.168.1.2/24"
-            ],
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E12,
-            "description" : "To subnet subnet-1641fa70",
-            "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
-              "sessionInterfaces" : [
-                "es-domain-subnet-1641fa70"
-              ]
-            },
-            "incomingFilter" : "~INGRESS_ACL~es-domain-subnet-1641fa70",
-            "mtu" : 1500,
-            "outgoingFilter" : "~EGRESS_ACL~es-domain-subnet-1641fa70",
-            "prefix" : "192.168.1.2/24",
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          },
-          "es-domain-subnet-7044ff16" : {
-            "name" : "es-domain-subnet-7044ff16",
-            "active" : true,
-            "additionalArpIps" : {
-              "class" : "org.batfish.datamodel.EmptyIpSpace"
-            },
-            "allPrefixes" : [
-              "192.168.2.2/28"
-            ],
-            "allowedVlans" : "",
-            "autostate" : true,
-            "bandwidth" : 1.0E12,
-            "description" : "To subnet subnet-7044ff16",
-            "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
-              "sessionInterfaces" : [
-                "es-domain-subnet-7044ff16"
-              ]
-            },
-            "incomingFilter" : "~INGRESS_ACL~es-domain-subnet-7044ff16",
-            "mtu" : 1500,
-            "outgoingFilter" : "~EGRESS_ACL~es-domain-subnet-7044ff16",
-            "prefix" : "192.168.2.2/28",
-            "proxyArp" : false,
-            "ripEnabled" : false,
-            "ripPassive" : false,
-            "spanningTreePortfast" : false,
-            "switchport" : false,
-            "switchportMode" : "NONE",
-            "switchportTrunkEncapsulation" : "DOT1Q",
-            "type" : "PHYSICAL",
-            "vrf" : "default"
-          }
-        },
-        "ipAccessLists" : {
-          "~EGRESS_ACL~es-domain-subnet-1641fa70" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.NotMatchExpr",
-                  "operand" : {
-                    "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                    "headerSpace" : {
-                      "negate" : false,
-                      "srcIps" : {
-                        "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
-                        "whitelist" : [
-                          "192.168.1.2"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Deny spoofed source IPs"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~EGRESS_ACL~es-domain-subnet-1641fa70"
-          },
-          "~EGRESS_ACL~es-domain-subnet-7044ff16" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "DENY",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.NotMatchExpr",
-                  "operand" : {
-                    "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                    "headerSpace" : {
-                      "negate" : false,
-                      "srcIps" : {
-                        "class" : "org.batfish.datamodel.IpWildcardSetIpSpace",
-                        "whitelist" : [
-                          "192.168.2.2"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Deny spoofed source IPs"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~EGRESS_ACL~es-domain-subnet-7044ff16"
-          },
-          "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "PERMIT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "dstIps" : {
-                      "class" : "org.batfish.datamodel.UniverseIpSpace"
-                    },
-                    "negate" : false
-                  },
-                  "traceElement" : {
-                    "fragments" : [
-                      {
-                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched destination address CIDR IP 0.0.0.0/0"
-                      }
-                    ]
-                  }
-                },
-                "name" : "sg-3dfb3140 - default [egress] 0",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with no description"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
-          },
-          "~INGRESS_ACL~es-domain-subnet-1641fa70" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~INGRESS_ACL~es-domain-subnet-1641fa70"
-          },
-          "~INGRESS_ACL~es-domain-subnet-7044ff16" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~",
-                "name" : "Security Group default",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched security group default"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~INGRESS_ACL~es-domain-subnet-7044ff16"
-          },
-          "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~" : {
-            "lines" : [
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "PERMIT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.OrMatchExpr",
-                  "disjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "negate" : false,
-                        "srcIps" : {
-                          "class" : "org.batfish.datamodel.IpIpSpace",
-                          "ip" : "192.168.1.3"
-                        }
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched private IP of RDS database test-rds"
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "traceElement" : {
-                    "fragments" : [
-                      {
-                        "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched source address Security Group default"
-                      }
-                    ]
-                  }
-                },
-                "name" : "sg-3dfb3140 - default [ingress] 0",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with no description"
-                    }
-                  ]
-                }
-              }
-            ],
-            "name" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
-          }
-        },
-        "vendorFamily" : {
-          "aws" : {
-            "region" : "us-west-2",
-            "subnetId" : "subnet-1641fa70",
-            "vpcId" : "vpc-b390fad5"
-          }
-        },
-        "vrfs" : {
-          "default" : {
-            "name" : "default",
-            "hasOriginatingSessions" : true,
-            "staticRoutes" : [
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 1,
-                "metric" : 0,
-                "network" : "0.0.0.0/0",
-                "nextHopInterface" : "dynamic",
-                "nextHopIp" : "192.168.1.1",
-                "tag" : -1
-              },
-              {
-                "class" : "org.batfish.datamodel.StaticRoute",
-                "administrativeCost" : 1,
-                "metric" : 0,
-                "network" : "0.0.0.0/0",
-                "nextHopInterface" : "dynamic",
-                "nextHopIp" : "192.168.2.1",
                 "tag" : -1
               }
             ]


### PR DESCRIPTION
1. Earlier, Batfish was generating one node for an ES domain and connecting it to all the subnets. This was inconsistent with how Batfish models other multi-instance resources (RDS, LBs). 

2. Earlier, Batfish was not accounting for the fact that the number of ESD instances can be greater the number of subnets. 

3. Earlier, the domain name was being used as node name, which is not unique enough. An ESD in another region may have the same name. 