### PR TITLE
SearchRoutePolicies: remove use of deprecated Long constructor

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -229,7 +229,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
       try {
         asns =
             Arrays.stream(asPathStr.split(" "))
-                .mapToLong(Long::new)
+                .mapToLong(Long::valueOf)
                 .boxed()
                 .collect(Collectors.toList());
       } catch (NumberFormatException nfe) {


### PR DESCRIPTION
Replace usage of deprecated Long(String) constructor with Long.valueOf(String).