### PR TITLE
bazel: disable error-prone on generated ANTLR4 grammar

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":AristaParserBaseListener.java",
         ":AristaParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/arista/parsing:arista_base_parser",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":CiscoParserBaseListener.java",
         ":CiscoParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/cisco/parsing:cisco_base_parser",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":CiscoNxosParserBaseListener.java",
         ":CiscoNxosParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/parsing:cisco_nxos_base",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/BUILD
@@ -4,30 +4,13 @@ package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "cisco_xr",
-    exports = [
-        ":lexer",
-        ":parser",
-    ],
-)
-
-java_library(
-    name = "lexer",
     srcs = [
         ":CiscoXrLexer.java",
-    ],
-    deps = [
-        "//projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/parsing:cisco_xr_base_parser",
-        "@maven//:org_antlr_antlr4_runtime",
-    ],
-)
-
-java_library(
-    name = "parser",
-    srcs = [
         ":CiscoXrParser.java",
         ":CiscoXrParserBaseListener.java",
         ":CiscoXrParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/parsing:cisco_xr_base_parser",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_concatenated/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_concatenated/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":CumulusConcatenatedParserBaseListener.java",
         ":CumulusConcatenatedParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":CumulusFrrParserBaseListener.java",
         ":CumulusFrrParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/parsing:cumulus_frr_base",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":CumulusInterfacesParserBaseListener.java",
         ":CumulusInterfacesParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/cumulus_interfaces/parsing:cumulus_interfaces_base",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_nclu/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":CumulusNcluParserBaseListener.java",
         ":CumulusNcluParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/grammar/cumulus_nclu/parsing:cumulus_nclu_base_parser",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_ports/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_ports/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":CumulusPortsParserBaseListener.java",
         ":CumulusPortsParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish/src/main/java/org/batfish/grammar/cumulus_ports/parsing:cumulus_ports_base",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_imish/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":F5BigipImishParserBaseListener.java",
         ":F5BigipImishParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/parsing:f5_bigip_imish_base_parser",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_structured/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/f5_bigip_structured/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":F5BigipStructuredParserBaseListener.java",
         ":F5BigipStructuredParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_structured/parsing:f5_bigip_structured_base",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":FlatJuniperParserBaseListener.java",
         ":FlatJuniperParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/parsing:flatjuniper_base",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatvyos/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":FlatVyosParserBaseListener.java",
         ":FlatVyosParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/iptables/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/iptables/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":IptablesParserBaseListener.java",
         ":IptablesParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":JuniperParserBaseListener.java",
         ":JuniperParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/mrv/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/mrv/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":MrvParserBaseListener.java",
         ":MrvParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":PaloAltoParserBaseListener.java",
         ":PaloAltoParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "//projects/batfish/src/main/java/org/batfish/grammar/palo_alto/parsing:palo_alto_base",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto_nested/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto_nested/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":PaloAltoNestedParserBaseListener.java",
         ":PaloAltoNestedParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/eos/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/eos/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":EosRoutingTableParserBaseListener.java",
         ":EosRoutingTableParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/ios/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/ios/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":IosRoutingTableParserBaseListener.java",
         ":IosRoutingTableParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/nxos/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/routing_table/nxos/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":NxosRoutingTableParserBaseListener.java",
         ":NxosRoutingTableParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/vyos/BUILD
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/vyos/BUILD
@@ -10,6 +10,7 @@ java_library(
         ":VyosParserBaseListener.java",
         ":VyosParserListener.java",
     ],
+    javacopts = ["-XepDisableAllChecks"],
     deps = [
         "//projects/batfish-common-protocol:parser_common",
         "@maven//:org_antlr_antlr4_runtime",


### PR DESCRIPTION
Error Prone will respect the `@Generated` annotation, but
ANTLR4 does not add it to generated classes:

https://github.com/antlr/antlr4/issues/2568

For now, manually tell error prone to ignore all such files.