### PR TITLE
PAN: support specifying managed device hostnames

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -1188,6 +1188,16 @@ RESOLVE
     'resolve'
 ;
 
+RESPONSE
+:
+    'response'
+;
+
+RESULT
+:
+    'result'
+;
+
 RETRANSMIT_INTERVAL
 :
     'retransmit-interval'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -14,6 +14,7 @@ import
     PaloAlto_network,
     PaloAlto_ospf,
     PaloAlto_readonly,
+    PaloAlto_response,
     PaloAlto_rip,
     PaloAlto_rulebase,
     PaloAlto_service,
@@ -155,6 +156,15 @@ set_line_readonly
 ;
 
 /*
+ * Special-case for handling extra data from device queries (e.g. hostname information for firewalls
+ * managed by a Panorama device)
+ */
+set_line_response
+:
+    RESPONSE sresp_result
+;
+
+/*
  * Device-group supports a subset of device configuration (statement_config_devices)
  * plus some device-group / panorama specific items
  */
@@ -185,6 +195,7 @@ set_line_tail
     | set_line_config_general
     | set_line_device_group
     | set_line_readonly
+    | set_line_response
     | set_line_template
     | set_line_template_stack
     | s_policy

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_response.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_response.g4
@@ -1,0 +1,23 @@
+parser grammar PaloAlto_readonly;
+
+import PaloAlto_common;
+
+sresp_result
+:
+    RESULT srespr_devices
+;
+
+srespr_devices
+:
+    DEVICES name = variable
+    (
+        sresprd_hostname
+        // null rule must come last
+        | null_rest_of_line
+    )
+;
+
+sresprd_hostname
+:
+    HOSTNAME hostname = variable
+;

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -265,6 +265,8 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Snsg_zone_definitionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snsgi_interfaceContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snsgzn_layer3Context;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Src_or_dst_list_itemContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Srespr_devicesContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sresprd_hostnameContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Srn_definitionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Srn_destinationContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Srn_destination_translationContext;
@@ -451,6 +453,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   private OspfVr _currentOspfVr;
   private RedistProfile _currentRedistProfile;
   private RedistRule _currentRedistRule;
+  private String _currentResultDeviceName;
   private RulebaseId _currentRuleScope;
   private SecurityRule _currentSecurityRule;
   private Service _currentService;
@@ -1719,6 +1722,21 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       _currentDeviceGroup.addVsys(getText(ctx.device), _currentDeviceGroupVsys);
     }
     _currentDeviceGroupVsys = null;
+  }
+
+  @Override
+  public void enterSrespr_devices(Srespr_devicesContext ctx) {
+    _currentResultDeviceName = getText(ctx.name);
+  }
+
+  @Override
+  public void exitSrespr_devices(Srespr_devicesContext ctx) {
+    _currentResultDeviceName = null;
+  }
+
+  @Override
+  public void exitSresprd_hostname(Sresprd_hostnameContext ctx) {
+    _currentConfiguration.addHostnameMapping(_currentResultDeviceName, getText(ctx.hostname));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -175,7 +175,10 @@ public class PaloAltoConfiguration extends VendorConfiguration {
 
   private String _hostname;
 
-  /** Map of device id to hostname. */
+  /**
+   * Map of device id to hostname. This represents hostname mapping extracted from Panorama `show
+   * devices` commands.
+   */
   private final Map<String, String> _hostnameMap;
 
   private final SortedMap<String, Interface> _interfaces;

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -175,6 +175,9 @@ public class PaloAltoConfiguration extends VendorConfiguration {
 
   private String _hostname;
 
+  /** Map of device id to hostname. */
+  private final Map<String, String> _hostnameMap;
+
   private final SortedMap<String, Interface> _interfaces;
 
   private Ip _mgmtIfaceAddress;
@@ -209,11 +212,17 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     _cryptoProfiles = new LinkedList<>();
     _deviceGroups = new TreeMap<>();
     _interfaces = new TreeMap<>();
+    _hostnameMap = new HashMap<>();
     _sharedGateways = new TreeMap<>();
     _templates = new TreeMap<>();
     _templateStacks = new HashMap<>();
     _virtualRouters = new TreeMap<>();
     _virtualSystems = new TreeMap<>();
+  }
+
+  /** Add mapping from specified device id to specified hostname. */
+  public void addHostnameMapping(String deviceId, String hostname) {
+    _hostnameMap.put(deviceId, hostname);
   }
 
   private NavigableSet<String> getDnsServers() {
@@ -2203,7 +2212,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
                             c.setRuntimeData(_runtimeData);
                             // This may not actually be the device's hostname
                             // but this is all we know at this point
-                            c.setHostname(name);
+                            c.setHostname(_hostnameMap.getOrDefault(name, name));
                             c.applyDeviceGroup(deviceGroupEntry.getValue(), _shared, _deviceGroups);
                             managedConfigurations.put(name, c);
                           }
@@ -2232,7 +2241,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
                           c.setRuntimeData(_runtimeData);
                           // This may not actually be the device's hostname
                           // but this is all we know at this point
-                          c.setHostname(deviceName);
+                          c.setHostname(_hostnameMap.getOrDefault(deviceName, deviceName));
                           c.applyDeviceGroup(deviceGroupEntry.getValue(), _shared, _deviceGroups);
                           managedConfigurations.put(deviceName, c);
                         }));
@@ -2255,7 +2264,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
                             c.setRuntimeData(_runtimeData);
                             // This may not actually be the device's hostname
                             // but this is all we know at this point
