### PR TITLE
FRR: Adding support for interface shutdown command

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -659,6 +659,11 @@ SERVICE
   'service'
 ;
 
+SHUTDOWN
+:
+  'shutdown'
+;
+
 SOFT_RECONFIGURATION
 :
   'soft-reconfiguration'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_interface.g4
@@ -14,7 +14,13 @@ s_interface
     | si_ip
     | si_ipv6
     | si_no
+    | si_shutdown
   )*
+;
+
+si_shutdown
+:
+  SHUTDOWN NEWLINE
 ;
 
 si_ip

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -131,6 +131,7 @@ import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Sbnp_peer_groupContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Sbnp_remote_asContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Sbnp_update_sourceContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Si_descriptionContext;
+import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Si_shutdownContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Siip_addressContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Siipo_areaContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Siipo_costContext;
@@ -630,6 +631,11 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   @Override
   public void exitS_interface(S_interfaceContext ctx) {
     _currentInterface = null;
+  }
+
+  @Override
+  public void exitSi_shutdown(Si_shutdownContext ctx) {
+    _currentInterface.setShutdown(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
@@ -247,6 +247,9 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration
     if (iface.getAlias() != null) {
       viIface.setDescription(iface.getAlias());
     }
+    if (iface.getShutdown()) {
+      viIface.setActive(false);
+    }
     if (!iface.getIpAddresses().isEmpty()) {
       viIface.setAddress(iface.getIpAddresses().get(0));
       viIface.setAllAddresses(

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/FrrInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/FrrInterface.java
@@ -16,7 +16,7 @@ public class FrrInterface implements Serializable {
   private final @Nonnull List<ConcreteInterfaceAddress> _ipAddresses;
   private final @Nonnull String _name;
   private final @Nullable String _vrfName;
-  private @Nonnull Boolean _shutdown = false;
+  private boolean _shutdown = false;
 
   private @Nullable OspfInterface _ospf;
 
@@ -52,7 +52,7 @@ public class FrrInterface implements Serializable {
     return _vrfName;
   }
 
-  public @Nonnull Boolean getShutdown() {
+  public boolean getShutdown() {
     return _shutdown;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/FrrInterface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/FrrInterface.java
@@ -16,6 +16,7 @@ public class FrrInterface implements Serializable {
   private final @Nonnull List<ConcreteInterfaceAddress> _ipAddresses;
   private final @Nonnull String _name;
   private final @Nullable String _vrfName;
+  private @Nonnull Boolean _shutdown = false;
 
   private @Nullable OspfInterface _ospf;
 
@@ -49,6 +50,14 @@ public class FrrInterface implements Serializable {
 
   public @Nullable String getVrfName() {
     return _vrfName;
+  }
+
+  public @Nonnull Boolean getShutdown() {
+    return _shutdown;
+  }
+
+  public void setShutdown(@Nonnull Boolean shutdown) {
+    _shutdown = shutdown;
   }
 
   @Nullable

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -1603,6 +1603,18 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
+  public void testSetInterfaceShutdown() {
+    parseLines("interface eth1", "shutdown");
+    assertTrue(_frr.getInterfaces().get("eth1").getShutdown());
+  }
+
+  @Test
+  public void testGetInterfaceShutdown() {
+    parseLines("interface eth1", "ip address 1.1.1.1/30");
+    assertFalse(_frr.getInterfaces().get("eth1").getShutdown());
+  }
+
+  @Test
   public void testFRRDefaultTraditional() {
     parse("frr defaults traditional\n");
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConcatenatedConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConcatenatedConfigurationTest.java
@@ -190,6 +190,58 @@ public class CumulusConcatenatedConfigurationTest {
             .getActive());
   }
 
+  @Test
+  public void testToVIConfigIntfShut() {
+    InterfacesInterface vsIface = new InterfacesInterface("swp1");
+    CumulusFrrConfiguration frrConfiguration = new CumulusFrrConfiguration();
+
+    CumulusConcatenatedConfiguration vsConfig =
+        CumulusConcatenatedConfiguration.builder()
+            .setHostname("c")
+            .addInterfaces(ImmutableMap.of(vsIface.getName(), vsIface))
+            .setFrrConfiguration(frrConfiguration)
+            .build();
+
+    // Setup the FRR Interface
+    FrrInterface frrInterface = new FrrInterface("swp1");
+    frrInterface.setShutdown(true);
+    frrConfiguration.getInterfaces().put("swp1", frrInterface);
+
+    // Convert - method under test
+    Configuration c = vsConfig.toVendorIndependentConfiguration();
+
+    assertFalse(c.getAllInterfaces().get(vsIface.getName()).getActive());
+
+    // Flip the shutdown status around and test again.
+    frrInterface.setShutdown(false);
+    frrConfiguration.getInterfaces().put("swp1", frrInterface);
+    c = vsConfig.toVendorIndependentConfiguration();
+
+    assertTrue(c.getAllInterfaces().get(vsIface.getName()).getActive());
+  }
+
+  @Test
+  public void testToVIConfigIntfNoShut() {
+    InterfacesInterface vsIface = new InterfacesInterface("swp1");
+    CumulusFrrConfiguration frrConfiguration = new CumulusFrrConfiguration();
+
+    CumulusConcatenatedConfiguration vsConfig =
+        CumulusConcatenatedConfiguration.builder()
+            .setHostname("c")
+            .addInterfaces(ImmutableMap.of(vsIface.getName(), vsIface))
+            .setFrrConfiguration(frrConfiguration)
+            .build();
+
+    // Setup the FRR Interface
+    FrrInterface frrInterface = new FrrInterface("swp1");
+    frrConfiguration.getInterfaces().put("swp1", frrInterface);
+
+    // Convert - method under test
+    Configuration c = vsConfig.toVendorIndependentConfiguration();
+
+    assertTrue(c.getAllInterfaces().get(vsIface.getName()).getActive());
+  }
+
   /** Tests that interfaces are assigned LLAs iff needed */
   @Test
   public void testInterface_assignLla() {


### PR DESCRIPTION
Behavior tested is that if you issue shutdown in Zebra, the interface is admin down.  If you configure "no shut" it just deletes the command - similar to unconfigured.  For that reason I made it non-null and initialized to false as default.  /etc/network/interfaces state parsing happens prior and also controls (hence I do not have a no-shut force admin up for Zebra)