### PR TITLE
AWS: ACLs representing security groups have 1 line per rule

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -433,8 +433,7 @@ public final class IpPermissions implements Serializable {
         /*
          TODO Should we set the trace element, either to null or something else? Currently it will
           be based on name, which results in trace elements like this:
-          "Matched line sgId - sgName [ingress] 4"
-          where 4 is the index of this rule in the ingress permissions.
+          "Matched line sgId - sgName [ingress]"
         */
         .setName(name)
         .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/IpPermissions.java
@@ -430,11 +430,8 @@ public final class IpPermissions implements Serializable {
             collectPrefixLists(region, _prefixList), protocolAndPortExprs, ingress));
     return ExprAclLine.accepting()
         .setMatchCondition(or(aclLineExprs.build()))
-        /*
-         TODO Should we set the trace element, either to null or something else? Currently it will
-          be based on name, which results in trace elements like this:
-          "Matched line sgId - sgName [ingress]"
-        */
+        // TODO Should we set this trace element? If so, to what?
+        .setTraceElement(null)
         .setName(name)
         .build();
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -102,13 +102,17 @@ public final class SecurityGroup implements AwsVpcEntity, Serializable {
 
   IpAccessList toAcl(Region region, boolean ingress, Warnings warnings) {
     List<AclLine> aclLines = toAclLines(region, ingress, warnings);
+    return IpAccessList.builder().setName(getViName(ingress)).setLines(aclLines).build();
+  }
+
+  /**
+   * Returns the name that will be assigned to the VI {@link IpAccessList} representing this
+   * security group's ingress or egress permissions.
+   */
+  public String getViName(boolean ingress) {
     // See note about naming on SecurityGroup#getGroupName.
-    return IpAccessList.builder()
-        .setName(
-            String.format(
-                "~%s~SECURITY-GROUP~%s~%s~", ingress ? INGRESS : EGRESS, _groupName, _groupId))
-        .setLines(aclLines)
-        .build();
+    return String.format(
+        "~%s~SECURITY-GROUP~%s~%s~", ingress ? INGRESS : EGRESS, _groupName, _groupId);
   }
 
   /** Converts this security group's ingress or egress permission terms to List of AclLines */

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -12,9 +12,9 @@ import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -114,20 +114,21 @@ public final class SecurityGroup implements AwsVpcEntity, Serializable {
 
   /** Converts this security group's ingress or egress permission terms to List of AclLines */
   List<AclLine> toAclLines(Region region, boolean ingress, Warnings warnings) {
-    ImmutableList.Builder<AclLine> aclLines = ImmutableList.builder();
     List<IpPermissions> ipPerms = ingress ? _ipPermsIngress : _ipPermsEgress;
-    for (ListIterator<IpPermissions> it = ipPerms.listIterator(); it.hasNext(); ) {
-      int seq = it.nextIndex();
-      IpPermissions p = it.next();
-      aclLines.add(
-          p.toIpAccessListLine(
-              ingress,
-              region,
-              String.format(
-                  "%s - %s [%s] %s", _groupId, _groupName, ingress ? "ingress" : "egress", seq),
-              warnings));
-    }
-    return aclLines.build();
+    return IntStream.range(0, ipPerms.size())
+        .mapToObj(
+            i ->
+                // NOTE: Keep VI ACL lines 1-to-1 with group's IpPermissions; do not filter
+                ipPerms
+                    .get(i)
+                    .toIpAccessListLine(
+                        ingress,
+                        region,
+                        String.format(
+                            "%s - %s [%s] %s",
+                            _groupId, _groupName, ingress ? "ingress" : "egress", i),
+                        warnings))
+        .collect(ImmutableList.toImmutableList());
   }
 
   @Nullable

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -119,8 +119,8 @@ public final class SecurityGroup implements AwsVpcEntity, Serializable {
     for (ListIterator<IpPermissions> it = ipPerms.listIterator(); it.hasNext(); ) {
       int seq = it.nextIndex();
       IpPermissions p = it.next();
-      aclLines.addAll(
-          p.toIpAccessListLines(
+      aclLines.add(
+          p.toIpAccessListLine(
               ingress,
               region,
               String.format(

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/SecurityGroup.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -115,19 +114,16 @@ public final class SecurityGroup implements AwsVpcEntity, Serializable {
   /** Converts this security group's ingress or egress permission terms to List of AclLines */
   List<AclLine> toAclLines(Region region, boolean ingress, Warnings warnings) {
     List<IpPermissions> ipPerms = ingress ? _ipPermsIngress : _ipPermsEgress;
-    return IntStream.range(0, ipPerms.size())
-        .mapToObj(
-            i ->
+    return ipPerms.stream()
+        .map(
+            rule ->
                 // NOTE: Keep VI ACL lines 1-to-1 with group's IpPermissions; do not filter
-                ipPerms
-                    .get(i)
-                    .toIpAccessListLine(
-                        ingress,
-                        region,
-                        String.format(
-                            "%s - %s [%s] %s",
-                            _groupId, _groupName, ingress ? "ingress" : "egress", i),
-                        warnings))
+                rule.toIpAccessListLine(
+                    ingress,
+                    region,
+                    String.format(
+                        "%s - %s [%s]", _groupId, _groupName, ingress ? "ingress" : "egress"),
+                    warnings))
         .collect(ImmutableList.toImmutableList());
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/IpPermissionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/IpPermissionsTest.java
@@ -1,7 +1,6 @@
 package org.batfish.representation.aws;
 
 import static org.batfish.datamodel.IpProtocol.TCP;
-import static org.batfish.datamodel.acl.TraceElements.matchedByAclLine;
 import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchCondition;
 import static org.batfish.datamodel.matchers.TraceTreeMatchers.isTraceTree;
 import static org.batfish.representation.aws.Utils.getTraceElementForRule;
@@ -161,14 +160,12 @@ public class IpPermissionsTest {
     assertThat(
         Iterables.getOnlyElement(root),
         isTraceTree(
-            matchedByAclLine(lineName),
+            getTraceElementForRule(SG_DESC),
+            isTraceTree(traceElementForProtocol(TCP)),
+            isTraceTree(traceElementForDstPorts(22, 22)),
             isTraceTree(
-                getTraceElementForRule(SG_DESC),
-                isTraceTree(traceElementForProtocol(TCP)),
-                isTraceTree(traceElementForDstPorts(22, 22)),
-                isTraceTree(
-                    traceElementForAddress("source", SG_NAME, AddressType.SECURITY_GROUP),
-                    isTraceTree(traceElementEniPrivateIp("eni-123"))))));
+                traceElementForAddress("source", SG_NAME, AddressType.SECURITY_GROUP),
+                isTraceTree(traceElementEniPrivateIp("eni-123")))));
 
     Flow deniedFlow =
         Flow.builder()

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -270,7 +270,7 @@ public class SecurityGroupsTest {
     assertThat(
         w.getText(),
         allOf(
-            containsString("ICMP types invalid with code only [ingress] 0"),
+            containsString("ICMP types invalid with code only [ingress]"),
             containsString("unexpected for ICMP to have FromPort=-1 and ToPort=9")));
   }
 
@@ -499,7 +499,7 @@ public class SecurityGroupsTest {
         equalTo(
             ImmutableList.of(
                 ExprAclLine.accepting()
-                    .setName("sg-001 - sg-1 [ingress] 0")
+                    .setName("sg-001 - sg-1 [ingress]")
                     .setMatchCondition(
                         new AndMatchExpr(
                             ImmutableList.of(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -500,6 +500,7 @@ public class SecurityGroupsTest {
             ImmutableList.of(
                 ExprAclLine.accepting()
                     .setName("sg-001 - sg-1 [ingress]")
+                    .setTraceElement(null)
                     .setMatchCondition(
                         new AndMatchExpr(
                             ImmutableList.of(

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/SecurityGroupsTest.java
@@ -4,7 +4,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.batfish.common.util.Resources.readResource;
 import static org.batfish.datamodel.IpProtocol.ICMP;
 import static org.batfish.datamodel.IpProtocol.TCP;
-import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
 import static org.batfish.datamodel.matchers.AclLineMatchers.isExprAclLineThat;
 import static org.batfish.datamodel.matchers.ExprAclLineMatchers.hasMatchCondition;
 import static org.batfish.representation.aws.AwsVpcEntity.JSON_KEY_SECURITY_GROUPS;
@@ -15,8 +15,8 @@ import static org.batfish.representation.aws.Utils.traceElementForIcmpCode;
 import static org.batfish.representation.aws.Utils.traceElementForIcmpType;
 import static org.batfish.representation.aws.Utils.traceElementForProtocol;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -45,6 +45,7 @@ import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.UniverseIpSpace;
+import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.representation.aws.IpPermissions.AddressType;
 import org.batfish.representation.aws.IpPermissions.IpRange;
@@ -152,65 +153,109 @@ public class SecurityGroupsTest {
   @Test
   public void testSinglePort() {
     SecurityGroup sg = _securityGroups.get(0);
+    String rangeDesc =
+        Iterables.getOnlyElement(Iterables.getOnlyElement(sg.getIpPermsIngress()).getIpRanges())
+            .getDescription();
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
-        line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(22, 22), matchIp))));
+        line,
+        isExprAclLineThat(
+            hasMatchCondition(
+                new AndMatchExpr(
+                    ImmutableList.of(matchTcp, matchPorts(22, 22), matchIp),
+                    getTraceElementForRule(rangeDesc)))));
   }
 
   @Test
   public void testBeginningHalfOpenInterval() {
     SecurityGroup sg = _securityGroups.get(1);
+    String rangeDesc =
+        Iterables.getOnlyElement(Iterables.getOnlyElement(sg.getIpPermsIngress()).getIpRanges())
+            .getDescription();
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
-        line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(0, 22), matchIp))));
+        line,
+        isExprAclLineThat(
+            hasMatchCondition(
+                new AndMatchExpr(
+                    ImmutableList.of(matchTcp, matchPorts(0, 22), matchIp),
+                    getTraceElementForRule(rangeDesc)))));
   }
 
   @Test
   public void testEndHalfOpenInterval() {
     SecurityGroup sg = _securityGroups.get(2);
+    String rangeDesc =
+        Iterables.getOnlyElement(Iterables.getOnlyElement(sg.getIpPermsIngress()).getIpRanges())
+            .getDescription();
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
         line,
-        isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(65530, 65535), matchIp))));
+        isExprAclLineThat(
+            hasMatchCondition(
+                new AndMatchExpr(
+                    ImmutableList.of(matchTcp, matchPorts(65530, 65535), matchIp),
+                    getTraceElementForRule(rangeDesc)))));
   }
 
   @Test
   public void testFullInterval() {
     SecurityGroup sg = _securityGroups.get(3);
+    String rangeDesc =
+        Iterables.getOnlyElement(Iterables.getOnlyElement(sg.getIpPermsIngress()).getIpRanges())
+            .getDescription();
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
-    assertThat(line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchIp))));
+    assertThat(
+        line,
+        isExprAclLineThat(
+            hasMatchCondition(
+                new AndMatchExpr(
+                    ImmutableList.of(matchTcp, matchIp), getTraceElementForRule(rangeDesc)))));
   }
 
   @Test
   public void testIcmpType() {
     SecurityGroup sg = _securityGroups.get(9);
+    String rangeDesc =
+        Iterables.getOnlyElement(Iterables.getOnlyElement(sg.getIpPermsIngress()).getIpRanges())
+            .getDescription();
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
         line,
         isExprAclLineThat(
             hasMatchCondition(
-                and(
-                    matchIcmp,
-                    new MatchHeaderSpace(
-                        HeaderSpace.builder().setIcmpTypes(8).build(), traceElementForIcmpType(8)),
-                    matchUniverse))));
+                new AndMatchExpr(
+                    ImmutableList.of(
+                        matchIcmp,
+                        new MatchHeaderSpace(
+                            HeaderSpace.builder().setIcmpTypes(8).build(),
+                            traceElementForIcmpType(8)),
+                        matchUniverse),
+                    getTraceElementForRule(rangeDesc)))));
   }
 
   @Test
   public void testIcmpTypeAndCode() {
     SecurityGroup sg = _securityGroups.get(10);
+    String rangeDesc =
+        Iterables.getOnlyElement(Iterables.getOnlyElement(sg.getIpPermsIngress()).getIpRanges())
+            .getDescription();
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
         line,
         isExprAclLineThat(
             hasMatchCondition(
-                and(
-                    matchIcmp,
-                    new MatchHeaderSpace(
-                        HeaderSpace.builder().setIcmpTypes(8).build(), traceElementForIcmpType(8)),
-                    new MatchHeaderSpace(
-                        HeaderSpace.builder().setIcmpCodes(9).build(), traceElementForIcmpCode(9)),
-                    matchUniverse))));
+                new AndMatchExpr(
+                    ImmutableList.of(
+                        matchIcmp,
+                        new MatchHeaderSpace(
+                            HeaderSpace.builder().setIcmpTypes(8).build(),
+                            traceElementForIcmpType(8)),
+                        new MatchHeaderSpace(
+                            HeaderSpace.builder().setIcmpCodes(9).build(),
+                            traceElementForIcmpCode(9)),
+                        matchUniverse),
+                    getTraceElementForRule(rangeDesc)))));
   }
 
   @Test
