### PR TITLE
bdp: remove queues for sending BGP messages

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -122,6 +122,12 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   @Nonnull Bgpv4Rib _ebgpv4StagingRib;
   /** RIB containing paths obtained with iBGP, for IPv4 unicast */
   @Nonnull Bgpv4Rib _ibgpv4Rib;
+
+  // outgoing RIB deltas for the current round.
+  RibDelta<Bgpv4Route> _ebgpDelta = null;
+  RibDelta<AnnotatedRoute<AbstractRoute>> _mainRibBgpv4RouteDelta = null;
+  RibDelta<Bgpv4Route> _bgpv4Delta = null;
+
   /**
    * Helper RIB containing paths obtained with iBGP during current iteration. An Adj-RIB-in of sorts
    * for IPv4 unicast
@@ -1067,6 +1073,10 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             // RIBs
             _bgpv4Rib.getTypedRoutes(),
             _evpnRib.getTypedRoutes(),
+            // Outgoing RIB deltas
+            _ebgpDelta,
+            _bgpv4Delta,
+            _mainRibBgpv4RouteDelta,
             // Message queues
             _bgpv4IncomingRoutes,
             _evpnType3IncomingRoutes,

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -19,6 +19,7 @@ import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -27,6 +28,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.batfish.common.BatfishLogger;
@@ -427,7 +429,6 @@ class IncrementalBdpEngine {
       }
 
       computeIterationOfBgpRoutes(
-          nodes,
           iterationLabel,
           allNodes,
           topologyContext.getBgpTopology(),
@@ -454,7 +455,6 @@ class IncrementalBdpEngine {
   }
 
   private static void computeIterationOfBgpRoutes(
-      Map<String, Node> nodes,
       String iterationLabel,
       Map<String, Node> allNodes,
       BgpTopology bgpTopology,
@@ -465,7 +465,7 @@ class IncrementalBdpEngine {
     LOGGER.info("{}: Init for new BGP iteration", iterationLabel);
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
       assert scope != null; // avoid unused warning
-      nodes
+      allNodes
           .values()
           .parallelStream()
           .forEach(
@@ -487,7 +487,7 @@ class IncrementalBdpEngine {
     try (Scope innerScope = GlobalTracer.get().scopeManager().activate(genSpan)) {
       assert innerScope != null; // avoid unused warning
       // first let's initialize nodes-level generated/aggregate routes
-      nodes
+      allNodes
           .values()
           .parallelStream()
           .forEach(
@@ -499,29 +499,51 @@ class IncrementalBdpEngine {
     Span propSpan =
         GlobalTracer.get().buildSpan(iterationLabel + ": Propagate BGP v4 routes").start();
     LOGGER.info("{}: Propagate BGP v4 routes", iterationLabel);
+
     try (Scope innerScope = GlobalTracer.get().scopeManager().activate(propSpan)) {
       assert innerScope != null; // avoid unused warning
-      nodes
-          .values()
-          .parallelStream()
-          .flatMap(n -> n.getVirtualRouters().values().stream())
-          .forEach(
-              vr -> {
-                Map<Bgpv4Rib, RibDelta<Bgpv4Route>> deltas =
-                    vr.processBgpMessages(bgpTopology, networkConfigurations, nodes);
-                vr.finalizeBgpRoutesAndQueueOutgoingMessages(
-                    deltas, allNodes, bgpTopology, networkConfigurations);
-              });
+
+      /*
+      In a round, each VR will process BGP messages from its neighbors, adding them to the right
+      RIBs and building a RibDelta containing messages that will be sent to neighbors in the next
+      round (the "outgoing delta"). Processing messages from a neighbor requires reading from
+      their outgoing delta. We do this for all VRs in parallel, so we need to be careful not to
+      read from and write to the same delta simultaneously. We separate reading and writing into
+      two stages. In the first stage, all VRs read from their neighbors' deltas, and build
+      Runnables (thunks) to clear and then write to their own deltas. In the second stage, we
+      simply run these Runnables (also in parallel).
+      */
+      List<Runnable> finalizeBgpRoutesAndQueueOutgoingMessages =
+          allNodes
+              .values()
+              .parallelStream()
+              .flatMap(n -> n.getVirtualRouters().values().stream())
+              .map(
+                  vr -> {
+                    // Stage 1: read from all eighbors' queues.
+                    Map<Bgpv4Rib, RibDelta<Bgpv4Route>> deltas =
+                        vr.processBgpMessages(bgpTopology, networkConfigurations, allNodes);
+                    // return a runnable for stage 2.
+                    return (Runnable)
+                        () -> {
+                          vr.clearBgpOutgoingDeltas();
+                          vr.finalizeBgpRoutesAndBuildOutgoingDeltas(deltas);
+                        };
+                  })
+              .collect(Collectors.toList());
+
+      // Stage 2: update all the outgoing queues
+      finalizeBgpRoutesAndQueueOutgoingMessages.parallelStream().forEach(Runnable::run);
 
       // Merge BGP routes from BGP process into the main RIB
