### PR TITLE
BgpTopologyUtils: only check valid candidates for BGP peers

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/BgpTopologyUtils.java
@@ -158,6 +158,7 @@ public final class BgpTopologyUtils {
       Map<String, Multimap<String, BgpPeerConfigId>> receivers = new HashMap<>();
       for (BgpPeerConfigId peer : graph.nodes()) {
         if (peer.getType() == BgpPeerConfigType.UNNUMBERED) {
+          // Unnumbered configs only form sessions with each other
           continue;
         }
         Multimap<String, BgpPeerConfigId> vrf =


### PR DESCRIPTION
With a little pre-work and moving the Host/VRF check up, we can
reduce from quadratic to linear complexity.