@@ -218,7 +263,8 @@ public class SecurityGroupsTest {
     SecurityGroup sg = _securityGroups.get(11);
     List<AclLine> inboundRules = sg.toAclLines(_region, true, _warnings);
 
-    assertThat(inboundRules, empty());
+    // Should still see a VI ACL line for this rule because we want a 1-to-1 mapping of rules:lines
+    assertThat(inboundRules, contains(isExprAclLineThat(hasMatchCondition(FALSE))));
     assertThat(_warnings.getRedFlagWarnings(), hasSize(1));
     Warning w = Iterables.getOnlyElement(_warnings.getRedFlagWarnings());
     assertThat(
@@ -231,52 +277,99 @@ public class SecurityGroupsTest {
   @Test
   public void testAllTrafficAllowed() {
     SecurityGroup sg = _securityGroups.get(4);
+    String rangeDesc =
+        Iterables.getOnlyElement(Iterables.getOnlyElement(sg.getIpPermsIngress()).getIpRanges())
+            .getDescription();
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
-    assertThat(line, isExprAclLineThat(hasMatchCondition(matchUniverse)));
+    assertThat(
+        line,
+        isExprAclLineThat(
+            hasMatchCondition(
+                new AndMatchExpr(
+                    ImmutableList.of(matchUniverse), getTraceElementForRule(rangeDesc)))));
   }
 
   @Test
   public void testClosedInterval() {
     SecurityGroup sg = _securityGroups.get(5);
+    String rangeDesc =
+        Iterables.getOnlyElement(Iterables.getOnlyElement(sg.getIpPermsIngress()).getIpRanges())
+            .getDescription();
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
-        line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(45, 50), matchIp))));
+        line,
+        isExprAclLineThat(
+            hasMatchCondition(
+                new AndMatchExpr(
+                    ImmutableList.of(matchTcp, matchPorts(45, 50), matchIp),
+                    getTraceElementForRule(rangeDesc)))));
   }
 
   @Test
   public void testInvalidStartInterval() {
     SecurityGroup sg = _securityGroups.get(6);
+    String rangeDesc =
+        Iterables.getOnlyElement(Iterables.getOnlyElement(sg.getIpPermsIngress()).getIpRanges())
+            .getDescription();
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
-        line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(0, 50), matchIp))));
+        line,
+        isExprAclLineThat(
+            hasMatchCondition(
+                new AndMatchExpr(
+                    ImmutableList.of(matchTcp, matchPorts(0, 50), matchIp),
+                    getTraceElementForRule(rangeDesc)))));
   }
 
   @Test
   public void testInvalidEndInterval() {
     SecurityGroup sg = _securityGroups.get(7);
+    String rangeDesc =
+        Iterables.getOnlyElement(Iterables.getOnlyElement(sg.getIpPermsIngress()).getIpRanges())
+            .getDescription();
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
-        line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(30, 65535), matchIp))));
+        line,
+        isExprAclLineThat(
+            hasMatchCondition(
+                new AndMatchExpr(
+                    ImmutableList.of(matchTcp, matchPorts(30, 65535), matchIp),
+                    getTraceElementForRule(rangeDesc)))));
   }
 
   @Test
   public void testStatefulTcpRules() {
     SecurityGroup sg = _securityGroups.get(8);
+    String rangeDesc =
+        Iterables.getOnlyElement(Iterables.getOnlyElement(sg.getIpPermsIngress()).getIpRanges())
+            .getDescription();
     AclLine line = Iterables.getOnlyElement(sg.toAclLines(_region, true, _warnings));
     assertThat(
-        line, isExprAclLineThat(hasMatchCondition(and(matchTcp, matchPorts(22, 22), matchIp))));
+        line,
+        isExprAclLineThat(
+            hasMatchCondition(
+                new AndMatchExpr(
+                    ImmutableList.of(matchTcp, matchPorts(22, 22), matchIp),
+                    getTraceElementForRule(rangeDesc)))));
+    String outRangeDesc =
+        Iterables.getOnlyElement(Iterables.getOnlyElement(sg.getIpPermsEgress()).getIpRanges())
+            .getDescription();
     AclLine outline = Iterables.getOnlyElement(sg.toAclLines(_region, false, _warnings));
     assertThat(
         outline,
         isExprAclLineThat(
             hasMatchCondition(
-                and(
-                    matchTcp,
-                    matchPorts(80, 80),
-                    new MatchHeaderSpace(
-                        HeaderSpace.builder().setDstIps(Ip.parse("5.6.7.8").toIpSpace()).build(),
-                        traceElementForAddress(
-                            "destination", "5.6.7.8/32", AddressType.CIDR_IP))))));
+                new AndMatchExpr(
+                    ImmutableList.of(
+                        matchTcp,
+                        matchPorts(80, 80),
+                        new MatchHeaderSpace(
+                            HeaderSpace.builder()
+                                .setDstIps(Ip.parse("5.6.7.8").toIpSpace())
+                                .build(),
+                            traceElementForAddress(
+                                "destination", "5.6.7.8/32", AddressType.CIDR_IP))),
+                    getTraceElementForRule(outRangeDesc)))));
   }
 
   @Test
