### PR TITLE
Fix FileBasedStorage exception when uploading snapshot with no files

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -1482,6 +1482,13 @@ public class FileBasedStorage implements StorageProvider {
   public Stream<String> listSnapshotInputObjectKeys(NetworkSnapshot snapshot) throws IOException {
     Path inputObjectsPath =
         getSnapshotInputObjectsDir(snapshot.getNetwork(), snapshot.getSnapshot());
+    if (!isDirectory(inputObjectsPath)) {
+      if (!isDirectory(inputObjectsPath.getParent())) {
+        throw new FileNotFoundException(String.format("Missing snapshot dir for %s", snapshot));
+      }
+      // snapshot contained no input objects
+      return Stream.empty();
+    }
     return Files.walk(inputObjectsPath)
         .filter(Files::isRegularFile)
         .map(inputObjectsPath::relativize)
@@ -1752,7 +1759,9 @@ public class FileBasedStorage implements StorageProvider {
     return getSnapshotDir(networkId, snapshotId).resolve(RELPATH_EXTENDED);
   }
 
-  private Path getSnapshotInputObjectsDir(NetworkId networkId, SnapshotId snapshotId) {
+  @VisibleForTesting
+  @Nonnull
+  Path getSnapshotInputObjectsDir(NetworkId networkId, SnapshotId snapshotId) {
     return getSnapshotDir(networkId, snapshotId).resolve(BfConsts.RELPATH_INPUT);
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -786,7 +786,7 @@ public final class FileBasedStorageTest {
   public void testListSnapshotInputObjectKeysNoInputs() throws IOException {
     NetworkId networkId = new NetworkId("n1");
     SnapshotId snapshotId = new SnapshotId("s1");
-    Files.createDirectories(_storage.getSnapshotInputObjectsDir(networkId, snapshotId));
+    Files.createDirectories(_storage.getSnapshotInputObjectsDir(networkId, snapshotId).getParent());
     try (Stream<String> keys =
         _storage.listSnapshotInputObjectKeys(new NetworkSnapshot(networkId, snapshotId))) {
       assertThat(keys.count(), equalTo(0L));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -780,7 +780,6 @@ public final class FileBasedStorageTest {
       // silence warning; shouldn't be hit because of expected exception
       assert keys != null;
     }
-    ;
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -768,5 +769,41 @@ public final class FileBasedStorageTest {
   public void testRunGarbageCollectionFreshStartup() throws IOException {
     // Should not throw
     _storage.runGarbageCollection(Instant.MAX);
+  }
+
+  @Test
+  public void testListSnapshotInputObjectKeysMissingSnapshot() throws IOException {
+    _thrown.expect(FileNotFoundException.class);
+    try (Stream<String> keys =
+        _storage.listSnapshotInputObjectKeys(
+            new NetworkSnapshot(new NetworkId("n1"), new SnapshotId("s1")))) {
+      // silence warning; shouldn't be hit because of expected exception
+      assert keys != null;
+    }
+    ;
+  }
+
+  @Test
+  public void testListSnapshotInputObjectKeysNoInputs() throws IOException {
+    NetworkId networkId = new NetworkId("n1");
+    SnapshotId snapshotId = new SnapshotId("s1");
+    Files.createDirectories(_storage.getSnapshotInputObjectsDir(networkId, snapshotId));
+    try (Stream<String> keys =
+        _storage.listSnapshotInputObjectKeys(new NetworkSnapshot(networkId, snapshotId))) {
+      assertThat(keys.count(), equalTo(0L));
+    }
+  }
+
+  @Test
+  public void testListSnapshotInputObjectKeys() throws IOException {
+    NetworkId networkId = new NetworkId("n1");
+    SnapshotId snapshotId = new SnapshotId("s1");
+    NetworkSnapshot snapshot = new NetworkSnapshot(networkId, snapshotId);
+    _storage.storeSnapshotInputObject(new ByteArrayInputStream(new byte[] {}), "k1", snapshot);
+    _storage.storeSnapshotInputObject(new ByteArrayInputStream(new byte[] {}), "k2", snapshot);
+    try (Stream<String> keys =
+        _storage.listSnapshotInputObjectKeys(new NetworkSnapshot(networkId, snapshotId))) {
+      assertThat(keys.collect(ImmutableSet.toImmutableSet()), equalTo(ImmutableSet.of("k1", "k2")));
+    }
   }
 }


### PR DESCRIPTION
- fixes opaque exception when snapshot has no files but is otherwise packaged correctly
- leave decision whether to reject snapshot to higher level code