### PR TITLE
AWS: simplify precomputed instance target maps

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/ConvertedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/ConvertedConfiguration.java
@@ -2,7 +2,6 @@ package org.batfish.representation.aws;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import java.io.Serializable;
 import java.util.Collection;
@@ -22,17 +21,20 @@ class ConvertedConfiguration implements Serializable {
 
   @Nonnull private final Map<String, Configuration> _configurationNodes;
   @Nonnull private final Set<Layer1Edge> _layer1Edges;
-  /** A multimap from Subnet -> Instance targets within subnet */
-  @Nonnull private final Multimap<Subnet, Instance> _subnetsToInstanceTargets;
+  /**
+   * Multimap of subnet IDs to {@link Instance} in that subnet used as targets by some {@link
+   * LoadBalancer}
+   */
+  @Nonnull private final Multimap<String, Instance> _subnetsToInstanceTargets;
 
-  /** A multimap from Subnet -> NLBs within subnet that have instance targets */
-  @Nonnull private final Multimap<Subnet, LoadBalancer> _subnetsToNlbs;
+  /**
+   * Multimap of subnet IDs to {@link LoadBalancer} connected to that subnet that have active
+   * instance targets
+   */
+  @Nonnull private final Multimap<String, LoadBalancer> _subnetsToNlbs;
 
-  /** A multimap of NLB -> instance targets */
-  @Nonnull private final Multimap<LoadBalancer, Instance> _nlbsToInstanceTargets;
-
-  /** A set of all VPCs that contain load balancers with active instance targets */
-  @Nonnull private final Set<Vpc> _vpcsWithInstanceTargets;
+  /** Multimap of load balancer ARNs to {@link Instance} used as targets for that load balancer */
+  @Nonnull private final Multimap<String, Instance> _nlbsToInstanceTargets;
 
   public ConvertedConfiguration(AwsConfiguration awsConfiguration) {
     this(
@@ -40,8 +42,7 @@ class ConvertedConfiguration implements Serializable {
         new HashSet<>(),
         awsConfiguration.getSubnetsToInstanceTargets(),
         awsConfiguration.getSubnetsToNlbs(),
-        awsConfiguration.getNlbsToInstanceTargets(),
-        awsConfiguration.getVpcsWithInstanceTargets());
+        awsConfiguration.getNlbsToInstanceTargets());
   }
 
   @VisibleForTesting
@@ -51,8 +52,7 @@ class ConvertedConfiguration implements Serializable {
         new HashSet<>(),
         ImmutableMultimap.of(),
         ImmutableMultimap.of(),
-        ImmutableMultimap.of(),
-        ImmutableSet.of());
+        ImmutableMultimap.of());
   }
 
   @VisibleForTesting
@@ -62,24 +62,21 @@ class ConvertedConfiguration implements Serializable {
         new HashSet<>(),
         ImmutableMultimap.of(),
         ImmutableMultimap.of(),
-        ImmutableMultimap.of(),
-        ImmutableSet.of());
+        ImmutableMultimap.of());
   }
 
   @VisibleForTesting
   ConvertedConfiguration(
       Map<String, Configuration> configurationNodes,
       Set<Layer1Edge> layer1Edges,
-      Multimap<Subnet, Instance> subnetsToInstanceTargets,
-      Multimap<Subnet, LoadBalancer> subnetsToNlbs,
-      Multimap<LoadBalancer, Instance> nlbsToInstanceTargets,
-      Set<Vpc> vpcsWithInstanceTargets) {
+      Multimap<String, Instance> subnetsToInstanceTargets,
+      Multimap<String, LoadBalancer> subnetsToNlbs,
+      Multimap<String, Instance> nlbsToInstanceTargets) {
     _configurationNodes = configurationNodes;
     _layer1Edges = layer1Edges;
     _subnetsToInstanceTargets = ImmutableMultimap.copyOf(subnetsToInstanceTargets);
     _subnetsToNlbs = ImmutableMultimap.copyOf(subnetsToNlbs);
     _nlbsToInstanceTargets = ImmutableMultimap.copyOf(nlbsToInstanceTargets);
-    _vpcsWithInstanceTargets = ImmutableSet.copyOf(vpcsWithInstanceTargets);
   }
 
   /** Return configuration nodes across all accounts */
