### PR TITLE
VirtualRouter: compute neighbor process only once

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -817,7 +817,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
    * @param exportCandidate a route to try and export
    * @param ourConfig {@link BgpPeerConfig} that sends the route
    * @param remoteConfig {@link BgpPeerConfig} that will be receiving the route
-   * @param remoteBgpRoutingProcess {@link BgpRoutingProcess} that will be reciving the route
+   * @param remoteBgpRoutingProcess {@link BgpRoutingProcess} that will be recieving the route
    * @param sessionProperties {@link BgpSessionProperties} representing the <em>incoming</em> edge:
    *     i.e. the edge from {@code remoteConfig} to {@code ourConfig}
    * @param afType {@link AddressFamily.Type} for which the transformation should occur

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -781,6 +781,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     BgpPeerConfig remoteConfig = nc.getBgpPeerConfig(remoteConfigId);
     assert ourConfig != null; // Invariant of the edge existing
     assert remoteConfig != null; // Invariant of the edge existing
+    BgpRoutingProcess remoteBgpRoutingProcess = getNeighborBgpProcess(remoteConfigId, allNodes);
     return Stream.concat(evpnDelta._ebgpDelta.getActions(), evpnDelta._ibgpDelta.getActions())
         .map(
             // TODO: take into account address-family session settings, such as add-path or
@@ -793,7 +794,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
                         remoteConfigId,
                         ourConfig,
                         remoteConfig,
-                        allNodes,
+                        remoteBgpRoutingProcess,
                         session,
                         Type.EVPN)
                     .map(
@@ -816,7 +817,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
    * @param exportCandidate a route to try and export
    * @param ourConfig {@link BgpPeerConfig} that sends the route
    * @param remoteConfig {@link BgpPeerConfig} that will be receiving the route
-   * @param allNodes all nodes in the network
+   * @param remoteBgpRoutingProcess {@link BgpRoutingProcess} that will be reciving the route
    * @param sessionProperties {@link BgpSessionProperties} representing the <em>incoming</em> edge:
    *     i.e. the edge from {@code remoteConfig} to {@code ourConfig}
    * @param afType {@link AddressFamily.Type} for which the transformation should occur
@@ -830,7 +831,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
           BgpPeerConfigId remoteConfigId,
           BgpPeerConfig ourConfig,
           BgpPeerConfig remoteConfig,
-          Map<String, Node> allNodes,
+          BgpRoutingProcess remoteBgpRoutingProcess,
           BgpSessionProperties sessionProperties,
           AddressFamily.Type afType) {
 
@@ -852,7 +853,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             remoteConfig,
             sessionProperties,
             _process,
-            getNeighborBgpProcess(remoteConfigId, allNodes)._process,
+            remoteBgpRoutingProcess._process,
             exportCandidate,
             addressFamily.getType());
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1430,6 +1430,8 @@ public class VirtualRouter implements Serializable {
     if (remoteVirtualRouter == null) {
       return;
     }
+    BgpRoutingProcess remoteBgpRoutingProcess = remoteVirtualRouter.getBgpRoutingProcess();
+    assert remoteBgpRoutingProcess != null;
 
     // Queue mainRib updates that were not introduced by BGP process (i.e., IGP routes)
     // Also, do not double-export main RIB routes
@@ -1494,6 +1496,7 @@ public class VirtualRouter implements Serializable {
     }
 
     RibDelta<AnnotatedRoute<Bgpv4Route>> bgpRoutesToExport = bgpRibExports.build();
+
     // Compute a set of advertisements that can be queued on remote VR
     Stream<RouteAdvertisement<Bgpv4Route>> exportedAdvertisements =
         Stream.concat(
@@ -1508,7 +1511,7 @@ public class VirtualRouter implements Serializable {
                               remoteConfigId,
                               ourConfig,
                               remoteConfig,
-                              allNodes,
+                              remoteBgpRoutingProcess,
                               session,
                               Type.IPV4_UNICAST);
                       // REPLACE does not make sense across routers, update with WITHDRAW
@@ -1758,6 +1761,8 @@ public class VirtualRouter implements Serializable {
     if (remoteVr == null) {
       return;
     }
+    BgpRoutingProcess remoteBgpRoutingProcess = remoteVr.getBgpRoutingProcess();
+    assert remoteBgpRoutingProcess != null;
 
     /*
     TODO:
@@ -1802,7 +1807,7 @@ public class VirtualRouter implements Serializable {
                       remoteConfigId,
                       localConfig,
                       remoteConfig,
-                      allNodes,
+                      remoteBgpRoutingProcess,
                       sessionProperties,
                       Type.IPV4_UNICAST);
                 })


### PR DESCRIPTION
Instead of doing a lookup once per exported route.