@@ -385,6 +478,7 @@ public class SecurityGroupsTest {
 
   @Test
   public void testToAclLines() {
+    String rangeDesc = "IP range description";
     SecurityGroup sg =
         new SecurityGroup(
             "sg-001",
@@ -395,7 +489,7 @@ public class SecurityGroupsTest {
                     "tcp",
                     22,
                     22,
-                    ImmutableList.of(new IpRange(Prefix.parse("2.2.2.0/24"))),
+                    ImmutableList.of(new IpRange(rangeDesc, Prefix.parse("2.2.2.0/24"))),
                     ImmutableList.of(),
                     ImmutableList.of())),
             "vpc");
@@ -407,16 +501,17 @@ public class SecurityGroupsTest {
                 ExprAclLine.accepting()
                     .setName("sg-001 - sg-1 [ingress] 0")
                     .setMatchCondition(
-                        and(
-                            matchTcp,
-                            matchPorts(22, 22),
-                            new MatchHeaderSpace(
-                                HeaderSpace.builder()
-                                    .setSrcIps(Prefix.parse("2.2.2.0/24").toIpSpace())
-                                    .build(),
-                                traceElementForAddress(
-                                    "source", "2.2.2.0/24", AddressType.CIDR_IP))))
-                    .setTraceElement(getTraceElementForRule(null))
+                        new AndMatchExpr(
+                            ImmutableList.of(
+                                matchTcp,
+                                matchPorts(22, 22),
+                                new MatchHeaderSpace(
+                                    HeaderSpace.builder()
+                                        .setSrcIps(Prefix.parse("2.2.2.0/24").toIpSpace())
+                                        .build(),
+                                    traceElementForAddress(
+                                        "source", "2.2.2.0/24", AddressType.CIDR_IP))),
+                            getTraceElementForRule(rangeDesc)))
                     .build())));
   }
 }

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -98,18 +98,31 @@
                 "class" : "org.batfish.datamodel.ExprAclLine",
                 "action" : "PERMIT",
                 "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "dstIps" : {
