### PR TITLE
PAN: trace details for security rules

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineMatchExprs.java
@@ -6,6 +6,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.Iterator;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.DscpType;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IntegerSpace;
@@ -317,7 +318,15 @@ public final class AclLineMatchExprs {
     return new PermittedByAcl(aclName);
   }
 
+  public static PermittedByAcl permittedByAcl(String aclName, @Nullable TraceElement traceElement) {
+    return new PermittedByAcl(aclName, traceElement);
+  }
+
   public static DeniedByAcl deniedByAcl(String aclName) {
     return new DeniedByAcl(aclName);
+  }
+
+  public static DeniedByAcl deniedByAcl(String aclName, @Nullable TraceElement traceElement) {
+    return new DeniedByAcl(aclName, traceElement);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AndMatchExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AndMatchExpr.java
@@ -14,19 +14,20 @@ public class AndMatchExpr extends AclLineMatchExpr {
 
   private final List<AclLineMatchExpr> _conjuncts;
 
-  public AndMatchExpr(Iterable<AclLineMatchExpr> conjuncts) {
+  public AndMatchExpr(Iterable<? extends AclLineMatchExpr> conjuncts) {
     this(conjuncts, (TraceElement) null);
   }
 
   @JsonCreator
   public AndMatchExpr(
-      @JsonProperty(PROP_CONJUNCTS) Iterable<AclLineMatchExpr> conjuncts,
+      @JsonProperty(PROP_CONJUNCTS) Iterable<? extends AclLineMatchExpr> conjuncts,
       @JsonProperty(PROP_TRACE_ELEMENT) @Nullable TraceElement traceElement) {
     super(traceElement);
     _conjuncts = conjuncts != null ? ImmutableList.copyOf(conjuncts) : ImmutableList.of();
   }
 
-  public AndMatchExpr(Iterable<AclLineMatchExpr> conjuncts, @Nullable String traceElement) {
+  public AndMatchExpr(
+      Iterable<? extends AclLineMatchExpr> conjuncts, @Nullable String traceElement) {
     this(conjuncts, traceElement == null ? null : TraceElement.of(traceElement));
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/OrMatchExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/OrMatchExpr.java
@@ -14,17 +14,18 @@ public class OrMatchExpr extends AclLineMatchExpr {
 
   private final List<AclLineMatchExpr> _disjuncts;
 
-  public OrMatchExpr(Iterable<AclLineMatchExpr> disjuncts) {
+  public OrMatchExpr(Iterable<? extends AclLineMatchExpr> disjuncts) {
     this(disjuncts, (TraceElement) null);
   }
 
-  public OrMatchExpr(Iterable<AclLineMatchExpr> disjuncts, @Nullable String traceElement) {
+  public OrMatchExpr(
+      Iterable<? extends AclLineMatchExpr> disjuncts, @Nullable String traceElement) {
     this(disjuncts, traceElement == null ? null : TraceElement.of(traceElement));
   }
 
   @JsonCreator
   public OrMatchExpr(
-      @JsonProperty(PROP_DISJUNCTS) Iterable<AclLineMatchExpr> disjuncts,
+      @JsonProperty(PROP_DISJUNCTS) Iterable<? extends AclLineMatchExpr> disjuncts,
       @JsonProperty(PROP_TRACE_ELEMENT) @Nullable TraceElement traceElement) {
     super(traceElement);
     _disjuncts = disjuncts != null ? ImmutableList.copyOf(disjuncts) : ImmutableList.of();

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
@@ -72,7 +72,7 @@ public final class PaloAltoTraceElementCreators {
             name,
             new VendorStructureId(
                 filename,
-                PaloAltoStructureType.ADDRESS_OBJECT.getDescription(),
+                PaloAltoStructureType.ADDRESS_GROUP.getDescription(),
                 computeObjectName(vsysName, name)))
         .build();
   }
@@ -83,11 +83,6 @@ public final class PaloAltoTraceElementCreators {
   }
 
   @VisibleForTesting
-  public static TraceElement matchSourceAddressAnyTraceElement() {
-    return TraceElement.of("Matched source address any");
-  }
-
-  @VisibleForTesting
   public static TraceElement matchDestinationAddressTraceElement() {
     return TraceElement.of("Matched destination address");
   }
@@ -95,11 +90,6 @@ public final class PaloAltoTraceElementCreators {
   @VisibleForTesting
   public static TraceElement matchDestinationAddressNegatedTraceElement() {
     return TraceElement.of("Matched negated destination address");
-  }
-
-  @VisibleForTesting
-  public static TraceElement matchDestinationAddressAnyTraceElement() {
-    return TraceElement.of("Matched destination address any");
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
@@ -102,11 +102,6 @@ public final class PaloAltoTraceElementCreators {
     return TraceElement.of("Matched service application-default");
   }
 
-  @VisibleForTesting
-  public static TraceElement matchApplicationTraceElement() {
-    return TraceElement.of("Matched an application");
-  }
-
   /**
    * Creates {@link TraceElement} for ACL line representing security rules for going from {@code
    * fromZone} to {@code toZone} (intrazone rules if zones are the same)

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
@@ -36,7 +36,45 @@ public final class PaloAltoTraceElementCreators {
 
   @VisibleForTesting
   public static TraceElement matchSourceAddressTraceElement() {
-    return TraceElement.of("Matched a source address");
+    return TraceElement.of("Matched source address");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchAddressAnyTraceElement() {
+    return TraceElement.of("Matched address any");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchAddressValueTraceElement(String value) {
+    return TraceElement.of(String.format("Matched address value %s", value));
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchAddressObjectTraceElement(
+      String name, String vsysName, String filename) {
+    return TraceElement.builder()
+        .add("Matched address object ")
+        .add(
+            name,
+            new VendorStructureId(
+                filename,
+                PaloAltoStructureType.ADDRESS_OBJECT.getDescription(),
+                computeObjectName(vsysName, name)))
+        .build();
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchAddressGroupTraceElement(
+      String name, String vsysName, String filename) {
+    return TraceElement.builder()
+        .add("Matched address-group ")
+        .add(
+            name,
+            new VendorStructureId(
+                filename,
+                PaloAltoStructureType.ADDRESS_OBJECT.getDescription(),
+                computeObjectName(vsysName, name)))
+        .build();
   }
 
   @VisibleForTesting
@@ -51,7 +89,7 @@ public final class PaloAltoTraceElementCreators {
 
   @VisibleForTesting
   public static TraceElement matchDestinationAddressTraceElement() {
-    return TraceElement.of("Matched a destination address");
+    return TraceElement.of("Matched destination address");
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
@@ -78,18 +78,13 @@ public final class PaloAltoTraceElementCreators {
   }
 
   @VisibleForTesting
-  public static TraceElement matchSourceAddressNegatedTraceElement() {
-    return TraceElement.of("Matched negated source address");
+  public static TraceElement matchNegatedAddressTraceElement() {
+    return TraceElement.of("Matched negated address");
   }
 
   @VisibleForTesting
   public static TraceElement matchDestinationAddressTraceElement() {
     return TraceElement.of("Matched destination address");
-  }
-
-  @VisibleForTesting
-  public static TraceElement matchDestinationAddressNegatedTraceElement() {
-    return TraceElement.of("Matched negated destination address");
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
@@ -29,6 +29,61 @@ public final class PaloAltoTraceElementCreators {
         .build();
   }
 
+  @VisibleForTesting
+  public static TraceElement matchServiceAnyTraceElement() {
+    return TraceElement.of("Matched service any");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchSourceAddressTraceElement() {
+    return TraceElement.of("Matched a source address");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchSourceAddressNegatedTraceElement() {
+    return TraceElement.of("Matched negated source address");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchSourceAddressAnyTraceElement() {
+    return TraceElement.of("Matched source address any");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchDestinationAddressTraceElement() {
+    return TraceElement.of("Matched a destination address");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchDestinationAddressNegatedTraceElement() {
+    return TraceElement.of("Matched negated destination address");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchDestinationAddressAnyTraceElement() {
+    return TraceElement.of("Matched destination address any");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchServiceTraceElement() {
+    return TraceElement.of("Matched a service");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchBuiltInServiceTraceElement() {
+    return TraceElement.of("Matched a built-in service");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchServiceApplicationDefaultTraceElement() {
+    return TraceElement.of("Matched service application-default");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchApplicationTraceElement() {
+    return TraceElement.of("Matched an application");
+  }
+
   /**
    * Creates {@link TraceElement} for ACL line representing security rules for going from {@code
    * fromZone} to {@code toZone} (intrazone rules if zones are the same)

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceBuiltIn.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ServiceBuiltIn.java
@@ -1,5 +1,8 @@
 package org.batfish.representation.palo_alto;
 
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchBuiltInServiceTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchServiceAnyTraceElement;
+
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
@@ -7,6 +10,10 @@ import java.util.function.Supplier;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.SubRange;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.FalseExpr;
+import org.batfish.datamodel.acl.MatchHeaderSpace;
+import org.batfish.datamodel.acl.TrueExpr;
 
 public enum ServiceBuiltIn {
   ANY,
@@ -42,6 +49,21 @@ public enum ServiceBuiltIn {
 
   public HeaderSpace getHeaderSpace() {
     return _serviceHeaderSpace.get();
+  }
+
+  public AclLineMatchExpr toAclLineMatchExpr() {
+    switch (this) {
+      case ANY:
+        return new TrueExpr(matchServiceAnyTraceElement());
+      case SERVICE_HTTP:
+      case SERVICE_HTTPS:
+        return new MatchHeaderSpace(_serviceHeaderSpace.get(), matchBuiltInServiceTraceElement());
+      case APPLICATION_DEFAULT:
+        // application-default doesn't provide useful headerspace info
+      default:
+        // Should never get here
+        return FalseExpr.INSTANCE;
+    }
   }
 
   public String getName() {

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -79,14 +79,15 @@ import static org.batfish.representation.palo_alto.PaloAltoStructureUsage.VIRTUA
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.emptyZoneRejectTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.ifaceOutgoingTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.intrazoneDefaultAcceptTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressAnyTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressGroupTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressObjectTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchBuiltInServiceTraceElement;
-import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchDestinationAddressAnyTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchDestinationAddressTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchSecurityRuleTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchServiceAnyTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchServiceApplicationDefaultTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchServiceTraceElement;
-import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchSourceAddressAnyTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchSourceAddressTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.originatedFromDeviceTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.unzonedIfaceRejectTraceElement;
@@ -3548,8 +3549,8 @@ public final class PaloAltoGrammarTest {
 
     Flow rule1aFlow = createFlow("1.1.1.10", "1.1.4.10", IpProtocol.TCP, 0, 1);
     Flow rule1bFlow = createFlow("1.1.1.10", "1.1.4.10", IpProtocol.TCP, 0, 443);
-    Flow rule2Flow = createFlow("1.1.1.10", "1.1.4.10", IpProtocol.TCP, 0, 53);
-    Flow rule3Flow = createFlow("1.1.4.10", "1.1.1.10", IpProtocol.TCP, 0, 53);
+    Flow rule2Flow = createFlow("1.1.4.10", "1.1.1.10", IpProtocol.TCP, 0, 53);
+    Flow rule3Flow = createFlow("1.1.1.10", "1.1.4.10", IpProtocol.TCP, 0, 53);
 
     IpAccessList filter = c.getIpAccessLists().get(crossZoneFilterName);
     BiFunction<String, Flow, List<TraceTree>> trace =
@@ -3569,8 +3570,12 @@ public final class PaloAltoGrammarTest {
           contains(
               isTraceTree(
                   matchSecurityRuleTraceElement("RULE1", "vsys1", filename),
-                  isTraceTree(matchSourceAddressTraceElement()),
-                  isTraceTree(matchDestinationAddressTraceElement()),
+                  isTraceTree(
+                      matchSourceAddressTraceElement(),
+                      isTraceTree(matchAddressGroupTraceElement("addr_group1", "vsys1", filename))),
+                  isTraceTree(
+                      matchDestinationAddressTraceElement(),
+                      isTraceTree(matchAddressObjectTraceElement("addr2", "vsys1", filename))),
                   isTraceTree(matchServiceTraceElement()))));
     }
     {
@@ -3580,8 +3585,12 @@ public final class PaloAltoGrammarTest {
           contains(
               isTraceTree(
                   matchSecurityRuleTraceElement("RULE1", "vsys1", filename),
-                  isTraceTree(matchSourceAddressTraceElement()),
-                  isTraceTree(matchDestinationAddressTraceElement()),
+                  isTraceTree(
+                      matchSourceAddressTraceElement(),
+                      isTraceTree(matchAddressGroupTraceElement("addr_group1", "vsys1", filename))),
+                  isTraceTree(
+                      matchDestinationAddressTraceElement(),
+                      isTraceTree(matchAddressObjectTraceElement("addr2", "vsys1", filename))),
                   isTraceTree(matchBuiltInServiceTraceElement()))));
     }
     {
@@ -3591,8 +3600,12 @@ public final class PaloAltoGrammarTest {
           contains(
               isTraceTree(
                   matchSecurityRuleTraceElement("RULE2", "vsys1", filename),
-                  isTraceTree(matchSourceAddressTraceElement()),
-                  isTraceTree(matchDestinationAddressTraceElement()),
+                  isTraceTree(
+                      matchSourceAddressTraceElement(),
+                      isTraceTree(matchAddressObjectTraceElement("addr2", "vsys1", filename))),
+                  isTraceTree(
+                      matchDestinationAddressTraceElement(),
+                      isTraceTree(matchAddressGroupTraceElement("addr_group1", "vsys1", filename))),
                   isTraceTree(matchServiceApplicationDefaultTraceElement()))));
     }
     {
@@ -3602,8 +3615,11 @@ public final class PaloAltoGrammarTest {
           contains(
               isTraceTree(
                   matchSecurityRuleTraceElement("RULE3", "vsys1", filename),
-                  isTraceTree(matchSourceAddressAnyTraceElement()),
-                  isTraceTree(matchDestinationAddressAnyTraceElement()),
+                  isTraceTree(
+                      matchSourceAddressTraceElement(), isTraceTree(matchAddressAnyTraceElement())),
+                  isTraceTree(
+                      matchDestinationAddressTraceElement(),
+                      isTraceTree(matchAddressAnyTraceElement())),
                   isTraceTree(matchServiceAnyTraceElement()))));
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -84,6 +84,7 @@ import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressObjectTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressValueTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchBuiltInServiceTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchDestinationAddressNegatedTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchDestinationAddressTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchSecurityRuleTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchServiceAnyTraceElement;
@@ -3639,8 +3640,10 @@ public final class PaloAltoGrammarTest {
                   isTraceTree(
                       matchSourceAddressTraceElement(), isTraceTree(matchAddressAnyTraceElement())),
                   isTraceTree(
-                      matchDestinationAddressTraceElement(),
-                      isTraceTree(matchAddressAnyTraceElement())),
+                      matchDestinationAddressNegatedTraceElement(),
+                      isTraceTree(
+                          matchDestinationAddressTraceElement(),
+                          isTraceTree(matchAddressValueTraceElement("10.11.12.13")))),
                   isTraceTree(matchServiceAnyTraceElement()))));
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -82,6 +82,7 @@ import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressAnyTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressGroupTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressObjectTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressValueTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchBuiltInServiceTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchDestinationAddressTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchSecurityRuleTraceElement;
@@ -2047,13 +2048,23 @@ public final class PaloAltoGrammarTest {
             c.getIpAccessLists(),
             ImmutableMap.of(),
             ImmutableMap.of());
+
     assertThat(
         flowTrace,
         contains(
-            isChainOfSingleChildren(
+            isTraceTree(
                 exitIfaceTe,
-                intrazoneRejectRulesTe,
-                matchSecurityRuleTraceElement("DENY", vsysName, filename))));
+                isTraceTree(
+                    intrazoneRejectRulesTe,
+                    isTraceTree(
+                        matchSecurityRuleTraceElement("DENY", vsysName, filename),
+                        isTraceTree(
+                            matchSourceAddressTraceElement(),
+                            isTraceTree(matchAddressValueTraceElement("2.2.2.2/32"))),
+                        isTraceTree(
+                            matchDestinationAddressTraceElement(),
+                            isTraceTree(matchAddressAnyTraceElement())),
+                        isTraceTree(matchServiceAnyTraceElement()))))));
 
     // Flow matching PERMIT security rule should generate a trace pointing to that rule.
     flowTrace =
@@ -2064,13 +2075,23 @@ public final class PaloAltoGrammarTest {
             c.getIpAccessLists(),
             ImmutableMap.of(),
             ImmutableMap.of());
+
     assertThat(
         flowTrace,
         contains(
-            isChainOfSingleChildren(
+            isTraceTree(
                 exitIfaceTe,
-                intrazoneRulesTe,
-                matchSecurityRuleTraceElement("PERMIT", vsysName, filename))));
+                isTraceTree(
+                    intrazoneRulesTe,
+                    isTraceTree(
+                        matchSecurityRuleTraceElement("PERMIT", vsysName, filename),
+                        isTraceTree(
+                            matchSourceAddressTraceElement(),
+                            isTraceTree(matchAddressValueTraceElement("3.3.3.3/32"))),
+                        isTraceTree(
+                            matchDestinationAddressTraceElement(),
+                            isTraceTree(matchAddressAnyTraceElement())),
+                        isTraceTree(matchServiceAnyTraceElement()))))));
   }
 
   @Test
@@ -3602,10 +3623,10 @@ public final class PaloAltoGrammarTest {
                   matchSecurityRuleTraceElement("RULE2", "vsys1", filename),
                   isTraceTree(
                       matchSourceAddressTraceElement(),
-                      isTraceTree(matchAddressObjectTraceElement("addr2", "vsys1", filename))),
+                      isTraceTree(matchAddressValueTraceElement("1.1.4.10/32"))),
                   isTraceTree(
                       matchDestinationAddressTraceElement(),
-                      isTraceTree(matchAddressGroupTraceElement("addr_group1", "vsys1", filename))),
+                      isTraceTree(matchAddressValueTraceElement("1.1.1.10"))),
                   isTraceTree(matchServiceApplicationDefaultTraceElement()))));
     }
     {

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoSecurityRuleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoSecurityRuleTest.java
@@ -2,9 +2,25 @@ package org.batfish.grammar.palo_alto;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.batfish.common.util.Resources.readResource;
+import static org.batfish.datamodel.Names.zoneToZoneFilter;
+import static org.batfish.datamodel.matchers.TraceTreeMatchers.isTraceTree;
 import static org.batfish.main.BatfishTestUtils.TEST_SNAPSHOT;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
 import static org.batfish.main.BatfishTestUtils.getBatfish;
+import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeObjectName;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressAnyTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressGroupTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressObjectTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressValueTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchBuiltInServiceTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchDestinationAddressTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchNegatedAddressTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchSecurityRuleTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchServiceAnyTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchServiceApplicationDefaultTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchServiceTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchSourceAddressTraceElement;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.junit.Assert.assertFalse;
@@ -18,6 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.function.BiFunction;
 import javax.annotation.Nonnull;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.lang3.SerializationUtils;
@@ -33,9 +50,12 @@ import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Flow.Builder;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.acl.AclTracer;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.flow.Trace;
+import org.batfish.datamodel.trace.TraceTree;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.representation.palo_alto.PaloAltoConfiguration;
@@ -86,6 +106,22 @@ public class PaloAltoSecurityRuleTest {
     pac.setRuntimeData(SnapshotRuntimeData.EMPTY_SNAPSHOT_RUNTIME_DATA);
     pac.setAnswerElement(answerElement);
     return pac;
+  }
+
+  private static Flow createFlow(
+      String sourceAddress,
+      String destinationAddress,
+      IpProtocol protocol,
+      int sourcePort,
+      int destinationPort) {
+    Flow.Builder fb = Flow.builder();
+    fb.setIngressNode("node");
+    fb.setSrcIp(Ip.parse(sourceAddress));
+    fb.setDstIp(Ip.parse(destinationAddress));
+    fb.setIpProtocol(protocol);
+    fb.setDstPort(destinationPort);
+    fb.setSrcPort(sourcePort);
+    return fb.build();
   }
 
   private Batfish getBatfishForConfigurationNames(String... configurationNames) throws IOException {
@@ -234,5 +270,96 @@ public class PaloAltoSecurityRuleTest {
     // Confirm flow from correct zone is accepted, matching rule w/ application = any and
     // service = application-default
     assertTrue(traces.get(flowPermit).get(0).getDisposition().isSuccessful());
+  }
+
+  @Test
+  public void testRulebaseTracing() {
+    String hostname = "rulebase-tracing";
+    String filename = "configs/" + hostname;
+    Configuration c = parseConfig(hostname);
+    String iface1 = "ethernet1/1";
+    String crossZoneFilterName =
+        zoneToZoneFilter(computeObjectName("vsys1", "z1"), computeObjectName("vsys1", "z2"));
+
+    Flow rule1aFlow = createFlow("1.1.1.10", "1.1.4.10", IpProtocol.TCP, 0, 1);
+    Flow rule1bFlow = createFlow("1.1.1.10", "1.1.4.10", IpProtocol.TCP, 0, 443);
+    Flow rule2Flow = createFlow("1.1.4.10", "1.1.1.10", IpProtocol.TCP, 0, 53);
+    Flow rule3Flow = createFlow("1.1.1.10", "1.1.4.10", IpProtocol.TCP, 0, 53);
+
+    IpAccessList filter = c.getIpAccessLists().get(crossZoneFilterName);
+    BiFunction<String, Flow, List<TraceTree>> trace =
+        (inIface, flow) ->
+            AclTracer.trace(
+                filter,
+                flow,
+                inIface,
+                c.getIpAccessLists(),
+                c.getIpSpaces(),
+                c.getIpSpaceMetadata());
+
+    {
+      List<TraceTree> traces = trace.apply(iface1, rule1aFlow);
+      assertThat(
+          traces,
+          contains(
+              isTraceTree(
+                  matchSecurityRuleTraceElement("RULE1", "vsys1", filename),
+                  isTraceTree(
+                      matchSourceAddressTraceElement(),
+                      isTraceTree(matchAddressGroupTraceElement("addr_group1", "vsys1", filename))),
+                  isTraceTree(
+                      matchDestinationAddressTraceElement(),
+                      isTraceTree(matchAddressObjectTraceElement("addr2", "vsys1", filename))),
+                  isTraceTree(matchServiceTraceElement()))));
+    }
+    {
+      List<TraceTree> traces = trace.apply(iface1, rule1bFlow);
+      assertThat(
+          traces,
+          contains(
+              isTraceTree(
+                  matchSecurityRuleTraceElement("RULE1", "vsys1", filename),
+                  isTraceTree(
+                      matchSourceAddressTraceElement(),
+                      isTraceTree(matchAddressGroupTraceElement("addr_group1", "vsys1", filename))),
+                  isTraceTree(
+                      matchDestinationAddressTraceElement(),
+                      isTraceTree(matchAddressObjectTraceElement("addr2", "vsys1", filename))),
+                  isTraceTree(matchBuiltInServiceTraceElement()))));
+    }
+    {
+      List<TraceTree> traces = trace.apply(iface1, rule2Flow);
+      assertThat(
+          traces,
+          contains(
+              isTraceTree(
+                  matchSecurityRuleTraceElement("RULE2", "vsys1", filename),
+                  isTraceTree(
+                      matchSourceAddressTraceElement(),
+                      isTraceTree(matchAddressValueTraceElement("1.1.4.10/32"))),
+                  isTraceTree(
+                      matchDestinationAddressTraceElement(),
+                      isTraceTree(matchAddressValueTraceElement("1.1.1.10"))),
+                  isTraceTree(matchServiceApplicationDefaultTraceElement()))));
+    }
+    {
+      List<TraceTree> traces = trace.apply(iface1, rule3Flow);
+      assertThat(
+          traces,
+          contains(
+              isTraceTree(
+                  matchSecurityRuleTraceElement("RULE3", "vsys1", filename),
+                  isTraceTree(
+                      matchSourceAddressTraceElement(), isTraceTree(matchAddressAnyTraceElement())),
+                  isTraceTree(
+                      matchDestinationAddressTraceElement(),
+                      isTraceTree(
+                          matchNegatedAddressTraceElement(),
+                          isTraceTree(matchAddressValueTraceElement("10.11.12.13"))),
+                      isTraceTree(
+                          matchNegatedAddressTraceElement(),
+                          isTraceTree(matchAddressValueTraceElement("10.11.11.0/24")))),
+                  isTraceTree(matchServiceAnyTraceElement()))));
+    }
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
@@ -24,9 +24,9 @@ set rulebase security rules RULE1 action deny
 
 set rulebase security rules RULE2 from any
 set rulebase security rules RULE2 to any
-set rulebase security rules RULE2 source [ addr_group1 addr2 ]
+set rulebase security rules RULE2 source [ 1.1.1.10/32 1.1.4.10/32 ]
 set rulebase security rules RULE2 source-user any
-set rulebase security rules RULE2 destination addr_group1
+set rulebase security rules RULE2 destination 1.1.1.10
 set rulebase security rules RULE2 service application-default
 set rulebase security rules RULE2 application app_group1
 set rulebase security rules RULE2 action allow

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
@@ -35,7 +35,8 @@ set rulebase security rules RULE3 from any
 set rulebase security rules RULE3 to any
 set rulebase security rules RULE3 source any
 set rulebase security rules RULE3 source-user any
-set rulebase security rules RULE3 destination any
+set rulebase security rules RULE3 destination 10.11.12.13
+set rulebase security rules RULE3 negate-destination yes
 set rulebase security rules RULE3 service any
 set rulebase security rules RULE3 application any
 set rulebase security rules RULE3 action allow

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
@@ -35,7 +35,7 @@ set rulebase security rules RULE3 from any
 set rulebase security rules RULE3 to any
 set rulebase security rules RULE3 source any
 set rulebase security rules RULE3 source-user any
-set rulebase security rules RULE3 destination 10.11.12.13
+set rulebase security rules RULE3 destination [ 10.11.12.13 10.11.11.0/24 ]
 set rulebase security rules RULE3 negate-destination yes
 set rulebase security rules RULE3 service any
 set rulebase security rules RULE3 application any

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
@@ -24,9 +24,9 @@ set rulebase security rules RULE1 action deny
 
 set rulebase security rules RULE2 from any
 set rulebase security rules RULE2 to any
-set rulebase security rules RULE2 source addr_group1
+set rulebase security rules RULE2 source [ addr_group1 addr2 ]
 set rulebase security rules RULE2 source-user any
-set rulebase security rules RULE2 destination [ addr_group1 addr2 ]
+set rulebase security rules RULE2 destination addr_group1
 set rulebase security rules RULE2 service application-default
 set rulebase security rules RULE2 application app_group1
 set rulebase security rules RULE2 action allow

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
@@ -1,0 +1,41 @@
+set deviceconfig system hostname rulebase-tracing
+set network interface ethernet ethernet1/1 layer3 ip 1.1.1.1/24
+set network interface ethernet ethernet1/4 layer3 ip 1.1.4.1/24
+set zone z1 network layer3 [ ethernet1/1 ]
+set zone z2 network layer3 ethernet1/4
+
+set address addr1 ip-netmask 1.1.1.10
+set address addr2 ip-netmask 1.1.4.10
+set address-group addr_group1 static addr1
+
+set application-group app_group1 members [ dns ]
+
+set service service1 protocol tcp port 1
+set service-group service_group1 members [ service1 ]
+
+set rulebase security rules RULE1 from any
+set rulebase security rules RULE1 to any
+set rulebase security rules RULE1 source addr_group1
+set rulebase security rules RULE1 source-user any
+set rulebase security rules RULE1 destination [ addr_group1 addr2 ]
+set rulebase security rules RULE1 service [ service_group1 service-https ]
+set rulebase security rules RULE1 application any
+set rulebase security rules RULE1 action deny
+
+set rulebase security rules RULE2 from any
+set rulebase security rules RULE2 to any
+set rulebase security rules RULE2 source addr_group1
+set rulebase security rules RULE2 source-user any
+set rulebase security rules RULE2 destination [ addr_group1 addr2 ]
+set rulebase security rules RULE2 service application-default
+set rulebase security rules RULE2 application app_group1
+set rulebase security rules RULE2 action allow
+
+set rulebase security rules RULE3 from any
+set rulebase security rules RULE3 to any
+set rulebase security rules RULE3 source any
+set rulebase security rules RULE3 source-user any
+set rulebase security rules RULE3 destination any
+set rulebase security rules RULE3 service any
+set rulebase security rules RULE3 application any
+set rulebase security rules RULE3 action allow


### PR DESCRIPTION
Add some shallow trace details for Palo Alto security rules. Specifically, adding basic info on first source address, first destination address, and first service matched for a given rule.

----

Some example traces for cross-zone policies might look like this:
```
Matched security rule RULE1
   Matched source address
      Matched address-group addr_group1
   Matched destination address
      Matched address object addr2
   Matched a service
```

```
Matched security rule RULE2
   Matched source address
      Matched address value 10.10.10.10
   Matched destination address
      Matched address value 10.11.12.0/24
   Matched service application-default
```

```
Matched security rule RULE3
   Matched source address
      Matched address any
   Matched destination address
      Matched address any
   Matched service any
```

