### PR TITLE
introduce TraceRecorder interface

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/HopInfo.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/HopInfo.java
@@ -1,0 +1,138 @@
+package org.batfish.dataplane.traceroute;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
+import org.batfish.datamodel.flow.Hop;
+
+/** Records information about a {@link Hop trace hop} needed to build a {@link TraceDag}. */
+public final class HopInfo {
+  private final Hop _hop;
+  // Flow as it entered the hop
+  private final Flow _initialFlow;
+  private final @Nullable FlowDisposition _disposition;
+  private final @Nullable Flow _returnFlow;
+  private final @Nullable FirewallSessionTraceInfo _firewallSessionTraceInfo;
+  private final @Nullable Breadcrumb _loopDetectedBreadcrumb;
+  private final @Nullable Breadcrumb _visitedBreadcrumb;
+
+  static HopInfo successHop(
+      Hop hop,
+      Flow initialFlow,
+      FlowDisposition successDisposition,
+      Flow returnFlow,
+      @Nullable FirewallSessionTraceInfo firewallSessionTraceInfo,
+      @Nullable Breadcrumb visitedBreadcrumb) {
+    checkArgument(successDisposition.isSuccessful());
+    return new HopInfo(
+        hop,
+        initialFlow,
+        successDisposition,
+        returnFlow,
+        firewallSessionTraceInfo,
+        null,
+        visitedBreadcrumb);
+  }
+
+  static HopInfo failureHop(
+      Hop hop,
+      Flow initialFlow,
+      FlowDisposition failureDisposition,
+      @Nullable FirewallSessionTraceInfo firewallSessionTraceInfo,
+      @Nullable Breadcrumb visitedBreadcrumb) {
+    checkArgument(!failureDisposition.isSuccessful());
+    checkArgument(failureDisposition != FlowDisposition.LOOP);
+    return new HopInfo(
+        hop,
+        initialFlow,
+        failureDisposition,
+        null,
+        firewallSessionTraceInfo,
+        null,
+        visitedBreadcrumb);
+  }
+
+  static HopInfo loopHop(
+      Hop hop,
+      Flow initialFlow,
+      Breadcrumb loopDetectedBreadcrumb,
+      @Nullable FirewallSessionTraceInfo firewallSessionTraceInfo) {
+    return new HopInfo(
+        hop,
+        initialFlow,
+        FlowDisposition.LOOP,
+        null,
+        firewallSessionTraceInfo,
+        loopDetectedBreadcrumb,
+        null);
+  }
+
+  static HopInfo forwardedHop(
+      Hop hop,
+      Flow initialFlow,
+      Breadcrumb visitedBreadcrumb,
+      @Nullable FirewallSessionTraceInfo firewallSessionTraceInfo) {
+    return new HopInfo(
+        hop, initialFlow, null, null, firewallSessionTraceInfo, null, visitedBreadcrumb);
+  }
+
+  private HopInfo(
+      Hop hop,
+      Flow initialFlow,
+      @Nullable FlowDisposition disposition,
+      @Nullable Flow returnFlow,
+      @Nullable FirewallSessionTraceInfo firewallSessionTraceInfo,
+      @Nullable Breadcrumb loopDetectedBreadcrumb,
+      @Nullable Breadcrumb visitedBreadcrumb) {
+    checkArgument(
+        loopDetectedBreadcrumb == null || visitedBreadcrumb == null,
+        "Cannot have loopDetectBreadcrumb and visitedBreadcrumbs");
+    checkArgument(
+        (disposition != null && disposition.isSuccessful()) == (returnFlow != null),
+        "return flow should be present if and only if the hop has a successful disposition");
+    _disposition = disposition;
+    _firewallSessionTraceInfo = firewallSessionTraceInfo;
+    _hop = hop;
+    _initialFlow = initialFlow;
+    _returnFlow = returnFlow;
+    _loopDetectedBreadcrumb = loopDetectedBreadcrumb;
+    _visitedBreadcrumb = visitedBreadcrumb;
+  }
+
+  public Hop getHop() {
+    return _hop;
+  }
+
+  Flow getInitialFlow() {
+    return _initialFlow;
+  }
+
+  @Nullable
+  Breadcrumb getLoopDetectedBreadcrumb() {
+    return _loopDetectedBreadcrumb;
+  }
+
+  @Nullable
+  Breadcrumb getVisitedBreadcrumb() {
+    return _visitedBreadcrumb;
+  }
+
+  /** Returns the return flow of this hop, if the trace ends here. */
+  @Nullable
+  Flow getReturnFlow() {
+    return _returnFlow;
+  }
+
+  @Nullable
+  FirewallSessionTraceInfo getFirewallSessionTraceInfo() {
+    return _firewallSessionTraceInfo;
+  }
+
+  @Nullable
+  public FlowDisposition getDisposition() {
+    return _disposition;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/HopInfo.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/HopInfo.java
@@ -89,7 +89,7 @@ public final class HopInfo {
       @Nullable Breadcrumb visitedBreadcrumb) {
     checkArgument(
         loopDetectedBreadcrumb == null || visitedBreadcrumb == null,
-        "Cannot have loopDetectBreadcrumb and visitedBreadcrumbs");
+        "Cannot have loopDetectBreadcrumb and visitedBreadcrumb");
     checkArgument(
         (disposition != null && disposition.isSuccessful()) == (returnFlow != null),
         "return flow should be present if and only if the hop has a successful disposition");

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/LegacyTraceRecorder.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/LegacyTraceRecorder.java
@@ -1,0 +1,42 @@
+package org.batfish.dataplane.traceroute;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import org.batfish.datamodel.flow.Trace;
+import org.batfish.datamodel.flow.TraceAndReverseFlow;
+
+public class LegacyTraceRecorder implements TraceRecorder {
+
+  private final Consumer<TraceAndReverseFlow> _consumer;
+
+  public LegacyTraceRecorder(Consumer<TraceAndReverseFlow> consumer) {
+    _consumer = consumer;
+  }
+
+  @Override
+  public void recordTrace(List<HopInfo> hops) {
+    HopInfo lastHop = hops.get(hops.size() - 1);
+    _consumer.accept(
+        new TraceAndReverseFlow(
+            new Trace(
+                checkNotNull(
+                    lastHop.getDisposition(),
+                    "Last hop of a complete trace must have a disposition"),
+                hops.stream().map(HopInfo::getHop).collect(ImmutableList.toImmutableList())),
+            lastHop.getReturnFlow(),
+            hops.stream()
+                .map(HopInfo::getFirewallSessionTraceInfo)
+                .filter(Objects::nonNull)
+                .collect(ImmutableSet.toImmutableSet())));
+  }
+
+  @Override
+  public boolean tryRecordPartialTrace(List<HopInfo> hops) {
+    return false;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/LegacyTraceRecorder.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/LegacyTraceRecorder.java
@@ -14,7 +14,9 @@ import org.batfish.datamodel.flow.Hop;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
 
-/** A {@link TraceRecorder} that only records complete traces, and passes them to a {@link Consumer}. */
+/**
+ * A {@link TraceRecorder} that only records complete traces, and passes them to a {@link Consumer}.
+ */
 public final class LegacyTraceRecorder implements TraceRecorder {
 
   private final Consumer<TraceAndReverseFlow> _consumer;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TraceRecorder.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TraceRecorder.java
@@ -12,7 +12,8 @@ public interface TraceRecorder {
 
   /**
    * Try to record a partial trace (i.e. one in which the final {@link HopInfo} does not have a
-   * nonnull {@link HopInfo#getDisposition() disposition}).
+   * nonnull {@link HopInfo#getDisposition() disposition}). This requires all possible suffixes of
+   * the partial trace to have been previously recorded.
    *
    * @return whether the trace was recorded successfully.
    */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TraceRecorder.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TraceRecorder.java
@@ -1,0 +1,10 @@
+package org.batfish.dataplane.traceroute;
+
+import java.util.List;
+
+/** Used by {@link FlowTracer} to record complete and partial traces. */
+public interface TraceRecorder {
+  void recordTrace(List<HopInfo> hops);
+
+  boolean tryRecordPartialTrace(List<HopInfo> hops);
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TraceRecorder.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TraceRecorder.java
@@ -4,7 +4,17 @@ import java.util.List;
 
 /** Used by {@link FlowTracer} to record complete and partial traces. */
 public interface TraceRecorder {
+  /**
+   * Record a complete trace, i.e. one in which the final {@link HopInfo} has a nonnull {@link
+   * HopInfo#getDisposition()} disposition}.
+   */
   void recordTrace(List<HopInfo> hops);
 
+  /**
+   * Try to record a partial trace (i.e. one in which the final {@link HopInfo} does not have a
+   * nonnull {@link HopInfo#getDisposition() disposition}).
+   *
+   * @return whether the trace was recorded successfully.
+   */
   boolean tryRecordPartialTrace(List<HopInfo> hops);
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -45,7 +45,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -193,15 +192,17 @@ public final class FlowTracerTest {
             c,
             null,
             new Node(c.getHostname()),
-            traces::add,
+            new LegacyTraceRecorder(traces::add),
             NodeInterfacePair.of("node", "iface"),
-            ImmutableSet.of(sessionInfo),
+            ImmutableList.of(sessionInfo),
             flow,
             vrf.getName(),
             new ArrayList<>(),
             ImmutableList.of(),
             new Stack<>(),
-            flow);
+            flow,
+            0,
+            0);
 
     flowTracer.buildDeniedTrace(DENIED_IN);
     assertThat(
@@ -262,15 +263,17 @@ public final class FlowTracerTest {
             c,
             ingressIface.getName(),
             new Node(c.getHostname()),
-            traces::add,
+            new LegacyTraceRecorder(traces::add),
             lastHopNodeAndOutgoingInterface,
-            new HashSet<>(),
+            new ArrayList<>(),
             flow,
             vrf.getName(),
             new ArrayList<>(),
             new ArrayList<>(),
             new Stack<>(),
-            flow);
+            flow,
+            0,
+            0);
     flowTracer.buildAcceptTrace();
     return Iterables.getOnlyElement(traces);
   }
@@ -404,15 +407,17 @@ public final class FlowTracerTest {
             c,
             null,
             new Node(c.getHostname()),
-            traces::add,
+            new LegacyTraceRecorder(traces::add),
             null,
-            new HashSet<>(),
+            new ArrayList<>(),
             flow,
             vrf.getName(),
             new ArrayList<>(),
             new ArrayList<>(),
             new Stack<>(),
-            flow);
+            flow,
+            0,
+            0);
 
     flowTracer.buildAcceptTrace();
     TraceAndReverseFlow traceAndReverseFlow = Iterables.getOnlyElement(traces);
@@ -490,15 +495,17 @@ public final class FlowTracerTest {
               c,
               null,
               new Node(c.getHostname()),
-              traces::add,
+              new LegacyTraceRecorder(traces::add),
               null,
-              new HashSet<>(),
+              new ArrayList<>(),
               returnFlow,
               vrf.getName(),
               new ArrayList<>(),
               new ArrayList<>(),
               new Stack<>(),
-              returnFlow);
+              returnFlow,
+              0,
+              0);
       flowTracer.processHop();
 
       // Reverse trace should match session and get forwarded out original ingress interface
@@ -519,15 +526,17 @@ public final class FlowTracerTest {
               c,
               null,
               new Node(c.getHostname()),
-              traces::add,
+              new LegacyTraceRecorder(traces::add),
               null,
-              new HashSet<>(),
+              new ArrayList<>(),
               nonMatchingReturnFlow,
               vrf.getName(),
               new ArrayList<>(),
               new ArrayList<>(),
               new Stack<>(),
-              nonMatchingReturnFlow);
+              nonMatchingReturnFlow,
+              0,
+              0);
       flowTracer.processHop();
 
       // Reverse trace should not match session, so should be dropped (FIB has no routes)
@@ -1162,15 +1171,17 @@ public final class FlowTracerTest {
             c,
             null,
             new Node(c.getHostname()),
-            traces::add,
+            new LegacyTraceRecorder(traces::add),
             NodeInterfacePair.of(node, iface),
-            ImmutableSet.of(),
+            new ArrayList<>(),
             flow,
             vrf.getName(),
             new ArrayList<>(),
             ImmutableList.of(),
             new Stack<>(),
-            flow);
+            flow,
+            0,
+            0);
 
     {
       FlowDisposition disposition = FlowDisposition.INSUFFICIENT_INFO;
@@ -1374,15 +1385,17 @@ public final class FlowTracerTest {
             currentConfig,
             null,
             new Node(node),
-            traceAndReverseFlow -> {},
+            new LegacyTraceRecorder(traceAndReverseFlow -> {}),
             null,
-            new HashSet<>(),
+            new ArrayList<>(),
             flow,
             vrf.getName(),
             new ArrayList<>(),
             new ArrayList<>(),
             breadcrumbs,
-            flow);
+            flow,
+            0,
+            0);
 
     Ip dstIp2 = Ip.parse("2.2.2.2");
     flowTracer.applyTransformation(
@@ -1509,15 +1522,17 @@ public final class FlowTracerTest {
               c,
               null,
               new Node(c.getHostname()),
-              traces::add,
+              new LegacyTraceRecorder(traces::add),
               NodeInterfacePair.of("node", "iface"),
-              ImmutableSet.of(),
+              new ArrayList<>(),
               flowWithBlockedSrc, // original flow
               vrf.getName(),
               new ArrayList<>(),
               steps,
               new Stack<>(),
-              flowWithPermittedSrc); // current flow
+              flowWithPermittedSrc, // current flow
+              0,
+              0);
 
       flowTracer.forwardOutInterface(iface, dstIp, null);
       assertThat(traces, hasSize(1));
@@ -1535,15 +1550,17 @@ public final class FlowTracerTest {
               c,
               null,
               new Node(c.getHostname()),
-              traces::add,
+              new LegacyTraceRecorder(traces::add),
               NodeInterfacePair.of("node", "iface"),
-              ImmutableSet.of(),
+              new ArrayList<>(),
               flowWithPermittedSrc, // original flow
               vrf.getName(),
               new ArrayList<>(),
               steps,
               new Stack<>(),
-              flowWithBlockedSrc); // current flow
+              flowWithBlockedSrc, // current flow
+              0,
+              0);
 
       flowTracer.forwardOutInterface(iface, dstIp, null);
       assertThat(traces, hasSize(1));


### PR DESCRIPTION
This is a behavior-preserving PR that lays the foundation for saving time and space usage in traceroute, by reusing previously-computed hops and (partial traces).

It introduces the `TraceRecorder` interface, which allows `FlowTracer` to stop tracing early if a previously-recorder trace suffix (or set of suffixes) can be reused. `TraceRecorder` takes as input a list of `HopInfo`, which augments the usual `Hop` with some extra metadata needed to determine when a trace suffix is compatible with a trace prefix, and to reconstruct concrete traces later. Most of that will show up in the next PR.

The big change in this PR is to FlowTracer, adapting it to `TraceRecorder` and building `HopInfo`. In particular, it needs to track which breadcrumb or new session was created for the current hop (if any). 