### PR TITLE
OSPF: improvements to inter-area route propagation

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -8,15 +8,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Streams;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Queue;
-import java.util.Set;
-import java.util.SortedMap;
+import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -110,7 +102,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   /* State we need to maintain between iterations */
 
   /** Delta that captures process initialization (creating intra-area routes based on interfaces) */
-  @Nonnull private RibDelta<OspfIntraAreaRoute> _initializationDelta;
+  @Nonnull private InternalDelta _initializationDelta;
   /** Delta to pass to the main RIB */
   @Nonnull private RibDelta.Builder<OspfRoute> _changeset;
   /** Delta of routes we have locally queued for re-distribution */
@@ -159,7 +151,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
     }
 
     _changeset = RibDelta.builder();
-    _initializationDelta = RibDelta.empty();
+    _initializationDelta = new InternalDelta(RibDelta.empty(), RibDelta.empty());
     _queuedForRedistribution = new ExternalDelta();
     _activatedGeneratedRoutes = RibDelta.empty();
     _neighborsWhereDefaultIARouteWasInjected = new HashSet<>(0);
@@ -175,9 +167,8 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
     if (!_initializationDelta.isEmpty()) {
       // If we haven't sent out the first round of updates after initialization, do so now. Then
       // clear the initialization delta
-      sendOutInternalRoutes(
-          new InternalDelta(_initializationDelta, RibDelta.empty()), allNodes, _topology);
-      _initializationDelta = RibDelta.empty();
+      sendOutInternalRoutes(_initializationDelta, allNodes, _topology);
+      _initializationDelta = new InternalDelta(RibDelta.empty(), RibDelta.empty());
     }
 
     // Process internal routes
@@ -316,10 +307,23 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
 
   /** Initialize intra-area routes based on available interfaces. */
   private void initializeIntraAreaRoutes() {
-    RibDelta.Builder<OspfIntraAreaRoute> deltaBuilder = RibDelta.builder();
-    _process.getAreas().values().forEach(area -> deltaBuilder.from(initializeRoutesByArea(area)));
-    _initializationDelta = deltaBuilder.build();
-    _changeset.from(RibDelta.importRibDelta(_ospfRib, _initializationDelta));
+    RibDelta.Builder<OspfIntraAreaRoute> intraAreaBuilder = RibDelta.builder();
+    _process
+        .getAreas()
+        .values()
+        .forEach(area -> intraAreaBuilder.from(initializeRoutesByArea(area)));
+    RibDelta<OspfIntraAreaRoute> intraAreaDelta = intraAreaBuilder.build();
+    RibDelta.Builder<OspfInterAreaRoute> interAreaBuilder = RibDelta.builder();
+    if (isABR()) {
+      // If we are an ABR, also do conversion to IA routes here.
+      intraAreaDelta
+          .getRoutesStream()
+          .forEach(
+              r -> interAreaBuilder.add(OspfInterAreaRoute.builder(r).setNonRouting(true).build()));
+    }
+
+    _initializationDelta = new InternalDelta(intraAreaDelta, interAreaBuilder.build());
+    _changeset.from(RibDelta.importRibDelta(_ospfRib, intraAreaDelta));
   }
 
   /**
@@ -447,10 +451,13 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   /** Process all OSPF internal messages from all the message queues */
   @Nonnull
   private InternalDelta processInternalRoutes() {
-    RibDelta<OspfIntraAreaRoute> intraAreaDelta = processIntraAreaRoutes();
+    InternalDelta intraProcessingDelta = processIntraAreaRoutes();
     RibDelta.Builder<OspfInterAreaRoute> interAreaDelta = processInterAreaRoutes();
     RibDelta<OspfInterAreaRoute> deltaOfSummaries = computeInterAreaSummaries();
-    return new InternalDelta(intraAreaDelta, interAreaDelta.from(deltaOfSummaries).build());
+    // Merge inter-area deltas
+    return new InternalDelta(
+        intraProcessingDelta._intraArea,
+        interAreaDelta.from(intraProcessingDelta._interArea).from(deltaOfSummaries).build());
   }
 
   /**
@@ -549,26 +556,61 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
    * @return the resulting intra-area RIB delta builder.
    */
   @Nonnull
