### PR TITLE
BgpRouteConstraints: replace IntegerSpace with LongSpace

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/BgpRouteConstraints.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/BgpRouteConstraints.java
@@ -1,15 +1,18 @@
 package org.batfish.minesweeper.question.searchroutepolicies;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.PrefixSpace;
 
 /** A set of constraints on a BGP route announcement. */
@@ -28,29 +31,76 @@ public class BgpRouteConstraints {
   // if this flag is set, then the prefix must be outside of the above space
   private final boolean _complementPrefix;
   // the announcement's local preference must be within this range
-  @Nonnull private final IntegerSpace _localPreference;
+  @Nonnull private final LongSpace _localPreference;
   // the announcement's MED must be within this range
-  @Nonnull private final IntegerSpace _med;
+  @Nonnull private final LongSpace _med;
   // the announcement must be tagged with at least one community matching a regex in this set
   @Nonnull private final Set<String> _communities;
   // if this flag is set, the announcement must not be tagged with any of
   // community matching a regex in the above set
   private final boolean _complementCommunities;
 
+  private static final LongSpace THIRTY_TWO_BIT_RANGE =
+      LongSpace.builder().including(Range.closed(0L, 4294967295L)).build();
+
   @JsonCreator
   private BgpRouteConstraints(
       @Nullable @JsonProperty(PROP_PREFIX) PrefixSpace prefix,
       @JsonProperty(PROP_COMPLEMENT_PREFIX) boolean complementPrefix,
-      @Nullable @JsonProperty(PROP_LOCAL_PREFERENCE) IntegerSpace localPreference,
-      @Nullable @JsonProperty(PROP_MED) IntegerSpace med,
+      @Nullable @JsonProperty(PROP_LOCAL_PREFERENCE) LongSpace.Builder localPreference,
+      @Nullable @JsonProperty(PROP_MED) LongSpace.Builder med,
       @Nullable @JsonProperty(PROP_COMMUNITIES) Set<String> communities,
       @JsonProperty(PROP_COMPLEMENT_COMMUNITIES) boolean complementCommunities) {
+    this(
+        prefix,
+        complementPrefix,
+        processBuilder(localPreference),
+        processBuilder(med),
+        communities,
+        complementCommunities);
+  }
+
+  private BgpRouteConstraints(
+      @Nullable PrefixSpace prefix,
+      boolean complementPrefix,
+      @Nullable LongSpace localPreference,
+      @Nullable LongSpace med,
+      @Nullable Set<String> communities,
+      boolean complementCommunities) {
     _prefix = firstNonNull(prefix, new PrefixSpace());
     _complementPrefix = complementPrefix;
-    _localPreference = firstNonNull(localPreference, IntegerSpace.EMPTY);
-    _med = firstNonNull(med, IntegerSpace.EMPTY);
+    _localPreference = firstNonNull(localPreference, LongSpace.EMPTY);
+    _med = firstNonNull(med, LongSpace.EMPTY);
     _communities = firstNonNull(communities, ImmutableSet.of());
     _complementCommunities = complementCommunities;
+    validate(this);
+  }
+
+  @VisibleForTesting
+  @Nullable
+  static LongSpace processBuilder(@Nullable LongSpace.Builder builder) {
+    if (builder == null) {
+      return null;
+    }
+    if (builder.hasExclusionsOnly()) {
+      return builder.including(THIRTY_TWO_BIT_RANGE).build();
+    }
+    return builder.build();
+  }
+
+  /** Check that the constraints contain valid values. */
+  private static void validate(@Nonnull BgpRouteConstraints constraints) {
+    LongSpace localPref = constraints.getLocalPreference();
+    LongSpace med = constraints.getMed();
+
+    checkArgument(is32BitRange(localPref), "Invalid value for local preference: %s", localPref);
+    checkArgument(is32BitRange(med), "Invalid value for MED: %s", med);
+  }
+
+  /** Check that the given long space only contains 32-bit integers. */
+  @VisibleForTesting
+  static boolean is32BitRange(@Nonnull LongSpace longSpace) {
+    return THIRTY_TWO_BIT_RANGE.contains(longSpace);
   }
 
   public static Builder builder() {
@@ -60,8 +110,8 @@ public class BgpRouteConstraints {
   public static final class Builder {
     private PrefixSpace _prefix;
     private boolean _complementPrefix = false;
-    private IntegerSpace _localPreference;
-    private IntegerSpace _med;
+    private LongSpace _localPreference;
+    private LongSpace _med;
     private Set<String> _communities;
     private boolean _complementCommunities = false;
 
@@ -77,12 +127,12 @@ public class BgpRouteConstraints {
       return this;
     }
 
-    public Builder setLocalPreference(IntegerSpace localPreference) {
+    public Builder setLocalPreference(LongSpace localPreference) {
       _localPreference = localPreference;
       return this;
     }
 
-    public Builder setMed(IntegerSpace med) {
+    public Builder setMed(LongSpace med) {
       _med = med;
       return this;
     }
@@ -116,13 +166,13 @@ public class BgpRouteConstraints {
 
   @JsonProperty(PROP_LOCAL_PREFERENCE)
   @Nonnull
-  public IntegerSpace getLocalPreference() {
+  public LongSpace getLocalPreference() {
     return _localPreference;
   }
 
   @JsonProperty(PROP_MED)
   @Nonnull
-  public IntegerSpace getMed() {
+  public LongSpace getMed() {
     return _med;
   }
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/BgpRouteConstraintsTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/BgpRouteConstraintsTest.java
@@ -1,0 +1,49 @@
+package org.batfish.minesweeper.question.searchroutepolicies;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.Range;
+import org.batfish.datamodel.LongSpace;
+import org.batfish.datamodel.LongSpace.Builder;
+import org.junit.Test;
+
+/** Tests for {@link BgpRouteConstraints}. */
+public class BgpRouteConstraintsTest {
+
+  @Test
+  public void testProcessBuilder() {
+
+    Range<Long> include = Range.closed(4L, 44L);
+    Range<Long> exclude = Range.singleton(43L);
+
+    // b3 only has exclusions and so will be transformed by processBuilder; the others will not
+    Builder b1 = null;
+    Builder b2 = LongSpace.builder().including(include);
+    Builder b3 = LongSpace.builder().excluding(exclude);
+    Builder b4 = LongSpace.builder().including(include).excluding(exclude);
+
+    LongSpace b3Expected =
+        LongSpace.builder().including(Range.closed(0L, 4294967295L)).excluding(exclude).build();
+
+    assertNull(BgpRouteConstraints.processBuilder(b1));
+    assertEquals(b2.build(), BgpRouteConstraints.processBuilder(b2));
+    assertEquals(b3Expected, BgpRouteConstraints.processBuilder(b3));
+    assertEquals(b4.build(), BgpRouteConstraints.processBuilder(b4));
+  }
+
+  @Test
+  public void testIs32BitRange() {
+    LongSpace s1 = LongSpace.builder().including(Range.closed(4L, 44L)).build();
+    // negative numbers are not allowed
+    LongSpace s2 = LongSpace.builder().including(Range.closed(-4L, 44L)).build();
+    // numbers higher than 2^32 - 1 are not allowed
+    LongSpace s3 = LongSpace.builder().including(Range.singleton(4294967296L)).build();
+
+    assertTrue(BgpRouteConstraints.is32BitRange(s1));
+    assertFalse(BgpRouteConstraints.is32BitRange(s2));
+    assertFalse(BgpRouteConstraints.is32BitRange(s3));
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswererTest.java
@@ -8,6 +8,7 @@ import static org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePo
 import static org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesAnswerer.COL_NODE;
 import static org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesAnswerer.COL_OUTPUT_ROUTE;
 import static org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesAnswerer.COL_POLICY_NAME;
+import static org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesAnswerer.toClosedRange;
 import static org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePoliciesQuestion.Action.DENY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -15,10 +16,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.BoundType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Range;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -30,8 +33,8 @@ import org.batfish.datamodel.CommunityList;
 import org.batfish.datamodel.CommunityListLine;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
-import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
@@ -746,8 +749,8 @@ public class SearchRoutePoliciesAnswererTest {
         _policyBuilder.addStatement(new StaticStatement(Statements.ExitAccept)).build();
 
     PrefixRange prefixRange = PrefixRange.fromPrefix(Prefix.parse("1.1.1.1/32"));
-    IntegerSpace localPref = IntegerSpace.builder().including(45).build();
-    IntegerSpace med = IntegerSpace.builder().including(56).build();
+    LongSpace localPref = LongSpace.builder().including(45L).build();
+    LongSpace med = LongSpace.builder().including(56L).build();
 
     SearchRoutePoliciesQuestion question =
         new SearchRoutePoliciesQuestion(
@@ -907,5 +910,33 @@ public class SearchRoutePoliciesAnswererTest {
     TableAnswerElement answer = (TableAnswerElement) answerer.answer(_batfish.getSnapshot());
 
     assertEquals(0, answer.getRows().size());
+  }
+
+  @Test
+  public void testToClosedRange() {
+    Range<Long> r1 = toClosedRange(Range.closed(5L, 10L));
+    Range<Long> r2 = toClosedRange(Range.closedOpen(5L, 11L));
+    Range<Long> r3 = toClosedRange(Range.openClosed(4L, 10L));
+    Range<Long> r4 = toClosedRange(Range.open(4L, 11L));
+
+    assertEquals(BoundType.CLOSED, r1.lowerBoundType());
+    assertEquals(new Long(5L), r1.lowerEndpoint());
+    assertEquals(BoundType.CLOSED, r1.upperBoundType());
+    assertEquals(new Long(10L), r1.upperEndpoint());
+
+    assertEquals(BoundType.CLOSED, r2.lowerBoundType());
+    assertEquals(new Long(5L), r2.lowerEndpoint());
+    assertEquals(BoundType.CLOSED, r2.upperBoundType());
+    assertEquals(new Long(10L), r2.upperEndpoint());
+
+    assertEquals(BoundType.CLOSED, r3.lowerBoundType());
+    assertEquals(new Long(5L), r3.lowerEndpoint());
+    assertEquals(BoundType.CLOSED, r3.upperBoundType());
+    assertEquals(new Long(10L), r3.upperEndpoint());
+
+    assertEquals(BoundType.CLOSED, r4.lowerBoundType());
+    assertEquals(new Long(5L), r4.lowerEndpoint());
+    assertEquals(BoundType.CLOSED, r4.upperBoundType());
+    assertEquals(new Long(10L), r4.upperEndpoint());
   }
 }


### PR DESCRIPTION

In BgpRouteConstraints, we now use a LongSpace rather than IntegerSpace to represent constraints on the local preference and the MED, since they are each unsigned 32-bit integers, which goes beyond the range of Java integers.  We also allow the constructor to pass in LongSpace.Builders instead of LongSpaces, and we add the range 0...(2^32-1) to the space if the builder only contains exclusions so the user doesn't have to explicitly do that.