### PR TITLE
jackson: upgrade after CVE-2020-24616

### DIFF
--- a/library_deps.bzl
+++ b/library_deps.bzl
@@ -2,7 +2,7 @@
 BATFISH_MAVEN_ARTIFACTS = [
     "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
     "com.fasterxml.jackson.core:jackson-core:2.9.10",
-    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5",
+    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6",
     "com.fasterxml.jackson.datatype:jackson-datatype-guava:2.9.10",
     "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.9.10",
     "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.10",

--- a/maven_install.json
+++ b/maven_install.json
@@ -90,8 +90,8 @@
                 "sha256": "68c6cea3770d2a7660e4ec0ceac41fd0e95b9e0595f50db8471b2030d76213c7"
             },
             {
-                "coord": "com.fasterxml.jackson.core:jackson-databind:2.9.10.5",
-                "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.5/jackson-databind-2.9.10.5.jar",
+                "coord": "com.fasterxml.jackson.core:jackson-databind:2.9.10.6",
+                "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.6/jackson-databind-2.9.10.6.jar",
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
                     "com.fasterxml.jackson.core:jackson-core:2.9.10"
@@ -103,15 +103,15 @@
                 "exclusions": [
                     "org.hamcrest:hamcrest-core"
                 ],
-                "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.5/jackson-databind-2.9.10.5.jar",
+                "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.6/jackson-databind-2.9.10.6.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.5/jackson-databind-2.9.10.5.jar"
+                    "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.6/jackson-databind-2.9.10.6.jar"
                 ],
-                "sha256": "2a10966c8ee38bf3949d6e35e65556eebb7935db0832b9e4414aa31427e73f18"
+                "sha256": "a2885687e7856c09923ecce53eb10d131f4339958b18ff111e2d66c5be7453da"
             },
             {
-                "coord": "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5",
-                "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.5/jackson-databind-2.9.10.5-sources.jar",
+                "coord": "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6",
+                "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.6/jackson-databind-2.9.10.6-sources.jar",
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10"
@@ -123,18 +123,18 @@
                 "exclusions": [
                     "org.hamcrest:hamcrest-core"
                 ],
-                "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.5/jackson-databind-2.9.10.5-sources.jar",
+                "url": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.6/jackson-databind-2.9.10.6-sources.jar",
                 "mirror_urls": [
-                    "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.5/jackson-databind-2.9.10.5-sources.jar"
+                    "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.10.6/jackson-databind-2.9.10.6-sources.jar"
                 ],
-                "sha256": "063870d4115f8bfa8d690a07a9705887a623c48c4f125048f996c5b1c3ce3d88"
+                "sha256": "102bd98fa7b403df7b6d1f0c2797b88ec1df07cb2cc7b9071f9b8c040d9e0755"
             },
             {
                 "coord": "com.fasterxml.jackson.datatype:jackson-datatype-guava:2.9.10",
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-guava/2.9.10/jackson-datatype-guava-2.9.10.jar",
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-core:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6",
                     "com.google.guava:guava:28.1-jre"
                 ],
                 "dependencies": [
@@ -144,9 +144,9 @@
                     "com.google.code.findbugs:jsr305:3.0.2",
                     "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
                     "com.google.guava:guava:28.1-jre",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5",
                     "com.fasterxml.jackson.core:jackson-core:2.9.10",
                     "org.checkerframework:checker-qual:2.8.1",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6",
                     "com.google.guava:failureaccess:1.0.1",
                     "com.google.errorprone:error_prone_annotations:2.3.2"
                 ],
@@ -164,7 +164,7 @@
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-guava/2.9.10/jackson-datatype-guava-2.9.10-sources.jar",
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6",
                     "com.google.guava:guava:jar:sources:28.1-jre"
                 ],
                 "dependencies": [
@@ -173,8 +173,8 @@
                     "com.google.guava:guava:jar:sources:28.1-jre",
                     "com.google.j2objc:j2objc-annotations:jar:sources:1.3",
                     "org.checkerframework:checker-qual:jar:sources:2.8.1",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
                     "com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava",
                     "com.google.guava:failureaccess:jar:sources:1.0.1",
@@ -194,10 +194,10 @@
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.9.10/jackson-datatype-jdk8-2.9.10.jar",
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-core:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5"
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6"
                 ],
                 "dependencies": [
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6",
                     "com.fasterxml.jackson.core:jackson-core:2.9.10",
                     "com.fasterxml.jackson.core:jackson-annotations:2.9.10"
                 ],
@@ -215,12 +215,12 @@
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.9.10/jackson-datatype-jdk8-2.9.10-sources.jar",
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5"
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6"
                 ],
                 "dependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5"
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6"
                 ],
                 "exclusions": [
                     "org.hamcrest:hamcrest-core"
@@ -237,10 +237,10 @@
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
                     "com.fasterxml.jackson.core:jackson-core:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5"
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6"
                 ],
                 "dependencies": [
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6",
                     "com.fasterxml.jackson.core:jackson-core:2.9.10",
                     "com.fasterxml.jackson.core:jackson-annotations:2.9.10"
                 ],
