### PR TITLE
BgpRoute: use CommunitySet instead of Set<Community>

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnRoute.java
@@ -99,9 +99,7 @@ public abstract class EvpnRoute<B extends Builder<B, R>, R extends BgpRoute<B, R
   /** Return extended communities that are route targets for this route */
   @JsonIgnore
   public Set<ExtendedCommunity> getRouteTargets() {
-    return _communities.stream()
-        .filter(c -> c instanceof ExtendedCommunity)
-        .map(ExtendedCommunity.class::cast)
+    return _communities.getExtendedCommunities().stream()
         .filter(ExtendedCommunity::isRouteTarget)
         .collect(ImmutableSet.toImmutableSet());
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunityContext.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunityContext.java
@@ -101,7 +101,7 @@ public final class CommunityContext {
           CommunitySet.of(environment.getIntermediateBgpAttributes().getCommunities());
     } else if (environment.getOriginalRoute() instanceof BgpRoute) {
       BgpRoute<?, ?> bgpRoute = (BgpRoute<?, ?>) environment.getOriginalRoute();
-      inputCommunitySet = CommunitySet.of(bgpRoute.getCommunities());
+      inputCommunitySet = bgpRoute.getCommunities();
     } else {
       inputCommunitySet = CommunitySet.empty();
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
@@ -15,6 +15,8 @@ import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.bgp.community.Community;
+import org.batfish.datamodel.bgp.community.ExtendedCommunity;
+import org.batfish.datamodel.bgp.community.StandardCommunity;
 
 /** A set of {@link Community} objects. */
 public final class CommunitySet implements Serializable {
@@ -56,6 +58,32 @@ public final class CommunitySet implements Serializable {
 
   public @Nonnull Set<Community> getCommunities() {
     return _communities;
+  }
+
+  public @Nonnull Set<ExtendedCommunity> getExtendedCommunities() {
+    if (_communities.isEmpty()) {
+      return ImmutableSet.of();
+    }
+    ImmutableSet.Builder<ExtendedCommunity> ret = ImmutableSet.builder();
+    for (Community c : _communities) {
+      if (c instanceof ExtendedCommunity) {
+        ret.add((ExtendedCommunity) c);
+      }
+    }
+    return ret.build();
+  }
+
+  public @Nonnull Set<StandardCommunity> getStandardCommunities() {
+    if (_communities.isEmpty()) {
+      return ImmutableSet.of();
+    }
+    ImmutableSet.Builder<StandardCommunity> ret = ImmutableSet.builder();
+    for (Community c : _communities) {
+      if (c instanceof StandardCommunity) {
+        ret.add((StandardCommunity) c);
+      }
+    }
+    return ret.build();
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchCommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchCommunitySet.java
@@ -47,7 +47,7 @@ public final class MatchCommunitySet extends BooleanExpr {
       inputCommunities = environment.getIntermediateBgpAttributes().getCommunities();
     } else if (environment.getOriginalRoute() instanceof BgpRoute) {
       BgpRoute<?, ?> bgpRoute = (BgpRoute<?, ?>) environment.getOriginalRoute();
-      inputCommunities = bgpRoute.getCommunities();
+      inputCommunities = bgpRoute.getCommunities().getCommunities();
     }
     return inputCommunities == null
         ? new Result(false)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchersImpl.java
@@ -22,7 +22,7 @@ final class BgpRouteMatchersImpl {
 
     @Override
     protected Set<Community> featureValueOf(BgpRoute<?, ?> actual) {
-      return actual.getCommunities();
+      return actual.getCommunities().getCommunities();
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/SetCommunitiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/communities/SetCommunitiesTest.java
@@ -61,7 +61,7 @@ public final class SetCommunitiesTest {
     Environment envWriteToOutput = Environment.builder(c).setOutputRoute(routeBuilder()).build();
     set.execute(envWriteToOutput);
     Bgpv4Route routeWriteToOutput = (Bgpv4Route) envWriteToOutput.getOutputRoute().build();
-    assertThat(routeWriteToOutput.getCommunities(), equalTo(cs.getCommunities()));
+    assertThat(routeWriteToOutput.getCommunities().getCommunities(), equalTo(cs.getCommunities()));
 
     // test writing to intermediate bgp attributes
     Environment envWriteToIntermediate =
@@ -73,6 +73,7 @@ public final class SetCommunitiesTest {
     set.execute(envWriteToIntermediate);
     Bgpv4Route routeWriteToIntermediate =
         (Bgpv4Route) envWriteToIntermediate.getIntermediateBgpAttributes().build();
-    assertThat(routeWriteToIntermediate.getCommunities(), equalTo(cs.getCommunities()));
+    assertThat(
+        routeWriteToIntermediate.getCommunities().getCommunities(), equalTo(cs.getCommunities()));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -642,7 +642,8 @@ public class VirtualRouter implements Serializable {
         transformedIncomingRouteBuilder.setAsPath(transformedOutgoingRoute.getAsPath());
 
         // Incoming communities
-        transformedIncomingRouteBuilder.addCommunities(transformedOutgoingRoute.getCommunities());
+        transformedIncomingRouteBuilder.addCommunities(
+            transformedOutgoingRoute.getCommunities().getCommunities());
 
         // Incoming protocol
         transformedIncomingRouteBuilder.setProtocol(targetProtocol);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -96,14 +96,14 @@ public final class BgpProtocolHelper {
 
     // Do not export route if it has NO_ADVERTISE community, or if its AS path contains the remote
     // peer's AS and local peer has not set getAllowRemoteOut
-    if (route.getCommunities().contains(StandardCommunity.NO_ADVERTISE)
+    if (route.getCommunities().getCommunities().contains(StandardCommunity.NO_ADVERTISE)
         || (sessionProperties.isEbgp()
             && route.getAsPath().containsAs(sessionProperties.getTailAs())
             && !af.getAddressFamilyCapabilities().getAllowRemoteAsOut())) {
       return null;
     }
     // Also do not export if route has NO_EXPORT community and this is a true ebgp session
-    if (route.getCommunities().contains(StandardCommunity.NO_EXPORT)
+    if (route.getCommunities().getCommunities().contains(StandardCommunity.NO_EXPORT)
         && sessionProperties.isEbgp()
         && sessionProperties.getConfedSessionType() != ConfedSessionType.WITHIN_CONFED) {
       return null;

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTest.java
@@ -319,6 +319,6 @@ public class BgpProtocolHelperTest {
             Ip.ZERO,
             true);
 
-    assertThat(result.getCommunities(), equalTo(ImmutableSet.of(community)));
+    assertThat(result.getCommunities().getCommunities(), equalTo(ImmutableSet.of(community)));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -6106,7 +6106,7 @@ public final class CiscoNxosGrammarTest {
               .build();
 
       Bgpv4Route route = processRouteIn(rp, inRoute);
-      assertThat(route.getCommunities(), contains(StandardCommunity.of(1, 1)));
+      assertThat(route.getCommunities().getCommunities(), contains(StandardCommunity.of(1, 1)));
     }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("set_comm_list_standard");
@@ -6118,7 +6118,8 @@ public final class CiscoNxosGrammarTest {
 
       Bgpv4Route route = processRouteIn(rp, inRoute);
       assertThat(
-          route.getCommunities(), contains(StandardCommunity.of(1, 1), StandardCommunity.of(2, 2)));
+          route.getCommunities().getCommunities(),
+          contains(StandardCommunity.of(1, 1), StandardCommunity.of(2, 2)));
     }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("set_comm_list_standard_single");
@@ -6129,7 +6130,7 @@ public final class CiscoNxosGrammarTest {
               .build();
 
       Bgpv4Route route = processRouteIn(rp, inRoute);
-      assertThat(route.getCommunities(), contains(StandardCommunity.of(2, 2)));
+      assertThat(route.getCommunities().getCommunities(), contains(StandardCommunity.of(2, 2)));
     }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("set_community");
@@ -6137,7 +6138,8 @@ public final class CiscoNxosGrammarTest {
           base.toBuilder().setCommunities(ImmutableSet.of(StandardCommunity.of(3, 3))).build();
       Bgpv4Route route = processRouteIn(rp, inRoute);
       assertThat(
-          route.getCommunities(), contains(StandardCommunity.of(1, 1), StandardCommunity.of(1, 2)));
+          route.getCommunities().getCommunities(),
+          contains(StandardCommunity.of(1, 1), StandardCommunity.of(1, 2)));
     }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("set_community_additive");
@@ -6145,7 +6147,7 @@ public final class CiscoNxosGrammarTest {
           base.toBuilder().setCommunities(ImmutableSet.of(StandardCommunity.of(3, 3))).build();
       Bgpv4Route route = processRouteIn(rp, inRoute);
       assertThat(
-          route.getCommunities(),
+          route.getCommunities().getCommunities(),
           containsInAnyOrder(
               StandardCommunity.of(1, 1), StandardCommunity.of(1, 2), StandardCommunity.of(3, 3)));
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -405,7 +405,7 @@ public final class XrGrammarTest {
               .build();
       Bgpv4Route route = processRouteIn(rp, inRoute);
       assertThat(
-          route.getCommunities(),
+          route.getCommunities().getCommunities(),
           containsInAnyOrder(StandardCommunity.of(1, 2), ExtendedCommunity.target(1L, 1L)));
     }
     {
@@ -414,7 +414,7 @@ public final class XrGrammarTest {
           base.toBuilder().setCommunities(ImmutableSet.of(StandardCommunity.of(9, 9))).build();
       Bgpv4Route route = processRouteIn(rp, inRoute);
       assertThat(
-          route.getCommunities(),
+          route.getCommunities().getCommunities(),
           containsInAnyOrder(StandardCommunity.of(1, 2), StandardCommunity.of(9, 9)));
     }
     {
@@ -425,7 +425,8 @@ public final class XrGrammarTest {
                   ImmutableSet.of(StandardCommunity.of(1, 1), StandardCommunity.INTERNET))
               .build();
       Bgpv4Route route = processRouteIn(rp, inRoute);
-      assertThat(route.getCommunities(), containsInAnyOrder(StandardCommunity.INTERNET));
+      assertThat(
+          route.getCommunities().getCommunities(), containsInAnyOrder(StandardCommunity.INTERNET));
     }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("deletein");
@@ -435,7 +436,7 @@ public final class XrGrammarTest {
                   ImmutableSet.of(StandardCommunity.of(1, 1), StandardCommunity.INTERNET))
               .build();
       Bgpv4Route route = processRouteIn(rp, inRoute);
-      assertThat(route.getCommunities(), empty());
+      assertThat(route.getCommunities().getCommunities(), empty());
     }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("deleteininline");
@@ -445,7 +446,7 @@ public final class XrGrammarTest {
                   ImmutableSet.of(StandardCommunity.of(1, 1), StandardCommunity.INTERNET))
               .build();
       Bgpv4Route route = processRouteIn(rp, inRoute);
-      assertThat(route.getCommunities(), empty());
+      assertThat(route.getCommunities().getCommunities(), empty());
     }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("deletenotin");
@@ -456,7 +457,7 @@ public final class XrGrammarTest {
               .build();
       Bgpv4Route route = processRouteIn(rp, inRoute);
       assertThat(
-          route.getCommunities(),
+          route.getCommunities().getCommunities(),
           containsInAnyOrder(StandardCommunity.of(1, 1), StandardCommunity.INTERNET));
     }
   }
@@ -585,7 +586,7 @@ public final class XrGrammarTest {
               .build();
       Bgpv4Route route = processRouteIn(rp, inRoute);
       assertThat(
-          route.getCommunities(),
+          route.getCommunities().getCommunities(),
           containsInAnyOrder(
               StandardCommunity.of(9, 9),
               ExtendedCommunity.target(1234L, 56L),
@@ -597,7 +598,7 @@ public final class XrGrammarTest {
       Bgpv4Route inRoute = base.toBuilder().build();
       Bgpv4Route route = processRouteIn(rp, inRoute);
       assertThat(
-          route.getCommunities(),
+          route.getCommunities().getCommunities(),
           containsInAnyOrder(
               ExtendedCommunity.target(1L, 1L), ExtendedCommunity.target((1L << 16) | 2, 3L)));
     }
@@ -609,7 +610,7 @@ public final class XrGrammarTest {
               .build();
       Bgpv4Route route = processRouteIn(rp, inRoute);
       assertThat(
-          route.getCommunities(),
+          route.getCommunities().getCommunities(),
           containsInAnyOrder(ExtendedCommunity.target(1L, 1L), ExtendedCommunity.target(2L, 2L)));
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
@@ -370,12 +370,13 @@ public class CumulusConcatenatedGrammarTest {
     Bgpv4Route outputRoute2 = processRouteIn(rp2, inRoute);
     Bgpv4Route outputRoute3 = processRouteIn(rp3, inRoute);
     assertThat(
-        outputRoute1.getCommunities(),
+        outputRoute1.getCommunities().getCommunities(),
         containsInAnyOrder(
             StandardCommunity.of(2, 2), StandardCommunity.of(3, 3), StandardCommunity.of(4, 4)));
-    assertThat(outputRoute2.getCommunities(), contains(StandardCommunity.of(1, 1)));
     assertThat(
-        outputRoute3.getCommunities(),
+        outputRoute2.getCommunities().getCommunities(), contains(StandardCommunity.of(1, 1)));
+    assertThat(
+        outputRoute3.getCommunities().getCommunities(),
         containsInAnyOrder(
             StandardCommunity.of(2, 2), StandardCommunity.of(3, 3), StandardCommunity.of(4, 4)));
   }
@@ -443,12 +444,12 @@ public class CumulusConcatenatedGrammarTest {
     // RMs using expanded comm-lists.
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("RM_EXPANDED_TEST_DELETE_ALL_COMMUNITIES");
-      assertThat(processRouteIn(rp, inRoute).getCommunities(), empty());
+      assertThat(processRouteIn(rp, inRoute).getCommunities().getCommunities(), empty());
     }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("RM_EXPANDED_TEST_DELETE_COMM_BEGIN_WITH_1");
       assertThat(
-          processRouteIn(rp, inRoute).getCommunities(),
+          processRouteIn(rp, inRoute).getCommunities().getCommunities(),
           contains(
               StandardCommunity.of(2, 1),
               StandardCommunity.of(2, 2),
@@ -458,7 +459,7 @@ public class CumulusConcatenatedGrammarTest {
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("RM_EXPANDED_TEST_DELETE_COMM_BEGIN_WITH_2");
       assertThat(
-          processRouteIn(rp, inRoute).getCommunities(),
+          processRouteIn(rp, inRoute).getCommunities().getCommunities(),
           contains(
               StandardCommunity.of(1, 1),
               StandardCommunity.of(1, 2),
@@ -468,7 +469,7 @@ public class CumulusConcatenatedGrammarTest {
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("RM_EXPANDED_TEST_DELETE_COMM_BEGIN_WITH_3");
       assertThat(
-          processRouteIn(rp, inRoute).getCommunities(),
+          processRouteIn(rp, inRoute).getCommunities().getCommunities(),
           contains(
               StandardCommunity.of(1, 1),
               StandardCommunity.of(1, 2),
@@ -478,7 +479,7 @@ public class CumulusConcatenatedGrammarTest {
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("RM_EXPANDED_TEST_DELETE_COMM_DENY_PERMIT");
       assertThat(
-          processRouteIn(rp, inRoute).getCommunities(),
+          processRouteIn(rp, inRoute).getCommunities().getCommunities(),
           contains(
               StandardCommunity.of(1, 1),
               StandardCommunity.of(1, 2),
@@ -490,7 +491,7 @@ public class CumulusConcatenatedGrammarTest {
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("RM_STANDARD_TEST_DELETE_COMM_1_1");
       assertThat(
-          processRouteIn(rp, inRoute).getCommunities(),
+          processRouteIn(rp, inRoute).getCommunities().getCommunities(),
           contains(
               StandardCommunity.of(1, 2),
               StandardCommunity.of(2, 1),
@@ -501,7 +502,7 @@ public class CumulusConcatenatedGrammarTest {
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("RM_STANDARD_TEST_DELETE_COMM_2_1");
       assertThat(
-          processRouteIn(rp, inRoute).getCommunities(),
+          processRouteIn(rp, inRoute).getCommunities().getCommunities(),
           contains(
               StandardCommunity.of(1, 1),
               StandardCommunity.of(1, 2),
@@ -512,7 +513,7 @@ public class CumulusConcatenatedGrammarTest {
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("RM_STANDARD_TEST_DELETE_COMM_3_1");
       assertThat(
-          processRouteIn(rp, inRoute).getCommunities(),
+          processRouteIn(rp, inRoute).getCommunities().getCommunities(),
           contains(
               StandardCommunity.of(1, 1),
               StandardCommunity.of(1, 2),
@@ -523,7 +524,7 @@ public class CumulusConcatenatedGrammarTest {
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("RM_STANDARD_TEST_DELETE_COMM_DENY_PERMIT");
       assertThat(
-          processRouteIn(rp, inRoute).getCommunities(),
+          processRouteIn(rp, inRoute).getCommunities().getCommunities(),
           contains(
               StandardCommunity.of(1, 1),
               StandardCommunity.of(2, 1),

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishGrammarTest.java
@@ -1137,7 +1137,7 @@ public final class F5BigipImishGrammarTest {
     assertTrue("rm1 accepts prefix 10.0.1.0/24 (via 20)", acceptedBy20.getBooleanValue());
     assertThat(
         "rm1 sets communities 1:2 and 33:44 on the output route",
-        outputRoute.build().getCommunities(),
+        outputRoute.build().getCommunities().getCommunities(),
         equalTo(ImmutableSet.of(StandardCommunity.of(1, 2), StandardCommunity.of(33, 44))));
 
     assertTrue(

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredGrammarTest.java
@@ -2698,7 +2698,7 @@ public final class F5BigipStructuredGrammarTest {
     assertTrue("rm1 accepts prefix 10.0.1.0/24 (via 20)", acceptedBy20.getBooleanValue());
     assertThat(
         "rm1 sets communities 1:2 and 33:44 on the output route",
-        outputRoute.build().getCommunities(),
+        outputRoute.build().getCommunities().getCommunities(),
         equalTo(ImmutableSet.of(StandardCommunity.of(1, 2), StandardCommunity.of(33, 44))));
 
     assertTrue(

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -982,7 +982,7 @@ public final class FlatJuniperGrammarTest {
     Bgpv4Route br1 = b1.build();
 
     assertThat(
-        br1.getCommunities(),
+        br1.getCommunities().getCommunities(),
         equalTo(
             ImmutableSet.of(
                 StandardCommunity.NO_ADVERTISE,
@@ -1002,7 +1002,7 @@ public final class FlatJuniperGrammarTest {
     Bgpv4Route br2 = b2.build();
 
     assertThat(
-        br2.getCommunities(),
+        br2.getCommunities().getCommunities(),
         equalTo(ImmutableSet.of(StandardCommunity.of(2L), StandardCommunity.of(3L))));
 
     // p3
@@ -1017,7 +1017,8 @@ public final class FlatJuniperGrammarTest {
     p3.process(cr, b3, Direction.OUT);
     Bgpv4Route br3 = b3.build();
 
-    assertThat(br3.getCommunities(), equalTo(ImmutableSet.of(StandardCommunity.of(5L))));
+    assertThat(
+        br3.getCommunities().getCommunities(), equalTo(ImmutableSet.of(StandardCommunity.of(5L))));
   }
 
   @Test
@@ -1039,7 +1040,7 @@ public final class FlatJuniperGrammarTest {
     Bgpv4Route br4 = b4.build();
 
     assertThat(
-        br4.getCommunities(),
+        br4.getCommunities().getCommunities(),
         equalTo(
             ImmutableSet.of(
                 StandardCommunity.NO_ADVERTISE,
@@ -1060,7 +1061,7 @@ public final class FlatJuniperGrammarTest {
     Bgpv4Route br5 = b5.build();
 
     assertThat(
-        br5.getCommunities(),
+        br5.getCommunities().getCommunities(),
         equalTo(
             ImmutableSet.of(
                 StandardCommunity.of(2L), StandardCommunity.of(3L), StandardCommunity.of(5L))));
@@ -1077,7 +1078,8 @@ public final class FlatJuniperGrammarTest {
     p6.process(cr, b6, Direction.OUT);
     Bgpv4Route br6 = b6.build();
 
-    assertThat(br6.getCommunities(), equalTo(ImmutableSet.of(StandardCommunity.of(5L))));
+    assertThat(
+        br6.getCommunities().getCommunities(), equalTo(ImmutableSet.of(StandardCommunity.of(5L))));
   }
 
   @Test
@@ -1102,7 +1104,9 @@ public final class FlatJuniperGrammarTest {
       rp.process(builder.build(), builder, Direction.OUT);
       Bgpv4Route outputRoute = builder.build();
 
-      assertThat(outputRoute.getCommunities(), equalTo(ImmutableSet.of(StandardCommunity.of(5L))));
+      assertThat(
+          outputRoute.getCommunities().getCommunities(),
+          equalTo(ImmutableSet.of(StandardCommunity.of(5L))));
     }
     {
       // p8 - delete mixed
@@ -1120,7 +1124,8 @@ public final class FlatJuniperGrammarTest {
       Bgpv4Route outputRoute = builder.build();
 
       assertThat(
-          outputRoute.getCommunities(), equalTo(ImmutableSet.of(StandardCommunity.of(0, 11))));
+          outputRoute.getCommunities().getCommunities(),
+          equalTo(ImmutableSet.of(StandardCommunity.of(0, 11))));
     }
     {
       // p9 - delete regex
@@ -1133,7 +1138,8 @@ public final class FlatJuniperGrammarTest {
       Bgpv4Route outputRoute = builder.build();
 
       assertThat(
-          outputRoute.getCommunities(), equalTo(ImmutableSet.of(StandardCommunity.of(0, 2))));
+          outputRoute.getCommunities().getCommunities(),
+          equalTo(ImmutableSet.of(StandardCommunity.of(0, 2))));
     }
     {
       // p10 - delete inverted
@@ -1146,7 +1152,8 @@ public final class FlatJuniperGrammarTest {
       Bgpv4Route outputRoute = builder.build();
 
       assertThat(
-          outputRoute.getCommunities(), equalTo(ImmutableSet.of(StandardCommunity.of(0, 12345))));
+          outputRoute.getCommunities().getCommunities(),
+          equalTo(ImmutableSet.of(StandardCommunity.of(0, 12345))));
     }
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -468,7 +468,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
         .setLocalPreference(dataplaneBgpRoute.getLocalPreference())
         .setWeight(dataplaneBgpRoute.getWeight())
         .setNetwork(dataplaneBgpRoute.getNetwork())
-        .setCommunities(dataplaneBgpRoute.getCommunities())
+        .setCommunities(dataplaneBgpRoute.getCommunities().getCommunities())
         .setAsPath(dataplaneBgpRoute.getAsPath())
         .build();
   }

--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
@@ -316,7 +316,7 @@ public class RoutesAnswererUtil {
         .put(COL_LOCAL_PREF, bgpv4Route.getLocalPreference())
         .put(
             COL_COMMUNITIES,
-            bgpv4Route.getCommunities().stream()
+            bgpv4Route.getCommunities().getCommunities().stream()
                 .map(Community::toString)
                 .collect(toImmutableList()))
         .put(COL_ORIGIN_PROTOCOL, bgpv4Route.getSrcProtocol())
@@ -349,7 +349,9 @@ public class RoutesAnswererUtil {
         .put(COL_LOCAL_PREF, evpnRoute.getLocalPreference())
         .put(
             COL_COMMUNITIES,
-            evpnRoute.getCommunities().stream().map(Community::toString).collect(toImmutableList()))
+            evpnRoute.getCommunities().getCommunities().stream()
+                .map(Community::toString)
+                .collect(toImmutableList()))
         .put(COL_ORIGIN_PROTOCOL, evpnRoute.getSrcProtocol())
         .put(COL_ORIGIN_TYPE, evpnRoute.getOriginType())
         .put(COL_ORIGINATOR_ID, evpnRoute.getOriginatorIp())
@@ -689,7 +691,7 @@ public class RoutesAnswererUtil {
                                                 .setAsPath(route.getAsPath())
                                                 .setLocalPreference(route.getLocalPreference())
                                                 .setCommunities(
-                                                    route.getCommunities().stream()
+                                                    route.getCommunities().getCommunities().stream()
                                                         .map(Community::toString)
                                                         .collect(toImmutableList()))
                                                 .setOriginType(route.getOriginType())

--- a/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/testroutepolicies/TestRoutePoliciesAnswerer.java
@@ -172,7 +172,7 @@ public final class TestRoutePoliciesAnswerer extends Answerer {
         .setLocalPreference(dataplaneBgpRoute.getLocalPreference())
         .setWeight(dataplaneBgpRoute.getWeight())
         .setNetwork(dataplaneBgpRoute.getNetwork())
-        .setCommunities(dataplaneBgpRoute.getCommunities())
+        .setCommunities(dataplaneBgpRoute.getCommunities().getCommunities())
         .setAsPath(dataplaneBgpRoute.getAsPath())
         .build();
   }


### PR DESCRIPTION
- CommunitySet has interning and jsonification already
- Compute standard and extended community sets on demand; we could memoize later
- Fixup callers