-                      "class" : "org.batfish.datamodel.UniverseIpSpace"
-                    },
-                    "negate" : false
-                  },
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "dstIps" : {
+                          "class" : "org.batfish.datamodel.UniverseIpSpace"
+                        },
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched destination address CIDR IP 0.0.0.0/0"
+                          }
+                        ]
+                      }
+                    }
+                  ],
                   "traceElement" : {
                     "fragments" : [
                       {
                         "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched destination address CIDR IP 0.0.0.0/0"
+                        "text" : "Matched rule with no description"
                       }
                     ]
                   }
@@ -119,7 +132,7 @@
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with no description"
+                      "text" : "Matched line sg-3dfb3140 - default [egress] 0"
                     }
                   ]
                 }
@@ -151,22 +164,35 @@
                 "class" : "org.batfish.datamodel.ExprAclLine",
                 "action" : "PERMIT",
                 "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.OrMatchExpr",
-                  "disjuncts" : [
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
                     {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "negate" : false,
-                        "srcIps" : {
-                          "class" : "org.batfish.datamodel.IpIpSpace",
-                          "ip" : "192.168.1.3"
+                      "class" : "org.batfish.datamodel.acl.OrMatchExpr",
+                      "disjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "negate" : false,
+                            "srcIps" : {
+                              "class" : "org.batfish.datamodel.IpIpSpace",
+                              "ip" : "192.168.1.3"
+                            }
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched private IP of RDS database test-rds"
+                              }
+                            ]
+                          }
                         }
