### PR TITLE
CiscoGenericParser: normalize to Port-channel

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -683,7 +683,7 @@ public final class Interface extends ComparableStructure<String> {
       return InterfaceType.NULL;
     } else if (name.startsWith("nve")) {
       return InterfaceType.VLAN;
-    } else if (name.startsWith("Port-Channel")) {
+    } else if (name.toLowerCase().startsWith("port-channel")) {
       if (name.contains(".")) {
         // Subinterface of a port channel
         return InterfaceType.AGGREGATE_CHILD;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -5090,10 +5090,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       case CISCO_ASA:
       case FORCE10:
       case CISCO_IOS:
-        return String.format("Port-Channel%d", num);
-
-      case CISCO_IOS_XR:
-        return String.format("Bundle-Ether%d", num);
+        return String.format("Port-channel%d", num);
 
       default:
         _w.redFlag("Don't know how to compute aggregated-interface name for format: " + format);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -296,7 +296,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
           .put("Multilink", "Multilink")
           .put("Null", "Null")
           .put("nve", "nve")
-          .put("Port-channel", "Port-Channel")
+          .put("Port-channel", "Port-channel")
           .put("POS", "POS")
           .put("PTP", "PTP")
           .put("Redundant", "Redundant")

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/Interface.java
@@ -65,7 +65,7 @@ public class Interface implements Serializable {
       return null;
     } else if (name.startsWith("Loopback")) {
       return DEFAULT_LOOPBACK_BANDWIDTH;
-    } else if (name.startsWith("Port-Channel")) {
+    } else if (name.startsWith("Port-channel")) {
       // Derived from member interfaces
       return null;
     } else if (name.startsWith("Vlan")) {
@@ -129,7 +129,7 @@ public class Interface implements Serializable {
     } else {
       // Bundle-Ethernet
       // Loopback
-      // Port-Channel
+      // Port-channel
       // Vlan
       // Wlan-ap0 (a management interface)
       // ... others

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -5939,11 +5939,11 @@ public final class CiscoGrammarTest {
     Configuration config = parseConfig("ios-portchannel-subinterface");
     double eth1Bandwidth = 1E7;
     assertThat(config, hasInterface("Ethernet1", hasBandwidth(eth1Bandwidth)));
-    assertThat(config, hasInterface("Port-Channel1", hasBandwidth(eth1Bandwidth)));
+    assertThat(config, hasInterface("Port-channel1", hasBandwidth(eth1Bandwidth)));
     assertThat(
         config,
         hasInterface(
-            "Port-Channel1.1",
+            "Port-channel1.1",
             allOf(
                 hasInterfaceType(InterfaceType.AGGREGATE_CHILD),
                 isActive(true),

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -1017,7 +1017,7 @@
       {
         "File_Name" : "configs/cisco_eigrp",
         "Struct_Type" : "interface",
-        "Ref_Name" : "Port-Channel34",
+        "Ref_Name" : "Port-channel34",
         "Context" : "eigrp passive-interface",
         "Lines" : {
           "filename" : "configs/cisco_eigrp",
@@ -1029,7 +1029,7 @@
       {
         "File_Name" : "configs/cisco_eigrp",
         "Struct_Type" : "interface",
-        "Ref_Name" : "Port-Channel35",
+        "Ref_Name" : "Port-channel35",
         "Context" : "eigrp passive-interface",
         "Lines" : {
           "filename" : "configs/cisco_eigrp",

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -22596,7 +22596,7 @@
             "allowedVlans" : "1-4094",
             "autostate" : true,
             "bandwidth" : 2.0E10,
-            "channelGroup" : "Port-Channel1",
+            "channelGroup" : "Port-channel1",
             "declaredNames" : [
               "Ethernet0"
             ],

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -88605,12 +88605,12 @@
                 28
               ]
             },
-            "Port-Channel34" : {
+            "Port-channel34" : {
               "eigrp passive-interface" : [
                 29
               ]
             },
-            "Port-Channel35" : {
+            "Port-channel35" : {
               "eigrp passive-interface" : [
                 30
               ]
@@ -93850,12 +93850,12 @@
                 28
               ]
             },
-            "Port-Channel34" : {
+            "Port-channel34" : {
               "eigrp passive-interface" : [
                 29
               ]
             },
-            "Port-Channel35" : {
+            "Port-channel35" : {
               "eigrp passive-interface" : [
                 30
               ]


### PR DESCRIPTION
IOS and IOS-XE, at least recent releases, normalize this way.

Arista is Port-Channel, but has been factored out.
NX-OS is port-channel.

Since we've moved those out, we can do this change.

Fixes a user complaint from `Marek Zbroch` of NTC on Slack.