### PR TITLE
AWS: Apply security groups to instance targets' new interfaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -837,6 +837,9 @@ public final class Region implements Serializable {
     // Must happen after ESD and RDS are converted (for security groups to get all referrer IPs) but
     // before subnets are converted (so that target instances' special interfaces can get the
     // instance's security groups applied; these interfaces are not covered by applySecurityGroups).
+    // It's safe to evaluate security groups' IP spaces before converting subnets because all
+    // interfaces created during subnet conversion either use link local addresses or are on subnet
+    // nodes, whose interface addresses don't affect security group IP spaces.
     convertSecurityGroups(awsConfiguration, warnings);
 
     for (Subnet subnet : getSubnets().values()) {
@@ -1026,8 +1029,8 @@ public final class Region implements Serializable {
 
   @VisibleForTesting
   void convertSecurityGroups(ConvertedConfiguration awsConfiguration, Warnings warnings) {
-    // Finalize security groups by adding referrer IPs from RDS and ESD instances, so that the
-    // security-group-as-IpSpace is correct, then convert security groups to ACLs.
+    // Finalize security groups by adding referrer IPs from all interfaces (real and generated), so
+    // that the security-group-as-IpSpace is correct, then convert security groups to ACLs.
     addNetworkInterfaceIpsToSecurityGroups(warnings);
     addApplicationInterfaceIpsToSecurityGroups(awsConfiguration, warnings);
     _sgIngressAcls =

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import java.io.Serializable;
 import java.util.Collection;
@@ -434,13 +433,8 @@ public class Subnet implements AwsVpcEntity, Serializable {
             instanceConfig.getAllInterfaces().get(instanceToSubnetIfaceName);
 
         // New interface on instance target needs security groups
-        Set<String> instanceSecurityGroups =
-            region.getNetworkInterfaces().values().stream()
-                .filter(ni -> instanceTarget.getId().equals(ni.getAttachmentInstanceId()))
-                .flatMap(ni -> ni.getGroups().stream())
-                .collect(ImmutableSet.toImmutableSet());
         region.applyAclsToInterfaceBasedOnSecurityGroups(
-            instanceSecurityGroups, instanceConfig, newInstanceIface);
+            instanceTarget.getSecurityGroups(), instanceConfig, newInstanceIface);
 
         // Subnet needs to set up a session for return traffic from the instance
         subnetToInstanceIface.setFirewallSessionInterfaceInfo(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import java.io.Serializable;
 import java.util.Collection;
@@ -312,7 +313,7 @@ public class Subnet implements AwsVpcEntity, Serializable {
     }
 
     addNlbInstanceTargetInterfaces(
-        awsConfiguration, cfgNode, vpcConfigNode, ingressNetworkAcl, egressNetworkAcl);
+        awsConfiguration, region, cfgNode, vpcConfigNode, ingressNetworkAcl, egressNetworkAcl);
 
     // create LocationInfo for each link location on the node.
     cfgNode.setLocationInfo(
@@ -336,6 +337,7 @@ public class Subnet implements AwsVpcEntity, Serializable {
   @VisibleForTesting
   void addNlbInstanceTargetInterfaces(
       ConvertedConfiguration awsConfiguration,
+      Region region,
       Configuration subnetCfg,
       Configuration vpcCfg,
       // These ACLs should be applied to all subnet interfaces that don't face instances
@@ -422,11 +424,25 @@ public class Subnet implements AwsVpcEntity, Serializable {
             instanceConfig.getDefaultVrf().getName(),
             NLB_INSTANCE_TARGETS_IFACE_SUFFIX);
 
-        // Subnet needs to set up a session for return traffic from the instance
         String subnetToInstanceIfaceName =
             interfaceNameToRemote(instanceConfig, NLB_INSTANCE_TARGETS_IFACE_SUFFIX);
         Interface subnetToInstanceIface =
             subnetCfg.getAllInterfaces().get(subnetToInstanceIfaceName);
+        String instanceToSubnetIfaceName =
+            interfaceNameToRemote(subnetCfg, NLB_INSTANCE_TARGETS_IFACE_SUFFIX);
+        Interface newInstanceIface =
+            instanceConfig.getAllInterfaces().get(instanceToSubnetIfaceName);
+
+        // New interface on instance target needs security groups
+        Set<String> instanceSecurityGroups =
+            region.getNetworkInterfaces().values().stream()
+                .filter(ni -> instanceTarget.getId().equals(ni.getAttachmentInstanceId()))
+                .flatMap(ni -> ni.getGroups().stream())
+                .collect(ImmutableSet.toImmutableSet());
+        region.applyAclsToInterfaceBasedOnSecurityGroups(
+            instanceSecurityGroups, instanceConfig, newInstanceIface);
+
+        // Subnet needs to set up a session for return traffic from the instance
         subnetToInstanceIface.setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
                 false, ImmutableList.of(subnetToInstanceIfaceName), null, null));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -177,7 +177,8 @@ public class RegionTest {
     region.getNetworkInterfaces().put(ni.getId(), ni);
     ConvertedConfiguration cfg = new ConvertedConfiguration();
     cfg.addNode(c);
-    region.computeSecurityGroups(cfg, new Warnings());
+    region.convertSecurityGroups(cfg, new Warnings());
+    region.applySecurityGroups(cfg, new Warnings());
 
     // security groups sg-001 and sg-002 converted to ExprAclLines
     assertThat(c.getIpAccessLists(), hasKey("~INGRESS~SECURITY-GROUP~sg-1~sg-001~"));
@@ -234,7 +235,8 @@ public class RegionTest {
     region.getNetworkInterfaces().put(ni.getId(), ni);
     ConvertedConfiguration cfg = new ConvertedConfiguration();
     cfg.addNode(c);
-    region.computeSecurityGroups(cfg, new Warnings());
+    region.convertSecurityGroups(cfg, new Warnings());
+    region.applySecurityGroups(cfg, new Warnings());
     IpAccessList ingressAcl = c.getIpAccessLists().get(eniIngressAclName(ni.getId()));
 
     Flow permittedFlow =

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -177,6 +177,7 @@ public class RegionTest {
     region.getNetworkInterfaces().put(ni.getId(), ni);
     ConvertedConfiguration cfg = new ConvertedConfiguration();
     cfg.addNode(c);
+    region.convertSecurityGroupsToAcls(new Warnings());
     region.computeSecurityGroups(cfg, new Warnings());
 
     // security groups sg-001 and sg-002 converted to ExprAclLines
@@ -234,6 +235,7 @@ public class RegionTest {
     region.getNetworkInterfaces().put(ni.getId(), ni);
     ConvertedConfiguration cfg = new ConvertedConfiguration();
     cfg.addNode(c);
+    region.convertSecurityGroupsToAcls(new Warnings());
     region.computeSecurityGroups(cfg, new Warnings());
     IpAccessList ingressAcl = c.getIpAccessLists().get(eniIngressAclName(ni.getId()));
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RegionTest.java
@@ -177,7 +177,6 @@ public class RegionTest {
     region.getNetworkInterfaces().put(ni.getId(), ni);
     ConvertedConfiguration cfg = new ConvertedConfiguration();
     cfg.addNode(c);
-    region.convertSecurityGroupsToAcls(new Warnings());
     region.computeSecurityGroups(cfg, new Warnings());
 
     // security groups sg-001 and sg-002 converted to ExprAclLines
@@ -235,7 +234,6 @@ public class RegionTest {
     region.getNetworkInterfaces().put(ni.getId(), ni);
     ConvertedConfiguration cfg = new ConvertedConfiguration();
     cfg.addNode(c);
-    region.convertSecurityGroupsToAcls(new Warnings());
     region.computeSecurityGroups(cfg, new Warnings());
     IpAccessList ingressAcl = c.getIpAccessLists().get(eniIngressAclName(ni.getId()));
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
@@ -694,7 +694,8 @@ public class SubnetTest {
     Configuration subnetCfg = configs.get(subnetHostname);
     Configuration vpcCfg = configs.get(vpcHostname);
     ConvertedConfiguration awsConf = new ConvertedConfiguration(configs);
-    subnet.addNlbInstanceTargetInterfaces(awsConf, subnetCfg, vpcCfg, null, null);
+    Region region = new Region("region");
+    subnet.addNlbInstanceTargetInterfaces(awsConf, region, subnetCfg, vpcCfg, null, null);
 
     // Nothing should have gotten a new VRF or any interfaces
     configs
@@ -772,7 +773,9 @@ public class SubnetTest {
             ImmutableMultimap.of(subnet, loadBalancerInSubnet), // subnets to NLBs
             ImmutableMultimap.of(loadBalancerInSubnet, instanceInOtherSubnet), // NLBs to targets
             ImmutableSet.of(vpc)); // VPCs with instance targets
-    subnet.addNlbInstanceTargetInterfaces(awsConf, subnetCfg, vpcCfg, ingressAcl, egressAcl);
+    Region region = new Region("region");
+    subnet.addNlbInstanceTargetInterfaces(
+        awsConf, region, subnetCfg, vpcCfg, ingressAcl, egressAcl);
 
     // New VRFs created in subnet and VPC configs
     assertThat(subnetCfg.getVrfs(), hasKey(NLB_INSTANCE_TARGETS_VRF_NAME));
@@ -909,7 +912,9 @@ public class SubnetTest {
             ImmutableMultimap.of(), // subnets to NLBs
             ImmutableMultimap.of(loadBalancerNotInSubnet, instanceInSubnet), // NLBs to targets
             ImmutableSet.of(vpc)); // VPCs with instance targets
-    subnet.addNlbInstanceTargetInterfaces(awsConf, subnetCfg, vpcCfg, ingressAcl, egressAcl);
+    Region region = new Region("region");
+    subnet.addNlbInstanceTargetInterfaces(
+        awsConf, region, subnetCfg, vpcCfg, ingressAcl, egressAcl);
 
     // New VRFs created in subnet and VPC configs
     assertThat(subnetCfg.getVrfs(), hasKey(NLB_INSTANCE_TARGETS_VRF_NAME));
@@ -949,7 +954,7 @@ public class SubnetTest {
         instanceCfg
             .getAllInterfaces()
             .get(interfaceNameToRemote(subnetCfg, NLB_INSTANCE_TARGETS_IFACE_SUFFIX)),
-        allOf(hasVrfName(DEFAULT_VRF_NAME), hasFirewallSessionInterfaceInfo(nullValue())));
+        allOf(hasVrfName(DEFAULT_VRF_NAME), hasFirewallSessionInterfaceInfo(hasNoAcls())));
 
     // Subnet should have static route to instance IP out the interface to the instance target
     assertThat(
@@ -1038,7 +1043,9 @@ public class SubnetTest {
             ImmutableMultimap.of(subnet, loadBalancerInSubnet), // subnets to NLBs
             ImmutableMultimap.of(loadBalancerInSubnet, instanceInSubnet), // NLBs to targets
             ImmutableSet.of(vpc)); // VPCs with instance targets
-    subnet.addNlbInstanceTargetInterfaces(awsConf, subnetCfg, vpcCfg, ingressAcl, egressAcl);
+    Region region = new Region("region");
+    subnet.addNlbInstanceTargetInterfaces(
+        awsConf, region, subnetCfg, vpcCfg, ingressAcl, egressAcl);
 
     // New VRFs created in subnet and VPC configs
     assertThat(subnetCfg.getVrfs(), hasKey(NLB_INSTANCE_TARGETS_VRF_NAME));
@@ -1099,7 +1106,7 @@ public class SubnetTest {
         instanceCfg
             .getAllInterfaces()
             .get(interfaceNameToRemote(subnetCfg, NLB_INSTANCE_TARGETS_IFACE_SUFFIX)),
-        allOf(hasVrfName(DEFAULT_VRF_NAME), hasFirewallSessionInterfaceInfo(nullValue())));
+        allOf(hasVrfName(DEFAULT_VRF_NAME), hasFirewallSessionInterfaceInfo(hasNoAcls())));
 
     // Subnet should have static route to instance IP out the interface to the instance target
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
@@ -1210,7 +1210,7 @@ public class SubnetTest {
             .setSecurityGroups(ImmutableMap.of(sgName, sg))
             .setSubnets(ImmutableMap.of(subnet.getId(), subnet))
             .build();
-    region.computeSecurityGroups(awsConf, new Warnings());
+    region.convertSecurityGroups(awsConf, new Warnings());
     subnet.addNlbInstanceTargetInterfaces(awsConf, region, subnetCfg, vpcCfg, null, null);
 
     // New interface on instance should filter with AclAclLines with ACL defined by security group

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
@@ -1232,7 +1232,7 @@ public class SubnetTest {
             .setSecurityGroups(ImmutableMap.of(niSecurityGroupName, niSecurityGroup))
             .setNetworkInterfaces(ImmutableMap.of(networkInterfaceId, networkInterface))
             .build();
-    region.convertSecurityGroupsToAcls(new Warnings());
+    region.computeSecurityGroups(awsConf, new Warnings());
     subnet.addNlbInstanceTargetInterfaces(awsConf, region, subnetCfg, vpcCfg, null, null);
 
     // New interface on instance should filter with AclAclLines with ACL defined by security group


### PR DESCRIPTION
Note first commit message is inaccurate; it adds security groups on instance targets' interfaces, not NLBs'.