### PR TITLE
Implement garbage collection for old orphaned data

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/ICoordinator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/ICoordinator.java
@@ -1,6 +1,7 @@
 package org.batfish.common.plugin;
 
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Set;
 import org.batfish.common.BatfishLogger;
 
@@ -10,7 +11,12 @@ public interface ICoordinator {
 
   Set<String> getNetworkNames();
 
-  void initSnapshot(String networkName, String snapshotName, Path srcDir, boolean autoAnalyze);
+  void initSnapshot(
+      String networkName,
+      String snapshotName,
+      Path srcDir,
+      boolean autoAnalyze,
+      Instant creationTime);
 
   void registerTestrigSyncer(String name, SyncTestrigsPlugin plugin);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -733,7 +733,8 @@ public interface StorageProvider {
   /**
    * Loads the original zip for a snapshot upload request associated with the given key.
    *
-   * @throws IOException if there is an error
+   * @throws FileNotFoundException if the zip is not found.
+   * @throws IOException if there is any other error
    */
   @MustBeClosed
   @Nonnull
@@ -959,4 +960,11 @@ public interface StorageProvider {
   @MustBeClosed
   @Nonnull
   Stream<String> listInputAwsSingleAccountKeys(NetworkSnapshot snapshot) throws IOException;
+
+  /**
+   * Run implementation-specific garbage collection.
+   *
+   * @throws IOException if there is an error
+   */
+  void runGarbageCollection() throws IOException;
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -963,8 +963,13 @@ public interface StorageProvider {
   Stream<String> listInputAwsSingleAccountKeys(NetworkSnapshot snapshot) throws IOException;
 
   /**
-   * Run implementation-specific garbage collection. Data last modified after {@code
-   * expungeBeforeDate} shall not be expunged.
+   * Run implementation-specific garbage collection.
+   *
+   * <p>The caller guarantees that data last modified before the {@code expungeBeforeDate} is not
+   * live/user-visible, and is therefore safe to expunge. An implementation should only expunge
+   * later data if it can guarantee the effects will not be visible to {@link StorageProvider}
+   * clients. For instance, snapshot data for a deleted snapshot may be expunged even if last
+   * modified after the {@code expungeBeforeDate}.
    *
    * @throws IOException if there is an error
    */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/StorageProvider.java
@@ -4,6 +4,7 @@ import com.google.errorprone.annotations.MustBeClosed;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -962,9 +963,10 @@ public interface StorageProvider {
   Stream<String> listInputAwsSingleAccountKeys(NetworkSnapshot snapshot) throws IOException;
 
   /**
-   * Run implementation-specific garbage collection.
+   * Run implementation-specific garbage collection. Data last modified after {@code
+   * expungeBeforeDate} shall not be expunged.
    *
    * @throws IOException if there is an error
    */
-  void runGarbageCollection() throws IOException;
+  void runGarbageCollection(Instant expungeBeforeDate) throws IOException;
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -672,7 +673,7 @@ public final class FileBasedStorageTest {
     AnswerId newAnswerId = new AnswerId("answerNew-id");
 
     Instant oldTime = Instant.now();
-    Instant newTime = oldTime.plus(GC_SKEW_ALLOWANCE);
+    Instant newTime = oldTime.plus(GC_SKEW_ALLOWANCE).plus(Duration.ofMinutes(1L));
 
     // mock modified times for test
     FileBasedStorage storage =

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -1,7 +1,7 @@
 package org.batfish.storage;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.batfish.storage.FileBasedStorage.GC_SKEW_ALLOWANCE_MINUTES;
+import static org.batfish.storage.FileBasedStorage.GC_SKEW_ALLOWANCE;
 import static org.batfish.storage.FileBasedStorage.ISP_CONFIGURATION_KEY;
 import static org.batfish.storage.FileBasedStorage.getWorkLogPath;
 import static org.batfish.storage.FileBasedStorage.objectKeyToRelativePath;
@@ -672,7 +672,7 @@ public final class FileBasedStorageTest {
     AnswerId newAnswerId = new AnswerId("answerNew-id");
 
     Instant oldTime = Instant.now();
-    Instant newTime = oldTime.plus(GC_SKEW_ALLOWANCE_MINUTES + 1, ChronoUnit.MINUTES);
+    Instant newTime = oldTime.plus(GC_SKEW_ALLOWANCE);
 
     // mock modified times for test
     FileBasedStorage storage =

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
@@ -2,6 +2,7 @@ package org.batfish.storage;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -631,5 +632,5 @@ public class TestStorageProvider implements StorageProvider {
   }
 
   @Override
-  public void runGarbageCollection() {}
+  public void runGarbageCollection(Instant expungeBeforeDate) {}
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/TestStorageProvider.java
@@ -629,4 +629,7 @@ public class TestStorageProvider implements StorageProvider {
   public Stream<String> listInputAwsSingleAccountKeys(NetworkSnapshot snapshot) throws IOException {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public void runGarbageCollection() {}
 }

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -357,7 +357,7 @@ public class Main {
                 try {
                   Thread.sleep(period * 1000); // s -> ms
                   _logger.debugf("Coordinator running garbage collection...\n");
-                  Main.getWorkMgr().getStorage().runGarbageCollection();
+                  Main.getWorkMgr().runGarbageCollection();
                   _logger.debugf("Coordinator completed garbage collection.\n");
                 } catch (InterruptedException | IOException e) {
                   _logger.errorf(

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -350,6 +350,25 @@ public class Main {
         bindPortFutures.getWorkV2Port());
   }
 
+  private static void initGarbageCollector(int period) {
+    new Thread(
+            () -> {
+              while (true) {
+                try {
+                  Thread.sleep(period * 1000); // s -> ms
+                  _logger.debugf("Coordinator running garbage collection...\n");
+                  Main.getWorkMgr().getStorage().runGarbageCollection();
+                  _logger.debugf("Coordinator completed garbage collection.\n");
+                } catch (InterruptedException | IOException e) {
+                  _logger.errorf(
+                      "Coordinator garbage collector encountered an error:\n%s",
+                      Throwables.getStackTraceAsString(e));
+                }
+              }
+            })
+        .start();
+  }
+
   public static void main(String[] args) {
     mainInit(args);
     _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile());
@@ -398,6 +417,7 @@ public class Main {
         initTracer();
       }
       initWorkManager(portFutures);
+      _settings.getGarbageCollectionPeriod().ifPresent(Main::initGarbageCollector);
     } catch (Exception e) {
       System.err.println(
           "org.batfish.coordinator: Initialization of a helper failed: "

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -405,6 +405,9 @@ public class Main {
       System.exit(1);
     }
 
+    // run GC on startup
+    _workManager.triggerGarbageCollection();
+
     // sleep indefinitely, in 10 minute chunks
     try {
       while (true) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -359,7 +359,7 @@ public class Main {
                   _logger.debugf("Coordinator running garbage collection...\n");
                   Main.getWorkMgr().runGarbageCollection();
                   _logger.debugf("Coordinator completed garbage collection.\n");
-                } catch (InterruptedException | IOException e) {
+                } catch (Exception e) {
                   _logger.errorf(
                       "Coordinator garbage collector encountered an error:\n%s",
                       Throwables.getStackTraceAsString(e));

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/Main.java
@@ -350,25 +350,6 @@ public class Main {
         bindPortFutures.getWorkV2Port());
   }
 
-  private static void initGarbageCollector(int period) {
-    new Thread(
-            () -> {
-              while (true) {
-                try {
-                  Thread.sleep(period * 1000); // s -> ms
-                  _logger.debugf("Coordinator running garbage collection...\n");
-                  Main.getWorkMgr().runGarbageCollection();
-                  _logger.debugf("Coordinator completed garbage collection.\n");
-                } catch (Exception e) {
-                  _logger.errorf(
-                      "Coordinator garbage collector encountered an error:\n%s",
-                      Throwables.getStackTraceAsString(e));
-                }
-              }
-            })
-        .start();
-  }
-
   public static void main(String[] args) {
     mainInit(args);
     _logger = new BatfishLogger(_settings.getLogLevel(), false, _settings.getLogFile());
@@ -417,7 +398,6 @@ public class Main {
         initTracer();
       }
       initWorkManager(portFutures);
-      _settings.getGarbageCollectionPeriod().ifPresent(Main::initGarbageCollector);
     } catch (Exception e) {
       System.err.println(
           "org.batfish.coordinator: Initialization of a helper failed: "

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -2393,6 +2393,8 @@ public class WorkMgr extends AbstractCoordinator {
     } finally {
       CommonUtil.deleteDirectory(unzipDir);
     }
+    // Trigger GC since uploading initial snapshot can change expungeBeforeDate
+    triggerGarbageCollection();
   }
 
   public boolean checkNetworkExists(String networkName) {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -203,7 +203,7 @@ public class WorkMgr extends AbstractCoordinator {
   }
 
   /** Instruct storage provider to expunge old data */
-  public void runGarbageCollection() throws IOException {
+  private void runGarbageCollection() throws IOException {
     _logger.debugf("WorkMgr running garbage collection...\n");
     Optional<Instant> expungeBeforeDateOpt = computeExpungeBeforeDate();
     if (expungeBeforeDateOpt.isPresent()) {
@@ -809,7 +809,8 @@ public class WorkMgr extends AbstractCoordinator {
     return result;
   }
 
-  private void triggerGarbageCollection() {
+  /** Queues garbage collection */
+  void triggerGarbageCollection() {
     try {
       _gcExecutor.submit(
           () -> {

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/config/Settings.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/config/Settings.java
@@ -4,8 +4,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import javax.annotation.Nonnull;
 import org.batfish.common.BaseSettings;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
@@ -27,7 +25,6 @@ public class Settings extends BaseSettings {
 
   private static final String ARG_FILE_AUTHORIZER_ROOT_DIR = "fileauthrootdir";
   private static final String ARG_FILE_AUTHORIZER_USERS_FILE = "fileauthusersfile";
-  private static final String ARG_GARBAGE_COLLECTION_PERIOD = "garbagecollectionperiod";
   private static final String ARG_HELP = "help";
   private static final String ARG_LOG_FILE = "logfile";
   private static final String ARG_LOG_LEVEL = "loglevel";
@@ -77,7 +74,6 @@ public class Settings extends BaseSettings {
   private Path _fileAuthorizerPermsFile;
   private Path _fileAuthorizerRootDir;
   private Path _fileAuthorizerUsersFile;
-  private int _garbageCollectionPeriod;
   private String _logFile;
   private String _logLevel;
   private long _periodAssignWorkMs;
@@ -154,17 +150,6 @@ public class Settings extends BaseSettings {
 
   public Path getFileAuthorizerUsersFile() {
     return _fileAuthorizerUsersFile;
-  }
-
-  /**
-   * Period with which to run garbage collection of batfish data, or {@link Optional#empty} if
-   * garbage collection is disabled.
-   */
-  public @Nonnull Optional<Integer> getGarbageCollectionPeriod() {
-    if (_garbageCollectionPeriod <= 0) {
-      return Optional.empty();
-    }
-    return Optional.of(_garbageCollectionPeriod);
   }
 
   public String getLogFile() {
@@ -312,7 +297,6 @@ public class Settings extends BaseSettings {
     setDefaultProperty(ARG_FILE_AUTHORIZER_PERMS_FILE, "perms.json");
     setDefaultProperty(ARG_FILE_AUTHORIZER_ROOT_DIR, "fileauthorizer");
     setDefaultProperty(ARG_FILE_AUTHORIZER_USERS_FILE, "users.json");
-    setDefaultProperty(ARG_GARBAGE_COLLECTION_PERIOD, 600);
     setDefaultProperty(ARG_HELP, false);
     setDefaultProperty(ARG_LOG_FILE, null);
     setDefaultProperty(ARG_LOG_LEVEL, BatfishLogger.getLogLevelStr(BatfishLogger.LEVEL_OUTPUT));
@@ -360,11 +344,6 @@ public class Settings extends BaseSettings {
         "expiration time (ms)");
 
     addBooleanOption(ARG_DRIVER_CLASS, "jdbc driver class to load explicitly");
-
-    addOption(
-        ARG_GARBAGE_COLLECTION_PERIOD,
-        "period with which to run garbage collection of batfish data (s). 0 indicates that garbage collection should be disabled.",
-        "period_s");
 
     addBooleanOption(ARG_HELP, "print this message");
 
@@ -447,7 +426,6 @@ public class Settings extends BaseSettings {
     _fileAuthorizerRootDir = Paths.get(getStringOptionValue(ARG_FILE_AUTHORIZER_ROOT_DIR));
     _fileAuthorizerPermsFile = Paths.get(getStringOptionValue(ARG_FILE_AUTHORIZER_PERMS_FILE));
     _fileAuthorizerUsersFile = Paths.get(getStringOptionValue(ARG_FILE_AUTHORIZER_USERS_FILE));
-    _garbageCollectionPeriod = getIntegerOptionValue(ARG_GARBAGE_COLLECTION_PERIOD);
     _questionTemplateDirs = getPathListOptionValue(ARG_QUESTION_TEMPLATE_DIRS);
     _queuIncompleteWork = getStringOptionValue(ARG_QUEUE_INCOMPLETE_WORK);
     _queueCompletedWork = getStringOptionValue(ARG_QUEUE_COMPLETED_WORK);

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/config/Settings.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/config/Settings.java
@@ -4,6 +4,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
 import org.batfish.common.BaseSettings;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
@@ -25,6 +27,7 @@ public class Settings extends BaseSettings {
 
   private static final String ARG_FILE_AUTHORIZER_ROOT_DIR = "fileauthrootdir";
   private static final String ARG_FILE_AUTHORIZER_USERS_FILE = "fileauthusersfile";
+  private static final String ARG_GARBAGE_COLLECTION_PERIOD = "garbagecollectionperiod";
   private static final String ARG_HELP = "help";
   private static final String ARG_LOG_FILE = "logfile";
   private static final String ARG_LOG_LEVEL = "loglevel";
@@ -74,6 +77,7 @@ public class Settings extends BaseSettings {
   private Path _fileAuthorizerPermsFile;
   private Path _fileAuthorizerRootDir;
   private Path _fileAuthorizerUsersFile;
+  private int _garbageCollectionPeriod;
   private String _logFile;
   private String _logLevel;
   private long _periodAssignWorkMs;
@@ -150,6 +154,17 @@ public class Settings extends BaseSettings {
 
   public Path getFileAuthorizerUsersFile() {
     return _fileAuthorizerUsersFile;
+  }
+
+  /**
+   * Period with which to run garbage collection of batfish data, or {@link Optional#empty} if
+   * garbage collection is disabled.
+   */
+  public @Nonnull Optional<Integer> getGarbageCollectionPeriod() {
+    if (_garbageCollectionPeriod <= 0) {
+      return Optional.empty();
+    }
+    return Optional.of(_garbageCollectionPeriod);
   }
 
   public String getLogFile() {
@@ -297,6 +312,7 @@ public class Settings extends BaseSettings {
     setDefaultProperty(ARG_FILE_AUTHORIZER_PERMS_FILE, "perms.json");
     setDefaultProperty(ARG_FILE_AUTHORIZER_ROOT_DIR, "fileauthorizer");
     setDefaultProperty(ARG_FILE_AUTHORIZER_USERS_FILE, "users.json");
+    setDefaultProperty(ARG_GARBAGE_COLLECTION_PERIOD, 600);
     setDefaultProperty(ARG_HELP, false);
     setDefaultProperty(ARG_LOG_FILE, null);
     setDefaultProperty(ARG_LOG_LEVEL, BatfishLogger.getLogLevelStr(BatfishLogger.LEVEL_OUTPUT));
@@ -344,6 +360,11 @@ public class Settings extends BaseSettings {
         "expiration time (ms)");
 
     addBooleanOption(ARG_DRIVER_CLASS, "jdbc driver class to load explicitly");
+
+    addOption(
+        ARG_GARBAGE_COLLECTION_PERIOD,
+        "period with which to run garbage collection of batfish data (s). 0 indicates that garbage collection should be disabled.",
+        "period_s");
 
     addBooleanOption(ARG_HELP, "print this message");
 
@@ -426,6 +447,7 @@ public class Settings extends BaseSettings {
     _fileAuthorizerRootDir = Paths.get(getStringOptionValue(ARG_FILE_AUTHORIZER_ROOT_DIR));
     _fileAuthorizerPermsFile = Paths.get(getStringOptionValue(ARG_FILE_AUTHORIZER_PERMS_FILE));
     _fileAuthorizerUsersFile = Paths.get(getStringOptionValue(ARG_FILE_AUTHORIZER_USERS_FILE));
+    _garbageCollectionPeriod = getIntegerOptionValue(ARG_GARBAGE_COLLECTION_PERIOD);
     _questionTemplateDirs = getPathListOptionValue(ARG_QUESTION_TEMPLATE_DIRS);
     _queuIncompleteWork = getStringOptionValue(ARG_QUEUE_INCOMPLETE_WORK);
     _queueCompletedWork = getStringOptionValue(ARG_QUEUE_COMPLETED_WORK);

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -50,11 +50,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -156,11 +156,16 @@ public final class WorkMgrTest {
   }
 
   private void createSnapshotWithMetadata(String network, String snapshot) throws IOException {
+    createSnapshotWithMetadata(network, snapshot, Instant.now());
+  }
+
+  private void createSnapshotWithMetadata(String network, String snapshot, Instant creationTime)
+      throws IOException {
     NetworkId networkId = _idManager.getNetworkId(network).get();
     SnapshotId snapshotId = _idManager.generateSnapshotId();
     _idManager.assignSnapshot(snapshot, networkId, snapshotId);
     _snapshotMetadataManager.writeMetadata(
-        new SnapshotMetadata(new Date().toInstant(), null), networkId, snapshotId);
+        new SnapshotMetadata(creationTime, null), networkId, snapshotId);
   }
 
   @Test
@@ -3439,5 +3444,39 @@ public final class WorkMgrTest {
 
     // Confirm filter options were applied correctly
     assertThat(processedRows, equalTo(table.getRowsList()));
+  }
+
+  @Test
+  public void testComputeExpungeBeforeTime() throws IOException {
+    String network = "network1";
+    String snapshotNew = "snapshotNew";
+    String snapshotOld = "snapshotOld";
+
+    Instant oldTime = Instant.now();
+    Instant newTime = oldTime.plus(1, ChronoUnit.MINUTES);
+
+    // In absence of snapshots, computeExpungeBeforeTime should return empty result.
+    assertThat(_manager.computeExpungeBeforeDate(), equalTo(Optional.empty()));
+    _manager.initNetwork(network, null);
+    assertThat(_manager.computeExpungeBeforeDate(), equalTo(Optional.empty()));
+
+    // Write old snapshot.
+    createSnapshotWithMetadata(network, snapshotOld, oldTime);
+
+    // Now computeExpungeBeforeTime should return the creation time of the old snapshot.
+    assertThat(_manager.computeExpungeBeforeDate(), equalTo(Optional.of(oldTime)));
+
+    // write new snapshot
+    createSnapshotWithMetadata(network, snapshotNew, newTime);
+
+    // computeExpungeBeforeTime should still return the creation time of the old snapshot.
+    assertThat(_manager.computeExpungeBeforeDate(), equalTo(Optional.of(oldTime)));
+
+    // delete old snapshot
+    _manager.delSnapshot(network, snapshotOld);
+
+    // With the old snapshot deleted, computeExpungeBeforeTime should return the creation time of
+    // the new snapshot.
+    assertThat(_manager.computeExpungeBeforeDate(), equalTo(Optional.of(newTime)));
   }
 }

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -959,7 +959,7 @@ public final class WorkMgrTest {
         snapshotDir.resolve(BfConsts.RELPATH_RUNTIME_DATA_FILE),
         BatfishObjectMapper.writePrettyString(runtimeData));
     _manager.initNetwork(networkName, null);
-    _manager.initSnapshot(networkName, baseSnapshotName, srcDir, false);
+    _manager.initSnapshot(networkName, baseSnapshotName, srcDir, false, Instant.now());
 
     // Create fork
     String forkName = "fork";
@@ -1039,7 +1039,7 @@ public final class WorkMgrTest {
         snapshotDir.resolve(BfConsts.RELPATH_INTERFACE_BLACKLIST_FILE),
         BatfishObjectMapper.writePrettyString(baseBlacklist));
     _manager.initNetwork(networkName, null);
-    _manager.initSnapshot(networkName, baseSnapshotName, srcDir, false);
+    _manager.initSnapshot(networkName, baseSnapshotName, srcDir, false, Instant.now());
 
     // Create fork
     String forkName = "fork";
@@ -1908,7 +1908,7 @@ public final class WorkMgrTest {
     // Create snapshot dir to pass into init
     Path srcDir = createSnapshot(snapshotName, fileName, fileContents, _folder);
 
-    _manager.initSnapshot(networkName, snapshotName, srcDir, false);
+    _manager.initSnapshot(networkName, snapshotName, srcDir, false, Instant.now());
 
     // Confirm the new snapshot exists
     assertThat(_manager.getLatestSnapshot(networkName), equalTo(Optional.of(snapshotName)));
@@ -1963,7 +1963,7 @@ public final class WorkMgrTest {
         snapshotDir.resolve(BfConsts.RELPATH_INTERFACE_BLACKLIST_FILE),
         BatfishObjectMapper.writePrettyString(blacklist));
     _manager.initNetwork(networkName, null);
-    _manager.initSnapshot(networkName, snapshotName, srcDir, false);
+    _manager.initSnapshot(networkName, snapshotName, srcDir, false, Instant.now());
 
     // Interface blacklist should not exist in new snapshot
     NetworkId networkId = _idManager.getNetworkId(networkName).get();
@@ -1996,7 +1996,8 @@ public final class WorkMgrTest {
 
     // Pass in path to subdir so init sees improperly formatted dir
     // i.e. sees dir containing 'configs/' instead of 'snapshotName/configs/'
-    _manager.initSnapshot(networkName, snapshotName, srcDir.resolve(snapshotName), false);
+    _manager.initSnapshot(
+        networkName, snapshotName, srcDir.resolve(snapshotName), false, Instant.now());
   }
 
   @Test


### PR DESCRIPTION
- coordinator runs garbage collection by default every 10 minutes
- Implement garbage collection for FileBasedStorage
  - delete files older than the oldest snapshot's creation time,
    minus an extra skew allowance of 10 minutes
  - delete:
    - snapshot folders
    - upload/fork zips
    - answers