### PR TITLE
VirtualRouter: uniquify export BGP Routes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1524,7 +1524,8 @@ public class VirtualRouter implements Serializable {
                                       .build())
                           .orElse(null);
                     })
-                .filter(Objects::nonNull),
+                .filter(Objects::nonNull)
+                .distinct(),
             mainRibExports);
 
     // Call this on the REMOTE VR and REVERSE the edge!


### PR DESCRIPTION
The process of exporting a BGP route changes the properties, so routes
that are distinct going in may be identical coming out. Before queueing
the routes for import on the neighbor, uniquify them.

On some large networks, this results in up to 100x fewer queued routes.