-                      },
+                      ],
                       "traceElement" : {
                         "fragments" : [
                           {
                             "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched private IP of RDS database test-rds"
+                            "text" : "Matched source address Security Group default"
                           }
                         ]
                       }
@@ -176,7 +202,7 @@
                     "fragments" : [
                       {
                         "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched source address Security Group default"
+                        "text" : "Matched rule with no description"
                       }
                     ]
                   }
@@ -186,7 +212,7 @@
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with no description"
+                      "text" : "Matched line sg-3dfb3140 - default [ingress] 0"
                     }
                   ]
                 }
@@ -318,18 +344,31 @@
                 "class" : "org.batfish.datamodel.ExprAclLine",
                 "action" : "PERMIT",
                 "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "dstIps" : {
-                      "class" : "org.batfish.datamodel.UniverseIpSpace"
-                    },
-                    "negate" : false
-                  },
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "dstIps" : {
+                          "class" : "org.batfish.datamodel.UniverseIpSpace"
+                        },
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched destination address CIDR IP 0.0.0.0/0"
+                          }
+                        ]
+                      }
+                    }
+                  ],
                   "traceElement" : {
                     "fragments" : [
                       {
                         "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched destination address CIDR IP 0.0.0.0/0"
+                        "text" : "Matched rule with no description"
                       }
                     ]
                   }
