### PR TITLE
Graph: more correct community regexes

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVar.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVar.java
@@ -46,6 +46,28 @@ public final class CommunityVar implements Comparable<CommunityVar> {
   @Nonnull private final String _regex;
   @Nullable private final Community _literalValue;
 
+  @Nonnull private static final String NUM_REGEX = "[0-9]+";
+
+  // a regex that represents the language of community literals supported by Batfish
+  // see Community::matchString() and its implementations
+  @Nonnull
+  private static final String COMMUNITY_REGEX =
+      // standard and extended communities
+      String.join(":", NUM_REGEX, NUM_REGEX)
+          + "|"
+          // large communities
+          + String.join(":", "large", NUM_REGEX, NUM_REGEX, NUM_REGEX);
+
+  /**
+   * When converting a community variable to an automaton (see toAutomaton()), we intersect with
+   * this automaton, which represents the language of community literals supported by Batfish. Doing
+   * so serves two purposes. First, it is necessary for correctness of the symbolic analysis. For
+   * example, a regex like ".*" does not actually match any possible string since communities cannot
+   * be arbitrary strings. Second, it ensures that when we solve for community literals that match
+   * regexes, we will get examples that are sensible and also parseable by Batfish.
+   */
+  @Nonnull static final Automaton COMMUNITY_FSM = new RegExp(COMMUNITY_REGEX).toAutomaton();
+
   private CommunityVar(Type type, String regex, @Nullable Community literalValue) {
     _type = type;
     _regex = regex;
@@ -103,7 +125,7 @@ public final class CommunityVar implements Comparable<CommunityVar> {
       regex = regex.replaceAll("\\$", "()");
     }
     // TODO: Handle the case when the regex only matches a prefix of the communities of interest
-    return new RegExp(regex).toAutomaton();
+    return new RegExp(regex).toAutomaton().intersection(COMMUNITY_FSM);
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVar.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVar.java
@@ -64,7 +64,7 @@ public final class CommunityVar implements Comparable<CommunityVar> {
    * so serves two purposes. First, it is necessary for correctness of the symbolic analysis. For
    * example, a regex like ".*" does not actually match any possible string since communities cannot
    * be arbitrary strings. Second, it ensures that when we solve for community literals that match
-   * regexes, we will get examples that are sensible and also parseable by Batfish.
+   * regexes, we will get examples that are sensible and also able to be parsed by Batfish.
    */
   @Nonnull static final Automaton COMMUNITY_FSM = new RegExp(COMMUNITY_REGEX).toAutomaton();
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/abstraction/Roles.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/abstraction/Roles.java
@@ -57,7 +57,7 @@ public class Roles {
   }
 
   private Roles(NetworkSnapshot snapshot, IBatfish batfish, NodesSpecifier nodesSpecifier) {
-    _graph = new Graph(batfish, snapshot);
+    _graph = new Graph(batfish, snapshot, true);
     _network = BDDNetwork.create(snapshot, new BDDPacket(), _graph, nodesSpecifier);
     _nodeSpecifier = nodesSpecifier;
     _bgpInEcs = null;

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDNetwork.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/BDDNetwork.java
@@ -29,8 +29,6 @@ public class BDDNetwork {
   private Graph _graph;
   private NodesSpecifier _nodeSpecifier;
 
-  private PolicyQuotient _policyQuotient;
-
   private Map<GraphEdge, BDDRoute> _exportBgpPolicies;
 
   private Map<GraphEdge, BDDRoute> _importBgpPolicies;
@@ -49,23 +47,17 @@ public class BDDNetwork {
 
   public static BDDNetwork create(
       NetworkSnapshot snapshot, BDDPacket pkt, Graph g, NodesSpecifier nodesSpecifier) {
-    PolicyQuotient pq = new PolicyQuotient(g);
-    BDDNetwork network = new BDDNetwork(snapshot, pkt, g, nodesSpecifier, pq);
+    BDDNetwork network = new BDDNetwork(snapshot, pkt, g, nodesSpecifier);
     network.computeInterfacePolicies();
     return network;
   }
 
   private BDDNetwork(
-      NetworkSnapshot snapshot,
-      BDDPacket pkt,
-      Graph graph,
-      NodesSpecifier nodesSpecifier,
-      PolicyQuotient pq) {
+      NetworkSnapshot snapshot, BDDPacket pkt, Graph graph, NodesSpecifier nodesSpecifier) {
     _graph = graph;
     _nodeSpecifier = nodesSpecifier;
     _snapshot = snapshot;
     _pkt = pkt;
-    _policyQuotient = pq;
     _importPolicyMap = new HashMap<>();
     _exportPolicyMap = new HashMap<>();
     _importBgpPolicies = new HashMap<>();
@@ -83,7 +75,7 @@ public class BDDNetwork {
     if (ignoreNetworks) {
       networks = Graph.getOriginatedNetworks(conf);
     }
-    TransferBDD t = new TransferBDD(g, conf, pol.getStatements(), _policyQuotient);
+    TransferBDD t = new TransferBDD(g, conf, pol.getStatements());
     return t.compute(networks).getReturnValue().getFirst();
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/PolicyQuotient.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/PolicyQuotient.java
@@ -34,13 +34,6 @@ public class PolicyQuotient {
 
   private Set<CommunityVar> _commsUsedOnlyLocally;
 
-  // create an empty policy quotient
-  public PolicyQuotient() {
-    _commsAssignedButNotMatched = new HashSet<>();
-    _commsMatchedButNotAssigned = new HashSet<>();
-    _commsUsedOnlyLocally = new HashSet<>();
-  }
-
   public PolicyQuotient(Graph graph) {
     _commsAssignedButNotMatched = new HashSet<>();
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -55,7 +55,6 @@ import org.batfish.minesweeper.CommunityVar;
 import org.batfish.minesweeper.Graph;
 import org.batfish.minesweeper.Protocol;
 import org.batfish.minesweeper.bdd.BDDRoute;
-import org.batfish.minesweeper.bdd.PolicyQuotient;
 import org.batfish.minesweeper.bdd.TransferBDD;
 import org.batfish.minesweeper.bdd.TransferReturn;
 import org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesQuestion.Action;
@@ -81,7 +80,6 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
   @Nonnull private final Action _action;
 
   @Nonnull private final Set<String> _communityRegexes;
-  @Nonnull private final PolicyQuotient _pq;
 
   public SearchRoutePoliciesAnswerer(SearchRoutePoliciesQuestion question, IBatfish batfish) {
     super(question, batfish);
@@ -100,7 +98,6 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
             .addAll(_inputConstraints.getCommunities())
             .addAll(_outputConstraints.getCommunities())
             .build();
-    _pq = new PolicyQuotient();
   }
 
   private static Optional<Community> stringToCommunity(String str) {
@@ -308,7 +305,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
                 .map(RegexCommunitySet::new)
                 .collect(ImmutableSet.toImmutableSet()));
     try {
-      TransferBDD tbdd = new TransferBDD(g, policy.getOwner(), policy.getStatements(), _pq);
+      TransferBDD tbdd = new TransferBDD(g, policy.getOwner(), policy.getStatements());
       result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     } catch (Exception e) {
       throw new BatfishException(

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -13,7 +13,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Ordering;
 import dk.brics.automaton.Automaton;
-import dk.brics.automaton.RegExp;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -74,10 +73,6 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
   public static final String COL_INPUT_ROUTE = "Input_Route";
   public static final String COL_ACTION = "Action";
   public static final String COL_OUTPUT_ROUTE = "Output_Route";
-
-  // concrete community literals that we generate must satisfy this regex,
-  // to help ensure that they will be parse-able
-  private static final Automaton COMMUNITY_FSM = new RegExp("[0-9]+(:[0-9]+)+").toAutomaton();
 
   @Nonnull private final BgpRouteConstraints _inputConstraints;
   @Nonnull private final BgpRouteConstraints _outputConstraints;
@@ -141,10 +136,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
     ImmutableSet.Builder<Community> comms = new ImmutableSet.Builder<>();
     for (int i = 0; i < aps.length; i++) {
       if (aps[i].andSat(fullModel)) {
-        // this atomic predicate is in the model, so create a concrete community for it.
-        // intersection with COMMUNITY_FSM helps ensure that the example we create will be
-        // a valid community.
-        Automaton a = apAutomata.get(i).intersection(COMMUNITY_FSM);
+        Automaton a = apAutomata.get(i);
         if (a.isEmpty()) {
           throw new BatfishException("Failed to produce a valid community for answer");
         }

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
@@ -2,15 +2,28 @@ package org.batfish.minesweeper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
+import dk.brics.automaton.RegExp;
 import java.util.List;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.junit.Test;
 
 /** Test of {@link CommunityVar} */
 public class CommunityVarTest {
+  @Test
+  public void testToAutomaton() {
+    CommunityVar cv1 = CommunityVar.from(".*");
+    CommunityVar cv2 = CommunityVar.from("^20:30$");
+    CommunityVar cv3 = CommunityVar.from("large:10:20:30");
+
+    assertEquals(CommunityVar.COMMUNITY_FSM, cv1.toAutomaton());
+    assertEquals(new RegExp("20:30").toAutomaton(), cv2.toAutomaton());
+    assertEquals(new RegExp("large:10:20:30").toAutomaton(), cv3.toAutomaton());
+  }
+
   @Test
   public void testEquals() {
     CommunityVar cv = CommunityVar.from(StandardCommunity.of(1, 1));

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
@@ -8,6 +8,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import dk.brics.automaton.RegExp;
 import java.util.List;
+import org.batfish.datamodel.bgp.community.ExtendedCommunity;
+import org.batfish.datamodel.bgp.community.LargeCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.junit.Test;
 
@@ -15,10 +17,12 @@ import org.junit.Test;
 public class CommunityVarTest {
   @Test
   public void testToAutomaton() {
-    CommunityVar cv1 = CommunityVar.from(".*");
-    CommunityVar cv2 = CommunityVar.from("^20:30$");
-    CommunityVar cv3 = CommunityVar.from("large:10:20:30");
+    CommunityVar cv0 = CommunityVar.from(StandardCommunity.of(20, 30));
+    CommunityVar cv1 = CommunityVar.from("^.*$");
+    CommunityVar cv2 = CommunityVar.from(ExtendedCommunity.of(10, 20, 30));
+    CommunityVar cv3 = CommunityVar.from(LargeCommunity.of(10, 20, 30));
 
+    assertEquals(new RegExp("20:30").toAutomaton(), cv0.toAutomaton());
     assertEquals(CommunityVar.COMMUNITY_FSM, cv1.toAutomaton());
     assertEquals(new RegExp("20:30").toAutomaton(), cv2.toAutomaton());
     assertEquals(new RegExp("large:10:20:30").toAutomaton(), cv3.toAutomaton());

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -66,7 +66,6 @@ public class TransferBDDTest {
   private IBatfish _batfish;
   private Configuration _baseConfig;
   private Graph _g;
-  private PolicyQuotient _pq;
   private BDDRoute _anyRoute;
 
   private static final String COMMUNITY_NAME = "community";
@@ -115,8 +114,6 @@ public class TransferBDDTest {
 
     _batfish = new MockBatfish(ImmutableSortedMap.of(HOSTNAME, _baseConfig));
     _anyRoute = new BDDRoute(0);
-
-    _pq = new PolicyQuotient();
   }
 
   private MatchPrefixSet matchPrefixSet(List<PrefixRange> prList) {
@@ -128,9 +125,9 @@ public class TransferBDDTest {
   public void testCaptureAll() {
     RoutingPolicy policy =
         _policyBuilder.addStatement(new StaticStatement(Statements.ExitAccept)).build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -146,9 +143,9 @@ public class TransferBDDTest {
   public void testCaptureNone() {
     RoutingPolicy policy =
         _policyBuilder.addStatement(new StaticStatement(Statements.ExitReject)).build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -163,8 +160,8 @@ public class TransferBDDTest {
   @Test
   public void testEmptyPolicy() {
 
-    _g = new Graph(_batfish, _batfish.getSnapshot());
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, ImmutableList.of(), _pq);
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, ImmutableList.of());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -183,9 +180,9 @@ public class TransferBDDTest {
                 ImmutableList.of(new PrefixRange(Prefix.parse("1.0.0.0/8"), new SubRange(16, 24)))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -211,9 +208,9 @@ public class TransferBDDTest {
                 Statements.ExitAccept.toStaticStatement())));
 
     RoutingPolicy policy = _policyBuilder.build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -237,9 +234,9 @@ public class TransferBDDTest {
                 Statements.ExitAccept.toStaticStatement())));
 
     RoutingPolicy policy = _policyBuilder.build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -266,9 +263,9 @@ public class TransferBDDTest {
                 Statements.ExitAccept.toStaticStatement())));
 
     RoutingPolicy policy = _policyBuilder.build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -305,9 +302,9 @@ public class TransferBDDTest {
                     ImmutableList.of(Statements.ExitAccept.toStaticStatement())))));
 
     RoutingPolicy policy = _policyBuilder.build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -329,9 +326,9 @@ public class TransferBDDTest {
                     new PrefixRange(Prefix.parse("1.2.0.0/16"), new SubRange(20, 32)))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -359,9 +356,9 @@ public class TransferBDDTest {
                             new PrefixRange(Prefix.parse("1.2.0.0/16"), new SubRange(20, 32)))))),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -380,9 +377,9 @@ public class TransferBDDTest {
             .addStatement(new SetLocalPreference(new LiteralLong(42)))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -404,9 +401,9 @@ public class TransferBDDTest {
             .addStatement(new SetMetric(new LiteralLong(50)))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -439,9 +436,9 @@ public class TransferBDDTest {
             new MatchCommunitySet(new NamedCommunitySet(COMMUNITY_NAME)),
             ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
     RoutingPolicy policy = _policyBuilder.build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -463,9 +460,9 @@ public class TransferBDDTest {
                 new DeleteCommunity(new LiteralCommunity(StandardCommunity.parse("20:30"))))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -490,9 +487,9 @@ public class TransferBDDTest {
             .addStatement(new SetCommunity(new LiteralCommunity(StandardCommunity.parse("4:44"))))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -517,9 +514,9 @@ public class TransferBDDTest {
             .addStatement(new SetCommunity(new LiteralCommunity(StandardCommunity.parse("4:44"))))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -551,9 +548,9 @@ public class TransferBDDTest {
             .addStatement(new AddCommunity(new LiteralCommunity(StandardCommunity.parse("4:44"))))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -584,9 +581,9 @@ public class TransferBDDTest {
             .addStatement(new SetCommunity(new LiteralCommunity(ExtendedCommunity.parse("0:4:44"))))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();
@@ -611,9 +608,9 @@ public class TransferBDDTest {
             .addStatement(new SetCommunity(new LiteralCommunity(LargeCommunity.of(10, 20, 30))))
             .addStatement(new StaticStatement(Statements.ExitAccept))
             .build();
-    _g = new Graph(_batfish, _batfish.getSnapshot());
+    _g = new Graph(_batfish, _batfish.getSnapshot(), true);
 
-    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements(), _pq);
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
     TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
     BDD acceptedAnnouncements = result.getSecond();
     BDDRoute outAnnouncements = result.getFirst();

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswererTest.java
@@ -825,4 +825,29 @@ public class SearchRoutePoliciesAnswererTest {
                 hasColumn(COL_INPUT_ROUTE, equalTo(inputRoute), Schema.BGP_ROUTE),
                 hasColumn(COL_OUTPUT_ROUTE, equalTo(inputRoute), Schema.BGP_ROUTE))));
   }
+
+  @Test
+  public void testTwoVersionsOfACommunity() {
+    _policyBuilder.addStatement(
+        new If(
+            matchNamedCommunity(REGEX_COMMUNITY_NAME),
+            ImmutableList.of(new StaticStatement(Statements.ExitAccept))));
+    RoutingPolicy policy = _policyBuilder.build();
+
+    SearchRoutePoliciesQuestion question =
+        new SearchRoutePoliciesQuestion(
+            EMPTY_CONSTRAINTS,
+            BgpRouteConstraints.builder()
+                .setCommunities(ImmutableSet.of("2[0-9]:30"))
+                .setComplementCommunities(true)
+                .build(),
+            HOSTNAME,
+            policy.getName(),
+            Action.PERMIT);
+    SearchRoutePoliciesAnswerer answerer = new SearchRoutePoliciesAnswerer(question, _batfish);
+
+    TableAnswerElement answer = (TableAnswerElement) answerer.answer(_batfish.getSnapshot());
+
+    assertEquals(0, answer.getRows().size());
+  }
 }


### PR DESCRIPTION
When producing atomic predicates for community regexes as part of the Graph object, we intersect each one with a regex representing the language of community literals supported by Batfish. Doing so serves two purposes. First, it is necessary for correctness of the route analysis. For example, a regex like .* does not actually match any possible string since communities cannot be arbitrary strings. Second, it ensures that when we solve for community literals that match regexes, we will get examples that are sensible and also able to be parsed by Batfish.

This update broke some of the SMT-based minesweeper code, which also relies on the Graph, since community atomic predicates impose some new restrictons on community regexes.  Therefore we've also introduced a flag in Graph to cleanly separate BDD-based analyses from SMT-based analyses.  The BDD-based analyses no longer depend on the old way of tracking community dependencies, and the SMT-based analyses no longer depend on community atomic predicates.