### PR TITLE
AWS NLBs: No src NAT for instance targets

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.datamodel.NamedPort.EPHEMERAL_HIGHEST;
 import static org.batfish.datamodel.NamedPort.EPHEMERAL_LOWEST;
 import static org.batfish.representation.aws.AwsLocationInfoUtils.INFRASTRUCTURE_LOCATION_INFO;
+import static org.batfish.representation.aws.TargetGroup.Type.INSTANCE;
 import static org.batfish.representation.aws.TargetGroup.Type.IP;
 import static org.batfish.representation.aws.Utils.addNodeToSubnet;
 import static org.batfish.representation.aws.Utils.checkNonNull;
@@ -537,11 +538,18 @@ public final class LoadBalancer implements AwsVpcEntity, Serializable {
       warnings.redFlag(String.format("Could not determine IP for load balancer target %s", target));
       return null;
     }
+    TransformationStep transformDstIp = TransformationStep.assignDestinationIp(targetIp, targetIp);
+    TransformationStep transformDstPort =
+        TransformationStep.assignDestinationPort(target.getPort(), target.getPort());
+    if (targetGroupType == INSTANCE) {
+      // No source NAT for instance targets
+      return new ApplyAll(transformDstIp, transformDstPort);
+    }
     return new ApplyAll(
         TransformationStep.assignSourceIp(loadBalancerIp, loadBalancerIp),
         TransformationStep.assignSourcePort(EPHEMERAL_LOWEST.number(), EPHEMERAL_HIGHEST.number()),
-        TransformationStep.assignDestinationIp(targetIp, targetIp),
-        TransformationStep.assignDestinationPort(target.getPort(), target.getPort()));
+        transformDstIp,
+        transformDstPort);
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerTest.java
@@ -626,26 +626,26 @@ public class LoadBalancerTest {
   public void testComputeTargetTransformationStep_instanceTarget() {
     Ip targetIp = Ip.parse("1.1.1.1");
     Ip loadBalancerIp = Ip.parse("10.10.10.10");
-    LoadBalancerTarget target = new LoadBalancerTarget("zone", targetIp.toString(), 80);
+    String instanceId = "instance";
+    LoadBalancerTarget target = new LoadBalancerTarget("zone", instanceId, 80);
 
     Region region =
         Region.builder("r1")
             .setInstances(
                 ImmutableMap.of(
-                    "instance",
+                    instanceId,
                     Instance.builder()
-                        .setInstanceId("instance")
+                        .setInstanceId(instanceId)
                         .setPrimaryPrivateIpAddress(targetIp)
                         .build()))
             .build();
+
+    // Should only do dst NAT for instance targets
     assertThat(
         computeTargetTransformationStep(
-            target, TargetGroup.Type.IP, loadBalancerIp, region, new Warnings()),
+            target, TargetGroup.Type.INSTANCE, loadBalancerIp, region, new Warnings()),
         equalTo(
             new ApplyAll(
-                TransformationStep.assignSourceIp(loadBalancerIp, loadBalancerIp),
-                TransformationStep.assignSourcePort(
-                    EPHEMERAL_LOWEST.number(), EPHEMERAL_HIGHEST.number()),
                 TransformationStep.assignDestinationIp(targetIp, targetIp),
                 TransformationStep.assignDestinationPort(target.getPort(), target.getPort()))));
   }


### PR DESCRIPTION
FYI - the modified test seems like it was intended to do what it's doing now, but the author copy-pasted the `testComputeTargetTransformationStep_ipTarget` test and forgot to switch the target type to `INSTANCE` for `testComputeTargetTransformationStep_instanceTarget`.