### PR TITLE
TraceDag and DagTraceRecorder

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/TraceAndReverseFlow.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/TraceAndReverseFlow.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.flow;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -44,5 +45,24 @@ public final class TraceAndReverseFlow {
   /** Return the new firewall sessions initialized by the trace. */
   public @Nonnull Set<FirewallSessionTraceInfo> getNewFirewallSessions() {
     return _newFirewallSessions;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TraceAndReverseFlow)) {
+      return false;
+    }
+    TraceAndReverseFlow that = (TraceAndReverseFlow) o;
+    return _trace.equals(that._trace)
+        && Objects.equals(_reverseFlow, that._reverseFlow)
+        && _newFirewallSessions.equals(that._newFirewallSessions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_trace, _reverseFlow, _newFirewallSessions);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/TraceAndReverseFlowTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/TraceAndReverseFlowTest.java
@@ -1,0 +1,57 @@
+package org.batfish.datamodel.flow;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import java.util.List;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.flow.InboundStep.InboundStepDetail;
+import org.batfish.datamodel.flow.OriginateStep.OriginateStepDetail;
+import org.batfish.datamodel.pojo.Node;
+import org.junit.Test;
+
+public class TraceAndReverseFlowTest {
+  private static Trace trace(String hostname) {
+    return new Trace(
+        FlowDisposition.ACCEPTED,
+        ImmutableList.of(
+            new Hop(
+                new Node(hostname),
+                ImmutableList.of(
+                    OriginateStep.builder()
+                        .setAction(StepAction.ORIGINATED)
+                        .setDetail(OriginateStepDetail.builder().setOriginatingVrf("vrf").build())
+                        .build(),
+                    InboundStep.builder().setDetail(new InboundStepDetail("iface")).build()))));
+  }
+
+  private static ImmutableList<FirewallSessionTraceInfo> sessions(String hostname) {
+    return ImmutableList.of(
+        new FirewallSessionTraceInfo(
+            hostname,
+            FibLookup.INSTANCE,
+            new OriginatingSessionScope("vrf"),
+            new SessionMatchExpr(IpProtocol.TCP, Ip.ZERO, Ip.ZERO, 0, 0),
+            null));
+  }
+
+  @Test
+  public void testEquals() {
+    Trace trace1 = trace("n1");
+    Trace trace2 = trace("n2");
+    Flow flow1 = Flow.builder().setIngressNode("n1").build();
+    Flow flow2 = Flow.builder().setIngressNode("n2").build();
+    List<FirewallSessionTraceInfo> sessions1 = sessions("n1");
+    List<FirewallSessionTraceInfo> sessions2 = sessions("n2");
+    new EqualsTester()
+        .addEqualityGroup(
+            new TraceAndReverseFlow(trace1, flow1, sessions1),
+            new TraceAndReverseFlow(trace1, flow1, sessions1))
+        .addEqualityGroup(new TraceAndReverseFlow(trace2, flow1, sessions1))
+        .addEqualityGroup(new TraceAndReverseFlow(trace1, flow2, sessions1))
+        .addEqualityGroup(new TraceAndReverseFlow(trace1, flow1, sessions2))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/DagTraceRecorder.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/DagTraceRecorder.java
@@ -40,11 +40,13 @@ public class DagTraceRecorder implements TraceRecorder {
    *
    * <p>TODO: implement equals/hashCode for {@link Hop} instead of using JSON.
    */
-  private static final class NodeKey {
+  @VisibleForTesting
+  static final class NodeKey {
     private final @Nonnull Flow _initialFlow;
     private final @Nonnull String _hopJson;
 
-    private NodeKey(Flow initialFlow, Hop hop) {
+    @VisibleForTesting
+    NodeKey(Flow initialFlow, Hop hop) {
       _initialFlow = initialFlow;
       _hopJson = BatfishObjectMapper.writeStringRuntimeError(hop);
     }
@@ -221,6 +223,7 @@ public class DagTraceRecorder implements TraceRecorder {
 
       HopInfo hopInfo = _hopInfo;
       nodeId = traceDagNodes.size();
+      cache.put(this, nodeId);
       traceDagNodes.add(
           new TraceDag.Node(
               hopInfo.getHop(),

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/DagTraceRecorder.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/DagTraceRecorder.java
@@ -1,0 +1,283 @@
+package org.batfish.dataplane.traceroute;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.flow.Hop;
+
+/**
+ * {@link TraceRecorder} that compresses traces into a {@link TraceDag} and allows partial traces to
+ * be recorded by reusing already-computed subgraphs.
+ */
+@ParametersAreNonnullByDefault
+public class DagTraceRecorder implements TraceRecorder {
+  private final @Nonnull Flow _flow;
+
+  DagTraceRecorder(@Nonnull Flow flow) {
+    _flow = flow;
+  }
+
+  /**
+   * The key used to lookup Nodes in a TraceDag.
+   *
+   * <p>TODO: implement equals/hashCode for {@link Hop} instead of using JSON.
+   */
+  private static final class NodeKey {
+    private final @Nonnull Flow _initialFlow;
+    private final @Nonnull String _hopJson;
+
+    private NodeKey(Flow initialFlow, Hop hop) {
+      _initialFlow = initialFlow;
+      _hopJson = BatfishObjectMapper.writeStringRuntimeError(hop);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof NodeKey)) {
+        return false;
+      }
+      NodeKey nodeKey = (NodeKey) o;
+      return _initialFlow.equals(nodeKey._initialFlow) && _hopJson.equals(nodeKey._hopJson);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_initialFlow, _hopJson);
+    }
+  }
+
+  /** Traces are generated in DFS order, i.e. grouped by common prefix. */
+  @VisibleForTesting
+  final class NodeBuilder {
+    private final @Nonnull NodeKey _key;
+    final List<Breadcrumb> _nextHopBreadcrumbs;
+    final HopInfo _hopInfo;
+    final boolean _isFinalHop;
+    @Nullable NodeBuilder _currentNextHopBuilder;
+    final @Nullable List<Node> _nextHops;
+
+    NodeBuilder(List<Breadcrumb> breadcrumbs, HopInfo hopInfo, NodeKey key) {
+      _hopInfo = hopInfo;
+      _key = key;
+
+      @Nullable Breadcrumb visitedBreadcrumb = _hopInfo.getVisitedBreadcrumb();
+      _nextHopBreadcrumbs =
+          visitedBreadcrumb == null
+              ? ImmutableList.copyOf(breadcrumbs)
+              : ImmutableList.<Breadcrumb>builder()
+                  .addAll(breadcrumbs)
+                  .add(_hopInfo.getVisitedBreadcrumb())
+                  .build();
+      _isFinalHop = _hopInfo.getDisposition() != null;
+      _nextHops = _isFinalHop ? null : new ArrayList<>();
+    }
+
+    boolean tryRecordPartialTrace(List<HopInfo> hops) {
+      assert !_isFinalHop || hops.isEmpty();
+      assert _isFinalHop == (_nextHops == null);
+      if (hops.isEmpty()) {
+        return _isFinalHop;
+      }
+      HopInfo nextHop = hops.get(0);
+      if (_currentNextHopBuilder != null && _currentNextHopBuilder._hopInfo != nextHop) {
+        _nextHops.add(_currentNextHopBuilder.build());
+        _currentNextHopBuilder = null;
+      }
+      if (_currentNextHopBuilder == null) {
+        NodeKey key = new NodeKey(nextHop.getInitialFlow(), nextHop.getHop());
+        Node node = findMatchingNode(key, _nextHopBreadcrumbs);
+        if (node != null) {
+          if (!_nextHops.contains(node)) {
+            _nextHops.add(node);
+          }
+          return true;
+        }
+        _currentNextHopBuilder = new NodeBuilder(_nextHopBreadcrumbs, nextHop, key);
+      }
+
+      assert _currentNextHopBuilder._hopInfo == nextHop;
+      return _currentNextHopBuilder.tryRecordPartialTrace(hops.subList(1, hops.size()));
+    }
+
+    Node build() {
+      Breadcrumb visitedBreadcrumb = _hopInfo.getVisitedBreadcrumb();
+      Breadcrumb loopDetectedBreadcrumb = _hopInfo.getLoopDetectedBreadcrumb();
+
+      if (_isFinalHop) {
+        Set<Breadcrumb> requiredBreadcrumbs =
+            loopDetectedBreadcrumb == null
+                ? ImmutableSet.of()
+                : ImmutableSet.of(loopDetectedBreadcrumb);
+        Set<Breadcrumb> forbiddenBreadcrumbs =
+            visitedBreadcrumb == null
+                ? ImmutableSet.of()
+                : ImmutableSet.of(_hopInfo.getVisitedBreadcrumb());
+        Node node =
+            new Node(_hopInfo, ImmutableList.of(), requiredBreadcrumbs, forbiddenBreadcrumbs);
+        _nodeMap.put(_key, node);
+        return node;
+      } else {
+        assert _nextHops != null : "_nextHops cannot be null if not the final hop";
+        assert visitedBreadcrumb != null : "visitedBreadcrumb cannot be null if not the final hop";
+
+        if (_currentNextHopBuilder != null) {
+          _nextHops.add(_currentNextHopBuilder.build());
+        }
+
+        ImmutableSet.Builder<Breadcrumb> requiredBreadcrumbsBuilder = ImmutableSet.builder();
+        ImmutableSet.Builder<Breadcrumb> forbiddenBreadcrumbsBuilder = ImmutableSet.builder();
+        forbiddenBreadcrumbsBuilder.add(visitedBreadcrumb);
+        for (Node nextHop : _nextHops) {
+          assert !nextHop._forbiddenBreadcrumbs.contains(visitedBreadcrumb)
+              : "Node's breadcrumb is forbidden by a successor";
+          forbiddenBreadcrumbsBuilder.addAll(nextHop._forbiddenBreadcrumbs);
+          requiredBreadcrumbsBuilder.addAll(
+              nextHop._requiredBreadcrumbs.contains(visitedBreadcrumb)
+                  ? Sets.difference(
+                      nextHop._requiredBreadcrumbs, ImmutableSet.of(visitedBreadcrumb))
+                  : nextHop._requiredBreadcrumbs);
+        }
+        ImmutableSet<Breadcrumb> requiredBreadcrumbs = requiredBreadcrumbsBuilder.build();
+        ImmutableSet<Breadcrumb> forbiddenBreadcrumbs = forbiddenBreadcrumbsBuilder.build();
+        assert !requiredBreadcrumbs.contains(visitedBreadcrumb) : "A node cannot require itself";
+        Node node =
+            new Node(
+                _hopInfo,
+                ImmutableList.copyOf(_nextHops),
+                requiredBreadcrumbs,
+                forbiddenBreadcrumbs);
+        _nodeMap.put(_key, node);
+        return node;
+      }
+    }
+  }
+
+  private static final class Node {
+    private final HopInfo _hopInfo;
+    private final List<Node> _successors;
+    private final Set<Breadcrumb> _requiredBreadcrumbs;
+    private final Set<Breadcrumb> _forbiddenBreadcrumbs;
+
+    private Node(
+        HopInfo hopInfo,
+        List<Node> successors,
+        Set<Breadcrumb> requiredBreadcrumbs,
+        Set<Breadcrumb> forbiddenBreadcrumbs) {
+      _hopInfo = hopInfo;
+      _successors = ImmutableList.copyOf(successors);
+      _requiredBreadcrumbs = ImmutableSet.copyOf(requiredBreadcrumbs);
+      _forbiddenBreadcrumbs = ImmutableSet.copyOf(forbiddenBreadcrumbs);
+    }
+
+    /**
+     * sessionAction will be non-null for checking if we can reuse traces in traceroute. it can be
+     * null when de-duping a node after creation.
+     */
+    boolean matches(List<Breadcrumb> breadcrumbs) {
+      return breadcrumbs.containsAll(_requiredBreadcrumbs)
+          && _forbiddenBreadcrumbs.stream().noneMatch(breadcrumbs::contains);
+    }
+
+    /** Convert a {@link Node} to a {@link TraceDag.Node}. */
+    private int buildTraceDagNode(Map<Node, Integer> cache, List<TraceDag.Node> traceDagNodes) {
+      @Nullable Integer nodeId = cache.get(this);
+      if (nodeId != null) {
+        return nodeId;
+      }
+
+      List<Integer> successorIds =
+          _successors.stream()
+              .map(successor -> successor.buildTraceDagNode(cache, traceDagNodes))
+              .collect(ImmutableList.toImmutableList());
+
+      HopInfo hopInfo = _hopInfo;
+      nodeId = traceDagNodes.size();
+      traceDagNodes.add(
+          new TraceDag.Node(
+              hopInfo.getHop(),
+              hopInfo.getFirewallSessionTraceInfo(),
+              hopInfo.getDisposition(),
+              hopInfo.getReturnFlow(),
+              successorIds));
+      return nodeId;
+    }
+  }
+
+  // indices are aligned
+  private final List<Node> _roots = new ArrayList<>();
+  private final Multimap<NodeKey, Node> _nodeMap = HashMultimap.create();
+  private NodeBuilder _rootBuilder = null;
+  private @Nullable TraceDag _builtTraceDag = null;
+
+  private @Nullable Node findMatchingNode(NodeKey key, List<Breadcrumb> breadcrumbs) {
+    Collection<Node> nodes = _nodeMap.get(key);
+    if (nodes.isEmpty()) {
+      return null;
+    }
+    List<Node> matches =
+        nodes.stream().filter(node -> node.matches(breadcrumbs)).collect(Collectors.toList());
+    checkState(matches.size() < 2, "Found 2 matching Trace nodes");
+    return matches.isEmpty() ? null : matches.get(0);
+  }
+
+  @Override
+  public boolean tryRecordPartialTrace(List<HopInfo> hops) {
+    checkState(_builtTraceDag == null, "Cannot add traces after the Dag has been built");
+    HopInfo rootHop = hops.get(0);
+    if (_rootBuilder != null && _rootBuilder._hopInfo != rootHop) {
+      buildRoot();
+    }
+    if (_rootBuilder == null) {
+      _rootBuilder =
+          new NodeBuilder(ImmutableList.of(), rootHop, new NodeKey(_flow, rootHop.getHop()));
+    }
+    return _rootBuilder.tryRecordPartialTrace(hops.subList(1, hops.size()));
+  }
+
+  @Override
+  public void recordTrace(List<HopInfo> hops) {
+    checkState(tryRecordPartialTrace(hops), "Failed to record a complete trace.");
+  }
+
+  private void buildRoot() {
+    _roots.add(_rootBuilder.build());
+    _rootBuilder = null;
+  }
+
+  public TraceDag build() {
+    if (_builtTraceDag != null) {
+      return _builtTraceDag;
+    }
+    if (_rootBuilder != null) {
+      buildRoot();
+    }
+    Map<Node, Integer> nodeIds = new HashMap<>();
+    List<TraceDag.Node> dagNodes = new ArrayList<>(_nodeMap.size());
+    List<Integer> rootIds =
+        _roots.stream()
+            .map(root -> root.buildTraceDagNode(nodeIds, dagNodes))
+            .collect(ImmutableList.toImmutableList());
+    return _builtTraceDag = new TraceDag(dagNodes, rootIds);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TraceDag.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TraceDag.java
@@ -1,0 +1,133 @@
+package org.batfish.dataplane.traceroute;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
+import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.Trace;
+import org.batfish.datamodel.flow.TraceAndReverseFlow;
+
+/**
+ * A DAG representation of a collection of {@link TraceAndReverseFlow traces}. Every path through
+ * the DAG from a root to a leaf is a valid {@link TraceAndReverseFlow trace}, i.e. one that {@link
+ * FlowTracer} would create.
+ */
+public class TraceDag {
+  /** A node in the DAG contains everything needed to reconstruct traces through the node. */
+  public static final class Node {
+    private final Hop _hop;
+    private final @Nullable FirewallSessionTraceInfo _firewallSessionTraceInfo;
+    private final @Nullable FlowDisposition _flowDisposition;
+    private final @Nullable Flow _returnFlow;
+    private final List<Integer> _successors;
+
+    public Node(
+        Hop hop,
+        @Nullable FirewallSessionTraceInfo firewallSessionTraceInfo,
+        @Nullable FlowDisposition flowDisposition,
+        @Nullable Flow returnFlow,
+        List<Integer> successors) {
+      checkArgument(
+          (flowDisposition != null && flowDisposition.isSuccessful()) == (returnFlow != null),
+          "returnFlow is present iff disposition is successful");
+      _hop = hop;
+      _firewallSessionTraceInfo = firewallSessionTraceInfo;
+      _flowDisposition = flowDisposition;
+      _returnFlow = returnFlow;
+      _successors = ImmutableList.copyOf(successors);
+    }
+  }
+
+  private final List<Node> _nodes;
+  private final List<Integer> _rootIds;
+
+  public TraceDag(List<Node> nodes, List<Integer> rootIds) {
+    _nodes = nodes;
+    _rootIds = rootIds;
+  }
+
+  public int size() {
+    return new SizeComputer().size();
+  }
+
+  /** Efficiently compute the number of traces in the DAG. */
+  private class SizeComputer {
+    private final Integer[] _cache;
+
+    SizeComputer() {
+      _cache = new Integer[_nodes.size()];
+    }
+
+    int size(int nodeId) {
+      @Nullable Integer cachedSize = _cache[nodeId];
+      if (cachedSize != null) {
+        return cachedSize;
+      }
+      Node node = _nodes.get(nodeId);
+      if (node._successors.isEmpty()) {
+        // leaf
+        _cache[nodeId] = 1;
+      } else {
+        _cache[nodeId] = node._successors.stream().mapToInt(this::size).sum();
+      }
+      return _cache[nodeId];
+    }
+
+    int size() {
+      return _rootIds.stream().mapToInt(this::size).sum();
+    }
+  }
+
+  private Stream<TraceAndReverseFlow> getTraces(
+      List<Hop> hopsInput, List<FirewallSessionTraceInfo> sessionsInput, int rootId) {
+    Node node = _nodes.get(rootId);
+
+    List<Hop> hops = new ArrayList<>(hopsInput);
+    hops.add(node._hop);
+
+    List<FirewallSessionTraceInfo> sessions;
+    FirewallSessionTraceInfo firewallSessionTraceInfo = node._firewallSessionTraceInfo;
+    if (firewallSessionTraceInfo != null) {
+      sessions = new ArrayList<>(sessionsInput);
+      sessions.add(firewallSessionTraceInfo);
+    } else {
+      sessions = sessionsInput;
+    }
+
+    List<Integer> successors = node._successors;
+    if (successors.isEmpty()) {
+      FlowDisposition disposition =
+          checkNotNull(node._flowDisposition, "failed to determine disposition from hop");
+      Trace trace = new Trace(disposition, hops);
+      return Stream.of(new TraceAndReverseFlow(trace, node._returnFlow, sessions));
+    } else {
+      return successors.stream().flatMap(successorId -> getTraces(hops, sessions, successorId));
+    }
+  }
+
+  int countEdges() {
+    return _nodes.stream().map(node -> node._successors).mapToInt(List::size).sum();
+  }
+
+  int countNodes() {
+    return _nodes.size();
+  }
+
+  private Stream<TraceAndReverseFlow> getTraces(int rootId) {
+    return getTraces(ImmutableList.of(), new Stack<>(), rootId);
+  }
+
+  public Stream<TraceAndReverseFlow> getTraces() {
+    return _rootIds.stream().map(this::getTraces).flatMap(Function.identity());
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/BUILD
@@ -1,0 +1,45 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+java_library(
+    name = "testlib",
+    srcs = ["HopTestUtils.java"],
+    deps = [
+        "//projects/batfish",
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:junit_junit",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "**/*Test.java",
+    ]),
+    resources = [
+        "//projects/batfish/src/test/resources",
+    ],
+    deps = [
+        "//projects/batfish",
+        "//projects/batfish:batfish_testlib",
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:common_testlib",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
+        "//projects/batfish/src/test/java/org/batfish/dataplane/traceroute:testlib",
+        "//projects/bdd",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
+        "@maven//:junit_junit",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/DagTraceRecorderTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/DagTraceRecorderTest.java
@@ -1,0 +1,175 @@
+package org.batfish.dataplane.traceroute;
+
+import static org.batfish.datamodel.matchers.TraceAndReverseFlowMatchers.hasReverseFlow;
+import static org.batfish.datamodel.matchers.TraceAndReverseFlowMatchers.hasTrace;
+import static org.batfish.datamodel.matchers.TraceMatchers.hasDisposition;
+import static org.batfish.datamodel.matchers.TraceMatchers.hasHops;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.datamodel.Ip;
+import org.junit.Test;
+
+public class DagTraceRecorderTest {
+  private static final Flow TEST_FLOW =
+      Flow.builder().setDstIp(Ip.parse("1.1.1.1")).setIngressNode("node").build();
+
+  private static Breadcrumb breadcrumb(String node, Flow flow) {
+    return new Breadcrumb(node, "vrf", null, flow);
+  }
+
+  private static HopInfo acceptedHop(String node) {
+    return HopInfo.successHop(
+        HopTestUtils.acceptedHop(node),
+        TEST_FLOW,
+        FlowDisposition.ACCEPTED,
+        TEST_FLOW,
+        null,
+        breadcrumb(node, TEST_FLOW));
+  }
+
+  private static HopInfo forwardedHop(String node) {
+    return forwardedHop(node, TEST_FLOW);
+  }
+
+  private static HopInfo forwardedHop(String node, Flow flow) {
+    return HopInfo.forwardedHop(
+        HopTestUtils.forwardedHop(node), flow, breadcrumb(node, flow), null);
+  }
+
+  private static HopInfo loopHop(String node) {
+    return loopHop(node, TEST_FLOW);
+  }
+
+  private static HopInfo loopHop(String node, Flow flow) {
+    return HopInfo.loopHop(HopTestUtils.loopHop(node), flow, breadcrumb(node, flow), null);
+  }
+
+  /**
+   * Test that a node on a looping path are not reused for paths that do include the breadcrumb
+   * required for detecting the loop.
+   *
+   * <p>Setup: We have a looping path A -> B -> A
+   *
+   * <p>We cannot record the partial trace: C -> B
+   */
+  @Test
+  public void testNoReuse_requiredBreadcrumb() {
+    HopInfo hopA = forwardedHop("A");
+    HopInfo hopB = forwardedHop("B");
+    HopInfo hopALoop = loopHop("A");
+    HopInfo hopC = forwardedHop("C");
+    DagTraceRecorder recorder = new DagTraceRecorder(TEST_FLOW);
+    assertTrue(recorder.tryRecordPartialTrace(ImmutableList.of(hopA, hopB, hopALoop)));
+    assertFalse(recorder.tryRecordPartialTrace(ImmutableList.of(hopC, hopB)));
+  }
+
+  /**
+   * Test nodes along a non-looping path are not reused for paths that include a breadcrumb that
+   * would cause a loop to be detected.
+   *
+   * <p>Setup: We have a non-looping path A -> B -> C -> D
+   *
+   * <p>We cannot record the partial trace: C -> B
+   */
+  @Test
+  public void testNoReuse_forbiddenBreadcrumb() {
+    Flow flow = Flow.builder().setDstIp(Ip.parse("1.1.1.1")).setIngressNode("node").build();
+    HopInfo hopA = forwardedHop("A");
+    HopInfo hopB = forwardedHop("B");
+    HopInfo hopC = forwardedHop("C");
+    HopInfo hopD = acceptedHop("D");
+    DagTraceRecorder recorder = new DagTraceRecorder(flow);
+    assertTrue(recorder.tryRecordPartialTrace(ImmutableList.of(hopA, hopB, hopC, hopD)));
+    assertFalse(recorder.tryRecordPartialTrace(ImmutableList.of(hopC, hopB)));
+  }
+
+  /**
+   * Test nodes constructed with one flow cannot be reused for other flows.
+   *
+   * <p>Setup: We have a non-looping path A -> B -> C
+   *
+   * <p>D transforms the flow, so we cannot record the partial trace: D -> B
+   */
+  @Test
+  public void testNoReuse_transformedFlow() {
+    Flow transformedFlow = TEST_FLOW.toBuilder().setDstIp(Ip.parse("2.2.2.2")).build();
+    HopInfo hopA = forwardedHop("A");
+    HopInfo hopB = forwardedHop("B");
+    HopInfo hopC = acceptedHop("C");
+    HopInfo hopD = forwardedHop("D");
+    HopInfo hopBTransformed = forwardedHop("B", transformedFlow);
+    DagTraceRecorder recorder = new DagTraceRecorder(TEST_FLOW);
+    assertTrue(recorder.tryRecordPartialTrace(ImmutableList.of(hopA, hopB, hopC)));
+    assertFalse(recorder.tryRecordPartialTrace(ImmutableList.of(hopD, hopBTransformed)));
+  }
+
+  @Test
+  public void testRecordPartialTrace() {
+    HopInfo hopA = forwardedHop("A");
+    HopInfo hopB = forwardedHop("B");
+    HopInfo hopC = acceptedHop("C");
+    HopInfo hopD = forwardedHop("D");
+    DagTraceRecorder recorder = new DagTraceRecorder(TEST_FLOW);
+    assertTrue(recorder.tryRecordPartialTrace(ImmutableList.of(hopA, hopB, hopC)));
+    assertTrue(recorder.tryRecordPartialTrace(ImmutableList.of(hopD, hopB)));
+  }
+
+  /**
+   * Test that trace order is preserved. This is important for making TraceDag transparent to users.
+   */
+  @Test
+  public void testTraceOrder() {
+    HopInfo hopA1 = forwardedHop("A1");
+    HopInfo hopA2 = forwardedHop("A2");
+    HopInfo hopB = forwardedHop("B");
+    HopInfo hopC1 = acceptedHop("C1");
+    HopInfo hopC2 = acceptedHop("C2");
+    DagTraceRecorder recorder = new DagTraceRecorder(TEST_FLOW);
+    // simulating the sequence of calls FlowTracer will make
+    assertFalse(recorder.tryRecordPartialTrace(ImmutableList.of(hopA1)));
+    assertFalse(recorder.tryRecordPartialTrace(ImmutableList.of(hopA1, hopB)));
+    recorder.recordTrace(ImmutableList.of(hopA1, hopB, hopC1));
+    recorder.recordTrace(ImmutableList.of(hopA1, hopB, hopC2));
+    assertFalse(recorder.tryRecordPartialTrace(ImmutableList.of(hopA2)));
+    assertTrue(recorder.tryRecordPartialTrace(ImmutableList.of(hopA2, hopB)));
+    TraceDag dag = recorder.build();
+    assertThat(
+        dag.getTraces().collect(ImmutableList.toImmutableList()),
+        contains(
+            // A1 -> B -> C1
+            allOf(
+                hasTrace(
+                    allOf(
+                        hasDisposition(FlowDisposition.ACCEPTED),
+                        hasHops(contains(hopA1.getHop(), hopB.getHop(), hopC1.getHop())))),
+                hasReverseFlow(hopC1.getReturnFlow())),
+            // A1 -> B -> C2
+            allOf(
+                hasTrace(
+                    allOf(
+                        hasDisposition(FlowDisposition.ACCEPTED),
+                        hasHops(contains(hopA1.getHop(), hopB.getHop(), hopC2.getHop())))),
+                hasReverseFlow(hopC2.getReturnFlow())),
+            // A2 -> B -> C1
+            allOf(
+                hasTrace(
+                    allOf(
+                        hasDisposition(FlowDisposition.ACCEPTED),
+                        hasHops(contains(hopA2.getHop(), hopB.getHop(), hopC1.getHop())))),
+                hasReverseFlow(hopC1.getReturnFlow())),
+            // A2 -> B -> C2
+            allOf(
+                hasTrace(
+                    allOf(
+                        hasDisposition(FlowDisposition.ACCEPTED),
+                        hasHops(contains(hopA2.getHop(), hopB.getHop(), hopC2.getHop())))),
+                hasReverseFlow(hopC2.getReturnFlow()))));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/HopTestUtils.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/HopTestUtils.java
@@ -1,0 +1,74 @@
+package org.batfish.dataplane.traceroute;
+
+import com.google.common.collect.ImmutableList;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.flow.EnterInputIfaceStep;
+import org.batfish.datamodel.flow.EnterInputIfaceStep.EnterInputIfaceStepDetail;
+import org.batfish.datamodel.flow.ExitOutputIfaceStep;
+import org.batfish.datamodel.flow.ExitOutputIfaceStep.ExitOutputIfaceStepDetail;
+import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.InboundStep;
+import org.batfish.datamodel.flow.InboundStep.InboundStepDetail;
+import org.batfish.datamodel.flow.LoopStep;
+import org.batfish.datamodel.flow.RoutingStep;
+import org.batfish.datamodel.flow.RoutingStep.RoutingStepDetail;
+import org.batfish.datamodel.flow.Step;
+import org.batfish.datamodel.flow.StepAction;
+import org.batfish.datamodel.pojo.Node;
+
+/** Utilities for building {@link Hop hops} and {@link Step steps} for testing. */
+final class HopTestUtils {
+  private static EnterInputIfaceStep enterInputIfaceStep(String node) {
+    return EnterInputIfaceStep.builder()
+        .setAction(StepAction.RECEIVED)
+        .setDetail(
+            EnterInputIfaceStepDetail.builder()
+                .setInputInterface(NodeInterfacePair.of(node, "inputIface"))
+                .setInputVrf("inputVrf")
+                .build())
+        .build();
+  }
+
+  /** Create a Hop with StepAction Forwarded. */
+  static Hop acceptedHop(String node) {
+    return new Hop(
+        new Node(node),
+        ImmutableList.of(
+            enterInputIfaceStep(node),
+            InboundStep.builder().setDetail(new InboundStepDetail("iface")).build()));
+  }
+
+  /** Create a Hop with StepAction Forwarded. */
+  static Hop forwardedHop(String node) {
+    return new Hop(
+        new Node(node),
+        ImmutableList.of(
+            enterInputIfaceStep(node),
+            RoutingStep.builder()
+                .setAction(StepAction.FORWARDED)
+                .setDetail(RoutingStepDetail.builder().build())
+                .build(),
+            ExitOutputIfaceStep.builder()
+                .setAction(StepAction.TRANSMITTED)
+                .setDetail(
+                    ExitOutputIfaceStepDetail.builder()
+                        .setOutputInterface(NodeInterfacePair.of(node, "outIface"))
+                        .build())
+                .build()));
+  }
+
+  static Hop loopHop(String node) {
+    return new Hop(new Node(node), ImmutableList.of(enterInputIfaceStep(node), LoopStep.INSTANCE));
+  }
+
+  static Hop noRouteHop(String node) {
+    return new Hop(
+        new Node(node),
+        ImmutableList.of(
+            enterInputIfaceStep(node),
+            RoutingStep.builder()
+                .setAction(StepAction.NO_ROUTE)
+                .setDetail(RoutingStepDetail.builder().build())
+                .build()));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TraceDagTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TraceDagTest.java
@@ -89,5 +89,7 @@ public class TraceDagTest {
                 null,
                 ImmutableList.of())));
     assertEquals(6, dag.size());
+    assertEquals(6, dag.countNodes());
+    assertEquals(8, dag.countEdges());
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TraceDagTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TraceDagTest.java
@@ -1,0 +1,93 @@
+package org.batfish.dataplane.traceroute;
+
+import static org.batfish.dataplane.traceroute.HopTestUtils.acceptedHop;
+import static org.batfish.dataplane.traceroute.HopTestUtils.forwardedHop;
+import static org.batfish.dataplane.traceroute.HopTestUtils.noRouteHop;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.flow.FibLookup;
+import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
+import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.OriginatingSessionScope;
+import org.batfish.datamodel.flow.SessionMatchExpr;
+import org.batfish.datamodel.flow.Trace;
+import org.batfish.datamodel.flow.TraceAndReverseFlow;
+import org.batfish.dataplane.traceroute.TraceDag.Node;
+import org.junit.Test;
+
+public class TraceDagTest {
+  private static final Flow TEST_FLOW =
+      Flow.builder().setDstIp(Ip.parse("1.1.1.1")).setIngressNode("src").build();
+
+  @Test
+  public void testTraceDag() {
+    Hop hopA = forwardedHop("A"); // 0
+    Hop hopB1 = forwardedHop("B1"); // 1
+    Hop hopB2 = forwardedHop("B2"); // 2
+    Hop hopC1 = acceptedHop("C1"); // 3
+    Hop hopC2 = noRouteHop("C2"); // 4
+    Hop hopC3 = noRouteHop("C3"); // 5
+    FirewallSessionTraceInfo session =
+        new FirewallSessionTraceInfo(
+            "B1",
+            FibLookup.INSTANCE,
+            new OriginatingSessionScope("vrf"),
+            new SessionMatchExpr(IpProtocol.TCP, Ip.ZERO, Ip.ZERO, 0, 0),
+            null);
+    Flow c1ReturnFlow = TEST_FLOW.toBuilder().setIngressNode("C1").build();
+    Flow c2ReturnFlow = TEST_FLOW.toBuilder().setIngressNode("C2").build();
+    Node nodeA = new Node(hopA, null, null, null, ImmutableList.of(1, 2));
+    Node nodeB1 = new Node(hopB1, session, null, null, ImmutableList.of(3, 4, 5));
+    Node nodeB2 = new Node(hopB2, null, null, null, ImmutableList.of(3, 4, 5));
+    Node nodeC1 = new Node(hopC1, null, FlowDisposition.ACCEPTED, c1ReturnFlow, ImmutableList.of());
+    Node nodeC2 = new Node(hopC2, null, FlowDisposition.ACCEPTED, c2ReturnFlow, ImmutableList.of());
+    Node nodeC3 = new Node(hopC3, null, FlowDisposition.NO_ROUTE, null, ImmutableList.of());
+    TraceDag dag =
+        new TraceDag(
+            ImmutableList.of(nodeA, nodeB1, nodeB2, nodeC1, nodeC2, nodeC3), ImmutableList.of(0));
+    List<TraceAndReverseFlow> traces = dag.getTraces().collect(Collectors.toList());
+    assertThat(
+        traces,
+        contains(
+            // A -> B1 -> C1
+            new TraceAndReverseFlow(
+                new Trace(FlowDisposition.ACCEPTED, ImmutableList.of(hopA, hopB1, hopC1)),
+                c1ReturnFlow,
+                ImmutableList.of(session)),
+            // A -> B1 -> C2
+            new TraceAndReverseFlow(
+                new Trace(FlowDisposition.ACCEPTED, ImmutableList.of(hopA, hopB1, hopC2)),
+                c2ReturnFlow,
+                ImmutableList.of(session)),
+            // A -> B1 -> C3
+            new TraceAndReverseFlow(
+                new Trace(FlowDisposition.NO_ROUTE, ImmutableList.of(hopA, hopB1, hopC3)),
+                null,
+                ImmutableList.of(session)),
+            // A -> B2 -> C1
+            new TraceAndReverseFlow(
+                new Trace(FlowDisposition.ACCEPTED, ImmutableList.of(hopA, hopB2, hopC1)),
+                c1ReturnFlow,
+                ImmutableList.of()),
+            // A -> B2 -> C2
+            new TraceAndReverseFlow(
+                new Trace(FlowDisposition.ACCEPTED, ImmutableList.of(hopA, hopB2, hopC2)),
+                c2ReturnFlow,
+                ImmutableList.of()),
+            // A -> B2 -> C3
+            new TraceAndReverseFlow(
+                new Trace(FlowDisposition.NO_ROUTE, ImmutableList.of(hopA, hopB2, hopC3)),
+                null,
+                ImmutableList.of())));
+    assertEquals(6, dag.size());
+  }
+}


### PR DESCRIPTION
`DagTraceRecorder` is a `TraceRecorder` that stores recorded traces in a DAG (`TraceDag`). This allows common subtraces to be shared, reducing time and space usage of traceroute.

This PR only adds the classes and tests. They are not being used yet. 