### PR TITLE
BDD: fix randomFullSatOne entropy

### DIFF
--- a/projects/bdd/BUILD
+++ b/projects/bdd/BUILD
@@ -38,8 +38,9 @@ junit_tests(
     deps = [
         ":bdd",
         ":bdd_testlib",
+        "@maven//:com_google_guava_guava",
         "@maven//:junit_junit",
-        "@maven//:org_hamcrest_hamcrest",
         "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_hamcrest_hamcrest",
     ],
 )

--- a/projects/bdd/pom.xml
+++ b/projects/bdd/pom.xml
@@ -121,6 +121,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <scope>test</scope>

--- a/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
+++ b/projects/bdd/src/main/java/net/sf/javabdd/JFactory.java
@@ -3154,7 +3154,7 @@ public final class JFactory extends BDDFactory {
     // is LEVEL(r) [aka, which variable is tested in this node] as well as the path we take through
     // the BDD. This is a lot like netconan, but no need for cryptographic security.
     int newSeed = seed * 31 + level;
-    boolean preferLo = (newSeed & 1) == 0;
+    boolean preferLo = (newSeed & 65536) == 0;
     if (level < LEVEL(r)) {
       // The BDD r is the same no matter which branch at the current level is taken. Pick one
       // randomly.

--- a/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
+++ b/projects/bdd/src/test/java/net/sf/javabdd/JFactoryTest.java
@@ -1,17 +1,37 @@
 package net.sf.javabdd;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
 import java.util.Arrays;
+import java.util.BitSet;
+import java.util.HashSet;
 import org.junit.Test;
 
 /** Tests of {@link JFactory}. */
 public class JFactoryTest {
   private JFactory _factory = (JFactory) JFactory.init(10000, 10000);
+
+  @Test
+  public void testRandomSatDoesntSuck() {
+    _factory.setVarNum(64);
+    HashSet<BitSet> differentAssignments = new HashSet<>();
+    BDD one = _factory.one();
+    HashFunction someFn = Hashing.goodFastHash(8);
+    for (int i = 0; i < 128; ++i) {
+      int seed = someFn.hashInt(i).asInt();
+      differentAssignments.add(one.randomFullSatOne(seed).minAssignmentBits());
+    }
+    // Collisions are plausible, but not all the time.
+    assertThat(differentAssignments, hasSize(greaterThanOrEqualTo(100)));
+  }
 
   @Test
   public void testAnd() {


### PR DESCRIPTION
Checking the lowest bit of a PRNG-generated integer does not work well with the
Linear congruential generatoras (LCGs) that are standard in Java. For the
original implementation, it resulted in only two different random assignments.

Check the middle of the int instead, and add a simple (deterministic) test of
the entropy.