### PR TITLE
PAN: add application trace details for security rules

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ApplicationGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ApplicationGroup.java
@@ -21,7 +21,7 @@ public final class ApplicationGroup implements Serializable {
   }
 
   @VisibleForTesting
-  Set<String> getDescendantObjects(
+  Set<Application> getDescendantObjects(
       Map<String, Application> applications,
       Map<String, ApplicationGroup> applicationGroups,
       Set<String> alreadyTraversedGroups) {
@@ -29,17 +29,17 @@ public final class ApplicationGroup implements Serializable {
       return ImmutableSet.of();
     }
     alreadyTraversedGroups.add(_name);
-    Set<String> descendantObjects = new HashSet<>();
+    Set<Application> descendantObjects = new HashSet<>();
     for (String member : _members) {
       if (applications.containsKey(member)) {
-        descendantObjects.add(member);
+        descendantObjects.add(applications.get(member));
       } else if (applicationGroups.containsKey(member)) {
         descendantObjects.addAll(
             applicationGroups
                 .get(member)
                 .getDescendantObjects(applications, applicationGroups, alreadyTraversedGroups));
       } else if (ApplicationBuiltIn.getBuiltInApplication(member).isPresent()) {
-        descendantObjects.add(member);
+        descendantObjects.add(ApplicationBuiltIn.getBuiltInApplication(member).get());
       }
     }
     return descendantObjects;
@@ -49,7 +49,7 @@ public final class ApplicationGroup implements Serializable {
    * Returns all {@link Application applications} that are directly or indirectly contained in this
    * group. Accounts for circular group references.
    */
-  public Set<String> getDescendantObjects(
+  public Set<Application> getDescendantObjects(
       Map<String, Application> applications, Map<String, ApplicationGroup> applicationGroups) {
     return getDescendantObjects(applications, applicationGroups, new HashSet<>());
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -25,6 +25,10 @@ import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressGroupTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressObjectTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressValueTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchApplicationAnyTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchApplicationGroupTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchApplicationObjectTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchBuiltInApplicationTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchDestinationAddressTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchNegatedAddressTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchServiceApplicationDefaultTraceElement;
@@ -66,13 +70,11 @@ import java.util.Map.Entry;
 import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1120,41 +1122,67 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     return Optional.of(new OrMatchExpr(serviceDisjuncts));
   }
 
-  private List<AclLineMatchExpr> matchServicesForApplications(SecurityRule rule, Vsys vsys) {
-    ImmutableList.Builder<AclLineMatchExpr> ret = ImmutableList.builder();
-    Queue<String> applications = new LinkedBlockingQueue<>(rule.getApplications());
-    while (!applications.isEmpty()) {
-      String name = applications.remove();
+  /**
+   * Create an {@link Optional} {@link AclLineMatchExpr} for the specified application/group name.
+   * If no corresponding application/group is found, then {@link Optional#empty()} is returned.
+   */
+  private Optional<AclLineMatchExpr> aclLineMatchExprForApplicationOrGroup(
+      String name, SecurityRule rule, Vsys vsys) {
+    String vsysName = vsys.getName();
 
-      // Assume all traffic matches some application under the "any" definition
-      if (name.equals(CATCHALL_APPLICATION_NAME)) {
-        return ImmutableList.of(TrueExpr.INSTANCE);
-      }
-      ApplicationGroup group = vsys.getApplicationGroups().get(name);
-      if (group != null) {
-        applications.addAll(
-            group.getDescendantObjects(vsys.getApplications(), vsys.getApplicationGroups()));
-        continue;
-      }
-      Application a = vsys.getApplications().get(name);
-      if (a != null) {
-        for (Service s : a.getServices()) {
-          ret.add(s.toMatchHeaderSpace(_w));
-        }
-        continue;
-      }
-      Optional<Application> builtIn = ApplicationBuiltIn.getBuiltInApplication(name);
-      if (builtIn.isPresent()) {
-        builtIn.get().getServices().forEach(s -> ret.add(s.toMatchHeaderSpace(_w)));
-        continue;
-      }
-      // Did not find in the right hierarchy, so stop and warn.
-      _w.redFlag(
-          String.format(
-              "Unable to identify application %s in vsys %s rule %s",
-              name, vsys.getName(), rule.getName()));
+    // Assume all traffic matches some application under the "any" definition
+    if (name.equals(CATCHALL_APPLICATION_NAME)) {
+      return Optional.of(new TrueExpr(matchApplicationAnyTraceElement()));
     }
-    return ret.build();
+
+    ApplicationGroup group = vsys.getApplicationGroups().get(name);
+    if (group != null) {
+      return Optional.of(
+          new OrMatchExpr(
+              group.getDescendantObjects(vsys.getApplications(), vsys.getApplicationGroups())
+                  .stream()
+                  // Don't add trace for children, since we flatten intermediate application groups
+                  .map(a -> aclLineMatchExprForApplication(a, null))
+                  .collect(ImmutableList.toImmutableList()),
+              matchApplicationGroupTraceElement(name, vsysName, _filename)));
+    }
+
+    Application a = vsys.getApplications().get(name);
+    if (a != null) {
+      return Optional.of(
+          aclLineMatchExprForApplication(
+              a, matchApplicationObjectTraceElement(name, vsysName, _filename)));
+    }
+
+    Optional<Application> builtIn = ApplicationBuiltIn.getBuiltInApplication(name);
+    if (builtIn.isPresent()) {
+      return Optional.of(
+          aclLineMatchExprForApplication(builtIn.get(), matchBuiltInApplicationTraceElement(name)));
+    }
+    // Did not find in the right hierarchy, so stop and warn.
+    _w.redFlag(
+        String.format(
+            "Unable to identify application %s in vsys %s rule %s",
+            name, vsys.getName(), rule.getName()));
+    return Optional.empty();
+  }
+
+  /** Create an {@link AclLineMatchExpr} matching any services in the specified application. */
+  private AclLineMatchExpr aclLineMatchExprForApplication(
+      Application application, @Nullable TraceElement traceElement) {
+    return new OrMatchExpr(
+        application.getServices().stream()
+            .map(s -> s.toMatchHeaderSpace(_w))
+            .collect(ImmutableList.toImmutableList()),
+        traceElement);
+  }
+
+  private List<AclLineMatchExpr> matchServicesForApplications(SecurityRule rule, Vsys vsys) {
+    return rule.getApplications().stream()
+        .map(a -> aclLineMatchExprForApplicationOrGroup(a, rule, vsys))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(ImmutableList.toImmutableList());
   }
 
   /** Converts interface address {@code String} to {@link IpSpace} */

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -1141,7 +1141,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
           new OrMatchExpr(
               group.getDescendantObjects(vsys.getApplications(), vsys.getApplicationGroups())
                   .stream()
-                  // Don't add trace for children, since we flatten intermediate application groups
+                  // Don't add trace for children; we've already flattened intermediate app groups
                   .map(a -> aclLineMatchExprForApplication(a, null))
                   .collect(ImmutableList.toImmutableList()),
               matchApplicationGroupTraceElement(name, vsysName, _filename)));

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
@@ -78,6 +78,44 @@ public final class PaloAltoTraceElementCreators {
   }
 
   @VisibleForTesting
+  public static TraceElement matchApplicationGroupTraceElement(
+      String name, String vsysName, String filename) {
+    return TraceElement.builder()
+        .add("Matched application-group ")
+        .add(
+            name,
+            new VendorStructureId(
+                filename,
+                PaloAltoStructureType.APPLICATION_GROUP.getDescription(),
+                computeObjectName(vsysName, name)))
+        .build();
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchApplicationObjectTraceElement(
+      String name, String vsysName, String filename) {
+    return TraceElement.builder()
+        .add("Matched application object ")
+        .add(
+            name,
+            new VendorStructureId(
+                filename,
+                PaloAltoStructureType.APPLICATION.getDescription(),
+                computeObjectName(vsysName, name)))
+        .build();
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchBuiltInApplicationTraceElement(String name) {
+    return TraceElement.of(String.format("Matched built-in application %s", name));
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchApplicationAnyTraceElement() {
+    return TraceElement.of("Matched application any");
+  }
+
+  @VisibleForTesting
   public static TraceElement matchNegatedAddressTraceElement() {
     return TraceElement.of("Matched negated address");
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoSecurityRuleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoSecurityRuleTest.java
@@ -12,6 +12,7 @@ import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressGroupTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressObjectTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchAddressValueTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchApplicationAnyTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchApplicationGroupTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchBuiltInApplicationTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchBuiltInServiceTraceElement;
@@ -287,7 +288,8 @@ public class PaloAltoSecurityRuleTest {
     Flow rule1bFlow = createFlow("1.1.1.10", "1.1.4.10", IpProtocol.TCP, 0, 443);
     Flow rule2aFlow = createFlow("1.1.4.10", "1.1.1.10", IpProtocol.TCP, 0, 53);
     Flow rule2bFlow = createFlow("1.1.4.10", "1.1.1.10", IpProtocol.TCP, 0, 179);
-    Flow rule3Flow = createFlow("1.1.1.10", "1.1.4.10", IpProtocol.TCP, 0, 53);
+    Flow rule3Flow = createFlow("1.1.4.10", "1.1.1.10", IpProtocol.TCP, 0, 1234);
+    Flow rule4Flow = createFlow("1.1.1.10", "1.1.4.10", IpProtocol.TCP, 0, 53);
 
     IpAccessList filter = c.getIpAccessLists().get(crossZoneFilterName);
     BiFunction<String, Flow, List<TraceTree>> trace =
@@ -372,6 +374,23 @@ public class PaloAltoSecurityRuleTest {
           contains(
               isTraceTree(
                   matchSecurityRuleTraceElement("RULE3", "vsys1", filename),
+                  isTraceTree(
+                      matchSourceAddressTraceElement(),
+                      isTraceTree(matchAddressValueTraceElement("1.1.4.10/32"))),
+                  isTraceTree(
+                      matchDestinationAddressTraceElement(),
+                      isTraceTree(matchAddressValueTraceElement("1.1.1.10"))),
+                  isTraceTree(
+                      matchServiceApplicationDefaultTraceElement(),
+                      isTraceTree(matchApplicationAnyTraceElement())))));
+    }
+    {
+      List<TraceTree> traces = trace.apply(iface1, rule4Flow);
+      assertThat(
+          traces,
+          contains(
+              isTraceTree(
+                  matchSecurityRuleTraceElement("RULE4", "vsys1", filename),
                   isTraceTree(
                       matchSourceAddressTraceElement(), isTraceTree(matchAddressAnyTraceElement())),
                   isTraceTree(

--- a/projects/batfish/src/test/java/org/batfish/representation/palo_alto/ApplicationGroupTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/palo_alto/ApplicationGroupTest.java
@@ -14,15 +14,15 @@ public class ApplicationGroupTest {
   @Test
   public void testGetDescendantObjectsBase() {
     ApplicationGroup ag = new ApplicationGroup("group");
-    Map<String, Application> applications =
-        ImmutableMap.of(
-            "a1", Application.builder("a1").build(), "a2", Application.builder("a2").build());
+    Application a1 = Application.builder("a1").build();
+    Application a2 = Application.builder("a2").build();
+    Map<String, Application> applications = ImmutableMap.of("a1", a1, "a2", a2);
 
     // only one of the address objects is a member
     ag.getMembers().add("a1");
     assertThat(
         ag.getDescendantObjects(applications, ImmutableMap.of(), new HashSet<>()),
-        equalTo(ImmutableSet.of("a1")));
+        equalTo(ImmutableSet.of(a1)));
   }
 
   @Test
@@ -32,11 +32,13 @@ public class ApplicationGroupTest {
 
     assertThat(
         ag.getDescendantObjects(ImmutableMap.of(), ImmutableMap.of(), new HashSet<>()),
-        equalTo(ImmutableSet.of(ApplicationBuiltIn.FTP.getName())));
+        equalTo(ImmutableSet.of(ApplicationBuiltIn.FTP)));
   }
 
   @Test
   public void testGetDescendantObjectsCircular() {
+    Application a1 = Application.builder("a1").build();
+    Application a2 = Application.builder("a2").build();
     Map<String, ApplicationGroup> applicationGroups =
         ImmutableMap.of(
             "parentGroup",
@@ -45,9 +47,7 @@ public class ApplicationGroupTest {
             new ApplicationGroup("childGroup"),
             "grandchildGroup",
             new ApplicationGroup("grandchildGroup"));
-    Map<String, Application> applications =
-        ImmutableMap.of(
-            "a1", Application.builder("a1").build(), "a2", Application.builder("a2").build());
+    Map<String, Application> applications = ImmutableMap.of("a1", a1, "a2", a2);
 
     // parent -> child -> {parent, grandChild}
     // grandChild -> {child, ad1}
@@ -62,7 +62,7 @@ public class ApplicationGroupTest {
         applicationGroups
             .get("parentGroup")
             .getDescendantObjects(applications, applicationGroups, new HashSet<>()),
-        equalTo(ImmutableSet.of("a1")));
+        equalTo(ImmutableSet.of(a1)));
   }
 
   @Test
@@ -75,15 +75,15 @@ public class ApplicationGroupTest {
 
   @Test
   public void testGetDescendantObjectsIndirect() {
+    Application a1 = Application.builder("a1").build();
+    Application a2 = Application.builder("a2").build();
     Map<String, ApplicationGroup> applicationGroups =
         ImmutableMap.of(
             "parentGroup",
             new ApplicationGroup("parentGroup"),
             "childGroup",
             new ApplicationGroup("childGroup"));
-    Map<String, Application> applications =
-        ImmutableMap.of(
-            "a1", Application.builder("a1").build(), "a2", Application.builder("a2").build());
+    Map<String, Application> applications = ImmutableMap.of("a1", a1, "a2", a2);
 
     applicationGroups.get("parentGroup").getMembers().add("childGroup");
     applicationGroups.get("childGroup").getMembers().add("a1");
@@ -92,6 +92,6 @@ public class ApplicationGroupTest {
         applicationGroups
             .get("parentGroup")
             .getDescendantObjects(applications, applicationGroups, new HashSet<>()),
-        equalTo(ImmutableSet.of("a1")));
+        equalTo(ImmutableSet.of(a1)));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
@@ -33,10 +33,19 @@ set rulebase security rules RULE2 action allow
 
 set rulebase security rules RULE3 from any
 set rulebase security rules RULE3 to any
-set rulebase security rules RULE3 source any
+set rulebase security rules RULE3 source [ 1.1.1.10/32 1.1.4.10/32 ]
 set rulebase security rules RULE3 source-user any
-set rulebase security rules RULE3 destination [ 10.11.12.13 10.11.11.0/24 ]
-set rulebase security rules RULE3 negate-destination yes
-set rulebase security rules RULE3 service any
+set rulebase security rules RULE3 destination 1.1.1.10
+set rulebase security rules RULE3 service application-default
 set rulebase security rules RULE3 application any
 set rulebase security rules RULE3 action allow
+
+set rulebase security rules RULE4 from any
+set rulebase security rules RULE4 to any
+set rulebase security rules RULE4 source any
+set rulebase security rules RULE4 source-user any
+set rulebase security rules RULE4 destination [ 10.11.12.13 10.11.11.0/24 ]
+set rulebase security rules RULE4 negate-destination yes
+set rulebase security rules RULE4 service any
+set rulebase security rules RULE4 application any
+set rulebase security rules RULE4 action allow

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/rulebase-tracing
@@ -28,7 +28,7 @@ set rulebase security rules RULE2 source [ 1.1.1.10/32 1.1.4.10/32 ]
 set rulebase security rules RULE2 source-user any
 set rulebase security rules RULE2 destination 1.1.1.10
 set rulebase security rules RULE2 service application-default
-set rulebase security rules RULE2 application app_group1
+set rulebase security rules RULE2 application [ app_group1 bgp ]
 set rulebase security rules RULE2 action allow
 
 set rulebase security rules RULE3 from any


### PR DESCRIPTION
Add top-level application tracing for Palo Alto security rules.
There is no recursive tracing for applications yet (similar to addresses and services).

----

For example, traces for rules matching an `application` might look something like this:

If the rule specifies an application group and a descendant of that group is matched:
```
Matched security rule RULE2
   Matched source address
      Matched address object addr2
   Matched destination address
      Matched address-group addr_group1
   Matched service application-default
      Matched application-group app_group1
```
or if the rule specifies an application directly, which is matched:
```
Matched security rule RULE2
   Matched source address
      Matched address object addr2
   Matched destination address
      Matched address-group addr_group1
   Matched service application-default
      Matched built-in application bgp
```

Because of how applications are matched (based on service values), they show up under the `Matched service application-default` trace details.