@@ -259,12 +259,12 @@
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5"
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6"
                 ],
                 "dependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5"
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6"
                 ],
                 "exclusions": [
                     "org.hamcrest:hamcrest-core"
@@ -280,10 +280,10 @@
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.9.10/jackson-jaxrs-base-2.9.10.jar",
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-core:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5"
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6"
                 ],
                 "dependencies": [
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6",
                     "com.fasterxml.jackson.core:jackson-core:2.9.10",
                     "com.fasterxml.jackson.core:jackson-annotations:2.9.10"
                 ],
@@ -301,12 +301,12 @@
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.9.10/jackson-jaxrs-base-2.9.10-sources.jar",
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5"
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6"
                 ],
                 "dependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5"
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6"
                 ],
                 "exclusions": [
                     "org.hamcrest:hamcrest-core"
@@ -323,10 +323,10 @@
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
                     "com.fasterxml.jackson.core:jackson-core:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5"
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6"
                 ],
                 "dependencies": [
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6",
                     "com.fasterxml.jackson.core:jackson-core:2.9.10",
                     "com.fasterxml.jackson.core:jackson-annotations:2.9.10"
                 ],
@@ -345,12 +345,12 @@
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5"
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6"
                 ],
                 "dependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5"
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6"
                 ],
                 "exclusions": [
                     "org.hamcrest:hamcrest-core"
@@ -3567,18 +3567,18 @@
                 "directDependencies": [
                     "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
                     "org.glassfish.jersey.ext:jersey-entity-filtering:2.27",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5",
                     "org.glassfish.jersey.core:jersey-common:2.27",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6",
                     "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.8.10"
                 ],
                 "dependencies": [
                     "org.glassfish.hk2:osgi-resource-locator:1.0.1",
                     "com.fasterxml.jackson.core:jackson-annotations:2.9.10",
                     "org.glassfish.jersey.ext:jersey-entity-filtering:2.27",
-                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.5",
                     "org.glassfish.jersey.core:jersey-common:2.27",
                     "com.fasterxml.jackson.core:jackson-core:2.9.10",
                     "javax.ws.rs:javax.ws.rs-api:2.1.1",
+                    "com.fasterxml.jackson.core:jackson-databind:2.9.10.6",
                     "javax.annotation:javax.annotation-api:1.3.2",
                     "org.glassfish.hk2.external:javax.inject:2.5.0-b42",
                     "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.8.10"
@@ -3597,18 +3597,18 @@
                 "file": "v1/https/repo1.maven.org/maven2/org/glassfish/jersey/media/jersey-media-json-jackson/2.27/jersey-media-json-jackson-2.27-sources.jar",
                 "directDependencies": [
                     "org.glassfish.jersey.core:jersey-common:jar:sources:2.27",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5",
                     "org.glassfish.jersey.ext:jersey-entity-filtering:jar:sources:2.27",
                     "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:sources:2.8.10",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10"
                 ],
                 "dependencies": [
                     "org.glassfish.jersey.core:jersey-common:jar:sources:2.27",
                     "org.glassfish.hk2:osgi-resource-locator:jar:sources:1.0.1",
-                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.5",
                     "com.fasterxml.jackson.core:jackson-core:jar:sources:2.9.10",
                     "org.glassfish.jersey.ext:jersey-entity-filtering:jar:sources:2.27",
                     "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:sources:2.8.10",
+                    "com.fasterxml.jackson.core:jackson-databind:jar:sources:2.9.10.6",
                     "com.fasterxml.jackson.core:jackson-annotations:jar:sources:2.9.10",
                     "org.glassfish.hk2.external:javax.inject:jar:sources:2.5.0-b42",
                     "javax.ws.rs:javax.ws.rs-api:jar:sources:2.1.1",
@@ -4631,6 +4631,6 @@
             }
         ],
         "version": "0.1.0",
-        "__AUTOGENERATED_FILE_DO_NOT_MODIFY_THIS_FILE_MANUALLY": -608552887
+        "__AUTOGENERATED_FILE_DO_NOT_MODIFY_THIS_FILE_MANUALLY": -937649186
     }
 }

--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -68,7 +68,7 @@
     <guava-eea.version>0.0.1</guava-eea.version>
     <hamcrest.version>2.2</hamcrest.version>
     <icu4j.version>63.1</icu4j.version>
-    <jackson.version>2.9.10.20200621</jackson.version>
+    <jackson.version>2.9.10.20200824</jackson.version>
     <javax-activation.version>1.1</javax-activation.version>
     <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
     <jaeger.version>1.2.0</jaeger.version>


### PR DESCRIPTION
https://buildkite.com/batfish/batfish-vulnerability-scan/builds/133#04badada-83a6-45b2-8807-0088b5e11db5

vulnerable: jackson-databind-2.9.10.5.jar: CVE-2020-24616

upgrading to 2.9.10.6