### PR TITLE
XR: parse and warn on ACL udf statements

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_acl.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_acl.g4
@@ -259,8 +259,14 @@ extended_access_list_additional_feature
    | TRACKED
    | TTL_EXCEEDED
    | TTL EQ DEC
+   | eacl_feature_udf
    | UNREACHABLE
    | URG
+;
+
+eacl_feature_udf
+:
+  UDF ~NEWLINE*
 ;
 
 extended_access_list_null_tail

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/GitHub6004Test.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/GitHub6004Test.java
@@ -1,0 +1,56 @@
+package org.batfish.grammar.cisco_xr;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.batfish.common.util.Resources.readResource;
+import static org.batfish.datamodel.matchers.MapMatchers.hasKeys;
+import static org.batfish.main.BatfishTestUtils.TEST_SNAPSHOT;
+import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
+import static org.junit.Assert.assertThat;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.BatfishLogger;
+import org.batfish.common.Warnings;
+import org.batfish.config.Settings;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.main.Batfish;
+import org.batfish.representation.cisco_xr.CiscoXrConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Tests for https://github.com/batfish/batfish/issues/6004. */
+@ParametersAreNonnullByDefault
+public final class GitHub6004Test {
+
+  private static final String TESTCONFIGS_PREFIX = "org/batfish/grammar/cisco_xr/testconfigs/";
+
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+
+  private @Nonnull CiscoXrConfiguration parseVendorConfig(String hostname) {
+    String src = readResource(TESTCONFIGS_PREFIX + hostname, UTF_8);
+    Settings settings = new Settings();
+    configureBatfishTestSettings(settings);
+    CiscoXrCombinedParser ciscoXrParser = new CiscoXrCombinedParser(src, settings);
+    CiscoXrControlPlaneExtractor extractor =
+        new CiscoXrControlPlaneExtractor(
+            src, ciscoXrParser, ConfigurationFormat.CISCO_IOS_XR, new Warnings());
+    ParserRuleContext tree =
+        Batfish.parse(
+            ciscoXrParser, new BatfishLogger(BatfishLogger.LEVELSTR_FATAL, false), settings);
+    extractor.processParseTree(TEST_SNAPSHOT, tree);
+    CiscoXrConfiguration vendorConfiguration =
+        (CiscoXrConfiguration) extractor.getVendorConfiguration();
+    vendorConfiguration.setFilename(TESTCONFIGS_PREFIX + hostname);
+    // crash if not serializable
+    return SerializationUtils.clone(vendorConfiguration);
+  }
+
+  @Test
+  public void testGitHub6004() {
+    CiscoXrConfiguration c = parseVendorConfig("gh6004");
+    assertThat(c.getIpv4Acls(), hasKeys("FOO", "BAR", "BAZ"));
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/gh6004
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/gh6004
@@ -1,0 +1,19 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+hostname gh6004
+interface Bundle-ether1
+ ipv4 address 1.1.1.1 255.255.255.248
+ ipv4 access-group FOO ingress
+!
+ipv4 access-list FOO
+ 10 permit icmp any any echo-reply
+ 30 permit ipv4 any any udf vlanid 0xcb1 0xfff set ttl 100 nexthop1 ipv4 2.2.2.2
+ 50 permit icmp any any
+ 70 permit ipv4 any any udf vlanid 0xcb2 0xfff set ttl 100 nexthop1 ipv4 2.2.2.2
+!
+ipv4 access-list BAR
+ 20 permit icmp any any echo-reply
+ 40 permit ipv4 any any udf vlanid 0x111 0xfff set ttl 100 nexthop1 ipv4 2.2.2.2
+!
+ipv4 access-list BAZ
+ 15 permit icmp any any echo-reply
+ 25 permit ipv4 any any udf vlanid 0xaaa 0x222 set ttl 100 nexthop1 ipv4 2.2.2.2


### PR DESCRIPTION
Fix #6004 - UDFs are not supported but they are warned on. cc: @SivaKesava1