### PR TITLE
AWS NLB static routes to instance targets

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
@@ -4,10 +4,13 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.datamodel.NamedPort.EPHEMERAL_HIGHEST;
 import static org.batfish.datamodel.NamedPort.EPHEMERAL_LOWEST;
 import static org.batfish.representation.aws.AwsLocationInfoUtils.INFRASTRUCTURE_LOCATION_INFO;
+import static org.batfish.representation.aws.Subnet.NLB_INSTANCE_TARGETS_IFACE_SUFFIX;
 import static org.batfish.representation.aws.TargetGroup.Type.IP;
 import static org.batfish.representation.aws.Utils.addNodeToSubnet;
 import static org.batfish.representation.aws.Utils.checkNonNull;
 import static org.batfish.representation.aws.Utils.createPublicIpsRefBook;
+import static org.batfish.representation.aws.Utils.interfaceNameToRemote;
+import static org.batfish.representation.aws.Utils.toStaticRoute;
 import static org.batfish.specifier.Location.interfaceLinkLocation;
 import static org.batfish.specifier.Location.interfaceLocation;
 
@@ -20,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -43,6 +47,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.TraceElement;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.TrueExpr;
@@ -247,6 +252,11 @@ public final class LoadBalancer implements AwsVpcEntity, Serializable {
     cfgNode.getVendorFamily().getAws().setSubnetId(availabilityZone.getSubnetId());
     cfgNode.getVendorFamily().getAws().setRegion(region.getName());
 
+    // Add static routes to any instance targets
+    getInstanceTargetStaticRoutes(
+            awsConfiguration.getNlbsToInstanceTargets().get(this), availabilityZone.getSubnetId())
+        .forEach(staticRoute -> Utils.addStaticRoute(cfgNode, staticRoute));
+
     Optional<NetworkInterface> networkInterface =
         findMyInterface(availabilityZone.getSubnetId(), _arn, region);
     if (!networkInterface.isPresent()) {
@@ -307,6 +317,31 @@ public final class LoadBalancer implements AwsVpcEntity, Serializable {
             INFRASTRUCTURE_LOCATION_INFO));
 
     return cfgNode;
+  }
+
+  /**
+   * Creates static routes to the IP of each of the given {@code instanceTargets} via subnet {@code
+   * lbSubnetId} (that is, using an interface to that subnet's instance target VRF as their next
+   * hop). The instance targets will be in the load balancer's VPC, but may not be in the given
+   * subnet's availability zone.
+   */
+  @VisibleForTesting
+  static List<StaticRoute> getInstanceTargetStaticRoutes(
+      Collection<Instance> instanceTargets, String lbSubnetId) {
+    return instanceTargets.stream()
+        .map(
+            instance -> {
+              String subnetCfgHostname = Subnet.nodeName(lbSubnetId);
+              String instanceTargetsIface =
+                  interfaceNameToRemote(subnetCfgHostname, NLB_INSTANCE_TARGETS_IFACE_SUFFIX);
+              // Guaranteed by isTargetInAnyEnabledAvailabilityZone
+              assert instance.getPrimaryPrivateIpAddress() != null;
+              return toStaticRoute(
+                  instance.getPrimaryPrivateIpAddress().toPrefix(),
+                  instanceTargetsIface,
+                  AwsConfiguration.LINK_LOCAL_IP);
+            })
+        .collect(ImmutableList.toImmutableList());
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -918,7 +918,7 @@ public final class Region implements Serializable {
     // Set up reverse sessions for outbound traffic.
     i.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(false, ImmutableList.of(i.getName()), null, null));
-    i.getVrf().setFirewallSessionVrfInfo(new FirewallSessionVrfInfo(true));
+    i.getVrf().setFirewallSessionVrfInfo(new FirewallSessionVrfInfo(false));
   }
 
   private void applyIngressAcl(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Utils.java
@@ -347,11 +347,15 @@ final class Utils {
   }
 
   static String interfaceNameToRemote(Configuration remoteCfg) {
-    return interfaceNameToRemote(remoteCfg, "");
+    return interfaceNameToRemote(remoteCfg.getHostname(), "");
   }
 
   static String interfaceNameToRemote(Configuration remoteCfg, String suffix) {
-    return suffix.isEmpty() ? remoteCfg.getHostname() : remoteCfg.getHostname() + "-" + suffix;
+    return interfaceNameToRemote(remoteCfg.getHostname(), suffix);
+  }
+
+  static String interfaceNameToRemote(String remoteCfgHostname, String suffix) {
+    return suffix.isEmpty() ? remoteCfgHostname : remoteCfgHostname + "-" + suffix;
   }
 
   /** Adds a bidirectional layer1 edge between the interfaces and nodes */

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationLoadBalancerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationLoadBalancerTest.java
@@ -149,9 +149,21 @@ public class AwsConfigurationLoadBalancerTest {
     testBidirectionalTrace(
         getTcpFlow(_instanceClient, nlb2Ip, _listenerPort, _batfish), // to second LB IP
         ImmutableList.of(
-            _instanceClient, _subnetClient, _vpc, _subnetS2, _nodeLoadBalancer2, _instanceS2),
+            _instanceClient,
+            _subnetClient,
+            _vpc,
+            _subnetS2,
+            _nodeLoadBalancer2,
+            _subnetS2,
+            _instanceS2),
         ImmutableList.of(
-            _instanceS2, _nodeLoadBalancer2, _subnetS2, _vpc, _subnetClient, _instanceClient),
+            _instanceS2,
+            _subnetS2,
+            _nodeLoadBalancer2,
+            _subnetS2,
+            _vpc,
+            _subnetClient,
+            _instanceClient),
         _batfish);
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerTest.java
@@ -945,7 +945,8 @@ public class LoadBalancerTest {
   }
 
   @Test
-  public void testInstanceTargetStaticRoutes() {
+  public void testInstanceTargetStaticRoutes_noInstanceTargets() {
+    // Load balancers with no instance targets should not have any static routes
     List<Configuration> cfgNodes =
         _loadBalancer.toConfigurationNodes(
             new ConvertedConfiguration(), Region.builder("r1").build(), new Warnings());
@@ -953,7 +954,9 @@ public class LoadBalancerTest {
   }
 
   @Test
-  public void testInstanceTargetStaticRoutes_noInstanceTargets() {
+  public void testInstanceTargetStaticRoutes() {
+    // Load balancers with instance targets should have static routes to each instance target via
+    // their subnet
     Ip instanceIp = Ip.parse("20.20.20.20");
     Instance instance =
         new Instance(

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -206,7 +206,7 @@
           "default" : {
             "name" : "default",
             "firewallSessionVrfInfo" : {
-              "fibLookup" : true
+              "fibLookup" : false
             },
             "staticRoutes" : [
               {
@@ -426,7 +426,7 @@
           "default" : {
             "name" : "default",
             "firewallSessionVrfInfo" : {
-              "fibLookup" : true
+              "fibLookup" : false
             },
             "staticRoutes" : [
               {
@@ -36538,7 +36538,7 @@
           "default" : {
             "name" : "default",
             "firewallSessionVrfInfo" : {
-              "fibLookup" : true
+              "fibLookup" : false
             },
             "staticRoutes" : [
               {


### PR DESCRIPTION
- Gives NLBs static routes to their instance targets
- Makes load balancers do dst NAT only for instance targets, not src NAT (cherry-picked from #5982)
- Makes instances' originating sessions forward out interface instead of doing FIB lookups