### PR TITLE
FileBasedStorage: Only match files in directory

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -16,6 +16,7 @@ import com.google.common.io.ByteStreams;
 import com.google.common.io.Closer;
 import com.google.errorprone.annotations.MustBeClosed;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -264,6 +265,11 @@ public class FileBasedStorage implements StorageProvider {
   @VisibleForTesting
   static final String ISP_CONFIGURATION_KEY =
       String.format("%s/%s", RELPATH_BATFISH_CONFIGS_DIR, RELPATH_ISP_CONFIG_FILE);
+
+  @VisibleForTesting
+  static boolean keyInDir(String key, String dirName) {
+    return key.startsWith(dirName.concat(File.separator));
+  }
 
   @Override
   public @Nullable IspConfiguration loadIspConfiguration(NetworkId network, SnapshotId snapshot) {
@@ -1856,7 +1862,7 @@ public class FileBasedStorage implements StorageProvider {
   public Stream<String> listInputHostConfigurationsKeys(NetworkSnapshot snapshot)
       throws IOException {
     return listSnapshotInputObjectKeys(snapshot)
-        .filter(key -> key.startsWith(BfConsts.RELPATH_HOST_CONFIGS_DIR));
+        .filter(key -> keyInDir(key, BfConsts.RELPATH_HOST_CONFIGS_DIR));
   }
 
   @MustBeClosed
@@ -1865,7 +1871,7 @@ public class FileBasedStorage implements StorageProvider {
   public Stream<String> listInputNetworkConfigurationsKeys(NetworkSnapshot snapshot)
       throws IOException {
     return listSnapshotInputObjectKeys(snapshot)
-        .filter(key -> key.startsWith(BfConsts.RELPATH_CONFIGURATIONS_DIR));
+        .filter(key -> keyInDir(key, BfConsts.RELPATH_CONFIGURATIONS_DIR));
   }
 
   @MustBeClosed
@@ -1873,7 +1879,7 @@ public class FileBasedStorage implements StorageProvider {
   @Override
   public Stream<String> listInputAwsMultiAccountKeys(NetworkSnapshot snapshot) throws IOException {
     return listSnapshotInputObjectKeys(snapshot)
-        .filter(key -> key.startsWith(RELPATH_AWS_ACCOUNTS_DIR));
+        .filter(key -> keyInDir(key, RELPATH_AWS_ACCOUNTS_DIR));
   }
 
   @MustBeClosed
@@ -1881,7 +1887,7 @@ public class FileBasedStorage implements StorageProvider {
   @Override
   public Stream<String> listInputAwsSingleAccountKeys(NetworkSnapshot snapshot) throws IOException {
     return listSnapshotInputObjectKeys(snapshot)
-        .filter(key -> key.startsWith(BfConsts.RELPATH_AWS_CONFIGS_DIR));
+        .filter(key -> keyInDir(key, BfConsts.RELPATH_AWS_CONFIGS_DIR));
   }
 
   private @Nonnull Path getParseVendorConfigurationAnswerElementPath(NetworkSnapshot snapshot) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/storage/FileBasedStorage.java
@@ -16,7 +16,6 @@ import com.google.common.io.ByteStreams;
 import com.google.common.io.Closer;
 import com.google.errorprone.annotations.MustBeClosed;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -268,7 +267,7 @@ public class FileBasedStorage implements StorageProvider {
 
   @VisibleForTesting
   static boolean keyInDir(String key, String dirName) {
-    return key.startsWith(dirName.concat(File.separator));
+    return key.startsWith(dirName + "/");
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/storage/FileBasedStorageTest.java
@@ -4,6 +4,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.batfish.storage.FileBasedStorage.GC_SKEW_ALLOWANCE;
 import static org.batfish.storage.FileBasedStorage.ISP_CONFIGURATION_KEY;
 import static org.batfish.storage.FileBasedStorage.getWorkLogPath;
+import static org.batfish.storage.FileBasedStorage.keyInDir;
 import static org.batfish.storage.FileBasedStorage.objectKeyToRelativePath;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -804,5 +805,11 @@ public final class FileBasedStorageTest {
         _storage.listSnapshotInputObjectKeys(new NetworkSnapshot(networkId, snapshotId))) {
       assertThat(keys.collect(ImmutableSet.toImmutableSet()), equalTo(ImmutableSet.of("k1", "k2")));
     }
+  }
+
+  @Test
+  public void testKeyInDir() {
+    assertTrue(keyInDir("configs/rtr.cfg", "configs"));
+    assertFalse(keyInDir("configs.ignore", "configs"));
   }
 }


### PR DESCRIPTION
The code was matching not only files in the `configs` directory but also other files that started with `configs`. 