### PR TITLE
RibDelta optimizations

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CollectionUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/CollectionUtil.java
@@ -3,6 +3,7 @@ package org.batfish.common.util;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.math.IntMath;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -110,6 +111,25 @@ public final class CollectionUtil {
    */
   public static <T> Collector<T, ?, Integer> toUnorderedHashCode() {
     return Collectors.summingInt(Objects::hashCode);
+  }
+
+  /** Return the max values of the input collection according to the input comparator. */
+  public static <R> Collection<R> maxValues(Collection<R> values, Comparator<R> comparator) {
+    List<R> maxValues = new ArrayList<>();
+    for (R value : values) {
+      if (maxValues.isEmpty()) {
+        maxValues.add(value);
+        continue;
+      }
+      int cmp = comparator.compare(value, maxValues.get(0));
+      if (cmp == 0) {
+        maxValues.add(value);
+      } else if (cmp > 0) {
+        maxValues.clear();
+        maxValues.add(value);
+      }
+    }
+    return maxValues;
   }
 
   private CollectionUtil() {} // prevent instantiation

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CollectionUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CollectionUtilTest.java
@@ -1,9 +1,11 @@
 package org.batfish.common.util;
 
+import static org.batfish.common.util.CollectionUtil.maxValues;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 import static org.batfish.common.util.CollectionUtil.toMap;
 import static org.batfish.common.util.CollectionUtil.toOrderedHashCode;
 import static org.batfish.common.util.CollectionUtil.toUnorderedHashCode;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
@@ -15,6 +17,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -68,5 +72,12 @@ public class CollectionUtilTest {
     assertThat(
         toMap(m, Function.identity(), x -> x.equals("a") ? 0 : 1),
         equalTo(ImmutableMap.of("a", 0, "b", 1)));
+  }
+
+  @Test
+  public void testMaxValues() {
+    Comparator<String> longest = Comparator.comparing(String::length);
+    List<String> strings = ImmutableList.of("a", "abc", "ab", "efg", "");
+    assertThat(maxValues(strings, longest), contains("abc", "efg"));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1761,21 +1761,14 @@ public class VirtualRouter implements Serializable {
     _bgpRoutingProcess._ebgpDelta =
         RibDelta.merge(
             _bgpRoutingProcess._ebgpDelta,
-            RibDelta.<Bgpv4Route>builder()
-                .add(_bgpRoutingProcess._ebgpv4Rib.getBestPathRoutes())
-                .build());
+            RibDelta.adding(_bgpRoutingProcess._ebgpv4Rib.getBestPathRoutes()));
     _bgpRoutingProcess._bgpv4Delta =
         RibDelta.merge(
             _bgpRoutingProcess._bgpv4Delta,
-            RibDelta.<Bgpv4Route>builder()
-                .add(_bgpRoutingProcess._bgpv4Rib.getTypedRoutes())
-                .build());
+            RibDelta.adding(_bgpRoutingProcess._bgpv4Rib.getTypedRoutes()));
     _bgpRoutingProcess._mainRibBgpv4RouteDelta =
         RibDelta.merge(
-            _bgpRoutingProcess._mainRibBgpv4RouteDelta,
-            RibDelta.<AnnotatedRoute<AbstractRoute>>builder()
-                .add(_mainRib.getTypedRoutes())
-                .build());
+            _bgpRoutingProcess._mainRibBgpv4RouteDelta, RibDelta.adding(_mainRib.getTypedRoutes()));
 
     /*
      * Export neighbor-specific generated routes, these routes skip global export policy
@@ -2088,9 +2081,7 @@ public class VirtualRouter implements Serializable {
     // from second iteration
     RibDelta<AnnotatedRoute<AbstractRoute>> ribDelta =
         numIterations == 1
-            ? RibDelta.<AnnotatedRoute<AbstractRoute>>builder()
-                .add(_mainRib.getTypedRoutes())
-                .build()
+            ? RibDelta.adding(_mainRib.getTypedRoutes())
             : _mainRibRouteDeltaBuilder.build();
     Streams.concat(_ospfProcesses.values().stream(), _eigrpProcesses.values().stream())
         .forEach(p -> p.redistribute(ribDelta));

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
@@ -132,10 +133,11 @@ public final class RibDelta<R extends AbstractRouteDecorator> {
   @ParametersAreNonnullByDefault
   public static final class Builder<R extends AbstractRouteDecorator> {
 
-    private LinkedHashMap<R, RouteAdvertisement<R>> _actions;
+    private HashMap<R, RouteAdvertisement<R>> _actions;
 
     /** Initialize a new RibDelta builder */
     private Builder() {
+      // use a LinkedHashMap to preserve insertion order
       _actions = new LinkedHashMap<>();
     }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -48,8 +47,12 @@ public final class RibDelta<R extends AbstractRouteDecorator> {
    * Reason#ADD}.
    */
   public static <R extends AbstractRouteDecorator> RibDelta<R> adding(Collection<R> routes) {
-    return new RibDelta<>(
-        routes.stream().map(RouteAdvertisement::adding).collect(ImmutableList.toImmutableList()));
+    ImmutableList.Builder<RouteAdvertisement<R>> builder =
+        ImmutableList.builderWithExpectedSize(routes.size());
+    for (R route : routes) {
+      builder.add(RouteAdvertisement.adding(route));
+    }
+    return new RibDelta<>(builder.build());
   }
 
   public static <R extends AbstractRouteDecorator> RibDelta<R> of(RouteAdvertisement<R> action) {
@@ -133,7 +136,8 @@ public final class RibDelta<R extends AbstractRouteDecorator> {
   @ParametersAreNonnullByDefault
   public static final class Builder<R extends AbstractRouteDecorator> {
 
-    private Map<R, RouteAdvertisement<R>> _actions;
+    @SuppressWarnings("PMD.LooseCoupling") // insertion order matters
+    private LinkedHashMap<R, RouteAdvertisement<R>> _actions;
 
     /** Initialize a new RibDelta builder */
     private Builder() {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
@@ -3,15 +3,10 @@ package org.batfish.dataplane.rib;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Ordering;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -29,15 +24,14 @@ import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
  * @param <R> route type
  */
 @ParametersAreNonnullByDefault
-public final class RibDelta<R> {
+public final class RibDelta<R extends AbstractRouteDecorator> {
 
-  /** Sorted for deterministic iteration order */
-  private final ImmutableSortedMap<Prefix, List<RouteAdvertisement<R>>> _actions;
+  private final List<RouteAdvertisement<R>> _actions;
 
-  private static final RibDelta<Object> EMPTY = new RibDelta<>(ImmutableSortedMap.of());
+  private static final RibDelta<AbstractRoute> EMPTY = new RibDelta<>(ImmutableList.of());
 
-  private RibDelta(ImmutableSortedMap<Prefix, List<RouteAdvertisement<R>>> actions) {
-    _actions = actions;
+  private RibDelta(List<RouteAdvertisement<R>> actions) {
+    _actions = ImmutableList.copyOf(actions);
   }
 
   public static <R extends AbstractRouteDecorator> RibDelta<R> merge(
@@ -54,18 +48,14 @@ public final class RibDelta<R> {
    * @return a set of {@link Prefix}
    */
   @Nonnull
-  public Set<Prefix> getPrefixes() {
-    return _actions.keySet();
+  public Stream<Prefix> getPrefixes() {
+    return _actions.stream().map(ra -> ra.getRoute().getNetwork()).distinct();
   }
 
   /** Return all the RIB actions that need to be applied (in order). */
   @Nonnull
   public Stream<RouteAdvertisement<R>> getActions() {
-    return _actions.values().stream().flatMap(List::stream);
-  }
-
-  private Map<Prefix, List<RouteAdvertisement<R>>> getActionMap() {
-    return _actions;
+    return _actions.stream();
   }
 
   /** Check whether this delta is empty (has no outstanding actions) */
@@ -87,7 +77,7 @@ public final class RibDelta<R> {
   /** Helper method: retrieves all routes affected by this delta. */
   @Nonnull
   public Stream<R> getRoutesStream() {
-    return _actions.values().stream().flatMap(List::stream).map(RouteAdvertisement::getRoute);
+    return _actions.stream().map(RouteAdvertisement::getRoute);
   }
 
   /**
@@ -116,16 +106,11 @@ public final class RibDelta<R> {
   @ParametersAreNonnullByDefault
   public static final class Builder<R extends AbstractRouteDecorator> {
 
-    private Map<Prefix, LinkedHashMap<R, RouteAdvertisement<R>>> _actions;
+    private LinkedHashMap<R, RouteAdvertisement<R>> _actions;
 
     /** Initialize a new RibDelta builder */
     private Builder() {
       _actions = new LinkedHashMap<>();
-    }
-
-    @SuppressWarnings("PMD.LooseCoupling") // insertion order matters
-    private LinkedHashMap<R, RouteAdvertisement<R>> getAdvertisements(Prefix network) {
-      return _actions.computeIfAbsent(network, p -> new LinkedHashMap<>(8));
     }
 
     /**
@@ -134,12 +119,10 @@ public final class RibDelta<R> {
      * @param route Route that was added
      */
     public Builder<R> add(R route) {
-      LinkedHashMap<R, RouteAdvertisement<R>> advertisedRoutes =
-          getAdvertisements(route.getNetwork());
-      RouteAdvertisement<R> old = advertisedRoutes.put(route, new RouteAdvertisement<>(route));
+      RouteAdvertisement<R> old = _actions.put(route, new RouteAdvertisement<>(route));
       if (old != null && old.isWithdrawn()) {
         // In this same delta, we withdrew the route and are now re-advertising. Should be no-op.
-        advertisedRoutes.remove(route);
+        _actions.remove(route);
       }
       return this;
     }
@@ -160,14 +143,12 @@ public final class RibDelta<R> {
      * @param route that was removed
      */
     public Builder<R> remove(R route, Reason reason) {
-      LinkedHashMap<R, RouteAdvertisement<R>> advertisedRoutes =
-          getAdvertisements(route.getNetwork());
       RouteAdvertisement<R> old =
-          advertisedRoutes.put(
+          _actions.put(
               route, RouteAdvertisement.<R>builder().setRoute(route).setReason(reason).build());
       if (old != null && old.getReason() == Reason.ADD) {
         // In this same delta, we added the route and are now withdrawing. Instead, no-op.
-        advertisedRoutes.remove(route);
+        _actions.remove(route);
       }
       return this;
     }
@@ -198,13 +179,7 @@ public final class RibDelta<R> {
       if (isEmpty()) {
         return empty();
       }
-      return new RibDelta<>(
-          _actions.entrySet().stream()
-              .collect(
-                  ImmutableSortedMap.toImmutableSortedMap(
-                      Ordering.natural(),
-                      Entry::getKey,
-                      e -> ImmutableList.copyOf(e.getValue().values()))));
+      return new RibDelta<>(ImmutableList.copyOf(_actions.values()));
     }
 
     /** Process all added and removed routes from a given delta */
@@ -239,7 +214,7 @@ public final class RibDelta<R> {
   /** Return an empty RIB delta */
   @Nonnull
   @SuppressWarnings("unchecked") // Fully variant implementation, never stores any Ts
-  public static <T> RibDelta<T> empty() {
+  public static <T extends AbstractRouteDecorator> RibDelta<T> empty() {
     return (RibDelta<T>) EMPTY;
   }
 
@@ -312,20 +287,15 @@ public final class RibDelta<R> {
       return empty();
     }
     Builder<T> builder = RibDelta.builder();
-    delta
-        .getActionMap()
-        .forEach(
-            (prefix, actions) -> {
-              for (RouteAdvertisement<U> uRouteAdvertisement : actions) {
-                T tRoute = converter.apply(uRouteAdvertisement.getRoute());
-                if (uRouteAdvertisement.isWithdrawn()) {
-                  builder.from(
-                      importingRib.removeRouteGetDelta(tRoute, uRouteAdvertisement.getReason()));
-                } else {
-                  builder.from(importingRib.mergeRouteGetDelta(tRoute));
-                }
-              }
-            });
+    delta._actions.forEach(
+        (uRouteAdvertisement) -> {
+          T tRoute = converter.apply(uRouteAdvertisement.getRoute());
+          if (uRouteAdvertisement.isWithdrawn()) {
+            builder.from(importingRib.removeRouteGetDelta(tRoute, uRouteAdvertisement.getReason()));
+          } else {
+            builder.from(importingRib.mergeRouteGetDelta(tRoute));
+          }
+        });
     return builder.build();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
@@ -4,9 +4,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -133,7 +133,7 @@ public final class RibDelta<R extends AbstractRouteDecorator> {
   @ParametersAreNonnullByDefault
   public static final class Builder<R extends AbstractRouteDecorator> {
 
-    private HashMap<R, RouteAdvertisement<R>> _actions;
+    private Map<R, RouteAdvertisement<R>> _actions;
 
     /** Initialize a new RibDelta builder */
     private Builder() {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
@@ -34,6 +34,32 @@ public final class RibDelta<R extends AbstractRouteDecorator> {
     _actions = ImmutableList.copyOf(actions);
   }
 
+  /**
+   * Create a new {@link RibDelta} advertising the input route with {@link Reason} {@link
+   * Reason#ADD}.
+   */
+  public static <R extends AbstractRouteDecorator> RibDelta<R> adding(R route) {
+    return new RibDelta<>(ImmutableList.of(RouteAdvertisement.adding(route)));
+  }
+
+  /**
+   * Create a new {@link RibDelta} advertising the input routes with {@link Reason} {@link
+   * Reason#ADD}.
+   */
+  public static <R extends AbstractRouteDecorator> RibDelta<R> adding(Collection<R> routes) {
+    return new RibDelta<>(
+        routes.stream().map(RouteAdvertisement::adding).collect(ImmutableList.toImmutableList()));
+  }
+
+  public static <R extends AbstractRouteDecorator> RibDelta<R> of(RouteAdvertisement<R> action) {
+    return new RibDelta<>(ImmutableList.of(action));
+  }
+
+  public static <R extends AbstractRouteDecorator> RibDelta<R> of(
+      Collection<RouteAdvertisement<R>> actions) {
+    return new RibDelta<>(ImmutableList.copyOf(actions));
+  }
+
   public static <R extends AbstractRouteDecorator> RibDelta<R> merge(
       @Nullable RibDelta<R> delta1, RibDelta<R> delta2) {
     if (delta1 == null || delta1.isEmpty()) {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RouteAdvertisement.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RouteAdvertisement.java
@@ -52,6 +52,18 @@ public final class RouteAdvertisement<T> {
     _reason = Reason.ADD;
   }
 
+  public static <T> RouteAdvertisement<T> adding(T route) {
+    return new RouteAdvertisement<>(route, Reason.ADD);
+  }
+
+  public static <T> RouteAdvertisement<T> replacing(T route) {
+    return new RouteAdvertisement<>(route, Reason.REPLACE);
+  }
+
+  public static <T> RouteAdvertisement<T> withdrawing(T route) {
+    return new RouteAdvertisement<>(route, Reason.WITHDRAW);
+  }
+
   /** Get the underlying route that's being advertised (or withdrawn) */
   @Nonnull
   public T getRoute() {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTreeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/RibTreeTest.java
@@ -1,0 +1,42 @@
+package org.batfish.dataplane.rib;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
+import org.junit.Test;
+
+public final class RibTreeTest {
+  @Test
+  public void testRemoveRouteGetDelta() {
+    StaticRoute.Builder srb = StaticRoute.builder().setNetwork(Prefix.parse("1.0.0.0/8"));
+    StaticRoute r1 = srb.setAdministrativeCost(2).setTag(1L).build();
+    StaticRoute r2 = srb.setAdministrativeCost(2).setTag(2L).build();
+    StaticRoute r3 = srb.setAdministrativeCost(1).setTag(3L).build();
+
+    AbstractRib<StaticRoute> owner =
+        new AbstractRib<StaticRoute>() {
+          @Override
+          public int comparePreference(StaticRoute lhs, StaticRoute rhs) {
+            // prefer routes with lower admin cost
+            return rhs.getAdministrativeCost() - lhs.getAdministrativeCost();
+          }
+        };
+    RibTree<StaticRoute> ribTree = new RibTree<>(owner);
+    RibDelta<StaticRoute> addR1 = ribTree.mergeRoute(r1);
+    assertThat(addR1, equalTo(RibDelta.adding(r1)));
+    RibDelta<StaticRoute> addR2 = ribTree.mergeRoute(r2);
+    assertThat(addR2, equalTo(RibDelta.adding(r2)));
+    RibDelta<StaticRoute> addR3 = ribTree.mergeRoute(r3);
+    assertThat(
+        addR3,
+        equalTo(
+            RibDelta.builder()
+                .remove(r1, Reason.REPLACE)
+                .remove(r2, Reason.REPLACE)
+                .add(r3)
+                .build()));
+  }
+}


### PR DESCRIPTION
1. flatten actions
Previously RibDelta._actions was a sorted map from Prefix to list of
advertisements for that prefix. The only use of the map was to
efficiently retrieve the keyset for getPrefixes. However, getPrefixes
is called at most once, and often 0 times. So we should only pay to
collect and dedup the prefixes if it's called.

2. avoid using Builders when possible 
Particularly in hot code. The builder allocates a linked hash map,
copies all the advertisements in, and then copies them out to a list
on build.