@@ -339,7 +378,7 @@
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with no description"
+                      "text" : "Matched line sg-3dfb3140 - default [egress] 0"
                     }
                   ]
                 }
@@ -371,22 +410,35 @@
                 "class" : "org.batfish.datamodel.ExprAclLine",
                 "action" : "PERMIT",
                 "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.OrMatchExpr",
-                  "disjuncts" : [
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
                     {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "negate" : false,
-                        "srcIps" : {
-                          "class" : "org.batfish.datamodel.IpIpSpace",
-                          "ip" : "192.168.1.3"
+                      "class" : "org.batfish.datamodel.acl.OrMatchExpr",
+                      "disjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "negate" : false,
+                            "srcIps" : {
+                              "class" : "org.batfish.datamodel.IpIpSpace",
+                              "ip" : "192.168.1.3"
+                            }
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched private IP of RDS database test-rds"
+                              }
+                            ]
+                          }
                         }
-                      },
+                      ],
                       "traceElement" : {
                         "fragments" : [
                           {
                             "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched private IP of RDS database test-rds"
+                            "text" : "Matched source address Security Group default"
                           }
                         ]
                       }
@@ -396,7 +448,7 @@
                     "fragments" : [
                       {
                         "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched source address Security Group default"
+                        "text" : "Matched rule with no description"
                       }
                     ]
                   }
@@ -406,7 +458,7 @@
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with no description"
+                      "text" : "Matched line sg-3dfb3140 - default [ingress] 0"
                     }
                   ]
                 }
@@ -39942,18 +39994,31 @@
                 "class" : "org.batfish.datamodel.ExprAclLine",
                 "action" : "PERMIT",
                 "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                  "headerSpace" : {
-                    "dstIps" : {
-                      "class" : "org.batfish.datamodel.UniverseIpSpace"
-                    },
-                    "negate" : false
-                  },
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                      "headerSpace" : {
+                        "dstIps" : {
+                          "class" : "org.batfish.datamodel.UniverseIpSpace"
+                        },
+                        "negate" : false
+                      },
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched destination address CIDR IP 0.0.0.0/0"
+                          }
+                        ]
+                      }
+                    }
+                  ],
                   "traceElement" : {
                     "fragments" : [
                       {
                         "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                        "text" : "Matched destination address CIDR IP 0.0.0.0/0"
+                        "text" : "Matched rule with no description"
                       }
                     ]
                   }
@@ -39963,7 +40028,7 @@
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with no description"
+                      "text" : "Matched line sg-55510831 - default [egress] 0"
                     }
                   ]
                 }
@@ -39995,56 +40060,329 @@
                 "class" : "org.batfish.datamodel.ExprAclLine",
                 "action" : "PERMIT",
                 "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
-                  "conjuncts" : [
+                  "class" : "org.batfish.datamodel.acl.OrMatchExpr",
+                  "disjuncts" : [
                     {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "ipProtocols" : [
-                          "TCP"
-                        ],
-                        "negate" : false
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched protocol TCP"
+                      "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "ipProtocols" : [
+                              "TCP"
+                            ],
+                            "negate" : false
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched protocol TCP"
+                              }
+                            ]
                           }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "dstPorts" : [
-                          "3306-3306"
-                        ],
-                        "negate" : false
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched destination port 3306"
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "dstPorts" : [
+                              "3306-3306"
+                            ],
+                            "negate" : false
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched destination port 3306"
+                              }
+                            ]
                           }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "negate" : false,
-                        "srcIps" : {
-                          "class" : "org.batfish.datamodel.PrefixIpSpace",
-                          "prefix" : "10.193.0.0/16"
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "negate" : false,
+                            "srcIps" : {
+                              "class" : "org.batfish.datamodel.PrefixIpSpace",
+                              "prefix" : "10.193.0.0/16"
+                            }
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched source address CIDR IP 10.193.0.0/16"
+                              }
+                            ]
+                          }
                         }
