### PR TITLE
traceroute: create a loop step

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/LoopStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/LoopStep.java
@@ -1,0 +1,31 @@
+package org.batfish.datamodel.flow;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.flow.LoopStep.LoopStepDetail;
+
+/** A terminal trace {@link Step} indicating that a forwarding loop has been detected. */
+@JsonTypeName("Loop")
+public final class LoopStep extends Step<LoopStepDetail> {
+  public static final LoopStep INSTANCE = new LoopStep();
+
+  private LoopStep() {
+    super(LOOP_STEP_DETAIL, StepAction.LOOP);
+  }
+
+  private static final LoopStepDetail LOOP_STEP_DETAIL = new LoopStepDetail();
+
+  static final class LoopStepDetail {
+    private LoopStepDetail() {}
+  }
+
+  @SuppressWarnings("PMD.UnusedFormalParameter")
+  @JsonCreator
+  private static LoopStep jsonCreator(
+      @Nullable @JsonProperty(Step.PROP_ACTION) String action,
+      @Nullable @JsonProperty(Step.PROP_DETAIL) String detail) {
+    return INSTANCE;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Step.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Step.java
@@ -17,6 +17,7 @@ import javax.annotation.Nonnull;
   @JsonSubTypes.Type(value = ExitOutputIfaceStep.class, name = "ExitOutputInterface"),
   @JsonSubTypes.Type(value = FilterStep.class, name = "Filter"),
   @JsonSubTypes.Type(value = InboundStep.class, name = "Inbound"),
+    @JsonSubTypes.Type(value = LoopStep.class, name = "Loop"),
   @JsonSubTypes.Type(value = MatchSessionStep.class, name = "MatchSession"),
   @JsonSubTypes.Type(value = OriginateStep.class, name = "Originate"),
   @JsonSubTypes.Type(value = RoutingStep.class, name = "Routing"),

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Step.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Step.java
@@ -17,7 +17,7 @@ import javax.annotation.Nonnull;
   @JsonSubTypes.Type(value = ExitOutputIfaceStep.class, name = "ExitOutputInterface"),
   @JsonSubTypes.Type(value = FilterStep.class, name = "Filter"),
   @JsonSubTypes.Type(value = InboundStep.class, name = "Inbound"),
-    @JsonSubTypes.Type(value = LoopStep.class, name = "Loop"),
+  @JsonSubTypes.Type(value = LoopStep.class, name = "Loop"),
   @JsonSubTypes.Type(value = MatchSessionStep.class, name = "MatchSession"),
   @JsonSubTypes.Type(value = OriginateStep.class, name = "Originate"),
   @JsonSubTypes.Type(value = RoutingStep.class, name = "Routing"),

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/StepAction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/StepAction.java
@@ -16,6 +16,8 @@ public enum StepAction {
   FORWARDED_TO_NEXT_VRF,
   /** Action if information is insufficient to tell the final fate of the flow */
   INSUFFICIENT_INFO,
+  /** Action if a forwarding loop is detected */
+  LOOP,
   /** Action if flow matches a session. */
   MATCHED_SESSION,
   /** Action when next neighbor is unreachable at the last hop */
@@ -35,5 +37,5 @@ public enum StepAction {
   /** Action to show the transmission of a flow from an output interface */
   TRANSMITTED,
   /** Action that a filter permits a packet */
-  PERMITTED
+  PERMITTED;
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/LoopStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/LoopStepTest.java
@@ -1,0 +1,21 @@
+package org.batfish.datamodel.flow;
+
+import static org.junit.Assert.assertEquals;
+
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+public class LoopStepTest {
+  @Test
+  public void testJsonSerialization() {
+    {
+      LoopStep clone = BatfishObjectMapper.clone(LoopStep.INSTANCE, LoopStep.class);
+      assertEquals(clone, LoopStep.INSTANCE);
+    }
+
+    {
+      LoopStep clone = (LoopStep) BatfishObjectMapper.clone(LoopStep.INSTANCE, Step.class);
+      assertEquals(clone, LoopStep.INSTANCE);
+    }
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -84,6 +84,7 @@ import org.batfish.datamodel.flow.Hop;
 import org.batfish.datamodel.flow.InboundStep;
 import org.batfish.datamodel.flow.InboundStep.InboundStepDetail;
 import org.batfish.datamodel.flow.IncomingSessionScope;
+import org.batfish.datamodel.flow.LoopStep;
 import org.batfish.datamodel.flow.MatchSessionStep;
 import org.batfish.datamodel.flow.MatchSessionStep.MatchSessionStepDetail;
 import org.batfish.datamodel.flow.OriginateStep;
@@ -1166,6 +1167,7 @@ class FlowTracer {
   }
 
   private void buildLoopTrace() {
+    _steps.add(LoopStep.INSTANCE);
     _hops.add(new Hop(_currentNode, _steps));
     Trace trace = new Trace(FlowDisposition.LOOP, _hops);
     _flowTraces.accept(new TraceAndReverseFlow(trace, null, _newSessions));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -98,6 +98,7 @@ import org.batfish.datamodel.flow.FibLookup;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
 import org.batfish.datamodel.flow.ForwardOutInterface;
 import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.LoopStep;
 import org.batfish.datamodel.flow.MatchSessionStep;
 import org.batfish.datamodel.flow.OriginatingSessionScope;
 import org.batfish.datamodel.flow.RouteInfo;
@@ -686,7 +687,12 @@ public final class FlowTracerTest {
     // - next-vr should occur in the first step
     // - next-vr should occur in the second step
 
-    assertThat(steps, contains(instanceOf(RoutingStep.class), instanceOf(RoutingStep.class)));
+    assertThat(
+        steps,
+        contains(
+            instanceOf(RoutingStep.class),
+            instanceOf(RoutingStep.class),
+            instanceOf(LoopStep.class)));
     assertThat(
         ((RoutingStep) steps.get(0)).getDetail().getRoutes().get(0).getNextVrf(),
         equalTo(vrf2Name));


### PR DESCRIPTION
Previously, looping traces ended abruptly without a step reflecting the
disposition. This was inconsistent with other dispositions (e.g.
InboundStep for ACCEPTED).