-  private RibDelta<OspfIntraAreaRoute> processIntraAreaRoutes() {
+  private InternalDelta processIntraAreaRoutes() {
     RibDelta.Builder<OspfIntraAreaRoute> intraAreaDelta = RibDelta.builder();
+    RibDelta.Builder<OspfInterAreaRoute> interAreaDelta = RibDelta.builder();
     _intraAreaIncomingRoutes.forEach(
         (edgeId, queue) -> {
           String ifaceName = edgeId.getHead().getInterfaceName();
           long incrementalCost = getIncrementalCost(ifaceName, false);
           while (!queue.isEmpty()) {
             RouteAdvertisement<OspfIntraAreaRoute> routeAdvertisement = queue.remove();
-            OspfIntraAreaRoute.Builder ospfRouteBuilder =
-                transformIntraAreaRouteOnImport(routeAdvertisement.getRoute(), incrementalCost);
-
-            applyDistributeList(_c, _vrfName, ifaceName, ospfRouteBuilder);
-
-            intraAreaDelta.from(
-                processRouteAdvertisement(
-                    routeAdvertisement.toBuilder().setRoute(ospfRouteBuilder.build()).build(),
-                    _intraAreaRib));
+            processIntraAreaAdvertisement(
+                intraAreaDelta, interAreaDelta, ifaceName, incrementalCost, routeAdvertisement);
           }
         });
-    return intraAreaDelta.build();
+    return new InternalDelta(intraAreaDelta.build(), interAreaDelta.build());
+  }
+
+  /** Process a intraArea advertisement from a neighbor.
+   * This will transform advertisement on import, and place it in the appropriate RIB(s).
+   *
+   * @param intraAreaDelta builder for the intraArea RIB delta
+   * @param interAreaDelta builder for the interArea RIB delta
+   * @param interAreaDelta builder for the interArea RIB delta
+   * */
+  @VisibleForTesting
+  void processIntraAreaAdvertisement(
+      RibDelta.Builder<OspfIntraAreaRoute> intraAreaDelta,
+      RibDelta.Builder<OspfInterAreaRoute> interAreaDelta,
+      String ifaceName,
+      long incrementalCost,
+      RouteAdvertisement<OspfIntraAreaRoute> routeAdvertisement) {
+    OspfIntraAreaRoute.Builder ospfRouteBuilder =
+        transformIntraAreaRouteOnImport(routeAdvertisement.getRoute(), incrementalCost);
+
+    applyDistributeList(_c, _vrfName, ifaceName, ospfRouteBuilder);
+
+    OspfIntraAreaRoute intraAreaRoute = ospfRouteBuilder.build();
+    intraAreaDelta.from(
+        processRouteAdvertisement(
+            routeAdvertisement.toBuilder().setRoute(intraAreaRoute).build(), _intraAreaRib));
+
+    /*
+    If we are an ABR, convert intra-area routes to inter-area routes (i.e., Type 1 -> Type 3) and put them
+    into our inter-area RIB. Note these non-routing because intra-area specific routes should always be preferred.
+    */
+    if (isABR()) {
+      OspfInterAreaRoute interAreaRoute =
+          OspfInterAreaRoute.builder(intraAreaRoute).setNonRouting(true).build();
+      interAreaDelta.from(
+          processRouteAdvertisement(
+              RouteAdvertisement.<OspfInterAreaRoute>builder()
+                  .setReason(routeAdvertisement.getReason())
+                  .setRoute(interAreaRoute)
+                  .build(),
+              _interAreaRib));
+    }
   }
 
   /**
@@ -710,7 +752,8 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
     sendOutIntraAreaRoutesPerEdge(
         delta._intraArea, edgeId, remoteProcess, areaConfig, session.get());
     if (isABR()) {
-      sendOutInterAreaRoutesPerEdgeABR(delta, edgeId, remoteProcess, areaConfig, session.get());
+      sendOutInterAreaRoutesPerEdgeABR(
+          delta._interArea, edgeId, remoteProcess, areaConfig, session.get());
     } else {
       sendOutInterAreaRoutesPerEdgeNonABR(
           delta._interArea, edgeId, remoteProcess, areaConfig, session.get());
@@ -765,7 +808,11 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
     Ip nextHopIp = sessionProperties.getIpLink().getIp2();
     Collection<RouteAdvertisement<OspfInterAreaRoute>> updatedDelta =
         transformInterAreaRoutesOnExportNonABR(
-            delta, areaConfig, nextHopIp, _process.getMaxMetricTransitLinks());
+            delta,
+            areaConfig,
+            sessionProperties.getIpLink().getIp1(),
+            nextHopIp,
+            _process.getMaxMetricTransitLinks());
     remoteProcess.enqueueMessagesInter(edgeId.reverse(), updatedDelta);
   }
 
@@ -775,6 +822,8 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
    *
    * @param delta RIB delta containing candidates for re-advertisement to neighbors
    * @param areaConfig {@link OspfArea} to which the routes will be sent
+   * @param neighborIp {@link Ip} of the neighbor to which the route is being sent. Used to
+   *     implement a split-horizon rule to avoid loops
    * @param nextHopIp next hop IP to use for the transformed route
    * @param customMetric if set (i.e., not {@code null}) will be used to override the route's
    *     original metric
@@ -783,6 +832,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   static Collection<RouteAdvertisement<OspfInterAreaRoute>> transformInterAreaRoutesOnExportNonABR(
       RibDelta<OspfInterAreaRoute> delta,
       OspfArea areaConfig,
+      Ip neighborIp,
       Ip nextHopIp,
       @Nullable Long customMetric) {
     return delta
@@ -792,6 +842,8 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
          * inter-area routes for area X in area X.
          */
         .filter(r -> r.getRoute().getArea() == areaConfig.getAreaNumber())
+        /* Do not send the route to the neighbor that has sent it to us originally. (split horizon) */
+        .filter(r -> !r.getRoute().getNextHopIp().equals(neighborIp))
         .map(
             r ->
                 r.toBuilder()
@@ -807,7 +859,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
 
   /** Send out inter-area routes from an ABR to a neighbor */
   private void sendOutInterAreaRoutesPerEdgeABR(
-      InternalDelta delta,
+      RibDelta<OspfInterAreaRoute> delta,
       EdgeId edgeId,
       OspfRoutingProcess remoteProcess,
       OspfArea areaConfig,
@@ -835,16 +887,11 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
     remoteProcess.enqueueMessagesInter(
         edgeId.reverse(),
         Streams.concat(
-                convertAndFilterIntraAreaRoutesToPropagate(
-                    delta._intraArea,
-                    areaConfig,
-                    filterList,
-                    nextHopIp,
-                    _process.getMaxMetricSummaryNetworks()),
                 filterInterAreaRoutesToPropagateAtABR(
-                    delta._interArea,
+                    delta,
                     areaConfig,
                     filterList,
+                    sessionProperties.getIpLink().getIp1(),
                     nextHopIp,
                     _process.getMaxMetricSummaryNetworks()),
                 computeDefaultInterAreaRouteToInject(edgeId, areaConfig, nextHopIp))
@@ -859,9 +906,9 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
    * @param delta ABR's inter- or intra- RIB delta
    * @param areaConfig area configuration at the ABR for this neighbor adjacency
    * @param filterList route filter list defined at the ABR (to enable correct summarization)
+   * @param neighborIp
    * @param nextHopIp next hop ip to use when creating the route.
    * @param customMetric if provided (i.e., not {@code null}) it will be used instead of the routes
-   *     original metric
    */
   @Nonnull
   @VisibleForTesting
@@ -869,6 +916,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
       RibDelta<OspfInterAreaRoute> delta,
       OspfArea areaConfig,
       @Nullable RouteFilterList filterList,
+      Ip neighborIp,
       Ip nextHopIp,
       @Nullable Long customMetric) {
     if (areaConfig.getStubType() == StubType.STUB && areaConfig.getStub().getSuppressType3()
@@ -880,6 +928,8 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
         .getActions()
         // Only propagate routes from different areas
         .filter(r -> r.getRoute().getArea() != areaConfig.getAreaNumber())
+        /* Do not send the route to the neighbor that has sent it to us originally. (split horizon) */
+        .filter(r -> !r.getRoute().getNextHopIp().equals(neighborIp))
         // Only propagate routes permitted by the filter list
         // Fail open. Treat missing filter list as "allow all".
         .filter(r -> filterList == null || filterList.permits(r.getRoute().getNetwork()))
@@ -894,44 +944,6 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
                             .setMetric(firstNonNull(customMetric, r.getRoute().getMetric()))
                             .setNextHopIp(nextHopIp)
                             .build())
-                    .build());
-  }
-
-  /**
-   * Convert intra-area routes to inter-area routes. Only routes that pass filtering conditions are
-   * returned.
-   */
-  @Nonnull
-  @VisibleForTesting
-  static Stream<RouteAdvertisement<OspfInterAreaRoute>> convertAndFilterIntraAreaRoutesToPropagate(
-      RibDelta<OspfIntraAreaRoute> delta,
-      OspfArea areaConfig,
-      @Nullable RouteFilterList filterList,
-      Ip nextHopIp,
-      @Nullable Long customMetric) {
-    if (areaConfig.getStubType() == StubType.STUB && areaConfig.getStub().getSuppressType3()
-        || areaConfig.getStubType() == StubType.NSSA && areaConfig.getNssa().getSuppressType3()) {
-      // Nothing to do for totally stubby areas, where summaries are suppressed
-      return Stream.empty();
-    }
-    return delta
-        .getActions()
-        // Only propagate routes from different areas
-        .filter(r -> r.getRoute().getArea() != areaConfig.getAreaNumber())
-        // Only propagate routes permitted by the filter list
-        // Fail open. Treat missing filter list as "allow all".
-        .filter(r -> filterList == null || filterList.permits(r.getRoute().getNetwork()))
-        // Overwrite area on the route before sending it out
-        .map(
-            r ->
-                RouteAdvertisement.<OspfInterAreaRoute>builder()
-                    .setRoute(
-                        OspfInterAreaRoute.builder(r.getRoute())
-                            .setArea(areaConfig.getAreaNumber())
-                            .setMetric(firstNonNull(customMetric, r.getRoute().getMetric()))
-                            .setNextHopIp(nextHopIp)
-                            .build())
-                    .setReason(r.getReason())
                     .build());
   }
 
@@ -1515,6 +1527,10 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
     InternalDelta(RibDelta<OspfIntraAreaRoute> intraArea, RibDelta<OspfInterAreaRoute> interArea) {
       _intraArea = intraArea;
       _interArea = interArea;
+    }
+
+    private boolean isEmpty() {
+      return _intraArea.isEmpty() && _interArea.isEmpty();
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -8,7 +8,15 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Streams;
-import java.util.*;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.SortedMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -907,7 +915,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
    * @param delta ABR's inter- or intra- RIB delta
    * @param areaConfig area configuration at the ABR for this neighbor adjacency
    * @param filterList route filter list defined at the ABR (to enable correct summarization)
-   * @param neighborIp
+   * @param neighborIp IP of the neighbor to which we're sending the route
    * @param nextHopIp next hop ip to use when creating the route.
    * @param customMetric if provided (i.e., not {@code null}) it will be used instead of the routes
    */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -572,13 +572,14 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
     return new InternalDelta(intraAreaDelta.build(), interAreaDelta.build());
   }
 
-  /** Process a intraArea advertisement from a neighbor.
-   * This will transform advertisement on import, and place it in the appropriate RIB(s).
+  /**
+   * Process a intraArea advertisement from a neighbor. This will transform advertisement on import,
+   * and place it in the appropriate RIB(s).
    *
    * @param intraAreaDelta builder for the intraArea RIB delta
    * @param interAreaDelta builder for the interArea RIB delta
    * @param interAreaDelta builder for the interArea RIB delta
-   * */
+   */
   @VisibleForTesting
   void processIntraAreaAdvertisement(
       RibDelta.Builder<OspfIntraAreaRoute> intraAreaDelta,

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -1170,11 +1170,19 @@ public class OspfRoutingProcessTest {
   public void testProcessIntraAreaAdvertisement() {
     RibDelta.Builder<OspfIntraAreaRoute> intraAreaDelta = RibDelta.builder();
     RibDelta.Builder<OspfInterAreaRoute> interAreaDelta = RibDelta.builder();
-    _routingProcess.processIntraAreaAdvertisement(intraAreaDelta, interAreaDelta, ACTIVE_IFACE_NAME, 10,
-            RouteAdvertisement.<OspfIntraAreaRoute>builder().setRoute(OspfIntraAreaRoute.builder()
-            .setArea(0)
-            .setNetwork(Prefix.parse("1.1.1.1/29"))
-            .setMetric(1).build()).build());
+    _routingProcess.processIntraAreaAdvertisement(
+        intraAreaDelta,
+        interAreaDelta,
+        ACTIVE_IFACE_NAME,
+        10,
+        RouteAdvertisement.<OspfIntraAreaRoute>builder()
+            .setRoute(
+                OspfIntraAreaRoute.builder()
+                    .setArea(0)
+                    .setNetwork(Prefix.parse("1.1.1.1/29"))
+                    .setMetric(1)
+                    .build())
+            .build());
 
     // Both deltas should have the route at ABR
     assertFalse(intraAreaDelta.isEmpty());

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -5,7 +5,6 @@ import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasN
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.batfish.dataplane.ibdp.OspfRoutingProcess.applyDistributeList;
 import static org.batfish.dataplane.ibdp.OspfRoutingProcess.computeDefaultInterAreaRouteToInject;
-import static org.batfish.dataplane.ibdp.OspfRoutingProcess.convertAndFilterIntraAreaRoutesToPropagate;
 import static org.batfish.dataplane.ibdp.OspfRoutingProcess.filterInterAreaRoutesToPropagateAtABR;
 import static org.batfish.dataplane.ibdp.OspfRoutingProcess.getIfaceAddressesForIntraAreaRoutes;
 import static org.batfish.dataplane.ibdp.OspfRoutingProcess.transformInterAreaRoutesOnExportNonABR;
@@ -561,97 +560,6 @@ public class OspfRoutingProcessTest {
   }
 
   @Test
-  public void testConvertAndFilterIntraAreaRoutesToPropagate() {
-    OspfIntraAreaRoute route0 =
-        OspfIntraAreaRoute.builder()
-            .setArea(0)
-            .setNetwork(Prefix.ZERO)
-            .setMetric(1)
-            .setNextHopIp(Ip.parse("8.8.8.8"))
-            .build();
-    OspfIntraAreaRoute route1 =
-        OspfIntraAreaRoute.builder()
-            .setArea(1)
-            .setNetwork(Prefix.parse("1.0.0.0/8"))
-            .setMetric(42)
-            .setNextHopIp(Ip.parse("8.8.8.8"))
-            .build();
-
-    final Ip nextHopIp = Ip.parse("9.9.9.9");
-    final RibDelta<OspfIntraAreaRoute> delta =
-        RibDelta.<OspfIntraAreaRoute>builder().add(route0).add(route1).build();
-
-    // Regular conversion
-    List<RouteAdvertisement<OspfInterAreaRoute>> transformed =
-        convertAndFilterIntraAreaRoutesToPropagate(delta, AREA0_CONFIG, null, nextHopIp, null)
-            .collect(Collectors.toList());
-    assertThat(
-        transformed,
-        contains(
-            hasRoute(
-                allOf(
-                    hasPrefix(route1.getNetwork()),
-                    hasNextHopIp(equalTo(nextHopIp)),
-                    hasMetric(route1.getMetric())))));
-
-    // Regular conversion but with custom metric
-    transformed =
-        convertAndFilterIntraAreaRoutesToPropagate(delta, AREA0_CONFIG, null, nextHopIp, 999L)
-            .collect(Collectors.toList());
-    assertThat(
-        transformed,
-        contains(
-            hasRoute(
-                allOf(
-                    hasPrefix(route1.getNetwork()),
-                    hasNextHopIp(equalTo(nextHopIp)),
-                    hasMetric(999L)))));
-
-    // Convert and filter with route filter list
-    transformed =
-        convertAndFilterIntraAreaRoutesToPropagate(
-                delta,
-                AREA0_CONFIG,
-                new RouteFilterList(
-                    "filter",
-                    ImmutableList.of(
-                        new RouteFilterLine(
-                            LineAction.DENY, Prefix.parse("1.0.0.0/8"), SubRange.singleton(8)))),
-                nextHopIp,
-                999L)
-            .collect(Collectors.toList());
-    assertThat(transformed, empty());
-
-    // Convert but filter because STUB and suppress type 3
-    transformed =
-        convertAndFilterIntraAreaRoutesToPropagate(
-                delta,
-                OspfArea.builder()
-                    .setStub(StubSettings.builder().setSuppressType3(true).build())
-                    .setNumber(2)
-                    .build(),
-                null,
-                nextHopIp,
-                null)
-            .collect(Collectors.toList());
-    assertThat(transformed, empty());
-
-    // Convert but filter because NSSA and suppress type 3
-    transformed =
-        convertAndFilterIntraAreaRoutesToPropagate(
-                delta,
-                OspfArea.builder()
-                    .setNssa(NssaSettings.builder().setSuppressType3(true).build())
-                    .setNumber(2)
-                    .build(),
-                null,
-                nextHopIp,
-                null)
-            .collect(Collectors.toList());
-    assertThat(transformed, empty());
-  }
-
-  @Test
   public void testFilterInterAreaRoutesToPropagateAtABR() {
     OspfInterAreaRoute route0 =
         OspfInterAreaRoute.builder()
@@ -669,12 +577,14 @@ public class OspfRoutingProcessTest {
             .build();
 
     final Ip nextHopIp = Ip.parse("9.9.9.9");
+    Ip neighborIp = Ip.parse("2.2.2.2");
     final RibDelta<OspfInterAreaRoute> delta =
         RibDelta.<OspfInterAreaRoute>builder().add(route0).add(route1).build();
 
     // Regular conversion
     List<RouteAdvertisement<OspfInterAreaRoute>> transformed =
-        filterInterAreaRoutesToPropagateAtABR(delta, AREA0_CONFIG, null, nextHopIp, null)
+        filterInterAreaRoutesToPropagateAtABR(
+                delta, AREA0_CONFIG, null, neighborIp, nextHopIp, null)
             .collect(Collectors.toList());
     assertThat(
         transformed,
@@ -687,7 +597,8 @@ public class OspfRoutingProcessTest {
 
     // Regular conversion but with custom metric
     transformed =
-        filterInterAreaRoutesToPropagateAtABR(delta, AREA0_CONFIG, null, nextHopIp, 999L)
+        filterInterAreaRoutesToPropagateAtABR(
+                delta, AREA0_CONFIG, null, neighborIp, nextHopIp, 999L)
             .collect(Collectors.toList());
     assertThat(
         transformed,
@@ -708,6 +619,7 @@ public class OspfRoutingProcessTest {
                     ImmutableList.of(
                         new RouteFilterLine(
                             LineAction.DENY, Prefix.parse("1.0.0.0/8"), SubRange.singleton(8)))),
+                neighborIp,
                 nextHopIp,
                 999L)
             .collect(Collectors.toList());
@@ -722,6 +634,7 @@ public class OspfRoutingProcessTest {
                     .setNumber(2)
                     .build(),
                 null,
+                neighborIp,
                 nextHopIp,
                 null)
             .collect(Collectors.toList());
@@ -736,6 +649,7 @@ public class OspfRoutingProcessTest {
                     .setNumber(2)
                     .build(),
                 null,
+                neighborIp,
                 nextHopIp,
                 null)
             .collect(Collectors.toList());
@@ -763,9 +677,11 @@ public class OspfRoutingProcessTest {
     final RibDelta<OspfInterAreaRoute> delta =
         RibDelta.<OspfInterAreaRoute>builder().add(route0).add(route1).build();
 
+    Ip neighborIp = Ip.parse("2.2.2.2");
+
     // Regular conversion
     Collection<RouteAdvertisement<OspfInterAreaRoute>> transformed =
-        transformInterAreaRoutesOnExportNonABR(delta, AREA0_CONFIG, nextHopIp, null);
+        transformInterAreaRoutesOnExportNonABR(delta, AREA0_CONFIG, neighborIp, nextHopIp, null);
     assertThat(
         transformed,
         contains(
@@ -776,7 +692,8 @@ public class OspfRoutingProcessTest {
                     hasMetric(route0.getMetric())))));
 
     // Regular conversion but with custom metric
-    transformed = transformInterAreaRoutesOnExportNonABR(delta, AREA0_CONFIG, nextHopIp, 999L);
+    transformed =
+        transformInterAreaRoutesOnExportNonABR(delta, AREA0_CONFIG, neighborIp, nextHopIp, 999L);
     assertThat(
         transformed,
         contains(
@@ -1247,5 +1164,20 @@ public class OspfRoutingProcessTest {
     assertThat(
         getIfaceAddressesForIntraAreaRoutes(p2pLoopback).collect(ImmutableList.toImmutableList()),
         containsInAnyOrder(primary, secondary));
+  }
+
+  @Test
+  public void testProcessIntraAreaAdvertisement() {
+    RibDelta.Builder<OspfIntraAreaRoute> intraAreaDelta = RibDelta.builder();
+    RibDelta.Builder<OspfInterAreaRoute> interAreaDelta = RibDelta.builder();
+    _routingProcess.processIntraAreaAdvertisement(intraAreaDelta, interAreaDelta, ACTIVE_IFACE_NAME, 10,
+            RouteAdvertisement.<OspfIntraAreaRoute>builder().setRoute(OspfIntraAreaRoute.builder()
+            .setArea(0)
+            .setNetwork(Prefix.parse("1.1.1.1/29"))
+            .setMetric(1).build()).build());
+
+    // Both deltas should have the route at ABR
+    assertFalse(intraAreaDelta.isEmpty());
+    assertFalse(interAreaDelta.isEmpty());
   }
 }


### PR DESCRIPTION
* Generate IA routes on initialization and import, as opposed to on export. This allows for better loop prevention by having a non-routing version of intra-area route as IA route in IA RIB.
* Implement split horizon rules for IA route propagation. Also helps loop prevention