@@ -105,23 +102,26 @@ class ConvertedConfiguration implements Serializable {
     _layer1Edges.add(new Layer1Edge(nodeName1, ifaceName1, nodeName2, ifaceName2));
   }
 
+  /** Subnet IDs to {@link Instance} in that subnet used as targets by some {@link LoadBalancer} */
   @VisibleForTesting
-  Multimap<Subnet, Instance> getSubnetsToInstanceTargets() {
+  @Nonnull
+  Multimap<String, Instance> getSubnetsToInstanceTargets() {
     return _subnetsToInstanceTargets;
   }
 
+  /**
+   * Subnet IDs to {@link LoadBalancer} connected to that subnet that have active instance targets
+   */
   @VisibleForTesting
-  Multimap<Subnet, LoadBalancer> getSubnetsToNlbs() {
+  @Nonnull
+  Multimap<String, LoadBalancer> getSubnetsToNlbs() {
     return _subnetsToNlbs;
   }
 
+  /** Load balancer ARNs to {@link Instance} used as targets for that load balancer */
   @VisibleForTesting
-  Multimap<LoadBalancer, Instance> getNlbsToInstanceTargets() {
+  @Nonnull
+  Multimap<String, Instance> getNlbsToInstanceTargets() {
     return _nlbsToInstanceTargets;
-  }
-
-  @VisibleForTesting
-  Set<Vpc> getVpcsWithInstanceTargets() {
-    return _vpcsWithInstanceTargets;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
@@ -254,7 +254,7 @@ public final class LoadBalancer implements AwsVpcEntity, Serializable {
 
     // Add static routes to any instance targets
     getInstanceTargetStaticRoutes(
-            awsConfiguration.getNlbsToInstanceTargets().get(this), availabilityZone.getSubnetId())
+            awsConfiguration.getNlbsToInstanceTargets().get(_arn), availabilityZone.getSubnetId())
         .forEach(staticRoute -> Utils.addStaticRoute(cfgNode, staticRoute));
 
     Optional<NetworkInterface> networkInterface =

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/AwsConfigurationTest.java
@@ -126,12 +126,12 @@ public class AwsConfigurationTest {
 
       c.populatePrecomputedMaps();
       assertThat(
-          c.getSubnetsToInstanceTargets(), equalTo(ImmutableMultimap.of(instanceSubnet, instance)));
+          c.getSubnetsToInstanceTargets(),
+          equalTo(ImmutableMultimap.of(instanceSubnetId, instance)));
       assertThat(
           c.getSubnetsToNlbs(),
-          equalTo(ImmutableMultimap.of(noInstanceSubnet, nlb, instanceSubnet, nlb)));
-      assertThat(c.getNlbsToInstanceTargets(), equalTo(ImmutableMultimap.of(nlb, instance)));
-      assertThat(c.getVpcsWithInstanceTargets(), contains(vpc));
+          equalTo(ImmutableMultimap.of(noInstanceSubnetId, nlb, instanceSubnetId, nlb)));
+      assertThat(c.getNlbsToInstanceTargets(), equalTo(ImmutableMultimap.of(lbArn, instance)));
     }
     {
       // Application load balancer (not supported): Maps should not get populated
@@ -150,7 +150,6 @@ public class AwsConfigurationTest {
       assertTrue(c.getSubnetsToInstanceTargets().isEmpty());
       assertTrue(c.getSubnetsToNlbs().isEmpty());
       assertTrue(c.getNlbsToInstanceTargets().isEmpty());
-      assertTrue(c.getVpcsWithInstanceTargets().isEmpty());
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerTest.java
@@ -978,8 +978,7 @@ public class LoadBalancerTest {
                 new HashSet<>(),
                 ImmutableMultimap.of(),
                 ImmutableMultimap.of(),
-                ImmutableMultimap.of(_loadBalancer, instance),
-                ImmutableSet.of()),
+                ImmutableMultimap.of(_loadBalancerArn, instance)),
             Region.builder("r1").build(),
             new Warnings());
 


### PR DESCRIPTION
After #5992 (not because of dependency, just because of merge conflicts otherwise).
- Switch `_subnetsToInstanceTargets` and `_subnetsToNlbs` to key on subnet IDs instead of `Subnet` objects
- Switch `_nlbsToInstanceTargets` to key on load balancer ARNs instead of `LoadBalancer` objects
- Remove `_vpcsWithInstanceTargets` as it is unused