### PR TITLE
IBDP: skip main rib route distribution for EVPN Type 5

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -493,6 +493,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
       RibDelta<? extends AnnotatedRoute<AbstractRoute>> mainRibDelta, String srcVrfName) {
     assert mainRibDelta != null; // unused
     assert srcVrfName != null; // unused
+    assert _mainRibRoutesToProcess != null; // unused
     // This is neither used nor cleared, so no-op for now.
     // _mainRibRoutesToProcess.put(srcVrfName, mainRibDelta);
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -491,7 +491,10 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   /** Redistribute routes from {@code srcVrfName} into our VRF. */
   public void redistribute(
       RibDelta<? extends AnnotatedRoute<AbstractRoute>> mainRibDelta, String srcVrfName) {
-    _mainRibRoutesToProcess.put(srcVrfName, mainRibDelta);
+    assert mainRibDelta != null; // unused
+    assert srcVrfName != null; // unused
+    // This is neither used nor cleared, so no-op for now.
+    // _mainRibRoutesToProcess.put(srcVrfName, mainRibDelta);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -524,32 +524,28 @@ class IncrementalBdpEngine {
           .forEach(VirtualRouter::mergeBgpRoutesToMainRib);
 
       // Multi-VRF redistribution of BGP routes:
-      if (false) {
-        // This is only used for EVPN Type 5 routes, which are currently disabled. See comments
-        // elsewhere in this file.
-        nodes
-            .values()
-            .parallelStream()
-            .forEach(
-                n -> {
-                  for (VirtualRouter srcVr : n.getVirtualRouters().values()) {
-                    for (VirtualRouter dstVr : n.getVirtualRouters().values()) {
-                      if (dstVr.getBgpRoutingProcess() == null) {
-                        continue;
-                      }
-                      dstVr
-                          .getBgpRoutingProcess()
-                          .redistribute(
-                              iteration > 1
-                                  ? srcVr._mainRibRouteDeltaBuilder.build()
-                                  : RibDelta.<AnnotatedRoute<AbstractRoute>>builder()
-                                      .add(srcVr.getMainRib().getTypedRoutes())
-                                      .build(),
-                              srcVr.getName());
+      nodes
+          .values()
+          .parallelStream()
+          .forEach(
+              n -> {
+                for (VirtualRouter srcVr : n.getVirtualRouters().values()) {
+                  for (VirtualRouter dstVr : n.getVirtualRouters().values()) {
+                    if (dstVr.getBgpRoutingProcess() == null) {
+                      continue;
                     }
+                    dstVr
+                        .getBgpRoutingProcess()
+                        .redistribute(
+                            iteration > 1
+                                ? srcVr._mainRibRouteDeltaBuilder.build()
+                                : RibDelta.<AnnotatedRoute<AbstractRoute>>builder()
+                                    .add(srcVr.getMainRib().getTypedRoutes())
+                                    .build(),
+                            srcVr.getName());
                   }
-                });
-      }
+                }
+              });
     } finally {
       propSpan.finish();
     }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -524,28 +524,32 @@ class IncrementalBdpEngine {
           .forEach(VirtualRouter::mergeBgpRoutesToMainRib);
 
       // Multi-VRF redistribution of BGP routes:
-      nodes
-          .values()
-          .parallelStream()
-          .forEach(
-              n -> {
-                for (VirtualRouter srcVr : n.getVirtualRouters().values()) {
-                  for (VirtualRouter dstVr : n.getVirtualRouters().values()) {
-                    if (dstVr.getBgpRoutingProcess() == null) {
-                      continue;
+      if (false) {
+        // This is only used for EVPN Type 5 routes, which are currently disabled. See comments
+        // elsewhere in this file.
+        nodes
+            .values()
+            .parallelStream()
+            .forEach(
+                n -> {
+                  for (VirtualRouter srcVr : n.getVirtualRouters().values()) {
+                    for (VirtualRouter dstVr : n.getVirtualRouters().values()) {
+                      if (dstVr.getBgpRoutingProcess() == null) {
+                        continue;
+                      }
+                      dstVr
+                          .getBgpRoutingProcess()
+                          .redistribute(
+                              iteration > 1
+                                  ? srcVr._mainRibRouteDeltaBuilder.build()
+                                  : RibDelta.<AnnotatedRoute<AbstractRoute>>builder()
+                                      .add(srcVr.getMainRib().getTypedRoutes())
+                                      .build(),
+                              srcVr.getName());
                     }
-                    dstVr
-                        .getBgpRoutingProcess()
-                        .redistribute(
-                            iteration > 1
-                                ? srcVr._mainRibRouteDeltaBuilder.build()
-                                : RibDelta.<AnnotatedRoute<AbstractRoute>>builder()
-                                    .add(srcVr.getMainRib().getTypedRoutes())
-                                    .build(),
-                            srcVr.getName());
                   }
-                }
-              });
+                });
+      }
     } finally {
       propSpan.finish();
     }


### PR DESCRIPTION
We disabled EVPN Type 5, but not this code. This results in a memory leak, as the
storage of the redistributed routes was never cleared.