### PR TITLE
NX-OS: route-map match as-number

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/LongSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/LongSpace.java
@@ -99,6 +99,10 @@ public final class LongSpace extends NumberSpace<Long, LongSpace, LongSpace.Buil
     return builder().including(rangeSet).build();
   }
 
+  public static @Nonnull LongSpace parse(String s) {
+    return create(s);
+  }
+
   /** Create a new {@link LongSpace} containing the union of the given {@link Range ranges}. */
   public static @Nonnull LongSpace unionOf(Iterable<Range<Long>> ranges) {
     return builder().includingAllRanges(ranges).build();

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
@@ -327,6 +327,11 @@ ARP
   'arp'
 ;
 
+AS_NUMBER
+:
+  'as-number'
+;
+
 AS_OVERRIDE
 :
   'as-override'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_common.g4
@@ -10,6 +10,30 @@ bgp_asn
   | high = uint16 PERIOD low = uint16
 ;
 
+// Like bgp_asn, but when it cannot be a 4-byte ASN a dotted ASN
+bgp_asn_simple
+:
+  // 1-4294967295
+  uint32
+;
+
+bgp_asn_range
+:
+  intervals += bgp_asn_interval
+  (
+    COMMA intervals += bgp_asn_interval
+  )*
+;
+
+bgp_asn_interval
+:
+  low = bgp_asn_simple
+  (
+    DASH high = bgp_asn_simple
+  )?
+;
+
+
 // Shared NX-OS syntax for route-target, redistribution, route leak, etc.
 both_export_import
 :

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_route_map.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_route_map.g4
@@ -48,7 +48,8 @@ rm_match
 :
   MATCH
   (
-    rmm_as_path
+    rmm_as_number
+    | rmm_as_path
     | rmm_community
     | rmm_interface
     | rmm_ip
@@ -59,6 +60,11 @@ rm_match
     | rmm_tag
     | rmm_vlan
   )
+;
+
+rmm_as_number
+:
+  AS_NUMBER numbers = bgp_asn_range NEWLINE
 ;
 
 rmm_as_path

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -6573,6 +6573,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     }
     return value;
   }
