### PR TITLE
IBDP: skip an unnecessary extra iteration and cleanup

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
@@ -10,6 +10,7 @@ import org.batfish.common.topology.TopologyProvider;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.answers.IncrementalBdpAnswerElement;
+import org.batfish.datamodel.isis.IsisTopology;
 
 /** A batfish plugin that registers the Incremental Batfish Data Plane (ibdp) Engine. */
 @AutoService(Plugin.class)
@@ -30,11 +31,15 @@ public class IncrementalDataPlanePlugin extends DataPlanePlugin {
     TopologyContext topologyContext =
         TopologyContext.builder()
             .setIpsecTopology(topologyProvider.getInitialIpsecTopology(snapshot))
+            .setIsisTopology(
+                IsisTopology.initIsisTopology(
+                    configurations, topologyProvider.getInitialLayer3Topology(snapshot)))
             .setLayer1LogicalTopology(topologyProvider.getLayer1LogicalTopology(snapshot))
             .setLayer2Topology(topologyProvider.getInitialLayer2Topology(snapshot))
             .setLayer3Topology(topologyProvider.getInitialLayer3Topology(snapshot))
             .setOspfTopology(topologyProvider.getInitialOspfTopology(snapshot))
             .setRawLayer1PhysicalTopology(topologyProvider.getRawLayer1PhysicalTopology(snapshot))
+            .setTunnelTopology(topologyProvider.getInitialTunnelTopology(snapshot))
             .build();
 
     ComputeDataPlaneResult answer =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -45,6 +45,7 @@ import org.batfish.datamodel.isis.IsisInterfaceMode;
 import org.batfish.datamodel.isis.IsisInterfaceSettings;
 import org.batfish.datamodel.isis.IsisLevelSettings;
 import org.batfish.datamodel.isis.IsisProcess;
+import org.batfish.datamodel.isis.IsisTopology;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -174,7 +175,10 @@ public class IsisTest {
     return (IncrementalDataPlane)
         engine.computeDataPlane(
                 configurations,
-                TopologyContext.builder().setLayer3Topology(topology).build(),
+                TopologyContext.builder()
+                    .setLayer3Topology(topology)
+                    .setIsisTopology(IsisTopology.initIsisTopology(configurations, topology))
+                    .build(),
                 Collections.emptySet())
             ._dataPlane;
   }
@@ -460,7 +464,10 @@ public class IsisTest {
         (IncrementalDataPlane)
             engine.computeDataPlane(
                     configurations,
-                    TopologyContext.builder().setLayer3Topology(topology).build(),
+                    TopologyContext.builder()
+                        .setLayer3Topology(topology)
+                        .setIsisTopology(IsisTopology.initIsisTopology(configurations, topology))
+                        .build(),
                     Collections.emptySet())
                 ._dataPlane;
     return dp;
@@ -651,7 +658,10 @@ public class IsisTest {
     return (IncrementalDataPlane)
         engine.computeDataPlane(
                 configurations,
-                TopologyContext.builder().setLayer3Topology(topology).build(),
+                TopologyContext.builder()
+                    .setLayer3Topology(topology)
+                    .setIsisTopology(IsisTopology.initIsisTopology(configurations, topology))
+                    .build(),
                 Collections.emptySet())
             ._dataPlane;
   }

--- a/tests/basic/genDp.ref
+++ b/tests/basic/genDp.ref
@@ -8,8 +8,7 @@
         "3" : 66,
         "4" : 75,
         "5" : 76,
-        "6" : 76,
-        "7" : 76
+        "6" : 76
       },
       "bgpMultipathRibRoutesByIteration" : {
         "1" : 28,
@@ -17,18 +16,16 @@
         "3" : 102,
         "4" : 119,
         "5" : 120,
-        "6" : 120,
-        "7" : 120
+        "6" : 120
       },
-      "dependentRoutesIterations" : 7,
+      "dependentRoutesIterations" : 6,
       "mainRibRoutesByIteration" : {
         "1" : 207,
         "2" : 271,
         "3" : 319,
         "4" : 338,
         "5" : 339,
-        "6" : 339,
-        "7" : 339
+        "6" : 339
       },
       "ospfInternalIterations" : 3,
       "version" : "0.36.0",


### PR DESCRIPTION
Cleanup and comment the topology iteration code.

Fixed at least one bug: IsisTopology was not being updated every
iteration.

Moving topology iteration to after the dataplane, and pulling one out of
the while loop, also save one iteration of dataplane when the topology
doesn't change.