### PR TITLE
coordinator: delete ssl support

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/BfCoordWorkHelper.java
@@ -90,15 +90,7 @@ public class BfCoordWorkHelper {
   }
 
   private ClientBuilder getClientBuilder() {
-    return CommonUtil.createHttpClientBuilder(
-            _settings.getSslDisable(),
-            _settings.getSslTrustAllCerts(),
-            _settings.getSslKeystoreFile(),
-            _settings.getSslKeystorePassword(),
-            _settings.getSslTruststoreFile(),
-            _settings.getSslTruststorePassword(),
-            true)
-        .register(MultiPartFeature.class);
+    return CommonUtil.createHttpClientBuilder(true).register(MultiPartFeature.class);
   }
 
   /**
@@ -172,10 +164,8 @@ public class BfCoordWorkHelper {
   }
 
   private WebTarget getTarget(String resource) {
-    String protocol = (_settings.getSslDisable()) ? "http" : "https";
     String urlString =
-        String.format(
-            "%s://%s%s/%s", protocol, _coordWorkMgr, CoordConsts.SVC_CFG_WORK_MGR, resource);
+        String.format("http://%s%s/%s", _coordWorkMgr, CoordConsts.SVC_CFG_WORK_MGR, resource);
     return _client.target(urlString);
   }
 
@@ -184,9 +174,7 @@ public class BfCoordWorkHelper {
    * {@code resources} to base url of service V2.
    */
   public WebTarget getTargetV2(List<String> resources) {
-    String protocol = (_settings.getSslDisable()) ? "http" : "https";
-    String urlString =
-        String.format("%s://%s%s", protocol, _coordWorkMgrV2, CoordConsts.SVC_CFG_WORK_MGR2);
+    String urlString = String.format("http://%s%s", _coordWorkMgrV2, CoordConsts.SVC_CFG_WORK_MGR2);
     WebTarget target = _client.target(urlString);
     for (String resource : resources) {
       target = target.path(resource);

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -1894,9 +1894,7 @@ public class Client extends AbstractClient implements IClient {
     }
     loadPlugins();
     initHelpers();
-    _logger.debugf(
-        "Will use coordinator at %s://%s\n",
-        (_settings.getSslDisable()) ? "http" : "https", _settings.getCoordinatorHost());
+    _logger.debugf("Will use coordinator at http://%s\n", _settings.getCoordinatorHost());
 
     if (!processCommands(initialCommands)) {
       return;

--- a/projects/batfish-client/src/main/java/org/batfish/client/config/Settings.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/config/Settings.java
@@ -1,6 +1,5 @@
 package org.batfish.client.config;
 
-import java.nio.file.Path;
 import org.batfish.common.BaseSettings;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.BfConsts;
@@ -34,6 +33,8 @@ public class Settings extends BaseSettings {
   private static final String ARG_TRACING_AGENT_HOST = "tracingagenthost";
   private static final String ARG_TRACING_AGENT_PORT = "tracingagentport";
   public static final String ARG_TRACING_ENABLE = "tracingenable";
+  private static final String DEPRECATED_ARG_DESC =
+      "(ignored, provided for backwards compatibility)";
   private static final String EXECUTABLE_NAME = "batfish_client";
 
   private String _apiKey;
@@ -54,12 +55,6 @@ public class Settings extends BaseSettings {
   private String _serviceName;
   private String _snapshotDir;
   private String _snapshotId;
-  private boolean _sslDisable;
-  private Path _sslKeystoreFile;
-  private String _sslKeystorePassword;
-  private boolean _sslTrustAllCerts;
-  private Path _sslTruststoreFile;
-  private String _sslTruststorePassword;
   private String _tracingAgentHost;
   private Integer _tracingAgentPort;
   private boolean _tracingEnable;
@@ -145,30 +140,6 @@ public class Settings extends BaseSettings {
     return _snapshotId;
   }
 
-  public boolean getSslDisable() {
-    return _sslDisable;
-  }
-
-  public Path getSslKeystoreFile() {
-    return _sslKeystoreFile;
-  }
-
-  public String getSslKeystorePassword() {
-    return _sslKeystorePassword;
-  }
-
-  public boolean getSslTrustAllCerts() {
-    return _sslTrustAllCerts;
-  }
-
-  public Path getSslTruststoreFile() {
-    return _sslTruststoreFile;
-  }
-
-  public String getSslTruststorePassword() {
-    return _sslTruststorePassword;
-  }
-
   public Integer getTracingAgentPort() {
     return _tracingAgentPort;
   }
@@ -187,8 +158,6 @@ public class Settings extends BaseSettings {
         ARG_BATFISH_LOG_LEVEL, BatfishLogger.getLogLevelStr(BatfishLogger.LEVEL_WARN));
     setDefaultProperty(ARG_COORDINATOR_HOST, "localhost");
     setDefaultProperty(ARG_DATAMODEL_DIR, "datamodel");
-    setDefaultProperty(BfConsts.ARG_SSL_DISABLE, CoordConsts.SVC_CFG_WORK_SSL_DISABLE);
-    setDefaultProperty(BfConsts.ARG_SSL_TRUST_ALL_CERTS, false);
     setDefaultProperty(ARG_HELP, false);
     setDefaultProperty(ARG_LOG_FILE, null);
     setDefaultProperty(ARG_LOG_LEVEL, BatfishLogger.getLogLevelStr(BatfishLogger.LEVEL_OUTPUT));
@@ -198,12 +167,6 @@ public class Settings extends BaseSettings {
     setDefaultProperty(ARG_SERVICE_NAME, "client-service");
     setDefaultProperty(ARG_SERVICE_WORK_PORT, CoordConsts.SVC_CFG_WORK_PORT);
     setDefaultProperty(ARG_SERVICE_WORK_V2_PORT, CoordConsts.SVC_CFG_WORK_V2_PORT);
-    setDefaultProperty(BfConsts.ARG_SSL_DISABLE, CoordConsts.SVC_CFG_WORK_SSL_DISABLE);
-    setDefaultProperty(BfConsts.ARG_SSL_KEYSTORE_FILE, null);
-    setDefaultProperty(BfConsts.ARG_SSL_KEYSTORE_PASSWORD, null);
-    setDefaultProperty(BfConsts.ARG_SSL_TRUST_ALL_CERTS, false);
-    setDefaultProperty(BfConsts.ARG_SSL_TRUSTSTORE_FILE, null);
-    setDefaultProperty(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD, null);
     setDefaultProperty(ARG_TRACING_AGENT_HOST, "localhost");
     setDefaultProperty(ARG_TRACING_AGENT_PORT, 5775);
     setDefaultProperty(ARG_TRACING_ENABLE, false);
@@ -247,18 +210,27 @@ public class Settings extends BaseSettings {
 
     addOption(ARG_SNAPSHOT_ID, "snapshot to attach to", "snapshot_id");
 
-    addBooleanOption(
-        BfConsts.ARG_SSL_DISABLE, "whether to disable SSL during communication with coordinator");
-
-    addBooleanOption(
-        BfConsts.ARG_SSL_TRUST_ALL_CERTS,
-        "whether to trust all SSL certificates during communication with coordinator");
-
     addOption(ARG_TRACING_AGENT_HOST, "jaeger agent host", "jaeger_agent_host");
 
     addOption(ARG_TRACING_AGENT_PORT, "jaeger agent port", "jaeger_agent_port");
 
     addBooleanOption(ARG_TRACING_ENABLE, "enable tracing");
+
+    // deprecated and ignored
+    for (String deprecatedStringArg :
+        new String[] {
+          "ssldisable",
+          "sslkeystorefile",
+          "sslkeystorepassword",
+          "ssltrustallcerts",
+          "ssltruststorefile",
+          "ssltruststorepassword",
+        }) {
+      addOption(deprecatedStringArg, DEPRECATED_ARG_DESC, "ignored");
+    }
+    for (String deprecatedBooleanArg : new String[] {"gs"}) {
+      addBooleanOption(deprecatedBooleanArg, DEPRECATED_ARG_DESC);
+    }
   }
 
   private void parseCommandLine(String[] args) {
@@ -281,12 +253,6 @@ public class Settings extends BaseSettings {
     _runMode = RunMode.valueOf(getStringOptionValue(ARG_RUN_MODE));
     _sanityCheck = !getBooleanOptionValue(ARG_NO_SANITY_CHECK);
     _serviceName = getStringOptionValue(ARG_SERVICE_NAME);
-    _sslDisable = getBooleanOptionValue(BfConsts.ARG_SSL_DISABLE);
-    _sslKeystoreFile = getPathOptionValue(BfConsts.ARG_SSL_KEYSTORE_FILE);
-    _sslKeystorePassword = getStringOptionValue(BfConsts.ARG_SSL_KEYSTORE_PASSWORD);
-    _sslTrustAllCerts = getBooleanOptionValue(BfConsts.ARG_SSL_TRUST_ALL_CERTS);
-    _sslTruststoreFile = getPathOptionValue(BfConsts.ARG_SSL_TRUSTSTORE_FILE);
-    _sslTruststorePassword = getStringOptionValue(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD);
     _tracingAgentHost = getStringOptionValue(ARG_TRACING_AGENT_HOST);
     _tracingAgentPort = getIntegerOptionValue(ARG_TRACING_AGENT_PORT);
     _tracingEnable = getBooleanOptionValue(ARG_TRACING_ENABLE);
@@ -313,29 +279,5 @@ public class Settings extends BaseSettings {
 
   public void setLogLevel(String logLevel) {
     _logLevel = logLevel;
-  }
-
-  public void setSslDisable(boolean sslDisable) {
-    _sslDisable = sslDisable;
-  }
-
-  public void setSslKeystoreFile(Path sslKeystoreFile) {
-    _sslKeystoreFile = sslKeystoreFile;
-  }
-
-  public void setSslKeystorePassword(String sslKeystorePassword) {
-    _sslKeystorePassword = sslKeystorePassword;
-  }
-
-  public void setSslTrustAllCerts(boolean sslTrustAllCerts) {
-    _sslTrustAllCerts = sslTrustAllCerts;
-  }
-
-  public void setSslTruststoreFile(Path sslTruststoreFile) {
-    _sslTruststoreFile = sslTruststoreFile;
-  }
-
-  public void setSslTruststorePassword(String sslTruststorePassword) {
-    _sslTruststorePassword = sslTruststorePassword;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/BfConsts.java
@@ -56,12 +56,6 @@ public class BfConsts {
   public static final String ARG_LOG_LEVEL = "loglevel";
   public static final String ARG_QUESTION_NAME = "questionname";
   public static final String ARG_SNAPSHOT_NAME = "snapshotname";
-  public static final String ARG_SSL_DISABLE = "ssldisable";
-  public static final String ARG_SSL_KEYSTORE_FILE = "sslkeystorefile";
-  public static final String ARG_SSL_KEYSTORE_PASSWORD = "sslkeystorepassword";
-  public static final String ARG_SSL_TRUST_ALL_CERTS = "ssltrustallcerts";
-  public static final String ARG_SSL_TRUSTSTORE_FILE = "ssltruststorefile";
-  public static final String ARG_SSL_TRUSTSTORE_PASSWORD = "ssltruststorepassword";
   public static final String ARG_STORAGE_BASE = "storagebase";
   public static final String ARG_SYNTHESIZE_TOPOLOGY = "synthesizetopology";
   public static final String ARG_TASK_PLUGIN = "taskplugin";

--- a/projects/batfish/src/main/java/org/batfish/config/Settings.java
+++ b/projects/batfish/src/main/java/org/batfish/config/Settings.java
@@ -369,31 +369,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     return _config.getString(BfConsts.ARG_SNAPSHOT_NAME);
   }
 
-  public boolean getSslDisable() {
-    return _config.getBoolean(BfConsts.ARG_SSL_DISABLE);
-  }
-
-  @Nullable
-  public Path getSslKeystoreFile() {
-    return nullablePath(_config.getString(BfConsts.ARG_SSL_KEYSTORE_FILE));
-  }
-
-  public String getSslKeystorePassword() {
-    return _config.getString(BfConsts.ARG_SSL_KEYSTORE_PASSWORD);
-  }
-
-  public boolean getSslTrustAllCerts() {
-    return _config.getBoolean(BfConsts.ARG_SSL_TRUST_ALL_CERTS);
-  }
-
-  public Path getSslTruststoreFile() {
-    return _config.get(Path.class, BfConsts.ARG_SSL_TRUSTSTORE_FILE);
-  }
-
-  public String getSslTruststorePassword() {
-    return _config.getString(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD);
-  }
-
   public @Nullable Path getStorageBase() {
     String storageBase = _config.getString(BfConsts.ARG_STORAGE_BASE);
     if (storageBase == null) {
@@ -521,12 +496,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     setDefaultProperty(ARG_SERVICE_NAME, "worker-service");
     setDefaultProperty(ARG_SERVICE_PORT, BfConsts.SVC_PORT);
     setDefaultProperty(BfConsts.ARG_SNAPSHOT_NAME, null);
-    setDefaultProperty(BfConsts.ARG_SSL_DISABLE, CoordConsts.SVC_CFG_POOL_SSL_DISABLE);
-    setDefaultProperty(BfConsts.ARG_SSL_KEYSTORE_FILE, null);
-    setDefaultProperty(BfConsts.ARG_SSL_KEYSTORE_PASSWORD, null);
-    setDefaultProperty(BfConsts.ARG_SSL_TRUST_ALL_CERTS, false);
-    setDefaultProperty(BfConsts.ARG_SSL_TRUSTSTORE_FILE, null);
-    setDefaultProperty(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD, null);
     setDefaultProperty(BfConsts.ARG_STORAGE_BASE, null);
     setDefaultProperty(BfConsts.ARG_TASK_PLUGIN, null);
     setDefaultProperty(ARG_THROW_ON_LEXER_ERROR, true);
@@ -711,13 +680,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
     addOption(BfConsts.ARG_SNAPSHOT_NAME, "name of snapshot", ARGNAME_NAME);
 
-    addBooleanOption(
-        BfConsts.ARG_SSL_DISABLE, "whether to disable SSL during communication with coordinator");
-
-    addBooleanOption(
-        BfConsts.ARG_SSL_TRUST_ALL_CERTS,
-        "whether to trust all SSL certificates during communication with coordinator");
-
     addOption(BfConsts.ARG_STORAGE_BASE, "path to the storage base", ARGNAME_PATH);
 
     addBooleanOption(
@@ -781,6 +743,12 @@ public final class Settings extends BaseSettings implements GrammarSettings {
           "pedanticsuppress",
           "ppa",
           "redflagsuppress",
+          "ssldisable",
+          "sslkeystorefile",
+          "sslkeystorepassword",
+          "ssltrustallcerts",
+          "ssltruststorefile",
+          "ssltruststorepassword",
           "stext",
           "unimplementedsuppress",
           "venv"
@@ -862,12 +830,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
     getBooleanOptionValue(ARG_NO_SHUFFLE);
     getBooleanOptionValue(ARG_PARSE_REUSE);
     getStringOptionValue(BfConsts.ARG_SNAPSHOT_NAME);
-    getBooleanOptionValue(BfConsts.ARG_SSL_DISABLE);
-    getPathOptionValue(BfConsts.ARG_SSL_KEYSTORE_FILE);
-    getStringOptionValue(BfConsts.ARG_SSL_KEYSTORE_PASSWORD);
-    getBooleanOptionValue(BfConsts.ARG_SSL_TRUST_ALL_CERTS);
-    getPathOptionValue(BfConsts.ARG_SSL_TRUSTSTORE_FILE);
-    getStringOptionValue(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD);
     getPathOptionValue(BfConsts.ARG_STORAGE_BASE);
     getStringOptionValue(BfConsts.ARG_TASK_PLUGIN);
     getStringOptionValue(BfConsts.ARG_TESTRIG);
@@ -959,30 +921,6 @@ public final class Settings extends BaseSettings implements GrammarSettings {
 
   public void setSequential(boolean sequential) {
     _config.setProperty(ARG_SEQUENTIAL, sequential);
-  }
-
-  public void setSslDisable(boolean sslDisable) {
-    _config.setProperty(BfConsts.ARG_SSL_DISABLE, sslDisable);
-  }
-
-  public void setSslKeystoreFile(Path sslKeystoreFile) {
-    _config.setProperty(BfConsts.ARG_SSL_KEYSTORE_FILE, sslKeystoreFile.toString());
-  }
-
-  public void setSslKeystorePassword(String sslKeystorePassword) {
-    _config.setProperty(BfConsts.ARG_SSL_KEYSTORE_PASSWORD, sslKeystorePassword);
-  }
-
-  public void setSslTrustAllCerts(boolean sslTrustAllCerts) {
-    _config.setProperty(BfConsts.ARG_SSL_TRUST_ALL_CERTS, sslTrustAllCerts);
-  }
-
-  public void setSslTruststoreFile(Path sslTruststoreFile) {
-    _config.setProperty(BfConsts.ARG_SSL_TRUSTSTORE_FILE, sslTruststoreFile.toString());
-  }
-
-  public void setSslTruststorePassword(String sslTruststorePassword) {
-    _config.setProperty(BfConsts.ARG_SSL_TRUSTSTORE_PASSWORD, sslTruststorePassword);
   }
 
   public void setStorageBase(Path storageBase) {

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -993,11 +993,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
     if (_settings.getCoordinatorHost() == null) {
       throw new BatfishException("Cannot get question templates: coordinator host is not set");
     }
-    String protocol = _settings.getSslDisable() ? "http" : "https";
     String url =
         String.format(
-            "%s://%s:%s%s/%s",
-            protocol,
+            "http://%s:%s%s/%s",
             _settings.getCoordinatorHost(),
             _settings.getCoordinatorPoolPort(),
             CoordConsts.SVC_CFG_POOL_MGR,

--- a/projects/batfish/src/main/java/org/batfish/main/CoordinatorClient.java
+++ b/projects/batfish/src/main/java/org/batfish/main/CoordinatorClient.java
@@ -22,16 +22,7 @@ public final class CoordinatorClient {
       String url, Map<String, String> params, Settings settings, BatfishLogger logger) {
     Client client = null;
     try {
-      client =
-          CommonUtil.createHttpClientBuilder(
-                  settings.getSslDisable(),
-                  settings.getSslTrustAllCerts(),
-                  settings.getSslKeystoreFile(),
-                  settings.getSslKeystorePassword(),
-                  settings.getSslTruststoreFile(),
-                  settings.getSslTruststorePassword(),
-                  true)
-              .build();
+      client = CommonUtil.createHttpClientBuilder(true).build();
       WebTarget webTarget = client.target(url);
       for (Map.Entry<String, String> entry : params.entrySet()) {
         webTarget = webTarget.queryParam(entry.getKey(), entry.getValue());

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/PoolMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/PoolMgr.java
@@ -43,7 +43,7 @@ public class PoolMgr {
     _workerPool = new HashMap<>();
   }
 
-  public synchronized void addToPool(final String worker) {
+  public synchronized void addToPool(String worker) {
     // start out as unknown and trigger refresh in the background
     _workerPool.put(worker, new WorkerStatus(WorkerStatus.StatusCode.UNKNOWN));
 
@@ -113,16 +113,7 @@ public class PoolMgr {
     Client client = null;
     try {
       // Client client = ClientBuilder.newClient();
-      client =
-          CommonUtil.createHttpClientBuilder(
-                  _settings.getSslPoolDisable(),
-                  _settings.getSslPoolTrustAllCerts(),
-                  _settings.getSslPoolKeystoreFile(),
-                  _settings.getSslPoolKeystorePassword(),
-                  _settings.getSslPoolTruststoreFile(),
-                  _settings.getSslPoolTruststorePassword(),
-                  false)
-              .build();
+      client = CommonUtil.createHttpClientBuilder(false).build();
       String protocol = _settings.getSslPoolDisable() ? "http" : "https";
       WebTarget webTarget =
           client.target(

--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -337,16 +337,7 @@ public class WorkMgr extends AbstractCoordinator {
           BfConsts.ARG_STORAGE_BASE,
           Main.getSettings().getContainersLocation().toAbsolutePath().toString());
 
-      client =
-          CommonUtil.createHttpClientBuilder(
-                  _settings.getSslPoolDisable(),
-                  _settings.getSslPoolTrustAllCerts(),
-                  _settings.getSslPoolKeystoreFile(),
-                  _settings.getSslPoolKeystorePassword(),
-                  _settings.getSslPoolTruststoreFile(),
-                  _settings.getSslPoolTruststorePassword(),
-                  true)
-              .build();
+      client = CommonUtil.createHttpClientBuilder(true).build();
 
       String protocol = _settings.getSslPoolDisable() ? "http" : "https";
       WebTarget webTarget =
@@ -503,16 +494,7 @@ public class WorkMgr extends AbstractCoordinator {
             .start();
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
-      client =
-          CommonUtil.createHttpClientBuilder(
-                  _settings.getSslPoolDisable(),
-                  _settings.getSslPoolTrustAllCerts(),
-                  _settings.getSslPoolKeystoreFile(),
-                  _settings.getSslPoolKeystorePassword(),
-                  _settings.getSslPoolTruststoreFile(),
-                  _settings.getSslPoolTruststorePassword(),
-                  true)
-              .build();
+      client = CommonUtil.createHttpClientBuilder(true).build();
 
       String protocol = _settings.getSslPoolDisable() ? "http" : "https";
       WebTarget webTarget =
@@ -1796,7 +1778,7 @@ public class WorkMgr extends AbstractCoordinator {
     createParentDirectories(outputFile);
     try (OutputStream fileOutputStream = Files.newOutputStream(outputFile)) {
       int read = 0;
-      final byte[] bytes = new byte[STREAMED_FILE_BUFFER_SIZE];
+      byte[] bytes = new byte[STREAMED_FILE_BUFFER_SIZE];
       while ((read = inputStream.read(bytes)) != -1) {
         fileOutputStream.write(bytes, 0, read);
       }


### PR DESCRIPTION
This is not tested nor used. Additionally, it has some bad coding
practices like putting passwords in Strings instead of byte[]. Easier
to delete than maintain.