### PR TITLE
ACL Tracing: add trace elements to trivial exprs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -268,6 +268,18 @@ public final class AclTracer extends AclLineEvaluator {
   }
 
   @Override
+  public Boolean visitTrueExpr(TrueExpr trueExpr) {
+    setTraceElement(trueExpr.getTraceElement());
+    return true;
+  }
+
+  @Override
+  public Boolean visitFalseExpr(FalseExpr falseExpr) {
+    setTraceElement(falseExpr.getTraceElement());
+    return false;
+  }
+
+  @Override
   public Boolean visitPermittedByAcl(PermittedByAcl permittedByAcl) {
     setTraceElement(permittedByAcl.getTraceElement());
     return trace(_availableAcls.get(permittedByAcl.getAclName())) == LineAction.PERMIT;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/FalseExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/FalseExpr.java
@@ -2,13 +2,23 @@ package org.batfish.datamodel.acl;
 
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.TraceElement;
 
 public class FalseExpr extends AclLineMatchExpr {
 
   public static final FalseExpr INSTANCE = new FalseExpr();
 
+  @Nullable private final TraceElement _traceElement;
+
   private FalseExpr() {
     super(null);
+    _traceElement = null;
+  }
+
+  public FalseExpr(@Nullable TraceElement traceElement) {
+    super(traceElement);
+    _traceElement = traceElement;
   }
 
   @Override
@@ -18,7 +28,19 @@ public class FalseExpr extends AclLineMatchExpr {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(((Boolean) false));
+    return Objects.hash((Boolean) false, _traceElement);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof FalseExpr)) {
+      return false;
+    }
+    FalseExpr rhs = (FalseExpr) obj;
+    return Objects.equals(_traceElement, rhs._traceElement);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TrueExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/TrueExpr.java
@@ -2,12 +2,22 @@ package org.batfish.datamodel.acl;
 
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.TraceElement;
 
 public class TrueExpr extends AclLineMatchExpr {
   public static final TrueExpr INSTANCE = new TrueExpr();
 
+  @Nullable private final TraceElement _traceElement;
+
   private TrueExpr() {
     super(null);
+    _traceElement = null;
+  }
+
+  public TrueExpr(@Nullable TraceElement traceElement) {
+    super(traceElement);
+    _traceElement = traceElement;
   }
 
   @Override
@@ -22,7 +32,19 @@ public class TrueExpr extends AclLineMatchExpr {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode((Boolean) true);
+    return Objects.hash((Boolean) true, _traceElement);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof TrueExpr)) {
+      return false;
+    }
+    TrueExpr rhs = (TrueExpr) obj;
+    return Objects.equals(_traceElement, rhs._traceElement);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -51,8 +51,6 @@ public class AclTracerTest {
   private static final String TEST_ACL = "test acl";
 
   private static final HeaderSpace TRUE_HEADERSPACE = HeaderSpace.builder().build();
-  private static final HeaderSpace FALSE_HEADERSPACE =
-      HeaderSpace.builder().setNotDstIps(UniverseIpSpace.INSTANCE).build();
 
   private static List<TraceTree> trace(IpAccessList acl) {
     return AclTracer.trace(
@@ -65,11 +63,11 @@ public class AclTracerTest {
   }
 
   private static AclLineMatchExpr trueExpr(String traceElement) {
-    return new MatchHeaderSpace(TRUE_HEADERSPACE, traceElement);
+    return new TrueExpr(TraceElement.of(traceElement));
   }
 
   private static AclLineMatchExpr falseExpr(String traceElement) {
-    return new MatchHeaderSpace(FALSE_HEADERSPACE, traceElement);
+    return new FalseExpr(TraceElement.of(traceElement));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/FalseExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/FalseExprTest.java
@@ -1,0 +1,18 @@
+package org.batfish.datamodel.acl;
+
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.TraceElement;
+import org.junit.Test;
+
+/** Tests of {@link FalseExpr} */
+public class FalseExprTest {
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(FalseExpr.INSTANCE, new FalseExpr(null))
+        .addEqualityGroup(new Object())
+        .addEqualityGroup(new FalseExpr(TraceElement.of("trace element")))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/datamodel/acl/TrueExprTest.java
+++ b/projects/batfish/src/test/java/org/batfish/datamodel/acl/TrueExprTest.java
@@ -1,0 +1,18 @@
+package org.batfish.datamodel.acl;
+
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.TraceElement;
+import org.junit.Test;
+
+/** Tests of {@link TrueExpr} */
+public class TrueExprTest {
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(TrueExpr.INSTANCE, new TrueExpr(null))
+        .addEqualityGroup(new Object())
+        .addEqualityGroup(new TrueExpr(TraceElement.of("trace element")))
+        .testEquals();
+  }
+}


### PR DESCRIPTION
Add trace elements to `TrueExpr` and `FalseExpr` and update `AclTracer` to trace these.
