### PR TITLE
Fix subnet firewall session interface info

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SubnetTest.java
@@ -910,7 +910,7 @@ public class SubnetTest {
     assertThat(subnetCfg.getVrfs(), hasKey(NLB_INSTANCE_TARGETS_VRF_NAME));
     assertThat(vpcCfg.getVrfs(), hasKey(NLB_INSTANCE_TARGETS_VRF_NAME));
 
-    // Subnet should be connected to VPC on their new VRFs; VPC iface should have session info
+    // Subnet should be connected to VPC on their new VRFs; both ifaces should have session info
     String vpcToSubnetIfaceName =
         interfaceNameToRemote(subnetCfg, NLB_INSTANCE_TARGETS_IFACE_SUFFIX);
     assertThat(
@@ -921,7 +921,7 @@ public class SubnetTest {
             hasVrfName(NLB_INSTANCE_TARGETS_VRF_NAME),
             hasIncomingFilter(equalTo(ingressAcl)),
             hasOutgoingFilter(equalTo(egressAcl)),
-            hasFirewallSessionInterfaceInfo(nullValue())));
+            hasFirewallSessionInterfaceInfo(hasAcls(ingressAcl.getName(), egressAcl.getName()))));
     assertThat(
         vpcCfg.getAllInterfaces().get(vpcToSubnetIfaceName),
         allOf(


### PR DESCRIPTION
We use sessions to bring traffic from a target instance back to a load balancer, but we still need to apply network ACLs when crossing from subnets to VPCs or VPCs to subnets. Therefore a subnet's interface to its VPC needs session info with:
- the outgoing network ACL if the subnet has instance targets
- the incoming network ACL if the subnet has NLBs
- both if the subnet has both

To make life easier, just use both network ACLs in subnets' VPC ifaces session info.