### PR TITLE
PAN: parse and extract device-group parent-dg

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -1018,6 +1018,11 @@ PANORAMA_SERVER
     'panorama-server'
 ;
 
+PARENT_DG
+:
+    'parent-dg'
+;
+
 PASSIVE
 :
     'passive'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -173,6 +173,7 @@ statement_device_group
     | s_pre_rulebase
     | sdg_description
     | sdg_devices
+    | sdg_parent_dg
     | sdg_profiles
     | sdg_profile_group
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_device_group.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_device_group.g4
@@ -16,6 +16,11 @@ sdg_devices
     DEVICES device = variable sdgd_vsys?
 ;
 
+sdg_parent_dg
+:
+    PARENT_DG name = variable
+;
+
 sdg_profile_group
 :
     PROFILE_GROUP null_rest_of_line

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -224,6 +224,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sappg_definitionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sappg_membersContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sdg_descriptionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sdg_devicesContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sdg_parent_dgContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sdgd_vsysContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sds_default_gatewayContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sds_hostnameContext;
@@ -1712,6 +1713,11 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       _currentDeviceGroup.addVsys(getText(ctx.device), _currentDeviceGroupVsys);
     }
     _currentDeviceGroupVsys = null;
+  }
+
+  @Override
+  public void exitSdg_parent_dg(Sdg_parent_dgContext ctx) {
+    _currentDeviceGroup.setParentDg(getText(ctx.name));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/DeviceGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/DeviceGroup.java
@@ -17,12 +17,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 @ParametersAreNonnullByDefault
 public final class DeviceGroup extends PaloAltoConfiguration {
-  private String _description;
+  private @Nullable String _description;
   private final Set<String> _devices;
+  private final String _name;
+
+  /** The parent {@link DeviceGroup}. */
+  private @Nullable String _parentDg;
+
   /** Map of Device name to set of Vsyses */
   private final Map<String, Set<String>> _vsys;
-
-  private final String _name;
 
   public DeviceGroup(String name) {
     super();
@@ -44,20 +47,28 @@ public final class DeviceGroup extends PaloAltoConfiguration {
     return _description;
   }
 
+  public void setDescription(String description) {
+    _description = description;
+  }
+
   public @Nonnull Set<String> getDevices() {
     return ImmutableSet.copyOf(_devices);
+  }
+
+  public @Nonnull String getName() {
+    return _name;
+  }
+
+  public @Nullable String getParentDg() {
+    return _parentDg;
+  }
+
+  public void setParentDg(@Nullable String parentDg) {
+    _parentDg = parentDg;
   }
 
   /** Return map of device name to set of vsys names, for vsys associated with this device-group. */
   public @Nonnull Map<String, Set<String>> getVsys() {
     return _vsys;
-  }
-
-  public String getName() {
-    return _name;
-  }
-
-  public void setDescription(String description) {
-    _description = description;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -262,6 +262,10 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     return _hostname;
   }
 
+  public @Nullable DeviceGroup getDeviceGroup(String name) {
+    return _deviceGroups.get(name);
+  }
+
   public DeviceGroup getOrCreateDeviceGroup(String name) {
     return _deviceGroups.computeIfAbsent(name, DeviceGroup::new);
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2983,20 +2983,24 @@ public final class PaloAltoGrammarTest {
     String firewallId3 = "00000003";
     PaloAltoConfiguration c = parsePaloAltoConfig(hostname);
 
-    DeviceGroup deviceGroup1 = c.getOrCreateDeviceGroup("DG1");
-    DeviceGroup deviceGroup2 = c.getOrCreateDeviceGroup("DG2");
+    DeviceGroup deviceGroup1 = c.getDeviceGroup("DG1");
+    assertThat(deviceGroup1, notNullValue());
     Vsys panoramaDg1 = deviceGroup1.getPanorama();
+    DeviceGroup deviceGroup2 = c.getDeviceGroup("DG2");
+    assertThat(deviceGroup2, notNullValue());
     Vsys panoramaDg2 = deviceGroup2.getPanorama();
 
     // Check first device-group
     assertThat(deviceGroup1.getDevices(), containsInAnyOrder(firewallId1, firewallId2));
     assertThat(deviceGroup1.getDescription(), equalTo("long description"));
+    assertThat(deviceGroup1.getParentDg(), nullValue());
     assertThat(panoramaDg1, notNullValue());
     assertThat(panoramaDg1.getPostRulebase().getSecurityRules().keySet(), contains("RULE1"));
     assertThat(panoramaDg1.getAddressObjects().keySet(), contains("ADDR1"));
 
     // Check second device-group
     assertThat(deviceGroup2.getDevices(), contains(firewallId3));
+    assertThat(deviceGroup2.getParentDg(), equalTo("DG1"));
     assertThat(panoramaDg2, notNullValue());
     assertThat(panoramaDg2.getAddressObjects().keySet(), contains("ADDR2"));
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/device-group
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/device-group
@@ -13,5 +13,6 @@ set device-group DG1 description "long description"
 set device-group DG1 devices 00000001
 set device-group DG1 devices 00000002
 set device-group DG2 devices 00000003
+set device-group DG2 parent-dg DG1
 # Regular, non-device-group config - intentionally after device-group config to confirm we pop out as expected
 set deviceconfig system hostname device-group


### PR DESCRIPTION
Plus minor cleanup in testing:
* missing annotations
* not using getOrCreate outside of parsing.