### PR TITLE
use DagTraceRecorder

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -89,9 +89,10 @@ public class TracerouteEngineImplContext {
               validateInputs(_configurations, flow);
               String ingressNodeName = flow.getIngressNode();
               String ingressInterfaceName = flow.getIngressInterface();
-              initialFlowTracer(
-                      this, ingressNodeName, ingressInterfaceName, flow, currentTraces::add)
+              DagTraceRecorder recorder = new DagTraceRecorder(flow);
+              initialFlowTracer(this, ingressNodeName, ingressInterfaceName, flow, recorder)
                   .processHop();
+              recorder.build().getTraces().forEach(currentTraces::add);
             });
     return new TreeMap<>(traces);
   }


### PR DESCRIPTION
Use `DagTraceRecorder` to reuse work and previously-constructed `Hop`s when computing traces. Can be significantly more efficient for networks with high ECMP.

Note: I had previously proposed plumbing through a parameter or using a debug flag to control which `TraceRecorder` is used. I have not done that yet because I'm now unsure it's worth the trouble/mess. 