### PR TITLE
bazel: add a z3 tag to tests that require it

### DIFF
--- a/projects/allinone/BUILD
+++ b/projects/allinone/BUILD
@@ -231,6 +231,7 @@ junit_tests(
     srcs = glob([
         "src/test/java/org/batfish/minesweeper/smt/*.java",
     ]),
+    tags = ["z3"],
     deps = [
         "//projects/batfish",
         "//projects/batfish:batfish_testlib",

--- a/projects/minesweeper/BUILD
+++ b/projects/minesweeper/BUILD
@@ -52,6 +52,7 @@ junit_tests(
     srcs = glob([
         "src/test/java/**/*Test.java",
     ]),
+    tags = ["z3"],
     runtime_deps = [
         "@maven//:org_slf4j_slf4j_jdk14",
     ],

--- a/tests/java-smt/BUILD
+++ b/tests/java-smt/BUILD
@@ -8,4 +8,5 @@ ref_tests(
         "*.ref",
         "networks/**",
     ]),
+    tags = ["z3"],
 )


### PR DESCRIPTION
This makes it easier to not run any tests that use z3

    --test_tag_filters=-z3

I don't install z3 on my machines anymore now that no
core code uses it.