### PR TITLE
Configuration.ipSpaces: make immutable, sort only for API

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Configuration.java
@@ -222,7 +222,7 @@ public final class Configuration implements Serializable {
 
   private Map<String, IpAccessList> _ipAccessLists;
 
-  private NavigableMap<String, IpSpace> _ipSpaces;
+  private Map<String, IpSpace> _ipSpaces;
 
   private NavigableMap<String, IpSpaceMetadata> _ipSpaceMetadata;
 
@@ -302,7 +302,7 @@ public final class Configuration implements Serializable {
     _interfaces = new TreeMap<>();
     _ipAccessLists = new TreeMap<>();
     _ip6AccessLists = new TreeMap<>();
-    _ipSpaces = new TreeMap<>();
+    _ipSpaces = new HashMap<>();
     _ipSpaceMetadata = new TreeMap<>();
     _ipsecPeerConfigs = ImmutableSortedMap.of();
     _ipsecPhase2Policies = ImmutableSortedMap.of();
@@ -566,9 +566,13 @@ public final class Configuration implements Serializable {
     return _ipsecPeerConfigs;
   }
 
-  @JsonProperty(PROP_IP_SPACES)
-  public NavigableMap<String, IpSpace> getIpSpaces() {
+  public Map<String, IpSpace> getIpSpaces() {
     return _ipSpaces;
+  }
+
+  @JsonProperty(PROP_IP_SPACES)
+  private NavigableMap<String, IpSpace> getIpSpacesJson() {
+    return ImmutableSortedMap.copyOf(_ipSpaces);
   }
 
   @JsonProperty(PROP_IP_SPACE_METADATA)
@@ -811,7 +815,7 @@ public final class Configuration implements Serializable {
   }
 
   @JsonProperty(PROP_IP_SPACES)
-  public void setIpSpaces(NavigableMap<String, IpSpace> ipSpaces) {
+  public void setIpSpaces(Map<String, IpSpace> ipSpaces) {
     _ipSpaces = ipSpaces;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
+++ b/projects/batfish/src/main/java/org/batfish/job/ConvertConfigurationJob.java
@@ -129,6 +129,7 @@ public class ConvertConfigurationJob extends BatfishJob<ConvertConfigurationResu
     c.setCommunitySets(toImmutableMap(c.getCommunitySets()));
     c.setInterfaces(verifyAndToImmutableMap(c.getAllInterfaces(), Interface::getName, w));
     c.setIpAccessLists(verifyAndToImmutableMap(c.getIpAccessLists(), IpAccessList::getName, w));
+    c.setIpSpaces(toImmutableMap(c.getIpSpaces()));
     c.setIp6AccessLists(verifyAndToImmutableMap(c.getIp6AccessLists(), Ip6AccessList::getName, w));
     c.setRouteFilterLists(
         verifyAndToImmutableMap(c.getRouteFilterLists(), RouteFilterList::getName, w));

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -120,7 +120,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableMap;
 import java.util.SortedMap;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -3338,7 +3337,7 @@ public final class PaloAltoGrammarTest {
     Configuration firewall1 =
         viConfigs.stream().filter(vi -> vi.getHostname().equals(firewallId1)).findFirst().get();
 
-    NavigableMap<String, IpSpace> ipSpaces = firewall1.getIpSpaces();
+    Map<String, IpSpace> ipSpaces = firewall1.getIpSpaces();
     assertThat(ipSpaces.keySet(), containsInAnyOrder(addrVsys1, addrVsys2));
     // Each vsys should inherit a different definition for the same address object
     assertIpSpacesEqual(ipSpaces.get(addrVsys1), Ip.parse("1.1.1.1").toIpSpace());


### PR DESCRIPTION
1. Because it was not immutable, it was being copied ALL THE TIME.
   On one firewall with a ton of named address objects, there was
   a large performance hit.
2. Move sorting to the API.