-      nodes
+      allNodes
           .values()
           .parallelStream()
           .flatMap(n -> n.getVirtualRouters().values().stream())
           .forEach(VirtualRouter::mergeBgpRoutesToMainRib);
 
       // Multi-VRF redistribution of BGP routes:
-      nodes
+      allNodes
           .values()
           .parallelStream()
           .forEach(
@@ -738,8 +760,7 @@ class IncrementalBdpEngine {
             .flatMap(n -> n.getVirtualRouters().values().stream())
             .forEach(
                 vr -> {
-                  vr.processExternalBgpAdvertisements(
-                      externalAdverts, ipVrfOwners, nodes, bgpTopology, networkConfigurations);
+                  vr.processExternalBgpAdvertisements(externalAdverts, ipVrfOwners);
                   vr.queueInitialBgpMessages(bgpTopology, nodes, networkConfigurations);
                 });
       } finally {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -499,14 +500,9 @@ public class VirtualRouter implements Serializable {
    *
    * @param externalAdverts a set of external BGP advertisements
    * @param ipVrfOwners mapping of IPs to their owners in our network
-   * @param bgpTopology the bgp peering relationships
    */
   void processExternalBgpAdvertisements(
-      Set<BgpAdvertisement> externalAdverts,
-      Map<Ip, Map<String, Set<String>>> ipVrfOwners,
-      Map<String, Node> allNodes,
-      BgpTopology bgpTopology,
-      NetworkConfigurations networkConfigurations) {
+      Set<BgpAdvertisement> externalAdverts, Map<Ip, Map<String, Set<String>>> ipVrfOwners) {
 
     if (_bgpRoutingProcess == null) {
       // Nothing to do
@@ -706,7 +702,7 @@ public class VirtualRouter implements Serializable {
         ribDeltas.entrySet().stream()
             .filter(e -> !e.getValue().isEmpty())
             .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().build()));
-    finalizeBgpRoutesAndQueueOutgoingMessages(deltas, allNodes, bgpTopology, networkConfigurations);
+    finalizeBgpRoutesAndBuildOutgoingDeltas(deltas);
   }
 
   /** Initialize RIP routes from the interface prefixes */
@@ -1155,9 +1151,17 @@ public class VirtualRouter implements Serializable {
               : _bgpRoutingProcess._ibgpv4StagingRib;
       Builder<AnnotatedRoute<AbstractRoute>> perNeighborDeltaForRibGroups = RibDelta.builder();
 
+      VirtualRouter neighborVr = getRemoteBgpNeighborVR(remoteConfigId, nodes);
+      Iterator<RouteAdvertisement<Bgpv4Route>> exportedRoutes =
+          neighborVr
+              .getOutgoingRoutesForEdge(e.getKey().reverse(), nodes, bgpTopology, nc)
+              .iterator();
+
       // Process all routes from neighbor
-      while (queue.peek() != null) {
-        RouteAdvertisement<Bgpv4Route> remoteRouteAdvert = queue.remove();
+      while (exportedRoutes.hasNext() || queue.peek() != null) {
+        // consume exported routes before reading from the queue
+        RouteAdvertisement<Bgpv4Route> remoteRouteAdvert =
+            exportedRoutes.hasNext() ? exportedRoutes.next() : queue.remove();
         Bgpv4Route remoteRoute = remoteRouteAdvert.getRoute();
 
         Bgpv4Route.Builder transformedIncomingRouteBuilder =
@@ -1382,41 +1386,8 @@ public class VirtualRouter implements Serializable {
     return changed;
   }
 
-  /**
-   * Queue advertised BGP routes to all BGP neighbors.
-   *
-   * @param ebgpBestPathDelta {@link RibDelta} indicating what changed in the {@link
-   *     BgpRoutingProcess#_ebgpv4Rib}
-   * @param bgpDelta a {@link RibDelta} indicating what changed in the {@link
-   *     BgpRoutingProcess#_bgpv4Rib}
-   * @param mainDelta a {@link RibDelta} indicating what changed in the {@link #_mainRib}
-   * @param allNodes map of all nodes in the network, keyed by hostname
-   * @param bgpTopology the bgp peering relationships
-   */
-  private void queueOutgoingBgpRoutes(
-      RibDelta<Bgpv4Route> ebgpBestPathDelta,
-      RibDelta<Bgpv4Route> bgpDelta,
-      RibDelta<AnnotatedRoute<AbstractRoute>> mainDelta,
-      Map<String, Node> allNodes,
-      BgpTopology bgpTopology,
-      NetworkConfigurations networkConfigurations) {
-    for (EdgeId edge : _bgpRoutingProcess._bgpv4IncomingRoutes.keySet()) {
-      queueOutgoingRoutesPerEdge(
-          edge,
-          ebgpBestPathDelta,
-          bgpDelta,
-          mainDelta,
-          allNodes,
-          bgpTopology,
-          networkConfigurations);
-    }
-  }
-
-  private void queueOutgoingRoutesPerEdge(
+  private Stream<RouteAdvertisement<Bgpv4Route>> getOutgoingRoutesForEdge(
       EdgeId edge,
-      RibDelta<Bgpv4Route> ebgpBestPathDelta,
-      RibDelta<Bgpv4Route> bgpDelta,
-      RibDelta<AnnotatedRoute<AbstractRoute>> mainDelta,
       Map<String, Node> allNodes,
       BgpTopology bgpTopology,
       NetworkConfigurations networkConfigurations) {
@@ -1428,7 +1399,7 @@ public class VirtualRouter implements Serializable {
     BgpPeerConfig remoteConfig = networkConfigurations.getBgpPeerConfig(edge.tail());
     VirtualRouter remoteVirtualRouter = getRemoteBgpNeighborVR(remoteConfigId, allNodes);
     if (remoteVirtualRouter == null) {
-      return;
+      return Stream.of();
     }
     BgpRoutingProcess remoteBgpRoutingProcess = remoteVirtualRouter.getBgpRoutingProcess();
     assert remoteBgpRoutingProcess != null;
@@ -1436,7 +1407,8 @@ public class VirtualRouter implements Serializable {
     // Queue mainRib updates that were not introduced by BGP process (i.e., IGP routes)
     // Also, do not double-export main RIB routes
     Stream<RouteAdvertisement<Bgpv4Route>> mainRibExports =
-        mainDelta
+        _bgpRoutingProcess
+            ._mainRibBgpv4RouteDelta
             .getActions()
             .filter(adv -> !(adv.getRoute().getRoute() instanceof BgpRoute))
             .map(
@@ -1467,14 +1439,15 @@ public class VirtualRouter implements Serializable {
      *    they are not active in the main RIB.
      */
     if (session.getAdvertiseExternal()) {
-      importDeltaToBuilder(bgpRibExports, ebgpBestPathDelta, _name);
+      importDeltaToBuilder(bgpRibExports, _bgpRoutingProcess._ebgpDelta, _name);
     }
     if (session.getAdvertiseInactive()) {
-      importDeltaToBuilder(bgpRibExports, bgpDelta, _name);
+      importDeltaToBuilder(bgpRibExports, _bgpRoutingProcess._bgpv4Delta, _name);
     } else {
       // Default behavior
       bgpRibExports.from(
-          bgpDelta
+          _bgpRoutingProcess
+              ._bgpv4Delta
               .getActions()
               .map(
                   r ->
@@ -1492,7 +1465,7 @@ public class VirtualRouter implements Serializable {
        AND the combination of vendor-specific knobs, none of which are currently supported.
     */
     if (session.getAdditionalPaths()) {
-      importDeltaToBuilder(bgpRibExports, bgpDelta, _name);
+      importDeltaToBuilder(bgpRibExports, _bgpRoutingProcess._bgpv4Delta, _name);
     }
 
     RibDelta<AnnotatedRoute<Bgpv4Route>> bgpRoutesToExport = bgpRibExports.build();
@@ -1530,9 +1503,7 @@ public class VirtualRouter implements Serializable {
                 .filter(Objects::nonNull)
                 .distinct(),
             mainRibExports);
-
-    // Call this on the REMOTE VR and REVERSE the edge!
-    remoteVirtualRouter.enqueueBgpMessages(edge.reverse(), exportedAdvertisements);
+    return exportedAdvertisements;
   }
 
   private static BgpSessionProperties getBgpSessionProperties(
@@ -1640,13 +1611,8 @@ public class VirtualRouter implements Serializable {
    *
    * @param stagingDeltas a map of RIB to corresponding delta. Keys are expected to contain {@link
    *     BgpRoutingProcess#_ebgpv4StagingRib} and {@link BgpRoutingProcess#_ibgpv4StagingRib}
-   * @param bgpTopology the bgp peering relationships
    */
-  void finalizeBgpRoutesAndQueueOutgoingMessages(
-      Map<Bgpv4Rib, RibDelta<Bgpv4Route>> stagingDeltas,
-      Map<String, Node> allNodes,
-      BgpTopology bgpTopology,
-      NetworkConfigurations networkConfigurations) {
+  void finalizeBgpRoutesAndBuildOutgoingDeltas(Map<Bgpv4Rib, RibDelta<Bgpv4Route>> stagingDeltas) {
 
     if (_bgpRoutingProcess == null) {
       return;
@@ -1665,16 +1631,25 @@ public class VirtualRouter implements Serializable {
         importRibDelta(_bgpRoutingProcess._bgpv4Rib, ebgpDelta));
     _bgpRoutingProcess._bgpv4DeltaBuilder.from(
         importRibDelta(_bgpRoutingProcess._bgpv4Rib, ibgpDelta));
-    _mainRibRouteDeltaBuilder.from(
-        RibDelta.importRibDelta(_mainRib, _bgpRoutingProcess._bgpv4DeltaBuilder.build(), _name));
 
-    queueOutgoingBgpRoutes(
-        ebgpDelta,
-        _bgpRoutingProcess._bgpv4DeltaBuilder.build(),
-        _mainRibRouteDeltaBuilder.build(),
-        allNodes,
-        bgpTopology,
-        networkConfigurations);
+    RibDelta<Bgpv4Route> newBgpv4Delta = _bgpRoutingProcess._bgpv4DeltaBuilder.build();
+    _mainRibRouteDeltaBuilder.from(RibDelta.importRibDelta(_mainRib, newBgpv4Delta, _name));
+
+    // TODO this merge nonsense sucks
+    _bgpRoutingProcess._bgpv4Delta = RibDelta.merge(_bgpRoutingProcess._bgpv4Delta, newBgpv4Delta);
+    _bgpRoutingProcess._ebgpDelta = RibDelta.merge(_bgpRoutingProcess._ebgpDelta, ebgpDelta);
+    _bgpRoutingProcess._mainRibBgpv4RouteDelta =
+        RibDelta.merge(
+            _bgpRoutingProcess._mainRibBgpv4RouteDelta, _mainRibRouteDeltaBuilder.build());
+  }
+
+  void clearBgpOutgoingDeltas() {
+    if (_bgpRoutingProcess == null) {
+      return;
+    }
+    _bgpRoutingProcess._bgpv4Delta = null;
+    _bgpRoutingProcess._ebgpDelta = null;
+    _bgpRoutingProcess._mainRibBgpv4RouteDelta = null;
   }
 
   /**
@@ -1738,8 +1713,7 @@ public class VirtualRouter implements Serializable {
       return;
     }
     for (EdgeId edge : _bgpRoutingProcess._bgpv4IncomingRoutes.keySet()) {
-      newBgpSessionEstablishedHook(
-          edge, getBgpSessionProperties(bgpTopology, edge), allNodes, nc, bgpTopology);
+      newBgpSessionEstablishedHook(edge, getBgpSessionProperties(bgpTopology, edge), allNodes, nc);
     }
     _bgpRoutingProcess.redistribute(
         RibDelta.<AnnotatedRoute<AbstractRoute>>builder().add(_mainRib.getTypedRoutes()).build());
@@ -1750,8 +1724,7 @@ public class VirtualRouter implements Serializable {
       @Nonnull EdgeId edge,
       @Nonnull BgpSessionProperties sessionProperties,
       @Nonnull Map<String, Node> allNodes,
-      NetworkConfigurations nc,
-      BgpTopology topology) {
+      NetworkConfigurations nc) {
 
     BgpPeerConfigId localConfigId = edge.head();
     BgpPeerConfigId remoteConfigId = edge.tail();
@@ -1776,16 +1749,25 @@ public class VirtualRouter implements Serializable {
     /*
      * Export routes by looking at main RIB and BGPv4 RIB
      */
-    queueOutgoingRoutesPerEdge(
-        edge,
-        RibDelta.<Bgpv4Route>builder()
-            .add(_bgpRoutingProcess._ebgpv4Rib.getBestPathRoutes())
-            .build(),
-        RibDelta.<Bgpv4Route>builder().add(_bgpRoutingProcess._bgpv4Rib.getTypedRoutes()).build(),
-        RibDelta.<AnnotatedRoute<AbstractRoute>>builder().add(_mainRib.getTypedRoutes()).build(),
-        allNodes,
-        topology,
-        nc);
+    // TODO this merging nonsense sucks. Try to get some reasonable invariants
+    _bgpRoutingProcess._ebgpDelta =
+        RibDelta.merge(
+            _bgpRoutingProcess._ebgpDelta,
+            RibDelta.<Bgpv4Route>builder()
+                .add(_bgpRoutingProcess._ebgpv4Rib.getBestPathRoutes())
+                .build());
+    _bgpRoutingProcess._bgpv4Delta =
+        RibDelta.merge(
+            _bgpRoutingProcess._bgpv4Delta,
+            RibDelta.<Bgpv4Route>builder()
+                .add(_bgpRoutingProcess._bgpv4Rib.getTypedRoutes())
+                .build());
+    _bgpRoutingProcess._mainRibBgpv4RouteDelta =
+        RibDelta.merge(
+            _bgpRoutingProcess._mainRibBgpv4RouteDelta,
+            RibDelta.<AnnotatedRoute<AbstractRoute>>builder()
+                .add(_mainRib.getTypedRoutes())
+                .build());
 
     /*
      * Export neighbor-specific generated routes, these routes skip global export policy
@@ -1905,6 +1887,7 @@ public class VirtualRouter implements Serializable {
     return Streams.concat(
             // RIB State
             Stream.of(_mainRib.getTypedRoutes()),
+            // Exported routes
             // Message queues
             Stream.of(_isisIncomingRoutes, _crossVrfIncomingRoutes)
                 .flatMap(m -> m.values().stream())
@@ -2138,12 +2121,6 @@ public class VirtualRouter implements Serializable {
   private void enqueueBgpMessages(
       @Nonnull EdgeId edgeId, @Nonnull Collection<RouteAdvertisement<Bgpv4Route>> routes) {
     _bgpRoutingProcess.enqueueBgpv4Routes(edgeId, routes);
-  }
-
-  /** Temporary wrapper for {@link BgpRoutingProcess#enqueueBgpMessages(EdgeId, Stream)} */
-  private void enqueueBgpMessages(
-      @Nonnull EdgeId edgeId, @Nonnull Stream<RouteAdvertisement<Bgpv4Route>> routes) {
-    _bgpRoutingProcess.enqueueBgpMessages(edgeId, routes);
   }
 
   /** Return all EVPN routes in this VRF */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.AbstractRouteDecorator;
@@ -37,6 +38,14 @@ public final class RibDelta<R> {
 
   private RibDelta(ImmutableSortedMap<Prefix, List<RouteAdvertisement<R>>> actions) {
     _actions = actions;
+  }
+
+  public static <R extends AbstractRouteDecorator> RibDelta<R> merge(
+      @Nullable RibDelta<R> delta1, RibDelta<R> delta2) {
+    if (delta1 == null || delta1.isEmpty()) {
+      return delta2;
+    }
+    return RibDelta.<R>builder().from(delta1.getActions()).from(delta2.getActions()).build();
   }
 
   /**

--- a/tests/basic/genDp.ref
+++ b/tests/basic/genDp.ref
@@ -3,32 +3,29 @@
     {
       "class" : "org.batfish.datamodel.answers.IncrementalBdpAnswerElement",
       "bgpBestPathRibRoutesByIteration" : {
-        "1" : 24,
-        "2" : 58,
-        "3" : 66,
-        "4" : 75,
+        "1" : 60,
+        "2" : 70,
+        "3" : 76,
+        "4" : 76,
         "5" : 76,
-        "6" : 76,
-        "7" : 76
+        "6" : 76
       },
       "bgpMultipathRibRoutesByIteration" : {
-        "1" : 28,
-        "2" : 90,
-        "3" : 102,
-        "4" : 119,
+        "1" : 92,
+        "2" : 108,
+        "3" : 120,
+        "4" : 120,
         "5" : 120,
-        "6" : 120,
-        "7" : 120
+        "6" : 120
       },
-      "dependentRoutesIterations" : 7,
+      "dependentRoutesIterations" : 6,
       "mainRibRoutesByIteration" : {
-        "1" : 207,
-        "2" : 271,
-        "3" : 319,
-        "4" : 338,
+        "1" : 269,
+        "2" : 289,
+        "3" : 337,
+        "4" : 339,
         "5" : 339,
-        "6" : 339,
-        "7" : 339
+        "6" : 339
       },
       "ospfInternalIterations" : 3,
       "version" : "0.36.0",


### PR DESCRIPTION
Try 2! This time, with a thread-safe `PrefixTracer`.