-                      },
+                      ],
                       "traceElement" : {
                         "fragments" : [
                           {
                             "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched source address CIDR IP 10.193.0.0/16"
+                            "text" : "Matched rule with description Internal traffic"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "ipProtocols" : [
+                              "TCP"
+                            ],
+                            "negate" : false
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched protocol TCP"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "dstPorts" : [
+                              "3306-3306"
+                            ],
+                            "negate" : false
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched destination port 3306"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "negate" : false,
+                            "srcIps" : {
+                              "class" : "org.batfish.datamodel.IpIpSpace",
+                              "ip" : "107.170.243.58"
+                            }
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched source address CIDR IP 107.170.243.58/32"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched rule with description inentionet-test"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "ipProtocols" : [
+                              "TCP"
+                            ],
+                            "negate" : false
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched protocol TCP"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "dstPorts" : [
+                              "3306-3306"
+                            ],
+                            "negate" : false
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched destination port 3306"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "negate" : false,
+                            "srcIps" : {
+                              "class" : "org.batfish.datamodel.IpIpSpace",
+                              "ip" : "104.236.156.171"
+                            }
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched source address CIDR IP 104.236.156.171/32"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched rule with description intentionet-dev"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "ipProtocols" : [
+                              "TCP"
+                            ],
+                            "negate" : false
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched protocol TCP"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "dstPorts" : [
+                              "3306-3306"
+                            ],
+                            "negate" : false
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched destination port 3306"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "negate" : false,
+                            "srcIps" : {
+                              "class" : "org.batfish.datamodel.IpIpSpace",
+                              "ip" : "162.243.144.192"
+                            }
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched source address CIDR IP 162.243.144.192/32"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched rule with description intentionet-web"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                      "conjuncts" : [
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "ipProtocols" : [
+                              "TCP"
+                            ],
+                            "negate" : false
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched protocol TCP"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "dstPorts" : [
+                              "3306-3306"
+                            ],
+                            "negate" : false
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched destination port 3306"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
+                          "headerSpace" : {
+                            "negate" : false,
+                            "srcIps" : {
+                              "class" : "org.batfish.datamodel.IpIpSpace",
+                              "ip" : "67.170.86.87"
+                            }
+                          },
+                          "traceElement" : {
+                            "fragments" : [
+                              {
+                                "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                                "text" : "Matched source address CIDR IP 67.170.86.87/32"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "traceElement" : {
+                        "fragments" : [
+                          {
+                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                            "text" : "Matched rule with description surf"
                           }
                         ]
                       }
@@ -40056,287 +40394,7 @@
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with description Internal traffic"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "PERMIT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "ipProtocols" : [
-                          "TCP"
-                        ],
-                        "negate" : false
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched protocol TCP"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "dstPorts" : [
-                          "3306-3306"
-                        ],
-                        "negate" : false
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched destination port 3306"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "negate" : false,
-                        "srcIps" : {
-                          "class" : "org.batfish.datamodel.IpIpSpace",
-                          "ip" : "107.170.243.58"
-                        }
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched source address CIDR IP 107.170.243.58/32"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                "name" : "sg-55510831 - default [ingress] 0",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with description inentionet-test"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "PERMIT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "ipProtocols" : [
-                          "TCP"
-                        ],
-                        "negate" : false
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched protocol TCP"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "dstPorts" : [
-                          "3306-3306"
-                        ],
-                        "negate" : false
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched destination port 3306"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "negate" : false,
-                        "srcIps" : {
-                          "class" : "org.batfish.datamodel.IpIpSpace",
-                          "ip" : "104.236.156.171"
-                        }
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched source address CIDR IP 104.236.156.171/32"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                "name" : "sg-55510831 - default [ingress] 0",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with description intentionet-dev"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "PERMIT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "ipProtocols" : [
-                          "TCP"
-                        ],
-                        "negate" : false
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched protocol TCP"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "dstPorts" : [
-                          "3306-3306"
-                        ],
-                        "negate" : false
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched destination port 3306"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "negate" : false,
-                        "srcIps" : {
-                          "class" : "org.batfish.datamodel.IpIpSpace",
-                          "ip" : "162.243.144.192"
-                        }
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched source address CIDR IP 162.243.144.192/32"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                "name" : "sg-55510831 - default [ingress] 0",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with description intentionet-web"
-                    }
-                  ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.ExprAclLine",
-                "action" : "PERMIT",
-                "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "ipProtocols" : [
-                          "TCP"
-                        ],
-                        "negate" : false
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched protocol TCP"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "dstPorts" : [
-                          "3306-3306"
-                        ],
-                        "negate" : false
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched destination port 3306"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
-                      "headerSpace" : {
-                        "negate" : false,
-                        "srcIps" : {
-                          "class" : "org.batfish.datamodel.IpIpSpace",
-                          "ip" : "67.170.86.87"
-                        }
-                      },
-                      "traceElement" : {
-                        "fragments" : [
-                          {
-                            "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                            "text" : "Matched source address CIDR IP 67.170.86.87/32"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                "name" : "sg-55510831 - default [ingress] 0",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched rule with description surf"
+                      "text" : "Matched line sg-55510831 - default [ingress] 0"
                     }
                   ]
                 }

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -127,15 +127,7 @@
                     ]
                   }
                 },
