### PR TITLE
Support partial-match community regexes in symbolic route analysis

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVar.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVar.java
@@ -46,7 +46,7 @@ public final class CommunityVar implements Comparable<CommunityVar> {
   @Nonnull private final String _regex;
   @Nullable private final Community _literalValue;
 
-  @Nonnull private static final String NUM_REGEX = "[0-9]+";
+  @Nonnull private static final String NUM_REGEX = "(0|[1-9][0-9]*)";
 
   // a regex that represents the language of community literals supported by Batfish
   // see Community::matchString() and its implementations

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -141,10 +141,13 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
     for (int i = 0; i < aps.length; i++) {
       if (aps[i].andSat(fullModel)) {
         Automaton a = apAutomata.get(i);
-        if (a.isEmpty()) {
-          throw new BatfishException("Failed to produce a valid community for answer");
-        }
         String str = a.getShortestExample(true);
+        if (!(str.startsWith("^") && str.endsWith("$"))) {
+          throw new BatfishException("Failed to produce a valid community for answer");
+        } else {
+          // strip off the leading ^ and trailing $
+          str = str.substring(1, str.length() - 1);
+        }
         Optional<Community> exampleOpt = stringToCommunity(str);
         if (exampleOpt.isPresent()) {
           comms.add(exampleOpt.get());

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
@@ -2,7 +2,6 @@ package org.batfish.minesweeper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
@@ -17,15 +16,25 @@ import org.junit.Test;
 public class CommunityVarTest {
   @Test
   public void testToAutomaton() {
-    CommunityVar cv0 = CommunityVar.from(StandardCommunity.of(20, 30));
-    CommunityVar cv1 = CommunityVar.from("^.*$");
-    CommunityVar cv2 = CommunityVar.from(ExtendedCommunity.of(10, 20, 30));
-    CommunityVar cv3 = CommunityVar.from(LargeCommunity.of(10, 20, 30));
 
-    assertEquals(new RegExp("20:30").toAutomaton(), cv0.toAutomaton());
-    assertEquals(CommunityVar.COMMUNITY_FSM, cv1.toAutomaton());
-    assertEquals(new RegExp("20:30").toAutomaton(), cv2.toAutomaton());
-    assertEquals(new RegExp("large:10:20:30").toAutomaton(), cv3.toAutomaton());
+    // community literals
+    CommunityVar cv0 = CommunityVar.from(StandardCommunity.of(20, 30));
+    CommunityVar cv1 = CommunityVar.from(ExtendedCommunity.of(10, 20, 30));
+    CommunityVar cv2 = CommunityVar.from(LargeCommunity.of(10, 20, 30));
+
+    // community regexes
+    CommunityVar cv3 = CommunityVar.from("^.*$");
+    CommunityVar cv4 = CommunityVar.from("^40:");
+    // the Java regex translation of _40:50_
+    CommunityVar cv5 = CommunityVar.from("(,|{|}|^|$| )" + "40:50" + "(,|{|}|^|$| )");
+
+    assertThat(cv0.toAutomaton(), equalTo(new RegExp("^20:30$").toAutomaton()));
+    assertThat(cv1.toAutomaton(), equalTo(new RegExp("^20:30$").toAutomaton()));
+    assertThat(cv2.toAutomaton(), equalTo(new RegExp("^large:10:20:30$").toAutomaton()));
+
+    assertThat(cv3.toAutomaton(), equalTo(CommunityVar.COMMUNITY_FSM));
+    assertThat(cv4.toAutomaton(), equalTo(new RegExp("^40:[0-9]+$").toAutomaton()));
+    assertThat(cv5.toAutomaton(), equalTo(new RegExp("^40:50$").toAutomaton()));
   }
 
   @Test

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarTest.java
@@ -28,13 +28,18 @@ public class CommunityVarTest {
     // the Java regex translation of _40:50_
     CommunityVar cv5 = CommunityVar.from("(,|{|}|^|$| )" + "40:50" + "(,|{|}|^|$| )");
 
+    // ensure we get well-formed numbers
+    CommunityVar cv6 = CommunityVar.from("^0:.0$");
+
     assertThat(cv0.toAutomaton(), equalTo(new RegExp("^20:30$").toAutomaton()));
     assertThat(cv1.toAutomaton(), equalTo(new RegExp("^20:30$").toAutomaton()));
     assertThat(cv2.toAutomaton(), equalTo(new RegExp("^large:10:20:30$").toAutomaton()));
 
     assertThat(cv3.toAutomaton(), equalTo(CommunityVar.COMMUNITY_FSM));
-    assertThat(cv4.toAutomaton(), equalTo(new RegExp("^40:[0-9]+$").toAutomaton()));
+    assertThat(cv4.toAutomaton(), equalTo(new RegExp("^40:(0|[1-9][0-9]*)$").toAutomaton()));
     assertThat(cv5.toAutomaton(), equalTo(new RegExp("^40:50$").toAutomaton()));
+
+    assertThat(cv6.toAutomaton(), equalTo(new RegExp("^0:[1-9]0$").toAutomaton()));
   }
 
   @Test

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/GraphTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/GraphTest.java
@@ -162,11 +162,11 @@ public class GraphTest {
 
     assertEquals(g.getNumAtomicPredicates(), 5);
 
-    Automaton a1 = new RegExp("20:40").toAutomaton();
-    Automaton a2 = new RegExp("21:40").toAutomaton();
-    Automaton a3 = new RegExp("2[2-3]:40").toAutomaton();
-    Automaton a4 = new RegExp("21:4[1-3]").toAutomaton();
-    Automaton a5 = new RegExp("22:22").toAutomaton();
+    Automaton a1 = new RegExp("^20:40$").toAutomaton();
+    Automaton a2 = new RegExp("^21:40$").toAutomaton();
+    Automaton a3 = new RegExp("^2[2-3]:40$").toAutomaton();
+    Automaton a4 = new RegExp("^21:4[1-3]$").toAutomaton();
+    Automaton a5 = new RegExp("^22:22$").toAutomaton();
 
     assertEquals(g.getAtomicPredicateAutomata().size(), 5);
     assertThat(g.getAtomicPredicateAutomata().values(), hasItem(a1));

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswererTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswererTest.java
@@ -297,7 +297,7 @@ public class SearchRoutePoliciesAnswererTest {
     SearchRoutePoliciesQuestion question =
         new SearchRoutePoliciesQuestion(
             BgpRouteConstraints.builder()
-                .setCommunities(ImmutableSet.of("20:30"))
+                .setCommunities(ImmutableSet.of("^20:30$"))
                 .setComplementCommunities(true)
                 .build(),
             EMPTY_CONSTRAINTS,
@@ -376,8 +376,8 @@ public class SearchRoutePoliciesAnswererTest {
 
     SearchRoutePoliciesQuestion question =
         new SearchRoutePoliciesQuestion(
-            BgpRouteConstraints.builder().setCommunities(ImmutableSet.of("40:33")).build(),
-            BgpRouteConstraints.builder().setCommunities(ImmutableSet.of("3:44")).build(),
+            BgpRouteConstraints.builder().setCommunities(ImmutableSet.of("^40:33$")).build(),
+            BgpRouteConstraints.builder().setCommunities(ImmutableSet.of("^3:44$")).build(),
             HOSTNAME,
             policy.getName(),
             Action.PERMIT);
@@ -420,7 +420,7 @@ public class SearchRoutePoliciesAnswererTest {
     SearchRoutePoliciesQuestion question =
         new SearchRoutePoliciesQuestion(
             EMPTY_CONSTRAINTS,
-            BgpRouteConstraints.builder().setCommunities(ImmutableSet.of("20:30")).build(),
+            BgpRouteConstraints.builder().setCommunities(ImmutableSet.of("^20:30$")).build(),
             HOSTNAME,
             policy.getName(),
             Action.PERMIT);
@@ -442,7 +442,7 @@ public class SearchRoutePoliciesAnswererTest {
 
     SearchRoutePoliciesQuestion question =
         new SearchRoutePoliciesQuestion(
-            BgpRouteConstraints.builder().setCommunities(ImmutableSet.of("1:40")).build(),
+            BgpRouteConstraints.builder().setCommunities(ImmutableSet.of("^1:40$")).build(),
             EMPTY_CONSTRAINTS,
             HOSTNAME,
             policy.getName(),
@@ -855,7 +855,7 @@ public class SearchRoutePoliciesAnswererTest {
         new SearchRoutePoliciesQuestion(
             EMPTY_CONSTRAINTS,
             BgpRouteConstraints.builder()
-                .setCommunities(ImmutableSet.of("4:44"))
+                .setCommunities(ImmutableSet.of("^4:44$"))
                 .setComplementCommunities(true)
                 .build(),
             HOSTNAME,
@@ -899,7 +899,7 @@ public class SearchRoutePoliciesAnswererTest {
         new SearchRoutePoliciesQuestion(
             EMPTY_CONSTRAINTS,
             BgpRouteConstraints.builder()
-                .setCommunities(ImmutableSet.of("2[0-9]:30"))
+                .setCommunities(ImmutableSet.of("^2[0-9]:30$"))
                 .setComplementCommunities(true)
                 .build(),
             HOSTNAME,


### PR DESCRIPTION

Community regexes in configurations need only match a portion of a community.  For example, the regex "^40:" matches any community of the form 40:N where N is a number.  Previously the symbolic route analysis required regexes to match entire communities, e.g. we would require "^40:.*" instead of "^40:".  Now we've lifted that restriction.