### PR TITLE
AWS subnets with NLB but no instance target: remove session info

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
@@ -369,9 +369,12 @@ public class Subnet implements AwsVpcEntity, Serializable {
     subnetToVpcIface.setIncomingFilter(ingressNetworkAcl);
     subnetToVpcIface.setOutgoingFilter(egressNetworkAcl);
     String incomingAclName = ingressNetworkAcl == null ? null : ingressNetworkAcl.getName();
-    subnetToVpcIface.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(
-            false, ImmutableList.of(subnetToVpcIfaceName), incomingAclName, null));
+    // If subnet has target instances, use a session to direct return traffic back to VPC
+    if (awsConfiguration.getSubnetsToInstanceTargets().containsKey(this)) {
+      subnetToVpcIface.setFirewallSessionInterfaceInfo(
+          new FirewallSessionInterfaceInfo(
+              false, ImmutableList.of(subnetToVpcIfaceName), incomingAclName, null));
+    }
 
     // For each NLB in the subnet: new interface connecting to NLB, no filters
     for (LoadBalancer nlb : nlbs) {

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
@@ -777,7 +777,7 @@ public class SubnetTest {
     assertThat(subnetCfg.getVrfs(), hasKey(NLB_INSTANCE_TARGETS_VRF_NAME));
     assertThat(vpcCfg.getVrfs(), hasKey(NLB_INSTANCE_TARGETS_VRF_NAME));
 
-    // Subnet should be connected to VPC on their new VRFs; subnet iface should have session info
+    // Subnet should be connected to VPC on their new VRFs; subnet iface does not need session info
     String subnetToVpcIfaceName = interfaceNameToRemote(vpcCfg, NLB_INSTANCE_TARGETS_IFACE_SUFFIX);
     assertThat(
         subnetCfg.getAllInterfaces().get(subnetToVpcIfaceName),
@@ -785,8 +785,7 @@ public class SubnetTest {
             hasVrfName(NLB_INSTANCE_TARGETS_VRF_NAME),
             hasIncomingFilter(equalTo(ingressAcl)),
             hasOutgoingFilter(equalTo(egressAcl)),
-            hasFirewallSessionInterfaceInfo(
-                hasProperty("incomingAclName", equalTo(ingressAcl.getName())))));
+            hasFirewallSessionInterfaceInfo(nullValue())));
     assertThat(
         vpcCfg
             .getAllInterfaces()


### PR DESCRIPTION
These subnets need session info on their instance targets interfaces to the NLBs, but not the instance target interface to the VPC.