-                "name" : "sg-3dfb3140 - default [egress]",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line sg-3dfb3140 - default [egress]"
-                    }
-                  ]
-                }
+                "name" : "sg-3dfb3140 - default [egress]"
               }
             ],
             "name" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
@@ -207,15 +199,7 @@
                     ]
                   }
                 },
-                "name" : "sg-3dfb3140 - default [ingress]",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line sg-3dfb3140 - default [ingress]"
-                    }
-                  ]
-                }
+                "name" : "sg-3dfb3140 - default [ingress]"
               }
             ],
             "name" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
@@ -373,15 +357,7 @@
                     ]
                   }
                 },
-                "name" : "sg-3dfb3140 - default [egress]",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line sg-3dfb3140 - default [egress]"
-                    }
-                  ]
-                }
+                "name" : "sg-3dfb3140 - default [egress]"
               }
             ],
             "name" : "~EGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
@@ -453,15 +429,7 @@
                     ]
                   }
                 },
-                "name" : "sg-3dfb3140 - default [ingress]",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line sg-3dfb3140 - default [ingress]"
-                    }
-                  ]
-                }
+                "name" : "sg-3dfb3140 - default [ingress]"
               }
             ],
             "name" : "~INGRESS~SECURITY-GROUP~default~sg-3dfb3140~"
@@ -40023,15 +39991,7 @@
                     ]
                   }
                 },
-                "name" : "sg-55510831 - default [egress]",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line sg-55510831 - default [egress]"
-                    }
-                  ]
-                }
+                "name" : "sg-55510831 - default [egress]"
               }
             ],
             "name" : "~EGRESS~SECURITY-GROUP~default~sg-55510831~"
@@ -40389,15 +40349,7 @@
                     }
                   ]
                 },
-                "name" : "sg-55510831 - default [ingress]",
-                "traceElement" : {
-                  "fragments" : [
-                    {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line sg-55510831 - default [ingress]"
-                    }
-                  ]
-                }
+                "name" : "sg-55510831 - default [ingress]"
               }
             ],
             "name" : "~INGRESS~SECURITY-GROUP~default~sg-55510831~"

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -127,12 +127,12 @@
                     ]
                   }
                 },
-                "name" : "sg-3dfb3140 - default [egress] 0",
+                "name" : "sg-3dfb3140 - default [egress]",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line sg-3dfb3140 - default [egress] 0"
+                      "text" : "Matched line sg-3dfb3140 - default [egress]"
                     }
                   ]
                 }
@@ -207,12 +207,12 @@
                     ]
                   }
                 },
-                "name" : "sg-3dfb3140 - default [ingress] 0",
+                "name" : "sg-3dfb3140 - default [ingress]",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line sg-3dfb3140 - default [ingress] 0"
+                      "text" : "Matched line sg-3dfb3140 - default [ingress]"
                     }
                   ]
                 }
@@ -373,12 +373,12 @@
                     ]
                   }
                 },
-                "name" : "sg-3dfb3140 - default [egress] 0",
+                "name" : "sg-3dfb3140 - default [egress]",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line sg-3dfb3140 - default [egress] 0"
+                      "text" : "Matched line sg-3dfb3140 - default [egress]"
                     }
                   ]
                 }
@@ -453,12 +453,12 @@
                     ]
                   }
                 },
-                "name" : "sg-3dfb3140 - default [ingress] 0",
+                "name" : "sg-3dfb3140 - default [ingress]",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line sg-3dfb3140 - default [ingress] 0"
+                      "text" : "Matched line sg-3dfb3140 - default [ingress]"
                     }
                   ]
                 }
@@ -40023,12 +40023,12 @@
                     ]
                   }
                 },
-                "name" : "sg-55510831 - default [egress] 0",
+                "name" : "sg-55510831 - default [egress]",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line sg-55510831 - default [egress] 0"
+                      "text" : "Matched line sg-55510831 - default [egress]"
                     }
                   ]
                 }
@@ -40389,12 +40389,12 @@
                     }
                   ]
                 },
-                "name" : "sg-55510831 - default [ingress] 0",
+                "name" : "sg-55510831 - default [ingress]",
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched line sg-55510831 - default [ingress] 0"
+                      "text" : "Matched line sg-55510831 - default [ingress]"
                     }
                   ]
                 }


### PR DESCRIPTION
ACLs representing a security group's ingress permissions has 1 line per ingress rule; same idea for egress permissions.