-                            c.setHostname(name);
+                            c.setHostname(_hostnameMap.getOrDefault(name, name));
                             managedConfigurations.put(name, c);
                           }
                           c.applyTemplateStack(stackEntry.getValue(), this);

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2183,9 +2183,8 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     c.setWarnings(_w);
     c.setVendor(_vendor);
     c.setRuntimeData(_runtimeData);
-    // Use hostname from device id -> hostname mapping if it exists
-    // Otherwise just use the device id
-    c.setHostname(_hostnameMap.getOrDefault(deviceId, deviceId));
+    // Assume hostname is device id for now
+    c.setHostname(deviceId);
     return c;
   }
 
@@ -2263,6 +2262,17 @@ public class PaloAltoConfiguration extends VendorConfiguration {
                           }
                           c.applyTemplateStack(stackEntry.getValue(), this);
                         }));
+
+    // Update hostnames for managed devices
+    _hostnameMap.forEach(
+        (deviceId, hostname) -> {
+          if (managedConfigurations.containsKey(deviceId)) {
+            managedConfigurations.get(deviceId).setHostname(hostname);
+          } else {
+            _w.redFlag(String.format("Cannot set hostname for unknown device id %s.", deviceId));
+          }
+        });
+
     // Once managed devices are built, convert them too
     outputConfigurations.addAll(
         managedConfigurations.values().stream()

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -3111,6 +3111,21 @@ public final class PaloAltoGrammarTest {
   }
 
   @Test
+  public void testPanoramaManagedDeviceHostname() {
+    String panoramaHostname = "panorama-managed-device-hostname";
+    String firewallId1 = "firewall-1";
+    String firewallId2 = "firewall-2";
+    String firewallId3 = "00000003";
+    PaloAltoConfiguration c = parsePaloAltoConfig(panoramaHostname);
+    List<Configuration> viConfigs = c.toVendorIndependentConfigurations();
+
+    // Should get four nodes from the one Panorama config with the correct hostnames
+    assertThat(
+        viConfigs.stream().map(Configuration::getHostname).collect(Collectors.toList()),
+        containsInAnyOrder(panoramaHostname, firewallId1, firewallId2, firewallId3));
+  }
+
+  @Test
   public void testTemplate() {
     String hostname = "template";
     PaloAltoConfiguration c = parsePaloAltoConfig(hostname);

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -3126,6 +3126,21 @@ public final class PaloAltoGrammarTest {
   }
 
   @Test
+  public void testPanoramaManagedDeviceHostnameWarning() throws IOException {
+    String hostname = "panorama-managed-device-hostname";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+
+    // Should have a warning about trying to set hostname for an unknown device id
+    assertThat(ccae.getWarnings().keySet(), hasItem(equalTo(hostname)));
+    Warnings warn = ccae.getWarnings().get(hostname);
+    assertThat(
+        warn.getRedFlagWarnings().stream().map(Warning::getText).collect(Collectors.toSet()),
+        contains("Cannot set hostname for unknown device id 00000004."));
+  }
+
+  @Test
   public void testTemplate() {
     String hostname = "template";
     PaloAltoConfiguration c = parsePaloAltoConfig(hostname);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-managed-device-hostname
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-managed-device-hostname
@@ -1,14 +1,17 @@
 set device-group DG1 address ADDR1 ip-netmask 10.10.10.10
 set device-group DG1 devices 00000001
+set device-group DG1 devices 00000002
 set device-group DG1 devices 00000003
 # Firewall 2 has a configured hostname
-set device-group DG2 deviceconfig system hostname other-hostname
-set device-group DG2 devices 00000002
+set template T1 config deviceconfig system hostname other-hostname
+set template-stack TS1 templates [ T1 ]
+set template-stack TS1 devices 00000002
 
 # Panorama response to query about managed devices
 # Indicating firewall 1 and 2 have these hostnames (should override assumed/inherited hostnames)
 set response result devices 00000001 hostname firewall-1
 set response result devices 00000002 hostname firewall-2
+set response result devices 00000004 hostname firewall-unknown
 
 # Regular, non-device-group config - intentionally after device-group config to confirm we pop out as expected
 set deviceconfig system hostname panorama-managed-device-hostname

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-managed-device-hostname
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/panorama-managed-device-hostname
@@ -1,0 +1,14 @@
+set device-group DG1 address ADDR1 ip-netmask 10.10.10.10
+set device-group DG1 devices 00000001
+set device-group DG1 devices 00000003
+# Firewall 2 has a configured hostname
+set device-group DG2 deviceconfig system hostname other-hostname
+set device-group DG2 devices 00000002
+
+# Panorama response to query about managed devices
+# Indicating firewall 1 and 2 have these hostnames (should override assumed/inherited hostnames)
+set response result devices 00000001 hostname firewall-1
+set response result devices 00000002 hostname firewall-2
+
+# Regular, non-device-group config - intentionally after device-group config to confirm we pop out as expected
+set deviceconfig system hostname panorama-managed-device-hostname


### PR DESCRIPTION
This PR adds support for specifying Panorama-managed-device hostnames - from the output of the `show devices <connected|all>` command.

----
For example, using the Palo Alto [`pan-python` module](http://api-lab.paloaltonetworks.com/pan-python.html), you can pull managed device hostnames as follows (assuming your `.panrc` file is setup with connection info for `panorama`):
```
panxapi.py -t panorama -Xxo 'show devices connected' > tmp_file
panconf.py --config tmp_file --set  > show_devices_connected
```
This will produce a text file `show_devices_connected` containing something like this:
```
...
set response result devices 00000001 hostname firewall-1-hostname
...
```
The contents of this file can be appended to you Panorama configuration and fed into Batfish, which will apply hostnames specified here to applicable Panorama-managed Palo Alto devices.
