### PR TITLE
Rib: factor out a read-only interface.

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRib.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRib.java
@@ -1,9 +1,6 @@
 package org.batfish.datamodel;
 
-import java.io.Serializable;
-import java.util.Set;
-
-public interface GenericRib<R extends AbstractRouteDecorator> extends Serializable {
+public interface GenericRib<R extends AbstractRouteDecorator> extends GenericRibReadOnly<R> {
 
   /**
    * Compare the preferability of one route with anther
@@ -14,39 +11,6 @@ public interface GenericRib<R extends AbstractRouteDecorator> extends Serializab
    *     preferable (i.e. for multipath routing); 1 if lhs route is strictly more preferred than rhs
    */
   int comparePreference(R lhs, R rhs);
-
-  /** Return set of {@link AbstractRoute abstract routes} this RIB contains. */
-  Set<AbstractRoute> getRoutes();
-
-  /** Return set of {@link R typed routes} this RIB contains. */
-  Set<R> getTypedRoutes();
-
-  /**
-   * Execute the longest prefix match for a given IP address.
-   *
-   * <p><strong>Note</strong>: this function returns only forwarding routes, aka, routes where
-   * {@link AbstractRoute#getNonForwarding()} returns false.
-   *
-   * @param address the IP address to match
-   * @return a set of routes with the maximum allowable prefix length that match the {@code address}
-   */
-  Set<R> longestPrefixMatch(Ip address);
-
-  /**
-   * Execute a constrained longest prefix match for a given IP address.
-   *
-   * <p><strong>Note</strong>: this function returns only forwarding routes, aka, routes where
-   * {@link AbstractRoute#getNonForwarding()} returns false.
-   *
-   * <p>Most callers should use {@link #longestPrefixMatch(Ip)}; this function may be used when the
-   * longest prefix matches are unsatisfactory and less specific routes are required.
-   *
-   * @param address the IP address to match
-   * @param maxPrefixLength the maximum prefix length allowed (i.e., do not match more specific
-   *     routes). This is a less than or equal constraint.
-   * @return a set of routes that match the {@code address} given the constraint.
-   */
-  Set<R> longestPrefixMatch(Ip address, int maxPrefixLength);
 
   boolean mergeRoute(R route);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRib.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRib.java
@@ -3,14 +3,11 @@ package org.batfish.datamodel;
 public interface GenericRib<R extends AbstractRouteDecorator> extends GenericRibReadOnly<R> {
 
   /**
-   * Compare the preferability of one route with anther
+   * Add a route to this RIB.
    *
-   * @param lhs 1st route with which to compare preference
-   * @param rhs 2nd route with which to compare preference
-   * @return -1 if lhs route is less preferable than rhs; 0 if lhs route and rhs are equally
-   *     preferable (i.e. for multipath routing); 1 if lhs route is strictly more preferred than rhs
+   * @param route route to add
+   * @return true if the route was merged, or false if it was discarded (e.g., a better route
+   *     already exists)
    */
-  int comparePreference(R lhs, R rhs);
-
   boolean mergeRoute(R route);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRibReadOnly.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRibReadOnly.java
@@ -5,6 +5,9 @@ import java.util.Set;
 
 public interface GenericRibReadOnly<R extends AbstractRouteDecorator> extends Serializable {
 
+  /** Check whether a given route is present in the RIB */
+  boolean containsRoute(R route);
+
   /** Return set of {@link AbstractRoute abstract routes} this RIB contains. */
   Set<AbstractRoute> getRoutes();
 
@@ -37,4 +40,14 @@ public interface GenericRibReadOnly<R extends AbstractRouteDecorator> extends Se
    * @return a set of routes that match the {@code address} given the constraint.
    */
   Set<R> longestPrefixMatch(Ip address, int maxPrefixLength);
+
+  /**
+   * Compare the preferability of one route with anther
+   *
+   * @param lhs 1st route with which to compare preference
+   * @param rhs 2nd route with which to compare preference
+   * @return -1 if lhs route is less preferable than rhs; 0 if lhs route and rhs are equally
+   *     preferable (i.e. for multipath routing); 1 if lhs route is strictly more preferred than rhs
+   */
+  int comparePreference(R lhs, R rhs);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRibReadOnly.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRibReadOnly.java
@@ -1,0 +1,40 @@
+package org.batfish.datamodel;
+
+import java.io.Serializable;
+import java.util.Set;
+
+public interface GenericRibReadOnly<R extends AbstractRouteDecorator> extends Serializable {
+
+  /** Return set of {@link AbstractRoute abstract routes} this RIB contains. */
+  Set<AbstractRoute> getRoutes();
+
+  /** Return set of {@link R typed routes} this RIB contains. */
+  Set<R> getTypedRoutes();
+
+  /**
+   * Execute the longest prefix match for a given IP address.
+   *
+   * <p><strong>Note</strong>: this function returns only forwarding routes, aka, routes where
+   * {@link AbstractRoute#getNonForwarding()} returns false.
+   *
+   * @param address the IP address to match
+   * @return a set of routes with the maximum allowable prefix length that match the {@code address}
+   */
+  Set<R> longestPrefixMatch(Ip address);
+
+  /**
+   * Execute a constrained longest prefix match for a given IP address.
+   *
+   * <p><strong>Note</strong>: this function returns only forwarding routes, aka, routes where
+   * {@link AbstractRoute#getNonForwarding()} returns false.
+   *
+   * <p>Most callers should use {@link #longestPrefixMatch(Ip)}; this function may be used when the
+   * longest prefix matches are unsatisfactory and less specific routes are required.
+   *
+   * @param address the IP address to match
+   * @param maxPrefixLength the maximum prefix length allowed (i.e., do not match more specific
+   *     routes). This is a less than or equal constraint.
+   * @return a set of routes that match the {@code address} given the constraint.
+   */
+  Set<R> longestPrefixMatch(Ip address, int maxPrefixLength);
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
@@ -72,6 +72,11 @@ public class MockRib implements GenericRib<AnnotatedRoute<AbstractRoute>> {
   }
 
   @Override
+  public boolean containsRoute(AnnotatedRoute<AbstractRoute> route) {
+    return _routes.contains(route);
+  }
+
+  @Override
   public Set<AbstractRoute> getRoutes() {
     return getTypedRoutes().stream()
         .map(AbstractRouteDecorator::getAbstractRoute)

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -46,6 +46,7 @@ import org.batfish.datamodel.EvpnRoute;
 import org.batfish.datamodel.EvpnType3Route;
 import org.batfish.datamodel.EvpnType5Route;
 import org.batfish.datamodel.GeneratedRoute;
+import org.batfish.datamodel.GenericRibReadOnly;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.NetworkConfigurations;
@@ -85,7 +86,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   /** Name of our VRF */
   @Nonnull private final String _vrfName;
   /** Reference to the parent {@link VirtualRouter} main RIB (read-only). */
-  @Nonnull private final Rib _mainRib;
+  @Nonnull private final GenericRibReadOnly<AnnotatedRoute<AbstractRoute>> _mainRib;
   /** Current BGP topology */
   @Nonnull private BgpTopology _topology;
   /** Metadata about propagated prefixes to/from neighbors */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -125,6 +125,7 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
     _allRoutes = null;
   }
 
+  @Override
   public final boolean containsRoute(R route) {
     return _tree.containsRoute(route);
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -19,6 +19,7 @@ import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.AsSet;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpTieBreaker;
+import org.batfish.datamodel.GenericRibReadOnly;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.Prefix;
@@ -33,7 +34,7 @@ import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
 
   /** Main RIB to use for IGP cost estimation */
-  @Nullable protected final AnnotatedRib<AbstractRoute> _mainRib;
+  @Nullable protected final GenericRibReadOnly<AnnotatedRoute<AbstractRoute>> _mainRib;
   /** Tie breaker to use if all route attributes appear to be equal */
   @Nonnull protected final BgpTieBreaker _tieBreaker;
   /** Maximum number of paths to install. Unconstrained (infinite) if {@code null} */
@@ -57,7 +58,7 @@ public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
   protected boolean _clusterListAsIgpCost;
 
   protected BgpRib(
-      @Nullable Rib mainRib,
+      @Nullable GenericRibReadOnly<AnnotatedRoute<AbstractRoute>> mainRib,
       BgpTieBreaker tieBreaker,
       @Nullable Integer maxPaths,
       @Nullable MultipathEquivalentAsPathMatchMode multipathEquivalentAsPathMatchMode,

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
@@ -2,8 +2,11 @@ package org.batfish.dataplane.rib;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.BgpTieBreaker;
 import org.batfish.datamodel.Bgpv4Route;
+import org.batfish.datamodel.GenericRibReadOnly;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 
 /** BGPv4-specific RIB implementation */
@@ -11,7 +14,7 @@ import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
 
   public Bgpv4Rib(
-      @Nullable Rib mainRib,
+      @Nullable GenericRibReadOnly<AnnotatedRoute<AbstractRoute>> mainRib,
       BgpTieBreaker tieBreaker,
       @Nullable Integer maxPaths,
       @Nullable MultipathEquivalentAsPathMatchMode multipathEquivalentAsPathMatchMode,

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/EvpnRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/EvpnRib.java
@@ -2,8 +2,11 @@ package org.batfish.dataplane.rib;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.BgpTieBreaker;
 import org.batfish.datamodel.EvpnRoute;
+import org.batfish.datamodel.GenericRibReadOnly;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 
 /** RIB implementation for all types of EVPN routes */
@@ -11,7 +14,7 @@ import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 public final class EvpnRib<R extends EvpnRoute<?, ?>> extends BgpRib<R> {
 
   public EvpnRib(
-      @Nullable Rib mainRib,
+      @Nullable GenericRibReadOnly<AnnotatedRoute<AbstractRoute>> mainRib,
       BgpTieBreaker tieBreaker,
       @Nullable Integer maxPaths,
       @Nullable MultipathEquivalentAsPathMatchMode multipathEquivalentAsPathMatchMode,

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -526,6 +526,11 @@ public class RoutesAnswererTest {
     }
 
     @Override
+    public boolean containsRoute(R route) {
+      return _routes.contains(route);
+    }
+
+    @Override
     public Set<AbstractRoute> getRoutes() {
       return _routes.stream()
           .map(AbstractRouteDecorator::getAbstractRoute)


### PR DESCRIPTION
This way it is far less likely that BGP/EVPN rib (or other code) can modify the main RIB w/o going through proper channels