### PR TITLE
Juniper: process subinterface vlan config

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -266,6 +266,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.I_enableContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.I_mtuContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.I_native_vlan_idContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.I_unitContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.I_vlan_idContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Icmp_codeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Icmp_typeContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.If_ethernet_switchingContext;
@@ -4220,6 +4221,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitI_unit(I_unitContext ctx) {
     _currentInterfaceOrRange = _currentMasterInterface;
+  }
+
+  @Override
+  public void exitI_vlan_id(I_vlan_idContext ctx) {
+    _currentInterfaceOrRange.setVlanId(toInt(ctx.DEC()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Interface.java
@@ -103,6 +103,7 @@ public class Interface implements Serializable {
   private String _routingInstance;
   private final SortedMap<String, Interface> _units;
   private final SortedMap<Integer, VrrpGroup> _vrrpGroups;
+  @Nullable private Integer _vlanId;
   private Integer _tcpMss;
 
   public Interface(String name) {
@@ -269,6 +270,15 @@ public class Interface implements Serializable {
 
   public Map<String, Interface> getUnits() {
     return _units;
+  }
+
+  @Nullable
+  public Integer getVlanId() {
+    return _vlanId;
+  }
+
+  public void setVlanId(@Nullable Integer vlanId) {
+    _vlanId = vlanId;
   }
 
   public SortedMap<Integer, VrrpGroup> getVrrpGroups() {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1838,7 +1838,14 @@ public final class JuniperConfiguration extends VendorConfiguration {
       newIface.setSwitchportMode(SwitchportMode.NONE);
       newIface.setSwitchport(false);
     }
-    newIface.setEncapsulationVlan(iface.getVlanId());
+    if (iface.getVlanId() != null) {
+      if (iface.getName().endsWith(".0")) {
+        _w.redFlag(
+            String.format("Setting vlan-id on unit 0 of %s is not allowed", iface.getName()));
+      } else {
+        newIface.setEncapsulationVlan(iface.getVlanId());
+      }
+    }
     newIface.setBandwidth(iface.getBandwidth());
     return newIface;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1838,6 +1838,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       newIface.setSwitchportMode(SwitchportMode.NONE);
       newIface.setSwitchport(false);
     }
+    newIface.setEncapsulationVlan(iface.getVlanId());
     newIface.setBandwidth(iface.getBandwidth());
     return newIface;
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -66,6 +66,7 @@ import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAdditionalArpI
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllAddresses;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllowedVlans;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDescription;
+import static org.batfish.datamodel.matchers.InterfaceMatchers.hasEncapsulationVlan;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasIsis;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasMtu;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasNativeVlan;
@@ -2686,6 +2687,9 @@ public final class FlatJuniperGrammarTest {
     // Expecting an Interface in TRUNK mode with VLANs 6
     assertThat(c, hasInterface("ge-0/3/0.1", hasSwitchPortMode(SwitchportMode.TRUNK)));
     assertThat(c, hasInterface("ge-0/3/0.1", hasAllowedVlans(IntegerSpace.of(6))));
+
+    // Expecting interface with encapsulation VLAN set to 1
+    assertThat(c, hasInterface("ge-0/4/0.1", hasEncapsulationVlan(1)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2690,6 +2690,8 @@ public final class FlatJuniperGrammarTest {
 
     // Expecting interface with encapsulation VLAN set to 1
     assertThat(c, hasInterface("ge-0/4/0.1", hasEncapsulationVlan(1)));
+    // Setting vlan-id on unit 0 is not allowed
+    assertThat(c, hasInterface("ge-0/4/0.0", hasEncapsulationVlan(nullValue())));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-vlan
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-vlan
@@ -8,6 +8,7 @@ set interfaces ge-0/3/0 unit 0 family ethernet-switching port-mode trunk
 set interfaces ge-0/3/0 unit 0 family ethernet-switching vlan members 1-5
 set interfaces ge-0/3/0 unit 1 family ethernet-switching interface-mode trunk
 set interfaces ge-0/3/0 unit 1 family ethernet-switching vlan members 6
+set interfaces ge-0/4/0 unit 0 vlan-id 1000
 set interfaces ge-0/4/0 unit 1 vlan-id 1
 set interfaces vlan unit 103 family inet address 192.168.3.35/24
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-vlan
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/interface-vlan
@@ -8,6 +8,7 @@ set interfaces ge-0/3/0 unit 0 family ethernet-switching port-mode trunk
 set interfaces ge-0/3/0 unit 0 family ethernet-switching vlan members 1-5
 set interfaces ge-0/3/0 unit 1 family ethernet-switching interface-mode trunk
 set interfaces ge-0/3/0 unit 1 family ethernet-switching vlan members 6
+set interfaces ge-0/4/0 unit 1 vlan-id 1
 set interfaces vlan unit 103 family inet address 192.168.3.35/24
 
 set vlans VLAN_TEST vlan-id 101


### PR DESCRIPTION
Fixes #6183 

We were parsing, but ignoring the `vlan-id` statement for L3 subinterfaces. 
Docs: https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/vlan-id-edit-vlans-qfx-series.html