### PR TITLE
Parsing: shuffle jobs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -2571,6 +2571,8 @@ public class Batfish extends PluginConsumer implements IBatfish {
         jobs =
             makeParseVendorConfigurationsJobs(
                 snapshot, keyedConfigText, ConfigurationFormat.UNKNOWN);
+        // Java parallel streams are not self-balancing in large networks, so shuffle the jobs.
+        Collections.shuffle(jobs);
       } finally {
         makeJobsSpan.finish();
       }


### PR DESCRIPTION
Since Java parallel streams are not self-balancing, it pays to randomize files.
It is common that

  filename -> device role

and it is almost certain that

  device role -> configuration complexity -> parsing work

so not grouping by name is likely to pay off.