### PR TITLE
ibdp: optimize computeIterationOfBgpRoutes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -465,20 +465,17 @@ class IncrementalBdpEngine {
     LOGGER.info("{}: Init for new BGP iteration", iterationLabel);
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
-      nodes.values().stream()
+      nodes
+          .values()
+          .parallelStream()
           .forEach(
-              n ->
-                  n.getVirtualRouters()
-                      .values()
-                      .forEach(
-                          vr -> {
-                            // Iteration for one VR
-                            vr.bgpIteration(allNodes);
-                            // Merge results into main RIB, for all VRs
-                            n.getVirtualRouters()
-                                .values()
-                                .forEach(VirtualRouter::mergeBgpRoutesToMainRib);
-                          }));
+              n -> {
+                // First init the iteration, then merge BGP routes into the main RIB. Do this in
+                // separate loops because route-leaking can send BGP routes between VRs, and we
+                // only want to do the merge once.
+                n.getVirtualRouters().values().forEach(vr -> vr.bgpIteration(allNodes));
+                n.getVirtualRouters().values().forEach(VirtualRouter::mergeBgpRoutesToMainRib);
+              });
     } finally {
       span.finish();
     }


### PR DESCRIPTION
When initializing the BGP iteration:
1. parallelize over nodes
2. For N virtual routers on a node, call `mergeBgpRoutesToMainRib` N times instead of N^2 times.