+
   /**
    * Helper for NX-OS integer space specifiers to convert to IntegerSpace if valid, or else {@link
    * Optional#empty}.

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -2761,6 +2761,12 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
         new RouteMapMatchVisitor<BoolExpr>() {
 
           @Override
+          public BoolExpr visitRouteMapMatchAsNumber(RouteMapMatchAsNumber routeMapMatchAsNumber) {
+            // Not applicable to PBR.
+            return null;
+          }
+
+          @Override
           public BoolExpr visitRouteMapMatchAsPath(RouteMapMatchAsPath routeMapMatchAsPath) {
             // Not applicable to PBR
             return null;
@@ -2963,6 +2969,14 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   private @Nonnull BooleanExpr toBooleanExpr(RouteMapMatch match) {
     return match.accept(
         new RouteMapMatchVisitor<BooleanExpr>() {
+
+          @Override
+          public BooleanExpr visitRouteMapMatchAsNumber(
+              RouteMapMatchAsNumber routeMapMatchAsNumber) {
+            // This clause is only used to identify a set of BGP peers to establish a session with,
+            // is ignored in "normal" route-map use.
+            return BooleanExprs.TRUE;
+          }
 
           @Override
           public BooleanExpr visitRouteMapMatchAsPath(RouteMapMatchAsPath routeMapMatchAsPath) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/RouteMapEntry.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/RouteMapEntry.java
@@ -12,6 +12,7 @@ public final class RouteMapEntry implements Serializable {
 
   private @Nonnull LineAction _action;
   private @Nullable Integer _continue;
+  private @Nullable RouteMapMatchAsNumber _matchAsNumber;
   private @Nullable RouteMapMatchAsPath _matchAsPath;
   private @Nullable RouteMapMatchCommunity _matchCommunity;
   private @Nullable RouteMapMatchInterface _matchInterface;
@@ -47,6 +48,10 @@ public final class RouteMapEntry implements Serializable {
     return _continue;
   }
 
+  public @Nullable RouteMapMatchAsNumber getMatchAsNumber() {
+    return _matchAsNumber;
+  }
+
   public @Nullable RouteMapMatchAsPath getMatchAsPath() {
     return _matchAsPath;
   }
@@ -57,6 +62,7 @@ public final class RouteMapEntry implements Serializable {
 
   public @Nonnull Stream<RouteMapMatch> getMatches() {
     return Stream.of(
+            _matchAsNumber,
             _matchAsPath,
             _matchCommunity,
             _matchInterface,
@@ -174,6 +180,10 @@ public final class RouteMapEntry implements Serializable {
 
   public void setContinue(@Nullable Integer continueNumber) {
     _continue = continueNumber;
+  }
+
+  public void setMatchAsNumber(@Nullable RouteMapMatchAsNumber matchAsNumber) {
+    _matchAsNumber = matchAsNumber;
   }
 
   public void setMatchAsPath(@Nullable RouteMapMatchAsPath matchAsPath) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/RouteMapMatchAsNumber.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/RouteMapMatchAsNumber.java
@@ -1,0 +1,30 @@
+package org.batfish.representation.cisco_nxos;
+
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.LongSpace;
+
+/**
+ * A {@link RouteMapMatch} that "provide a list of AS numbers or an AS-path access list using a
+ * regular expression. BGP uses this match criteria to determine which BGP peers to create a BGP
+ * session with"
+ * (https://www.cisco.com/c/m/en_us/techdoc/dc/reference/cli/nxos/commands/bgp/match-as-number.html)
+ *
+ * <p>AFAICT this does not have any effect when a route-map is used for import/export policy, etc.
+ */
+public final class RouteMapMatchAsNumber implements RouteMapMatch {
+
+  private final @Nonnull LongSpace _asns;
+
+  public RouteMapMatchAsNumber(LongSpace asns) {
+    _asns = asns;
+  }
+
+  @Override
+  public <T> T accept(RouteMapMatchVisitor<T> visitor) {
+    return visitor.visitRouteMapMatchAsNumber(this);
+  }
+
+  public @Nonnull LongSpace getAsns() {
+    return _asns;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/RouteMapMatchVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/RouteMapMatchVisitor.java
@@ -3,6 +3,8 @@ package org.batfish.representation.cisco_nxos;
 /** A visitor of {@link RouteMapMatch}. */
 public interface RouteMapMatchVisitor<T> {
 
+  T visitRouteMapMatchAsNumber(RouteMapMatchAsNumber routeMapMatchAsNumber);
+
   T visitRouteMapMatchAsPath(RouteMapMatchAsPath routeMapMatchAsPath);
 
   T visitRouteMapMatchCommunity(RouteMapMatchCommunity routeMapMatchCommunity);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -178,6 +178,7 @@ import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LocalRoute;
+import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.OspfExternalRoute;
@@ -313,6 +314,7 @@ import org.batfish.representation.cisco_nxos.RedistributionPolicy;
 import org.batfish.representation.cisco_nxos.RouteDistinguisherOrAuto;
 import org.batfish.representation.cisco_nxos.RouteMap;
 import org.batfish.representation.cisco_nxos.RouteMapEntry;
+import org.batfish.representation.cisco_nxos.RouteMapMatchAsNumber;
 import org.batfish.representation.cisco_nxos.RouteMapMatchAsPath;
 import org.batfish.representation.cisco_nxos.RouteMapMatchCommunity;
 import org.batfish.representation.cisco_nxos.RouteMapMatchInterface;
@@ -5794,6 +5796,7 @@ public final class CiscoNxosGrammarTest {
             "empty_deny",
             "empty_permit",
             "empty_pbr_statistics",
+            "match_as_number",
             "match_as_path",
             "match_community_standard",
             "match_community_expanded",
@@ -5876,6 +5879,11 @@ public final class CiscoNxosGrammarTest {
     }
 
     // matches
+    {
+      RoutingPolicy rp = c.getRoutingPolicies().get("match_as_number");
+      // TODO
+      assertThat(rp, notNullValue());
+    }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("match_as_path");
       assertRoutingPolicyDeniesRoute(rp, base);
@@ -6278,6 +6286,7 @@ public final class CiscoNxosGrammarTest {
             "empty_deny",
             "empty_permit",
             "empty_pbr_statistics",
+            "match_as_number",
             "match_as_path",
             "match_community_standard",
             "match_community_expanded",
@@ -6347,6 +6356,23 @@ public final class CiscoNxosGrammarTest {
       RouteMap rm = vc.getRouteMaps().get("empty_pbr_statistics");
       assertThat(rm.getEntries(), anEmptyMap());
       assertTrue(rm.getPbrStatistics());
+    }
+    {
+      RouteMap rm = vc.getRouteMaps().get("match_as_number");
+      assertThat(rm.getEntries().keySet(), contains(10));
+      RouteMapEntry entry = getOnlyElement(rm.getEntries().values());
+      assertThat(entry.getAction(), equalTo(LineAction.PERMIT));
+      assertThat(entry.getSequence(), equalTo(10));
+      RouteMapMatchAsNumber match = entry.getMatchAsNumber();
+      assertThat(entry.getMatches().collect(onlyElement()), equalTo(match));
+      assertThat(
+          match.getAsns(),
+          equalTo(
+              LongSpace.builder()
+                  .including(64496L)
+                  .including(Range.closed(64498L, 64510L))
+                  .including(3000000000L)
+                  .build()));
     }
     {
       RouteMap rm = vc.getRouteMaps().get("match_as_path");

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -5881,8 +5881,7 @@ public final class CiscoNxosGrammarTest {
     // matches
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("match_as_number");
-      // TODO
-      assertThat(rp, notNullValue());
+      assertRoutingPolicyPermitsRoute(rp, base);
     }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("match_as_path");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_route_map
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_route_map
@@ -39,6 +39,9 @@ route-map empty_permit permit 10
 route-map empty_pbr_statistics pbr-statistics
 
 !!! Simple matches
+route-map match_as_number permit 10
+  match as-number 64496, 64498-64510, 3000000000
+
 route-map match_as_path permit 10
   match as-path as_path_access_list1
 


### PR DESCRIPTION
https://www.cisco.com/c/m/en_us/techdoc/dc/reference/cli/nxos/commands/bgp/match-as-number.html

This is used

>  to provide a list of AS numbers or an AS-path access list using a regular
>  expression. BGP uses this match criteria to determine which BGP peers to
>  create a BGP session with.