### PR TITLE
BDP: Split VR initialization into two steps

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -162,7 +162,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   /** Delta builder for routes that must be propagated to the main RIB */
   @Nonnull private RibDelta.Builder<BgpRoute<?, ?>> _changeSet = RibDelta.builder();
 
-  /* Hacky way to not re-init the process across topology computations. Not a permanent solution */
+  /* Indicates whether this BGP process has been initialized. */
   private boolean _initialized = false;
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -122,6 +122,20 @@ class IncrementalBdpEngine {
       // TODO: eventually, IGP needs to be part of fixed-point below, because tunnels.
       computeIgpDataPlane(nodes, initialTopologyContext, answerElement);
 
+      LOGGER.info("Initialize virtual routers before topology fixed point");
+      Span initializationSpan =
+          GlobalTracer.get().buildSpan("Initialize virtual routers for iBDP-external").start();
+      try (Scope innerScope = GlobalTracer.get().scopeManager().activate(initializationSpan)) {
+        assert innerScope != null; // avoid unused warning
+        nodes
+            .values()
+            .parallelStream()
+            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .forEach(VirtualRouter::initForEgpComputationBeforeTopologyLoop);
+      } finally {
+        initializationSpan.finish();
+      }
+
       /*
        * Perform a fixed-point computation.
        */
@@ -720,16 +734,18 @@ class IncrementalBdpEngine {
       /*
        * Initialize all routers and their message queues (can be done as parallel as possible)
        */
-      LOGGER.info("Initialize virtual routers");
+      LOGGER.info("Initialize virtual routers with updated topologies");
       Span initializationSpan =
-          GlobalTracer.get().buildSpan("Initialize virtual routers for iBDP-external").start();
+          GlobalTracer.get()
+              .buildSpan("Initialize virtual routers with updated topologies")
+              .start();
       try (Scope innerScope = GlobalTracer.get().scopeManager().activate(initializationSpan)) {
         assert innerScope != null; // avoid unused warning
         nodes
             .values()
             .parallelStream()
             .flatMap(n -> n.getVirtualRouters().values().stream())
-            .forEach(vr -> vr.initForEgpComputation(topologyContext));
+            .forEach(vr -> vr.initForEgpComputationWithNewTopology(topologyContext));
       } finally {
         initializationSpan.finish();
       }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -338,19 +338,26 @@ public class VirtualRouter implements Serializable {
   }
 
   /**
-   * Prepare for the EGP part of the computation
+   * Prepare for the EGP part of the computation. Handles updating routing processes given new
+   * topology information.
    *
    * @param topologyContext The various network topologies
    */
-  void initForEgpComputation(TopologyContext topologyContext) {
+  void initForEgpComputationWithNewTopology(TopologyContext topologyContext) {
     initQueuesAndDeltaBuilders(topologyContext);
-    // Handle BGP process state
-    if (_bgpRoutingProcess != null && !_bgpRoutingProcess.isInitialized()) {
-      _bgpRoutingProcess.initialize(_node);
-    }
     if (_bgpRoutingProcess != null) {
       // If the process exists, update the topology
       _bgpRoutingProcess.updateTopology(topologyContext.getBgpTopology());
+    }
+  }
+
+  /**
+   * Initialize for EGP computation. Handles any state that does <b>not</b> depend on neighbor
+   * relationships (i.e., purely local).
+   */
+  void initForEgpComputationBeforeTopologyLoop() {
+    if (_bgpRoutingProcess != null && !_bgpRoutingProcess.isInitialized()) {
+      _bgpRoutingProcess.initialize(_node);
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -576,7 +576,7 @@ public class VirtualRouterTest {
     vrs.values()
         .forEach(
             vr ->
-                vr.initForEgpComputation(
+                vr.initForEgpComputationWithNewTopology(
                     TopologyContext.builder()
                         .setBgpTopology(bgpTopology)
                         .setEigrpTopology(eigrpTopology)
@@ -601,7 +601,7 @@ public class VirtualRouterTest {
     for (Node n : nodes.values()) {
       n.getVirtualRouters()
           .get(DEFAULT_VRF_NAME)
-          .initForEgpComputation(
+          .initForEgpComputationWithNewTopology(
               TopologyContext.builder()
                   .setBgpTopology(bgpTopology2)
                   .setEigrpTopology(eigrpTopology)


### PR DESCRIPTION
two versions: 
1. global init, local to the VR
2. topology-dependent init, called each time new topologies are computed.