### PR TITLE
Defintion/Reference: Reduce space used

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DefinedStructureInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DefinedStructureInfo.java
@@ -5,7 +5,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Range;
 import java.io.Serializable;
+import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 
 public class DefinedStructureInfo implements Serializable {
@@ -38,6 +40,16 @@ public class DefinedStructureInfo implements Serializable {
   }
 
   public void addDefinitionLines(int... lines) {
+    _definitionLines = _definitionLines.toBuilder().including(lines).build();
+  }
+
+  public void addDefinitionLines(IntStream lines) {
+    IntegerSpace.Builder newLines = _definitionLines.toBuilder();
+    lines.forEach(newLines::including);
+    _definitionLines = newLines.build();
+  }
+
+  public void addDefinitionLines(Range<Integer> lines) {
     _definitionLines = _definitionLines.toBuilder().including(lines).build();
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DefinedStructureInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DefinedStructureInfo.java
@@ -6,8 +6,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
-import java.util.SortedSet;
-import java.util.TreeSet;
 import javax.annotation.Nonnull;
 
 public class DefinedStructureInfo implements Serializable {
@@ -15,21 +13,32 @@ public class DefinedStructureInfo implements Serializable {
   private static final String PROP_DEFINITION_LINES = "definitionLines";
   private static final String PROP_NUM_REFERRERS = "numReferrers";
 
-  @Nonnull private SortedSet<Integer> _definitionLines;
+  @Nonnull private IntegerSpace _definitionLines;
   private int _numReferrers;
 
   @JsonCreator
   public DefinedStructureInfo(
-      @JsonProperty(PROP_DEFINITION_LINES) SortedSet<Integer> definitionLines,
+      @JsonProperty(PROP_DEFINITION_LINES) IntegerSpace definitionLines,
       @JsonProperty(PROP_NUM_REFERRERS) Integer numReferrers) {
     checkArgument(numReferrers != null, "Missing %s", PROP_NUM_REFERRERS);
-    _definitionLines = firstNonNull(definitionLines, new TreeSet<>());
+    _definitionLines = firstNonNull(definitionLines, IntegerSpace.EMPTY);
     _numReferrers = numReferrers;
   }
 
   @JsonProperty(PROP_DEFINITION_LINES)
-  public SortedSet<Integer> getDefinitionLines() {
+  public @Nonnull IntegerSpace getDefinitionLines() {
     return _definitionLines;
+  }
+
+  public void addDefinitionLines(int line) {
+    if (_definitionLines.contains(line)) {
+      return;
+    }
+    _definitionLines = _definitionLines.toBuilder().including(line).build();
+  }
+
+  public void addDefinitionLines(int... lines) {
+    _definitionLines = _definitionLines.toBuilder().including(lines).build();
   }
 
   @JsonProperty(PROP_NUM_REFERRERS)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IntegerSpace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IntegerSpace.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import java.util.Arrays;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -69,7 +70,7 @@ public final class IntegerSpace extends NumberSpace<Integer, IntegerSpace, Integ
 
   /** Return an ordered set of integers described by this space. */
   @Override
-  public @Nonnull Set<Integer> enumerate() {
+  public @Nonnull SortedSet<Integer> enumerate() {
     return ImmutableRangeSet.copyOf(_rangeset).asSet(DiscreteDomain.integers());
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ConvertConfigurationAnswerElement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/answers/ConvertConfigurationAnswerElement.java
@@ -12,7 +12,6 @@ import com.google.common.collect.TreeMultimap;
 import java.io.Serializable;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -20,6 +19,7 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.ErrorDetails;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.DefinedStructureInfo;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.version.BatfishVersion;
 
 /**
@@ -49,25 +49,24 @@ public class ConvertConfigurationAnswerElement extends InitStepAnswerElement
       _definedStructures;
 
   /* Map of source filename to generated nodes (e.g. "configs/j1.cfg" -> ["j1_master", "j1_logical_system1"]) */
-  @Nonnull private Multimap<String, String> _fileMap;
+  @Nonnull private final Multimap<String, String> _fileMap;
 
   // filename -> structType -> structName -> usage -> lines
   @Nonnull
-  private SortedMap<
-          String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+  private final SortedMap<
+          String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
       _referencedStructures;
 
   @Nonnull private SortedMap<String, BatfishException.BatfishStackTrace> _errors;
 
-  @Nonnull private SortedMap<String, ErrorDetails> _errorDetails;
+  @Nonnull private final SortedMap<String, ErrorDetails> _errorDetails;
 
   // This is just to support legacy objects, before _convertStatus map was used
   @Nullable private Set<String> _failed;
 
   // filename -> structType -> structName -> usage -> lines
   @Nonnull
-  private SortedMap<
-          String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+  private SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
       _undefinedReferences;
 
   @Nonnull private String _version;
@@ -85,17 +84,13 @@ public class ConvertConfigurationAnswerElement extends InitStepAnswerElement
           SortedMap<String, SortedMap<String, SortedMap<String, DefinedStructureInfo>>>
               definedStructures,
       @JsonProperty(PROP_REFERENCED_STRUCTURES)
-          SortedMap<
-                  String,
-                  SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+          SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
               referencedstructures,
       @JsonProperty(PROP_CONVERT_STATUS) SortedMap<String, ConvertStatus> convertStatus,
       @JsonProperty(PROP_ERRORS) SortedMap<String, BatfishException.BatfishStackTrace> errors,
       @JsonProperty(PROP_ERROR_DETAILS) SortedMap<String, ErrorDetails> errorDetails,
       @JsonProperty(PROP_UNDEFINED_REFERENCES)
-          SortedMap<
-                  String,
-                  SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+          SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
               undefinedReferences,
       @JsonProperty(PROP_VERSION) String version,
       @JsonProperty(PROP_WARNINGS) SortedMap<String, Warnings> warnings,
@@ -132,7 +127,7 @@ public class ConvertConfigurationAnswerElement extends InitStepAnswerElement
       return ImmutableSortedMap.copyOf(_convertStatus);
     } else if (_failed != null) {
       ImmutableSortedMap.Builder<String, ConvertStatus> map = ImmutableSortedMap.naturalOrder();
-      _failed.stream().forEach(n -> map.put(n, ConvertStatus.FAILED));
+      _failed.forEach(n -> map.put(n, ConvertStatus.FAILED));
       return map.build();
     } else {
       return ImmutableSortedMap.of();
@@ -160,16 +155,14 @@ public class ConvertConfigurationAnswerElement extends InitStepAnswerElement
 
   @JsonProperty(PROP_REFERENCED_STRUCTURES)
   @Nonnull
-  public SortedMap<
-          String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+  public SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
       getReferencedStructures() {
     return _referencedStructures;
   }
 
   @JsonProperty(PROP_UNDEFINED_REFERENCES)
   @Nonnull
-  public SortedMap<
-          String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+  public SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
       getUndefinedReferences() {
     return _undefinedReferences;
   }
@@ -201,7 +194,7 @@ public class ConvertConfigurationAnswerElement extends InitStepAnswerElement
   }
 
   @Override
-  public void setErrors(SortedMap<String, BatfishException.BatfishStackTrace> errors) {
+  public void setErrors(@Nonnull SortedMap<String, BatfishException.BatfishStackTrace> errors) {
     _errors = errors;
   }
 
@@ -213,19 +206,17 @@ public class ConvertConfigurationAnswerElement extends InitStepAnswerElement
 
   public void setUndefinedReferences(
       @Nonnull
-          SortedMap<
-                  String,
-                  SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+          SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
               undefinedReferences) {
     _undefinedReferences = undefinedReferences;
   }
 
-  public void setVersion(String version) {
+  public void setVersion(@Nonnull String version) {
     _version = version;
   }
 
   @Override
-  public void setWarnings(SortedMap<String, Warnings> warnings) {
+  public void setWarnings(@Nonnull SortedMap<String, Warnings> warnings) {
     _warnings = warnings;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
+import com.google.common.collect.Range;
 import com.google.common.collect.SortedMultiset;
 import com.google.common.collect.TreeMultiset;
 import java.io.Serializable;
@@ -17,6 +18,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -243,17 +245,38 @@ public abstract class VendorConfiguration implements Serializable {
         _answerElement.getUndefinedReferences(), structureType, name, usage, line);
   }
 
+  /* Recursively process children to find all relevant definition lines for the specified context */
+  private static IntStream collectLines(RuleContext ctx, BatfishCombinedParser<?, ?> parser) {
+    return IntStream.range(0, ctx.getChildCount())
+        .flatMap(
+            i -> {
+              ParseTree child = ctx.getChild(i);
+              if (child instanceof TerminalNode) {
+                return IntStream.of(parser.getLine(((TerminalNode) child).getSymbol()));
+              } else if (child instanceof RuleContext) {
+                return collectLines((RuleContext) child, parser);
+              }
+              return IntStream.empty();
+            });
+  }
+
+  /**
+   * Gets the {@link DefinedStructureInfo} for the specified structure {@code name} and {@code
+   * structureType}, initializing if necessary.
+   */
+  private DefinedStructureInfo getStructureInfo(StructureType structureType, String name) {
+    String type = structureType.getDescription();
+    SortedMap<String, DefinedStructureInfo> byName =
+        _structureDefinitions.computeIfAbsent(type, k -> new TreeMap<>());
+    return byName.computeIfAbsent(name, k -> new DefinedStructureInfo(IntegerSpace.EMPTY, 0));
+  }
+
   /**
    * Updates structure definitions to include the specified structure {@code name} and {@code
    * structureType} and initializes the number of referrers.
    */
   public void defineSingleLineStructure(StructureType structureType, String name, int line) {
-    String type = structureType.getDescription();
-    SortedMap<String, DefinedStructureInfo> byName =
-        _structureDefinitions.computeIfAbsent(type, k -> new TreeMap<>());
-    DefinedStructureInfo info =
-        byName.computeIfAbsent(name, k -> new DefinedStructureInfo(IntegerSpace.EMPTY, 0));
-    info.addDefinitionLines(line);
+    getStructureInfo(structureType, name).addDefinitionLines(line);
   }
 
   /**
@@ -267,15 +290,7 @@ public abstract class VendorConfiguration implements Serializable {
    */
   public void defineFlattenedStructure(
       StructureType type, String name, RuleContext ctx, BatfishCombinedParser<?, ?> parser) {
-    /* Recursively process children to find all relevant definition lines for the specified context */
-    for (int i = 0; i < ctx.getChildCount(); i++) {
-      ParseTree child = ctx.getChild(i);
-      if (child instanceof TerminalNode) {
-        defineSingleLineStructure(type, name, parser.getLine(((TerminalNode) child).getSymbol()));
-      } else if (child instanceof RuleContext) {
-        defineFlattenedStructure(type, name, (RuleContext) child, parser);
-      }
-    }
+    getStructureInfo(type, name).addDefinitionLines(collectLines(ctx, parser));
   }
 
   /**
@@ -286,9 +301,8 @@ public abstract class VendorConfiguration implements Serializable {
    * RuleContext, BatfishCombinedParser)}.
    */
   public void defineStructure(StructureType type, String name, ParserRuleContext ctx) {
-    for (int i = ctx.getStart().getLine(); i <= ctx.getStop().getLine(); ++i) {
-      defineSingleLineStructure(type, name, i);
-    }
+    getStructureInfo(type, name)
+        .addDefinitionLines(Range.closed(ctx.getStart().getLine(), ctx.getStop().getLine()));
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -257,7 +257,8 @@ public abstract class VendorConfiguration implements Serializable {
                 return collectLines((RuleContext) child, parser);
               }
               return IntStream.empty();
-            });
+            })
+        .distinct();
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -16,9 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import java.util.TreeMap;
-import java.util.TreeSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -220,23 +218,24 @@ public abstract class VendorConfiguration implements Serializable {
       throws VendorConversionException;
 
   private void addStructureReference(
-      SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+      SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
           referenceMap,
       StructureType structureType,
       String name,
       StructureUsage usage,
       int line) {
     String filename = getFilename();
-    SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> byType =
+    SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>> byType =
         referenceMap.computeIfAbsent(filename, k -> new TreeMap<>());
     String type = structureType.getDescription();
-    SortedMap<String, SortedMap<String, SortedSet<Integer>>> byName =
+    SortedMap<String, SortedMap<String, IntegerSpace>> byName =
         byType.computeIfAbsent(type, k -> new TreeMap<>());
-    SortedMap<String, SortedSet<Integer>> byUsage =
-        byName.computeIfAbsent(name, k -> new TreeMap<>());
+    SortedMap<String, IntegerSpace> byUsage = byName.computeIfAbsent(name, k -> new TreeMap<>());
     String usageStr = usage.getDescription();
-    SortedSet<Integer> lines = byUsage.computeIfAbsent(usageStr, k -> new TreeSet<>());
-    lines.add(line);
+    byUsage.compute(
+        usageStr,
+        (ignored, refs) ->
+            (refs == null ? IntegerSpace.of(line) : refs.toBuilder().including(line).build()));
   }
 
   public void undefined(StructureType structureType, String name, StructureUsage usage, int line) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -32,6 +32,7 @@ import org.batfish.common.topology.Layer1Edge;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DefinedStructureInfo;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.isp_configuration.IspConfiguration;
 import org.batfish.grammar.BatfishCombinedParser;
@@ -252,8 +253,8 @@ public abstract class VendorConfiguration implements Serializable {
     SortedMap<String, DefinedStructureInfo> byName =
         _structureDefinitions.computeIfAbsent(type, k -> new TreeMap<>());
     DefinedStructureInfo info =
-        byName.computeIfAbsent(name, k -> new DefinedStructureInfo(new TreeSet<>(), 0));
-    info.getDefinitionLines().add(line);
+        byName.computeIfAbsent(name, k -> new DefinedStructureInfo(IntegerSpace.EMPTY, 0));
+    info.addDefinitionLines(line);
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConvertConfigurationAnswerElementMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/ConvertConfigurationAnswerElementMatchers.java
@@ -2,11 +2,11 @@ package org.batfish.datamodel.matchers;
 
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import javax.annotation.Nonnull;
 import org.batfish.common.Warning;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.DefinedStructureInfo;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.vendor.StructureType;
 import org.batfish.vendor.StructureUsage;
@@ -162,7 +162,8 @@ final class ConvertConfigurationAnswerElementMatchers {
                 _filename, _type, _structureName));
         return false;
       }
-      if (!_subMatcher.matches(byStructureName.get(_structureName).getDefinitionLines())) {
+      if (!_subMatcher.matches(
+          byStructureName.get(_structureName).getDefinitionLines().enumerate())) {
         mismatchDescription.appendText(
             String.format(
                 "File '%s' has no defined structure of type '%s' named '%s' matching definition lines '%s'",
@@ -201,14 +202,14 @@ final class ConvertConfigurationAnswerElementMatchers {
     @Override
     protected boolean matchesSafely(
         ConvertConfigurationAnswerElement item, Description mismatchDescription) {
-      SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+      SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
           byFile = item.getUndefinedReferences();
       if (!byFile.containsKey(_filename)) {
         mismatchDescription.appendText(
             String.format("File '%s' has no undefined references", _filename));
         return false;
       }
-      SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> byType =
+      SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>> byType =
           byFile.get(_filename);
       if (!byType.containsKey(_type)) {
         mismatchDescription.appendText(
@@ -217,7 +218,7 @@ final class ConvertConfigurationAnswerElementMatchers {
                 _filename, _type));
         return false;
       }
-      SortedMap<String, SortedMap<String, SortedSet<Integer>>> byStructureName = byType.get(_type);
+      SortedMap<String, SortedMap<String, IntegerSpace>> byStructureName = byType.get(_type);
       if (!byStructureName.containsKey(_structureName)) {
         mismatchDescription.appendText(
             String.format(
@@ -263,14 +264,14 @@ final class ConvertConfigurationAnswerElementMatchers {
     @Override
     protected boolean matchesSafely(
         ConvertConfigurationAnswerElement item, Description mismatchDescription) {
-      SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+      SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
           byFile = item.getUndefinedReferences();
       if (!byFile.containsKey(_filename)) {
         mismatchDescription.appendText(
             String.format("File '%s' has no undefined references", _filename));
         return false;
       }
-      SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> byType =
+      SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>> byType =
           byFile.get(_filename);
       if (!byType.containsKey(_type)) {
         mismatchDescription.appendText(
@@ -279,7 +280,7 @@ final class ConvertConfigurationAnswerElementMatchers {
                 _filename, _type));
         return false;
       }
-      SortedMap<String, SortedMap<String, SortedSet<Integer>>> byStructureName = byType.get(_type);
+      SortedMap<String, SortedMap<String, IntegerSpace>> byStructureName = byType.get(_type);
       if (!byStructureName.containsKey(_structureName)) {
         mismatchDescription.appendText(
             String.format(
@@ -287,7 +288,7 @@ final class ConvertConfigurationAnswerElementMatchers {
                 _filename, _type, _structureName));
         return false;
       }
-      SortedMap<String, SortedSet<Integer>> byUsage = byStructureName.get(_structureName);
+      SortedMap<String, IntegerSpace> byUsage = byStructureName.get(_structureName);
       if (!byUsage.containsKey(_usage)) {
         mismatchDescription.appendText(
             String.format(
@@ -338,21 +339,21 @@ final class ConvertConfigurationAnswerElementMatchers {
     @Override
     protected boolean matchesSafely(
         ConvertConfigurationAnswerElement item, Description mismatchDescription) {
-      SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+      SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
           byFile = item.getUndefinedReferences();
       if (!byFile.containsKey(_filename)) {
         mismatchDescription.appendText(
             String.format("File '%s' has no undefined references", _filename));
         return false;
       }
-      SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> byType =
+      SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>> byType =
           byFile.get(_filename);
       if (!byType.containsKey(_type)) {
         mismatchDescription.appendText(
             String.format("File '%s' has no undefined reference of type '%s'", _filename, _type));
         return false;
       }
-      SortedMap<String, SortedMap<String, SortedSet<Integer>>> byStructureName = byType.get(_type);
+      SortedMap<String, SortedMap<String, IntegerSpace>> byStructureName = byType.get(_type);
       if (!byStructureName.containsKey(_structureName)) {
         mismatchDescription.appendText(
             String.format(
@@ -360,7 +361,7 @@ final class ConvertConfigurationAnswerElementMatchers {
                 _filename, _type, _structureName));
         return false;
       }
-      SortedMap<String, SortedSet<Integer>> byUsage = byStructureName.get(_structureName);
+      SortedMap<String, IntegerSpace> byUsage = byStructureName.get(_structureName);
       if (!byUsage.containsKey(_usage)) {
         mismatchDescription.appendText(
             String.format(
@@ -369,7 +370,7 @@ final class ConvertConfigurationAnswerElementMatchers {
                 _filename, _type, _structureName, _usage));
         return false;
       }
-      if (!_subMatcher.matches(byUsage.get(_usage))) {
+      if (!_subMatcher.matches(byUsage.get(_usage).enumerate())) {
         mismatchDescription.appendText(
             String.format(
                 "File '%s' has no undefined reference of type '%s' named '%s' of usage '%s' matching reference lines '%s'",

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -254,7 +254,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -680,7 +679,7 @@ public final class CiscoGrammarTest {
                 .build(),
             _folder);
 
-    SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+    SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
         undefinedReferences =
             batfish
                 .loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot())
@@ -688,10 +687,10 @@ public final class CiscoGrammarTest {
 
     // only mac_acl_udef and ip_acl_udef should be undefined references
     assertThat(undefinedReferences, hasKey(filename));
-    SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> byHost =
+    SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>> byHost =
         undefinedReferences.get(filename);
     assertThat(byHost, hasKey(ACCESS_LIST.getDescription()));
-    SortedMap<String, SortedMap<String, SortedSet<Integer>>> byType =
+    SortedMap<String, SortedMap<String, IntegerSpace>> byType =
         byHost.get(ACCESS_LIST.getDescription());
 
     assertThat(byType.keySet(), hasSize(2));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -151,7 +151,8 @@ public class CumulusFrrGrammarTest {
         .get(FILENAME)
         .get(type.getDescription())
         .get(name)
-        .get(usage.getDescription());
+        .get(usage.getDescription())
+        .enumerate();
   }
 
   private static void parse(String src) {
@@ -786,7 +787,7 @@ public class CumulusFrrGrammarTest {
     _frr.getVrfs().put("NAME", new Vrf("NAME"));
     parse("vrf NAME\n exit-vrf\n");
     assertThat(
-        getDefinedStructureInfo(CumulusStructureType.VRF, "NAME").getDefinitionLines(),
+        getDefinedStructureInfo(CumulusStructureType.VRF, "NAME").getDefinitionLines().enumerate(),
         contains(1, 2));
   }
 
@@ -846,7 +847,9 @@ public class CumulusFrrGrammarTest {
     assertThat(entry2.getAction(), equalTo(LineAction.DENY));
 
     assertThat(
-        getDefinedStructureInfo(CumulusStructureType.ROUTE_MAP, name).getDefinitionLines(),
+        getDefinedStructureInfo(CumulusStructureType.ROUTE_MAP, name)
+            .getDefinitionLines()
+            .enumerate(),
         equalTo(ImmutableSet.of(1, 2)));
   }
 
@@ -1155,7 +1158,7 @@ public class CumulusFrrGrammarTest {
     // Check that the AS-path access list definition was registered
     DefinedStructureInfo definedStructureInfo =
         getDefinedStructureInfo(CumulusStructureType.IP_AS_PATH_ACCESS_LIST, name);
-    assertThat(definedStructureInfo.getDefinitionLines(), contains(1, 2));
+    assertThat(definedStructureInfo.getDefinitionLines().enumerate(), contains(1, 2));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
@@ -79,7 +79,8 @@ public class CumulusInterfacesGrammarTest {
         .get(FILENAME)
         .get(type.getDescription())
         .get(name)
-        .get(usage.getDescription());
+        .get(usage.getDescription())
+        .enumerate();
   }
 
   private static CumulusInterfacesConfiguration parse(String input) {
@@ -118,7 +119,9 @@ public class CumulusInterfacesGrammarTest {
     CumulusInterfacesConfiguration interfaces = parse(input);
     assertThat(interfaces.getInterfaces(), hasKeys("swp1"));
     assertThat(
-        getDefinedStructureInfo(CumulusStructureType.INTERFACE, "swp1").getDefinitionLines(),
+        getDefinedStructureInfo(CumulusStructureType.INTERFACE, "swp1")
+            .getDefinitionLines()
+            .enumerate(),
         contains(1));
     assertThat(
         getStructureReferences(

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -189,7 +189,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
@@ -1252,7 +1251,7 @@ public final class FlatJuniperGrammarTest {
     Batfish batfish = getBatfishForConfigurationNames(hostname);
     ConvertConfigurationAnswerElement ccae =
         batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
-    SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+    SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
         undefinedReferences = ccae.getUndefinedReferences();
     Configuration c = parseConfig(hostname);
 

--- a/projects/question/src/main/java/org/batfish/question/UndefinedReferencesQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/UndefinedReferencesQuestionPlugin.java
@@ -22,6 +22,7 @@ import org.batfish.common.Answerer;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.common.plugin.Plugin;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.collections.FileLines;
 import org.batfish.datamodel.questions.Question;
@@ -66,7 +67,7 @@ public class UndefinedReferencesQuestionPlugin extends QuestionPlugin {
               .collect(Collectors.toSet());
 
       Multiset<Row> rows = LinkedHashMultiset.create();
-      SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+      SortedMap<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
           undefinedReferences =
               _batfish
                   .loadConvertConfigurationAnswerElementOrReparse(snapshot)
@@ -83,18 +84,17 @@ public class UndefinedReferencesQuestionPlugin extends QuestionPlugin {
     @VisibleForTesting
     // Entry is: filename -> struct type -> struct name -> context -> line nums
     public static List<Row> processEntryToRows(
-        Entry<String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
-            e) {
+        Entry<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>> e) {
       List<Row> rows = new ArrayList<>();
       String filename = e.getKey();
-      for (Entry<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>> e1 :
+      for (Entry<String, SortedMap<String, SortedMap<String, IntegerSpace>>> e1 :
           e.getValue().entrySet()) {
         String structType = e1.getKey();
-        for (Entry<String, SortedMap<String, SortedSet<Integer>>> e2 : e1.getValue().entrySet()) {
+        for (Entry<String, SortedMap<String, IntegerSpace>> e2 : e1.getValue().entrySet()) {
           String name = e2.getKey();
-          for (Entry<String, SortedSet<Integer>> e3 : e2.getValue().entrySet()) {
+          for (Entry<String, IntegerSpace> e3 : e2.getValue().entrySet()) {
             String context = e3.getKey();
-            SortedSet<Integer> lineNums = e3.getValue();
+            SortedSet<Integer> lineNums = e3.getValue().enumerate();
             rows.add(
                 Row.of(
                     COL_FILENAME,

--- a/projects/question/src/main/java/org/batfish/question/UnusedStructuresQuestionPlugin.java
+++ b/projects/question/src/main/java/org/batfish/question/UnusedStructuresQuestionPlugin.java
@@ -97,7 +97,9 @@ public class UnusedStructuresQuestionPlugin extends QuestionPlugin {
                 Row.builder(COLUMN_METADATA_MAP)
                     .put(COL_STRUCTURE_TYPE, structType)
                     .put(COL_STRUCTURE_NAME, name)
-                    .put(COL_SOURCE_LINES, new FileLines(filename, info.getDefinitionLines()))
+                    .put(
+                        COL_SOURCE_LINES,
+                        new FileLines(filename, info.getDefinitionLines().enumerate()))
                     .build());
           }
         }

--- a/projects/question/src/main/java/org/batfish/question/definedstructures/DefinedStructuresAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/definedstructures/DefinedStructuresAnswerer.java
@@ -81,7 +81,10 @@ public class DefinedStructuresAnswerer extends Answerer {
                           }
                           DefinedStructureRow row =
                               new DefinedStructureRow(
-                                  filename, structType, structName, info.getDefinitionLines());
+                                  filename,
+                                  structType,
+                                  structName,
+                                  info.getDefinitionLines().enumerate());
                           structures.add(toRow(row));
                         });
                   });

--- a/projects/question/src/main/java/org/batfish/question/referencedstructures/ReferencedStructuresAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/referencedstructures/ReferencedStructuresAnswerer.java
@@ -79,7 +79,7 @@ public class ReferencedStructuresAnswerer extends Answerer {
                                         COL_CONTEXT,
                                         context,
                                         COL_SOURCE_LINES,
-                                        new FileLines(filename, lineNums)));
+                                        new FileLines(filename, lineNums.enumerate())));
                               });
                         });
                   });

--- a/projects/question/src/test/java/org/batfish/question/UndefinedReferencesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/UndefinedReferencesAnswererTest.java
@@ -16,11 +16,11 @@ import com.google.common.collect.ImmutableSortedSet;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.collections.FileLines;
@@ -36,14 +36,12 @@ import org.junit.Test;
 public class UndefinedReferencesAnswererTest {
 
   private static final SortedMap<
-          String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
+          String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>>
       BASIC_UNDEFINED_REFS_MAP =
           ImmutableSortedMap.of(
               "f",
               ImmutableSortedMap.of(
-                  "t",
-                  ImmutableSortedMap.of(
-                      "n", ImmutableSortedMap.of("c", ImmutableSortedSet.of(1)))));
+                  "t", ImmutableSortedMap.of("n", ImmutableSortedMap.of("c", IntegerSpace.of(1)))));
   private static final Row BASIC_ROW =
       Row.of(
           COL_FILENAME,
@@ -69,17 +67,16 @@ public class UndefinedReferencesAnswererTest {
 
   @Test
   public void testProcessMultipleEntries() {
-    Map<String, SortedMap<String, SortedMap<String, SortedMap<String, SortedSet<Integer>>>>>
-        refsMap =
-            ImmutableMap.of(
-                "f",
+    Map<String, SortedMap<String, SortedMap<String, SortedMap<String, IntegerSpace>>>> refsMap =
+        ImmutableMap.of(
+            "f",
+            ImmutableSortedMap.of(
+                "t",
+                ImmutableSortedMap.of("n", ImmutableSortedMap.of("c", IntegerSpace.of(1))),
+                "t2",
                 ImmutableSortedMap.of(
-                    "t",
-                    ImmutableSortedMap.of(
-                        "n", ImmutableSortedMap.of("c", ImmutableSortedSet.of(1))),
-                    "t2",
-                    ImmutableSortedMap.of(
-                        "n2", ImmutableSortedMap.of("c2", ImmutableSortedSet.of(2, 3)))));
+                    "n2",
+                    ImmutableSortedMap.of("c2", IntegerSpace.builder().including(2, 3).build()))));
 
     List<Row> expected =
         ImmutableList.of(

--- a/projects/question/src/test/java/org/batfish/question/UnusedStructuresAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/UnusedStructuresAnswererTest.java
@@ -19,6 +19,7 @@ import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DefinedStructureInfo;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.collections.FileLines;
@@ -43,9 +44,9 @@ public class UnusedStructuresAnswererTest {
                   "t",
                   ImmutableSortedMap.of(
                       "n",
-                      new DefinedStructureInfo(ImmutableSortedSet.of(1), 0),
+                      new DefinedStructureInfo(IntegerSpace.of(1), 0),
                       "n2",
-                      new DefinedStructureInfo(ImmutableSortedSet.of(2), 1))));
+                      new DefinedStructureInfo(IntegerSpace.of(2), 1))));
   private static final Row BASIC_ROW =
       Row.of(
           COL_STRUCTURE_TYPE,
@@ -74,9 +75,9 @@ public class UnusedStructuresAnswererTest {
                 "t",
                 ImmutableSortedMap.of(
                     "n",
-                    new DefinedStructureInfo(ImmutableSortedSet.of(1), 0),
+                    new DefinedStructureInfo(IntegerSpace.of(1), 0),
                     "n2",
-                    new DefinedStructureInfo(ImmutableSortedSet.of(2, 3), 0))));
+                    new DefinedStructureInfo(IntegerSpace.builder().including(2, 3).build(), 0))));
 
     List<Row> expected =
         ImmutableList.of(

--- a/projects/question/src/test/java/org/batfish/question/definedstructures/DefinedStructuresAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/definedstructures/DefinedStructuresAnswererTest.java
@@ -21,6 +21,7 @@ import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DefinedStructureInfo;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.answers.Schema;
@@ -40,17 +41,17 @@ public class DefinedStructuresAnswererTest {
                   "type1",
                   ImmutableSortedMap.of(
                       "name1",
-                      new DefinedStructureInfo(ImmutableSortedSet.of(1), 1),
+                      new DefinedStructureInfo(IntegerSpace.of(1), 1),
                       "name2",
-                      new DefinedStructureInfo(ImmutableSortedSet.of(2), 1))),
+                      new DefinedStructureInfo(IntegerSpace.of(2), 1))),
               "file2",
               ImmutableSortedMap.of(
                   "type1",
                   ImmutableSortedMap.of(
                       "name2",
-                      new DefinedStructureInfo(ImmutableSortedSet.of(1), 1),
+                      new DefinedStructureInfo(IntegerSpace.of(1), 1),
                       "name3",
-                      new DefinedStructureInfo(ImmutableSortedSet.of(2), 1))));
+                      new DefinedStructureInfo(IntegerSpace.of(2), 1))));
 
   // Hostname -> Files that make up that host.
   private static final Multimap<String, String> FILE_MAP =

--- a/tests/aws/init-example-aws.ref
+++ b/tests/aws/init-example-aws.ref
@@ -51,298 +51,149 @@
       "configs/lhr-border-02.cfg" : {
         "bgp peer-group" : {
           "FW" : {
-            "definitionLines" : [
-              198
-            ],
+            "definitionLines" : "198",
             "numReferrers" : 2
           }
         },
         "crypto ipsec profile" : {
           "ipsec-vpn-ba2e34a8-0" : {
-            "definitionLines" : [
-              92,
-              93,
-              94
-            ],
+            "definitionLines" : "92-94",
             "numReferrers" : 1
           },
           "ipsec-vpn-ba2e34a8-1" : {
-            "definitionLines" : [
-              96,
-              97,
-              98
-            ],
+            "definitionLines" : "96-98",
             "numReferrers" : 1
           }
         },
         "crypto ipsec transform-set" : {
           "ipsec-prop-vpn-ba2e34a8-0" : {
-            "definitionLines" : [
-              85,
-              86
-            ],
+            "definitionLines" : "85-86",
             "numReferrers" : 1
           },
           "ipsec-prop-vpn-ba2e34a8-1" : {
-            "definitionLines" : [
-              87,
-              88
-            ],
+            "definitionLines" : "87-88",
             "numReferrers" : 1
           }
         },
         "crypto isakmp policy" : {
           "200" : {
-            "definitionLines" : [
-              62,
-              63,
-              64,
-              65,
-              66
-            ],
+            "definitionLines" : "62-66",
             "numReferrers" : 1
           },
           "201" : {
-            "definitionLines" : [
-              68,
-              69,
-              70,
-              71,
-              72
-            ],
+            "definitionLines" : "68-72",
             "numReferrers" : 1
           }
         },
         "crypto isakmp profile" : {
           "isakmp-vpn-ba2e34a8-0" : {
-            "definitionLines" : [
-              74,
-              75,
-              76,
-              77
-            ],
+            "definitionLines" : "74-77",
             "numReferrers" : 1
           },
           "isakmp-vpn-ba2e34a8-1" : {
-            "definitionLines" : [
-              78,
-              79,
-              80,
-              81
-            ],
+            "definitionLines" : "78-81",
             "numReferrers" : 1
           }
         },
         "crypto keyring" : {
           "keyring-vpn-ba2e34a8-0" : {
-            "definitionLines" : [
-              52,
-              53,
-              54
-            ],
+            "definitionLines" : "52-54",
             "numReferrers" : 1
           },
           "keyring-vpn-ba2e34a8-1" : {
-            "definitionLines" : [
-              55,
-              56,
-              57
-            ],
+            "definitionLines" : "55-57",
             "numReferrers" : 1
           }
         },
         "extended ipv4 access-list" : {
           "2001" : {
-            "definitionLines" : [
-              248,
-              249
-            ],
+            "definitionLines" : "248-249",
             "numReferrers" : 0
           },
           "LIMIT_PEER" : {
-            "definitionLines" : [
-              239,
-              240,
-              241
-            ],
+            "definitionLines" : "239-241",
             "numReferrers" : 1
           },
           "MATCH_ALL_BGP" : {
-            "definitionLines" : [
-              242,
-              243
-            ],
+            "definitionLines" : "242-243",
             "numReferrers" : 1
           }
         },
         "interface" : {
           "Ethernet0/0" : {
-            "definitionLines" : [
-              124,
-              125,
-              126,
-              127
-            ],
+            "definitionLines" : "124-127",
             "numReferrers" : 1
           },
           "Ethernet1/0" : {
-            "definitionLines" : [
-              136,
-              137,
-              138,
-              139,
-              140
-            ],
+            "definitionLines" : "136-140",
             "numReferrers" : 1
           },
           "Ethernet1/1" : {
-            "definitionLines" : [
-              142,
-              143,
-              144,
-              145,
-              146
-            ],
+            "definitionLines" : "142-146",
             "numReferrers" : 1
           },
           "Ethernet1/2" : {
-            "definitionLines" : [
-              148,
-              149,
-              150
-            ],
+            "definitionLines" : "148-150",
             "numReferrers" : 1
           },
           "Ethernet1/3" : {
-            "definitionLines" : [
-              152,
-              153,
-              154,
-              155,
-              156,
-              157
-            ],
+            "definitionLines" : "152-157",
             "numReferrers" : 1
           },
           "Ethernet1/4" : {
-            "definitionLines" : [
-              159,
-              160,
-              161,
-              162
-            ],
+            "definitionLines" : "159-162",
             "numReferrers" : 1
           },
           "Ethernet1/5" : {
-            "definitionLines" : [
-              164,
-              165,
-              166,
-              167
-            ],
+            "definitionLines" : "164-167",
             "numReferrers" : 1
           },
           "Ethernet1/6" : {
-            "definitionLines" : [
-              169,
-              170,
-              171,
-              172
-            ],
+            "definitionLines" : "169-172",
             "numReferrers" : 1
           },
           "Ethernet1/7" : {
-            "definitionLines" : [
-              174,
-              175,
-              176,
-              177
-            ],
+            "definitionLines" : "174-177",
             "numReferrers" : 1
           },
           "GigabitEthernet0/0" : {
-            "definitionLines" : [
-              129,
-              130,
-              131,
-              132,
-              133,
-              134
-            ],
+            "definitionLines" : "129-134",
             "numReferrers" : 1
           },
           "GigabitEthernet2/0" : {
-            "definitionLines" : [
-              179,
-              180,
-              181,
-              182,
-              183
-            ],
+            "definitionLines" : "179-183",
             "numReferrers" : 1
           },
           "Loopback0" : {
-            "definitionLines" : [
-              105,
-              106
-            ],
+            "definitionLines" : "105-106",
             "numReferrers" : 2
           },
           "Null0" : {
-            "definitionLines" : [
-              236
-            ],
+            "definitionLines" : "236",
             "numReferrers" : 1
           },
           "Tunnel1" : {
-            "definitionLines" : [
-              108,
-              109,
-              110,
-              111,
-              112,
-              113,
-              114
-            ],
+            "definitionLines" : "108-114",
             "numReferrers" : 1
           },
           "Tunnel2" : {
-            "definitionLines" : [
-              116,
-              117,
-              118,
-              119,
-              120,
-              121,
-              122
-            ],
+            "definitionLines" : "116-122",
             "numReferrers" : 1
           }
         },
         "ipv4 prefix-list" : {
           "PROTECT_LOOPBACK" : {
-            "definitionLines" : [
-              246,
-              247
-            ],
+            "definitionLines" : "246-247",
             "numReferrers" : 1
           }
         },
         "route-map" : {
           "PROTECT_LOOPBACK" : {
-            "definitionLines" : [
-              251,
-              252
-            ],
+            "definitionLines" : "251-252",
             "numReferrers" : 3
           },
           "SET_LOCAL_PREF" : {
-            "definitionLines" : [
-              254,
-              255,
-              257,
-              258
-            ],
+            "definitionLines" : "254-255,257-258",
             "numReferrers" : 1
           }
         }

--- a/tests/aws/init-example-aws.ref
+++ b/tests/aws/init-example-aws.ref
@@ -232,183 +232,116 @@
       "configs/lhr-border-02.cfg" : {
         "bgp peer-group" : {
           "FW" : {
-            "bgp neighbor peer-group" : [
-              200,
-              202
-            ]
+            "bgp neighbor peer-group" : "200,202"
           }
         },
         "crypto ipsec profile" : {
           "ipsec-vpn-ba2e34a8-0" : {
-            "interface TunnelX tunnel protection ipsec profile" : [
-              114
-            ]
+            "interface TunnelX tunnel protection ipsec profile" : "114"
           },
           "ipsec-vpn-ba2e34a8-1" : {
-            "interface TunnelX tunnel protection ipsec profile" : [
-              122
-            ]
+            "interface TunnelX tunnel protection ipsec profile" : "122"
           }
         },
         "crypto ipsec transform-set" : {
           "ipsec-prop-vpn-ba2e34a8-0" : {
-            "ipsec profile set transform-set" : [
-              93
-            ]
+            "ipsec profile set transform-set" : "93"
           },
           "ipsec-prop-vpn-ba2e34a8-1" : {
-            "ipsec profile set transform-set" : [
-              97
-            ]
+            "ipsec profile set transform-set" : "97"
           }
         },
         "crypto isakmp policy" : {
           "200" : {
-            "isakmp policy" : [
-              62
-            ]
+            "isakmp policy" : "62"
           },
           "201" : {
-            "isakmp policy" : [
-              68
-            ]
+            "isakmp policy" : "68"
           }
         },
         "crypto isakmp profile" : {
           "isakmp-vpn-ba2e34a8-0" : {
-            "isakmp profile" : [
-              74
-            ]
+            "isakmp profile" : "74"
           },
           "isakmp-vpn-ba2e34a8-1" : {
-            "isakmp profile" : [
-              78
-            ]
+            "isakmp profile" : "78"
           }
         },
         "crypto keyring" : {
           "keyring-vpn-ba2e34a8-0" : {
-            "isakmp profile keyring" : [
-              75
-            ]
+            "isakmp profile keyring" : "75"
           },
           "keyring-vpn-ba2e34a8-1" : {
-            "isakmp profile keyring" : [
-              79
-            ]
+            "isakmp profile keyring" : "79"
           }
         },
         "interface" : {
           "Ethernet0/0" : {
-            "interface" : [
-              124
-            ]
+            "interface" : "124"
           },
           "Ethernet1/0" : {
-            "interface" : [
-              136
-            ]
+            "interface" : "136"
           },
           "Ethernet1/1" : {
-            "interface" : [
-              142
-            ]
+            "interface" : "142"
           },
           "Ethernet1/2" : {
-            "interface" : [
-              148
-            ]
+            "interface" : "148"
           },
           "Ethernet1/3" : {
-            "interface" : [
-              152
-            ]
+            "interface" : "152"
           },
           "Ethernet1/4" : {
-            "interface" : [
-              159
-            ]
+            "interface" : "159"
           },
           "Ethernet1/5" : {
-            "interface" : [
-              164
-            ]
+            "interface" : "164"
           },
           "Ethernet1/6" : {
-            "interface" : [
-              169
-            ]
+            "interface" : "169"
           },
           "Ethernet1/7" : {
-            "interface" : [
-              174
-            ]
+            "interface" : "174"
           },
           "GigabitEthernet0/0" : {
-            "interface" : [
-              129
-            ]
+            "interface" : "129"
           },
           "GigabitEthernet2/0" : {
-            "interface" : [
-              179
-            ]
+            "interface" : "179"
           },
           "Loopback0" : {
-            "interface" : [
-              105
-            ],
-            "update-source interface" : [
-              205
-            ]
+            "interface" : "105",
+            "update-source interface" : "205"
           },
           "Null0" : {
-            "ip route next-hop interface" : [
-              236
-            ]
+            "ip route next-hop interface" : "236"
           },
           "Tunnel1" : {
-            "interface" : [
-              108
-            ]
+            "interface" : "108"
           },
           "Tunnel2" : {
-            "interface" : [
-              116
-            ]
+            "interface" : "116"
           }
         },
         "ipv4 acl" : {
           "LIMIT_PEER" : {
-            "interface incoming ip access-list" : [
-              155
-            ]
+            "interface incoming ip access-list" : "155"
           },
           "MATCH_ALL_BGP" : {
-            "route-map match ipv4 access-list" : [
-              258
-            ]
+            "route-map match ipv4 access-list" : "258"
           }
         },
         "ipv4 prefix-list" : {
           "PROTECT_LOOPBACK" : {
-            "route-map match ipv4 prefix-list" : [
-              252
-            ]
+            "route-map match ipv4 prefix-list" : "252"
           }
         },
         "route-map" : {
           "PROTECT_LOOPBACK" : {
-            "bgp inbound route-map" : [
-              217,
-              223,
-              227
-            ]
+            "bgp inbound route-map" : "217,223,227"
           },
           "SET_LOCAL_PREF" : {
-            "bgp inbound route-map" : [
-              214
-            ]
+            "bgp inbound route-map" : "214"
           }
         }
       }

--- a/tests/basic/example-iptables-init.ref
+++ b/tests/basic/example-iptables-init.ref
@@ -124,24 +124,15 @@
         "configs/r1.cfg" : {
           "interface" : {
             "Ethernet0" : {
-              "definitionLines" : [
-                7,
-                8
-              ],
+              "definitionLines" : "7-8",
               "numReferrers" : 1
             },
             "Ethernet1" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 1
             },
             "Ethernet2" : {
-              "definitionLines" : [
-                1,
-                2
-              ],
+              "definitionLines" : "1-2",
               "numReferrers" : 1
             }
           }
@@ -149,24 +140,15 @@
         "configs/r2.cfg" : {
           "interface" : {
             "Ethernet0" : {
-              "definitionLines" : [
-                7,
-                8
-              ],
+              "definitionLines" : "7-8",
               "numReferrers" : 1
             },
             "Ethernet1" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 1
             },
             "Ethernet2" : {
-              "definitionLines" : [
-                1,
-                2
-              ],
+              "definitionLines" : "1-2",
               "numReferrers" : 1
             }
           }
@@ -174,24 +156,15 @@
         "configs/r3.cfg" : {
           "interface" : {
             "Ethernet0" : {
-              "definitionLines" : [
-                7,
-                8
-              ],
+              "definitionLines" : "7-8",
               "numReferrers" : 1
             },
             "Ethernet1" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 1
             },
             "Ethernet2" : {
-              "definitionLines" : [
-                1,
-                2
-              ],
+              "definitionLines" : "1-2",
               "numReferrers" : 1
             }
           }
@@ -199,17 +172,11 @@
         "configs/z1-firewall.cfg" : {
           "interface" : {
             "Ethernet0" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 1
             },
             "Ethernet1" : {
-              "definitionLines" : [
-                1,
-                2
-              ],
+              "definitionLines" : "1-2",
               "numReferrers" : 1
             }
           }
@@ -217,17 +184,11 @@
         "configs/z2-firewall.cfg" : {
           "interface" : {
             "Ethernet0" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 1
             },
             "Ethernet1" : {
-              "definitionLines" : [
-                1,
-                2
-              ],
+              "definitionLines" : "1-2",
               "numReferrers" : 1
             }
           }

--- a/tests/basic/example-iptables-init.ref
+++ b/tests/basic/example-iptables-init.ref
@@ -235,85 +235,59 @@
         "configs/r1.cfg" : {
           "interface" : {
             "Ethernet0" : {
-              "interface" : [
-                7
-              ]
+              "interface" : "7"
             },
             "Ethernet1" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             },
             "Ethernet2" : {
-              "interface" : [
-                1
-              ]
+              "interface" : "1"
             }
           }
         },
         "configs/r2.cfg" : {
           "interface" : {
             "Ethernet0" : {
-              "interface" : [
-                7
-              ]
+              "interface" : "7"
             },
             "Ethernet1" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             },
             "Ethernet2" : {
-              "interface" : [
-                1
-              ]
+              "interface" : "1"
             }
           }
         },
         "configs/r3.cfg" : {
           "interface" : {
             "Ethernet0" : {
-              "interface" : [
-                7
-              ]
+              "interface" : "7"
             },
             "Ethernet1" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             },
             "Ethernet2" : {
-              "interface" : [
-                1
-              ]
+              "interface" : "1"
             }
           }
         },
         "configs/z1-firewall.cfg" : {
           "interface" : {
             "Ethernet0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             },
             "Ethernet1" : {
-              "interface" : [
-                1
-              ]
+              "interface" : "1"
             }
           }
         },
         "configs/z2-firewall.cfg" : {
           "interface" : {
             "Ethernet0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             },
             "Ethernet1" : {
-              "interface" : [
-                1
-              ]
+              "interface" : "1"
             }
           }
         }

--- a/tests/basic/init-candidate.ref
+++ b/tests/basic/init-candidate.ref
@@ -99,176 +99,97 @@
         "configs/as1border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                79
-              ],
+              "definitionLines" : "79",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 1
             },
             "as3" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 0
             },
             "bad-ebgp" : {
-              "definitionLines" : [
-                87
-              ],
+              "definitionLines" : "87",
               "numReferrers" : 1
             },
             "xanadu" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                119
-              ],
+              "definitionLines" : "119",
               "numReferrers" : 0
             },
             "as2_community" : {
-              "definitionLines" : [
-                120
-              ],
+              "definitionLines" : "120",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                121
-              ],
+              "definitionLines" : "121",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                131,
-                132
-              ],
+              "definitionLines" : "131-132",
               "numReferrers" : 2
             },
             "102" : {
-              "definitionLines" : [
-                133,
-                134
-              ],
+              "definitionLines" : "133-134",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                135,
-                136
-              ],
+              "definitionLines" : "135-136",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "59-64",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "default_list" : {
-              "definitionLines" : [
-                127
-              ],
+              "definitionLines" : "127",
               "numReferrers" : 1
             },
             "inbound_route_filter" : {
-              "definitionLines" : [
-                129,
-                130
-              ],
+              "definitionLines" : "129-130",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                138,
-                139,
-                140,
-                141,
-                143,
-                144,
-                145,
-                146,
-                148,
-                149,
-                150,
-                151
-              ],
+              "definitionLines" : "138-141,143-146,148-151",
               "numReferrers" : 1
             },
             "as1_to_as3" : {
-              "definitionLines" : [
-                157,
-                158,
-                159,
-                160,
-                162,
-                163,
-                164,
-                165
-              ],
+              "definitionLines" : "157-160,162-165",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                153,
-                154,
-                155
-              ],
+              "definitionLines" : "153-155",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                167,
-                168,
-                169
-              ],
+              "definitionLines" : "167-169",
               "numReferrers" : 1
             }
           }
@@ -276,196 +197,109 @@
         "configs/as1border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                87
-              ],
+              "definitionLines" : "87",
               "numReferrers" : 0
             },
             "as3" : {
-              "definitionLines" : [
-                89
-              ],
+              "definitionLines" : "89",
               "numReferrers" : 1
             },
             "as4" : {
-              "definitionLines" : [
-                91
-              ],
+              "definitionLines" : "91",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                123
-              ],
+              "definitionLines" : "123",
               "numReferrers" : 0
             },
             "as2_community" : {
-              "definitionLines" : [
-                124
-              ],
+              "definitionLines" : "124",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                125
-              ],
+              "definitionLines" : "125",
               "numReferrers" : 1
             },
             "as4_community" : {
-              "definitionLines" : [
-                126
-              ],
+              "definitionLines" : "126",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                136,
-                137
-              ],
+              "definitionLines" : "136-137",
               "numReferrers" : 2
             },
             "102" : {
-              "definitionLines" : [
-                138,
-                139
-              ],
+              "definitionLines" : "138-139",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                140
-              ],
+              "definitionLines" : "140",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "73-75",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "as4-prefixes" : {
-              "definitionLines" : [
-                132
-              ],
+              "definitionLines" : "132",
               "numReferrers" : 1
             },
             "inbound_route_filter" : {
-              "definitionLines" : [
-                134,
-                135
-              ],
+              "definitionLines" : "134-135",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                142,
-                143,
-                144,
-                145,
-                147,
-                148,
-                149,
-                150
-              ],
+              "definitionLines" : "142-145,147-150",
               "numReferrers" : 1
             },
             "as1_to_as3" : {
-              "definitionLines" : [
-                156,
-                157,
-                158,
-                159,
-                161,
-                162,
-                163,
-                164
-              ],
+              "definitionLines" : "156-159,161-164",
               "numReferrers" : 1
             },
             "as1_to_as4" : {
-              "definitionLines" : [
-                170,
-                171,
-                172
-              ],
+              "definitionLines" : "170-172",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                152,
-                153,
-                154
-              ],
+              "definitionLines" : "152-154",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                166,
-                167,
-                168
-              ],
+              "definitionLines" : "166-168",
               "numReferrers" : 1
             },
             "as4_to_as1" : {
-              "definitionLines" : [
-                174,
-                175,
-                176,
-                177
-              ],
+              "definitionLines" : "174-177",
               "numReferrers" : 1
             }
           }
@@ -473,46 +307,25 @@
         "configs/as1core1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                80
-              ],
+              "definitionLines" : "80",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 3
             }
           }
@@ -520,183 +333,97 @@
         "configs/as2border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                89
-              ],
+              "definitionLines" : "89",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                91
-              ],
+              "definitionLines" : "91",
               "numReferrers" : 2
             },
             "as3" : {
-              "definitionLines" : [
-                93
-              ],
+              "definitionLines" : "93",
               "numReferrers" : 0
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                123
-              ],
+              "definitionLines" : "123",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                124
-              ],
+              "definitionLines" : "124",
               "numReferrers" : 0
             },
             "as3_community" : {
-              "definitionLines" : [
-                125
-              ],
+              "definitionLines" : "125",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                144,
-                145
-              ],
+              "definitionLines" : "144-145",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                146,
-                147
-              ],
+              "definitionLines" : "146-147",
               "numReferrers" : 1
             },
             "INSIDE_TO_AS1" : {
-              "definitionLines" : [
-                130,
-                131,
-                132,
-                133
-              ],
+              "definitionLines" : "130-133",
               "numReferrers" : 1
             },
             "OUTSIDE_TO_INSIDE" : {
-              "definitionLines" : [
-                134,
-                135,
-                136,
-                137
-              ],
+              "definitionLines" : "134-137",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62
-              ],
+              "definitionLines" : "59-62",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                64,
-                65,
-                66,
-                67,
-                68,
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "64-71",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "73-75",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                77,
-                78,
-                79
-              ],
+              "definitionLines" : "77-79",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                56,
-                57
-              ],
+              "definitionLines" : "56-57",
               "numReferrers" : 3
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                140,
-                141
-              ],
+              "definitionLines" : "140-141",
               "numReferrers" : 0
             },
             "outbound_routes" : {
-              "definitionLines" : [
-                143
-              ],
+              "definitionLines" : "143",
               "numReferrers" : 2
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                159,
-                160,
-                161,
-                162
-              ],
+              "definitionLines" : "159-162",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                149,
-                150,
-                151,
-                152,
-                154,
-                155,
-                156,
-                157
-              ],
+              "definitionLines" : "149-152,154-157",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                164,
-                165,
-                166,
-                167,
-                169,
-                170,
-                171,
-                172
-              ],
+              "definitionLines" : "164-167,169-172",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                174,
-                175,
-                176,
-                177
-              ],
+              "definitionLines" : "174-177",
               "numReferrers" : 1
             }
           }
@@ -704,182 +431,97 @@
         "configs/as2border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                86
-              ],
+              "definitionLines" : "86",
               "numReferrers" : 0
             },
             "as2" : {
-              "definitionLines" : [
-                88
-              ],
+              "definitionLines" : "88",
               "numReferrers" : 2
             },
             "as3" : {
-              "definitionLines" : [
-                90
-              ],
+              "definitionLines" : "90",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                120
-              ],
+              "definitionLines" : "120",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                121
-              ],
+              "definitionLines" : "121",
               "numReferrers" : 0
             },
             "as3_community" : {
-              "definitionLines" : [
-                122
-              ],
+              "definitionLines" : "122",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                140,
-                141
-              ],
+              "definitionLines" : "140-141",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                142,
-                143
-              ],
+              "definitionLines" : "142-143",
               "numReferrers" : 1
             },
             "INSIDE_TO_AS3" : {
-              "definitionLines" : [
-                127,
-                128,
-                129,
-                130
-              ],
+              "definitionLines" : "127-130",
               "numReferrers" : 1
             },
             "OUTSIDE_TO_INSIDE" : {
-              "definitionLines" : [
-                131,
-                132,
-                133
-              ],
+              "definitionLines" : "131-133",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                56,
-                57,
-                58,
-                59
-              ],
+              "definitionLines" : "56-59",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                61,
-                62,
-                63,
-                64,
-                65,
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "61-68",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72
-              ],
+              "definitionLines" : "70-72",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                74,
-                75,
-                76
-              ],
+              "definitionLines" : "74-76",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                53,
-                54
-              ],
+              "definitionLines" : "53-54",
               "numReferrers" : 3
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                136,
-                137
-              ],
+              "definitionLines" : "136-137",
               "numReferrers" : 0
             },
             "outbound_routes" : {
-              "definitionLines" : [
-                139
-              ],
+              "definitionLines" : "139",
               "numReferrers" : 2
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                155,
-                156,
-                157,
-                158
-              ],
+              "definitionLines" : "155-158",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                145,
-                146,
-                147,
-                148,
-                150,
-                151,
-                152,
-                153
-              ],
+              "definitionLines" : "145-148,150-153",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                160,
-                161,
-                162,
-                163,
-                165,
-                166,
-                167,
-                168
-              ],
+              "definitionLines" : "160-163,165-168",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                170,
-                171,
-                172,
-                173
-              ],
+              "definitionLines" : "170-173",
               "numReferrers" : 1
             }
           }
@@ -887,74 +529,39 @@
         "configs/as2core1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                90
-              ],
+              "definitionLines" : "90",
               "numReferrers" : 4
             }
           },
           "extended ipv4 access-list" : {
             "blocktelnet" : {
-              "definitionLines" : [
-                121,
-                122,
-                123
-              ],
+              "definitionLines" : "121-123",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75,
-                76
-              ],
+              "definitionLines" : "73-76",
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
-              "definitionLines" : [
-                78,
-                79,
-                80,
-                81
-              ],
+              "definitionLines" : "78-81",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 5
             }
           }
@@ -962,65 +569,33 @@
         "configs/as2core2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                91
-              ],
+              "definitionLines" : "91",
               "numReferrers" : 4
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "62-68",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72,
-                73
-              ],
+              "definitionLines" : "70-73",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                75,
-                76,
-                77,
-                78
-              ],
+              "definitionLines" : "75-78",
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
-              "definitionLines" : [
-                80,
-                81,
-                82
-              ],
+              "definitionLines" : "80-82",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 5
             }
           }
@@ -1028,129 +603,67 @@
         "configs/as2dept1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 2
             }
           },
           "expanded community-list" : {
             "as2_community" : {
-              "definitionLines" : [
-                107
-              ],
+              "definitionLines" : "107",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "102" : {
-              "definitionLines" : [
-                121,
-                122
-              ],
+              "definitionLines" : "121-122",
               "numReferrers" : 1
             },
             "105" : {
-              "definitionLines" : [
-                123,
-                124,
-                125,
-                126
-              ],
+              "definitionLines" : "123-126",
               "numReferrers" : 0
             },
             "RESTRICT_HOST_TRAFFIC_IN" : {
-              "definitionLines" : [
-                112,
-                113,
-                114,
-                115
-              ],
+              "definitionLines" : "112-115",
               "numReferrers" : 3
             },
             "RESTRICT_HOST_TRAFFIC_OUT" : {
-              "definitionLines" : [
-                116,
-                117,
-                118,
-                119
-              ],
+              "definitionLines" : "116-119",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "59-64",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72,
-                73,
-                74
-              ],
+              "definitionLines" : "70-74",
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
-              "definitionLines" : [
-                76,
-                77,
-                78,
-                79,
-                80
-              ],
+              "definitionLines" : "76-80",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 1
             }
           },
           "route-map" : {
             "as2_to_dept" : {
-              "definitionLines" : [
-                133,
-                134,
-                135
-              ],
+              "definitionLines" : "133-135",
               "numReferrers" : 1
             },
             "dept_to_as2" : {
-              "definitionLines" : [
-                128,
-                129,
-                130,
-                131
-              ],
+              "definitionLines" : "128-131",
               "numReferrers" : 1
             }
           }
@@ -1158,104 +671,59 @@
         "configs/as2dist1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 2
             },
             "dept" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "dept_community" : {
-              "definitionLines" : [
-                111
-              ],
+              "definitionLines" : "111",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "102" : {
-              "definitionLines" : [
-                116
-              ],
+              "definitionLines" : "116",
               "numReferrers" : 0
             },
             "105" : {
-              "definitionLines" : [
-                117,
-                118,
-                119,
-                120
-              ],
+              "definitionLines" : "117-120",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "59-64",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72
-              ],
+              "definitionLines" : "70-72",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 3
             }
           },
           "route-map" : {
             "as2dist_to_dept" : {
-              "definitionLines" : [
-                122,
-                123,
-                124,
-                125
-              ],
+              "definitionLines" : "122-125",
               "numReferrers" : 1
             },
             "dept_to_as2dist" : {
-              "definitionLines" : [
-                127,
-                128,
-                129
-              ],
+              "definitionLines" : "127-129",
               "numReferrers" : 1
             }
           }
@@ -1263,104 +731,59 @@
         "configs/as2dist2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 2
             },
             "dept" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "dept_community" : {
-              "definitionLines" : [
-                111
-              ],
+              "definitionLines" : "111",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "102" : {
-              "definitionLines" : [
-                116
-              ],
+              "definitionLines" : "116",
               "numReferrers" : 0
             },
             "105" : {
-              "definitionLines" : [
-                117,
-                118,
-                119,
-                120
-              ],
+              "definitionLines" : "117-120",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "59-64",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72
-              ],
+              "definitionLines" : "70-72",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 3
             }
           },
           "route-map" : {
             "as2dist_to_dept" : {
-              "definitionLines" : [
-                122,
-                123,
-                124,
-                125
-              ],
+              "definitionLines" : "122-125",
               "numReferrers" : 1
             },
             "dept_to_as2dist" : {
-              "definitionLines" : [
-                127,
-                128,
-                129
-              ],
+              "definitionLines" : "127-129",
               "numReferrers" : 1
             }
           }
@@ -1368,164 +791,89 @@
         "configs/as3border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 0
             },
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 1
             },
             "as3" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                113
-              ],
+              "definitionLines" : "113",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                114
-              ],
+              "definitionLines" : "114",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                115
-              ],
+              "definitionLines" : "115",
               "numReferrers" : 0
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                125,
-                126
-              ],
+              "definitionLines" : "125-126",
               "numReferrers" : 1
             },
             "102" : {
-              "definitionLines" : [
-                127,
-                128
-              ],
+              "definitionLines" : "127-128",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                129,
-                130
-              ],
+              "definitionLines" : "129-130",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "default_list" : {
-              "definitionLines" : [
-                121
-              ],
+              "definitionLines" : "121",
               "numReferrers" : 1
             },
             "inbound_route_filter" : {
-              "definitionLines" : [
-                123,
-                124
-              ],
+              "definitionLines" : "123-124",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "definitionLines" : [
-                142,
-                143,
-                144
-              ],
+              "definitionLines" : "142-144",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                161,
-                162,
-                163
-              ],
+              "definitionLines" : "161-163",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                132,
-                133,
-                134,
-                135,
-                137,
-                138,
-                139,
-                140
-              ],
+              "definitionLines" : "132-135,137-140",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                146,
-                147,
-                148,
-                149,
-                151,
-                152,
-                153,
-                154,
-                156,
-                157,
-                158,
-                159
-              ],
+              "definitionLines" : "146-149,151-154,156-159",
               "numReferrers" : 1
             }
           }
@@ -1533,154 +881,85 @@
         "configs/as3border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 0
             },
             "as3" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                113
-              ],
+              "definitionLines" : "113",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                114
-              ],
+              "definitionLines" : "114",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                115
-              ],
+              "definitionLines" : "115",
               "numReferrers" : 0
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                123,
-                124
-              ],
+              "definitionLines" : "123-124",
               "numReferrers" : 1
             },
             "102" : {
-              "definitionLines" : [
-                125,
-                126
-              ],
+              "definitionLines" : "125-126",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                127,
-                128
-              ],
+              "definitionLines" : "127-128",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                121,
-                122
-              ],
+              "definitionLines" : "121-122",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "definitionLines" : [
-                140,
-                141,
-                142
-              ],
+              "definitionLines" : "140-142",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                154,
-                155,
-                156
-              ],
+              "definitionLines" : "154-156",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                130,
-                131,
-                132,
-                133,
-                135,
-                136,
-                137,
-                138
-              ],
+              "definitionLines" : "130-133,135-138",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                144,
-                145,
-                146,
-                147,
-                149,
-                150,
-                151,
-                152
-              ],
+              "definitionLines" : "144-147,149-152",
               "numReferrers" : 1
             }
           }
@@ -1688,62 +967,33 @@
         "configs/as3core1.cfg" : {
           "bgp peer-group" : {
             "as3" : {
-              "definitionLines" : [
-                87
-              ],
+              "definitionLines" : "87",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "73-75",
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
-              "definitionLines" : [
-                77,
-                78,
-                79
-              ],
+              "definitionLines" : "77-79",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 3
             }
           }

--- a/tests/basic/init-candidate.ref
+++ b/tests/basic/init-candidate.ref
@@ -1052,1063 +1052,666 @@
         "configs/as1border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                89
-              ]
+              "bgp neighbor peer-group" : "89"
             },
             "as2" : {
-              "bgp neighbor peer-group" : [
-                93
-              ]
+              "bgp neighbor peer-group" : "93"
             },
             "bad-ebgp" : {
-              "bgp neighbor peer-group" : [
-                91
-              ]
+              "bgp neighbor peer-group" : "91"
             },
             "xanadu" : {
-              "bgp neighbor peer-group" : [
-                92
-              ]
+              "bgp neighbor peer-group" : "92"
             }
           },
           "community-list" : {
             "as2_community" : {
-              "route-map match community-list" : [
-                154
-              ]
+              "route-map match community-list" : "154"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                168
-              ]
+              "route-map match community-list" : "168"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ],
-              "update-source interface" : [
-                90
-              ]
+              "interface" : "51",
+              "update-source interface" : "90"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                139,
-                158
-              ]
+              "route-map match ipv4 access-list" : "139,158"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                163
-              ]
+              "route-map match ipv4 access-list" : "163"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                144
-              ]
+              "route-map match ipv4 access-list" : "144"
             }
           },
           "ipv4 prefix-list" : {
             "default_list" : {
-              "route-map match ipv4 prefix-list" : [
-                149
-              ]
+              "route-map match ipv4 prefix-list" : "149"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp outbound route-map" : [
-                105
-              ]
+              "bgp outbound route-map" : "105"
             },
             "as1_to_as3" : {
-              "bgp outbound route-map" : [
-                108
-              ]
+              "bgp outbound route-map" : "108"
             },
             "as2_to_as1" : {
-              "bgp inbound route-map" : [
-                104
-              ]
+              "bgp inbound route-map" : "104"
             },
             "as3_to_as1" : {
-              "bgp inbound route-map" : [
-                107
-              ]
+              "bgp inbound route-map" : "107"
             }
           }
         },
         "configs/as1border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                93
-              ]
+              "bgp neighbor peer-group" : "93"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                95
-              ]
+              "bgp neighbor peer-group" : "95"
             },
             "as4" : {
-              "bgp neighbor peer-group" : [
-                96
-              ]
+              "bgp neighbor peer-group" : "96"
             }
           },
           "community-list" : {
             "as2_community" : {
-              "route-map match community-list" : [
-                153
-              ]
+              "route-map match community-list" : "153"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                167
-              ]
+              "route-map match community-list" : "167"
             },
             "as4_community" : {
-              "route-map match community-list" : [
-                176
-              ]
+              "route-map match community-list" : "176"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                94
-              ]
+              "interface" : "54",
+              "update-source interface" : "94"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                143,
-                157
-              ]
+              "route-map match ipv4 access-list" : "143,157"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                162
-              ]
+              "route-map match ipv4 access-list" : "162"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                148
-              ]
+              "route-map match ipv4 access-list" : "148"
             }
           },
           "ipv4 prefix-list" : {
             "as4-prefixes" : {
-              "route-map match ipv4 prefix-list" : [
-                175
-              ]
+              "route-map match ipv4 prefix-list" : "175"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp outbound route-map" : [
-                108
-              ]
+              "bgp outbound route-map" : "108"
             },
             "as1_to_as3" : {
-              "bgp outbound route-map" : [
-                111
-              ]
+              "bgp outbound route-map" : "111"
             },
             "as1_to_as4" : {
-              "bgp outbound route-map" : [
-                113
-              ]
+              "bgp outbound route-map" : "113"
             },
             "as2_to_as1" : {
-              "bgp inbound route-map" : [
-                107
-              ]
+              "bgp inbound route-map" : "107"
             },
             "as3_to_as1" : {
-              "bgp inbound route-map" : [
-                110
-              ]
+              "bgp inbound route-map" : "110"
             },
             "as4_to_as1" : {
-              "bgp inbound route-map" : [
-                112
-              ]
+              "bgp inbound route-map" : "112"
             }
           }
         },
         "configs/as1core1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                82,
-                84
-              ]
+              "bgp neighbor peer-group" : "82,84"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                83,
-                85
-              ]
+              "interface" : "54",
+              "update-source interface" : "83,85"
             }
           }
         },
         "configs/as2border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                99
-              ]
+              "bgp neighbor peer-group" : "99"
             },
             "as2" : {
-              "bgp neighbor peer-group" : [
-                95,
-                97
-              ]
+              "bgp neighbor peer-group" : "95,97"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                160
-              ]
+              "route-map match community-list" : "160"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                175
-              ]
+              "route-map match community-list" : "175"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                64
-              ]
+              "interface" : "64"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                77
-              ]
+              "interface" : "77"
             },
             "Loopback0" : {
-              "interface" : [
-                56
-              ],
-              "update-source interface" : [
-                96,
-                98
-              ]
+              "interface" : "56",
+              "update-source interface" : "96,98"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                165
-              ]
+              "route-map match ipv4 access-list" : "165"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                155
-              ]
+              "route-map match ipv4 access-list" : "155"
             },
             "INSIDE_TO_AS1" : {
-              "interface outgoing ip access-list" : [
-                67
-              ]
+              "interface outgoing ip access-list" : "67"
             },
             "OUTSIDE_TO_INSIDE" : {
-              "interface incoming ip access-list" : [
-                66
-              ]
+              "interface incoming ip access-list" : "66"
             }
           },
           "ipv4 prefix-list" : {
             "outbound_routes" : {
-              "route-map match ipv4 prefix-list" : [
-                150,
-                170
-              ]
+              "route-map match ipv4 prefix-list" : "150,170"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp inbound route-map" : [
-                107
-              ]
+              "bgp inbound route-map" : "107"
             },
             "as2_to_as1" : {
-              "bgp outbound route-map" : [
-                108
-              ]
+              "bgp outbound route-map" : "108"
             },
             "as2_to_as3" : {
-              "bgp outbound route-map" : [
-                113
-              ]
+              "bgp outbound route-map" : "113"
             },
             "as3_to_as2" : {
-              "bgp inbound route-map" : [
-                112
-              ]
+              "bgp inbound route-map" : "112"
             }
           }
         },
         "configs/as2border2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                92,
-                94
-              ]
+              "bgp neighbor peer-group" : "92,94"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                96
-              ]
+              "bgp neighbor peer-group" : "96"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                156
-              ]
+              "route-map match community-list" : "156"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                171
-              ]
+              "route-map match community-list" : "171"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                56
-              ]
+              "interface" : "56"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                61
-              ]
+              "interface" : "61"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                74
-              ]
+              "interface" : "74"
             },
             "Loopback0" : {
-              "interface" : [
-                53
-              ],
-              "update-source interface" : [
-                93,
-                95
-              ]
+              "interface" : "53",
+              "update-source interface" : "93,95"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                161
-              ]
+              "route-map match ipv4 access-list" : "161"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                151
-              ]
+              "route-map match ipv4 access-list" : "151"
             },
             "INSIDE_TO_AS3" : {
-              "interface outgoing ip access-list" : [
-                64
-              ]
+              "interface outgoing ip access-list" : "64"
             },
             "OUTSIDE_TO_INSIDE" : {
-              "interface incoming ip access-list" : [
-                63
-              ]
+              "interface incoming ip access-list" : "63"
             }
           },
           "ipv4 prefix-list" : {
             "outbound_routes" : {
-              "route-map match ipv4 prefix-list" : [
-                146,
-                166
-              ]
+              "route-map match ipv4 prefix-list" : "146,166"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp inbound route-map" : [
-                104
-              ]
+              "bgp inbound route-map" : "104"
             },
             "as2_to_as1" : {
-              "bgp outbound route-map" : [
-                105
-              ]
+              "bgp outbound route-map" : "105"
             },
             "as2_to_as3" : {
-              "bgp outbound route-map" : [
-                110
-              ]
+              "bgp outbound route-map" : "110"
             },
             "as3_to_as2" : {
-              "bgp inbound route-map" : [
-                109
-              ]
+              "bgp inbound route-map" : "109"
             }
           }
         },
         "configs/as2core1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                92,
-                94,
-                96,
-                98
-              ]
+              "bgp neighbor peer-group" : "92,94,96,98"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "GigabitEthernet3/0" : {
-              "interface" : [
-                78
-              ]
+              "interface" : "78"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                93,
-                95,
-                97,
-                99
-              ]
+              "interface" : "54",
+              "update-source interface" : "93,95,97,99"
             }
           },
           "ipv4 acl" : {
             "blocktelnet" : {
-              "interface incoming ip access-list" : [
-                75,
-                80
-              ]
+              "interface incoming ip access-list" : "75,80"
             }
           }
         },
         "configs/as2core2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                93,
-                95,
-                97,
-                99
-              ]
+              "bgp neighbor peer-group" : "93,95,97,99"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                75
-              ]
+              "interface" : "75"
             },
             "GigabitEthernet3/0" : {
-              "interface" : [
-                80
-              ]
+              "interface" : "80"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                94,
-                96,
-                98,
-                100
-              ]
+              "interface" : "54",
+              "update-source interface" : "94,96,98,100"
             }
           },
           "route-map" : {
             "filter-bogons" : {
-              "bgp inbound route-map" : [
-                109
-              ]
+              "bgp inbound route-map" : "109"
             }
           }
         },
         "configs/as2dept1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                87,
-                88
-              ]
+              "bgp neighbor peer-group" : "87-88"
             }
           },
           "community-list" : {
             "as2_community" : {
-              "route-map match community-list" : [
-                134
-              ]
+              "route-map match community-list" : "134"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "GigabitEthernet3/0" : {
-              "interface" : [
-                76
-              ]
+              "interface" : "76"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ]
+              "interface" : "51"
             }
           },
           "ipv4 acl" : {
             "102" : {
-              "route-map match ipv4 access-list" : [
-                129
-              ]
+              "route-map match ipv4 access-list" : "129"
             },
             "RESTRICT_HOST_TRAFFIC_IN" : {
-              "interface incoming ip access-list" : [
-                72,
-                78
-              ],
-              "interface outgoing ip access-list" : [
-                73
-              ]
+              "interface incoming ip access-list" : "72,78",
+              "interface outgoing ip access-list" : "73"
             },
             "RESTRICT_HOST_TRAFFIC_OUT" : {
-              "interface outgoing ip access-list" : [
-                79
-              ]
+              "interface outgoing ip access-list" : "79"
             }
           },
           "route-map" : {
             "as2_to_dept" : {
-              "bgp inbound route-map" : [
-                97
-              ]
+              "bgp inbound route-map" : "97"
             },
             "dept_to_as2" : {
-              "bgp outbound route-map" : [
-                98
-              ]
+              "bgp outbound route-map" : "98"
             }
           }
         },
         "configs/as2dist1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                87,
-                89
-              ]
+              "bgp neighbor peer-group" : "87,89"
             },
             "dept" : {
-              "bgp neighbor peer-group" : [
-                91
-              ]
+              "bgp neighbor peer-group" : "91"
             }
           },
           "community-list" : {
             "dept_community" : {
-              "route-map match community-list" : [
-                128
-              ]
+              "route-map match community-list" : "128"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ],
-              "update-source interface" : [
-                88,
-                90
-              ]
+              "interface" : "51",
+              "update-source interface" : "88,90"
             }
           },
           "ipv4 acl" : {
             "105" : {
-              "route-map match ipv4 access-list" : [
-                123
-              ]
+              "route-map match ipv4 access-list" : "123"
             }
           },
           "route-map" : {
             "as2dist_to_dept" : {
-              "bgp outbound route-map" : [
-                101
-              ]
+              "bgp outbound route-map" : "101"
             },
             "dept_to_as2dist" : {
-              "bgp inbound route-map" : [
-                100
-              ]
+              "bgp inbound route-map" : "100"
             }
           }
         },
         "configs/as2dist2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                87,
-                89
-              ]
+              "bgp neighbor peer-group" : "87,89"
             },
             "dept" : {
-              "bgp neighbor peer-group" : [
-                91
-              ]
+              "bgp neighbor peer-group" : "91"
             }
           },
           "community-list" : {
             "dept_community" : {
-              "route-map match community-list" : [
-                128
-              ]
+              "route-map match community-list" : "128"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ],
-              "update-source interface" : [
-                88,
-                90
-              ]
+              "interface" : "51",
+              "update-source interface" : "88,90"
             }
           },
           "ipv4 acl" : {
             "105" : {
-              "route-map match ipv4 access-list" : [
-                123
-              ]
+              "route-map match ipv4 access-list" : "123"
             }
           },
           "route-map" : {
             "as2dist_to_dept" : {
-              "bgp outbound route-map" : [
-                101
-              ]
+              "bgp outbound route-map" : "101"
             },
             "dept_to_as2dist" : {
-              "bgp inbound route-map" : [
-                100
-              ]
+              "bgp inbound route-map" : "100"
             }
           }
         },
         "configs/as3border1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                89
-              ]
+              "bgp neighbor peer-group" : "89"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                87
-              ]
+              "bgp neighbor peer-group" : "87"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                143
-              ]
+              "route-map match community-list" : "143"
             },
             "as2_community" : {
-              "route-map match community-list" : [
-                162
-              ]
+              "route-map match community-list" : "162"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                88
-              ]
+              "interface" : "54",
+              "update-source interface" : "88"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                147
-              ]
+              "route-map match ipv4 access-list" : "147"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                133
-              ]
+              "route-map match ipv4 access-list" : "133"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                138,
-                152
-              ]
+              "route-map match ipv4 access-list" : "138,152"
             }
           },
           "ipv4 prefix-list" : {
             "default_list" : {
-              "route-map match ipv4 prefix-list" : [
-                157
-              ]
+              "route-map match ipv4 prefix-list" : "157"
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "bgp inbound route-map" : [
-                98
-              ]
+              "bgp inbound route-map" : "98"
             },
             "as2_to_as3" : {
-              "bgp inbound route-map" : [
-                101
-              ]
+              "bgp inbound route-map" : "101"
             },
             "as3_to_as1" : {
-              "bgp outbound route-map" : [
-                99
-              ]
+              "bgp outbound route-map" : "99"
             },
             "as3_to_as2" : {
-              "bgp outbound route-map" : [
-                102
-              ]
+              "bgp outbound route-map" : "102"
             }
           }
         },
         "configs/as3border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                89
-              ]
+              "bgp neighbor peer-group" : "89"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                87
-              ]
+              "bgp neighbor peer-group" : "87"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                141
-              ]
+              "route-map match community-list" : "141"
             },
             "as2_community" : {
-              "route-map match community-list" : [
-                155
-              ]
+              "route-map match community-list" : "155"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                88
-              ]
+              "interface" : "54",
+              "update-source interface" : "88"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                145
-              ]
+              "route-map match ipv4 access-list" : "145"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                131
-              ]
+              "route-map match ipv4 access-list" : "131"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                136,
-                150
-              ]
+              "route-map match ipv4 access-list" : "136,150"
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "bgp inbound route-map" : [
-                98
-              ]
+              "bgp inbound route-map" : "98"
             },
             "as2_to_as3" : {
-              "bgp inbound route-map" : [
-                101
-              ]
+              "bgp inbound route-map" : "101"
             },
             "as3_to_as1" : {
-              "bgp outbound route-map" : [
-                99
-              ]
+              "bgp outbound route-map" : "99"
             },
             "as3_to_as2" : {
-              "bgp outbound route-map" : [
-                102
-              ]
+              "bgp outbound route-map" : "102"
             }
           }
         },
         "configs/as3core1.cfg" : {
           "bgp peer-group" : {
             "as3" : {
-              "bgp neighbor peer-group" : [
-                89,
-                91
-              ]
+              "bgp neighbor peer-group" : "89,91"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "GigabitEthernet3/0" : {
-              "interface" : [
-                77
-              ]
+              "interface" : "77"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                90,
-                92
-              ]
+              "interface" : "54",
+              "update-source interface" : "90,92"
             }
           }
         }
@@ -2117,9 +1720,7 @@
         "configs/as2core2.cfg" : {
           "route-map" : {
             "filter-bogons" : {
-              "bgp inbound route-map" : [
-                109
-              ]
+              "bgp inbound route-map" : "109"
             }
           }
         }

--- a/tests/basic/init-with-ba.ref
+++ b/tests/basic/init-with-ba.ref
@@ -99,176 +99,97 @@
         "configs/as1border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                79
-              ],
+              "definitionLines" : "79",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 1
             },
             "as3" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 0
             },
             "bad-ebgp" : {
-              "definitionLines" : [
-                87
-              ],
+              "definitionLines" : "87",
               "numReferrers" : 1
             },
             "xanadu" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                119
-              ],
+              "definitionLines" : "119",
               "numReferrers" : 0
             },
             "as2_community" : {
-              "definitionLines" : [
-                120
-              ],
+              "definitionLines" : "120",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                121
-              ],
+              "definitionLines" : "121",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                131,
-                132
-              ],
+              "definitionLines" : "131-132",
               "numReferrers" : 2
             },
             "102" : {
-              "definitionLines" : [
-                133,
-                134
-              ],
+              "definitionLines" : "133-134",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                135,
-                136
-              ],
+              "definitionLines" : "135-136",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "59-64",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "default_list" : {
-              "definitionLines" : [
-                127
-              ],
+              "definitionLines" : "127",
               "numReferrers" : 1
             },
             "inbound_route_filter" : {
-              "definitionLines" : [
-                129,
-                130
-              ],
+              "definitionLines" : "129-130",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                138,
-                139,
-                140,
-                141,
-                143,
-                144,
-                145,
-                146,
-                148,
-                149,
-                150,
-                151
-              ],
+              "definitionLines" : "138-141,143-146,148-151",
               "numReferrers" : 1
             },
             "as1_to_as3" : {
-              "definitionLines" : [
-                157,
-                158,
-                159,
-                160,
-                162,
-                163,
-                164,
-                165
-              ],
+              "definitionLines" : "157-160,162-165",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                153,
-                154,
-                155
-              ],
+              "definitionLines" : "153-155",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                167,
-                168,
-                169
-              ],
+              "definitionLines" : "167-169",
               "numReferrers" : 1
             }
           }
@@ -276,196 +197,109 @@
         "configs/as1border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                87
-              ],
+              "definitionLines" : "87",
               "numReferrers" : 0
             },
             "as3" : {
-              "definitionLines" : [
-                89
-              ],
+              "definitionLines" : "89",
               "numReferrers" : 1
             },
             "as4" : {
-              "definitionLines" : [
-                91
-              ],
+              "definitionLines" : "91",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                123
-              ],
+              "definitionLines" : "123",
               "numReferrers" : 0
             },
             "as2_community" : {
-              "definitionLines" : [
-                124
-              ],
+              "definitionLines" : "124",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                125
-              ],
+              "definitionLines" : "125",
               "numReferrers" : 1
             },
             "as4_community" : {
-              "definitionLines" : [
-                126
-              ],
+              "definitionLines" : "126",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                136,
-                137
-              ],
+              "definitionLines" : "136-137",
               "numReferrers" : 2
             },
             "102" : {
-              "definitionLines" : [
-                138,
-                139
-              ],
+              "definitionLines" : "138-139",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                140
-              ],
+              "definitionLines" : "140",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "73-75",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "as4-prefixes" : {
-              "definitionLines" : [
-                132
-              ],
+              "definitionLines" : "132",
               "numReferrers" : 1
             },
             "inbound_route_filter" : {
-              "definitionLines" : [
-                134,
-                135
-              ],
+              "definitionLines" : "134-135",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                142,
-                143,
-                144,
-                145,
-                147,
-                148,
-                149,
-                150
-              ],
+              "definitionLines" : "142-145,147-150",
               "numReferrers" : 1
             },
             "as1_to_as3" : {
-              "definitionLines" : [
-                156,
-                157,
-                158,
-                159,
-                161,
-                162,
-                163,
-                164
-              ],
+              "definitionLines" : "156-159,161-164",
               "numReferrers" : 1
             },
             "as1_to_as4" : {
-              "definitionLines" : [
-                170,
-                171,
-                172
-              ],
+              "definitionLines" : "170-172",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                152,
-                153,
-                154
-              ],
+              "definitionLines" : "152-154",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                166,
-                167,
-                168
-              ],
+              "definitionLines" : "166-168",
               "numReferrers" : 1
             },
             "as4_to_as1" : {
-              "definitionLines" : [
-                174,
-                175,
-                176,
-                177
-              ],
+              "definitionLines" : "174-177",
               "numReferrers" : 1
             }
           }
@@ -473,46 +307,25 @@
         "configs/as1core1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                80
-              ],
+              "definitionLines" : "80",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 3
             }
           }
@@ -520,183 +333,97 @@
         "configs/as2border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                89
-              ],
+              "definitionLines" : "89",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                91
-              ],
+              "definitionLines" : "91",
               "numReferrers" : 2
             },
             "as3" : {
-              "definitionLines" : [
-                93
-              ],
+              "definitionLines" : "93",
               "numReferrers" : 0
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                123
-              ],
+              "definitionLines" : "123",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                124
-              ],
+              "definitionLines" : "124",
               "numReferrers" : 0
             },
             "as3_community" : {
-              "definitionLines" : [
-                125
-              ],
+              "definitionLines" : "125",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                144,
-                145
-              ],
+              "definitionLines" : "144-145",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                146,
-                147
-              ],
+              "definitionLines" : "146-147",
               "numReferrers" : 1
             },
             "INSIDE_TO_AS1" : {
-              "definitionLines" : [
-                130,
-                131,
-                132,
-                133
-              ],
+              "definitionLines" : "130-133",
               "numReferrers" : 1
             },
             "OUTSIDE_TO_INSIDE" : {
-              "definitionLines" : [
-                134,
-                135,
-                136,
-                137
-              ],
+              "definitionLines" : "134-137",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62
-              ],
+              "definitionLines" : "59-62",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                64,
-                65,
-                66,
-                67,
-                68,
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "64-71",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "73-75",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                77,
-                78,
-                79
-              ],
+              "definitionLines" : "77-79",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                56,
-                57
-              ],
+              "definitionLines" : "56-57",
               "numReferrers" : 3
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                140,
-                141
-              ],
+              "definitionLines" : "140-141",
               "numReferrers" : 0
             },
             "outbound_routes" : {
-              "definitionLines" : [
-                143
-              ],
+              "definitionLines" : "143",
               "numReferrers" : 2
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                159,
-                160,
-                161,
-                162
-              ],
+              "definitionLines" : "159-162",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                149,
-                150,
-                151,
-                152,
-                154,
-                155,
-                156,
-                157
-              ],
+              "definitionLines" : "149-152,154-157",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                164,
-                165,
-                166,
-                167,
-                169,
-                170,
-                171,
-                172
-              ],
+              "definitionLines" : "164-167,169-172",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                174,
-                175,
-                176,
-                177
-              ],
+              "definitionLines" : "174-177",
               "numReferrers" : 1
             }
           }
@@ -704,182 +431,97 @@
         "configs/as2border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                86
-              ],
+              "definitionLines" : "86",
               "numReferrers" : 0
             },
             "as2" : {
-              "definitionLines" : [
-                88
-              ],
+              "definitionLines" : "88",
               "numReferrers" : 2
             },
             "as3" : {
-              "definitionLines" : [
-                90
-              ],
+              "definitionLines" : "90",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                120
-              ],
+              "definitionLines" : "120",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                121
-              ],
+              "definitionLines" : "121",
               "numReferrers" : 0
             },
             "as3_community" : {
-              "definitionLines" : [
-                122
-              ],
+              "definitionLines" : "122",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                140,
-                141
-              ],
+              "definitionLines" : "140-141",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                142,
-                143
-              ],
+              "definitionLines" : "142-143",
               "numReferrers" : 1
             },
             "INSIDE_TO_AS3" : {
-              "definitionLines" : [
-                127,
-                128,
-                129,
-                130
-              ],
+              "definitionLines" : "127-130",
               "numReferrers" : 1
             },
             "OUTSIDE_TO_INSIDE" : {
-              "definitionLines" : [
-                131,
-                132,
-                133
-              ],
+              "definitionLines" : "131-133",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                56,
-                57,
-                58,
-                59
-              ],
+              "definitionLines" : "56-59",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                61,
-                62,
-                63,
-                64,
-                65,
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "61-68",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72
-              ],
+              "definitionLines" : "70-72",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                74,
-                75,
-                76
-              ],
+              "definitionLines" : "74-76",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                53,
-                54
-              ],
+              "definitionLines" : "53-54",
               "numReferrers" : 3
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                136,
-                137
-              ],
+              "definitionLines" : "136-137",
               "numReferrers" : 0
             },
             "outbound_routes" : {
-              "definitionLines" : [
-                139
-              ],
+              "definitionLines" : "139",
               "numReferrers" : 2
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                155,
-                156,
-                157,
-                158
-              ],
+              "definitionLines" : "155-158",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                145,
-                146,
-                147,
-                148,
-                150,
-                151,
-                152,
-                153
-              ],
+              "definitionLines" : "145-148,150-153",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                160,
-                161,
-                162,
-                163,
-                165,
-                166,
-                167,
-                168
-              ],
+              "definitionLines" : "160-163,165-168",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                170,
-                171,
-                172,
-                173
-              ],
+              "definitionLines" : "170-173",
               "numReferrers" : 1
             }
           }
@@ -887,74 +529,39 @@
         "configs/as2core1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                90
-              ],
+              "definitionLines" : "90",
               "numReferrers" : 4
             }
           },
           "extended ipv4 access-list" : {
             "blocktelnet" : {
-              "definitionLines" : [
-                121,
-                122,
-                123
-              ],
+              "definitionLines" : "121-123",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75,
-                76
-              ],
+              "definitionLines" : "73-76",
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
-              "definitionLines" : [
-                78,
-                79,
-                80,
-                81
-              ],
+              "definitionLines" : "78-81",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 5
             }
           }
@@ -962,65 +569,33 @@
         "configs/as2core2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                91
-              ],
+              "definitionLines" : "91",
               "numReferrers" : 4
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "62-68",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72,
-                73
-              ],
+              "definitionLines" : "70-73",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                75,
-                76,
-                77,
-                78
-              ],
+              "definitionLines" : "75-78",
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
-              "definitionLines" : [
-                80,
-                81,
-                82
-              ],
+              "definitionLines" : "80-82",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 5
             }
           }
@@ -1028,129 +603,67 @@
         "configs/as2dept1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 2
             }
           },
           "expanded community-list" : {
             "as2_community" : {
-              "definitionLines" : [
-                107
-              ],
+              "definitionLines" : "107",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "102" : {
-              "definitionLines" : [
-                121,
-                122
-              ],
+              "definitionLines" : "121-122",
               "numReferrers" : 1
             },
             "105" : {
-              "definitionLines" : [
-                123,
-                124,
-                125,
-                126
-              ],
+              "definitionLines" : "123-126",
               "numReferrers" : 0
             },
             "RESTRICT_HOST_TRAFFIC_IN" : {
-              "definitionLines" : [
-                112,
-                113,
-                114,
-                115
-              ],
+              "definitionLines" : "112-115",
               "numReferrers" : 3
             },
             "RESTRICT_HOST_TRAFFIC_OUT" : {
-              "definitionLines" : [
-                116,
-                117,
-                118,
-                119
-              ],
+              "definitionLines" : "116-119",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "59-64",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72,
-                73,
-                74
-              ],
+              "definitionLines" : "70-74",
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
-              "definitionLines" : [
-                76,
-                77,
-                78,
-                79,
-                80
-              ],
+              "definitionLines" : "76-80",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 1
             }
           },
           "route-map" : {
             "as2_to_dept" : {
-              "definitionLines" : [
-                133,
-                134,
-                135
-              ],
+              "definitionLines" : "133-135",
               "numReferrers" : 1
             },
             "dept_to_as2" : {
-              "definitionLines" : [
-                128,
-                129,
-                130,
-                131
-              ],
+              "definitionLines" : "128-131",
               "numReferrers" : 1
             }
           }
@@ -1158,104 +671,59 @@
         "configs/as2dist1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 2
             },
             "dept" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "dept_community" : {
-              "definitionLines" : [
-                111
-              ],
+              "definitionLines" : "111",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "102" : {
-              "definitionLines" : [
-                116
-              ],
+              "definitionLines" : "116",
               "numReferrers" : 0
             },
             "105" : {
-              "definitionLines" : [
-                117,
-                118,
-                119,
-                120
-              ],
+              "definitionLines" : "117-120",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "59-64",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72
-              ],
+              "definitionLines" : "70-72",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 3
             }
           },
           "route-map" : {
             "as2dist_to_dept" : {
-              "definitionLines" : [
-                122,
-                123,
-                124,
-                125
-              ],
+              "definitionLines" : "122-125",
               "numReferrers" : 1
             },
             "dept_to_as2dist" : {
-              "definitionLines" : [
-                127,
-                128,
-                129
-              ],
+              "definitionLines" : "127-129",
               "numReferrers" : 1
             }
           }
@@ -1263,104 +731,59 @@
         "configs/as2dist2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 2
             },
             "dept" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "dept_community" : {
-              "definitionLines" : [
-                111
-              ],
+              "definitionLines" : "111",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "102" : {
-              "definitionLines" : [
-                116
-              ],
+              "definitionLines" : "116",
               "numReferrers" : 0
             },
             "105" : {
-              "definitionLines" : [
-                117,
-                118,
-                119,
-                120
-              ],
+              "definitionLines" : "117-120",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "59-64",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72
-              ],
+              "definitionLines" : "70-72",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 3
             }
           },
           "route-map" : {
             "as2dist_to_dept" : {
-              "definitionLines" : [
-                122,
-                123,
-                124,
-                125
-              ],
+              "definitionLines" : "122-125",
               "numReferrers" : 1
             },
             "dept_to_as2dist" : {
-              "definitionLines" : [
-                127,
-                128,
-                129
-              ],
+              "definitionLines" : "127-129",
               "numReferrers" : 1
             }
           }
@@ -1368,164 +791,89 @@
         "configs/as3border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 0
             },
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 1
             },
             "as3" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                113
-              ],
+              "definitionLines" : "113",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                114
-              ],
+              "definitionLines" : "114",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                115
-              ],
+              "definitionLines" : "115",
               "numReferrers" : 0
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                125,
-                126
-              ],
+              "definitionLines" : "125-126",
               "numReferrers" : 1
             },
             "102" : {
-              "definitionLines" : [
-                127,
-                128
-              ],
+              "definitionLines" : "127-128",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                129,
-                130
-              ],
+              "definitionLines" : "129-130",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "default_list" : {
-              "definitionLines" : [
-                121
-              ],
+              "definitionLines" : "121",
               "numReferrers" : 1
             },
             "inbound_route_filter" : {
-              "definitionLines" : [
-                123,
-                124
-              ],
+              "definitionLines" : "123-124",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "definitionLines" : [
-                142,
-                143,
-                144
-              ],
+              "definitionLines" : "142-144",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                161,
-                162,
-                163
-              ],
+              "definitionLines" : "161-163",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                132,
-                133,
-                134,
-                135,
-                137,
-                138,
-                139,
-                140
-              ],
+              "definitionLines" : "132-135,137-140",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                146,
-                147,
-                148,
-                149,
-                151,
-                152,
-                153,
-                154,
-                156,
-                157,
-                158,
-                159
-              ],
+              "definitionLines" : "146-149,151-154,156-159",
               "numReferrers" : 1
             }
           }
@@ -1533,154 +881,85 @@
         "configs/as3border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 0
             },
             "as3" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                113
-              ],
+              "definitionLines" : "113",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                114
-              ],
+              "definitionLines" : "114",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                115
-              ],
+              "definitionLines" : "115",
               "numReferrers" : 0
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                123,
-                124
-              ],
+              "definitionLines" : "123-124",
               "numReferrers" : 1
             },
             "102" : {
-              "definitionLines" : [
-                125,
-                126
-              ],
+              "definitionLines" : "125-126",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                127,
-                128
-              ],
+              "definitionLines" : "127-128",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                121,
-                122
-              ],
+              "definitionLines" : "121-122",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "definitionLines" : [
-                140,
-                141,
-                142
-              ],
+              "definitionLines" : "140-142",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                154,
-                155,
-                156
-              ],
+              "definitionLines" : "154-156",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                130,
-                131,
-                132,
-                133,
-                135,
-                136,
-                137,
-                138
-              ],
+              "definitionLines" : "130-133,135-138",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                144,
-                145,
-                146,
-                147,
-                149,
-                150,
-                151,
-                152
-              ],
+              "definitionLines" : "144-147,149-152",
               "numReferrers" : 1
             }
           }
@@ -1688,62 +967,33 @@
         "configs/as3core1.cfg" : {
           "bgp peer-group" : {
             "as3" : {
-              "definitionLines" : [
-                87
-              ],
+              "definitionLines" : "87",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "73-75",
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
-              "definitionLines" : [
-                77,
-                78,
-                79
-              ],
+              "definitionLines" : "77-79",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 3
             }
           }

--- a/tests/basic/init-with-ba.ref
+++ b/tests/basic/init-with-ba.ref
@@ -1052,1063 +1052,666 @@
         "configs/as1border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                89
-              ]
+              "bgp neighbor peer-group" : "89"
             },
             "as2" : {
-              "bgp neighbor peer-group" : [
-                93
-              ]
+              "bgp neighbor peer-group" : "93"
             },
             "bad-ebgp" : {
-              "bgp neighbor peer-group" : [
-                91
-              ]
+              "bgp neighbor peer-group" : "91"
             },
             "xanadu" : {
-              "bgp neighbor peer-group" : [
-                92
-              ]
+              "bgp neighbor peer-group" : "92"
             }
           },
           "community-list" : {
             "as2_community" : {
-              "route-map match community-list" : [
-                154
-              ]
+              "route-map match community-list" : "154"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                168
-              ]
+              "route-map match community-list" : "168"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ],
-              "update-source interface" : [
-                90
-              ]
+              "interface" : "51",
+              "update-source interface" : "90"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                139,
-                158
-              ]
+              "route-map match ipv4 access-list" : "139,158"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                163
-              ]
+              "route-map match ipv4 access-list" : "163"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                144
-              ]
+              "route-map match ipv4 access-list" : "144"
             }
           },
           "ipv4 prefix-list" : {
             "default_list" : {
-              "route-map match ipv4 prefix-list" : [
-                149
-              ]
+              "route-map match ipv4 prefix-list" : "149"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp outbound route-map" : [
-                105
-              ]
+              "bgp outbound route-map" : "105"
             },
             "as1_to_as3" : {
-              "bgp outbound route-map" : [
-                108
-              ]
+              "bgp outbound route-map" : "108"
             },
             "as2_to_as1" : {
-              "bgp inbound route-map" : [
-                104
-              ]
+              "bgp inbound route-map" : "104"
             },
             "as3_to_as1" : {
-              "bgp inbound route-map" : [
-                107
-              ]
+              "bgp inbound route-map" : "107"
             }
           }
         },
         "configs/as1border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                93
-              ]
+              "bgp neighbor peer-group" : "93"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                95
-              ]
+              "bgp neighbor peer-group" : "95"
             },
             "as4" : {
-              "bgp neighbor peer-group" : [
-                96
-              ]
+              "bgp neighbor peer-group" : "96"
             }
           },
           "community-list" : {
             "as2_community" : {
-              "route-map match community-list" : [
-                153
-              ]
+              "route-map match community-list" : "153"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                167
-              ]
+              "route-map match community-list" : "167"
             },
             "as4_community" : {
-              "route-map match community-list" : [
-                176
-              ]
+              "route-map match community-list" : "176"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                94
-              ]
+              "interface" : "54",
+              "update-source interface" : "94"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                143,
-                157
-              ]
+              "route-map match ipv4 access-list" : "143,157"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                162
-              ]
+              "route-map match ipv4 access-list" : "162"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                148
-              ]
+              "route-map match ipv4 access-list" : "148"
             }
           },
           "ipv4 prefix-list" : {
             "as4-prefixes" : {
-              "route-map match ipv4 prefix-list" : [
-                175
-              ]
+              "route-map match ipv4 prefix-list" : "175"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp outbound route-map" : [
-                108
-              ]
+              "bgp outbound route-map" : "108"
             },
             "as1_to_as3" : {
-              "bgp outbound route-map" : [
-                111
-              ]
+              "bgp outbound route-map" : "111"
             },
             "as1_to_as4" : {
-              "bgp outbound route-map" : [
-                113
-              ]
+              "bgp outbound route-map" : "113"
             },
             "as2_to_as1" : {
-              "bgp inbound route-map" : [
-                107
-              ]
+              "bgp inbound route-map" : "107"
             },
             "as3_to_as1" : {
-              "bgp inbound route-map" : [
-                110
-              ]
+              "bgp inbound route-map" : "110"
             },
             "as4_to_as1" : {
-              "bgp inbound route-map" : [
-                112
-              ]
+              "bgp inbound route-map" : "112"
             }
           }
         },
         "configs/as1core1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                82,
-                84
-              ]
+              "bgp neighbor peer-group" : "82,84"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                83,
-                85
-              ]
+              "interface" : "54",
+              "update-source interface" : "83,85"
             }
           }
         },
         "configs/as2border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                99
-              ]
+              "bgp neighbor peer-group" : "99"
             },
             "as2" : {
-              "bgp neighbor peer-group" : [
-                95,
-                97
-              ]
+              "bgp neighbor peer-group" : "95,97"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                160
-              ]
+              "route-map match community-list" : "160"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                175
-              ]
+              "route-map match community-list" : "175"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                64
-              ]
+              "interface" : "64"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                77
-              ]
+              "interface" : "77"
             },
             "Loopback0" : {
-              "interface" : [
-                56
-              ],
-              "update-source interface" : [
-                96,
-                98
-              ]
+              "interface" : "56",
+              "update-source interface" : "96,98"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                165
-              ]
+              "route-map match ipv4 access-list" : "165"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                155
-              ]
+              "route-map match ipv4 access-list" : "155"
             },
             "INSIDE_TO_AS1" : {
-              "interface outgoing ip access-list" : [
-                67
-              ]
+              "interface outgoing ip access-list" : "67"
             },
             "OUTSIDE_TO_INSIDE" : {
-              "interface incoming ip access-list" : [
-                66
-              ]
+              "interface incoming ip access-list" : "66"
             }
           },
           "ipv4 prefix-list" : {
             "outbound_routes" : {
-              "route-map match ipv4 prefix-list" : [
-                150,
-                170
-              ]
+              "route-map match ipv4 prefix-list" : "150,170"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp inbound route-map" : [
-                107
-              ]
+              "bgp inbound route-map" : "107"
             },
             "as2_to_as1" : {
-              "bgp outbound route-map" : [
-                108
-              ]
+              "bgp outbound route-map" : "108"
             },
             "as2_to_as3" : {
-              "bgp outbound route-map" : [
-                113
-              ]
+              "bgp outbound route-map" : "113"
             },
             "as3_to_as2" : {
-              "bgp inbound route-map" : [
-                112
-              ]
+              "bgp inbound route-map" : "112"
             }
           }
         },
         "configs/as2border2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                92,
-                94
-              ]
+              "bgp neighbor peer-group" : "92,94"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                96
-              ]
+              "bgp neighbor peer-group" : "96"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                156
-              ]
+              "route-map match community-list" : "156"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                171
-              ]
+              "route-map match community-list" : "171"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                56
-              ]
+              "interface" : "56"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                61
-              ]
+              "interface" : "61"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                74
-              ]
+              "interface" : "74"
             },
             "Loopback0" : {
-              "interface" : [
-                53
-              ],
-              "update-source interface" : [
-                93,
-                95
-              ]
+              "interface" : "53",
+              "update-source interface" : "93,95"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                161
-              ]
+              "route-map match ipv4 access-list" : "161"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                151
-              ]
+              "route-map match ipv4 access-list" : "151"
             },
             "INSIDE_TO_AS3" : {
-              "interface outgoing ip access-list" : [
-                64
-              ]
+              "interface outgoing ip access-list" : "64"
             },
             "OUTSIDE_TO_INSIDE" : {
-              "interface incoming ip access-list" : [
-                63
-              ]
+              "interface incoming ip access-list" : "63"
             }
           },
           "ipv4 prefix-list" : {
             "outbound_routes" : {
-              "route-map match ipv4 prefix-list" : [
-                146,
-                166
-              ]
+              "route-map match ipv4 prefix-list" : "146,166"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp inbound route-map" : [
-                104
-              ]
+              "bgp inbound route-map" : "104"
             },
             "as2_to_as1" : {
-              "bgp outbound route-map" : [
-                105
-              ]
+              "bgp outbound route-map" : "105"
             },
             "as2_to_as3" : {
-              "bgp outbound route-map" : [
-                110
-              ]
+              "bgp outbound route-map" : "110"
             },
             "as3_to_as2" : {
-              "bgp inbound route-map" : [
-                109
-              ]
+              "bgp inbound route-map" : "109"
             }
           }
         },
         "configs/as2core1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                92,
-                94,
-                96,
-                98
-              ]
+              "bgp neighbor peer-group" : "92,94,96,98"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "GigabitEthernet3/0" : {
-              "interface" : [
-                78
-              ]
+              "interface" : "78"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                93,
-                95,
-                97,
-                99
-              ]
+              "interface" : "54",
+              "update-source interface" : "93,95,97,99"
             }
           },
           "ipv4 acl" : {
             "blocktelnet" : {
-              "interface incoming ip access-list" : [
-                75,
-                80
-              ]
+              "interface incoming ip access-list" : "75,80"
             }
           }
         },
         "configs/as2core2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                93,
-                95,
-                97,
-                99
-              ]
+              "bgp neighbor peer-group" : "93,95,97,99"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                75
-              ]
+              "interface" : "75"
             },
             "GigabitEthernet3/0" : {
-              "interface" : [
-                80
-              ]
+              "interface" : "80"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                94,
-                96,
-                98,
-                100
-              ]
+              "interface" : "54",
+              "update-source interface" : "94,96,98,100"
             }
           },
           "route-map" : {
             "filter-bogons" : {
-              "bgp inbound route-map" : [
-                109
-              ]
+              "bgp inbound route-map" : "109"
             }
           }
         },
         "configs/as2dept1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                87,
-                88
-              ]
+              "bgp neighbor peer-group" : "87-88"
             }
           },
           "community-list" : {
             "as2_community" : {
-              "route-map match community-list" : [
-                134
-              ]
+              "route-map match community-list" : "134"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "GigabitEthernet3/0" : {
-              "interface" : [
-                76
-              ]
+              "interface" : "76"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ]
+              "interface" : "51"
             }
           },
           "ipv4 acl" : {
             "102" : {
-              "route-map match ipv4 access-list" : [
-                129
-              ]
+              "route-map match ipv4 access-list" : "129"
             },
             "RESTRICT_HOST_TRAFFIC_IN" : {
-              "interface incoming ip access-list" : [
-                72,
-                78
-              ],
-              "interface outgoing ip access-list" : [
-                73
-              ]
+              "interface incoming ip access-list" : "72,78",
+              "interface outgoing ip access-list" : "73"
             },
             "RESTRICT_HOST_TRAFFIC_OUT" : {
-              "interface outgoing ip access-list" : [
-                79
-              ]
+              "interface outgoing ip access-list" : "79"
             }
           },
           "route-map" : {
             "as2_to_dept" : {
-              "bgp inbound route-map" : [
-                97
-              ]
+              "bgp inbound route-map" : "97"
             },
             "dept_to_as2" : {
-              "bgp outbound route-map" : [
-                98
-              ]
+              "bgp outbound route-map" : "98"
             }
           }
         },
         "configs/as2dist1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                87,
-                89
-              ]
+              "bgp neighbor peer-group" : "87,89"
             },
             "dept" : {
-              "bgp neighbor peer-group" : [
-                91
-              ]
+              "bgp neighbor peer-group" : "91"
             }
           },
           "community-list" : {
             "dept_community" : {
-              "route-map match community-list" : [
-                128
-              ]
+              "route-map match community-list" : "128"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ],
-              "update-source interface" : [
-                88,
-                90
-              ]
+              "interface" : "51",
+              "update-source interface" : "88,90"
             }
           },
           "ipv4 acl" : {
             "105" : {
-              "route-map match ipv4 access-list" : [
-                123
-              ]
+              "route-map match ipv4 access-list" : "123"
             }
           },
           "route-map" : {
             "as2dist_to_dept" : {
-              "bgp outbound route-map" : [
-                101
-              ]
+              "bgp outbound route-map" : "101"
             },
             "dept_to_as2dist" : {
-              "bgp inbound route-map" : [
-                100
-              ]
+              "bgp inbound route-map" : "100"
             }
           }
         },
         "configs/as2dist2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                87,
-                89
-              ]
+              "bgp neighbor peer-group" : "87,89"
             },
             "dept" : {
-              "bgp neighbor peer-group" : [
-                91
-              ]
+              "bgp neighbor peer-group" : "91"
             }
           },
           "community-list" : {
             "dept_community" : {
-              "route-map match community-list" : [
-                128
-              ]
+              "route-map match community-list" : "128"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ],
-              "update-source interface" : [
-                88,
-                90
-              ]
+              "interface" : "51",
+              "update-source interface" : "88,90"
             }
           },
           "ipv4 acl" : {
             "105" : {
-              "route-map match ipv4 access-list" : [
-                123
-              ]
+              "route-map match ipv4 access-list" : "123"
             }
           },
           "route-map" : {
             "as2dist_to_dept" : {
-              "bgp outbound route-map" : [
-                101
-              ]
+              "bgp outbound route-map" : "101"
             },
             "dept_to_as2dist" : {
-              "bgp inbound route-map" : [
-                100
-              ]
+              "bgp inbound route-map" : "100"
             }
           }
         },
         "configs/as3border1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                89
-              ]
+              "bgp neighbor peer-group" : "89"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                87
-              ]
+              "bgp neighbor peer-group" : "87"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                143
-              ]
+              "route-map match community-list" : "143"
             },
             "as2_community" : {
-              "route-map match community-list" : [
-                162
-              ]
+              "route-map match community-list" : "162"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                88
-              ]
+              "interface" : "54",
+              "update-source interface" : "88"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                147
-              ]
+              "route-map match ipv4 access-list" : "147"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                133
-              ]
+              "route-map match ipv4 access-list" : "133"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                138,
-                152
-              ]
+              "route-map match ipv4 access-list" : "138,152"
             }
           },
           "ipv4 prefix-list" : {
             "default_list" : {
-              "route-map match ipv4 prefix-list" : [
-                157
-              ]
+              "route-map match ipv4 prefix-list" : "157"
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "bgp inbound route-map" : [
-                98
-              ]
+              "bgp inbound route-map" : "98"
             },
             "as2_to_as3" : {
-              "bgp inbound route-map" : [
-                101
-              ]
+              "bgp inbound route-map" : "101"
             },
             "as3_to_as1" : {
-              "bgp outbound route-map" : [
-                99
-              ]
+              "bgp outbound route-map" : "99"
             },
             "as3_to_as2" : {
-              "bgp outbound route-map" : [
-                102
-              ]
+              "bgp outbound route-map" : "102"
             }
           }
         },
         "configs/as3border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                89
-              ]
+              "bgp neighbor peer-group" : "89"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                87
-              ]
+              "bgp neighbor peer-group" : "87"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                141
-              ]
+              "route-map match community-list" : "141"
             },
             "as2_community" : {
-              "route-map match community-list" : [
-                155
-              ]
+              "route-map match community-list" : "155"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                88
-              ]
+              "interface" : "54",
+              "update-source interface" : "88"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                145
-              ]
+              "route-map match ipv4 access-list" : "145"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                131
-              ]
+              "route-map match ipv4 access-list" : "131"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                136,
-                150
-              ]
+              "route-map match ipv4 access-list" : "136,150"
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "bgp inbound route-map" : [
-                98
-              ]
+              "bgp inbound route-map" : "98"
             },
             "as2_to_as3" : {
-              "bgp inbound route-map" : [
-                101
-              ]
+              "bgp inbound route-map" : "101"
             },
             "as3_to_as1" : {
-              "bgp outbound route-map" : [
-                99
-              ]
+              "bgp outbound route-map" : "99"
             },
             "as3_to_as2" : {
-              "bgp outbound route-map" : [
-                102
-              ]
+              "bgp outbound route-map" : "102"
             }
           }
         },
         "configs/as3core1.cfg" : {
           "bgp peer-group" : {
             "as3" : {
-              "bgp neighbor peer-group" : [
-                89,
-                91
-              ]
+              "bgp neighbor peer-group" : "89,91"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "GigabitEthernet3/0" : {
-              "interface" : [
-                77
-              ]
+              "interface" : "77"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                90,
-                92
-              ]
+              "interface" : "54",
+              "update-source interface" : "90,92"
             }
           }
         }
@@ -2117,9 +1720,7 @@
         "configs/as2core2.cfg" : {
           "route-map" : {
             "filter-bogons" : {
-              "bgp inbound route-map" : [
-                109
-              ]
+              "bgp inbound route-map" : "109"
             }
           }
         }

--- a/tests/basic/init.ref
+++ b/tests/basic/init.ref
@@ -1052,1055 +1052,662 @@
         "configs/as1border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                89
-              ]
+              "bgp neighbor peer-group" : "89"
             },
             "as2" : {
-              "bgp neighbor peer-group" : [
-                93
-              ]
+              "bgp neighbor peer-group" : "93"
             },
             "bad-ebgp" : {
-              "bgp neighbor peer-group" : [
-                91
-              ]
+              "bgp neighbor peer-group" : "91"
             },
             "xanadu" : {
-              "bgp neighbor peer-group" : [
-                92
-              ]
+              "bgp neighbor peer-group" : "92"
             }
           },
           "community-list" : {
             "as2_community" : {
-              "route-map match community-list" : [
-                154
-              ]
+              "route-map match community-list" : "154"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                168
-              ]
+              "route-map match community-list" : "168"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ],
-              "update-source interface" : [
-                90
-              ]
+              "interface" : "51",
+              "update-source interface" : "90"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                139,
-                158
-              ]
+              "route-map match ipv4 access-list" : "139,158"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                163
-              ]
+              "route-map match ipv4 access-list" : "163"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                144
-              ]
+              "route-map match ipv4 access-list" : "144"
             }
           },
           "ipv4 prefix-list" : {
             "default_list" : {
-              "route-map match ipv4 prefix-list" : [
-                149
-              ]
+              "route-map match ipv4 prefix-list" : "149"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp outbound route-map" : [
-                105
-              ]
+              "bgp outbound route-map" : "105"
             },
             "as1_to_as3" : {
-              "bgp outbound route-map" : [
-                108
-              ]
+              "bgp outbound route-map" : "108"
             },
             "as2_to_as1" : {
-              "bgp inbound route-map" : [
-                104
-              ]
+              "bgp inbound route-map" : "104"
             },
             "as3_to_as1" : {
-              "bgp inbound route-map" : [
-                107
-              ]
+              "bgp inbound route-map" : "107"
             }
           }
         },
         "configs/as1border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                93
-              ]
+              "bgp neighbor peer-group" : "93"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                95
-              ]
+              "bgp neighbor peer-group" : "95"
             },
             "as4" : {
-              "bgp neighbor peer-group" : [
-                96
-              ]
+              "bgp neighbor peer-group" : "96"
             }
           },
           "community-list" : {
             "as2_community" : {
-              "route-map match community-list" : [
-                153
-              ]
+              "route-map match community-list" : "153"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                167
-              ]
+              "route-map match community-list" : "167"
             },
             "as4_community" : {
-              "route-map match community-list" : [
-                176
-              ]
+              "route-map match community-list" : "176"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                94
-              ]
+              "interface" : "54",
+              "update-source interface" : "94"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                143,
-                157
-              ]
+              "route-map match ipv4 access-list" : "143,157"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                162
-              ]
+              "route-map match ipv4 access-list" : "162"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                148
-              ]
+              "route-map match ipv4 access-list" : "148"
             }
           },
           "ipv4 prefix-list" : {
             "as4-prefixes" : {
-              "route-map match ipv4 prefix-list" : [
-                175
-              ]
+              "route-map match ipv4 prefix-list" : "175"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp outbound route-map" : [
-                108
-              ]
+              "bgp outbound route-map" : "108"
             },
             "as1_to_as3" : {
-              "bgp outbound route-map" : [
-                111
-              ]
+              "bgp outbound route-map" : "111"
             },
             "as1_to_as4" : {
-              "bgp outbound route-map" : [
-                113
-              ]
+              "bgp outbound route-map" : "113"
             },
             "as2_to_as1" : {
-              "bgp inbound route-map" : [
-                107
-              ]
+              "bgp inbound route-map" : "107"
             },
             "as3_to_as1" : {
-              "bgp inbound route-map" : [
-                110
-              ]
+              "bgp inbound route-map" : "110"
             },
             "as4_to_as1" : {
-              "bgp inbound route-map" : [
-                112
-              ]
+              "bgp inbound route-map" : "112"
             }
           }
         },
         "configs/as1core1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                82,
-                84
-              ]
+              "bgp neighbor peer-group" : "82,84"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                83,
-                85
-              ]
+              "interface" : "54",
+              "update-source interface" : "83,85"
             }
           }
         },
         "configs/as2border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                99
-              ]
+              "bgp neighbor peer-group" : "99"
             },
             "as2" : {
-              "bgp neighbor peer-group" : [
-                95,
-                97
-              ]
+              "bgp neighbor peer-group" : "95,97"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                160
-              ]
+              "route-map match community-list" : "160"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                175
-              ]
+              "route-map match community-list" : "175"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                64
-              ]
+              "interface" : "64"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                77
-              ]
+              "interface" : "77"
             },
             "Loopback0" : {
-              "interface" : [
-                56
-              ],
-              "update-source interface" : [
-                96,
-                98
-              ]
+              "interface" : "56",
+              "update-source interface" : "96,98"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                165
-              ]
+              "route-map match ipv4 access-list" : "165"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                155
-              ]
+              "route-map match ipv4 access-list" : "155"
             },
             "INSIDE_TO_AS1" : {
-              "interface outgoing ip access-list" : [
-                67
-              ]
+              "interface outgoing ip access-list" : "67"
             },
             "OUTSIDE_TO_INSIDE" : {
-              "interface incoming ip access-list" : [
-                66
-              ]
+              "interface incoming ip access-list" : "66"
             }
           },
           "ipv4 prefix-list" : {
             "outbound_routes" : {
-              "route-map match ipv4 prefix-list" : [
-                150,
-                170
-              ]
+              "route-map match ipv4 prefix-list" : "150,170"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp inbound route-map" : [
-                107
-              ]
+              "bgp inbound route-map" : "107"
             },
             "as2_to_as1" : {
-              "bgp outbound route-map" : [
-                108
-              ]
+              "bgp outbound route-map" : "108"
             },
             "as2_to_as3" : {
-              "bgp outbound route-map" : [
-                113
-              ]
+              "bgp outbound route-map" : "113"
             },
             "as3_to_as2" : {
-              "bgp inbound route-map" : [
-                112
-              ]
+              "bgp inbound route-map" : "112"
             }
           }
         },
         "configs/as2border2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                92,
-                94
-              ]
+              "bgp neighbor peer-group" : "92,94"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                96
-              ]
+              "bgp neighbor peer-group" : "96"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                156
-              ]
+              "route-map match community-list" : "156"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                171
-              ]
+              "route-map match community-list" : "171"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                56
-              ]
+              "interface" : "56"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                61
-              ]
+              "interface" : "61"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                74
-              ]
+              "interface" : "74"
             },
             "Loopback0" : {
-              "interface" : [
-                53
-              ],
-              "update-source interface" : [
-                93,
-                95
-              ]
+              "interface" : "53",
+              "update-source interface" : "93,95"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                161
-              ]
+              "route-map match ipv4 access-list" : "161"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                151
-              ]
+              "route-map match ipv4 access-list" : "151"
             },
             "INSIDE_TO_AS3" : {
-              "interface outgoing ip access-list" : [
-                64
-              ]
+              "interface outgoing ip access-list" : "64"
             },
             "OUTSIDE_TO_INSIDE" : {
-              "interface incoming ip access-list" : [
-                63
-              ]
+              "interface incoming ip access-list" : "63"
             }
           },
           "ipv4 prefix-list" : {
             "outbound_routes" : {
-              "route-map match ipv4 prefix-list" : [
-                146,
-                166
-              ]
+              "route-map match ipv4 prefix-list" : "146,166"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp inbound route-map" : [
-                104
-              ]
+              "bgp inbound route-map" : "104"
             },
             "as2_to_as1" : {
-              "bgp outbound route-map" : [
-                105
-              ]
+              "bgp outbound route-map" : "105"
             },
             "as2_to_as3" : {
-              "bgp outbound route-map" : [
-                110
-              ]
+              "bgp outbound route-map" : "110"
             },
             "as3_to_as2" : {
-              "bgp inbound route-map" : [
-                109
-              ]
+              "bgp inbound route-map" : "109"
             }
           }
         },
         "configs/as2core1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                92,
-                94,
-                96,
-                98
-              ]
+              "bgp neighbor peer-group" : "92,94,96,98"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "GigabitEthernet3/0" : {
-              "interface" : [
-                78
-              ]
+              "interface" : "78"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                93,
-                95,
-                97,
-                99
-              ]
+              "interface" : "54",
+              "update-source interface" : "93,95,97,99"
             }
           },
           "ipv4 acl" : {
             "blocktelnet" : {
-              "interface incoming ip access-list" : [
-                75,
-                80
-              ]
+              "interface incoming ip access-list" : "75,80"
             }
           }
         },
         "configs/as2core2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                93,
-                95,
-                97,
-                99
-              ]
+              "bgp neighbor peer-group" : "93,95,97,99"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                75
-              ]
+              "interface" : "75"
             },
             "GigabitEthernet3/0" : {
-              "interface" : [
-                80
-              ]
+              "interface" : "80"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                94,
-                96,
-                98,
-                100
-              ]
+              "interface" : "54",
+              "update-source interface" : "94,96,98,100"
             }
           },
           "route-map" : {
             "filter-bogons" : {
-              "bgp inbound route-map" : [
-                109
-              ]
+              "bgp inbound route-map" : "109"
             }
           }
         },
         "configs/as2dept1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                85,
-                86
-              ]
+              "bgp neighbor peer-group" : "85-86"
             }
           },
           "community-list" : {
             "as2_community" : {
-              "route-map match community-list" : [
-                132
-              ]
+              "route-map match community-list" : "132"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "GigabitEthernet3/0" : {
-              "interface" : [
-                75
-              ]
+              "interface" : "75"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ]
+              "interface" : "51"
             }
           },
           "ipv4 acl" : {
             "102" : {
-              "route-map match ipv4 access-list" : [
-                127
-              ]
+              "route-map match ipv4 access-list" : "127"
             },
             "RESTRICT_HOST_TRAFFIC_IN" : {
-              "interface incoming ip access-list" : [
-                72,
-                77
-              ]
+              "interface incoming ip access-list" : "72,77"
             }
           },
           "route-map" : {
             "as2_to_dept" : {
-              "bgp inbound route-map" : [
-                95
-              ]
+              "bgp inbound route-map" : "95"
             },
             "dept_to_as2" : {
-              "bgp outbound route-map" : [
-                96
-              ]
+              "bgp outbound route-map" : "96"
             }
           }
         },
         "configs/as2dist1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                87,
-                89
-              ]
+              "bgp neighbor peer-group" : "87,89"
             },
             "dept" : {
-              "bgp neighbor peer-group" : [
-                91
-              ]
+              "bgp neighbor peer-group" : "91"
             }
           },
           "community-list" : {
             "dept_community" : {
-              "route-map match community-list" : [
-                128
-              ]
+              "route-map match community-list" : "128"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ],
-              "update-source interface" : [
-                88,
-                90
-              ]
+              "interface" : "51",
+              "update-source interface" : "88,90"
             }
           },
           "ipv4 acl" : {
             "105" : {
-              "route-map match ipv4 access-list" : [
-                123
-              ]
+              "route-map match ipv4 access-list" : "123"
             }
           },
           "route-map" : {
             "as2dist_to_dept" : {
-              "bgp outbound route-map" : [
-                101
-              ]
+              "bgp outbound route-map" : "101"
             },
             "dept_to_as2dist" : {
-              "bgp inbound route-map" : [
-                100
-              ]
+              "bgp inbound route-map" : "100"
             }
           }
         },
         "configs/as2dist2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                87,
-                89
-              ]
+              "bgp neighbor peer-group" : "87,89"
             },
             "dept" : {
-              "bgp neighbor peer-group" : [
-                91
-              ]
+              "bgp neighbor peer-group" : "91"
             }
           },
           "community-list" : {
             "dept_community" : {
-              "route-map match community-list" : [
-                128
-              ]
+              "route-map match community-list" : "128"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                70
-              ]
+              "interface" : "70"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ],
-              "update-source interface" : [
-                88,
-                90
-              ]
+              "interface" : "51",
+              "update-source interface" : "88,90"
             }
           },
           "ipv4 acl" : {
             "105" : {
-              "route-map match ipv4 access-list" : [
-                123
-              ]
+              "route-map match ipv4 access-list" : "123"
             }
           },
           "route-map" : {
             "as2dist_to_dept" : {
-              "bgp outbound route-map" : [
-                101
-              ]
+              "bgp outbound route-map" : "101"
             },
             "dept_to_as2dist" : {
-              "bgp inbound route-map" : [
-                100
-              ]
+              "bgp inbound route-map" : "100"
             }
           }
         },
         "configs/as3border1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                89
-              ]
+              "bgp neighbor peer-group" : "89"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                87
-              ]
+              "bgp neighbor peer-group" : "87"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                143
-              ]
+              "route-map match community-list" : "143"
             },
             "as2_community" : {
-              "route-map match community-list" : [
-                162
-              ]
+              "route-map match community-list" : "162"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                88
-              ]
+              "interface" : "54",
+              "update-source interface" : "88"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                147
-              ]
+              "route-map match ipv4 access-list" : "147"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                133
-              ]
+              "route-map match ipv4 access-list" : "133"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                138,
-                152
-              ]
+              "route-map match ipv4 access-list" : "138,152"
             }
           },
           "ipv4 prefix-list" : {
             "default_list" : {
-              "route-map match ipv4 prefix-list" : [
-                157
-              ]
+              "route-map match ipv4 prefix-list" : "157"
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "bgp inbound route-map" : [
-                98
-              ]
+              "bgp inbound route-map" : "98"
             },
             "as2_to_as3" : {
-              "bgp inbound route-map" : [
-                101
-              ]
+              "bgp inbound route-map" : "101"
             },
             "as3_to_as1" : {
-              "bgp outbound route-map" : [
-                99
-              ]
+              "bgp outbound route-map" : "99"
             },
             "as3_to_as2" : {
-              "bgp outbound route-map" : [
-                102
-              ]
+              "bgp outbound route-map" : "102"
             }
           }
         },
         "configs/as3border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                89
-              ]
+              "bgp neighbor peer-group" : "89"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                87
-              ]
+              "bgp neighbor peer-group" : "87"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                141
-              ]
+              "route-map match community-list" : "141"
             },
             "as2_community" : {
-              "route-map match community-list" : [
-                155
-              ]
+              "route-map match community-list" : "155"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                88
-              ]
+              "interface" : "54",
+              "update-source interface" : "88"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                145
-              ]
+              "route-map match ipv4 access-list" : "145"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                131
-              ]
+              "route-map match ipv4 access-list" : "131"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                136,
-                150
-              ]
+              "route-map match ipv4 access-list" : "136,150"
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "bgp inbound route-map" : [
-                98
-              ]
+              "bgp inbound route-map" : "98"
             },
             "as2_to_as3" : {
-              "bgp inbound route-map" : [
-                101
-              ]
+              "bgp inbound route-map" : "101"
             },
             "as3_to_as1" : {
-              "bgp outbound route-map" : [
-                99
-              ]
+              "bgp outbound route-map" : "99"
             },
             "as3_to_as2" : {
-              "bgp outbound route-map" : [
-                102
-              ]
+              "bgp outbound route-map" : "102"
             }
           }
         },
         "configs/as3core1.cfg" : {
           "bgp peer-group" : {
             "as3" : {
-              "bgp neighbor peer-group" : [
-                89,
-                91
-              ]
+              "bgp neighbor peer-group" : "89,91"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "GigabitEthernet1/0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             },
             "GigabitEthernet2/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "GigabitEthernet3/0" : {
-              "interface" : [
-                77
-              ]
+              "interface" : "77"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                90,
-                92
-              ]
+              "interface" : "54",
+              "update-source interface" : "90,92"
             }
           }
         }
@@ -2109,9 +1716,7 @@
         "configs/as2core2.cfg" : {
           "route-map" : {
             "filter-bogons" : {
-              "bgp inbound route-map" : [
-                109
-              ]
+              "bgp inbound route-map" : "109"
             }
           }
         }

--- a/tests/basic/init.ref
+++ b/tests/basic/init.ref
@@ -99,176 +99,97 @@
         "configs/as1border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                79
-              ],
+              "definitionLines" : "79",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 1
             },
             "as3" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 0
             },
             "bad-ebgp" : {
-              "definitionLines" : [
-                87
-              ],
+              "definitionLines" : "87",
               "numReferrers" : 1
             },
             "xanadu" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                119
-              ],
+              "definitionLines" : "119",
               "numReferrers" : 0
             },
             "as2_community" : {
-              "definitionLines" : [
-                120
-              ],
+              "definitionLines" : "120",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                121
-              ],
+              "definitionLines" : "121",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                131,
-                132
-              ],
+              "definitionLines" : "131-132",
               "numReferrers" : 2
             },
             "102" : {
-              "definitionLines" : [
-                133,
-                134
-              ],
+              "definitionLines" : "133-134",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                135,
-                136
-              ],
+              "definitionLines" : "135-136",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "59-64",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "default_list" : {
-              "definitionLines" : [
-                127
-              ],
+              "definitionLines" : "127",
               "numReferrers" : 1
             },
             "inbound_route_filter" : {
-              "definitionLines" : [
-                129,
-                130
-              ],
+              "definitionLines" : "129-130",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                138,
-                139,
-                140,
-                141,
-                143,
-                144,
-                145,
-                146,
-                148,
-                149,
-                150,
-                151
-              ],
+              "definitionLines" : "138-141,143-146,148-151",
               "numReferrers" : 1
             },
             "as1_to_as3" : {
-              "definitionLines" : [
-                157,
-                158,
-                159,
-                160,
-                162,
-                163,
-                164,
-                165
-              ],
+              "definitionLines" : "157-160,162-165",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                153,
-                154,
-                155
-              ],
+              "definitionLines" : "153-155",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                167,
-                168,
-                169
-              ],
+              "definitionLines" : "167-169",
               "numReferrers" : 1
             }
           }
@@ -276,196 +197,109 @@
         "configs/as1border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                87
-              ],
+              "definitionLines" : "87",
               "numReferrers" : 0
             },
             "as3" : {
-              "definitionLines" : [
-                89
-              ],
+              "definitionLines" : "89",
               "numReferrers" : 1
             },
             "as4" : {
-              "definitionLines" : [
-                91
-              ],
+              "definitionLines" : "91",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                123
-              ],
+              "definitionLines" : "123",
               "numReferrers" : 0
             },
             "as2_community" : {
-              "definitionLines" : [
-                124
-              ],
+              "definitionLines" : "124",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                125
-              ],
+              "definitionLines" : "125",
               "numReferrers" : 1
             },
             "as4_community" : {
-              "definitionLines" : [
-                126
-              ],
+              "definitionLines" : "126",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                136,
-                137
-              ],
+              "definitionLines" : "136-137",
               "numReferrers" : 2
             },
             "102" : {
-              "definitionLines" : [
-                138,
-                139
-              ],
+              "definitionLines" : "138-139",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                140
-              ],
+              "definitionLines" : "140",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "73-75",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "as4-prefixes" : {
-              "definitionLines" : [
-                132
-              ],
+              "definitionLines" : "132",
               "numReferrers" : 1
             },
             "inbound_route_filter" : {
-              "definitionLines" : [
-                134,
-                135
-              ],
+              "definitionLines" : "134-135",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                142,
-                143,
-                144,
-                145,
-                147,
-                148,
-                149,
-                150
-              ],
+              "definitionLines" : "142-145,147-150",
               "numReferrers" : 1
             },
             "as1_to_as3" : {
-              "definitionLines" : [
-                156,
-                157,
-                158,
-                159,
-                161,
-                162,
-                163,
-                164
-              ],
+              "definitionLines" : "156-159,161-164",
               "numReferrers" : 1
             },
             "as1_to_as4" : {
-              "definitionLines" : [
-                170,
-                171,
-                172
-              ],
+              "definitionLines" : "170-172",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                152,
-                153,
-                154
-              ],
+              "definitionLines" : "152-154",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                166,
-                167,
-                168
-              ],
+              "definitionLines" : "166-168",
               "numReferrers" : 1
             },
             "as4_to_as1" : {
-              "definitionLines" : [
-                174,
-                175,
-                176,
-                177
-              ],
+              "definitionLines" : "174-177",
               "numReferrers" : 1
             }
           }
@@ -473,46 +307,25 @@
         "configs/as1core1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                80
-              ],
+              "definitionLines" : "80",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 3
             }
           }
@@ -520,183 +333,97 @@
         "configs/as2border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                89
-              ],
+              "definitionLines" : "89",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                91
-              ],
+              "definitionLines" : "91",
               "numReferrers" : 2
             },
             "as3" : {
-              "definitionLines" : [
-                93
-              ],
+              "definitionLines" : "93",
               "numReferrers" : 0
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                123
-              ],
+              "definitionLines" : "123",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                124
-              ],
+              "definitionLines" : "124",
               "numReferrers" : 0
             },
             "as3_community" : {
-              "definitionLines" : [
-                125
-              ],
+              "definitionLines" : "125",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                144,
-                145
-              ],
+              "definitionLines" : "144-145",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                146,
-                147
-              ],
+              "definitionLines" : "146-147",
               "numReferrers" : 1
             },
             "INSIDE_TO_AS1" : {
-              "definitionLines" : [
-                130,
-                131,
-                132,
-                133
-              ],
+              "definitionLines" : "130-133",
               "numReferrers" : 1
             },
             "OUTSIDE_TO_INSIDE" : {
-              "definitionLines" : [
-                134,
-                135,
-                136,
-                137
-              ],
+              "definitionLines" : "134-137",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62
-              ],
+              "definitionLines" : "59-62",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                64,
-                65,
-                66,
-                67,
-                68,
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "64-71",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "73-75",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                77,
-                78,
-                79
-              ],
+              "definitionLines" : "77-79",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                56,
-                57
-              ],
+              "definitionLines" : "56-57",
               "numReferrers" : 3
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                140,
-                141
-              ],
+              "definitionLines" : "140-141",
               "numReferrers" : 0
             },
             "outbound_routes" : {
-              "definitionLines" : [
-                143
-              ],
+              "definitionLines" : "143",
               "numReferrers" : 2
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                159,
-                160,
-                161,
-                162
-              ],
+              "definitionLines" : "159-162",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                149,
-                150,
-                151,
-                152,
-                154,
-                155,
-                156,
-                157
-              ],
+              "definitionLines" : "149-152,154-157",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                164,
-                165,
-                166,
-                167,
-                169,
-                170,
-                171,
-                172
-              ],
+              "definitionLines" : "164-167,169-172",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                174,
-                175,
-                176,
-                177
-              ],
+              "definitionLines" : "174-177",
               "numReferrers" : 1
             }
           }
@@ -704,182 +431,97 @@
         "configs/as2border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                86
-              ],
+              "definitionLines" : "86",
               "numReferrers" : 0
             },
             "as2" : {
-              "definitionLines" : [
-                88
-              ],
+              "definitionLines" : "88",
               "numReferrers" : 2
             },
             "as3" : {
-              "definitionLines" : [
-                90
-              ],
+              "definitionLines" : "90",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                120
-              ],
+              "definitionLines" : "120",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                121
-              ],
+              "definitionLines" : "121",
               "numReferrers" : 0
             },
             "as3_community" : {
-              "definitionLines" : [
-                122
-              ],
+              "definitionLines" : "122",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                140,
-                141
-              ],
+              "definitionLines" : "140-141",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                142,
-                143
-              ],
+              "definitionLines" : "142-143",
               "numReferrers" : 1
             },
             "INSIDE_TO_AS3" : {
-              "definitionLines" : [
-                127,
-                128,
-                129,
-                130
-              ],
+              "definitionLines" : "127-130",
               "numReferrers" : 1
             },
             "OUTSIDE_TO_INSIDE" : {
-              "definitionLines" : [
-                131,
-                132,
-                133
-              ],
+              "definitionLines" : "131-133",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                56,
-                57,
-                58,
-                59
-              ],
+              "definitionLines" : "56-59",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                61,
-                62,
-                63,
-                64,
-                65,
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "61-68",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72
-              ],
+              "definitionLines" : "70-72",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                74,
-                75,
-                76
-              ],
+              "definitionLines" : "74-76",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                53,
-                54
-              ],
+              "definitionLines" : "53-54",
               "numReferrers" : 3
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                136,
-                137
-              ],
+              "definitionLines" : "136-137",
               "numReferrers" : 0
             },
             "outbound_routes" : {
-              "definitionLines" : [
-                139
-              ],
+              "definitionLines" : "139",
               "numReferrers" : 2
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                155,
-                156,
-                157,
-                158
-              ],
+              "definitionLines" : "155-158",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                145,
-                146,
-                147,
-                148,
-                150,
-                151,
-                152,
-                153
-              ],
+              "definitionLines" : "145-148,150-153",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                160,
-                161,
-                162,
-                163,
-                165,
-                166,
-                167,
-                168
-              ],
+              "definitionLines" : "160-163,165-168",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                170,
-                171,
-                172,
-                173
-              ],
+              "definitionLines" : "170-173",
               "numReferrers" : 1
             }
           }
@@ -887,74 +529,39 @@
         "configs/as2core1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                90
-              ],
+              "definitionLines" : "90",
               "numReferrers" : 4
             }
           },
           "extended ipv4 access-list" : {
             "blocktelnet" : {
-              "definitionLines" : [
-                121,
-                122,
-                123
-              ],
+              "definitionLines" : "121-123",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75,
-                76
-              ],
+              "definitionLines" : "73-76",
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
-              "definitionLines" : [
-                78,
-                79,
-                80,
-                81
-              ],
+              "definitionLines" : "78-81",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 5
             }
           }
@@ -962,65 +569,33 @@
         "configs/as2core2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                91
-              ],
+              "definitionLines" : "91",
               "numReferrers" : 4
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "62-68",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72,
-                73
-              ],
+              "definitionLines" : "70-73",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                75,
-                76,
-                77,
-                78
-              ],
+              "definitionLines" : "75-78",
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
-              "definitionLines" : [
-                80,
-                81,
-                82
-              ],
+              "definitionLines" : "80-82",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 5
             }
           }
@@ -1028,127 +603,67 @@
         "configs/as2dept1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 2
             }
           },
           "expanded community-list" : {
             "as2_community" : {
-              "definitionLines" : [
-                105
-              ],
+              "definitionLines" : "105",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "102" : {
-              "definitionLines" : [
-                119,
-                120
-              ],
+              "definitionLines" : "119-120",
               "numReferrers" : 1
             },
             "105" : {
-              "definitionLines" : [
-                121,
-                122,
-                123,
-                124
-              ],
+              "definitionLines" : "121-124",
               "numReferrers" : 0
             },
             "RESTRICT_HOST_TRAFFIC_IN" : {
-              "definitionLines" : [
-                110,
-                111,
-                112,
-                113
-              ],
+              "definitionLines" : "110-113",
               "numReferrers" : 2
             },
             "RESTRICT_HOST_TRAFFIC_OUT" : {
-              "definitionLines" : [
-                114,
-                115,
-                116,
-                117
-              ],
+              "definitionLines" : "114-117",
               "numReferrers" : 0
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "59-64",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72,
-                73
-              ],
+              "definitionLines" : "70-73",
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
-              "definitionLines" : [
-                75,
-                76,
-                77,
-                78
-              ],
+              "definitionLines" : "75-78",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 1
             }
           },
           "route-map" : {
             "as2_to_dept" : {
-              "definitionLines" : [
-                131,
-                132,
-                133
-              ],
+              "definitionLines" : "131-133",
               "numReferrers" : 1
             },
             "dept_to_as2" : {
-              "definitionLines" : [
-                126,
-                127,
-                128,
-                129
-              ],
+              "definitionLines" : "126-129",
               "numReferrers" : 1
             }
           }
@@ -1156,104 +671,59 @@
         "configs/as2dist1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 2
             },
             "dept" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "dept_community" : {
-              "definitionLines" : [
-                111
-              ],
+              "definitionLines" : "111",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "102" : {
-              "definitionLines" : [
-                116
-              ],
+              "definitionLines" : "116",
               "numReferrers" : 0
             },
             "105" : {
-              "definitionLines" : [
-                117,
-                118,
-                119,
-                120
-              ],
+              "definitionLines" : "117-120",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "59-64",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72
-              ],
+              "definitionLines" : "70-72",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 3
             }
           },
           "route-map" : {
             "as2dist_to_dept" : {
-              "definitionLines" : [
-                122,
-                123,
-                124,
-                125
-              ],
+              "definitionLines" : "122-125",
               "numReferrers" : 1
             },
             "dept_to_as2dist" : {
-              "definitionLines" : [
-                127,
-                128,
-                129
-              ],
+              "definitionLines" : "127-129",
               "numReferrers" : 1
             }
           }
@@ -1261,104 +731,59 @@
         "configs/as2dist2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 2
             },
             "dept" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "dept_community" : {
-              "definitionLines" : [
-                111
-              ],
+              "definitionLines" : "111",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "102" : {
-              "definitionLines" : [
-                116
-              ],
+              "definitionLines" : "116",
               "numReferrers" : 0
             },
             "105" : {
-              "definitionLines" : [
-                117,
-                118,
-                119,
-                120
-              ],
+              "definitionLines" : "117-120",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "59-64",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                70,
-                71,
-                72
-              ],
+              "definitionLines" : "70-72",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 3
             }
           },
           "route-map" : {
             "as2dist_to_dept" : {
-              "definitionLines" : [
-                122,
-                123,
-                124,
-                125
-              ],
+              "definitionLines" : "122-125",
               "numReferrers" : 1
             },
             "dept_to_as2dist" : {
-              "definitionLines" : [
-                127,
-                128,
-                129
-              ],
+              "definitionLines" : "127-129",
               "numReferrers" : 1
             }
           }
@@ -1366,164 +791,89 @@
         "configs/as3border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 0
             },
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 1
             },
             "as3" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                113
-              ],
+              "definitionLines" : "113",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                114
-              ],
+              "definitionLines" : "114",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                115
-              ],
+              "definitionLines" : "115",
               "numReferrers" : 0
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                125,
-                126
-              ],
+              "definitionLines" : "125-126",
               "numReferrers" : 1
             },
             "102" : {
-              "definitionLines" : [
-                127,
-                128
-              ],
+              "definitionLines" : "127-128",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                129,
-                130
-              ],
+              "definitionLines" : "129-130",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "default_list" : {
-              "definitionLines" : [
-                121
-              ],
+              "definitionLines" : "121",
               "numReferrers" : 1
             },
             "inbound_route_filter" : {
-              "definitionLines" : [
-                123,
-                124
-              ],
+              "definitionLines" : "123-124",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "definitionLines" : [
-                142,
-                143,
-                144
-              ],
+              "definitionLines" : "142-144",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                161,
-                162,
-                163
-              ],
+              "definitionLines" : "161-163",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                132,
-                133,
-                134,
-                135,
-                137,
-                138,
-                139,
-                140
-              ],
+              "definitionLines" : "132-135,137-140",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                146,
-                147,
-                148,
-                149,
-                151,
-                152,
-                153,
-                154,
-                156,
-                157,
-                158,
-                159
-              ],
+              "definitionLines" : "146-149,151-154,156-159",
               "numReferrers" : 1
             }
           }
@@ -1531,154 +881,85 @@
         "configs/as3border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 0
             },
             "as3" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                113
-              ],
+              "definitionLines" : "113",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                114
-              ],
+              "definitionLines" : "114",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                115
-              ],
+              "definitionLines" : "115",
               "numReferrers" : 0
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                123,
-                124
-              ],
+              "definitionLines" : "123-124",
               "numReferrers" : 1
             },
             "102" : {
-              "definitionLines" : [
-                125,
-                126
-              ],
+              "definitionLines" : "125-126",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                127,
-                128
-              ],
+              "definitionLines" : "127-128",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                121,
-                122
-              ],
+              "definitionLines" : "121-122",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "definitionLines" : [
-                140,
-                141,
-                142
-              ],
+              "definitionLines" : "140-142",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                154,
-                155,
-                156
-              ],
+              "definitionLines" : "154-156",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                130,
-                131,
-                132,
-                133,
-                135,
-                136,
-                137,
-                138
-              ],
+              "definitionLines" : "130-133,135-138",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                144,
-                145,
-                146,
-                147,
-                149,
-                150,
-                151,
-                152
-              ],
+              "definitionLines" : "144-147,149-152",
               "numReferrers" : 1
             }
           }
@@ -1686,62 +967,33 @@
         "configs/as3core1.cfg" : {
           "bgp peer-group" : {
             "as3" : {
-              "definitionLines" : [
-                87
-              ],
+              "definitionLines" : "87",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "62-67",
               "numReferrers" : 1
             },
             "GigabitEthernet1/0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             },
             "GigabitEthernet2/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "73-75",
               "numReferrers" : 1
             },
             "GigabitEthernet3/0" : {
-              "definitionLines" : [
-                77,
-                78,
-                79
-              ],
+              "definitionLines" : "77-79",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 3
             }
           }

--- a/tests/parsing-tests/example-juniper.ref
+++ b/tests/parsing-tests/example-juniper.ref
@@ -11527,971 +11527,603 @@
         "configs/as1border1.cfg" : {
           "bgp group" : {
             "as1" : {
-              "bgp group neighbor" : [
-                14
-              ]
+              "bgp group neighbor" : "14"
             },
             "as2" : {
-              "bgp group neighbor" : [
-                19
-              ]
+              "bgp group neighbor" : "19"
             },
             "bad-ebgp" : {
-              "bgp group neighbor" : [
-                27
-              ]
+              "bgp group neighbor" : "27"
             },
             "xanadu" : {
-              "bgp group neighbor" : [
-                23
-              ]
+              "bgp group neighbor" : "23"
             }
           },
           "interface" : {
             "fe-0/0/0" : {
-              "interface" : [
-                4,
-                5
-              ]
+              "interface" : "4-5"
             },
             "fe-0/0/0.0" : {
-              "interface" : [
-                4
-              ],
-              "ospf area interface" : [
-                7
-              ]
+              "interface" : "4",
+              "ospf area interface" : "7"
             },
             "fe-0/0/0.1" : {
-              "interface" : [
-                5
-              ]
+              "interface" : "5"
             },
             "lo0" : {
-              "interface" : [
-                3
-              ]
+              "interface" : "3"
             },
             "lo0.0" : {
-              "interface" : [
-                3
-              ],
-              "ospf area interface" : [
-                6
-              ]
+              "interface" : "3",
+              "ospf area interface" : "6"
             }
           },
           "policy-statement" : {
             "as1_to_as1" : {
-              "bgp export policy-statement" : [
-                13
-              ]
+              "bgp export policy-statement" : "13"
             },
             "as1_to_as2" : {
-              "bgp export policy-statement" : [
-                17
-              ]
+              "bgp export policy-statement" : "17"
             },
             "as2_to_as1" : {
-              "bgp import policy-statement" : [
-                18
-              ]
+              "bgp import policy-statement" : "18"
             },
             "match_original_prefixes" : {
-              "bgp export policy-statement" : [
-                22,
-                26
-              ]
+              "bgp export policy-statement" : "22,26"
             },
             "ospf-redistribute-connected" : {
-              "ospf export policy-statement" : [
-                8
-              ]
+              "ospf export policy-statement" : "8"
             }
           },
           "prefix-list" : {
             "as3_prefixes" : {
-              "policy-statement prefix-list" : [
-                38
-              ]
+              "policy-statement prefix-list" : "38"
             },
             "original_prefixes" : {
-              "policy-statement prefix-list" : [
-                32,
-                34,
-                45
-              ]
+              "policy-statement prefix-list" : "32,34,45"
             }
           }
         },
         "configs/as1border2.cfg" : {
           "bgp group" : {
             "as1" : {
-              "bgp group neighbor" : [
-                15
-              ]
+              "bgp group neighbor" : "15"
             },
             "as3" : {
-              "bgp group neighbor" : [
-                20
-              ]
+              "bgp group neighbor" : "20"
             },
             "as4" : {
-              "bgp group neighbor" : [
-                25
-              ]
+              "bgp group neighbor" : "25"
             }
           },
           "interface" : {
             "fe-0/0/0" : {
-              "interface" : [
-                4,
-                5,
-                6
-              ]
+              "interface" : "4-6"
             },
             "fe-0/0/0.0" : {
-              "interface" : [
-                4
-              ],
-              "ospf area interface" : [
-                8
-              ]
+              "interface" : "4",
+              "ospf area interface" : "8"
             },
             "fe-0/0/0.1" : {
-              "interface" : [
-                5
-              ]
+              "interface" : "5"
             },
             "fe-0/0/0.2" : {
-              "interface" : [
-                6
-              ]
+              "interface" : "6"
             },
             "lo0" : {
-              "interface" : [
-                3
-              ]
+              "interface" : "3"
             },
             "lo0.0" : {
-              "interface" : [
-                3
-              ],
-              "ospf area interface" : [
-                7
-              ]
+              "interface" : "3",
+              "ospf area interface" : "7"
             }
           },
           "policy-statement" : {
             "as1_to_as1" : {
-              "bgp export policy-statement" : [
-                14
-              ]
+              "bgp export policy-statement" : "14"
             },
             "as1_to_as3" : {
-              "bgp export policy-statement" : [
-                18
-              ]
+              "bgp export policy-statement" : "18"
             },
             "as1_to_as4" : {
-              "bgp export policy-statement" : [
-                23
-              ]
+              "bgp export policy-statement" : "23"
             },
             "as3_to_as1" : {
-              "bgp import policy-statement" : [
-                19
-              ]
+              "bgp import policy-statement" : "19"
             },
             "as4_to_as1" : {
-              "bgp import policy-statement" : [
-                24
-              ]
+              "bgp import policy-statement" : "24"
             },
             "ospf-redistribute-connected" : {
-              "ospf export policy-statement" : [
-                9
-              ]
+              "ospf export policy-statement" : "9"
             }
           },
           "prefix-list" : {
             "as2_prefixes" : {
-              "policy-statement prefix-list" : [
-                36
-              ]
+              "policy-statement prefix-list" : "36"
             },
             "as4_prefixes" : {
-              "policy-statement prefix-list-filter" : [
-                51
-              ]
+              "policy-statement prefix-list-filter" : "51"
             },
             "original_prefixes" : {
-              "policy-statement prefix-list" : [
-                30,
-                32,
-                43
-              ]
+              "policy-statement prefix-list" : "30,32,43"
             }
           }
         },
         "configs/as1core1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                74,
-                76
-              ]
+              "bgp neighbor peer-group" : "74,76"
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "FastEthernet0/1" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "Loopback0" : {
-              "interface" : [
-                51
-              ],
-              "update-source interface" : [
-                75,
-                77
-              ]
+              "interface" : "51",
+              "update-source interface" : "75,77"
             }
           }
         },
         "configs/as2border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                91
-              ]
+              "bgp neighbor peer-group" : "91"
             },
             "as2" : {
-              "bgp neighbor peer-group" : [
-                87,
-                88
-              ]
+              "bgp neighbor peer-group" : "87-88"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                148
-              ]
+              "route-map match community-list" : "148"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                162
-              ]
+              "route-map match community-list" : "162"
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                55
-              ]
+              "interface" : "55"
             },
             "FastEthernet0/1" : {
-              "interface" : [
-                61
-              ]
+              "interface" : "61"
             },
             "FastEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "Loopback0" : {
-              "interface" : [
-                52
-              ],
-              "update-source interface" : [
-                89,
-                90
-              ]
+              "interface" : "52",
+              "update-source interface" : "89-90"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                152
-              ]
+              "route-map match ipv4 access-list" : "152"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                138,
-                157
-              ]
+              "route-map match ipv4 access-list" : "138,157"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                143
-              ]
+              "route-map match ipv4 access-list" : "143"
             },
             "BLOCK_SPOOF_IN" : {
-              "interface incoming ip access-list" : [
-                57
-              ]
+              "interface incoming ip access-list" : "57"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp inbound route-map" : [
-                100
-              ]
+              "bgp inbound route-map" : "100"
             },
             "as2_to_as1" : {
-              "bgp outbound route-map" : [
-                99
-              ]
+              "bgp outbound route-map" : "99"
             },
             "as2_to_as3" : {
-              "bgp outbound route-map" : [
-                101
-              ]
+              "bgp outbound route-map" : "101"
             },
             "as3_to_as2" : {
-              "bgp inbound route-map" : [
-                102
-              ]
+              "bgp inbound route-map" : "102"
             }
           }
         },
         "configs/as2border2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                87,
-                88
-              ]
+              "bgp neighbor peer-group" : "87-88"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                91
-              ]
+              "bgp neighbor peer-group" : "91"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                147
-              ]
+              "route-map match community-list" : "147"
             },
             "as3_community" : {
-              "route-map match community-list" : [
-                162
-              ]
+              "route-map match community-list" : "162"
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                55
-              ]
+              "interface" : "55"
             },
             "FastEthernet0/1" : {
-              "interface" : [
-                61
-              ]
+              "interface" : "61"
             },
             "FastEthernet1/0" : {
-              "interface" : [
-                66
-              ]
+              "interface" : "66"
             },
             "Loopback0" : {
-              "interface" : [
-                52
-              ],
-              "update-source interface" : [
-                89,
-                90
-              ]
+              "interface" : "52",
+              "update-source interface" : "89-90"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                152
-              ]
+              "route-map match ipv4 access-list" : "152"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                137,
-                157
-              ]
+              "route-map match ipv4 access-list" : "137,157"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                142
-              ]
+              "route-map match ipv4 access-list" : "142"
             },
             "BLOCK_SPOOF_IN" : {
-              "interface incoming ip access-list" : [
-                57
-              ]
+              "interface incoming ip access-list" : "57"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp inbound route-map" : [
-                100
-              ]
+              "bgp inbound route-map" : "100"
             },
             "as2_to_as1" : {
-              "bgp outbound route-map" : [
-                99
-              ]
+              "bgp outbound route-map" : "99"
             },
             "as2_to_as3" : {
-              "bgp outbound route-map" : [
-                101
-              ]
+              "bgp outbound route-map" : "101"
             },
             "as3_to_as2" : {
-              "bgp inbound route-map" : [
-                102
-              ]
+              "bgp inbound route-map" : "102"
             }
           }
         },
         "configs/as2core1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                89,
-                91,
-                93,
-                95
-              ]
+              "bgp neighbor peer-group" : "89,91,93,95"
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "FastEthernet0/1" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "FastEthernet1/0" : {
-              "interface" : [
-                67
-              ]
+              "interface" : "67"
             },
             "FastEthernet2/0" : {
-              "interface" : [
-                73
-              ]
+              "interface" : "73"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                90,
-                92,
-                94,
-                96
-              ]
+              "interface" : "54",
+              "update-source interface" : "90,92,94,96"
             }
           },
           "ipv4 acl" : {
             "blocktelnet" : {
-              "interface incoming ip access-list" : [
-                69,
-                75
-              ]
+              "interface incoming ip access-list" : "69,75"
             }
           }
         },
         "configs/as2core2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                88,
-                90,
-                92,
-                94
-              ]
+              "bgp neighbor peer-group" : "88,90,92,94"
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "FastEthernet0/1" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "FastEthernet1/0" : {
-              "interface" : [
-                67
-              ]
+              "interface" : "67"
             },
             "FastEthernet2/0" : {
-              "interface" : [
-                72
-              ]
+              "interface" : "72"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                89,
-                91,
-                93,
-                95
-              ]
+              "interface" : "54",
+              "update-source interface" : "89,91,93,95"
             }
           },
           "route-map" : {
             "filter-bogons" : {
-              "bgp inbound route-map" : [
-                87
-              ]
+              "bgp inbound route-map" : "87"
             }
           }
         },
         "configs/as2dept1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                72,
-                73
-              ]
+              "bgp neighbor peer-group" : "72-73"
             }
           },
           "community-list" : {
             "as2_community" : {
-              "route-map match community-list" : [
-                121
-              ]
+              "route-map match community-list" : "121"
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                51
-              ]
+              "interface" : "51"
             },
             "FastEthernet0/1" : {
-              "interface" : [
-                56
-              ]
+              "interface" : "56"
             },
             "FastEthernet1/0" : {
-              "interface" : [
-                61
-              ]
+              "interface" : "61"
             },
             "Loopback0" : {
-              "interface" : [
-                48
-              ]
+              "interface" : "48"
             }
           },
           "ipv4 acl" : {
             "102" : {
-              "route-map match ipv4 access-list" : [
-                116
-              ]
+              "route-map match ipv4 access-list" : "116"
             },
             "RESTRICT_HOST_TRAFFIC_IN" : {
-              "interface incoming ip access-list" : [
-                63
-              ]
+              "interface incoming ip access-list" : "63"
             }
           },
           "route-map" : {
             "as2_to_dept" : {
-              "bgp inbound route-map" : [
-                78
-              ]
+              "bgp inbound route-map" : "78"
             },
             "dept_to_as2" : {
-              "bgp outbound route-map" : [
-                79
-              ]
+              "bgp outbound route-map" : "79"
             }
           }
         },
         "configs/as2dist1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                86,
-                88
-              ]
+              "bgp neighbor peer-group" : "86,88"
             },
             "dept" : {
-              "bgp neighbor peer-group" : [
-                90
-              ]
+              "bgp neighbor peer-group" : "90"
             }
           },
           "community-list" : {
             "dept_community" : {
-              "route-map match community-list" : [
-                129
-              ]
+              "route-map match community-list" : "129"
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "FastEthernet0/1" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "FastEthernet1/0" : {
-              "interface" : [
-                67
-              ]
+              "interface" : "67"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                87,
-                89
-              ]
+              "interface" : "54",
+              "update-source interface" : "87,89"
             }
           },
           "ipv4 acl" : {
             "105" : {
-              "route-map match ipv4 access-list" : [
-                124
-              ]
+              "route-map match ipv4 access-list" : "124"
             }
           },
           "route-map" : {
             "as2_to_dept" : {
-              "bgp outbound route-map" : [
-                96
-              ]
+              "bgp outbound route-map" : "96"
             },
             "dept_to_as2" : {
-              "bgp inbound route-map" : [
-                97
-              ]
+              "bgp inbound route-map" : "97"
             }
           }
         },
         "configs/as2dist2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                86,
-                88
-              ]
+              "bgp neighbor peer-group" : "86,88"
             },
             "dept" : {
-              "bgp neighbor peer-group" : [
-                90
-              ]
+              "bgp neighbor peer-group" : "90"
             }
           },
           "community-list" : {
             "dept_community" : {
-              "route-map match community-list" : [
-                129
-              ]
+              "route-map match community-list" : "129"
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "FastEthernet0/1" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "FastEthernet1/0" : {
-              "interface" : [
-                67
-              ]
+              "interface" : "67"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ],
-              "update-source interface" : [
-                87,
-                89
-              ]
+              "interface" : "54",
+              "update-source interface" : "87,89"
             }
           },
           "ipv4 acl" : {
             "105" : {
-              "route-map match ipv4 access-list" : [
-                124
-              ]
+              "route-map match ipv4 access-list" : "124"
             }
           },
           "route-map" : {
             "as2_to_dept" : {
-              "bgp outbound route-map" : [
-                96
-              ]
+              "bgp outbound route-map" : "96"
             },
             "dept_to_as2" : {
-              "bgp inbound route-map" : [
-                97
-              ]
+              "bgp inbound route-map" : "97"
             }
           }
         },
         "configs/as2host1.cfg" : {
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                57
-              ]
+              "interface" : "57"
             },
             "FastEthernet0/1" : {
-              "interface" : [
-                62
-              ]
+              "interface" : "62"
             },
             "Loopback0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             }
           }
         },
         "configs/as3border1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "bgp neighbor peer-group" : [
-                82
-              ]
+              "bgp neighbor peer-group" : "82"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                80
-              ]
+              "bgp neighbor peer-group" : "80"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                134
-              ]
+              "route-map match community-list" : "134"
             },
             "as2_community" : {
-              "route-map match community-list" : [
-                148
-              ]
+              "route-map match community-list" : "148"
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                55
-              ]
+              "interface" : "55"
             },
             "FastEthernet0/1" : {
-              "interface" : [
-                60
-              ]
+              "interface" : "60"
             },
             "Loopback0" : {
-              "interface" : [
-                52
-              ],
-              "update-source interface" : [
-                81
-              ]
+              "interface" : "52",
+              "update-source interface" : "81"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                138
-              ]
+              "route-map match ipv4 access-list" : "138"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                124
-              ]
+              "route-map match ipv4 access-list" : "124"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                129,
-                143
-              ]
+              "route-map match ipv4 access-list" : "129,143"
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "bgp inbound route-map" : [
-                90
-              ]
+              "bgp inbound route-map" : "90"
             },
             "as2_to_as3" : {
-              "bgp inbound route-map" : [
-                92
-              ]
+              "bgp inbound route-map" : "92"
             },
             "as3_to_as1" : {
-              "bgp outbound route-map" : [
-                89
-              ]
+              "bgp outbound route-map" : "89"
             },
             "as3_to_as2" : {
-              "bgp outbound route-map" : [
-                91
-              ]
+              "bgp outbound route-map" : "91"
             }
           }
         },
         "configs/as3border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                83
-              ]
+              "bgp neighbor peer-group" : "83"
             },
             "as3" : {
-              "bgp neighbor peer-group" : [
-                81
-              ]
+              "bgp neighbor peer-group" : "81"
             }
           },
           "community-list" : {
             "as1_community" : {
-              "route-map match community-list" : [
-                135
-              ]
+              "route-map match community-list" : "135"
             },
             "as2_community" : {
-              "route-map match community-list" : [
-                149
-              ]
+              "route-map match community-list" : "149"
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                55
-              ]
+              "interface" : "55"
             },
             "FastEthernet0/1" : {
-              "interface" : [
-                60
-              ]
+              "interface" : "60"
             },
             "Loopback0" : {
-              "interface" : [
-                52
-              ],
-              "update-source interface" : [
-                82
-              ]
+              "interface" : "52",
+              "update-source interface" : "82"
             }
           },
           "ipv4 acl" : {
             "101" : {
-              "route-map match ipv4 access-list" : [
-                139
-              ]
+              "route-map match ipv4 access-list" : "139"
             },
             "102" : {
-              "route-map match ipv4 access-list" : [
-                125
-              ]
+              "route-map match ipv4 access-list" : "125"
             },
             "103" : {
-              "route-map match ipv4 access-list" : [
-                130,
-                144
-              ]
+              "route-map match ipv4 access-list" : "130,144"
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "bgp inbound route-map" : [
-                91
-              ]
+              "bgp inbound route-map" : "91"
             },
             "as2_to_as3" : {
-              "bgp inbound route-map" : [
-                93
-              ]
+              "bgp inbound route-map" : "93"
             },
             "as3_to_as1" : {
-              "bgp outbound route-map" : [
-                90
-              ]
+              "bgp outbound route-map" : "90"
             },
             "as3_to_as2" : {
-              "bgp outbound route-map" : [
-                92
-              ]
+              "bgp outbound route-map" : "92"
             }
           }
         },
         "configs/as3core1.cfg" : {
           "bgp peer-group" : {
             "as3" : {
-              "bgp neighbor peer-group" : [
-                83,
-                85
-              ]
+              "bgp neighbor peer-group" : "83,85"
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                58
-              ]
+              "interface" : "58"
             },
             "FastEthernet0/1" : {
-              "interface" : [
-                63
-              ]
+              "interface" : "63"
             },
             "FastEthernet1/0" : {
-              "interface" : [
-                68
-              ]
+              "interface" : "68"
             },
             "FastEthernet1/1" : {
-              "interface" : [
-                71
-              ]
+              "interface" : "71"
             },
             "Loopback0" : {
-              "interface" : [
-                55
-              ],
-              "update-source interface" : [
-                84,
-                86
-              ]
+              "interface" : "55",
+              "update-source interface" : "84,86"
             }
           }
         }
@@ -12500,9 +12132,7 @@
         "configs/as2core2.cfg" : {
           "route-map" : {
             "filter-bogons" : {
-              "bgp inbound route-map" : [
-                87
-              ]
+              "bgp inbound route-map" : "87"
             }
           }
         }

--- a/tests/parsing-tests/example-juniper.ref
+++ b/tests/parsing-tests/example-juniper.ref
@@ -10675,136 +10675,73 @@
         "configs/as1border1.cfg" : {
           "bgp group" : {
             "as1" : {
-              "definitionLines" : [
-                10,
-                11,
-                12,
-                13,
-                14
-              ],
+              "definitionLines" : "10-14",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                15,
-                16,
-                17,
-                18,
-                19
-              ],
+              "definitionLines" : "15-19",
               "numReferrers" : 1
             },
             "bad-ebgp" : {
-              "definitionLines" : [
-                24,
-                25,
-                26,
-                27
-              ],
+              "definitionLines" : "24-27",
               "numReferrers" : 1
             },
             "xanadu" : {
-              "definitionLines" : [
-                20,
-                21,
-                22,
-                23
-              ],
+              "definitionLines" : "20-23",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "fe-0/0/0" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 2
             },
             "fe-0/0/0.0" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 2
             },
             "fe-0/0/0.1" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "lo0" : {
-              "definitionLines" : [
-                3
-              ],
+              "definitionLines" : "3",
               "numReferrers" : 1
             },
             "lo0.0" : {
-              "definitionLines" : [
-                3
-              ],
+              "definitionLines" : "3",
               "numReferrers" : 2
             }
           },
           "policy-statement" : {
             "as1_to_as1" : {
-              "definitionLines" : [
-                30,
-                31,
-                32,
-                33
-              ],
+              "definitionLines" : "30-33",
               "numReferrers" : 1
             },
             "as1_to_as2" : {
-              "definitionLines" : [
-                34,
-                35,
-                36,
-                37,
-                38,
-                39,
-                40,
-                41
-              ],
+              "definitionLines" : "34-41",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                42,
-                43,
-                44
-              ],
+              "definitionLines" : "42-44",
               "numReferrers" : 1
             },
             "match_original_prefixes" : {
-              "definitionLines" : [
-                45,
-                46
-              ],
+              "definitionLines" : "45-46",
               "numReferrers" : 2
             },
             "ospf-redistribute-connected" : {
-              "definitionLines" : [
-                28,
-                29
-              ],
+              "definitionLines" : "28-29",
               "numReferrers" : 1
             }
           },
           "prefix-list" : {
             "as3_prefixes" : {
-              "definitionLines" : [
-                49,
-                50
-              ],
+              "definitionLines" : "49-50",
               "numReferrers" : 1
             },
             "original_prefixes" : {
-              "definitionLines" : [
-                47,
-                48
-              ],
+              "definitionLines" : "47-48",
               "numReferrers" : 3
             }
           }
@@ -10812,155 +10749,81 @@
         "configs/as1border2.cfg" : {
           "bgp group" : {
             "as1" : {
-              "definitionLines" : [
-                11,
-                12,
-                13,
-                14,
-                15
-              ],
+              "definitionLines" : "11-15",
               "numReferrers" : 1
             },
             "as3" : {
-              "definitionLines" : [
-                16,
-                17,
-                18,
-                19,
-                20
-              ],
+              "definitionLines" : "16-20",
               "numReferrers" : 1
             },
             "as4" : {
-              "definitionLines" : [
-                21,
-                22,
-                23,
-                24,
-                25
-              ],
+              "definitionLines" : "21-25",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "fe-0/0/0" : {
-              "definitionLines" : [
-                4,
-                5,
-                6
-              ],
+              "definitionLines" : "4-6",
               "numReferrers" : 3
             },
             "fe-0/0/0.0" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 2
             },
             "fe-0/0/0.1" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "fe-0/0/0.2" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 1
             },
             "lo0" : {
-              "definitionLines" : [
-                3
-              ],
+              "definitionLines" : "3",
               "numReferrers" : 1
             },
             "lo0.0" : {
-              "definitionLines" : [
-                3
-              ],
+              "definitionLines" : "3",
               "numReferrers" : 2
             }
           },
           "policy-statement" : {
             "as1_to_as1" : {
-              "definitionLines" : [
-                28,
-                29,
-                30,
-                31
-              ],
+              "definitionLines" : "28-31",
               "numReferrers" : 1
             },
             "as1_to_as3" : {
-              "definitionLines" : [
-                32,
-                33,
-                34,
-                35,
-                36,
-                37,
-                38,
-                39
-              ],
+              "definitionLines" : "32-39",
               "numReferrers" : 1
             },
             "as1_to_as4" : {
-              "definitionLines" : [
-                43,
-                44,
-                45,
-                46,
-                47,
-                48,
-                49
-              ],
+              "definitionLines" : "43-49",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                40,
-                41,
-                42
-              ],
+              "definitionLines" : "40-42",
               "numReferrers" : 1
             },
             "as4_to_as1" : {
-              "definitionLines" : [
-                50,
-                51,
-                52,
-                53
-              ],
+              "definitionLines" : "50-53",
               "numReferrers" : 1
             },
             "ospf-redistribute-connected" : {
-              "definitionLines" : [
-                26,
-                27
-              ],
+              "definitionLines" : "26-27",
               "numReferrers" : 1
             }
           },
           "prefix-list" : {
             "as2_prefixes" : {
-              "definitionLines" : [
-                56,
-                57
-              ],
+              "definitionLines" : "56-57",
               "numReferrers" : 1
             },
             "as4_prefixes" : {
-              "definitionLines" : [
-                58
-              ],
+              "definitionLines" : "58",
               "numReferrers" : 1
             },
             "original_prefixes" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 3
             }
           }
@@ -10968,36 +10831,21 @@
         "configs/as1core1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                72
-              ],
+              "definitionLines" : "72",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56,
-                57
-              ],
+              "definitionLines" : "54-57",
               "numReferrers" : 1
             },
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62
-              ],
+              "definitionLines" : "59-62",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                51,
-                52
-              ],
+              "definitionLines" : "51-52",
               "numReferrers" : 3
             }
           }
@@ -11005,162 +10853,89 @@
         "configs/as2border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 2
             },
             "as3" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 0
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                115
-              ],
+              "definitionLines" : "115",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                116
-              ],
+              "definitionLines" : "116",
               "numReferrers" : 0
             },
             "as3_community" : {
-              "definitionLines" : [
-                117
-              ],
+              "definitionLines" : "117",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                130,
-                131
-              ],
+              "definitionLines" : "130-131",
               "numReferrers" : 1
             },
             "102" : {
-              "definitionLines" : [
-                132,
-                133
-              ],
+              "definitionLines" : "132-133",
               "numReferrers" : 2
             },
             "103" : {
-              "definitionLines" : [
-                134,
-                135
-              ],
+              "definitionLines" : "134-135",
               "numReferrers" : 1
             },
             "BLOCK_SPOOF_IN" : {
-              "definitionLines" : [
-                122,
-                123,
-                124
-              ],
+              "definitionLines" : "122-124",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                55,
-                56,
-                57,
-                58,
-                59
-              ],
+              "definitionLines" : "55-59",
               "numReferrers" : 1
             },
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "61-64",
               "numReferrers" : 1
             },
             "FastEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68,
-                69
-              ],
+              "definitionLines" : "66-69",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                52,
-                53
-              ],
+              "definitionLines" : "52-53",
               "numReferrers" : 3
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                128,
-                129
-              ],
+              "definitionLines" : "128-129",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                147,
-                148,
-                149
-              ],
+              "definitionLines" : "147-149",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                137,
-                138,
-                139,
-                140,
-                142,
-                143,
-                144,
-                145
-              ],
+              "definitionLines" : "137-140,142-145",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                151,
-                152,
-                153,
-                154,
-                156,
-                157,
-                158,
-                159
-              ],
+              "definitionLines" : "151-154,156-159",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                161,
-                162,
-                163
-              ],
+              "definitionLines" : "161-163",
               "numReferrers" : 1
             }
           }
@@ -11168,164 +10943,89 @@
         "configs/as2border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 0
             },
             "as2" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 2
             },
             "as3" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                115
-              ],
+              "definitionLines" : "115",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                116
-              ],
+              "definitionLines" : "116",
               "numReferrers" : 0
             },
             "as3_community" : {
-              "definitionLines" : [
-                117
-              ],
+              "definitionLines" : "117",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                129,
-                130
-              ],
+              "definitionLines" : "129-130",
               "numReferrers" : 1
             },
             "102" : {
-              "definitionLines" : [
-                131,
-                132
-              ],
+              "definitionLines" : "131-132",
               "numReferrers" : 2
             },
             "103" : {
-              "definitionLines" : [
-                133,
-                134
-              ],
+              "definitionLines" : "133-134",
               "numReferrers" : 1
             },
             "BLOCK_SPOOF_IN" : {
-              "definitionLines" : [
-                122,
-                123,
-                124
-              ],
+              "definitionLines" : "122-124",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                55,
-                56,
-                57,
-                58,
-                59
-              ],
+              "definitionLines" : "55-59",
               "numReferrers" : 1
             },
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "61-64",
               "numReferrers" : 1
             },
             "FastEthernet1/0" : {
-              "definitionLines" : [
-                66,
-                67,
-                68,
-                69
-              ],
+              "definitionLines" : "66-69",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                52,
-                53
-              ],
+              "definitionLines" : "52-53",
               "numReferrers" : 3
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                127,
-                128
-              ],
+              "definitionLines" : "127-128",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "definitionLines" : [
-                146,
-                147,
-                148,
-                149
-              ],
+              "definitionLines" : "146-149",
               "numReferrers" : 1
             },
             "as2_to_as1" : {
-              "definitionLines" : [
-                136,
-                137,
-                138,
-                139,
-                141,
-                142,
-                143,
-                144
-              ],
+              "definitionLines" : "136-139,141-144",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                151,
-                152,
-                153,
-                154,
-                156,
-                157,
-                158,
-                159
-              ],
+              "definitionLines" : "151-154,156-159",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                161,
-                162,
-                163,
-                164
-              ],
+              "definitionLines" : "161-164",
               "numReferrers" : 1
             }
           }
@@ -11333,66 +11033,35 @@
         "configs/as2core1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                87
-              ],
+              "definitionLines" : "87",
               "numReferrers" : 4
             }
           },
           "extended ipv4 access-list" : {
             "blocktelnet" : {
-              "definitionLines" : [
-                118,
-                119,
-                120
-              ],
+              "definitionLines" : "118-120",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65
-              ],
+              "definitionLines" : "62-65",
               "numReferrers" : 1
             },
             "FastEthernet1/0" : {
-              "definitionLines" : [
-                67,
-                68,
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "67-71",
               "numReferrers" : 1
             },
             "FastEthernet2/0" : {
-              "definitionLines" : [
-                73,
-                74,
-                75,
-                76,
-                77
-              ],
+              "definitionLines" : "73-77",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 5
             }
           }
@@ -11400,54 +11069,29 @@
         "configs/as2core2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 4
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65
-              ],
+              "definitionLines" : "62-65",
               "numReferrers" : 1
             },
             "FastEthernet1/0" : {
-              "definitionLines" : [
-                67,
-                68,
-                69,
-                70
-              ],
+              "definitionLines" : "67-70",
               "numReferrers" : 1
             },
             "FastEthernet2/0" : {
-              "definitionLines" : [
-                72,
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "72-75",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 5
             }
           }
@@ -11455,108 +11099,59 @@
         "configs/as2dept1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                70
-              ],
+              "definitionLines" : "70",
               "numReferrers" : 2
             }
           },
           "expanded community-list" : {
             "as2_community" : {
-              "definitionLines" : [
-                92
-              ],
+              "definitionLines" : "92",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "102" : {
-              "definitionLines" : [
-                109
-              ],
+              "definitionLines" : "109",
               "numReferrers" : 1
             },
             "105" : {
-              "definitionLines" : [
-                110,
-                111,
-                112,
-                113
-              ],
+              "definitionLines" : "110-113",
               "numReferrers" : 0
             },
             "RESTRICT_HOST_TRAFFIC_IN" : {
-              "definitionLines" : [
-                102,
-                103,
-                104,
-                105
-              ],
+              "definitionLines" : "102-105",
               "numReferrers" : 1
             },
             "RESTRICT_HOST_TRAFFIC_OUT" : {
-              "definitionLines" : [
-                97,
-                98,
-                99,
-                100
-              ],
+              "definitionLines" : "97-100",
               "numReferrers" : 0
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                51,
-                52,
-                53,
-                54
-              ],
+              "definitionLines" : "51-54",
               "numReferrers" : 1
             },
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                56,
-                57,
-                58,
-                59
-              ],
+              "definitionLines" : "56-59",
               "numReferrers" : 1
             },
             "FastEthernet1/0" : {
-              "definitionLines" : [
-                61,
-                62,
-                63,
-                64,
-                65
-              ],
+              "definitionLines" : "61-65",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                48,
-                49
-              ],
+              "definitionLines" : "48-49",
               "numReferrers" : 1
             }
           },
           "route-map" : {
             "as2_to_dept" : {
-              "definitionLines" : [
-                120,
-                121,
-                122
-              ],
+              "definitionLines" : "120-122",
               "numReferrers" : 1
             },
             "dept_to_as2" : {
-              "definitionLines" : [
-                115,
-                116,
-                117,
-                118
-              ],
+              "definitionLines" : "115-118",
               "numReferrers" : 1
             }
           }
@@ -11564,95 +11159,55 @@
         "configs/as2dist1.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                82
-              ],
+              "definitionLines" : "82",
               "numReferrers" : 2
             },
             "dept" : {
-              "definitionLines" : [
-                84
-              ],
+              "definitionLines" : "84",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "dept_community" : {
-              "definitionLines" : [
-                110
-              ],
+              "definitionLines" : "110",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "102" : {
-              "definitionLines" : [
-                117
-              ],
+              "definitionLines" : "117",
               "numReferrers" : 0
             },
             "105" : {
-              "definitionLines" : [
-                118,
-                119,
-                120,
-                121
-              ],
+              "definitionLines" : "118-121",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65
-              ],
+              "definitionLines" : "62-65",
               "numReferrers" : 1
             },
             "FastEthernet1/0" : {
-              "definitionLines" : [
-                67,
-                68,
-                69,
-                70
-              ],
+              "definitionLines" : "67-70",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 3
             }
           },
           "route-map" : {
             "as2_to_dept" : {
-              "definitionLines" : [
-                123,
-                124,
-                125,
-                126
-              ],
+              "definitionLines" : "123-126",
               "numReferrers" : 1
             },
             "dept_to_as2" : {
-              "definitionLines" : [
-                128,
-                129,
-                130
-              ],
+              "definitionLines" : "128-130",
               "numReferrers" : 1
             }
           }
@@ -11660,95 +11215,55 @@
         "configs/as2dist2.cfg" : {
           "bgp peer-group" : {
             "as2" : {
-              "definitionLines" : [
-                82
-              ],
+              "definitionLines" : "82",
               "numReferrers" : 2
             },
             "dept" : {
-              "definitionLines" : [
-                84
-              ],
+              "definitionLines" : "84",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "dept_community" : {
-              "definitionLines" : [
-                110
-              ],
+              "definitionLines" : "110",
               "numReferrers" : 1
             }
           },
           "extended ipv4 access-list" : {
             "102" : {
-              "definitionLines" : [
-                117
-              ],
+              "definitionLines" : "117",
               "numReferrers" : 0
             },
             "105" : {
-              "definitionLines" : [
-                118,
-                119,
-                120,
-                121
-              ],
+              "definitionLines" : "118-121",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65
-              ],
+              "definitionLines" : "62-65",
               "numReferrers" : 1
             },
             "FastEthernet1/0" : {
-              "definitionLines" : [
-                67,
-                68,
-                69,
-                70
-              ],
+              "definitionLines" : "67-70",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 3
             }
           },
           "route-map" : {
             "as2_to_dept" : {
-              "definitionLines" : [
-                123,
-                124,
-                125,
-                126
-              ],
+              "definitionLines" : "123-126",
               "numReferrers" : 1
             },
             "dept_to_as2" : {
-              "definitionLines" : [
-                128,
-                129,
-                130
-              ],
+              "definitionLines" : "128-130",
               "numReferrers" : 1
             }
           }
@@ -11756,29 +11271,15 @@
         "configs/as2host1.cfg" : {
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 1
             },
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66
-              ],
+              "definitionLines" : "62-66",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                54,
-                55
-              ],
+              "definitionLines" : "54-55",
               "numReferrers" : 1
             }
           }
@@ -11786,144 +11287,81 @@
         "configs/as3border1.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                74
-              ],
+              "definitionLines" : "74",
               "numReferrers" : 0
             },
             "as2" : {
-              "definitionLines" : [
-                76
-              ],
+              "definitionLines" : "76",
               "numReferrers" : 1
             },
             "as3" : {
-              "definitionLines" : [
-                78
-              ],
+              "definitionLines" : "78",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                106
-              ],
+              "definitionLines" : "106",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                107
-              ],
+              "definitionLines" : "107",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                108
-              ],
+              "definitionLines" : "108",
               "numReferrers" : 0
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                116,
-                117
-              ],
+              "definitionLines" : "116-117",
               "numReferrers" : 1
             },
             "102" : {
-              "definitionLines" : [
-                118,
-                119
-              ],
+              "definitionLines" : "118-119",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                120,
-                121
-              ],
+              "definitionLines" : "120-121",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                55,
-                56,
-                57,
-                58
-              ],
+              "definitionLines" : "55-58",
               "numReferrers" : 1
             },
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                60,
-                61,
-                62,
-                63
-              ],
+              "definitionLines" : "60-63",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                52,
-                53
-              ],
+              "definitionLines" : "52-53",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                114,
-                115
-              ],
+              "definitionLines" : "114-115",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "definitionLines" : [
-                133,
-                134,
-                135
-              ],
+              "definitionLines" : "133-135",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                147,
-                148,
-                149
-              ],
+              "definitionLines" : "147-149",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                123,
-                124,
-                125,
-                126,
-                128,
-                129,
-                130,
-                131
-              ],
+              "definitionLines" : "123-126,128-131",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                137,
-                138,
-                139,
-                140,
-                142,
-                143,
-                144,
-                145
-              ],
+              "definitionLines" : "137-140,142-145",
               "numReferrers" : 1
             }
           }
@@ -11931,144 +11369,81 @@
         "configs/as3border2.cfg" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                75
-              ],
+              "definitionLines" : "75",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                77
-              ],
+              "definitionLines" : "77",
               "numReferrers" : 0
             },
             "as3" : {
-              "definitionLines" : [
-                79
-              ],
+              "definitionLines" : "79",
               "numReferrers" : 1
             }
           },
           "expanded community-list" : {
             "as1_community" : {
-              "definitionLines" : [
-                107
-              ],
+              "definitionLines" : "107",
               "numReferrers" : 1
             },
             "as2_community" : {
-              "definitionLines" : [
-                108
-              ],
+              "definitionLines" : "108",
               "numReferrers" : 1
             },
             "as3_community" : {
-              "definitionLines" : [
-                109
-              ],
+              "definitionLines" : "109",
               "numReferrers" : 0
             }
           },
           "extended ipv4 access-list" : {
             "101" : {
-              "definitionLines" : [
-                117,
-                118
-              ],
+              "definitionLines" : "117-118",
               "numReferrers" : 1
             },
             "102" : {
-              "definitionLines" : [
-                119,
-                120
-              ],
+              "definitionLines" : "119-120",
               "numReferrers" : 1
             },
             "103" : {
-              "definitionLines" : [
-                121,
-                122
-              ],
+              "definitionLines" : "121-122",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                55,
-                56,
-                57,
-                58
-              ],
+              "definitionLines" : "55-58",
               "numReferrers" : 1
             },
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                60,
-                61,
-                62,
-                63
-              ],
+              "definitionLines" : "60-63",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                52,
-                53
-              ],
+              "definitionLines" : "52-53",
               "numReferrers" : 2
             }
           },
           "ipv4 prefix-list" : {
             "inbound_route_filter" : {
-              "definitionLines" : [
-                115,
-                116
-              ],
+              "definitionLines" : "115-116",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "as1_to_as3" : {
-              "definitionLines" : [
-                134,
-                135,
-                136
-              ],
+              "definitionLines" : "134-136",
               "numReferrers" : 1
             },
             "as2_to_as3" : {
-              "definitionLines" : [
-                148,
-                149,
-                150
-              ],
+              "definitionLines" : "148-150",
               "numReferrers" : 1
             },
             "as3_to_as1" : {
-              "definitionLines" : [
-                124,
-                125,
-                126,
-                127,
-                129,
-                130,
-                131,
-                132
-              ],
+              "definitionLines" : "124-127,129-132",
               "numReferrers" : 1
             },
             "as3_to_as2" : {
-              "definitionLines" : [
-                138,
-                139,
-                140,
-                141,
-                143,
-                144,
-                145,
-                146
-              ],
+              "definitionLines" : "138-141,143-146",
               "numReferrers" : 1
             }
           }
@@ -12076,50 +11451,29 @@
         "configs/as3core1.cfg" : {
           "bgp peer-group" : {
             "as3" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                58,
-                59,
-                60,
-                61
-              ],
+              "definitionLines" : "58-61",
               "numReferrers" : 1
             },
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                63,
-                64,
-                65,
-                66
-              ],
+              "definitionLines" : "63-66",
               "numReferrers" : 1
             },
             "FastEthernet1/0" : {
-              "definitionLines" : [
-                68,
-                69
-              ],
+              "definitionLines" : "68-69",
               "numReferrers" : 1
             },
             "FastEthernet1/1" : {
-              "definitionLines" : [
-                71,
-                72
-              ],
+              "definitionLines" : "71-72",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                55,
-                56
-              ],
+              "definitionLines" : "55-56",
               "numReferrers" : 3
             }
           }

--- a/tests/parsing-tests/srx-testbed.ref
+++ b/tests/parsing-tests/srx-testbed.ref
@@ -6535,577 +6535,305 @@
         "configs/junos-srx-1.cfg" : {
           "bgp group" : {
             "physical" : {
-              "bgp group neighbor" : [
-                113,
-                114
-              ]
+              "bgp group neighbor" : "113-114"
             }
           },
           "ike gateway" : {
             "gateway-2" : {
-              "ipsec vpn ike gateway" : [
-                37
-              ]
+              "ipsec vpn ike gateway" : "37"
             },
             "gateway-3" : {
-              "ipsec vpn ike gateway" : [
-                34
-              ]
+              "ipsec vpn ike gateway" : "34"
             }
           },
           "ike policy" : {
             "test-ike-policy" : {
-              "ike gateway ike policy" : [
-                25,
-                28
-              ]
+              "ike gateway ike policy" : "25,28"
             }
           },
           "interface" : {
             "fxp0" : {
-              "interface" : [
-                99
-              ]
+              "interface" : "99"
             },
             "fxp0.0" : {
-              "interface" : [
-                99
-              ]
+              "interface" : "99"
             },
             "ge-0/0/0" : {
-              "interface" : [
-                96
-              ]
+              "interface" : "96"
             },
             "ge-0/0/0.0" : {
-              "ike gateway external-interface" : [
-                30
-              ],
-              "interface" : [
-                96
-              ],
-              "security zones security-zone interfaces" : [
-                89
-              ]
+              "ike gateway external-interface" : "30",
+              "interface" : "96",
+              "security zones security-zone interfaces" : "89"
             },
             "ge-0/0/1" : {
-              "interface" : [
-                97
-              ]
+              "interface" : "97"
             },
             "ge-0/0/1.0" : {
-              "ike gateway external-interface" : [
-                27
-              ],
-              "interface" : [
-                97
-              ],
-              "security zones security-zone interfaces" : [
-                90
-              ]
+              "ike gateway external-interface" : "27",
+              "interface" : "97",
+              "security zones security-zone interfaces" : "90"
             },
             "ge-0/0/2" : {
-              "interface" : [
-                98
-              ]
+              "interface" : "98"
             },
             "ge-0/0/2.0" : {
-              "interface" : [
-                98
-              ],
-              "security zones security-zone interfaces" : [
-                93
-              ]
+              "interface" : "98",
+              "security zones security-zone interfaces" : "93"
             },
             "lo0" : {
-              "interface" : [
-                100
-              ]
+              "interface" : "100"
             },
             "lo0.0" : {
-              "interface" : [
-                100
-              ],
-              "security zones security-zone interfaces" : [
-                95
-              ]
+              "interface" : "100",
+              "security zones security-zone interfaces" : "95"
             },
             "st0" : {
-              "interface" : [
-                101,
-                102
-              ]
+              "interface" : "101-102"
             },
             "st0.2" : {
-              "interface" : [
-                101
-              ],
-              "ipsec vpn bind-interface" : [
-                36
-              ],
-              "security zones security-zone interfaces" : [
-                82
-              ]
+              "interface" : "101",
+              "ipsec vpn bind-interface" : "36",
+              "security zones security-zone interfaces" : "82"
             },
             "st0.3" : {
-              "interface" : [
-                102
-              ],
-              "ipsec vpn bind-interface" : [
-                33
-              ],
-              "security zones security-zone interfaces" : [
-                83
-              ]
+              "interface" : "102",
+              "ipsec vpn bind-interface" : "33",
+              "security zones security-zone interfaces" : "83"
             }
           },
           "ipsec policy" : {
             "test-ipsec-policy" : {
-              "ipsec vpn ipsec policy" : [
-                35,
-                38
-              ]
+              "ipsec vpn ipsec policy" : "35,38"
             }
           },
           "policy-statement" : {
             "bgp_export" : {
-              "bgp export policy-statement" : [
-                105
-              ]
+              "bgp export policy-statement" : "105"
             },
             "loadbal" : {
-              "forwarding-table export policy-statement" : [
-                104
-              ]
+              "forwarding-table export policy-statement" : "104"
             }
           },
           "security policy" : {
             "zone~junos-host~to~zone~untrust" : {
-              "security policy" : [
-                68,
-                69,
-                70,
-                71,
-                72,
-                73,
-                74,
-                75
-              ]
+              "security policy" : "68-75"
             },
             "zone~loopback~to~zone~junos-host" : {
-              "security policy" : [
-                60,
-                61,
-                62,
-                63
-              ]
+              "security policy" : "60-63"
             },
             "zone~trust~to~zone~trust" : {
-              "security policy" : [
-                48,
-                49,
-                50,
-                51
-              ]
+              "security policy" : "48-51"
             },
             "zone~untrust~to~zone~junos-host" : {
-              "security policy" : [
-                56,
-                57,
-                58,
-                59
-              ]
+              "security policy" : "56-59"
             },
             "zone~untrust~to~zone~loopback" : {
-              "security policy" : [
-                52,
-                53,
-                54,
-                55
-              ]
+              "security policy" : "52-55"
             },
             "zone~untrust~to~zone~untrust" : {
-              "security policy" : [
-                64,
-                65,
-                66,
-                67
-              ]
+              "security policy" : "64-67"
             }
           },
           "security policy term" : {
             "zone~junos-host~to~zone~untrust p" : {
-              "security policy term" : [
-                68,
-                69,
-                70,
-                71
-              ]
+              "security policy term" : "68-71"
             },
             "zone~junos-host~to~zone~untrust p2" : {
-              "security policy term" : [
-                72,
-                73,
-                74,
-                75
-              ]
+              "security policy term" : "72-75"
             },
             "zone~loopback~to~zone~junos-host p" : {
-              "security policy term" : [
-                60,
-                61,
-                62,
-                63
-              ]
+              "security policy term" : "60-63"
             },
             "zone~trust~to~zone~trust default-permit" : {
-              "security policy term" : [
-                48,
-                49,
-                50,
-                51
-              ]
+              "security policy term" : "48-51"
             },
             "zone~untrust~to~zone~junos-host p" : {
-              "security policy term" : [
-                56,
-                57,
-                58,
-                59
-              ]
+              "security policy term" : "56-59"
             },
             "zone~untrust~to~zone~loopback p" : {
-              "security policy term" : [
-                52,
-                53,
-                54,
-                55
-              ]
+              "security policy term" : "52-55"
             },
             "zone~untrust~to~zone~untrust p" : {
-              "security policy term" : [
-                64,
-                65,
-                66,
-                67
-              ]
+              "security policy term" : "64-67"
             }
           }
         },
         "configs/junos-srx-2.cfg" : {
           "bgp group" : {
             "physical" : {
-              "bgp group neighbor" : [
-                92,
-                93
-              ]
+              "bgp group neighbor" : "92-93"
             }
           },
           "ike gateway" : {
             "gateway-1" : {
-              "ipsec vpn ike gateway" : [
-                34
-              ]
+              "ipsec vpn ike gateway" : "34"
             },
             "gateway-3" : {
-              "ipsec vpn ike gateway" : [
-                37
-              ]
+              "ipsec vpn ike gateway" : "37"
             }
           },
           "ike policy" : {
             "test-ike-policy" : {
-              "ike gateway ike policy" : [
-                25,
-                28
-              ]
+              "ike gateway ike policy" : "25,28"
             }
           },
           "interface" : {
             "fxp0" : {
-              "interface" : [
-                85
-              ]
+              "interface" : "85"
             },
             "fxp0.0" : {
-              "interface" : [
-                85
-              ]
+              "interface" : "85"
             },
             "ge-0/0/0" : {
-              "interface" : [
-                82
-              ]
+              "interface" : "82"
             },
             "ge-0/0/0.0" : {
-              "ike gateway external-interface" : [
-                27
-              ],
-              "interface" : [
-                82
-              ],
-              "security zones security-zone interfaces" : [
-                75
-              ]
+              "ike gateway external-interface" : "27",
+              "interface" : "82",
+              "security zones security-zone interfaces" : "75"
             },
             "ge-0/0/1" : {
-              "interface" : [
-                83
-              ]
+              "interface" : "83"
             },
             "ge-0/0/1.0" : {
-              "ike gateway external-interface" : [
-                30
-              ],
-              "interface" : [
-                83
-              ],
-              "security zones security-zone interfaces" : [
-                76
-              ]
+              "ike gateway external-interface" : "30",
+              "interface" : "83",
+              "security zones security-zone interfaces" : "76"
             },
             "ge-0/0/2" : {
-              "interface" : [
-                84
-              ]
+              "interface" : "84"
             },
             "ge-0/0/2.0" : {
-              "interface" : [
-                84
-              ],
-              "security zones security-zone interfaces" : [
-                81
-              ]
+              "interface" : "84",
+              "security zones security-zone interfaces" : "81"
             },
             "lo0" : {
-              "interface" : [
-                86
-              ]
+              "interface" : "86"
             },
             "lo0.0" : {
-              "interface" : [
-                86
-              ],
-              "security zones security-zone interfaces" : [
-                78
-              ]
+              "interface" : "86",
+              "security zones security-zone interfaces" : "78"
             },
             "st0" : {
-              "interface" : [
-                87,
-                88
-              ]
+              "interface" : "87-88"
             },
             "st0.1" : {
-              "interface" : [
-                87
-              ],
-              "ipsec vpn bind-interface" : [
-                33
-              ],
-              "security zones security-zone interfaces" : [
-                68
-              ]
+              "interface" : "87",
+              "ipsec vpn bind-interface" : "33",
+              "security zones security-zone interfaces" : "68"
             },
             "st0.3" : {
-              "interface" : [
-                88
-              ],
-              "ipsec vpn bind-interface" : [
-                36
-              ],
-              "security zones security-zone interfaces" : [
-                69
-              ]
+              "interface" : "88",
+              "ipsec vpn bind-interface" : "36",
+              "security zones security-zone interfaces" : "69"
             }
           },
           "ipsec policy" : {
             "test-ipsec-policy" : {
-              "ipsec vpn ipsec policy" : [
-                35,
-                38
-              ]
+              "ipsec vpn ipsec policy" : "35,38"
             }
           },
           "policy-statement" : {
             "bgp_export" : {
-              "bgp export policy-statement" : [
-                89
-              ]
+              "bgp export policy-statement" : "89"
             }
           },
           "security policy" : {
             "zone~trust~to~zone~trust" : {
-              "security policy" : [
-                48,
-                49,
-                50,
-                51
-              ]
+              "security policy" : "48-51"
             }
           },
           "security policy term" : {
             "zone~trust~to~zone~trust default-permit" : {
-              "security policy term" : [
-                48,
-                49,
-                50,
-                51
-              ]
+              "security policy term" : "48-51"
             }
           }
         },
         "configs/junos-srx-3.cfg" : {
           "bgp group" : {
             "physical" : {
-              "bgp group neighbor" : [
-                86,
-                87
-              ]
+              "bgp group neighbor" : "86-87"
             }
           },
           "ike gateway" : {
             "gateway-2" : {
-              "ipsec vpn ike gateway" : [
-                34
-              ]
+              "ipsec vpn ike gateway" : "34"
             }
           },
           "ike policy" : {
             "test-ike-policy" : {
-              "ike gateway ike policy" : [
-                25,
-                28
-              ]
+              "ike gateway ike policy" : "25,28"
             }
           },
           "interface" : {
             "fxp0" : {
-              "interface" : [
-                79
-              ]
+              "interface" : "79"
             },
             "fxp0.0" : {
-              "interface" : [
-                79
-              ]
+              "interface" : "79"
             },
             "ge-0/0/0" : {
-              "interface" : [
-                76
-              ]
+              "interface" : "76"
             },
             "ge-0/0/0.0" : {
-              "ike gateway external-interface" : [
-                30
-              ],
-              "interface" : [
-                76
-              ],
-              "security zones security-zone interfaces" : [
-                69
-              ]
+              "ike gateway external-interface" : "30",
+              "interface" : "76",
+              "security zones security-zone interfaces" : "69"
             },
             "ge-0/0/1" : {
-              "interface" : [
-                77
-              ]
+              "interface" : "77"
             },
             "ge-0/0/1.0" : {
-              "ike gateway external-interface" : [
-                27
-              ],
-              "interface" : [
-                77
-              ],
-              "security zones security-zone interfaces" : [
-                70
-              ]
+              "ike gateway external-interface" : "27",
+              "interface" : "77",
+              "security zones security-zone interfaces" : "70"
             },
             "ge-0/0/2" : {
-              "interface" : [
-                78
-              ]
+              "interface" : "78"
             },
             "ge-0/0/2.0" : {
-              "interface" : [
-                78
-              ],
-              "security zones security-zone interfaces" : [
-                75
-              ]
+              "interface" : "78",
+              "security zones security-zone interfaces" : "75"
             },
             "lo0" : {
-              "interface" : [
-                80
-              ]
+              "interface" : "80"
             },
             "lo0.0" : {
-              "interface" : [
-                80
-              ],
-              "security zones security-zone interfaces" : [
-                72
-              ]
+              "interface" : "80",
+              "security zones security-zone interfaces" : "72"
             },
             "st0" : {
-              "interface" : [
-                81,
-                82
-              ]
+              "interface" : "81-82"
             },
             "st0.1" : {
-              "interface" : [
-                81
-              ],
-              "security zones security-zone interfaces" : [
-                62
-              ]
+              "interface" : "81",
+              "security zones security-zone interfaces" : "62"
             },
             "st0.2" : {
-              "interface" : [
-                82
-              ],
-              "ipsec vpn bind-interface" : [
-                33
-              ],
-              "security zones security-zone interfaces" : [
-                63
-              ]
+              "interface" : "82",
+              "ipsec vpn bind-interface" : "33",
+              "security zones security-zone interfaces" : "63"
             }
           },
           "ipsec policy" : {
             "test-ipsec-policy" : {
-              "ipsec vpn ipsec policy" : [
-                35
-              ]
+              "ipsec vpn ipsec policy" : "35"
             }
           },
           "policy-statement" : {
             "bgp_export" : {
-              "bgp export policy-statement" : [
-                83
-              ]
+              "bgp export policy-statement" : "83"
             }
           },
           "security policy" : {
             "zone~trust~to~zone~trust" : {
-              "security policy" : [
-                52,
-                53,
-                54,
-                55
-              ]
+              "security policy" : "52-55"
             }
           },
           "security policy term" : {
             "zone~trust~to~zone~trust default-permit" : {
-              "security policy term" : [
-                52,
-                53,
-                54,
-                55
-              ]
+              "security policy term" : "52-55"
             }
           }
         }

--- a/tests/parsing-tests/srx-testbed.ref
+++ b/tests/parsing-tests/srx-testbed.ref
@@ -6168,270 +6168,149 @@
         "configs/junos-srx-1.cfg" : {
           "bgp group" : {
             "physical" : {
-              "definitionLines" : [
-                111,
-                112,
-                113,
-                114
-              ],
+              "definitionLines" : "111-114",
               "numReferrers" : 2
             }
           },
           "ike gateway" : {
             "gateway-2" : {
-              "definitionLines" : [
-                28,
-                29,
-                30
-              ],
+              "definitionLines" : "28-30",
               "numReferrers" : 1
             },
             "gateway-3" : {
-              "definitionLines" : [
-                25,
-                26,
-                27
-              ],
+              "definitionLines" : "25-27",
               "numReferrers" : 1
             }
           },
           "ike policy" : {
             "test-ike-policy" : {
-              "definitionLines" : [
-                23,
-                24
-              ],
+              "definitionLines" : "23-24",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "fxp0" : {
-              "definitionLines" : [
-                99
-              ],
+              "definitionLines" : "99",
               "numReferrers" : 1
             },
             "fxp0.0" : {
-              "definitionLines" : [
-                99
-              ],
+              "definitionLines" : "99",
               "numReferrers" : 1
             },
             "ge-0/0/0" : {
-              "definitionLines" : [
-                96
-              ],
+              "definitionLines" : "96",
               "numReferrers" : 1
             },
             "ge-0/0/0.0" : {
-              "definitionLines" : [
-                96
-              ],
+              "definitionLines" : "96",
               "numReferrers" : 3
             },
             "ge-0/0/1" : {
-              "definitionLines" : [
-                97
-              ],
+              "definitionLines" : "97",
               "numReferrers" : 1
             },
             "ge-0/0/1.0" : {
-              "definitionLines" : [
-                97
-              ],
+              "definitionLines" : "97",
               "numReferrers" : 3
             },
             "ge-0/0/2" : {
-              "definitionLines" : [
-                98
-              ],
+              "definitionLines" : "98",
               "numReferrers" : 1
             },
             "ge-0/0/2.0" : {
-              "definitionLines" : [
-                98
-              ],
+              "definitionLines" : "98",
               "numReferrers" : 2
             },
             "lo0" : {
-              "definitionLines" : [
-                100
-              ],
+              "definitionLines" : "100",
               "numReferrers" : 1
             },
             "lo0.0" : {
-              "definitionLines" : [
-                100
-              ],
+              "definitionLines" : "100",
               "numReferrers" : 2
             },
             "st0" : {
-              "definitionLines" : [
-                101,
-                102
-              ],
+              "definitionLines" : "101-102",
               "numReferrers" : 2
             },
             "st0.2" : {
-              "definitionLines" : [
-                101
-              ],
+              "definitionLines" : "101",
               "numReferrers" : 3
             },
             "st0.3" : {
-              "definitionLines" : [
-                102
-              ],
+              "definitionLines" : "102",
               "numReferrers" : 3
             }
           },
           "ipsec policy" : {
             "test-ipsec-policy" : {
-              "definitionLines" : [
-                31,
-                32
-              ],
+              "definitionLines" : "31-32",
               "numReferrers" : 0
             }
           },
           "policy-statement" : {
             "bgp_export" : {
-              "definitionLines" : [
-                115,
-                116
-              ],
+              "definitionLines" : "115-116",
               "numReferrers" : 1
             },
             "loadbal" : {
-              "definitionLines" : [
-                117,
-                118
-              ],
+              "definitionLines" : "117-118",
               "numReferrers" : 1
             }
           },
           "security policy" : {
             "zone~junos-host~to~zone~untrust" : {
-              "definitionLines" : [
-                68,
-                69,
-                70,
-                71,
-                72,
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "68-75",
               "numReferrers" : 8
             },
             "zone~loopback~to~zone~junos-host" : {
-              "definitionLines" : [
-                60,
-                61,
-                62,
-                63
-              ],
+              "definitionLines" : "60-63",
               "numReferrers" : 4
             },
             "zone~trust~to~zone~trust" : {
-              "definitionLines" : [
-                48,
-                49,
-                50,
-                51
-              ],
+              "definitionLines" : "48-51",
               "numReferrers" : 4
             },
             "zone~untrust~to~zone~junos-host" : {
-              "definitionLines" : [
-                56,
-                57,
-                58,
-                59
-              ],
+              "definitionLines" : "56-59",
               "numReferrers" : 4
             },
             "zone~untrust~to~zone~loopback" : {
-              "definitionLines" : [
-                52,
-                53,
-                54,
-                55
-              ],
+              "definitionLines" : "52-55",
               "numReferrers" : 4
             },
             "zone~untrust~to~zone~untrust" : {
-              "definitionLines" : [
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "64-67",
               "numReferrers" : 4
             }
           },
           "security policy term" : {
             "zone~junos-host~to~zone~untrust p" : {
-              "definitionLines" : [
-                68,
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "68-71",
               "numReferrers" : 4
             },
             "zone~junos-host~to~zone~untrust p2" : {
-              "definitionLines" : [
-                72,
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "72-75",
               "numReferrers" : 4
             },
             "zone~loopback~to~zone~junos-host p" : {
-              "definitionLines" : [
-                60,
-                61,
-                62,
-                63
-              ],
+              "definitionLines" : "60-63",
               "numReferrers" : 4
             },
             "zone~trust~to~zone~trust default-permit" : {
-              "definitionLines" : [
-                48,
-                49,
-                50,
-                51
-              ],
+              "definitionLines" : "48-51",
               "numReferrers" : 4
             },
             "zone~untrust~to~zone~junos-host p" : {
-              "definitionLines" : [
-                56,
-                57,
-                58,
-                59
-              ],
+              "definitionLines" : "56-59",
               "numReferrers" : 4
             },
             "zone~untrust~to~zone~loopback p" : {
-              "definitionLines" : [
-                52,
-                53,
-                54,
-                55
-              ],
+              "definitionLines" : "52-55",
               "numReferrers" : 4
             },
             "zone~untrust~to~zone~untrust p" : {
-              "definitionLines" : [
-                64,
-                65,
-                66,
-                67
-              ],
+              "definitionLines" : "64-67",
               "numReferrers" : 4
             }
           }
@@ -6439,159 +6318,101 @@
         "configs/junos-srx-2.cfg" : {
           "bgp group" : {
             "physical" : {
-              "definitionLines" : [
-                91,
-                92,
-                93
-              ],
+              "definitionLines" : "91-93",
               "numReferrers" : 2
             }
           },
           "ike gateway" : {
             "gateway-1" : {
-              "definitionLines" : [
-                25,
-                26,
-                27
-              ],
+              "definitionLines" : "25-27",
               "numReferrers" : 1
             },
             "gateway-3" : {
-              "definitionLines" : [
-                28,
-                29,
-                30
-              ],
+              "definitionLines" : "28-30",
               "numReferrers" : 1
             }
           },
           "ike policy" : {
             "test-ike-policy" : {
-              "definitionLines" : [
-                23,
-                24
-              ],
+              "definitionLines" : "23-24",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "fxp0" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             },
             "fxp0.0" : {
-              "definitionLines" : [
-                85
-              ],
+              "definitionLines" : "85",
               "numReferrers" : 1
             },
             "ge-0/0/0" : {
-              "definitionLines" : [
-                82
-              ],
+              "definitionLines" : "82",
               "numReferrers" : 1
             },
             "ge-0/0/0.0" : {
-              "definitionLines" : [
-                82
-              ],
+              "definitionLines" : "82",
               "numReferrers" : 3
             },
             "ge-0/0/1" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 1
             },
             "ge-0/0/1.0" : {
-              "definitionLines" : [
-                83
-              ],
+              "definitionLines" : "83",
               "numReferrers" : 3
             },
             "ge-0/0/2" : {
-              "definitionLines" : [
-                84
-              ],
+              "definitionLines" : "84",
               "numReferrers" : 1
             },
             "ge-0/0/2.0" : {
-              "definitionLines" : [
-                84
-              ],
+              "definitionLines" : "84",
               "numReferrers" : 2
             },
             "lo0" : {
-              "definitionLines" : [
-                86
-              ],
+              "definitionLines" : "86",
               "numReferrers" : 1
             },
             "lo0.0" : {
-              "definitionLines" : [
-                86
-              ],
+              "definitionLines" : "86",
               "numReferrers" : 2
             },
             "st0" : {
-              "definitionLines" : [
-                87,
-                88
-              ],
+              "definitionLines" : "87-88",
               "numReferrers" : 2
             },
             "st0.1" : {
-              "definitionLines" : [
-                87
-              ],
+              "definitionLines" : "87",
               "numReferrers" : 3
             },
             "st0.3" : {
-              "definitionLines" : [
-                88
-              ],
+              "definitionLines" : "88",
               "numReferrers" : 3
             }
           },
           "ipsec policy" : {
             "test-ipsec-policy" : {
-              "definitionLines" : [
-                31,
-                32
-              ],
+              "definitionLines" : "31-32",
               "numReferrers" : 0
             }
           },
           "policy-statement" : {
             "bgp_export" : {
-              "definitionLines" : [
-                98,
-                99
-              ],
+              "definitionLines" : "98-99",
               "numReferrers" : 1
             }
           },
           "security policy" : {
             "zone~trust~to~zone~trust" : {
-              "definitionLines" : [
-                48,
-                49,
-                50,
-                51
-              ],
+              "definitionLines" : "48-51",
               "numReferrers" : 4
             }
           },
           "security policy term" : {
             "zone~trust~to~zone~trust default-permit" : {
-              "definitionLines" : [
-                48,
-                49,
-                50,
-                51
-              ],
+              "definitionLines" : "48-51",
               "numReferrers" : 4
             }
           }
@@ -6599,159 +6420,101 @@
         "configs/junos-srx-3.cfg" : {
           "bgp group" : {
             "physical" : {
-              "definitionLines" : [
-                85,
-                86,
-                87
-              ],
+              "definitionLines" : "85-87",
               "numReferrers" : 2
             }
           },
           "ike gateway" : {
             "gateway-1" : {
-              "definitionLines" : [
-                28,
-                29,
-                30
-              ],
+              "definitionLines" : "28-30",
               "numReferrers" : 0
             },
             "gateway-2" : {
-              "definitionLines" : [
-                25,
-                26,
-                27
-              ],
+              "definitionLines" : "25-27",
               "numReferrers" : 1
             }
           },
           "ike policy" : {
             "test-ike-policy" : {
-              "definitionLines" : [
-                23,
-                24
-              ],
+              "definitionLines" : "23-24",
               "numReferrers" : 2
             }
           },
           "interface" : {
             "fxp0" : {
-              "definitionLines" : [
-                79
-              ],
+              "definitionLines" : "79",
               "numReferrers" : 1
             },
             "fxp0.0" : {
-              "definitionLines" : [
-                79
-              ],
+              "definitionLines" : "79",
               "numReferrers" : 1
             },
             "ge-0/0/0" : {
-              "definitionLines" : [
-                76
-              ],
+              "definitionLines" : "76",
               "numReferrers" : 1
             },
             "ge-0/0/0.0" : {
-              "definitionLines" : [
-                76
-              ],
+              "definitionLines" : "76",
               "numReferrers" : 3
             },
             "ge-0/0/1" : {
-              "definitionLines" : [
-                77
-              ],
+              "definitionLines" : "77",
               "numReferrers" : 1
             },
             "ge-0/0/1.0" : {
-              "definitionLines" : [
-                77
-              ],
+              "definitionLines" : "77",
               "numReferrers" : 3
             },
             "ge-0/0/2" : {
-              "definitionLines" : [
-                78
-              ],
+              "definitionLines" : "78",
               "numReferrers" : 1
             },
             "ge-0/0/2.0" : {
-              "definitionLines" : [
-                78
-              ],
+              "definitionLines" : "78",
               "numReferrers" : 2
             },
             "lo0" : {
-              "definitionLines" : [
-                80
-              ],
+              "definitionLines" : "80",
               "numReferrers" : 1
             },
             "lo0.0" : {
-              "definitionLines" : [
-                80
-              ],
+              "definitionLines" : "80",
               "numReferrers" : 2
             },
             "st0" : {
-              "definitionLines" : [
-                81,
-                82
-              ],
+              "definitionLines" : "81-82",
               "numReferrers" : 2
             },
             "st0.1" : {
-              "definitionLines" : [
-                81
-              ],
+              "definitionLines" : "81",
               "numReferrers" : 2
             },
             "st0.2" : {
-              "definitionLines" : [
-                82
-              ],
+              "definitionLines" : "82",
               "numReferrers" : 3
             }
           },
           "ipsec policy" : {
             "test-ipsec-policy" : {
-              "definitionLines" : [
-                31,
-                32
-              ],
+              "definitionLines" : "31-32",
               "numReferrers" : 0
             }
           },
           "policy-statement" : {
             "bgp_export" : {
-              "definitionLines" : [
-                92,
-                93
-              ],
+              "definitionLines" : "92-93",
               "numReferrers" : 1
             }
           },
           "security policy" : {
             "zone~trust~to~zone~trust" : {
-              "definitionLines" : [
-                52,
-                53,
-                54,
-                55
-              ],
+              "definitionLines" : "52-55",
               "numReferrers" : 4
             }
           },
           "security policy term" : {
             "zone~trust~to~zone~trust default-permit" : {
-              "definitionLines" : [
-                52,
-                53,
-                54,
-                55
-              ],
+              "definitionLines" : "52-55",
               "numReferrers" : 4
             }
           }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -78676,12 +78676,7 @@
         "configs/arista_acl" : {
           "extended ipv4 access-list" : {
             "abcd" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8
-              ],
+              "definitionLines" : "5-8",
               "numReferrers" : 0
             }
           }
@@ -78689,9 +78684,7 @@
         "configs/arista_bgp" : {
           "route-map" : {
             "ROUTE_MAP" : {
-              "definitionLines" : [
-                16
-              ],
+              "definitionLines" : "16",
               "numReferrers" : 1
             }
           }
@@ -78700,18 +78693,11 @@
         "configs/arista_dhcp_relay" : {
           "interface" : {
             "Ethernet0" : {
-              "definitionLines" : [
-                10,
-                11,
-                12
-              ],
+              "definitionLines" : "10-12",
               "numReferrers" : 1
             },
             "Ethernet1" : {
-              "definitionLines" : [
-                14,
-                15
-              ],
+              "definitionLines" : "14-15",
               "numReferrers" : 1
             }
           }
@@ -78719,21 +78705,7 @@
         "configs/arista_interface" : {
           "interface" : {
             "Vlan1" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17
-              ],
+              "definitionLines" : "5-17",
               "numReferrers" : 1
             }
           }
@@ -78741,9 +78713,7 @@
         "configs/arista_ip_route" : {
           "interface" : {
             "Null0" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             }
           }
@@ -78751,10 +78721,7 @@
         "configs/arista_misc" : {
           "standard ipv4 access-list" : {
             "sshabc" : {
-              "definitionLines" : [
-                30,
-                31
-              ],
+              "definitionLines" : "30-31",
               "numReferrers" : 1
             }
           }
@@ -78762,40 +78729,27 @@
         "configs/arista_nat" : {
           "extended ipv4 access-list" : {
             "acl1" : {
-              "definitionLines" : [
-                7,
-                8
-              ],
+              "definitionLines" : "7-8",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet1" : {
-              "definitionLines" : [
-                14,
-                15,
-                16
-              ],
+              "definitionLines" : "14-16",
               "numReferrers" : 1
             }
           },
           "nat pool" : {
             "pool1" : {
-              "definitionLines" : [
-                10
-              ],
+              "definitionLines" : "10",
               "numReferrers" : 1
             },
             "pool2" : {
-              "definitionLines" : [
-                11
-              ],
+              "definitionLines" : "11",
               "numReferrers" : 0
             },
             "pool3" : {
-              "definitionLines" : [
-                12
-              ],
+              "definitionLines" : "12",
               "numReferrers" : 0
             }
           }
@@ -78803,10 +78757,7 @@
         "configs/arista_ospf" : {
           "interface" : {
             "Ethernet1" : {
-              "definitionLines" : [
-                5,
-                6
-              ],
+              "definitionLines" : "5-6",
               "numReferrers" : 1
             }
           }
@@ -78820,27 +78771,13 @@
         "configs/aruba_crypto" : {
           "crypto isakmp policy" : {
             "1" : {
-              "definitionLines" : [
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20
-              ],
+              "definitionLines" : "12-20",
               "numReferrers" : 1
             }
           },
           "crypto-dynamic-map-set" : {
             "abcd" : {
-              "definitionLines" : [
-                4,
-                5,
-                6
-              ],
+              "definitionLines" : "4-6",
               "numReferrers" : 0
             }
           }
@@ -78849,24 +78786,7 @@
         "configs/aruba_interface" : {
           "interface" : {
             "GigabitEthernet0/0/0" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19
-              ],
+              "definitionLines" : "4-19",
               "numReferrers" : 1
             }
           }
@@ -78883,10 +78803,7 @@
         "configs/as_path_prepend" : {
           "route-map" : {
             "rmap" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 0
             }
           }
@@ -78894,48 +78811,21 @@
         "configs/asa_acl" : {
           "extended ipv4 access-list" : {
             "inline_specifiers" : {
-              "definitionLines" : [
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31
-              ],
+              "definitionLines" : "12-31",
               "numReferrers" : 0
             },
             "outside" : {
-              "definitionLines" : [
-                9
-              ],
+              "definitionLines" : "9",
               "numReferrers" : 0
             },
             "outside_in" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 0
             }
           },
           "standard ipv4 access-list" : {
             "Local_LAN_Access" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 0
             }
           }
@@ -78944,16 +78834,11 @@
         "configs/asa_interface" : {
           "interface" : {
             "GigabitEthernet0/1" : {
-              "definitionLines" : [
-                6,
-                7
-              ],
+              "definitionLines" : "6-7",
               "numReferrers" : 2
             },
             "ifname" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 1
             }
           }
@@ -78961,17 +78846,7 @@
         "configs/asa_nat" : {
           "object network" : {
             "source-real" : {
-              "definitionLines" : [
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23
-              ],
+              "definitionLines" : "15-23",
               "numReferrers" : 8
             }
           }
@@ -78979,34 +78854,23 @@
         "configs/asa_object_groups" : {
           "extended ipv4 access-list" : {
             "ALLOW_SERVER02" : {
-              "definitionLines" : [
-                15
-              ],
+              "definitionLines" : "15",
               "numReferrers" : 0
             }
           },
           "object network" : {
             "range-10.0.0.10-20" : {
-              "definitionLines" : [
-                9,
-                10
-              ],
+              "definitionLines" : "9-10",
               "numReferrers" : 0
             },
             "server02" : {
-              "definitionLines" : [
-                6,
-                7
-              ],
+              "definitionLines" : "6-7",
               "numReferrers" : 1
             }
           },
           "object-group service" : {
             "service-ssh" : {
-              "definitionLines" : [
-                12,
-                13
-              ],
+              "definitionLines" : "12-13",
               "numReferrers" : 0
             }
           }
@@ -79014,18 +78878,11 @@
         "configs/asa_ospf" : {
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8
-              ],
+              "definitionLines" : "5-8",
               "numReferrers" : 1
             },
             "blah" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 1
             }
           }
@@ -79034,27 +78891,19 @@
         "configs/bgp_address_family" : {
           "bgp peer-group" : {
             "as1" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 1
             },
             "as2" : {
-              "definitionLines" : [
-                9
-              ],
+              "definitionLines" : "9",
               "numReferrers" : 1
             },
             "as3" : {
-              "definitionLines" : [
-                11
-              ],
+              "definitionLines" : "11",
               "numReferrers" : 0
             },
             "dcp-rrs" : {
-              "definitionLines" : [
-                16
-              ],
+              "definitionLines" : "16",
               "numReferrers" : 0
             }
           }
@@ -79062,20 +78911,7 @@
         "configs/bgp_default_originate_policy" : {
           "bgp neighbor-group" : {
             "ama-coe" : {
-              "definitionLines" : [
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17
-              ],
+              "definitionLines" : "6-17",
               "numReferrers" : 0
             }
           }
@@ -79083,9 +78919,7 @@
         "configs/bgp_foundry" : {
           "bgp peer-group" : {
             "ucr" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 0
             }
           }
@@ -79095,47 +78929,21 @@
         "configs/cadant_acl" : {
           "extended ipv6 access-list" : {
             "ipv6-acl-foo" : {
-              "definitionLines" : [
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29
-              ],
+              "definitionLines" : "18-29",
               "numReferrers" : 0
             }
           },
           "standard ipv4 access-list" : {
             "50" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8
-              ],
+              "definitionLines" : "5-8",
               "numReferrers" : 0
             },
             "51" : {
-              "definitionLines" : [
-                10,
-                11,
-                12
-              ],
+              "definitionLines" : "10-12",
               "numReferrers" : 0
             },
             "99" : {
-              "definitionLines" : [
-                14,
-                15,
-                16
-              ],
+              "definitionLines" : "14-16",
               "numReferrers" : 0
             }
           }
@@ -79145,22 +78953,13 @@
         "configs/cadant_cable" : {
           "docsis-policy" : {
             "1" : {
-              "definitionLines" : [
-                48
-              ],
+              "definitionLines" : "48",
               "numReferrers" : 0
             }
           },
           "docsis-policy-rule" : {
             "1" : {
-              "definitionLines" : [
-                49,
-                50,
-                51,
-                52,
-                53,
-                54
-              ],
+              "definitionLines" : "49-54",
               "numReferrers" : 1
             }
           }
@@ -79168,213 +78967,63 @@
         "configs/cadant_interface" : {
           "interface" : {
             "Ethernet6/0.0" : {
-              "definitionLines" : [
-                104,
-                105,
-                106,
-                107,
-                108,
-                109,
-                110,
-                111,
-                112,
-                113,
-                114,
-                115,
-                116,
-                117,
-                118,
-                119,
-                120,
-                121,
-                122,
-                123
-              ],
+              "definitionLines" : "104-123",
               "numReferrers" : 1
             },
             "Ethernet6/0.48" : {
-              "definitionLines" : [
-                124,
-                125,
-                126,
-                127,
-                128
-              ],
+              "definitionLines" : "124-128",
               "numReferrers" : 1
             },
             "Ethernet6/1" : {
-              "definitionLines" : [
-                129,
-                130,
-                131,
-                132,
-                133
-              ],
+              "definitionLines" : "129-133",
               "numReferrers" : 1
             },
             "cable-downstream1/2" : {
-              "definitionLines" : [
-                5,
-                6,
-                7
-              ],
+              "definitionLines" : "5-7",
               "numReferrers" : 1
             },
             "cable-downstream1/2/3" : {
-              "definitionLines" : [
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14
-              ],
+              "definitionLines" : "8-14",
               "numReferrers" : 1
             },
             "cable-downstream5/0/0" : {
-              "definitionLines" : [
-                15,
-                16,
-                17,
-                18,
-                19,
-                20
-              ],
+              "definitionLines" : "15-20",
               "numReferrers" : 1
             },
             "cable-mac1" : {
-              "definitionLines" : [
-                39,
-                42,
-                43,
-                44,
-                45,
-                46,
-                47,
-                48,
-                49,
-                50,
-                51,
-                52,
-                53,
-                54,
-                55,
-                56,
-                57,
-                58
-              ],
+              "definitionLines" : "39,42-58",
               "numReferrers" : 2
             },
             "cable-mac1.1" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62,
-                63,
-                64,
-                65,
-                66,
-                67,
-                68,
-                69,
-                70,
-                71,
-                72,
-                73,
-                74,
-                75,
-                76,
-                77,
-                78,
-                79,
-                80,
-                81,
-                82,
-                83,
-                84,
-                85,
-                86,
-                87
-              ],
+              "definitionLines" : "59-87",
               "numReferrers" : 1
             },
             "cable-mac1.2" : {
-              "definitionLines" : [
-                88,
-                89,
-                90,
-                91,
-                92,
-                93,
-                94,
-                95,
-                96,
-                97,
-                98,
-                99,
-                100,
-                101,
-                102,
-                103
-              ],
+              "definitionLines" : "88-103",
               "numReferrers" : 1
             },
             "cable-mac2" : {
-              "definitionLines" : [
-                40
-              ],
+              "definitionLines" : "40",
               "numReferrers" : 1
             },
             "cable-mac3" : {
-              "definitionLines" : [
-                41
-              ],
+              "definitionLines" : "41",
               "numReferrers" : 1
             },
             "cable-upstream1/0/0" : {
-              "definitionLines" : [
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28
-              ],
+              "definitionLines" : "21-28",
               "numReferrers" : 1
             },
             "cable-upstream1/0/0.0" : {
-              "definitionLines" : [
-                31,
-                32,
-                33,
-                34,
-                35,
-                36,
-                37,
-                38
-              ],
+              "definitionLines" : "31-38",
               "numReferrers" : 1
             },
             "cable-upstream1/0/10" : {
-              "definitionLines" : [
-                29,
-                30
-              ],
+              "definitionLines" : "29-30",
               "numReferrers" : 2
             },
             "mgmt6/0" : {
-              "definitionLines" : [
-                134,
-                135,
-                136,
-                137,
-                138,
-                139
-              ],
+              "definitionLines" : "134-139",
               "numReferrers" : 1
             }
           }
@@ -79387,25 +79036,17 @@
         "configs/cadant_prefix_list" : {
           "ipv4 prefix-list" : {
             "A+C" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 0
             },
             "foo" : {
-              "definitionLines" : [
-                5,
-                6
-              ],
+              "definitionLines" : "5-6",
               "numReferrers" : 0
             }
           },
           "ipv6 prefix-list" : {
             "bar" : {
-              "definitionLines" : [
-                8,
-                9
-              ],
+              "definitionLines" : "8-9",
               "numReferrers" : 0
             }
           }
@@ -79415,19 +79056,11 @@
         "configs/cadant_route_map" : {
           "route-map" : {
             "bar" : {
-              "definitionLines" : [
-                9,
-                10,
-                11
-              ],
+              "definitionLines" : "9-11",
               "numReferrers" : 0
             },
             "foo" : {
-              "definitionLines" : [
-                5,
-                6,
-                7
-              ],
+              "definitionLines" : "5-7",
               "numReferrers" : 0
             }
           }
@@ -79437,84 +79070,37 @@
         "configs/cisco_acl" : {
           "extended ipv4 access-list" : {
             "BLAH-BLAH" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28
-              ],
+              "definitionLines" : "4-28",
               "numReferrers" : 0
             },
             "TEST" : {
-              "definitionLines" : [
-                66,
-                67,
-                68
-              ],
+              "definitionLines" : "66-68",
               "numReferrers" : 0
             },
             "blah" : {
-              "definitionLines" : [
-                35,
-                36
-              ],
+              "definitionLines" : "35-36",
               "numReferrers" : 0
             },
             "extended" : {
-              "definitionLines" : [
-                31
-              ],
+              "definitionLines" : "31",
               "numReferrers" : 0
             },
             "standard" : {
-              "definitionLines" : [
-                33
-              ],
+              "definitionLines" : "33",
               "numReferrers" : 0
             },
             "test-codes" : {
-              "definitionLines" : [
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "62-64",
               "numReferrers" : 0
             }
           },
           "ipv4 prefix-list" : {
             "allowprefix" : {
-              "definitionLines" : [
-                38,
-                39
-              ],
+              "definitionLines" : "38-39",
               "numReferrers" : 0
             },
             "allowprefix-asa" : {
-              "definitionLines" : [
-                41,
-                42
-              ],
+              "definitionLines" : "41-42",
               "numReferrers" : 0
             }
           }
@@ -79523,77 +79109,35 @@
         "configs/cisco_asa/asa-interface-redundant" : {
           "interface" : {
             "GigabitEthernet0/1" : {
-              "definitionLines" : [
-                7,
-                8,
-                9,
-                10,
-                11,
-                12
-              ],
+              "definitionLines" : "7-12",
               "numReferrers" : 1
             },
             "GigabitEthernet0/2" : {
-              "definitionLines" : [
-                15,
-                16,
-                17,
-                18,
-                19,
-                20
-              ],
+              "definitionLines" : "15-20",
               "numReferrers" : 1
             },
             "Redundant1" : {
-              "definitionLines" : [
-                23,
-                24,
-                25,
-                26,
-                27,
-                28
-              ],
+              "definitionLines" : "23-28",
               "numReferrers" : 1
             },
             "Redundant1.2" : {
-              "definitionLines" : [
-                31,
-                32,
-                33,
-                34,
-                35
-              ],
+              "definitionLines" : "31-35",
               "numReferrers" : 1
             },
             "Redundant2" : {
-              "definitionLines" : [
-                38,
-                39,
-                40,
-                41
-              ],
+              "definitionLines" : "38-41",
               "numReferrers" : 1
             },
             "Redundant2.2" : {
-              "definitionLines" : [
-                44,
-                45,
-                46,
-                47,
-                48
-              ],
+              "definitionLines" : "44-48",
               "numReferrers" : 1
             },
             "redundant1sub" : {
-              "definitionLines" : [
-                33
-              ],
+              "definitionLines" : "33",
               "numReferrers" : 1
             },
             "redundant2sub" : {
-              "definitionLines" : [
-                46
-              ],
+              "definitionLines" : "46",
               "numReferrers" : 1
             }
           }
@@ -79602,67 +79146,45 @@
         "configs/cisco_bgp" : {
           "as-path access-list" : {
             "10" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 1
             },
             "20" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 1
             },
             "30" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 0
             }
           },
           "bgp template peer-policy" : {
             "p1" : {
-              "definitionLines" : [
-                35,
-                36,
-                37,
-                38
-              ],
+              "definitionLines" : "35-38",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "AGGREGATE-MAP" : {
-              "definitionLines" : [
-                57
-              ],
+              "definitionLines" : "57",
               "numReferrers" : 1
             },
             "CONNECTED-TO-BGP" : {
-              "definitionLines" : [
-                55
-              ],
+              "definitionLines" : "55",
               "numReferrers" : 1
             },
             "UNSUPP-MAP" : {
-              "definitionLines" : [
-                59
-              ],
+              "definitionLines" : "59",
               "numReferrers" : 1
             },
             "ospfv3_map" : {
-              "definitionLines" : [
-                53
-              ],
+              "definitionLines" : "53",
               "numReferrers" : 1
             }
           },
           "standard ipv4 access-list" : {
             "5" : {
-              "definitionLines" : [
-                61
-              ],
+              "definitionLines" : "61",
               "numReferrers" : 2
             }
           }
@@ -79671,118 +79193,53 @@
         "configs/cisco_cable" : {
           "cable service-class" : {
             "1" : {
-              "definitionLines" : [
-                88,
-                89,
-                90,
-                91,
-                92,
-                93,
-                94,
-                95,
-                96,
-                97,
-                98,
-                99
-              ],
+              "definitionLines" : "88-99",
               "numReferrers" : 0
             }
           },
           "depi-class" : {
             "depiclass1" : {
-              "definitionLines" : [
-                131,
-                132
-              ],
+              "definitionLines" : "131-132",
               "numReferrers" : 1
             }
           },
           "depi-tunnel" : {
             "bar1" : {
-              "definitionLines" : [
-                137,
-                138,
-                139,
-                140,
-                141
-              ],
+              "definitionLines" : "137-141",
               "numReferrers" : 0
             },
             "foo1" : {
-              "definitionLines" : [
-                134,
-                135
-              ],
+              "definitionLines" : "134-135",
               "numReferrers" : 1
             }
           },
           "docsis-policy" : {
             "1" : {
-              "definitionLines" : [
-                42
-              ],
+              "definitionLines" : "42",
               "numReferrers" : 1
             }
           },
           "docsis-policy-rule" : {
             "1" : {
-              "definitionLines" : [
-                48
-              ],
+              "definitionLines" : "48",
               "numReferrers" : 1
             },
             "2" : {
-              "definitionLines" : [
-                49
-              ],
+              "definitionLines" : "49",
               "numReferrers" : 0
             },
             "3" : {
-              "definitionLines" : [
-                50
-              ],
+              "definitionLines" : "50",
               "numReferrers" : 0
             },
             "4" : {
-              "definitionLines" : [
-                51
-              ],
+              "definitionLines" : "51",
               "numReferrers" : 0
             }
           },
           "interface" : {
             "Cable1/2/3" : {
-              "definitionLines" : [
-                143,
-                144,
-                145,
-                146,
-                147,
-                148,
-                149,
-                150,
-                151,
-                152,
-                153,
-                154,
-                155,
-                156,
-                157,
-                158,
-                159,
-                160,
-                161,
-                162,
-                163,
-                164,
-                165,
-                166,
-                167,
-                168,
-                169,
-                170,
-                171
-              ],
+              "definitionLines" : "143-171",
               "numReferrers" : 1
             }
           }
@@ -79793,163 +79250,81 @@
         "configs/cisco_crypto" : {
           "crypto ipsec profile" : {
             "abcdefg" : {
-              "definitionLines" : [
-                159,
-                160,
-                161,
-                162,
-                163
-              ],
+              "definitionLines" : "159-163",
               "numReferrers" : 0
             }
           },
           "crypto ipsec transform-set" : {
             "ESP-3DES-MD5" : {
-              "definitionLines" : [
-                168,
-                169,
-                170
-              ],
+              "definitionLines" : "168-170",
               "numReferrers" : 0
             },
             "IPSEC_AES_256" : {
-              "definitionLines" : [
-                171
-              ],
+              "definitionLines" : "171",
               "numReferrers" : 0
             },
             "cipts1" : {
-              "definitionLines" : [
-                172
-              ],
+              "definitionLines" : "172",
               "numReferrers" : 0
             },
             "cipts2" : {
-              "definitionLines" : [
-                173
-              ],
+              "definitionLines" : "173",
               "numReferrers" : 0
             },
             "noAuthHeader" : {
-              "definitionLines" : [
-                174
-              ],
+              "definitionLines" : "174",
               "numReferrers" : 0
             }
           },
           "crypto isakmp policy" : {
             "1" : {
-              "definitionLines" : [
-                181,
-                182,
-                183,
-                184,
-                185,
-                186,
-                187,
-                188
-              ],
+              "definitionLines" : "181-188",
               "numReferrers" : 1
             }
           },
           "crypto isakmp profile" : {
             "myprofile" : {
-              "definitionLines" : [
-                190,
-                191,
-                192,
-                193,
-                194,
-                195,
-                196,
-                197,
-                198
-              ],
+              "definitionLines" : "190-198",
               "numReferrers" : 1
             }
           },
           "crypto keyring" : {
             "VRF:ABC:DEF:GHI:1234" : {
-              "definitionLines" : [
-                217,
-                218
-              ],
+              "definitionLines" : "217-218",
               "numReferrers" : 0
             }
           },
           "crypto named rsa pubkey" : {
             "a.example.com" : {
-              "definitionLines" : [
-                203,
-                204,
-                205,
-                206,
-                207,
-                208,
-                209,
-                210,
-                211,
-                212,
-                213,
-                214,
-                215,
-                216
-              ],
+              "definitionLines" : "203-216",
               "numReferrers" : 1
             }
           },
           "crypto-dynamic-map-set" : {
             "asadynamicmaps" : {
-              "definitionLines" : [
-                94
-              ],
+              "definitionLines" : "94",
               "numReferrers" : 0
             },
             "mydefaultcryptomap" : {
-              "definitionLines" : [
-                100,
-                101
-              ],
+              "definitionLines" : "100-101",
               "numReferrers" : 1
             },
             "mydynamicmap" : {
-              "definitionLines" : [
-                110,
-                111
-              ],
+              "definitionLines" : "110-111",
               "numReferrers" : 0
             }
           },
           "crypto-map-set" : {
             "VPN" : {
-              "definitionLines" : [
-                223,
-                224,
-                225,
-                226,
-                227,
-                228
-              ],
+              "definitionLines" : "223-228",
               "numReferrers" : 0
             },
             "VPNMAP" : {
-              "definitionLines" : [
-                238,
-                239,
-                240,
-                241,
-                242,
-                243,
-                244,
-                245,
-                246
-              ],
+              "definitionLines" : "238-246",
               "numReferrers" : 0
             },
             "myothermap" : {
-              "definitionLines" : [
-                220
-              ],
+              "definitionLines" : "220",
               "numReferrers" : 0
             }
           }
@@ -79963,30 +79338,17 @@
         "configs/cisco_eigrp" : {
           "extended ipv4 access-list" : {
             "bippety" : {
-              "definitionLines" : [
-                49,
-                50,
-                51,
-                52,
-                53,
-                54,
-                55
-              ],
+              "definitionLines" : "49-55",
               "numReferrers" : 0
             },
             "bloop_blop" : {
-              "definitionLines" : [
-                118,
-                119
-              ],
+              "definitionLines" : "118-119",
               "numReferrers" : 0
             }
           },
           "interface" : {
             "Ethernet0" : {
-              "definitionLines" : [
-                165
-              ],
+              "definitionLines" : "165",
               "numReferrers" : 2
             }
           }
@@ -79995,10 +79357,7 @@
         "configs/cisco_flow" : {
           "interface" : {
             "GigabitEthernet0/1" : {
-              "definitionLines" : [
-                52,
-                53
-              ],
+              "definitionLines" : "52-53",
               "numReferrers" : 1
             }
           }
@@ -80007,23 +79366,7 @@
         "configs/cisco_hsrp" : {
           "interface" : {
             "TenGigabitEthernet0/0/2/2" : {
-              "definitionLines" : [
-                33,
-                34,
-                35,
-                36,
-                37,
-                38,
-                39,
-                40,
-                41,
-                42,
-                43,
-                44,
-                45,
-                46,
-                47
-              ],
+              "definitionLines" : "33-47",
               "numReferrers" : 1
             }
           }
@@ -80031,453 +79374,109 @@
         "configs/cisco_interface" : {
           "extended ipv4 access-list" : {
             "abc" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 0
             }
           },
           "interface" : {
             "Async1" : {
-              "definitionLines" : [
-                281
-              ],
+              "definitionLines" : "281",
               "numReferrers" : 1
             },
             "Cable1/2/3:4" : {
-              "definitionLines" : [
-                283
-              ],
+              "definitionLines" : "283",
               "numReferrers" : 1
             },
             "Crypto-Engine1/2/3" : {
-              "definitionLines" : [
-                285
-              ],
+              "definitionLines" : "285",
               "numReferrers" : 1
             },
             "Dot11Radio0" : {
-              "definitionLines" : [
-                287
-              ],
+              "definitionLines" : "287",
               "numReferrers" : 1
             },
             "Ethernet0" : {
-              "definitionLines" : [
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                35,
-                36,
-                37,
-                38,
-                39,
-                40,
-                41,
-                42,
-                43,
-                44,
-                45,
-                46,
-                47,
-                48,
-                49,
-                50,
-                51,
-                52,
-                53,
-                54,
-                55,
-                56,
-                57,
-                58,
-                59,
-                60,
-                61,
-                62,
-                63,
-                64,
-                65,
-                66,
-                67,
-                68,
-                69,
-                70,
-                71,
-                72,
-                73,
-                74,
-                75,
-                76,
-                77,
-                78,
-                79,
-                80,
-                81,
-                82,
-                83,
-                84,
-                85,
-                86,
-                87,
-                88,
-                89,
-                90,
-                91,
-                92,
-                93,
-                94,
-                95,
-                96,
-                97,
-                98,
-                99,
-                100,
-                101,
-                102,
-                103,
-                104,
-                105,
-                106,
-                107,
-                108,
-                109,
-                110,
-                111,
-                112,
-                113,
-                114,
-                115,
-                116,
-                117,
-                118,
-                119,
-                120,
-                121,
-                122,
-                123,
-                124,
-                125,
-                126,
-                127,
-                128,
-                129,
-                130,
-                131,
-                132,
-                133,
-                134,
-                135,
-                136,
-                137,
-                138,
-                139,
-                140,
-                141,
-                142,
-                143,
-                144,
-                145,
-                146,
-                147,
-                148,
-                149,
-                150,
-                151,
-                152,
-                153,
-                154,
-                155,
-                156,
-                157,
-                158,
-                159,
-                160,
-                161,
-                162,
-                163,
-                164,
-                165,
-                166,
-                167,
-                168,
-                169,
-                170,
-                171,
-                172,
-                173,
-                174,
-                175,
-                176,
-                177,
-                178,
-                179,
-                180,
-                181,
-                182,
-                183,
-                184,
-                185,
-                186,
-                187,
-                188,
-                189,
-                190,
-                191,
-                192,
-                193,
-                194,
-                195,
-                196,
-                197,
-                198,
-                199,
-                200,
-                201,
-                202,
-                203,
-                204,
-                205,
-                206,
-                207,
-                208,
-                209,
-                210,
-                211,
-                212,
-                213,
-                214,
-                215,
-                216,
-                217,
-                218,
-                219,
-                220,
-                221,
-                222,
-                223,
-                224,
-                225,
-                226,
-                227,
-                228,
-                229,
-                230,
-                231,
-                232,
-                233,
-                234,
-                235,
-                236,
-                237,
-                238,
-                239,
-                240,
-                241,
-                242,
-                243,
-                244,
-                245,
-                246,
-                247,
-                248,
-                249,
-                250,
-                251,
-                252,
-                253,
-                254,
-                255,
-                256,
-                257,
-                258,
-                259,
-                260,
-                261,
-                262,
-                263,
-                264,
-                265,
-                266,
-                267,
-                268,
-                269,
-                270,
-                271,
-                272,
-                273,
-                274,
-                275,
-                276,
-                277,
-                278,
-                279
-              ],
+              "definitionLines" : "7-279",
               "numReferrers" : 1
             },
             "Ethernet1/11" : {
-              "definitionLines" : [
-                289
-              ],
+              "definitionLines" : "289",
               "numReferrers" : 1
             },
             "Ethernet1/12" : {
-              "definitionLines" : [
-                342,
-                343
-              ],
+              "definitionLines" : "342-343",
               "numReferrers" : 1
             },
             "GigabitEthernet0/0" : {
-              "definitionLines" : [
-                291,
-                292,
-                293,
-                294,
-                295
-              ],
+              "definitionLines" : "291-295",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                297,
-                298,
-                299,
-                300
-              ],
+              "definitionLines" : "297-300",
               "numReferrers" : 1
             },
             "Modular-Cable1/2/3:4" : {
-              "definitionLines" : [
-                302
-              ],
+              "definitionLines" : "302",
               "numReferrers" : 1
             },
             "Null0" : {
-              "definitionLines" : [
-                304
-              ],
+              "definitionLines" : "304",
               "numReferrers" : 1
             },
             "Tunnel0" : {
-              "definitionLines" : [
-                308,
-                309,
-                310,
-                311,
-                312,
-                313,
-                314,
-                315,
-                316,
-                317,
-                318,
-                319
-              ],
+              "definitionLines" : "308-319",
               "numReferrers" : 1
             },
             "Vlan1" : {
-              "definitionLines" : [
-                322
-              ],
+              "definitionLines" : "322",
               "numReferrers" : 1
             },
             "Vlan1005" : {
-              "definitionLines" : [
-                328
-              ],
+              "definitionLines" : "328",
               "numReferrers" : 1
             },
             "Vlan1006" : {
-              "definitionLines" : [
-                330
-              ],
+              "definitionLines" : "330",
               "numReferrers" : 1
             },
             "Vlan111" : {
-              "definitionLines" : [
-                320
-              ],
+              "definitionLines" : "320",
               "numReferrers" : 1
             },
             "Vlan1234" : {
-              "definitionLines" : [
-                332
-              ],
+              "definitionLines" : "332",
               "numReferrers" : 1
             },
             "Vlan2" : {
-              "definitionLines" : [
-                324
-              ],
+              "definitionLines" : "324",
               "numReferrers" : 1
             },
             "Vlan3" : {
-              "definitionLines" : [
-                326
-              ],
+              "definitionLines" : "326",
               "numReferrers" : 1
             },
             "Vlan4094" : {
-              "definitionLines" : [
-                334
-              ],
+              "definitionLines" : "334",
               "numReferrers" : 1
             },
             "Wideband-Cable1/2/3:4" : {
-              "definitionLines" : [
-                336
-              ],
+              "definitionLines" : "336",
               "numReferrers" : 1
             },
             "Wlan-GigabitEthernet0" : {
-              "definitionLines" : [
-                340
-              ],
+              "definitionLines" : "340",
               "numReferrers" : 1
             },
             "Wlan-ap0" : {
-              "definitionLines" : [
-                338
-              ],
+              "definitionLines" : "338",
               "numReferrers" : 1
             },
             "inside" : {
-              "definitionLines" : [
-                292
-              ],
+              "definitionLines" : "292",
               "numReferrers" : 1
             },
             "tunnel-ip6" : {
-              "definitionLines" : [
-                306
-              ],
+              "definitionLines" : "306",
               "numReferrers" : 1
             }
           }
@@ -80485,15 +79484,11 @@
         "configs/cisco_ios_neighbor" : {
           "bgp peer-group" : {
             "8075-CORE" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 0
             },
             "LEAF" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 1
             }
           }
@@ -80502,22 +79497,15 @@
         "configs/cisco_ip_nat" : {
           "nat pool" : {
             "abc" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 0
             },
             "example-1-dynamic-nat-pool" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 0
             },
             "example-2-dynamic-nat-pool" : {
-              "definitionLines" : [
-                10
-              ],
+              "definitionLines" : "10",
               "numReferrers" : 0
             }
           }
@@ -80528,31 +79516,11 @@
         "configs/cisco_ipv6_access_list" : {
           "extended ipv6 access-list" : {
             "RT404888-XO" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16
-              ],
+              "definitionLines" : "4-16",
               "numReferrers" : 0
             },
             "abcdefg" : {
-              "definitionLines" : [
-                19,
-                20,
-                21,
-                22,
-                23
-              ],
+              "definitionLines" : "19-23",
               "numReferrers" : 0
             }
           }
@@ -80560,52 +79528,19 @@
         "configs/cisco_isis" : {
           "interface" : {
             "GigabitEthernet0/0/1" : {
-              "definitionLines" : [
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                35
-              ],
+              "definitionLines" : "10-35",
               "numReferrers" : 1
             },
             "GigabitEthernet0/1" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 1
             },
             "HundredGigabitEthernet0/0/0/0.2302" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             },
             "Serial4/0" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 1
             }
           }
@@ -80613,25 +79548,7 @@
         "configs/cisco_l2tp" : {
           "l2tp-class" : {
             "foobar" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20
-              ],
+              "definitionLines" : "4-20",
               "numReferrers" : 0
             }
           }
@@ -80641,22 +79558,15 @@
         "configs/cisco_mac_acl" : {
           "mac acl" : {
             "1199" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 0
             },
             "700" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 0
             },
             "copp-system-p-acl-mac-cdp-udld-vtp" : {
-              "definitionLines" : [
-                6,
-                7
-              ],
+              "definitionLines" : "6-7",
               "numReferrers" : 0
             }
           }
@@ -80664,43 +79574,19 @@
         "configs/cisco_misc" : {
           "class-map" : {
             "class-default" : {
-              "definitionLines" : [
-                210
-              ],
+              "definitionLines" : "210",
               "numReferrers" : 1
             }
           },
           "object-group service" : {
             "SVCGRP-ICMP" : {
-              "definitionLines" : [
-                177,
-                178
-              ],
+              "definitionLines" : "177-178",
               "numReferrers" : 0
             }
           },
           "policy-map" : {
             "global_policy" : {
-              "definitionLines" : [
-                194,
-                195,
-                196,
-                197,
-                198,
-                199,
-                200,
-                201,
-                202,
-                203,
-                204,
-                205,
-                206,
-                207,
-                208,
-                209,
-                210,
-                211
-              ],
+              "definitionLines" : "194-211",
               "numReferrers" : 1
             }
           }
@@ -80712,12 +79598,7 @@
         "configs/cisco_nomaskreply" : {
           "interface" : {
             "GigabitEthernet1" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7
-              ],
+              "definitionLines" : "4-7",
               "numReferrers" : 1
             }
           }
@@ -80727,14 +79608,7 @@
         "configs/cisco_opsfv3" : {
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7,
-                8,
-                9
-              ],
+              "definitionLines" : "4-9",
               "numReferrers" : 1
             }
           }
@@ -80742,32 +79616,15 @@
         "configs/cisco_ospf" : {
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                7,
-                8,
-                9,
-                10,
-                12,
-                13,
-                14,
-                15
-              ],
+              "definitionLines" : "7-10,12-15",
               "numReferrers" : 3
             },
             "Ethernet1/0" : {
-              "definitionLines" : [
-                17,
-                18,
-                19,
-                20
-              ],
+              "definitionLines" : "17-20",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 1
             }
           }
@@ -80775,12 +79632,7 @@
         "configs/cisco_ospf_ipv6" : {
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7
-              ],
+              "definitionLines" : "4-7",
               "numReferrers" : 2
             }
           }
@@ -80788,26 +79640,15 @@
         "configs/cisco_ospf_multi_process" : {
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                4,
-                5,
-                6
-              ],
+              "definitionLines" : "4-6",
               "numReferrers" : 1
             },
             "Ethernet1/0" : {
-              "definitionLines" : [
-                8,
-                9,
-                10
-              ],
+              "definitionLines" : "8-10",
               "numReferrers" : 1
             },
             "Loopback0" : {
-              "definitionLines" : [
-                12,
-                13
-              ],
+              "definitionLines" : "12-13",
               "numReferrers" : 1
             }
           }
@@ -80818,111 +79659,55 @@
         "configs/cisco_qos" : {
           "class-map" : {
             "ABC" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10
-              ],
+              "definitionLines" : "5-10",
               "numReferrers" : 0
             },
             "bippety" : {
-              "definitionLines" : [
-                11,
-                12,
-                13
-              ],
+              "definitionLines" : "11-13",
               "numReferrers" : 0
             },
             "boop" : {
-              "definitionLines" : [
-                19,
-                20,
-                21
-              ],
+              "definitionLines" : "19-21",
               "numReferrers" : 0
             },
             "boppety" : {
-              "definitionLines" : [
-                14,
-                15,
-                16,
-                17
-              ],
+              "definitionLines" : "14-17",
               "numReferrers" : 0
             },
             "cos_all" : {
-              "definitionLines" : [
-                23,
-                24,
-                25
-              ],
+              "definitionLines" : "23-25",
               "numReferrers" : 0
             }
           },
           "object network" : {
             "obj_any" : {
-              "definitionLines" : [
-                31,
-                32
-              ],
+              "definitionLines" : "31-32",
               "numReferrers" : 0
             }
           },
           "object-group network" : {
             "1.2.3.4-24" : {
-              "definitionLines" : [
-                33,
-                34
-              ],
+              "definitionLines" : "33-34",
               "numReferrers" : 0
             },
             "dns_servers" : {
-              "definitionLines" : [
-                35,
-                36,
-                37
-              ],
+              "definitionLines" : "35-37",
               "numReferrers" : 0
             },
             "ntp_servers" : {
-              "definitionLines" : [
-                38,
-                39,
-                40,
-                41
-              ],
+              "definitionLines" : "38-41",
               "numReferrers" : 0
             }
           },
           "policy-map type inspect" : {
             "pminspect" : {
-              "definitionLines" : [
-                42,
-                43,
-                44,
-                45,
-                46,
-                47
-              ],
+              "definitionLines" : "42-47",
               "numReferrers" : 0
             }
           },
           "service-template" : {
             "template_name" : {
-              "definitionLines" : [
-                142,
-                143,
-                144,
-                145,
-                146,
-                147,
-                148,
-                149,
-                150
-              ],
+              "definitionLines" : "142-150",
               "numReferrers" : 0
             }
           }
@@ -80934,110 +79719,57 @@
         "configs/cisco_route_map" : {
           "as-path access-list" : {
             "AS_PATH_ACL1" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 1
             },
             "AS_PATH_ACL2" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 1
             },
             "AS_PATH_ACL_UNUSED" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "MAP_NAME1" : {
-              "definitionLines" : [
-                50,
-                51
-              ],
+              "definitionLines" : "50-51",
               "numReferrers" : 0
             },
             "MAP_NAME2" : {
-              "definitionLines" : [
-                53,
-                54,
-                56,
-                57
-              ],
+              "definitionLines" : "53-54,56-57",
               "numReferrers" : 0
             },
             "MSDP-SA-RP-FILTER" : {
-              "definitionLines" : [
-                24,
-                25,
-                26
-              ],
+              "definitionLines" : "24-26",
               "numReferrers" : 0
             },
             "beeble" : {
-              "definitionLines" : [
-                35,
-                36,
-                37,
-                38,
-                40,
-                41,
-                42,
-                43,
-                44,
-                45
-              ],
+              "definitionLines" : "35-38,40-45",
               "numReferrers" : 0
             },
             "connected-to-bgp" : {
-              "definitionLines" : [
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15
-              ],
+              "definitionLines" : "9-15",
               "numReferrers" : 0
             },
             "ijfw$%^&****(((([]grr" : {
-              "definitionLines" : [
-                22
-              ],
+              "definitionLines" : "22",
               "numReferrers" : 0
             },
             "mgmt" : {
-              "definitionLines" : [
-                31,
-                32,
-                33
-              ],
+              "definitionLines" : "31-33",
               "numReferrers" : 0
             },
             "multicaststuff" : {
-              "definitionLines" : [
-                47,
-                48
-              ],
+              "definitionLines" : "47-48",
               "numReferrers" : 0
             },
             "next-hop-null" : {
-              "definitionLines" : [
-                28,
-                29
-              ],
+              "definitionLines" : "28-29",
               "numReferrers" : 0
             },
             "to_svl-hub-router" : {
-              "definitionLines" : [
-                17,
-                18
-              ],
+              "definitionLines" : "17-18",
               "numReferrers" : 0
             }
           }
@@ -81050,10 +79782,7 @@
         "configs/cisco_style_acl1" : {
           "extended ipv4 access-list" : {
             "blah" : {
-              "definitionLines" : [
-                1,
-                2
-              ],
+              "definitionLines" : "1-2",
               "numReferrers" : 0
             }
           }
@@ -81061,9 +79790,7 @@
         "configs/cisco_style_acl2" : {
           "standard ipv4 access-list" : {
             "1" : {
-              "definitionLines" : [
-                1
-              ],
+              "definitionLines" : "1",
               "numReferrers" : 0
             }
           }
@@ -81072,34 +79799,19 @@
         "configs/cisco_track" : {
           "track" : {
             "1" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 0
             },
             "2" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 0
             },
             "3" : {
-              "definitionLines" : [
-                6,
-                7,
-                8,
-                9,
-                10
-              ],
+              "definitionLines" : "6-10",
               "numReferrers" : 0
             },
             "IPv6Loopback" : {
-              "definitionLines" : [
-                12,
-                13,
-                14,
-                15
-              ],
+              "definitionLines" : "12-15",
               "numReferrers" : 0
             }
           }
@@ -81114,18 +79826,7 @@
         "configs/cisco_vrrp" : {
           "interface" : {
             "Ethernet0" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13
-              ],
+              "definitionLines" : "4-13",
               "numReferrers" : 1
             }
           }
@@ -81135,32 +79836,23 @@
         "configs/cisco_zone" : {
           "zone" : {
             "t1" : {
-              "definitionLines" : [
-                10
-              ],
+              "definitionLines" : "10",
               "numReferrers" : 0
             }
           },
           "zone security" : {
             "z1" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 1
             },
             "z2" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             }
           },
           "zone-pair security" : {
             "zp1" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 0
             }
           }
@@ -81169,27 +79861,19 @@
         "configs/community_list_named" : {
           "ipv4 prefix-list" : {
             "PFX_LIST" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 1
             }
           },
           "route-map" : {
             "TO_NEIGHBOR" : {
-              "definitionLines" : [
-                8,
-                9,
-                10
-              ],
+              "definitionLines" : "8-10",
               "numReferrers" : 0
             }
           },
           "standard community-list" : {
             "COMM_LIST_NAME" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 1
             }
           }
@@ -81197,21 +79881,13 @@
         "configs/community_name_numbers" : {
           "route-map" : {
             "AAA1-BBB-CCC" : {
-              "definitionLines" : [
-                6,
-                7,
-                8,
-                9,
-                10
-              ],
+              "definitionLines" : "6-10",
               "numReferrers" : 0
             }
           },
           "standard community-list" : {
             "9999-RRR" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 1
             }
           }
@@ -81219,21 +79895,13 @@
         "configs/community_name_numbers_dos" : {
           "route-map" : {
             "AAA1-BBB-CCC" : {
-              "definitionLines" : [
-                6,
-                7,
-                8,
-                9,
-                10
-              ],
+              "definitionLines" : "6-10",
               "numReferrers" : 0
             }
           },
           "standard community-list" : {
             "9999-RRR" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 1
             }
           }
@@ -81241,19 +79909,11 @@
         "configs/community_set" : {
           "community-set" : {
             "190" : {
-              "definitionLines" : [
-                10,
-                11,
-                12,
-                13
-              ],
+              "definitionLines" : "10-13",
               "numReferrers" : 0
             },
             "foo" : {
-              "definitionLines" : [
-                6,
-                7
-              ],
+              "definitionLines" : "6-7",
               "numReferrers" : 0
             }
           }
@@ -81261,131 +79921,91 @@
         "configs/cumulus_nclu" : {
           "bond" : {
             "bond1" : {
-              "definitionLines" : [
-                15
-              ],
+              "definitionLines" : "15",
               "numReferrers" : 1
             },
             "bond2" : {
-              "definitionLines" : [
-                17
-              ],
+              "definitionLines" : "17",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "bond1.4094" : {
-              "definitionLines" : [
-                20
-              ],
+              "definitionLines" : "20",
               "numReferrers" : 5
             },
             "eth0" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 1
             },
             "swp1" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 4
             },
             "swp2" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 5
             },
             "swp3" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 4
             },
             "swp4" : {
-              "definitionLines" : [
-                15
-              ],
+              "definitionLines" : "15",
               "numReferrers" : 1
             },
             "swp5" : {
-              "definitionLines" : [
-                15
-              ],
+              "definitionLines" : "15",
               "numReferrers" : 1
             },
             "swp6" : {
-              "definitionLines" : [
-                15
-              ],
+              "definitionLines" : "15",
               "numReferrers" : 1
             },
             "swp7" : {
-              "definitionLines" : [
-                15
-              ],
+              "definitionLines" : "15",
               "numReferrers" : 1
             },
             "swp8" : {
-              "definitionLines" : [
-                15
-              ],
+              "definitionLines" : "15",
               "numReferrers" : 1
             }
           },
           "loopback" : {
             "lo" : {
-              "definitionLines" : [
-                11,
-                12,
-                13
-              ],
+              "definitionLines" : "11-13",
               "numReferrers" : 4
             }
           },
           "route-map" : {
             "rm1" : {
-              "definitionLines" : [
-                80
-              ],
+              "definitionLines" : "80",
               "numReferrers" : 1
             }
           },
           "vlan" : {
             "vlan4" : {
-              "definitionLines" : [
-                88
-              ],
+              "definitionLines" : "88",
               "numReferrers" : 6
             }
           },
           "vrf" : {
             "mgmt" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 5
             },
             "vrf1" : {
-              "definitionLines" : [
-                52
-              ],
+              "definitionLines" : "52",
               "numReferrers" : 11
             }
           },
           "vxlan" : {
             "vni10001" : {
-              "definitionLines" : [
-                99
-              ],
+              "definitionLines" : "99",
               "numReferrers" : 1
             },
             "vni10004" : {
-              "definitionLines" : [
-                105
-              ],
+              "definitionLines" : "105",
               "numReferrers" : 1
             }
           }
@@ -81393,9 +80013,7 @@
         "configs/cumulus_nclu_bgp" : {
           "vrf" : {
             "vrf1" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             }
           }
@@ -81404,9 +80022,7 @@
         "configs/cumulus_nclu_bgp_no_remote_as" : {
           "vrf" : {
             "vrf1" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             }
           }
@@ -81414,9 +80030,7 @@
         "configs/cumulus_nclu_bgp_no_router_id" : {
           "loopback" : {
             "lo" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 1
             }
           }
@@ -81424,9 +80038,7 @@
         "configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip" : {
           "loopback" : {
             "lo" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 1
             }
           }
@@ -81434,83 +80046,57 @@
         "configs/cumulus_nclu_bond" : {
           "bond" : {
             "AGG" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "otherbond" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "swp1" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "swp10" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "swp2" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "swp3" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "swp3s0" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             },
             "swp4" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "swp5" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "swp6" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "swp7" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "swp8" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "swp9" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             }
           }
@@ -81518,15 +80104,11 @@
         "configs/cumulus_nclu_interface" : {
           "interface" : {
             "swp1" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 13
             },
             "swp1s2" : {
-              "definitionLines" : [
-                21
-              ],
+              "definitionLines" : "21",
               "numReferrers" : 1
             }
           }
@@ -81534,17 +80116,13 @@
         "configs/cumulus_nclu_invalid_bonds" : {
           "vrf" : {
             "vrf1" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             }
           },
           "vxlan" : {
             "v1" : {
-              "definitionLines" : [
-                18
-              ],
+              "definitionLines" : "18",
               "numReferrers" : 1
             }
           }
@@ -81552,25 +80130,19 @@
         "configs/cumulus_nclu_invalid_interfaces" : {
           "bond" : {
             "bond1" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 1
             }
           },
           "vrf" : {
             "vrf1" : {
-              "definitionLines" : [
-                16
-              ],
+              "definitionLines" : "16",
               "numReferrers" : 1
             }
           },
           "vxlan" : {
             "v1" : {
-              "definitionLines" : [
-                19
-              ],
+              "definitionLines" : "19",
               "numReferrers" : 1
             }
           }
@@ -81578,25 +80150,19 @@
         "configs/cumulus_nclu_invalid_vrfs" : {
           "bond" : {
             "bond1" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "swp1" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             }
           },
           "vxlan" : {
             "vx1" : {
-              "definitionLines" : [
-                16
-              ],
+              "definitionLines" : "16",
               "numReferrers" : 1
             }
           }
@@ -81604,25 +80170,19 @@
         "configs/cumulus_nclu_invalid_vxlans" : {
           "bond" : {
             "bond1" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "swp0" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             }
           },
           "vrf" : {
             "vrf1" : {
-              "definitionLines" : [
-                11
-              ],
+              "definitionLines" : "11",
               "numReferrers" : 1
             }
           }
@@ -81631,17 +80191,13 @@
         "configs/cumulus_nclu_stp" : {
           "bond" : {
             "bond1" : {
-              "definitionLines" : [
-                12
-              ],
+              "definitionLines" : "12",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "swp1" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 7
             }
           }
@@ -81649,19 +80205,11 @@
         "configs/eos_mlag" : {
           "interface" : {
             "Port-Channel1" : {
-              "definitionLines" : [
-                9,
-                10,
-                11
-              ],
+              "definitionLines" : "9-11",
               "numReferrers" : 2
             },
             "Port-Channel2" : {
-              "definitionLines" : [
-                13,
-                14,
-                15
-              ],
+              "definitionLines" : "13-15",
               "numReferrers" : 1
             }
           }
@@ -81669,12 +80217,7 @@
         "configs/eos_trunk_group" : {
           "interface" : {
             "Port-Channel1" : {
-              "definitionLines" : [
-                34,
-                35,
-                36,
-                37
-              ],
+              "definitionLines" : "34-37",
               "numReferrers" : 1
             }
           }
@@ -81682,38 +80225,23 @@
         "configs/f5_bigip/f5_bigip_imish_malformed" : {
           "bgp neighbor" : {
             "2::2" : {
-              "definitionLines" : [
-                20
-              ],
+              "definitionLines" : "20",
               "numReferrers" : 1
             },
             "3.3.3.3" : {
-              "definitionLines" : [
-                17
-              ],
+              "definitionLines" : "17",
               "numReferrers" : 1
             }
           },
           "bgp process" : {
             "1" : {
-              "definitionLines" : [
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22
-              ],
+              "definitionLines" : "15-22",
               "numReferrers" : 1
             }
           },
           "prefix-list" : {
             "pl1" : {
-              "definitionLines" : [
-                9
-              ],
+              "definitionLines" : "9",
               "numReferrers" : 0
             }
           }
@@ -81721,132 +80249,35 @@
         "configs/f5_bigip/f5_bigip_structured_cm" : {
           "device" : {
             "/Common/f5_bigip_structured_cm" : {
-              "definitionLines" : [
-                61,
-                62,
-                63,
-                64,
-                65,
-                66,
-                67,
-                68,
-                69,
-                70,
-                71,
-                72,
-                73,
-                74,
-                75,
-                76,
-                77,
-                78,
-                79,
-                80,
-                81,
-                82,
-                83,
-                84,
-                85,
-                86,
-                87,
-                88,
-                89,
-                90,
-                91
-              ],
+              "definitionLines" : "61-91",
               "numReferrers" : 4
             },
             "/Common/f5_bigip_structured_cm2" : {
-              "definitionLines" : [
-                92,
-                93,
-                94,
-                95,
-                96,
-                97,
-                98,
-                99,
-                100,
-                101,
-                102,
-                103,
-                104,
-                105,
-                106,
-                107,
-                108,
-                109,
-                110,
-                111,
-                112,
-                113,
-                114,
-                115,
-                116,
-                117,
-                118,
-                119,
-                120,
-                121
-              ],
+              "definitionLines" : "92-121",
               "numReferrers" : 3
             }
           },
           "device-group" : {
             "/Common/device_group_snc" : {
-              "definitionLines" : [
-                122,
-                123,
-                124,
-                125,
-                126,
-                127,
-                128
-              ],
+              "definitionLines" : "122-128",
               "numReferrers" : 0
             },
             "/Common/device_trust_group" : {
-              "definitionLines" : [
-                129,
-                130,
-                131,
-                132,
-                133,
-                134,
-                135,
-                136,
-                137
-              ],
+              "definitionLines" : "129-137",
               "numReferrers" : 1
             },
             "/Common/gtm" : {
-              "definitionLines" : [
-                138,
-                139,
-                140,
-                141,
-                142,
-                143,
-                144
-              ],
+              "definitionLines" : "138-144",
               "numReferrers" : 0
             }
           },
           "traffic-group" : {
             "/Common/traffic-group-1" : {
-              "definitionLines" : [
-                167,
-                168,
-                169,
-                170,
-                171
-              ],
+              "definitionLines" : "167-171",
               "numReferrers" : 0
             },
             "/Common/traffic-group-local-only" : {
-              "definitionLines" : [
-                172
-              ],
+              "definitionLines" : "172",
               "numReferrers" : 0
             }
           }
@@ -81854,404 +80285,109 @@
         "configs/f5_bigip/f5_bigip_structured_ltm" : {
           "monitor http" : {
             "/Common/SOME_MONITOR1" : {
-              "definitionLines" : [
-                135,
-                136,
-                137,
-                138,
-                139,
-                140,
-                141,
-                142,
-                143,
-                144,
-                145,
-                146,
-                147,
-                148,
-                149,
-                150
-              ],
+              "definitionLines" : "135-150",
               "numReferrers" : 0
             }
           },
           "monitor https" : {
             "/Common/SOME_MONITOR2" : {
-              "definitionLines" : [
-                151,
-                152,
-                153,
-                154,
-                155,
-                156,
-                157,
-                158,
-                159,
-                160,
-                161,
-                162,
-                163,
-                164,
-                165,
-                166,
-                167,
-                168,
-                169
-              ],
+              "definitionLines" : "151-169",
               "numReferrers" : 0
             }
           },
           "node" : {
             "/Common/SOME_LTM_NODE" : {
-              "definitionLines" : [
-                16,
-                17,
-                18
-              ],
+              "definitionLines" : "16-18",
               "numReferrers" : 0
             }
           },
           "persistence source-addr" : {
             "/Common/SOME_PERSISTENCE_SOURCE_ADDR" : {
-              "definitionLines" : [
-                170,
-                171,
-                172,
-                173,
-                174
-              ],
+              "definitionLines" : "170-174",
               "numReferrers" : 0
             }
           },
           "persistence ssl" : {
             "/Common/SOME_PERSISTENCE_SSL" : {
-              "definitionLines" : [
-                175,
-                176,
-                177,
-                178,
-                179,
-                180,
-                181,
-                182,
-                183
-              ],
+              "definitionLines" : "175-183",
               "numReferrers" : 0
             }
           },
           "pool" : {
             "/Common/SOME_LTM_POOL" : {
-              "definitionLines" : [
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                35,
-                36
-              ],
+              "definitionLines" : "19-36",
               "numReferrers" : 0
             }
           },
           "profile client-ssl" : {
             "/Common/SOME_PROFILE_CLIENT_SSL" : {
-              "definitionLines" : [
-                184,
-                185,
-                186,
-                187,
-                188,
-                189,
-                190,
-                191,
-                192,
-                193,
-                194,
-                195,
-                196,
-                197,
-                198,
-                199,
-                200,
-                201,
-                202,
-                203,
-                204,
-                205,
-                206,
-                207,
-                208,
-                209,
-                210,
-                211,
-                212,
-                213,
-                214,
-                215,
-                216,
-                217,
-                218,
-                219,
-                220,
-                221,
-                222,
-                223,
-                224,
-                225,
-                226,
-                227,
-                228,
-                229,
-                230,
-                231,
-                232,
-                233,
-                234,
-                235,
-                236,
-                237,
-                238,
-                239,
-                240,
-                241
-              ],
+              "definitionLines" : "184-241",
               "numReferrers" : 0
             }
           },
           "profile ocsp-stapling-params" : {
             "/Common/SOME_PROFILE_OCSP_STAPLING_PARAMS" : {
-              "definitionLines" : [
-                242,
-                243,
-                244,
-                245,
-                246,
-                247,
-                248
-              ],
+              "definitionLines" : "242-248",
               "numReferrers" : 0
             }
           },
           "profile one-connect" : {
             "/Common/oneconnect" : {
-              "definitionLines" : [
-                249,
-                250,
-                251,
-                252,
-                253,
-                254,
-                255,
-                256,
-                257
-              ],
+              "definitionLines" : "249-257",
               "numReferrers" : 0
             }
           },
           "profile server-ssl" : {
             "/Common/SOME_PROFILE_SERVER_SSL" : {
-              "definitionLines" : [
-                258,
-                259,
-                260,
-                261,
-                262,
-                263,
-                264,
-                265,
-                266,
-                267,
-                268,
-                269,
-                270,
-                271,
-                272,
-                273,
-                274,
-                275,
-                276,
-                277,
-                278,
-                279,
-                280,
-                281,
-                282,
-                283,
-                284,
-                285,
-                286,
-                287,
-                288,
-                289,
-                290,
-                291
-              ],
+              "definitionLines" : "258-291",
               "numReferrers" : 0
             }
           },
           "rule" : {
             "/Common/SOME_RULE1" : {
-              "definitionLines" : [
-                37,
-                38,
-                39,
-                40,
-                41,
-                42
-              ],
+              "definitionLines" : "37-42",
               "numReferrers" : 1
             },
             "/Common/SOME_RULE2" : {
-              "definitionLines" : [
-                43,
-                44,
-                45,
-                46,
-                47,
-                48
-              ],
+              "definitionLines" : "43-48",
               "numReferrers" : 0
             },
             "/Common/SOME_RULE3" : {
-              "definitionLines" : [
-                49,
-                50,
-                51,
-                52,
-                53,
-                54,
-                55
-              ],
+              "definitionLines" : "49-55",
               "numReferrers" : 0
             },
             "/Common/SOME_RULE4" : {
-              "definitionLines" : [
-                56,
-                57,
-                58,
-                59,
-                60,
-                61,
-                62,
-                63,
-                64,
-                65,
-                66
-              ],
+              "definitionLines" : "56-66",
               "numReferrers" : 0
             }
           },
           "snat" : {
             "/Common/SOME_SNAT" : {
-              "definitionLines" : [
-                67,
-                68,
-                69,
-                70,
-                71,
-                72,
-                73,
-                74,
-                75,
-                76,
-                77,
-                78
-              ],
+              "definitionLines" : "67-78",
               "numReferrers" : 1
             }
           },
           "snat-translation" : {
             "/Common/192.0.2.4" : {
-              "definitionLines" : [
-                79,
-                80,
-                81,
-                82
-              ],
+              "definitionLines" : "79-82",
               "numReferrers" : 0
             }
           },
           "snatpool" : {
             "/Common/SOME_SNATPOOL" : {
-              "definitionLines" : [
-                83,
-                84,
-                85,
-                86,
-                87,
-                88
-              ],
+              "definitionLines" : "83-88",
               "numReferrers" : 2
             }
           },
           "virtual" : {
             "/Common/SOME_VIRTUAL" : {
-              "definitionLines" : [
-                89,
-                90,
-                91,
-                92,
-                93,
-                94,
-                95,
-                96,
-                97,
-                98,
-                99,
-                100,
-                101,
-                102,
-                103,
-                104,
-                105,
-                106,
-                107,
-                108,
-                109,
-                110,
-                111,
-                112,
-                113,
-                114,
-                115,
-                116,
-                117,
-                118,
-                119,
-                120,
-                121,
-                122,
-                123,
-                124
-              ],
+              "definitionLines" : "89-124",
               "numReferrers" : 1
             }
           },
           "virtual-address" : {
             "/Common/192.0.2.8" : {
-              "definitionLines" : [
-                125,
-                126,
-                127,
-                128,
-                129,
-                130,
-                131,
-                132,
-                133,
-                134
-              ],
+              "definitionLines" : "125-134",
               "numReferrers" : 0
             }
           }
@@ -82259,56 +80395,29 @@
         "configs/f5_bigip/f5_bigip_structured_malformed" : {
           "route" : {
             "/Common/bad_gw" : {
-              "definitionLines" : [
-                15,
-                16,
-                17,
-                18
-              ],
+              "definitionLines" : "15-18",
               "numReferrers" : 1
             },
             "/Common/missing_gw" : {
-              "definitionLines" : [
-                11,
-                12,
-                13
-              ],
+              "definitionLines" : "11-13",
               "numReferrers" : 1
             },
             "/Common/missing_network" : {
-              "definitionLines" : [
-                30,
-                31,
-                32
-              ],
+              "definitionLines" : "30-32",
               "numReferrers" : 1
             },
             "/Common/mixed_protocols1" : {
-              "definitionLines" : [
-                20,
-                21,
-                22,
-                23
-              ],
+              "definitionLines" : "20-23",
               "numReferrers" : 1
             },
             "/Common/mixed_protocols2" : {
-              "definitionLines" : [
-                25,
-                26,
-                27,
-                28
-              ],
+              "definitionLines" : "25-28",
               "numReferrers" : 1
             }
           },
           "self" : {
             "/Common/self1" : {
-              "definitionLines" : [
-                7,
-                8,
-                9
-              ],
+              "definitionLines" : "7-9",
               "numReferrers" : 1
             }
           }
@@ -82316,90 +80425,43 @@
         "configs/f5_bigip/f5_bigip_structured_net" : {
           "interface" : {
             "1.0" : {
-              "definitionLines" : [
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17
-              ],
+              "definitionLines" : "8-17",
               "numReferrers" : 2
             },
             "2.0" : {
-              "definitionLines" : [
-                67
-              ],
+              "definitionLines" : "67",
               "numReferrers" : 1
             },
             "3.0" : {
-              "definitionLines" : [
-                68
-              ],
+              "definitionLines" : "68",
               "numReferrers" : 1
             }
           },
           "route" : {
             "/Common/route1" : {
-              "definitionLines" : [
-                34,
-                35,
-                36,
-                37
-              ],
+              "definitionLines" : "34-37",
               "numReferrers" : 1
             }
           },
           "self" : {
             "/Common/MYSELF" : {
-              "definitionLines" : [
-                28,
-                29,
-                30,
-                31,
-                32,
-                33
-              ],
+              "definitionLines" : "28-33",
               "numReferrers" : 1
             },
             "/Common/MYSELF6" : {
-              "definitionLines" : [
-                38,
-                39,
-                40,
-                41
-              ],
+              "definitionLines" : "38-41",
               "numReferrers" : 1
             }
           },
           "trunk" : {
             "trunk1" : {
-              "definitionLines" : [
-                65,
-                66,
-                67,
-                68,
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "65-71",
               "numReferrers" : 0
             }
           },
           "vlan" : {
             "/Common/MYVLAN" : {
-              "definitionLines" : [
-                76,
-                77,
-                78,
-                79,
-                80,
-                81
-              ],
+              "definitionLines" : "76-81",
               "numReferrers" : 2
             }
           }
@@ -82407,129 +80469,17 @@
         "configs/f5_bigip/f5_bigip_structured_net_routing_bgp" : {
           "bgp neighbor" : {
             "192.0.2.1" : {
-              "definitionLines" : [
-                42,
-                43,
-                44,
-                45,
-                46,
-                47,
-                48,
-                49,
-                50,
-                51,
-                52,
-                53,
-                54,
-                55,
-                56,
-                57,
-                58,
-                59,
-                60,
-                61,
-                62,
-                63,
-                64
-              ],
+              "definitionLines" : "42-64",
               "numReferrers" : 1
             },
             "dead:beef::1" : {
-              "definitionLines" : [
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                35,
-                36,
-                37,
-                38,
-                39,
-                40,
-                41
-              ],
+              "definitionLines" : "20-41",
               "numReferrers" : 1
             }
           },
           "bgp process" : {
             "/Common/my_bgp" : {
-              "definitionLines" : [
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                35,
-                36,
-                37,
-                38,
-                39,
-                40,
-                41,
-                42,
-                43,
-                44,
-                45,
-                46,
-                47,
-                48,
-                49,
-                50,
-                51,
-                52,
-                53,
-                54,
-                55,
-                56,
-                57,
-                58,
-                59,
-                60,
-                61,
-                62,
-                63,
-                64,
-                65,
-                66,
-                67,
-                68,
-                69,
-                70
-              ],
+              "definitionLines" : "7-70",
               "numReferrers" : 1
             }
           }
@@ -82537,43 +80487,11 @@
         "configs/f5_bigip/f5_bigip_structured_net_routing_prefix_list" : {
           "prefix-list" : {
             "/Common/MY_IPV4_PREFIX_LIST" : {
-              "definitionLines" : [
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21
-              ],
+              "definitionLines" : "7-21",
               "numReferrers" : 0
             },
             "/Common/MY_IPV6_PREFIX_LIST" : {
-              "definitionLines" : [
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                35,
-                36
-              ],
+              "definitionLines" : "22-36",
               "numReferrers" : 0
             }
           }
@@ -82581,46 +80499,7 @@
         "configs/f5_bigip/f5_bigip_structured_net_routing_route_map" : {
           "route-map" : {
             "/Common/MY_ROUTE_MAP" : {
-              "definitionLines" : [
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                35,
-                36,
-                37,
-                38,
-                39,
-                40,
-                41,
-                42,
-                43,
-                44
-              ],
+              "definitionLines" : "7-44",
               "numReferrers" : 0
             }
           }
@@ -82629,23 +80508,7 @@
         "configs/f5_bigip/f5_bigip_structured_sys_ha_group" : {
           "ha-group" : {
             "g1" : {
-              "definitionLines" : [
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21
-              ],
+              "definitionLines" : "7-21",
               "numReferrers" : 0
             }
           }
@@ -82653,172 +80516,93 @@
         "configs/f5_bigip/f5_bigip_structured_with_imish" : {
           "IMISH interface" : {
             "lo" : {
-              "definitionLines" : [
-                13
-              ],
+              "definitionLines" : "13",
               "numReferrers" : 1
             },
             "tmm" : {
-              "definitionLines" : [
-                15
-              ],
+              "definitionLines" : "15",
               "numReferrers" : 1
             },
             "vlan_active" : {
-              "definitionLines" : [
-                17,
-                18
-              ],
+              "definitionLines" : "17-18",
               "numReferrers" : 1
             },
             "vlan_passive" : {
-              "definitionLines" : [
-                20
-              ],
+              "definitionLines" : "20",
               "numReferrers" : 2
             }
           },
           "access-list" : {
             "acl1" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             },
             "acl2" : {
-              "definitionLines" : [
-                9
-              ],
+              "definitionLines" : "9",
               "numReferrers" : 0
             }
           },
           "bgp neighbor" : {
             "10.0.0.1" : {
-              "definitionLines" : [
-                52
-              ],
+              "definitionLines" : "52",
               "numReferrers" : 1
             },
             "1:2:3:4:5:6:7::" : {
-              "definitionLines" : [
-                47
-              ],
+              "definitionLines" : "47",
               "numReferrers" : 1
             },
             "1:2:3:4:5:6:9.8.7.6" : {
-              "definitionLines" : [
-                51
-              ],
+              "definitionLines" : "51",
               "numReferrers" : 1
             },
             "1:2:3::" : {
-              "definitionLines" : [
-                45
-              ],
+              "definitionLines" : "45",
               "numReferrers" : 1
             },
             "1:2:3::4:5:6" : {
-              "definitionLines" : [
-                46
-              ],
+              "definitionLines" : "46",
               "numReferrers" : 1
             },
             "1:2::3:4.5.6.7" : {
-              "definitionLines" : [
-                50
-              ],
+              "definitionLines" : "50",
               "numReferrers" : 1
             },
             "::1:2:3:4:5:6" : {
-              "definitionLines" : [
-                48
-              ],
+              "definitionLines" : "48",
               "numReferrers" : 1
             },
             "::1:2:3:4:5:6:7" : {
-              "definitionLines" : [
-                49
-              ],
+              "definitionLines" : "49",
               "numReferrers" : 1
             }
           },
           "bgp process" : {
             "65500" : {
-              "definitionLines" : [
-                32,
-                33,
-                34,
-                35,
-                36,
-                37,
-                38,
-                39,
-                40,
-                41,
-                42,
-                43,
-                44,
-                45,
-                46,
-                47,
-                48,
-                49,
-                50,
-                51,
-                52,
-                53,
-                54,
-                55,
-                56,
-                57,
-                58
-              ],
+              "definitionLines" : "32-58",
               "numReferrers" : 1
             }
           },
           "peer-group" : {
             "pg1" : {
-              "definitionLines" : [
-                40
-              ],
+              "definitionLines" : "40",
               "numReferrers" : 0
             }
           },
           "prefix-list" : {
             "pl1" : {
-              "definitionLines" : [
-                22,
-                23,
-                24
-              ],
+              "definitionLines" : "22-24",
               "numReferrers" : 1
             }
           },
           "route-map" : {
             "rm1" : {
-              "definitionLines" : [
-                62,
-                63,
-                64,
-                65,
-                66,
-                67,
-                68,
-                69,
-                71
-              ],
+              "definitionLines" : "62-69,71",
               "numReferrers" : 1
             }
           },
           "router ospf" : {
             "65001" : {
-              "definitionLines" : [
-                26,
-                27,
-                28,
-                29,
-                30
-              ],
+              "definitionLines" : "26-30",
               "numReferrers" : 1
             }
           }
@@ -82826,18 +80610,7 @@
         "configs/foundry_access_list" : {
           "extended ipv6 access-list" : {
             "RT404888-Caltech" : {
-              "definitionLines" : [
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17
-              ],
+              "definitionLines" : "8-17",
               "numReferrers" : 0
             }
           }
@@ -82845,15 +80618,11 @@
         "configs/foundry_bgp" : {
           "bgp peer-group" : {
             "bippety" : {
-              "definitionLines" : [
-                11
-              ],
+              "definitionLines" : "11",
               "numReferrers" : 0
             },
             "boop" : {
-              "definitionLines" : [
-                18
-              ],
+              "definitionLines" : "18",
               "numReferrers" : 0
             }
           }
@@ -82861,24 +80630,7 @@
         "configs/foundry_interface" : {
           "interface" : {
             "Ethernet1/15" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20
-              ],
+              "definitionLines" : "5-20",
               "numReferrers" : 1
             }
           }
@@ -82886,10 +80638,7 @@
         "configs/foundry_misc" : {
           "policy-map" : {
             "limitarp" : {
-              "definitionLines" : [
-                41,
-                42
-              ],
+              "definitionLines" : "41-42",
               "numReferrers" : 0
             }
           }
@@ -82898,238 +80647,89 @@
         "configs/gh-2658-juniper-vrf-import-export.cfg" : {
           "bgp group" : {
             "overlay" : {
-              "definitionLines" : [
-                136,
-                137,
-                138,
-                139,
-                140,
-                143,
-                144,
-                145,
-                146,
-                148,
-                149,
-                150,
-                151,
-                152
-              ],
+              "definitionLines" : "136-140,143-146,148-152",
               "numReferrers" : 4
             },
             "underlay" : {
-              "definitionLines" : [
-                118,
-                120,
-                121,
-                122,
-                123,
-                125,
-                126,
-                127,
-                129,
-                130,
-                132,
-                133
-              ],
+              "definitionLines" : "118,120-123,125-127,129-130,132-133",
               "numReferrers" : 3
             }
           },
           "interface" : {
             "fxp0" : {
-              "definitionLines" : [
-                75,
-                76,
-                77,
-                78
-              ],
+              "definitionLines" : "75-78",
               "numReferrers" : 1
             },
             "fxp0.0" : {
-              "definitionLines" : [
-                76,
-                77,
-                78
-              ],
+              "definitionLines" : "76-78",
               "numReferrers" : 1
             },
             "irb" : {
-              "definitionLines" : [
-                82,
-                83,
-                84,
-                85,
-                86,
-                88
-              ],
+              "definitionLines" : "82-86,88",
               "numReferrers" : 3
             },
             "irb.100" : {
-              "definitionLines" : [
-                83,
-                84,
-                85,
-                86,
-                88
-              ],
+              "definitionLines" : "83-86,88",
               "numReferrers" : 3
             },
             "lo0" : {
-              "definitionLines" : [
-                91,
-                92,
-                93,
-                94,
-                97,
-                98,
-                99
-              ],
+              "definitionLines" : "91-94,97-99",
               "numReferrers" : 2
             },
             "lo0.0" : {
-              "definitionLines" : [
-                92,
-                93,
-                94
-              ],
+              "definitionLines" : "92-94",
               "numReferrers" : 3
             },
             "lo0.1" : {
-              "definitionLines" : [
-                97,
-                98,
-                99
-              ],
+              "definitionLines" : "97-99",
               "numReferrers" : 2
             },
             "xe-0/0/2" : {
-              "definitionLines" : [
-                53,
-                54,
-                55,
-                56
-              ],
+              "definitionLines" : "53-56",
               "numReferrers" : 1
             },
             "xe-0/0/2.0" : {
-              "definitionLines" : [
-                54,
-                55,
-                56
-              ],
+              "definitionLines" : "54-56",
               "numReferrers" : 1
             },
             "xe-0/0/3" : {
-              "definitionLines" : [
-                60,
-                61,
-                62,
-                63
-              ],
+              "definitionLines" : "60-63",
               "numReferrers" : 1
             },
             "xe-0/0/3.0" : {
-              "definitionLines" : [
-                61,
-                62,
-                63
-              ],
+              "definitionLines" : "61-63",
               "numReferrers" : 1
             },
             "xe-0/0/4" : {
-              "definitionLines" : [
-                67,
-                68,
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "67-71",
               "numReferrers" : 2
             },
             "xe-0/0/4.0" : {
-              "definitionLines" : [
-                69,
-                70,
-                71
-              ],
+              "definitionLines" : "69-71",
               "numReferrers" : 1
             }
           },
           "policy-statement" : {
             "export-loopback" : {
-              "definitionLines" : [
-                161,
-                162,
-                163,
-                164
-              ],
+              "definitionLines" : "161-164",
               "numReferrers" : 1
             },
             "fabric" : {
-              "definitionLines" : [
-                167,
-                168,
-                169,
-                170,
-                171,
-                173,
-                175,
-                176,
-                177,
-                179,
-                180,
-                181
-              ],
+              "definitionLines" : "167-171,173,175-177,179-181",
               "numReferrers" : 1
             },
             "lbpp" : {
-              "definitionLines" : [
-                184,
-                185,
-                186,
-                187
-              ],
+              "definitionLines" : "184-187",
               "numReferrers" : 1
             }
           },
           "routing-instance" : {
             "fabric" : {
-              "definitionLines" : [
-                200,
-                201,
-                202,
-                203,
-                204,
-                205,
-                206,
-                207,
-                208,
-                209,
-                210,
-                211,
-                213,
-                214,
-                217,
-                218,
-                221,
-                222,
-                223,
-                224,
-                225,
-                226,
-                229,
-                230,
-                231,
-                232,
-                233
-              ],
+              "definitionLines" : "200-211,213-214,217-218,221-226,229-233",
               "numReferrers" : 0
             },
             "vr" : {
-              "definitionLines" : [
-                196,
-                197,
-                198
-              ],
+              "definitionLines" : "196-198",
               "numReferrers" : 0
             }
           }
@@ -83137,17 +80737,11 @@
         "configs/host2" : {
           "interface" : {
             "Ethernet0" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 1
             },
             "Ethernet1" : {
-              "definitionLines" : [
-                7,
-                8
-              ],
+              "definitionLines" : "7-8",
               "numReferrers" : 1
             }
           }
@@ -83155,26 +80749,7 @@
         "configs/if_tag_is" : {
           "route-policy" : {
             "FOO" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22
-              ],
+              "definitionLines" : "5-22",
               "numReferrers" : 0
             }
           }
@@ -83182,33 +80757,11 @@
         "configs/interface_exit" : {
           "interface" : {
             "Vlan303" : {
-              "definitionLines" : [
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23
-              ],
+              "definitionLines" : "17-23",
               "numReferrers" : 1
             },
             "Vlan803" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16
-              ],
+              "definitionLines" : "4-16",
               "numReferrers" : 1
             }
           }
@@ -83216,28 +80769,19 @@
         "configs/interface_name" : {
           "interface" : {
             "FastEthernet12/13" : {
-              "definitionLines" : [
-                3
-              ],
+              "definitionLines" : "3",
               "numReferrers" : 1
             },
             "HundredGigE0/6/0/8" : {
-              "definitionLines" : [
-                10,
-                11
-              ],
+              "definitionLines" : "10-11",
               "numReferrers" : 1
             },
             "Port-Channel1" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 1
             },
             "Vlan100" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             }
           }
@@ -83245,15 +80789,7 @@
         "configs/interface_sdr" : {
           "interface" : {
             "Loopback0" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10
-              ],
+              "definitionLines" : "4-10",
               "numReferrers" : 1
             }
           }
@@ -83263,11 +80799,7 @@
         "configs/ios_bfd" : {
           "bfd-template" : {
             "GRE" : {
-              "definitionLines" : [
-                4,
-                5,
-                6
-              ],
+              "definitionLines" : "4-6",
               "numReferrers" : 0
             }
           }
@@ -83276,18 +80808,13 @@
         "configs/ios_bgp_aggregate_address" : {
           "ipv4 prefix-list" : {
             "ScienceDMZ-networks" : {
-              "definitionLines" : [
-                14
-              ],
+              "definitionLines" : "14",
               "numReferrers" : 0
             }
           },
           "ipv6 prefix-list" : {
             "ScienceDMZ-networks" : {
-              "definitionLines" : [
-                16,
-                17
-              ],
+              "definitionLines" : "16-17",
               "numReferrers" : 0
             }
           }
@@ -83295,11 +80822,7 @@
         "configs/ios_interface" : {
           "interface" : {
             "GigabitEthernet1/0/1" : {
-              "definitionLines" : [
-                4,
-                5,
-                6
-              ],
+              "definitionLines" : "4-6",
               "numReferrers" : 1
             }
           }
@@ -83307,11 +80830,7 @@
         "configs/ios_interface_eigrp_settings" : {
           "interface" : {
             "Ethernet0" : {
-              "definitionLines" : [
-                4,
-                5,
-                6
-              ],
+              "definitionLines" : "4-6",
               "numReferrers" : 1
             }
           }
@@ -83319,11 +80838,7 @@
         "configs/ios_interface_ip_autentication" : {
           "interface" : {
             "Ethernet0" : {
-              "definitionLines" : [
-                4,
-                5,
-                6
-              ],
+              "definitionLines" : "4-6",
               "numReferrers" : 1
             }
           }
@@ -83331,14 +80846,7 @@
         "configs/ios_interface_ip_tcp" : {
           "interface" : {
             "Ethernet0" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7,
-                8,
-                9
-              ],
+              "definitionLines" : "4-9",
               "numReferrers" : 1
             }
           }
@@ -83346,16 +80854,7 @@
         "configs/ios_standby" : {
           "interface" : {
             "Vlan1000" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12
-              ],
+              "definitionLines" : "5-12",
               "numReferrers" : 1
             }
           }
@@ -83364,22 +80863,13 @@
         "configs/ios_xe_bgp" : {
           "bgp template peer-policy" : {
             "FOO-BAR:BAZ" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8
-              ],
+              "definitionLines" : "5-8",
               "numReferrers" : 0
             }
           },
           "bgp template peer-session" : {
             "FOO-BAR_BAZ:QUX" : {
-              "definitionLines" : [
-                9,
-                10,
-                11
-              ],
+              "definitionLines" : "9-11",
               "numReferrers" : 0
             }
           }
@@ -83387,10 +80877,7 @@
         "configs/ios_xr_acl" : {
           "ipv4 access-list" : {
             "DENY_ALL" : {
-              "definitionLines" : [
-                9,
-                10
-              ],
+              "definitionLines" : "9-10",
               "numReferrers" : 0
             }
           }
@@ -83399,115 +80886,43 @@
         "configs/ios_xr_bgp_neighbor_group" : {
           "bgp af-group" : {
             "blabbety" : {
-              "definitionLines" : [
-                11,
-                12,
-                13,
-                14
-              ],
+              "definitionLines" : "11-14",
               "numReferrers" : 0
             },
             "blappety" : {
-              "definitionLines" : [
-                6,
-                7,
-                8,
-                9
-              ],
+              "definitionLines" : "6-9",
               "numReferrers" : 0
             }
           },
           "bgp neighbor-group" : {
             "BGPMonitor" : {
-              "definitionLines" : [
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30
-              ],
+              "definitionLines" : "21-30",
               "numReferrers" : 1
             },
             "foobar-iBGP_border_ipv4" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60,
-                61,
-                62,
-                63,
-                64,
-                65
-              ],
+              "definitionLines" : "57-65",
               "numReferrers" : 1
             },
             "foobar-iBGP_border_ipv6" : {
-              "definitionLines" : [
-                68,
-                69,
-                70,
-                71,
-                72,
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "68-75",
               "numReferrers" : 0
             },
             "foobar-iBGP_ipv4" : {
-              "definitionLines" : [
-                33,
-                34,
-                35,
-                36,
-                37,
-                38,
-                39,
-                40,
-                41,
-                42,
-                43,
-                44
-              ],
+              "definitionLines" : "33-44",
               "numReferrers" : 2
             },
             "foobar-iBGP_ipv6" : {
-              "definitionLines" : [
-                47,
-                48,
-                49,
-                50,
-                51,
-                52,
-                53,
-                54
-              ],
+              "definitionLines" : "47-54",
               "numReferrers" : 0
             }
           },
           "bgp session-group" : {
             "OLA" : {
-              "definitionLines" : [
-                93,
-                94,
-                95,
-                96
-              ],
+              "definitionLines" : "93-96",
               "numReferrers" : 0
             },
             "blibber" : {
-              "definitionLines" : [
-                16,
-                17,
-                18,
-                19
-              ],
+              "definitionLines" : "16-19",
               "numReferrers" : 0
             }
           }
@@ -83515,19 +80930,11 @@
         "configs/ios_xr_class_map" : {
           "class-map" : {
             "ABC" : {
-              "definitionLines" : [
-                5,
-                6,
-                7
-              ],
+              "definitionLines" : "5-7",
               "numReferrers" : 0
             },
             "ABCD" : {
-              "definitionLines" : [
-                9,
-                10,
-                11
-              ],
+              "definitionLines" : "9-11",
               "numReferrers" : 0
             }
           }
@@ -83535,108 +80942,55 @@
         "configs/ios_xr_community_set" : {
           "community-set" : {
             "EBGP-PEER" : {
-              "definitionLines" : [
-                41,
-                42,
-                43,
-                44
-              ],
+              "definitionLines" : "41-44",
               "numReferrers" : 0
             },
             "all_community" : {
-              "definitionLines" : [
-                8,
-                9,
-                10
-              ],
+              "definitionLines" : "8-10",
               "numReferrers" : 0
             },
             "cenic_default_network_community" : {
-              "definitionLines" : [
-                32,
-                33,
-                34
-              ],
+              "definitionLines" : "32-34",
               "numReferrers" : 0
             },
             "community_52" : {
-              "definitionLines" : [
-                5,
-                6,
-                7
-              ],
+              "definitionLines" : "5-7",
               "numReferrers" : 0
             },
             "dc_and_isp_blackhole_community" : {
-              "definitionLines" : [
-                29,
-                30,
-                31
-              ],
+              "definitionLines" : "29-31",
               "numReferrers" : 0
             },
             "dc_and_isp_routes_community" : {
-              "definitionLines" : [
-                26,
-                27,
-                28
-              ],
+              "definitionLines" : "26-28",
               "numReferrers" : 0
             },
             "hpr_blackhole_community" : {
-              "definitionLines" : [
-                14,
-                15,
-                16
-              ],
+              "definitionLines" : "14-16",
               "numReferrers" : 0
             },
             "hpr_routes_community" : {
-              "definitionLines" : [
-                11,
-                12,
-                13
-              ],
+              "definitionLines" : "11-13",
               "numReferrers" : 0
             },
             "ucla_blackhole_community" : {
-              "definitionLines" : [
-                17,
-                18,
-                19
-              ],
+              "definitionLines" : "17-19",
               "numReferrers" : 0
             },
             "ucla_to_dc_and_isp_community_ipv4" : {
-              "definitionLines" : [
-                35,
-                36,
-                37
-              ],
+              "definitionLines" : "35-37",
               "numReferrers" : 0
             },
             "ucla_to_dc_and_isp_community_ipv6" : {
-              "definitionLines" : [
-                38,
-                39,
-                40
-              ],
+              "definitionLines" : "38-40",
               "numReferrers" : 0
             },
             "ucla_to_hpr_community_ipv4" : {
-              "definitionLines" : [
-                20,
-                21,
-                22
-              ],
+              "definitionLines" : "20-22",
               "numReferrers" : 0
             },
             "ucla_to_hpr_community_ipv6" : {
-              "definitionLines" : [
-                23,
-                24,
-                25
-              ],
+              "definitionLines" : "23-25",
               "numReferrers" : 0
             }
           }
@@ -83653,28 +81007,11 @@
         "configs/ios_xr_prefix_set" : {
           "prefix-set" : {
             "default_route" : {
-              "definitionLines" : [
-                5,
-                6,
-                7
-              ],
+              "definitionLines" : "5-7",
               "numReferrers" : 0
             },
             "ucla_networks" : {
-              "definitionLines" : [
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19
-              ],
+              "definitionLines" : "8-19",
               "numReferrers" : 0
             }
           }
@@ -83682,246 +81019,63 @@
         "configs/ios_xr_route_policy" : {
           "route-policy" : {
             "EBGP-PEER-AS2828-LAX-PNI-OUT" : {
-              "definitionLines" : [
-                87,
-                88,
-                89,
-                90,
-                91,
-                92,
-                93,
-                94,
-                95,
-                96,
-                97,
-                98,
-                99,
-                100,
-                101,
-                102,
-                103,
-                104,
-                105
-              ],
+              "definitionLines" : "87-105",
               "numReferrers" : 0
             },
             "EBGP-PEER-AS6461-LAX-PNI-IN" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60,
-                61,
-                62,
-                63,
-                64,
-                65
-              ],
+              "definitionLines" : "57-65",
               "numReferrers" : 0
             },
             "EBGP-PEER-SANITY-IN" : {
-              "definitionLines" : [
-                76,
-                77,
-                78,
-                79,
-                80,
-                81,
-                82,
-                83,
-                84,
-                85,
-                86
-              ],
+              "definitionLines" : "76-86",
               "numReferrers" : 0
             },
             "aaaa" : {
-              "definitionLines" : [
-                28,
-                29,
-                30,
-                31,
-                32
-              ],
+              "definitionLines" : "28-32",
               "numReferrers" : 0
             },
             "barbar_to_fooey_community_ipv4" : {
-              "definitionLines" : [
-                51,
-                52,
-                53,
-                54,
-                55,
-                56
-              ],
+              "definitionLines" : "51-56",
               "numReferrers" : 0
             },
             "doodlepop" : {
-              "definitionLines" : [
-                158,
-                159,
-                160,
-                161,
-                162,
-                163,
-                164,
-                165,
-                166,
-                167
-              ],
+              "definitionLines" : "158-167",
               "numReferrers" : 0
             },
             "drop_community_5555" : {
-              "definitionLines" : [
-                33,
-                34,
-                35,
-                36,
-                37,
-                38
-              ],
+              "definitionLines" : "33-38",
               "numReferrers" : 0
             },
             "fooey_blackhole" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12
-              ],
+              "definitionLines" : "5-12",
               "numReferrers" : 0
             },
             "fooey_to_barbar_ipv4" : {
-              "definitionLines" : [
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20
-              ],
+              "definitionLines" : "13-20",
               "numReferrers" : 0
             },
             "fooey_to_barbar_ipv6" : {
-              "definitionLines" : [
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27
-              ],
+              "definitionLines" : "21-27",
               "numReferrers" : 0
             },
             "ospf_default_ipv4" : {
-              "definitionLines" : [
-                39,
-                40,
-                41,
-                42,
-                43
-              ],
+              "definitionLines" : "39-43",
               "numReferrers" : 0
             },
             "perfsonar_andsn_ipv4" : {
-              "definitionLines" : [
-                44,
-                45,
-                46,
-                47,
-                48,
-                49,
-                50
-              ],
+              "definitionLines" : "44-50",
               "numReferrers" : 0
             },
             "redistribute-static-isis" : {
-              "definitionLines" : [
-                66,
-                67,
-                68,
-                69,
-                70,
-                71,
-                72,
-                73,
-                74,
-                75
-              ],
+              "definitionLines" : "66-75",
               "numReferrers" : 0
             },
             "routetype" : {
-              "definitionLines" : [
-                169,
-                170,
-                171,
-                172,
-                173,
-                174,
-                175
-              ],
+              "definitionLines" : "169-175",
               "numReferrers" : 0
             },
             "to_chillmap" : {
-              "definitionLines" : [
-                107,
-                108,
-                109,
-                110,
-                111,
-                112,
-                113,
-                114,
-                115,
-                116,
-                117,
-                118,
-                119,
-                120,
-                121,
-                122,
-                123,
-                124,
-                125,
-                126,
-                127,
-                128,
-                129,
-                130,
-                131,
-                132,
-                133,
-                134,
-                135,
-                136,
-                137,
-                138,
-                139,
-                140,
-                141,
-                142,
-                143,
-                144,
-                145,
-                146,
-                147,
-                148,
-                149,
-                150,
-                151,
-                152,
-                153,
-                154,
-                155,
-                156
-              ],
+              "definitionLines" : "107-156",
               "numReferrers" : 0
             }
           }
@@ -83929,9 +81083,7 @@
         "configs/ios_xr_router_static" : {
           "interface" : {
             "Null0" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 7
             }
           }
@@ -83942,9 +81094,7 @@
         "configs/ip_prefix_list_single_line" : {
           "ipv4 prefix-list" : {
             "DENY-IPV4-ANY-IN" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 0
             }
           }
@@ -83954,24 +81104,15 @@
         "configs/juniper-interfaces" : {
           "interface" : {
             "xe-0/0/0" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 2
             },
             "xe-0/0/0:0" : {
-              "definitionLines" : [
-                4,
-                5,
-                15
-              ],
+              "definitionLines" : "4-5,15",
               "numReferrers" : 4
             },
             "xe-0/0/0:0.0" : {
-              "definitionLines" : [
-                5,
-                15
-              ],
+              "definitionLines" : "5,15",
               "numReferrers" : 3
             }
           }
@@ -83979,17 +81120,13 @@
         "configs/juniper-tcpflags" : {
           "firewall filter" : {
             "foo" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 0
             }
           },
           "firewall filter term" : {
             "foo bar" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 1
             }
           }
@@ -83997,16 +81134,11 @@
         "configs/juniper_application" : {
           "application" : {
             "APP" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 0
             },
             "APP-POP3" : {
-              "definitionLines" : [
-                6,
-                7
-              ],
+              "definitionLines" : "6-7",
               "numReferrers" : 0
             }
           }
@@ -84015,24 +81147,17 @@
         "configs/juniper_as_path_group" : {
           "as-path-group" : {
             "AS_PATH_GROUP1" : {
-              "definitionLines" : [
-                5,
-                6
-              ],
+              "definitionLines" : "5-6",
               "numReferrers" : 0
             }
           },
           "as-path-group as-path" : {
             "AS_PATH_REGEX_NAME1" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 0
             },
             "AS_PATH_REGEX_NAME2" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 0
             }
           }
@@ -84040,59 +81165,19 @@
         "configs/juniper_bgp" : {
           "bgp group" : {
             "someinternalipv4group" : {
-              "definitionLines" : [
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                35,
-                36
-              ],
+              "definitionLines" : "28-36",
               "numReferrers" : 2
             },
             "someinternalipv6group" : {
-              "definitionLines" : [
-                37,
-                38,
-                39,
-                40,
-                41,
-                42,
-                43,
-                44
-              ],
+              "definitionLines" : "37-44",
               "numReferrers" : 1
             },
             "someipv4bgpgroup" : {
-              "definitionLines" : [
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20
-              ],
+              "definitionLines" : "9-20",
               "numReferrers" : 3
             },
             "someipv6bgpgroup" : {
-              "definitionLines" : [
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27
-              ],
+              "definitionLines" : "21-27",
               "numReferrers" : 1
             }
           }
@@ -84100,11 +81185,7 @@
         "configs/juniper_bgp_allow" : {
           "bgp group" : {
             "GROUP" : {
-              "definitionLines" : [
-                6,
-                7,
-                8
-              ],
+              "definitionLines" : "6-8",
               "numReferrers" : 1
             }
           }
@@ -84112,36 +81193,17 @@
         "configs/juniper_bgp_authentication" : {
           "authentication-key-chain" : {
             "bgp-auth" : {
-              "definitionLines" : [
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18
-              ],
+              "definitionLines" : "12-18",
               "numReferrers" : 1
             }
           },
           "bgp group" : {
             "ext" : {
-              "definitionLines" : [
-                6,
-                7,
-                8,
-                10,
-                11
-              ],
+              "definitionLines" : "6-8,10-11",
               "numReferrers" : 1
             },
             "ext1" : {
-              "definitionLines" : [
-                20,
-                21,
-                22,
-                23
-              ],
+              "definitionLines" : "20-23",
               "numReferrers" : 1
             }
           }
@@ -84149,9 +81211,7 @@
         "configs/juniper_bgp_disable" : {
           "bgp group" : {
             "GROUP" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 0
             }
           }
@@ -84159,12 +81219,7 @@
         "configs/juniper_bgp_enforce_fist_as" : {
           "bgp group" : {
             "MYGROUP" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8
-              ],
+              "definitionLines" : "5-8",
               "numReferrers" : 1
             }
           }
@@ -84172,23 +81227,11 @@
         "configs/juniper_bgp_remove_private_as" : {
           "bgp group" : {
             "someipv4bgpgroup" : {
-              "definitionLines" : [
-                5,
-                9,
-                10,
-                11,
-                12
-              ],
+              "definitionLines" : "5,9-12",
               "numReferrers" : 0
             },
             "someipv6bgpgroup" : {
-              "definitionLines" : [
-                7,
-                13,
-                14,
-                15,
-                16
-              ],
+              "definitionLines" : "7,13-16",
               "numReferrers" : 0
             }
           }
@@ -84197,161 +81240,61 @@
         "configs/juniper_firewall" : {
           "firewall filter" : {
             "ISP-INBOUND-L2" : {
-              "definitionLines" : [
-                47
-              ],
+              "definitionLines" : "47",
               "numReferrers" : 0
             },
             "blah" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                30,
-                32,
-                35,
-                36,
-                38,
-                40
-              ],
+              "definitionLines" : "5-28,30,32,35-36,38,40",
               "numReferrers" : 0
             },
             "blah6" : {
-              "definitionLines" : [
-                42,
-                43,
-                44
-              ],
+              "definitionLines" : "42-44",
               "numReferrers" : 0
             },
             "f1" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 0
             },
             "ip_options" : {
-              "definitionLines" : [
-                48,
-                49,
-                50,
-                51,
-                52,
-                53,
-                54,
-                55
-              ],
+              "definitionLines" : "48-55",
               "numReferrers" : 0
             }
           },
           "firewall filter term" : {
             "ISP-INBOUND-L2 ALLOW-ARP" : {
-              "definitionLines" : [
-                47
-              ],
+              "definitionLines" : "47",
               "numReferrers" : 1
             },
             "blah blorp" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                35,
-                36
-              ],
+              "definitionLines" : "5-28,35-36",
               "numReferrers" : 26
             },
             "blah prefix-list" : {
-              "definitionLines" : [
-                30
-              ],
+              "definitionLines" : "30",
               "numReferrers" : 1
             },
             "blah some term" : {
-              "definitionLines" : [
-                32
-              ],
+              "definitionLines" : "32",
               "numReferrers" : 1
             },
             "blah t2" : {
-              "definitionLines" : [
-                38
-              ],
+              "definitionLines" : "38",
               "numReferrers" : 1
             },
             "blah t3" : {
-              "definitionLines" : [
-                40
-              ],
+              "definitionLines" : "40",
               "numReferrers" : 1
             },
             "blah6 blorp6" : {
-              "definitionLines" : [
-                42,
-                43,
-                44
-              ],
+              "definitionLines" : "42-44",
               "numReferrers" : 3
             },
             "f1 t1" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 1
             },
             "ip_options t1" : {
-              "definitionLines" : [
-                48,
-                49,
-                50,
-                51,
-                52,
-                53,
-                54,
-                55
-              ],
+              "definitionLines" : "48-55",
               "numReferrers" : 8
             }
           }
@@ -84359,16 +81302,11 @@
         "configs/juniper_forwarding_options" : {
           "dhcp-relay server-group" : {
             "dhcpgrp" : {
-              "definitionLines" : [
-                24,
-                25
-              ],
+              "definitionLines" : "24-25",
               "numReferrers" : 0
             },
             "test2" : {
-              "definitionLines" : [
-                26
-              ],
+              "definitionLines" : "26",
               "numReferrers" : 2
             }
           }
@@ -84376,166 +81314,107 @@
         "configs/juniper_interfaces" : {
           "interface" : {
             "ae0" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "ae0.0" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 1
             },
             "fab0" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 1
             },
             "ge-0/0/0" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 1
             },
             "ge-1/0/0" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             },
             "ge-2/0/0" : {
-              "definitionLines" : [
-                9,
-                10
-              ],
+              "definitionLines" : "9-10",
               "numReferrers" : 2
             },
             "ge-2/0/0.0" : {
-              "definitionLines" : [
-                9
-              ],
+              "definitionLines" : "9",
               "numReferrers" : 1
             },
             "ge-2/0/0.1" : {
-              "definitionLines" : [
-                10
-              ],
+              "definitionLines" : "10",
               "numReferrers" : 1
             },
             "ge-3/0/0" : {
-              "definitionLines" : [
-                11
-              ],
+              "definitionLines" : "11",
               "numReferrers" : 1
             },
             "ge-3/0/0.0" : {
-              "definitionLines" : [
-                11
-              ],
+              "definitionLines" : "11",
               "numReferrers" : 1
             },
             "ge-4/0/0" : {
-              "definitionLines" : [
-                12
-              ],
+              "definitionLines" : "12",
               "numReferrers" : 1
             },
             "ge-4/0/0.0" : {
-              "definitionLines" : [
-                12
-              ],
+              "definitionLines" : "12",
               "numReferrers" : 1
             },
             "ge-5/0/0" : {
-              "definitionLines" : [
-                13
-              ],
+              "definitionLines" : "13",
               "numReferrers" : 1
             },
             "ge-5/0/0.0" : {
-              "definitionLines" : [
-                13
-              ],
+              "definitionLines" : "13",
               "numReferrers" : 1
             },
             "irb" : {
-              "definitionLines" : [
-                16,
-                17,
-                18,
-                19
-              ],
+              "definitionLines" : "16-19",
               "numReferrers" : 4
             },
             "irb.5" : {
-              "definitionLines" : [
-                16,
-                17,
-                18,
-                19
-              ],
+              "definitionLines" : "16-19",
               "numReferrers" : 4
             },
             "vme" : {
-              "definitionLines" : [
-                22
-              ],
+              "definitionLines" : "22",
               "numReferrers" : 1
             },
             "vme.0" : {
-              "definitionLines" : [
-                22
-              ],
+              "definitionLines" : "22",
               "numReferrers" : 1
             },
             "xe-0/0/0:0" : {
-              "definitionLines" : [
-                14,
-                15
-              ],
+              "definitionLines" : "14-15",
               "numReferrers" : 2
             },
             "xe-0/0/0:0.0" : {
-              "definitionLines" : [
-                15
-              ],
+              "definitionLines" : "15",
               "numReferrers" : 1
             },
             "xe-0/0/5:0" : {
-              "definitionLines" : [
-                20
-              ],
+              "definitionLines" : "20",
               "numReferrers" : 1
             },
             "xe-0/0/5:0.0" : {
-              "definitionLines" : [
-                20
-              ],
+              "definitionLines" : "20",
               "numReferrers" : 1
             },
             "xe-0/0/6" : {
-              "definitionLines" : [
-                21
-              ],
+              "definitionLines" : "21",
               "numReferrers" : 1
             }
           },
           "routing-instance" : {
             "SOME_INSTANCE" : {
-              "definitionLines" : [
-                24
-              ],
+              "definitionLines" : "24",
               "numReferrers" : 0
             }
           },
           "vlan" : {
             "unused-vlan" : {
-              "definitionLines" : [
-                26,
-                27
-              ],
+              "definitionLines" : "26-27",
               "numReferrers" : 0
             }
           }
@@ -84543,15 +81422,11 @@
         "configs/juniper_isis" : {
           "interface" : {
             "ge-0/0/0" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 1
             },
             "ge-0/0/0.0" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 8
             }
           }
@@ -84560,9 +81435,7 @@
         "configs/juniper_misc" : {
           "routing-instance" : {
             "ROUTING_INSTANCE" : {
-              "definitionLines" : [
-                9
-              ],
+              "definitionLines" : "9",
               "numReferrers" : 0
             }
           }
@@ -84570,89 +81443,45 @@
         "configs/juniper_nat" : {
           "interface" : {
             "ge-0/0/0" : {
-              "definitionLines" : [
-                33
-              ],
+              "definitionLines" : "33",
               "numReferrers" : 1
             },
             "ge-0/0/0.0" : {
-              "definitionLines" : [
-                33
-              ],
+              "definitionLines" : "33",
               "numReferrers" : 2
             }
           },
           "nat pool" : {
             "POOL" : {
-              "definitionLines" : [
-                6,
-                23
-              ],
+              "definitionLines" : "6,23",
               "numReferrers" : 0
             }
           },
           "nat rule" : {
             "DST-RULE" : {
-              "definitionLines" : [
-                27,
-                28,
-                29,
-                30,
-                31
-              ],
+              "definitionLines" : "27-31",
               "numReferrers" : 0
             },
             "SRC-RULE1" : {
-              "definitionLines" : [
-                11,
-                12,
-                13,
-                14,
-                15
-              ],
+              "definitionLines" : "11-15",
               "numReferrers" : 0
             },
             "SRC-RULE2" : {
-              "definitionLines" : [
-                17,
-                18
-              ],
+              "definitionLines" : "17-18",
               "numReferrers" : 0
             },
             "SRC-RULE3" : {
-              "definitionLines" : [
-                20,
-                21
-              ],
+              "definitionLines" : "20-21",
               "numReferrers" : 0
             }
           },
           "nat rule set" : {
             "DST-NAT" : {
-              "definitionLines" : [
-                25,
-                27,
-                28,
-                29,
-                30,
-                31
-              ],
+              "definitionLines" : "25,27-31",
               "numReferrers" : 0
             },
             "SRC-NAT" : {
-              "definitionLines" : [
-                8,
-                9,
-                11,
-                12,
-                13,
-                14,
-                15,
-                17,
-                18,
-                20,
-                21
-              ],
+              "definitionLines" : "8-9,11-15,17-18,20-21",
               "numReferrers" : 0
             }
           }
@@ -84662,15 +81491,11 @@
         "configs/juniper_ospf_disable" : {
           "interface" : {
             "ge-0/0/0" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 1
             },
             "ge-0/0/0.0" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 2
             }
           }
@@ -84680,56 +81505,17 @@
         "configs/juniper_policy_statement" : {
           "as-path" : {
             "ORIGINATED_IN_65535" : {
-              "definitionLines" : [
-                39
-              ],
+              "definitionLines" : "39",
               "numReferrers" : 1
             },
             "UNUSED_ORIGINATED_IN_65535" : {
-              "definitionLines" : [
-                40
-              ],
+              "definitionLines" : "40",
               "numReferrers" : 0
             }
           },
           "policy-statement" : {
             "POLICY-NAME" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                35,
-                36,
-                37
-              ],
+              "definitionLines" : "4-37",
               "numReferrers" : 0
             }
           }
@@ -84737,9 +81523,7 @@
         "configs/juniper_relay" : {
           "dhcp-relay server-group" : {
             "site-dhcp" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 2
             }
           }
@@ -84747,41 +81531,27 @@
         "configs/juniper_reth_interfaces" : {
           "interface" : {
             "ge-0/0/0" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 2
             },
             "ge-0/0/0.0" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 1
             },
             "ge-0/0/1" : {
-              "definitionLines" : [
-                6,
-                7
-              ],
+              "definitionLines" : "6-7",
               "numReferrers" : 2
             },
             "ge-0/0/1.0" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 1
             },
             "reth0" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             },
             "reth0.3" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 1
             }
           }
@@ -84789,61 +81559,29 @@
         "configs/juniper_rib_groups" : {
           "bgp group" : {
             "BGP_GROUP" : {
-              "definitionLines" : [
-                15,
-                16,
-                18,
-                19,
-                21,
-                22,
-                24,
-                25
-              ],
+              "definitionLines" : "15-16,18-19,21-22,24-25",
               "numReferrers" : 4
             }
           },
           "logical-system" : {
             "LOGICALSYSTEM" : {
-              "definitionLines" : [
-                17,
-                18,
-                19,
-                20,
-                21,
-                22
-              ],
+              "definitionLines" : "17-22",
               "numReferrers" : 0
             }
           },
           "rib-group" : {
             "bgp-rib-group" : {
-              "definitionLines" : [
-                11,
-                12
-              ],
+              "definitionLines" : "11-12",
               "numReferrers" : 0
             },
             "interface-routes-rib" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9
-              ],
+              "definitionLines" : "5-9",
               "numReferrers" : 0
             }
           },
           "routing-instance" : {
             "ROUTING_INSTANCE_NAME" : {
-              "definitionLines" : [
-                20,
-                21,
-                22,
-                23,
-                24,
-                25
-              ],
+              "definitionLines" : "20-25",
               "numReferrers" : 0
             }
           }
@@ -84851,25 +81589,11 @@
         "configs/juniper_route_filter" : {
           "policy-statement" : {
             "route-filter-test-v4" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7,
-                8,
-                9
-              ],
+              "definitionLines" : "4-9",
               "numReferrers" : 0
             },
             "route-filter-test-v6" : {
-              "definitionLines" : [
-                11,
-                12,
-                13,
-                14,
-                15,
-                16
-              ],
+              "definitionLines" : "11-16",
               "numReferrers" : 0
             }
           }
@@ -84877,9 +81601,7 @@
         "configs/juniper_routing_options" : {
           "policy-statement" : {
             "POLICY" : {
-              "definitionLines" : [
-                20
-              ],
+              "definitionLines" : "20",
               "numReferrers" : 1
             }
           }
@@ -84887,28 +81609,17 @@
         "configs/juniper_routing_policy" : {
           "interface" : {
             "ge-0/0/0" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 2
             },
             "ge-0/0/0.0" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 3
             }
           },
           "policy-statement" : {
             "POLICY-NAME" : {
-              "definitionLines" : [
-                7,
-                8,
-                9,
-                10
-              ],
+              "definitionLines" : "7-10",
               "numReferrers" : 0
             }
           }
@@ -84916,68 +81627,43 @@
         "configs/juniper_security" : {
           "address-book" : {
             "notglobalAttached" : {
-              "definitionLines" : [
-                9,
-                10
-              ],
+              "definitionLines" : "9-10",
               "numReferrers" : 1
             },
             "notglobalUnattached" : {
-              "definitionLines" : [
-                11
-              ],
+              "definitionLines" : "11",
               "numReferrers" : 0
             }
           },
           "ike policy" : {
             "1.2.3.4" : {
-              "definitionLines" : [
-                14
-              ],
+              "definitionLines" : "14",
               "numReferrers" : 0
             }
           },
           "ike proposal" : {
             "PROPOSAL" : {
-              "definitionLines" : [
-                13
-              ],
+              "definitionLines" : "13",
               "numReferrers" : 1
             }
           },
           "security policy" : {
             "zone~A~to~zone~B" : {
-              "definitionLines" : [
-                19,
-                20,
-                21,
-                22
-              ],
+              "definitionLines" : "19-22",
               "numReferrers" : 4
             },
             "~GLOBAL_SECURITY_POLICY~" : {
-              "definitionLines" : [
-                16,
-                17
-              ],
+              "definitionLines" : "16-17",
               "numReferrers" : 2
             }
           },
           "security policy term" : {
             "zone~A~to~zone~B 123-4" : {
-              "definitionLines" : [
-                19,
-                20,
-                21,
-                22
-              ],
+              "definitionLines" : "19-22",
               "numReferrers" : 4
             },
             "~GLOBAL_SECURITY_POLICY~ p1" : {
-              "definitionLines" : [
-                16,
-                17
-              ],
+              "definitionLines" : "16-17",
               "numReferrers" : 2
             }
           }
@@ -84987,14 +81673,7 @@
         "configs/juniper_system" : {
           "security-profile" : {
             "ls1" : {
-              "definitionLines" : [
-                16,
-                17,
-                18,
-                19,
-                20,
-                21
-              ],
+              "definitionLines" : "16-21",
               "numReferrers" : 0
             }
           }
@@ -85004,39 +81683,21 @@
         "configs/juniper_vlan" : {
           "interface" : {
             "xe-0/0/0" : {
-              "definitionLines" : [
-                10,
-                11,
-                12,
-                13,
-                14
-              ],
+              "definitionLines" : "10-14",
               "numReferrers" : 5
             },
             "xe-0/0/0.0" : {
-              "definitionLines" : [
-                10,
-                11,
-                12,
-                13,
-                14
-              ],
+              "definitionLines" : "10-14",
               "numReferrers" : 5
             }
           },
           "vlan" : {
             "VLAN30" : {
-              "definitionLines" : [
-                5,
-                6
-              ],
+              "definitionLines" : "5-6",
               "numReferrers" : 1
             },
             "VLAN40" : {
-              "definitionLines" : [
-                7,
-                8
-              ],
+              "definitionLines" : "7-8",
               "numReferrers" : 1
             }
           }
@@ -85044,9 +81705,7 @@
         "configs/local_v6_addr" : {
           "bgp peer-group" : {
             "NEIGH" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 0
             }
           }
@@ -85054,35 +81713,19 @@
         "configs/mac_access_list" : {
           "mac acl" : {
             "STPDENY" : {
-              "definitionLines" : [
-                13,
-                14,
-                15,
-                16
-              ],
+              "definitionLines" : "13-16",
               "numReferrers" : 0
             },
             "filtermac" : {
-              "definitionLines" : [
-                8
-              ],
+              "definitionLines" : "8",
               "numReferrers" : 0
             },
             "ipmi_test" : {
-              "definitionLines" : [
-                9,
-                10,
-                11
-              ],
+              "definitionLines" : "9-11",
               "numReferrers" : 0
             },
             "permitCDP" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7
-              ],
+              "definitionLines" : "4-7",
               "numReferrers" : 0
             }
           }
@@ -85090,33 +81733,19 @@
         "configs/mos_interface" : {
           "interface" : {
             "Ethernet1" : {
-              "definitionLines" : [
-                6,
-                7
-              ],
+              "definitionLines" : "6-7",
               "numReferrers" : 1
             },
             "Ethernet2" : {
-              "definitionLines" : [
-                9,
-                10,
-                11,
-                12,
-                13,
-                14
-              ],
+              "definitionLines" : "9-14",
               "numReferrers" : 1
             },
             "Management1" : {
-              "definitionLines" : [
-                16
-              ],
+              "definitionLines" : "16",
               "numReferrers" : 1
             },
             "ap1" : {
-              "definitionLines" : [
-                4
-              ],
+              "definitionLines" : "4",
               "numReferrers" : 1
             }
           }
@@ -85126,10 +81755,7 @@
         "configs/named_and_numbered_lists" : {
           "route-map" : {
             "foo" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 0
             }
           }
@@ -85142,80 +81768,51 @@
         "configs/nxos/nxos_bgp" : {
           "bgp template peer" : {
             "PEER_BLLF" : {
-              "definitionLines" : [
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                35,
-                36
-              ],
+              "definitionLines" : "25-36",
               "numReferrers" : 1
             }
           },
           "class-map type control-plane" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "default-out-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "vrf" : {
             "default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "management" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           }
@@ -85223,94 +81820,61 @@
         "configs/nxos/nxos_interface" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                6,
-                7,
-                8,
-                9,
-                10
-              ],
+              "definitionLines" : "6-10",
               "numReferrers" : 1
             },
             "Ethernet0/1" : {
-              "definitionLines" : [
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21
-              ],
+              "definitionLines" : "15-21",
               "numReferrers" : 1
             }
           },
           "nve" : {
             "nve1" : {
-              "definitionLines" : [
-                12,
-                13
-              ],
+              "definitionLines" : "12-13",
               "numReferrers" : 1
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "default-out-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "vrf" : {
             "default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "management" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           }
@@ -85318,61 +81882,45 @@
         "configs/nxos/nxos_misc" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "default-out-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "vrf" : {
             "default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "management" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           }
@@ -85380,61 +81928,45 @@
         "configs/nxos/nxos_ntp" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "default-out-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "vrf" : {
             "default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "management" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           }
@@ -85442,130 +81974,79 @@
         "configs/nxos/nxos_ospf" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "definitionLines" : [
-                9,
-                10,
-                11,
-                12,
-                13,
-                14
-              ],
+              "definitionLines" : "9-14",
               "numReferrers" : 1
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "default-out-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "router ospf" : {
             "1" : {
-              "definitionLines" : [
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                38,
-                39,
-                40
-              ],
+              "definitionLines" : "23-28,38-40",
               "numReferrers" : 3
             },
             "100" : {
-              "definitionLines" : [
-                34,
-                35,
-                36
-              ],
+              "definitionLines" : "34-36",
               "numReferrers" : 1
             },
             "ignored" : {
-              "definitionLines" : [
-                18,
-                19,
-                20,
-                21,
-                30,
-                31,
-                32
-              ],
+              "definitionLines" : "18-21,30-32",
               "numReferrers" : 2
             }
           },
           "router ospf area" : {
             "1" : {
-              "definitionLines" : [
-                40
-              ],
+              "definitionLines" : "40",
               "numReferrers" : 0
             }
           },
           "vrf" : {
             "OTHER" : {
-              "definitionLines" : [
-                6
-              ],
+              "definitionLines" : "6",
               "numReferrers" : 1
             },
             "default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "foo" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 0
             },
             "management" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           }
@@ -85573,443 +82054,177 @@
         "configs/nxos/nxos_route_map_continue" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "default-out-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "route-map" : {
             "foobar" : {
-              "definitionLines" : [
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33,
-                34,
-                35,
-                36,
-                37,
-                38,
-                39,
-                40,
-                41,
-                42,
-                43,
-                44,
-                45,
-                46,
-                47,
-                48,
-                49,
-                50,
-                51,
-                52,
-                53,
-                54,
-                55,
-                56,
-                57,
-                58,
-                59,
-                60,
-                61,
-                62,
-                63,
-                64,
-                65,
-                66,
-                67,
-                68,
-                69,
-                70,
-                71,
-                72,
-                73,
-                74,
-                75,
-                76,
-                77,
-                78,
-                79,
-                80,
-                81,
-                82,
-                83,
-                84,
-                85,
-                86,
-                87,
-                88,
-                89,
-                90,
-                91,
-                92,
-                93,
-                94,
-                95,
-                96,
-                97,
-                98,
-                99,
-                100,
-                101,
-                102,
-                103,
-                104,
-                105,
-                106,
-                107,
-                108,
-                109,
-                110,
-                111,
-                112,
-                113,
-                114
-              ],
+              "definitionLines" : "6-114",
               "numReferrers" : 0
             }
           },
           "route-map entry" : {
             "foobar 10" : {
-              "definitionLines" : [
-                6,
-                7
-              ],
+              "definitionLines" : "6-7",
               "numReferrers" : 1
             },
             "foobar 100" : {
-              "definitionLines" : [
-                37,
-                38,
-                39
-              ],
+              "definitionLines" : "37-39",
               "numReferrers" : 2
             },
             "foobar 110" : {
-              "definitionLines" : [
-                40,
-                41,
-                42
-              ],
+              "definitionLines" : "40-42",
               "numReferrers" : 1
             },
             "foobar 120" : {
-              "definitionLines" : [
-                43,
-                44,
-                45,
-                46
-              ],
+              "definitionLines" : "43-46",
               "numReferrers" : 3
             },
             "foobar 130" : {
-              "definitionLines" : [
-                47,
-                48,
-                49,
-                50
-              ],
+              "definitionLines" : "47-50",
               "numReferrers" : 2
             },
             "foobar 140" : {
-              "definitionLines" : [
-                51,
-                52,
-                53,
-                54
-              ],
+              "definitionLines" : "51-54",
               "numReferrers" : 2
             },
             "foobar 150" : {
-              "definitionLines" : [
-                55,
-                56,
-                57,
-                58
-              ],
+              "definitionLines" : "55-58",
               "numReferrers" : 2
             },
             "foobar 160" : {
-              "definitionLines" : [
-                59,
-                60,
-                61,
-                62
-              ],
+              "definitionLines" : "59-62",
               "numReferrers" : 2
             },
             "foobar 170" : {
-              "definitionLines" : [
-                63,
-                64,
-                65,
-                66
-              ],
+              "definitionLines" : "63-66",
               "numReferrers" : 2
             },
             "foobar 180" : {
-              "definitionLines" : [
-                67,
-                68,
-                69,
-                70
-              ],
+              "definitionLines" : "67-70",
               "numReferrers" : 2
             },
             "foobar 190" : {
-              "definitionLines" : [
-                71,
-                72,
-                73,
-                74
-              ],
+              "definitionLines" : "71-74",
               "numReferrers" : 2
             },
             "foobar 20" : {
-              "definitionLines" : [
-                8,
-                9
-              ],
+              "definitionLines" : "8-9",
               "numReferrers" : 1
             },
             "foobar 200" : {
-              "definitionLines" : [
-                75,
-                76,
-                77,
-                78
-              ],
+              "definitionLines" : "75-78",
               "numReferrers" : 2
             },
             "foobar 210" : {
-              "definitionLines" : [
-                79,
-                80,
-                81,
-                82
-              ],
+              "definitionLines" : "79-82",
               "numReferrers" : 2
             },
             "foobar 220" : {
-              "definitionLines" : [
-                83,
-                84,
-                85
-              ],
+              "definitionLines" : "83-85",
               "numReferrers" : 2
             },
             "foobar 230" : {
-              "definitionLines" : [
-                86
-              ],
+              "definitionLines" : "86",
               "numReferrers" : 1
             },
             "foobar 240" : {
-              "definitionLines" : [
-                87,
-                88,
-                89,
-                90
-              ],
+              "definitionLines" : "87-90",
               "numReferrers" : 2
             },
             "foobar 250" : {
-              "definitionLines" : [
-                91,
-                92,
-                93,
-                94
-              ],
+              "definitionLines" : "91-94",
               "numReferrers" : 2
             },
             "foobar 260" : {
-              "definitionLines" : [
-                95,
-                96,
-                97,
-                98
-              ],
+              "definitionLines" : "95-98",
               "numReferrers" : 2
             },
             "foobar 270" : {
-              "definitionLines" : [
-                99,
-                100,
-                101,
-                102
-              ],
+              "definitionLines" : "99-102",
               "numReferrers" : 2
             },
             "foobar 280" : {
-              "definitionLines" : [
-                103,
-                104,
-                105,
-                106
-              ],
+              "definitionLines" : "103-106",
               "numReferrers" : 2
             },
             "foobar 290" : {
-              "definitionLines" : [
-                107,
-                108,
-                109,
-                110
-              ],
+              "definitionLines" : "107-110",
               "numReferrers" : 2
             },
             "foobar 30" : {
-              "definitionLines" : [
-                10,
-                11,
-                12
-              ],
+              "definitionLines" : "10-12",
               "numReferrers" : 1
             },
             "foobar 300" : {
-              "definitionLines" : [
-                111,
-                112,
-                113
-              ],
+              "definitionLines" : "111-113",
               "numReferrers" : 2
             },
             "foobar 310" : {
-              "definitionLines" : [
-                114
-              ],
+              "definitionLines" : "114",
               "numReferrers" : 2
             },
             "foobar 40" : {
-              "definitionLines" : [
-                13
-              ],
+              "definitionLines" : "13",
               "numReferrers" : 1
             },
             "foobar 50" : {
-              "definitionLines" : [
-                14,
-                15,
-                16
-              ],
+              "definitionLines" : "14-16",
               "numReferrers" : 2
             },
             "foobar 60" : {
-              "definitionLines" : [
-                17,
-                18,
-                19,
-                20,
-                21
-              ],
+              "definitionLines" : "17-21",
               "numReferrers" : 2
             },
             "foobar 70" : {
-              "definitionLines" : [
-                22,
-                23,
-                24,
-                25,
-                26
-              ],
+              "definitionLines" : "22-26",
               "numReferrers" : 2
             },
             "foobar 80" : {
-              "definitionLines" : [
-                27,
-                28,
-                29,
-                30,
-                31
-              ],
+              "definitionLines" : "27-31",
               "numReferrers" : 2
             },
             "foobar 90" : {
-              "definitionLines" : [
-                32,
-                33,
-                34,
-                35,
-                36
-              ],
+              "definitionLines" : "32-36",
               "numReferrers" : 2
             }
           },
           "vrf" : {
             "default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "management" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           }
@@ -86017,61 +82232,45 @@
         "configs/nxos/nxos_ssh" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "default-out-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "vrf" : {
             "default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "management" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           }
@@ -86079,61 +82278,45 @@
         "configs/nxos/nxos_system" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 2
             },
             "default-out-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 2
             }
           },
           "vrf" : {
             "default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "management" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           }
@@ -86141,86 +82324,49 @@
         "configs/nxos/nxos_vrf" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "default-out-policy" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             }
           },
           "vrf" : {
             "default" : {
-              "definitionLines" : [
-                0
-              ],
+              "definitionLines" : "0",
               "numReferrers" : 1
             },
             "management" : {
-              "definitionLines" : [
-                0,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13
-              ],
+              "definitionLines" : "0,6-13",
               "numReferrers" : 1
             },
             "vrf1" : {
-              "definitionLines" : [
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26
-              ],
+              "definitionLines" : "15-26",
               "numReferrers" : 0
             }
           }
@@ -86228,22 +82374,15 @@
         "configs/nxos_acl" : {
           "extended ipv4 access-list" : {
             "blah" : {
-              "definitionLines" : [
-                9,
-                10
-              ],
+              "definitionLines" : "9-10",
               "numReferrers" : 0
             },
             "extended" : {
-              "definitionLines" : [
-                5
-              ],
+              "definitionLines" : "5",
               "numReferrers" : 0
             },
             "standard" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 0
             }
           }
@@ -86252,17 +82391,11 @@
         "configs/palo_alto/applications" : {
           "application-group" : {
             "EMPTY~panorama" : {
-              "definitionLines" : [
-                19,
-                20
-              ],
+              "definitionLines" : "19-20",
               "numReferrers" : 0
             },
             "SSH_OR_SSL~panorama" : {
-              "definitionLines" : [
-                16,
-                17
-              ],
+              "definitionLines" : "16-17",
               "numReferrers" : 0
             }
           }
@@ -86270,83 +82403,39 @@
         "configs/palo_alto/interfaces" : {
           "interface" : {
             "ethernet1/1" : {
-              "definitionLines" : [
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27
-              ],
+              "definitionLines" : "13-18,22-27",
               "numReferrers" : 0
             },
             "ethernet1/1.4" : {
-              "definitionLines" : [
-                16,
-                17,
-                18
-              ],
+              "definitionLines" : "16-18",
               "numReferrers" : 0
             },
             "ethernet1/1.5" : {
-              "definitionLines" : [
-                24,
-                25,
-                26,
-                27
-              ],
+              "definitionLines" : "24-27",
               "numReferrers" : 0
             },
             "loopback" : {
-              "definitionLines" : [
-                33,
-                34,
-                35,
-                36
-              ],
+              "definitionLines" : "33-36",
               "numReferrers" : 0
             },
             "loopback.1" : {
-              "definitionLines" : [
-                36
-              ],
+              "definitionLines" : "36",
               "numReferrers" : 0
             },
             "tunnel" : {
-              "definitionLines" : [
-                39,
-                40,
-                41,
-                42
-              ],
+              "definitionLines" : "39-42",
               "numReferrers" : 0
             },
             "tunnel.3" : {
-              "definitionLines" : [
-                41,
-                42
-              ],
+              "definitionLines" : "41-42",
               "numReferrers" : 0
             },
             "vlan" : {
-              "definitionLines" : [
-                46,
-                47,
-                48,
-                49
-              ],
+              "definitionLines" : "46-49",
               "numReferrers" : 0
             },
             "vlan.1" : {
-              "definitionLines" : [
-                49
-              ],
+              "definitionLines" : "49",
               "numReferrers" : 0
             }
           }
@@ -86354,71 +82443,31 @@
         "configs/palo_alto/nat" : {
           "nat rule" : {
             "MISSING_DESTINATION~panorama" : {
-              "definitionLines" : [
-                57,
-                58,
-                59,
-                60
-              ],
+              "definitionLines" : "57-60",
               "numReferrers" : 0
             },
             "MISSING_FROM~panorama" : {
-              "definitionLines" : [
-                50,
-                51
-              ],
+              "definitionLines" : "50-51",
               "numReferrers" : 0
             },
             "MISSING_SOURCE~panorama" : {
-              "definitionLines" : [
-                53,
-                54,
-                55
-              ],
+              "definitionLines" : "53-55",
               "numReferrers" : 0
             },
             "MISSING_TO~panorama" : {
-              "definitionLines" : [
-                49
-              ],
+              "definitionLines" : "49",
               "numReferrers" : 0
             },
             "RULE_1~panorama" : {
-              "definitionLines" : [
-                18,
-                19,
-                20,
-                22,
-                23,
-                24,
-                27,
-                28,
-                29,
-                30
-              ],
+              "definitionLines" : "18-20,22-24,27-30",
               "numReferrers" : 0
             },
             "RULE_2~panorama" : {
-              "definitionLines" : [
-                32,
-                33,
-                34,
-                35,
-                36
-              ],
+              "definitionLines" : "32-36",
               "numReferrers" : 0
             },
             "RULE_3~panorama" : {
-              "definitionLines" : [
-                38,
-                39,
-                40,
-                41,
-                42,
-                45,
-                46,
-                47
-              ],
+              "definitionLines" : "38-42,45-47",
               "numReferrers" : 0
             }
           }
@@ -86426,10 +82475,7 @@
         "configs/palo_alto/policy" : {
           "address object" : {
             "rfc1918_10~panorama" : {
-              "definitionLines" : [
-                17,
-                18
-              ],
+              "definitionLines" : "17-18",
               "numReferrers" : 0
             }
           }
@@ -86437,23 +82483,11 @@
         "configs/palo_alto/virtual-routers" : {
           "virtual-router" : {
             "vr1" : {
-              "definitionLines" : [
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19
-              ],
+              "definitionLines" : "12-19",
               "numReferrers" : 2
             },
             "vr2" : {
-              "definitionLines" : [
-                26,
-                27
-              ],
+              "definitionLines" : "26-27",
               "numReferrers" : 2
             }
           }
@@ -86461,73 +82495,41 @@
         "configs/palo_alto/zones" : {
           "interface" : {
             "ethernet1/1" : {
-              "definitionLines" : [
-                13,
-                14
-              ],
+              "definitionLines" : "13-14",
               "numReferrers" : 2
             },
             "ethernet1/2" : {
-              "definitionLines" : [
-                16,
-                17
-              ],
+              "definitionLines" : "16-17",
               "numReferrers" : 2
             },
             "ethernet1/3" : {
-              "definitionLines" : [
-                19,
-                20
-              ],
+              "definitionLines" : "19-20",
               "numReferrers" : 2
             },
             "ethernet1/4" : {
-              "definitionLines" : [
-                22,
-                23
-              ],
+              "definitionLines" : "22-23",
               "numReferrers" : 2
             }
           },
           "zone" : {
             "zext~vsys10" : {
-              "definitionLines" : [
-                36,
-                37,
-                38
-              ],
+              "definitionLines" : "36-38",
               "numReferrers" : 0
             },
             "zl2~vsys10" : {
-              "definitionLines" : [
-                41,
-                42,
-                43
-              ],
+              "definitionLines" : "41-43",
               "numReferrers" : 1
             },
             "zl3~vsys10" : {
-              "definitionLines" : [
-                46,
-                47,
-                48
-              ],
+              "definitionLines" : "46-48",
               "numReferrers" : 1
             },
             "ztap~vsys10" : {
-              "definitionLines" : [
-                51,
-                52,
-                53
-              ],
+              "definitionLines" : "51-53",
               "numReferrers" : 1
             },
             "zvirtual-wire~vsys10" : {
-              "definitionLines" : [
-                56,
-                57,
-                58
-              ],
+              "definitionLines" : "56-58",
               "numReferrers" : 1
             }
           }
@@ -86535,15 +82537,7 @@
         "configs/pim" : {
           "interface" : {
             "Loopback1" : {
-              "definitionLines" : [
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31
-              ],
+              "definitionLines" : "25-31",
               "numReferrers" : 1
             }
           }
@@ -86552,25 +82546,17 @@
         "configs/prefix_list_ipv4" : {
           "ipv4 prefix-list" : {
             "default" : {
-              "definitionLines" : [
-                7
-              ],
+              "definitionLines" : "7",
               "numReferrers" : 1
             },
             "test" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 0
             }
           },
           "route-map" : {
             "to_elacc" : {
-              "definitionLines" : [
-                9,
-                10
-              ],
+              "definitionLines" : "9-10",
               "numReferrers" : 0
             }
           }
@@ -86578,68 +82564,25 @@
         "configs/route_policy_as_path" : {
           "as-path-set" : {
             "ama-coe-as-path" : {
-              "definitionLines" : [
-                35,
-                36,
-                37
-              ],
+              "definitionLines" : "35-37",
               "numReferrers" : 0
             },
             "ama-coe-as-path2" : {
-              "definitionLines" : [
-                38,
-                39
-              ],
+              "definitionLines" : "38-39",
               "numReferrers" : 0
             },
             "ama-coe-as-path3" : {
-              "definitionLines" : [
-                40,
-                41,
-                42,
-                43,
-                44
-              ],
+              "definitionLines" : "40-44",
               "numReferrers" : 0
             }
           },
           "route-policy" : {
             "erick-test" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12
-              ],
+              "definitionLines" : "5-12",
               "numReferrers" : 0
             },
             "to_fooey" : {
-              "definitionLines" : [
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                32,
-                33
-              ],
+              "definitionLines" : "14-33",
               "numReferrers" : 0
             }
           }
@@ -86647,17 +82590,7 @@
         "configs/route_policy_igp_cost" : {
           "route-policy" : {
             "EBGP_CUST_FULL_v4" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13
-              ],
+              "definitionLines" : "5-13",
               "numReferrers" : 0
             }
           }
@@ -86665,18 +82598,7 @@
         "configs/route_policy_metric_type" : {
           "route-policy" : {
             "to_csuchico" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14
-              ],
+              "definitionLines" : "5-14",
               "numReferrers" : 0
             }
           }
@@ -86684,30 +82606,11 @@
         "configs/route_policy_param" : {
           "route-policy" : {
             "cust_v4_in" : {
-              "definitionLines" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11
-              ],
+              "definitionLines" : "5-11",
               "numReferrers" : 0
             },
             "global_cust_v4" : {
-              "definitionLines" : [
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22
-              ],
+              "definitionLines" : "13-22",
               "numReferrers" : 0
             }
           }
@@ -86716,11 +82619,7 @@
         "configs/set_inline_community" : {
           "route-policy" : {
             "FOOBAR" : {
-              "definitionLines" : [
-                5,
-                6,
-                7
-              ],
+              "definitionLines" : "5-7",
               "numReferrers" : 0
             }
           }
@@ -86729,11 +82628,7 @@
         "configs/switchport_range" : {
           "interface" : {
             "FastEthernet0/1" : {
-              "definitionLines" : [
-                4,
-                5,
-                6
-              ],
+              "definitionLines" : "4-6",
               "numReferrers" : 1
             }
           }
@@ -86743,14 +82638,7 @@
         "configs/tcpflags" : {
           "extended ipv4 access-list" : {
             "100" : {
-              "definitionLines" : [
-                4,
-                5,
-                6,
-                7,
-                8,
-                9
-              ],
+              "definitionLines" : "4-9",
               "numReferrers" : 0
             }
           }
@@ -86758,10 +82646,7 @@
         "configs/underscore_variable" : {
           "route-map" : {
             "JKL_MNO_PQR" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 0
             }
           }
@@ -86769,10 +82654,7 @@
         "configs/variables" : {
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 1
             }
           }
@@ -86780,10 +82662,7 @@
         "configs/variables_dos" : {
           "interface" : {
             "FastEthernet0/0" : {
-              "definitionLines" : [
-                4,
-                5
-              ],
+              "definitionLines" : "4-5",
               "numReferrers" : 1
             }
           }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -83588,5734 +83588,3657 @@
         "configs/arista_bgp" : {
           "bgp peer-group" : {
             "UNDEFINED_PEER_GROUP" : {
-              "bgp neighbor peer-group" : [
-                12
-              ]
+              "bgp neighbor peer-group" : "12"
             }
           },
           "route-map" : {
             "ROUTE_MAP" : {
-              "bgp redistribute ospfv3 route-map" : [
-                13
-              ]
+              "bgp redistribute ospfv3 route-map" : "13"
             },
             "UNDEFINED_MAP" : {
-              "bgp redistribute ospfv3 route-map" : [
-                14
-              ]
+              "bgp redistribute ospfv3 route-map" : "14"
             }
           }
         },
         "configs/arista_dhcp_relay" : {
           "interface" : {
             "Ethernet0" : {
-              "interface" : [
-                10
-              ]
+              "interface" : "10"
             },
             "Ethernet1" : {
-              "interface" : [
-                14
-              ]
+              "interface" : "14"
             }
           }
         },
         "configs/arista_interface" : {
           "interface" : {
             "Vlan1" : {
-              "interface" : [
-                5
-              ]
+              "interface" : "5"
             }
           },
           "policy-map" : {
             "pbr-pmap" : {
-              "interface service-policy" : [
-                10
-              ]
+              "interface service-policy" : "10"
             },
             "qos-pmap" : {
-              "interface service-policy" : [
-                11
-              ]
+              "interface service-policy" : "11"
             }
           },
           "standard ipv4 access-list" : {
             "some_acl" : {
-              "interface ip multicast boundary" : [
-                9
-              ]
+              "interface ip multicast boundary" : "9"
             }
           }
         },
         "configs/arista_ip_route" : {
           "interface" : {
             "Null0" : {
-              "ip route next-hop interface" : [
-                5
-              ]
+              "ip route next-hop interface" : "5"
             }
           }
         },
         "configs/arista_misc" : {
           "ipv4 acl" : {
             "abc" : {
-              "management telnet ip access-group" : [
-                41
-              ]
+              "management telnet ip access-group" : "41"
             },
             "sshabc" : {
-              "management ssh ip access-group" : [
-                35
-              ]
+              "management ssh ip access-group" : "35"
             }
           }
         },
         "configs/arista_nat" : {
           "interface" : {
             "Ethernet1" : {
-              "interface" : [
-                14
-              ]
+              "interface" : "14"
             }
           },
           "ipv4 acl" : {
             "acl1" : {
-              "ip nat source dynamic access-list" : [
-                16
-              ]
+              "ip nat source dynamic access-list" : "16"
             }
           },
           "nat pool" : {
             "pool1" : {
-              "ip nat source pool" : [
-                16
-              ]
+              "ip nat source pool" : "16"
             }
           }
         },
         "configs/arista_ospf" : {
           "interface" : {
             "Ethernet1" : {
-              "interface" : [
-                5
-              ]
+              "interface" : "5"
             }
           }
         },
         "configs/aruba_crypto" : {
           "crypto ipsec transform-set" : {
             "\"" : {
-              "crypto dynamic-map transform-set" : [
-                5
-              ]
+              "crypto dynamic-map transform-set" : "5"
             },
             "bar" : {
-              "crypto dynamic-map transform-set" : [
-                5
-              ]
+              "crypto dynamic-map transform-set" : "5"
             },
             "baz" : {
-              "crypto dynamic-map transform-set" : [
-                5
-              ]
+              "crypto dynamic-map transform-set" : "5"
             },
             "foo" : {
-              "crypto dynamic-map transform-set" : [
-                5
-              ]
+              "crypto dynamic-map transform-set" : "5"
             }
           },
           "crypto isakmp policy" : {
             "1" : {
-              "isakmp policy" : [
-                12
-              ]
+              "isakmp policy" : "12"
             }
           }
         },
         "configs/aruba_interface" : {
           "interface" : {
             "GigabitEthernet0/0/0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           }
         },
         "configs/asa_acl" : {
           "object-group network" : {
             "drawbridge_hosts" : {
-              "extended access-list network object-group" : [
-                9
-              ]
+              "extended access-list network object-group" : "9"
             }
           }
         },
         "configs/asa_interface" : {
           "interface" : {
             "GigabitEthernet0/1" : {
-              "interface" : [
-                6
-              ],
-              "service-policy interface" : [
-                8
-              ]
+              "interface" : "6",
+              "service-policy interface" : "8"
             },
             "ifname" : {
-              "interface" : [
-                7
-              ]
+              "interface" : "7"
             }
           },
           "policy-map" : {
             "some-interface-policy" : {
-              "service-policy interface policy" : [
-                8
-              ]
+              "service-policy interface policy" : "8"
             }
           }
         },
         "configs/asa_nat" : {
           "interface" : {
             "inside" : {
-              "object nat real interface" : [
-                16,
-                17,
-                18,
-                19
-              ],
-              "twice nat real interface" : [
-                7,
-                8,
-                9
-              ]
+              "object nat real interface" : "16-19",
+              "twice nat real interface" : "7-9"
             },
             "outside" : {
-              "object nat mapped interface" : [
-                16,
-                17,
-                18,
-                20
-              ],
-              "twice nat mapped interface" : [
-                7,
-                8,
-                9
-              ]
+              "object nat mapped interface" : "16-18,20",
+              "twice nat mapped interface" : "7-9"
             }
           },
           "object network" : {
             "interface" : {
-              "twice nat mapped destination network object" : [
-                8
-              ],
-              "twice nat mapped source network object" : [
-                8
-              ]
+              "twice nat mapped destination network object" : "8",
+              "twice nat mapped source network object" : "8"
             },
             "net1" : {
-              "twice nat real source network object" : [
-                8,
-                9,
-                11,
-                12,
-                13
-              ]
+              "twice nat real source network object" : "8-9,11-13"
             },
             "net2" : {
-              "twice nat mapped source network object" : [
-                9,
-                11,
-                12,
-                13
-              ],
-              "twice nat real destination network object" : [
-                8
-              ]
+              "twice nat mapped source network object" : "9,11-13",
+              "twice nat real destination network object" : "8"
             },
             "net3" : {
-              "twice nat mapped destination network object" : [
-                11
-              ]
+              "twice nat mapped destination network object" : "11"
             },
             "net4" : {
-              "twice nat real destination network object" : [
-                11
-              ]
+              "twice nat real destination network object" : "11"
             },
             "source-mapped" : {
-              "object nat mapped source network object" : [
-                18,
-                22,
-                23
-              ]
+              "object nat mapped source network object" : "18,22-23"
             },
             "source-real" : {
-              "object nat real source network object" : [
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23
-              ]
+              "object nat real source network object" : "16-23"
             }
           }
         },
         "configs/asa_object_groups" : {
           "object network" : {
             "server02" : {
-              "extended access-list network object" : [
-                15
-              ]
+              "extended access-list network object" : "15"
             }
           }
         },
         "configs/asa_ospf" : {
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                5
-              ]
+              "interface" : "5"
             },
             "blah" : {
-              "interface" : [
-                7
-              ]
+              "interface" : "7"
             }
           }
         },
         "configs/bgp_address_family" : {
           "bgp peer-group" : {
             "as1" : {
-              "bgp neighbor peer-group" : [
-                13
-              ]
+              "bgp neighbor peer-group" : "13"
             },
             "as2" : {
-              "bgp neighbor peer-group" : [
-                15
-              ]
+              "bgp neighbor peer-group" : "15"
             }
           },
           "interface" : {
             "Loopback0" : {
-              "update-source interface" : [
-                14
-              ]
+              "update-source interface" : "14"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp outbound route-map" : [
-                26
-              ]
+              "bgp outbound route-map" : "26"
             },
             "as1_to_as3" : {
-              "bgp outbound route-map" : [
-                28
-              ]
+              "bgp outbound route-map" : "28"
             },
             "as2_to_as1" : {
-              "bgp inbound route-map" : [
-                27
-              ]
+              "bgp inbound route-map" : "27"
             },
             "as3_to_as1" : {
-              "bgp inbound route-map" : [
-                29
-              ]
+              "bgp inbound route-map" : "29"
             }
           },
           "undeclared bgp peer" : {
             "13.16.3.16" : {
-              "bgp neighbor without remote-as" : [
-                17
-              ]
+              "bgp neighbor without remote-as" : "17"
             }
           }
         },
         "configs/bgp_default_originate_policy" : {
           "route-policy" : {
             "EBGP_CUST_FULL_v4" : {
-              "bgp neighbor route-policy out" : [
-                14
-              ]
+              "bgp neighbor route-policy out" : "14"
             },
             "cust_v4_in" : {
-              "bgp neighbor route-policy in" : [
-                12
-              ]
+              "bgp neighbor route-policy in" : "12"
             }
           }
         },
         "configs/bgp_foundry" : {
           "route-map" : {
             "from_ucr" : {
-              "bgp inbound route-map" : [
-                10
-              ]
+              "bgp inbound route-map" : "10"
             },
             "tag-bbone-prefixes" : {
-              "bgp ipv4 network statement route-map" : [
-                15
-              ]
+              "bgp ipv4 network statement route-map" : "15"
             }
           }
         },
         "configs/bgp_route_policy" : {
           "bgp neighbor-group" : {
             "EBGP-PEER-SVL-PNI" : {
-              "bgp use neighbor-group" : [
-                20
-              ]
+              "bgp use neighbor-group" : "20"
             }
           },
           "route-policy" : {
             "EBGP-PEER-AS11164-SVL-PNI-IN" : {
-              "bgp neighbor route-policy in" : [
-                24
-              ]
+              "bgp neighbor route-policy in" : "24"
             },
             "EBGP-PEER-AS11164-SVL-PNI-OUT" : {
-              "bgp neighbor route-policy out" : [
-                26
-              ]
+              "bgp neighbor route-policy out" : "26"
             }
           }
         },
         "configs/cadant_bgp" : {
           "interface" : {
             "Loopback15" : {
-              "update-source interface" : [
-                12,
-                17
-              ]
+              "update-source interface" : "12,17"
             }
           },
           "route-map" : {
             "blarp" : {
-              "bgp outbound route-map" : [
-                28
-              ]
+              "bgp outbound route-map" : "28"
             },
             "blerp" : {
-              "bgp outbound ipv6 route-map" : [
-                35
-              ]
+              "bgp outbound ipv6 route-map" : "35"
             }
           }
         },
         "configs/cadant_cable" : {
           "docsis-policy-rule" : {
             "1" : {
-              "cable load-balance docsis-policy rule" : [
-                48
-              ]
+              "cable load-balance docsis-policy rule" : "48"
             }
           }
         },
         "configs/cadant_interface" : {
           "interface" : {
             "Ethernet6/0.0" : {
-              "interface" : [
-                104
-              ]
+              "interface" : "104"
             },
             "Ethernet6/0.48" : {
-              "interface" : [
-                124
-              ]
+              "interface" : "124"
             },
             "Ethernet6/1" : {
-              "interface" : [
-                129
-              ]
+              "interface" : "129"
             },
             "cable-downstream1/2" : {
-              "interface" : [
-                5
-              ]
+              "interface" : "5"
             },
             "cable-downstream1/2/3" : {
-              "interface" : [
-                8
-              ]
+              "interface" : "8"
             },
             "cable-downstream5/0/0" : {
-              "interface" : [
-                15
-              ]
+              "interface" : "15"
             },
             "cable-mac1" : {
-              "interface" : [
-                39,
-                42
-              ]
+              "interface" : "39,42"
             },
             "cable-mac1.1" : {
-              "interface" : [
-                59
-              ]
+              "interface" : "59"
             },
             "cable-mac1.2" : {
-              "interface" : [
-                88
-              ]
+              "interface" : "88"
             },
             "cable-mac2" : {
-              "interface" : [
-                40
-              ]
+              "interface" : "40"
             },
             "cable-mac3" : {
-              "interface" : [
-                41
-              ]
+              "interface" : "41"
             },
             "cable-upstream1/0/0" : {
-              "interface" : [
-                21
-              ]
+              "interface" : "21"
             },
             "cable-upstream1/0/0.0" : {
-              "interface" : [
-                31
-              ]
+              "interface" : "31"
             },
             "cable-upstream1/0/10" : {
-              "interface" : [
-                29,
-                30
-              ]
+              "interface" : "29-30"
             },
             "mgmt6/0" : {
-              "interface" : [
-                134
-              ]
+              "interface" : "134"
             }
           },
           "ipv4/6 acl" : {
             "fleep-acl" : {
-              "interface ip inband access-group" : [
-                130
-              ]
+              "interface ip inband access-group" : "130"
             }
           },
           "ipv6 acl" : {
             "bar-filter" : {
-              "interface ipv6 traffic-filter out" : [
-                86
-              ]
+              "interface ipv6 traffic-filter out" : "86"
             },
             "foo-filter" : {
-              "interface ipv6 traffic-filter in" : [
-                85
-              ]
+              "interface ipv6 traffic-filter in" : "85"
             }
           }
         },
         "configs/cadant_isis" : {
           "ipv4/6 acl" : {
             "blah-acl-99" : {
-              "router isis distribute-list acl" : [
-                15
-              ]
+              "router isis distribute-list acl" : "15"
             },
             "blah-ipv6-access-list" : {
-              "router isis distribute-list acl" : [
-                20
-              ]
+              "router isis distribute-list acl" : "20"
             }
           }
         },
         "configs/cadant_misc" : {
           "interface" : {
             "Loopback0" : {
-              "ntp source-interface" : [
-                80
-              ],
-              "tacacs source-interface" : [
-                94
-              ]
+              "ntp source-interface" : "80",
+              "tacacs source-interface" : "94"
             }
           }
         },
         "configs/cadant_rip" : {
           "ipv4/6 acl" : {
             "blah-std-acl" : {
-              "router rip distribute-list" : [
-                6
-              ]
+              "router rip distribute-list" : "6"
             }
           }
         },
         "configs/cadant_route_map" : {
           "ipv4 prefix-list" : {
             "bar-prefix-list" : {
-              "route-map match ipv4 prefix-list" : [
-                6
-              ]
+              "route-map match ipv4 prefix-list" : "6"
             }
           },
           "ipv6 prefix-list" : {
             "baz-ipv6-prefix-list" : {
-              "route-map match ipv6 prefix-list" : [
-                10
-              ]
+              "route-map match ipv6 prefix-list" : "10"
             }
           }
         },
         "configs/cadant_snmp" : {
           "interface" : {
             "Loopback0" : {
-              "snmp-server source-interface" : [
-                18
-              ]
+              "snmp-server source-interface" : "18"
             }
           },
           "ipv4 acl" : {
             "52" : {
-              "snmp server community ipv4 acl" : [
-                7
-              ]
+              "snmp server community ipv4 acl" : "7"
             }
           }
         },
         "configs/cisco_additional_paths" : {
           "undeclared bgp peer" : {
             "1.2.3.4" : {
-              "bgp neighbor without remote-as" : [
-                8,
-                9
-              ]
+              "bgp neighbor without remote-as" : "8-9"
             }
           }
         },
         "configs/cisco_asa/asa-interface-redundant" : {
           "interface" : {
             "GigabitEthernet0/1" : {
-              "interface" : [
-                7
-              ],
-              "interface member-interface" : [
-                25
-              ]
+              "interface" : "7",
+              "interface member-interface" : "25"
             },
             "GigabitEthernet0/2" : {
-              "interface" : [
-                15
-              ],
-              "interface member-interface" : [
-                24
-              ]
+              "interface" : "15",
+              "interface member-interface" : "24"
             },
             "Redundant1" : {
-              "interface" : [
-                23
-              ]
+              "interface" : "23"
             },
             "Redundant1.2" : {
-              "interface" : [
-                31
-              ]
+              "interface" : "31"
             },
             "Redundant2" : {
-              "interface" : [
-                38
-              ]
+              "interface" : "38"
             },
             "Redundant2.2" : {
-              "interface" : [
-                44
-              ]
+              "interface" : "44"
             },
             "redundant1sub" : {
-              "interface" : [
-                33
-              ]
+              "interface" : "33"
             },
             "redundant2sub" : {
-              "interface" : [
-                46
-              ]
+              "interface" : "46"
             }
           }
         },
         "configs/cisco_bgp" : {
           "as-path access-list" : {
             "10" : {
-              "bgp neighbor filter-list access-list" : [
-                10
-              ]
+              "bgp neighbor filter-list access-list" : "10"
             },
             "20" : {
-              "bgp neighbor filter-list access-list" : [
-                14
-              ]
+              "bgp neighbor filter-list access-list" : "14"
             },
             "40" : {
-              "bgp neighbor filter-list access-list" : [
-                18
-              ]
+              "bgp neighbor filter-list access-list" : "18"
             }
           },
           "bgp template peer-policy" : {
             "p2" : {
-              "inherited BGP peer-policy" : [
-                36
-              ]
+              "inherited BGP peer-policy" : "36"
             },
             "p310" : {
-              "inherited BGP peer-policy" : [
-                37
-              ]
+              "inherited BGP peer-policy" : "37"
             }
           },
           "ipv4 acl" : {
             "5" : {
-              "bgp neighbor distribute-list access-list in" : [
-                41
-              ],
-              "bgp neighbor distribute-list access-list out" : [
-                42
-              ]
+              "bgp neighbor distribute-list access-list in" : "41",
+              "bgp neighbor distribute-list access-list out" : "42"
             }
           },
           "route-map" : {
             "AGGREGATE-MAP" : {
-              "bgp vrf aggregate-address attribute-map" : [
-                49
-              ]
+              "bgp vrf aggregate-address attribute-map" : "49"
             },
             "CONNECTED-TO-BGP" : {
-              "bgp redistribute connected route-map" : [
-                50
-              ]
+              "bgp redistribute connected route-map" : "50"
             },
             "UNSUPP-MAP" : {
-              "bgp unsuppress-map" : [
-                40
-              ]
+              "bgp unsuppress-map" : "40"
             },
             "abcdefg" : {
-              "bgp redistribute static route-map" : [
-                33
-              ]
+              "bgp redistribute static route-map" : "33"
             },
             "blah" : {
-              "bgp redistribute rip route-map" : [
-                34
-              ]
+              "bgp redistribute rip route-map" : "34"
             },
             "bloop" : {
-              "bgp redistribute connected route-map" : [
-                28
-              ]
+              "bgp redistribute connected route-map" : "28"
             },
             "ospfv3_map" : {
-              "bgp redistribute ospfv3 route-map" : [
-                45
-              ]
+              "bgp redistribute ospfv3 route-map" : "45"
             }
           },
           "undeclared bgp peer" : {
             "10.0.0.1" : {
-              "bgp neighbor without remote-as" : [
-                39,
-                40,
-                41,
-                42
-              ]
+              "bgp neighbor without remote-as" : "39-42"
             },
             "10.20.2.2" : {
-              "bgp neighbor without remote-as" : [
-                10
-              ]
+              "bgp neighbor without remote-as" : "10"
             },
             "192.168.3.2" : {
-              "bgp neighbor without remote-as" : [
-                14
-              ]
+              "bgp neighbor without remote-as" : "14"
             },
             "192.168.4.2" : {
-              "bgp neighbor without remote-as" : [
-                18
-              ]
+              "bgp neighbor without remote-as" : "18"
             }
           }
         },
         "configs/cisco_cable" : {
           "cable service-class" : {
             "barfoo" : {
-              "cable qos enforce-rule service-class" : [
-                77
-              ]
+              "cable qos enforce-rule service-class" : "77"
             },
             "foobar" : {
-              "cable qos enforce-rule service-class" : [
-                78
-              ]
+              "cable qos enforce-rule service-class" : "78"
             }
           },
           "depi-class" : {
             "depiclass1" : {
-              "depi-tunnel depi-class" : [
-                138
-              ]
+              "depi-tunnel depi-class" : "138"
             }
           },
           "depi-tunnel" : {
             "depitun0" : {
-              "controller rf-channel depi-tunnel" : [
-                124
-              ]
+              "controller rf-channel depi-tunnel" : "124"
             },
             "foo1" : {
-              "depi-tunnel protect-tunnel" : [
-                141
-              ]
+              "depi-tunnel protect-tunnel" : "141"
             }
           },
           "docsis-policy" : {
             "1" : {
-              "cable load-balance docsis-group docsis-policy" : [
-                30
-              ]
+              "cable load-balance docsis-group docsis-policy" : "30"
             }
           },
           "docsis-policy-rule" : {
             "1" : {
-              "cable load-balance docsis-policy rule" : [
-                42
-              ]
+              "cable load-balance docsis-policy rule" : "42"
             }
           },
           "interface" : {
             "Cable1/2/3" : {
-              "interface" : [
-                143
-              ]
+              "interface" : "143"
             }
           },
           "l2tp-class" : {
             "l2tpclass1" : {
-              "depi-tunnel l2tp-class" : [
-                140
-              ]
+              "depi-tunnel l2tp-class" : "140"
             }
           }
         },
         "configs/cisco_control_plane" : {
           "policy-map" : {
             "copp-policy" : {
-              "control-plane service-policy input" : [
-                5
-              ]
+              "control-plane service-policy input" : "5"
             },
             "copp-policy-out" : {
-              "control-plane service-policy output" : [
-                6
-              ]
+              "control-plane service-policy output" : "6"
             }
           }
         },
         "configs/cisco_crypto" : {
           "crypto ipsec transform-set" : {
             "ESP-3DES-MD5" : {
-              "crypto dynamic-map transform-set" : [
-                101,
-                105,
-                111
-              ]
+              "crypto dynamic-map transform-set" : "101,105,111"
             },
             "ESP-3DES-MD5-trans" : {
-              "crypto dynamic-map transform-set" : [
-                101
-              ]
+              "crypto dynamic-map transform-set" : "101"
             },
             "ESP-3DES-SHA" : {
-              "crypto dynamic-map transform-set" : [
-                101,
-                105,
-                111
-              ]
+              "crypto dynamic-map transform-set" : "101,105,111"
             },
             "ESP-3DES-SHA-TRANS" : {
-              "crypto dynamic-map transform-set" : [
-                101
-              ]
+              "crypto dynamic-map transform-set" : "101"
             },
             "ESP-AES-128-MD5" : {
-              "crypto dynamic-map transform-set" : [
-                105
-              ]
+              "crypto dynamic-map transform-set" : "105"
             },
             "ESP-AES-128-SHA" : {
-              "crypto dynamic-map transform-set" : [
-                105
-              ]
+              "crypto dynamic-map transform-set" : "105"
             },
             "ESP-AES-192-MD5" : {
-              "crypto dynamic-map transform-set" : [
-                105
-              ]
+              "crypto dynamic-map transform-set" : "105"
             },
             "ESP-AES-192-SHA" : {
-              "crypto dynamic-map transform-set" : [
-                105
-              ]
+              "crypto dynamic-map transform-set" : "105"
             },
             "ESP-AES-256-MD5" : {
-              "crypto dynamic-map transform-set" : [
-                105
-              ]
+              "crypto dynamic-map transform-set" : "105"
             },
             "ESP-AES-256-SHA" : {
-              "crypto dynamic-map transform-set" : [
-                105
-              ]
+              "crypto dynamic-map transform-set" : "105"
             },
             "ESP-DES-MD5" : {
-              "crypto dynamic-map transform-set" : [
-                105
-              ]
+              "crypto dynamic-map transform-set" : "105"
             },
             "ESP-DES-SHA" : {
-              "crypto dynamic-map transform-set" : [
-                105
-              ]
+              "crypto dynamic-map transform-set" : "105"
             },
             "bleep" : {
-              "crypto map ipsec-isakmp transform-set" : [
-                227
-              ]
+              "crypto map ipsec-isakmp transform-set" : "227"
             },
             "hijklmnop" : {
-              "ipsec profile set transform-set" : [
-                160
-              ]
+              "ipsec profile set transform-set" : "160"
             },
             "mytransformset" : {
-              "crypto map ipsec-isakmp transform-set" : [
-                246
-              ]
+              "crypto map ipsec-isakmp transform-set" : "246"
             }
           },
           "crypto isakmp policy" : {
             "1" : {
-              "isakmp policy" : [
-                181
-              ]
+              "isakmp policy" : "181"
             }
           },
           "crypto isakmp profile" : {
             "myisakmpprofile" : {
-              "crypto map ipsec-isakmp isakmp-profile" : [
-                242
-              ]
+              "crypto map ipsec-isakmp isakmp-profile" : "242"
             },
             "myprofile" : {
-              "isakmp profile" : [
-                190
-              ]
+              "isakmp profile" : "190"
             },
             "someOtherprofile" : {
-              "ipsec profile set isakmp-profile" : [
-                163
-              ]
+              "ipsec profile set isakmp-profile" : "163"
             }
           },
           "crypto keyring" : {
             "VRF:MMS:RMT:UPM:1143" : {
-              "isakmp profile keyring" : [
-                191
-              ]
+              "isakmp profile keyring" : "191"
             }
           },
           "crypto named rsa pubkey" : {
             "a.example.com" : {
-              "named rsa pubkey" : [
-                203
-              ]
+              "named rsa pubkey" : "203"
             }
           },
           "crypto-dynamic-map-set" : {
             "bippety" : {
-              "crypto map ipsec-isakmp crypto-dynamic-map-set" : [
-                229
-              ]
+              "crypto map ipsec-isakmp crypto-dynamic-map-set" : "229"
             },
             "mydefaultcryptomap" : {
-              "crypto map ipsec-isakmp crypto-dynamic-map-set" : [
-                220
-              ]
+              "crypto map ipsec-isakmp crypto-dynamic-map-set" : "220"
             }
           },
           "ipv4/6 acl" : {
             "myvpnacl" : {
-              "crypto map ipsec-isakmp acl" : [
-                240
-              ]
+              "crypto map ipsec-isakmp acl" : "240"
             },
             "someacl" : {
-              "crypto map ipsec-isakmp acl" : [
-                224
-              ],
-              "crypto map match address" : [
-                232
-              ]
+              "crypto map ipsec-isakmp acl" : "224",
+              "crypto map match address" : "232"
             }
           }
         },
         "configs/cisco_domain" : {
           "interface" : {
             "Loopback666" : {
-              "domain lookup source-interface" : [
-                5
-              ]
+              "domain lookup source-interface" : "5"
             }
           }
         },
         "configs/cisco_eigrp" : {
           "interface" : {
             "Ethernet0" : {
-              "eigrp address-family af-interface" : [
-                123
-              ],
-              "interface" : [
-                165
-              ]
+              "eigrp address-family af-interface" : "123",
+              "interface" : "165"
             },
             "FastEthernet0/1" : {
-              "eigrp passive-interface" : [
-                147
-              ]
+              "eigrp passive-interface" : "147"
             },
             "GigabitEthernet1/5/3" : {
-              "eigrp passive-interface" : [
-                27
-              ]
+              "eigrp passive-interface" : "27"
             },
             "GigabitEthernet2/5/3" : {
-              "eigrp passive-interface" : [
-                28
-              ]
+              "eigrp passive-interface" : "28"
             },
             "Port-channel34" : {
-              "eigrp passive-interface" : [
-                29
-              ]
+              "eigrp passive-interface" : "29"
             },
             "Port-channel35" : {
-              "eigrp passive-interface" : [
-                30
-              ]
+              "eigrp passive-interface" : "30"
             }
           },
           "route-map" : {
             "BGP_TO_EIGRP" : {
-              "eigrp redistribute bgp route-map" : [
-                35
-              ]
+              "eigrp redistribute bgp route-map" : "35"
             },
             "CONNECTED_TO_EIGRP" : {
-              "eigrp redistribute connected route-map" : [
-                36
-              ]
+              "eigrp redistribute connected route-map" : "36"
             },
             "EIGRP_TO_EIGRP" : {
-              "eigrp redistribute eigrp route-map" : [
-                37
-              ]
+              "eigrp redistribute eigrp route-map" : "37"
             },
             "ISIS_TO_EIGRP" : {
-              "eigrp redistribute isis route-map" : [
-                38
-              ]
+              "eigrp redistribute isis route-map" : "38"
             },
             "OSPF_TO_EIGRP" : {
-              "eigrp redistribute ospf route-map" : [
-                39
-              ]
+              "eigrp redistribute ospf route-map" : "39"
             },
             "RIP_TO_EIGRP" : {
-              "eigrp redistribute rip route-map" : [
-                40
-              ]
+              "eigrp redistribute rip route-map" : "40"
             },
             "STATIC_TO_EIGRP" : {
-              "eigrp redistribute static route-map" : [
-                41
-              ]
+              "eigrp redistribute static route-map" : "41"
             }
           }
         },
         "configs/cisco_flow" : {
           "interface" : {
             "GigabitEthernet0/1" : {
-              "interface" : [
-                52
-              ]
+              "interface" : "52"
             }
           }
         },
         "configs/cisco_hsrp" : {
           "interface" : {
             "TenGigabitEthernet0/0/2/2" : {
-              "interface" : [
-                33
-              ]
+              "interface" : "33"
             }
           }
         },
         "configs/cisco_interface" : {
           "interface" : {
             "Async1" : {
-              "interface" : [
-                281
-              ]
+              "interface" : "281"
             },
             "Cable1/2/3:4" : {
-              "interface" : [
-                283
-              ]
+              "interface" : "283"
             },
             "Cellular0" : {
-              "tunnel source" : [
-                317
-              ]
+              "tunnel source" : "317"
             },
             "Crypto-Engine1/2/3" : {
-              "interface" : [
-                285
-              ]
+              "interface" : "285"
             },
             "Dot11Radio0" : {
-              "interface" : [
-                287
-              ]
+              "interface" : "287"
             },
             "Ethernet0" : {
-              "interface" : [
-                7
-              ],
-              "tunnel source" : [
-                318
-              ]
+              "interface" : "7",
+              "tunnel source" : "318"
             },
             "Ethernet1/11" : {
-              "interface" : [
-                289
-              ]
+              "interface" : "289"
             },
             "Ethernet1/12" : {
-              "interface" : [
-                342
-              ]
+              "interface" : "342"
             },
             "GigabitEthernet0/0" : {
-              "interface" : [
-                291
-              ]
+              "interface" : "291"
             },
             "Loopback0" : {
-              "interface" : [
-                297
-              ]
+              "interface" : "297"
             },
             "Modular-Cable1/2/3:4" : {
-              "interface" : [
-                302
-              ]
+              "interface" : "302"
             },
             "Null0" : {
-              "interface" : [
-                304
-              ]
+              "interface" : "304"
             },
             "Tunnel0" : {
-              "interface" : [
-                308
-              ]
+              "interface" : "308"
             },
             "Vlan1" : {
-              "interface" : [
-                322
-              ]
+              "interface" : "322"
             },
             "Vlan1005" : {
-              "interface" : [
-                328
-              ]
+              "interface" : "328"
             },
             "Vlan1006" : {
-              "interface" : [
-                330
-              ]
+              "interface" : "330"
             },
             "Vlan111" : {
-              "interface" : [
-                320
-              ]
+              "interface" : "320"
             },
             "Vlan1234" : {
-              "interface" : [
-                332
-              ]
+              "interface" : "332"
             },
             "Vlan2" : {
-              "interface" : [
-                324
-              ]
+              "interface" : "324"
             },
             "Vlan3" : {
-              "interface" : [
-                326
-              ]
+              "interface" : "326"
             },
             "Vlan4094" : {
-              "interface" : [
-                334
-              ]
+              "interface" : "334"
             },
             "Wideband-Cable1/2/3:4" : {
-              "interface" : [
-                336
-              ]
+              "interface" : "336"
             },
             "Wlan-GigabitEthernet0" : {
-              "interface" : [
-                340
-              ]
+              "interface" : "340"
             },
             "Wlan-ap0" : {
-              "interface" : [
-                338
-              ]
+              "interface" : "338"
             },
             "inside" : {
-              "interface" : [
-                292
-              ]
+              "interface" : "292"
             },
             "tunnel-ip6" : {
-              "interface" : [
-                306
-              ]
+              "interface" : "306"
             }
           },
           "ipv4 acl" : {
             "167" : {
-              "interface ip verify access-list" : [
-                129
-              ]
+              "interface ip verify access-list" : "129"
             },
             "310-systems" : {
-              "interface outgoing ip access-list" : [
-                137
-              ]
+              "interface outgoing ip access-list" : "137"
             },
             "ag1" : {
-              "interface incoming ip access-list" : [
-                56
-              ]
+              "interface incoming ip access-list" : "56"
             },
             "ag2" : {
-              "interface outgoing ip access-list" : [
-                57
-              ]
+              "interface outgoing ip access-list" : "57"
             }
           },
           "ipv4/6 acl" : {
             "1" : {
-              "interface igmp access-group acl" : [
-                80
-              ]
+              "interface igmp access-group acl" : "80"
             },
             "hpaccesslist" : {
-              "interface igmp host-proxy access-list" : [
-                82
-              ]
+              "interface igmp host-proxy access-list" : "82"
             }
           },
           "route-map" : {
             "SITEMAP" : {
-              "interface ip vrf sitemap" : [
-                135
-              ]
+              "interface ip vrf sitemap" : "135"
             },
             "eigrp-leak-map" : {
-              "interface summary-address eigrp leak-map" : [
-                125
-              ]
+              "interface summary-address eigrp leak-map" : "125"
             }
           },
           "zone" : {
             "t1" : {
-              "interface zone-member" : [
-                278
-              ]
+              "interface zone-member" : "278"
             }
           },
           "zone security" : {
             "z1" : {
-              "interface zone-member security" : [
-                279
-              ]
+              "interface zone-member security" : "279"
             }
           }
         },
         "configs/cisco_ios_neighbor" : {
           "bgp peer-group" : {
             "LEAF" : {
-              "bgp listen range peer-group" : [
-                8
-              ]
+              "bgp listen range peer-group" : "8"
             }
           }
         },
         "configs/cisco_ip" : {
           "ipv4/6 acl" : {
             "wccp-cachelist" : {
-              "ip wccp group-list" : [
-                11
-              ]
+              "ip wccp group-list" : "11"
             },
             "wccp-redir" : {
-              "ip wccp redirect-list" : [
-                11
-              ]
+              "ip wccp redirect-list" : "11"
             }
           }
         },
         "configs/cisco_ip_route" : {
           "interface" : {
             "Dialer1" : {
-              "ip route next-hop interface" : [
-                14
-              ]
+              "ip route next-hop interface" : "14"
             },
             "Dialer2" : {
-              "ip route next-hop interface" : [
-                15
-              ]
+              "ip route next-hop interface" : "15"
             },
             "GigabitEthernet3/0/0.212" : {
-              "ip route next-hop interface" : [
-                6
-              ]
+              "ip route next-hop interface" : "6"
             },
             "Loopback66" : {
-              "ip route next-hop interface" : [
-                12
-              ]
+              "ip route next-hop interface" : "12"
             },
             "Loopback99" : {
-              "ip route next-hop interface" : [
-                13
-              ]
+              "ip route next-hop interface" : "13"
             },
             "POS5/3:10" : {
-              "ip route next-hop interface" : [
-                10
-              ]
+              "ip route next-hop interface" : "10"
             },
             "Serial5/0:2" : {
-              "ip route next-hop interface" : [
-                7
-              ]
+              "ip route next-hop interface" : "7"
             },
             "Serial5/1:5" : {
-              "ip route next-hop interface" : [
-                9
-              ]
+              "ip route next-hop interface" : "9"
             }
           }
         },
         "configs/cisco_isis" : {
           "interface" : {
             "GigabitEthernet0/0/1" : {
-              "interface" : [
-                10
-              ]
+              "interface" : "10"
             },
             "GigabitEthernet0/1" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             },
             "HundredGigabitEthernet0/0/0/0.2302" : {
-              "interface" : [
-                8
-              ]
+              "interface" : "8"
             },
             "Serial4/0" : {
-              "interface" : [
-                6
-              ]
+              "interface" : "6"
             }
           },
           "route-map" : {
             "connected-to-isis" : {
-              "isis redistribute connected route-map" : [
-                66
-              ]
+              "isis redistribute connected route-map" : "66"
             },
             "connected-to-isis-v6" : {
-              "isis redistribute connected route-map" : [
-                69
-              ]
+              "isis redistribute connected route-map" : "69"
             },
             "static-to-bgp" : {
-              "isis redistribute static route-map" : [
-                61
-              ]
+              "isis redistribute static route-map" : "61"
             }
           }
         },
         "configs/cisco_line" : {
           "ipv4 acl" : {
             "40" : {
-              "line access-class list" : [
-                6,
-                26
-              ]
+              "line access-class list" : "6,26"
             },
             "99" : {
-              "line access-class list" : [
-                56
-              ]
+              "line access-class list" : "56"
             },
             "vty-acl" : {
-              "line access-class list" : [
-                22
-              ]
+              "line access-class list" : "22"
             }
           },
           "ipv6 acl" : {
             "ipv6-vty-acl" : {
-              "line access-class ipv6 list" : [
-                61
-              ]
+              "line access-class ipv6 list" : "61"
             }
           }
         },
         "configs/cisco_misc" : {
           "class-map" : {
             "ICMP-cmap" : {
-              "policy-map class" : [
-                206
-              ]
+              "policy-map class" : "206"
             },
             "TCP-cmap" : {
-              "policy-map class" : [
-                208
-              ]
+              "policy-map class" : "208"
             },
             "class-default" : {
-              "policy-map class" : [
-                210
-              ]
+              "policy-map class" : "210"
             },
             "inspection_default" : {
-              "policy-map class" : [
-                195
-              ]
+              "policy-map class" : "195"
             }
           },
           "ipv4/6 acl" : {
             "cops-acl" : {
-              "cops listener access-list" : [
-                42
-              ]
+              "cops listener access-list" : "42"
             }
           },
           "policy-map" : {
             "global_policy" : {
-              "service-policy global" : [
-                237
-              ]
+              "service-policy global" : "237"
             }
           }
         },
         "configs/cisco_nomaskreply" : {
           "interface" : {
             "GigabitEthernet1" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           }
         },
         "configs/cisco_ntp" : {
           "interface" : {
             "Loopback0" : {
-              "ntp source-interface" : [
-                7
-              ]
+              "ntp source-interface" : "7"
             }
           },
           "ipv4 acl" : {
             "ntp-peer-group" : {
-              "ntp access-group" : [
-                4
-              ]
+              "ntp access-group" : "4"
             }
           }
         },
         "configs/cisco_opsfv3" : {
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           }
         },
         "configs/cisco_ospf" : {
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                7,
-                12
-              ],
-              "router ospf distribute-list in" : [
-                54
-              ]
+              "interface" : "7,12",
+              "router ospf distribute-list in" : "54"
             },
             "Ethernet1/0" : {
-              "interface" : [
-                17
-              ]
+              "interface" : "17"
             },
             "Loopback0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           },
           "ipv4 prefix-list" : {
             "INFILTER" : {
-              "ospf area filter-list" : [
-                82
-              ]
+              "ospf area filter-list" : "82"
             },
             "OUTFILTER" : {
-              "ospf area filter-list" : [
-                83
-              ]
+              "ospf area filter-list" : "83"
             },
             "filterName" : {
-              "ospf area filter-list" : [
-                26,
-                27
-              ]
+              "ospf area filter-list" : "26-27"
             },
             "plin" : {
-              "router ospf distribute-list prefix in" : [
-                56
-              ]
+              "router ospf distribute-list prefix in" : "56"
             },
             "plout" : {
-              "router ospf distribute-list prefix out" : [
-                57
-              ]
+              "router ospf distribute-list prefix out" : "57"
             }
           },
           "ipv4/6 acl" : {
             "aclin" : {
-              "router ospf distribute-list in" : [
-                53,
-                54
-              ]
+              "router ospf distribute-list in" : "53-54"
             },
             "aclout" : {
-              "router ospf distribute-list out" : [
-                55
-              ]
+              "router ospf distribute-list out" : "55"
             }
           },
           "route-map" : {
             "DEFAULT_ORIGINATE_OSPF" : {
-              "ospf default-originate route-map" : [
-                47
-              ]
+              "ospf default-originate route-map" : "47"
             },
             "DIRECT_OSPF" : {
-              "ospf redistribute connected route-map" : [
-                68
-              ]
+              "ospf redistribute connected route-map" : "68"
             },
             "eigrp-ospf-route-map" : {
-              "ospf redistribute eigrp route-map" : [
-                69
-              ]
+              "ospf redistribute eigrp route-map" : "69"
             },
             "rmin" : {
-              "router ospf distribute-list route-map in" : [
-                58
-              ]
+              "router ospf distribute-list route-map in" : "58"
             },
             "rmout" : {
-              "router ospf distribute-list route-map out" : [
-                59
-              ]
+              "router ospf distribute-list route-map out" : "59"
             }
           }
         },
         "configs/cisco_ospf_ipv6" : {
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                4
-              ],
-              "ipv6 router ospf distribute-list prefix-list out" : [
-                15
-              ]
+              "interface" : "4",
+              "ipv6 router ospf distribute-list prefix-list out" : "15"
             }
           },
           "ipv6 prefix-list" : {
             "SWITCHLAN" : {
-              "ipv6 router ospf distribute-list prefix-list in" : [
-                14
-              ]
+              "ipv6 router ospf distribute-list prefix-list in" : "14"
             },
             "SWITCHLAN-OUT" : {
-              "ipv6 router ospf distribute-list prefix-list out" : [
-                15
-              ]
+              "ipv6 router ospf distribute-list prefix-list out" : "15"
             }
           }
         },
         "configs/cisco_ospf_multi_process" : {
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             },
             "Ethernet1/0" : {
-              "interface" : [
-                8
-              ]
+              "interface" : "8"
             },
             "Loopback0" : {
-              "interface" : [
-                12
-              ]
+              "interface" : "12"
             }
           },
           "ipv4 prefix-list" : {
             "filterName" : {
-              "ospf area filter-list" : [
-                22,
-                23
-              ]
+              "ospf area filter-list" : "22-23"
             }
           }
         },
         "configs/cisco_pim" : {
           "ipv4 acl" : {
             "foobar" : {
-              "pim rp-address" : [
-                7
-              ]
+              "pim rp-address" : "7"
             },
             "foobarmap" : {
-              "pim rp-address" : [
-                8
-              ]
+              "pim rp-address" : "8"
             }
           }
         },
         "configs/cisco_qos" : {
           "acl" : {
             "boop" : {
-              "class-map access-group" : [
-                20
-              ]
+              "class-map access-group" : "20"
             },
             "boop2" : {
-              "class-map access-list" : [
-                21
-              ]
+              "class-map access-list" : "21"
             }
           },
           "class-map" : {
             "MY_CLASS_1" : {
-              "policy-map event class" : [
-                129
-              ]
+              "policy-map event class" : "129"
             },
             "MY_CLASS_2" : {
-              "policy-map event class" : [
-                131
-              ]
+              "policy-map event class" : "131"
             },
             "bippetyboo-drop" : {
-              "policy-map class" : [
-                50
-              ]
+              "policy-map class" : "50"
             },
             "bippetyboo-ndrop" : {
-              "policy-map class" : [
-                66
-              ]
+              "policy-map class" : "66"
             },
             "bippetyboo-ndrop-fcoe" : {
-              "policy-map class" : [
-                62
-              ]
+              "policy-map class" : "62"
             },
             "bleefee" : {
-              "policy-map class" : [
-                102
-              ]
+              "policy-map class" : "102"
             },
             "bleefee2" : {
-              "policy-map class" : [
-                107
-              ]
+              "policy-map class" : "107"
             },
             "blerf" : {
-              "policy-map class" : [
-                98
-              ]
+              "policy-map class" : "98"
             },
             "c-bleeb-drop" : {
-              "policy-map class" : [
-                109
-              ]
+              "policy-map class" : "109"
             },
             "c-bleeb-ndrop-fcoe" : {
-              "policy-map class" : [
-                114
-              ]
+              "policy-map class" : "114"
             },
             "c-foob-drop" : {
-              "policy-map class" : [
-                81
-              ]
+              "policy-map class" : "81"
             },
             "c-foob-ndrop" : {
-              "policy-map class" : [
-                93
-              ]
+              "policy-map class" : "93"
             },
             "c-foob-ndrop-fcoe" : {
-              "policy-map class" : [
-                89
-              ]
+              "policy-map class" : "89"
             },
             "fffoooddd" : {
-              "policy-map class" : [
-                72
-              ]
+              "policy-map class" : "72"
             },
             "floop" : {
-              "policy-map class" : [
-                119
-              ]
+              "policy-map class" : "119"
             }
           },
           "class-map type inspect" : {
             "cinspect" : {
-              "policy-map type inspect class type inspect" : [
-                43
-              ]
+              "policy-map type inspect class type inspect" : "43"
             }
           },
           "policy-map" : {
             "prioritize_backbone" : {
-              "policy-map class service-policy" : [
-                74
-              ]
+              "policy-map class service-policy" : "74"
             }
           },
           "service-template" : {
             "DEF" : {
-              "class-map activate-service-template" : [
-                9
-              ]
+              "class-map activate-service-template" : "9"
             },
             "GHI" : {
-              "class-map service-template" : [
-                10
-              ]
+              "class-map service-template" : "10"
             },
             "my_TEMPLATE_NAME" : {
-              "policy-map event class activate" : [
-                130
-              ]
+              "policy-map event class activate" : "130"
             }
           }
         },
         "configs/cisco_rip" : {
           "ipv4/6 acl" : {
             "some-ACL" : {
-              "router rip distribute-list" : [
-                10,
-                11,
-                12,
-                13
-              ]
+              "router rip distribute-list" : "10-13"
             }
           }
         },
         "configs/cisco_route_map" : {
           "as-path access-list" : {
             "AS_PATH_ACL1" : {
-              "route-map match as-path access-list" : [
-                51
-              ]
+              "route-map match as-path access-list" : "51"
             },
             "AS_PATH_ACL2" : {
-              "route-map match as-path access-list" : [
-                54
-              ]
+              "route-map match as-path access-list" : "54"
             },
             "AS_PATH_UNDEF" : {
-              "route-map match as-path access-list" : [
-                57
-              ]
+              "route-map match as-path access-list" : "57"
             }
           },
           "ipv4 acl" : {
             "test" : {
-              "route-map match ipv4 access-list" : [
-                26
-              ]
+              "route-map match ipv4 access-list" : "26"
             }
           },
           "ipv4 prefix-list" : {
             "bobble" : {
-              "route-map match ipv4 prefix-list" : [
-                36
-              ]
+              "route-map match ipv4 prefix-list" : "36"
             },
             "hpr-connector-subnets" : {
-              "route-map match ipv4 prefix-list" : [
-                10
-              ]
+              "route-map match ipv4 prefix-list" : "10"
             }
           }
         },
         "configs/cisco_snmp" : {
           "interface" : {
             "Loopback0" : {
-              "snmp-server source-interface" : [
-                89
-              ]
+              "snmp-server source-interface" : "89"
             },
             "Vlan1" : {
-              "snmp-server source-interface" : [
-                91
-              ]
+              "snmp-server source-interface" : "91"
             },
             "mgmt0" : {
-              "snmp-server source-interface" : [
-                90
-              ]
+              "snmp-server source-interface" : "90"
             }
           },
           "ipv4 acl" : {
             "1" : {
-              "snmp server community ipv4 acl" : [
-                9
-              ]
+              "snmp server community ipv4 acl" : "9"
             },
             "2" : {
-              "snmp server community ipv4 acl" : [
-                8,
-                10
-              ]
+              "snmp server community ipv4 acl" : "8,10"
             },
             "50" : {
-              "snmp-server group v3 access" : [
-                69
-              ]
+              "snmp-server group v3 access" : "69"
             },
             "customer-snmp" : {
-              "snmp server community ipv4 acl" : [
-                14
-              ]
+              "snmp server community ipv4 acl" : "14"
             },
             "dummyacl" : {
-              "snmp server community ipv4 acl" : [
-                13
-              ]
+              "snmp server community ipv4 acl" : "13"
             },
             "snmp-acl" : {
-              "snmp server community ipv4 acl" : [
-                7,
-                11
-              ]
+              "snmp server community ipv4 acl" : "7,11"
             },
             "snmp-arpa-acl" : {
-              "snmp server community ipv4 acl" : [
-                12
-              ]
+              "snmp server community ipv4 acl" : "12"
             },
             "to-VTY" : {
-              "snmp server community ipv4 acl" : [
-                16
-              ]
+              "snmp server community ipv4 acl" : "16"
             }
           },
           "ipv4/6 acl" : {
             "8" : {
-              "snmp server file transfer acl" : [
-                67
-              ],
-              "snmp server tftp-server list" : [
-                94
-              ]
+              "snmp server file transfer acl" : "67",
+              "snmp server tftp-server list" : "94"
             },
             "Loopback0" : {
-              "snmp-server trap-source" : [
-                96,
-                97
-              ]
+              "snmp-server trap-source" : "96-97"
             }
           },
           "ipv6 acl" : {
             "dummyacl" : {
-              "snmp server community ipv6 acl" : [
-                15
-              ]
+              "snmp server community ipv6 acl" : "15"
             },
             "snmp6" : {
-              "snmp-server group v3 access ipv6" : [
-                70
-              ]
+              "snmp-server group v3 access ipv6" : "70"
             },
             "to-VTY" : {
-              "snmp server community ipv6 acl" : [
-                16
-              ]
+              "snmp server community ipv6 acl" : "16"
             }
           }
         },
         "configs/cisco_system" : {
           "policy-map" : {
             "POLICY" : {
-              "system service-policy" : [
-                21
-              ]
+              "system service-policy" : "21"
             }
           }
         },
         "configs/cisco_track" : {
           "interface" : {
             "GigabitEthernet0/0" : {
-              "track interface" : [
-                4
-              ]
+              "track interface" : "4"
             },
             "GigabitEthernet0/1" : {
-              "track interface" : [
-                5
-              ]
+              "track interface" : "5"
             }
           }
         },
         "configs/cisco_vrrp" : {
           "interface" : {
             "Ethernet0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             },
             "GigabitEthernet0/0/0/19" : {
-              "router vrrp interface" : [
-                16
-              ]
+              "router vrrp interface" : "16"
             },
             "ManagementEthernet0/RSP0/CPU0/0" : {
-              "router vrrp interface" : [
-                26
-              ]
+              "router vrrp interface" : "26"
             },
             "ManagementEthernet0/RSP1/CPU0/0" : {
-              "router vrrp interface" : [
-                28
-              ]
+              "router vrrp interface" : "28"
             }
           }
         },
         "configs/cisco_zone" : {
           "policy-map type inspect" : {
             "p1" : {
-              "zone-pair service-policy type inspect" : [
-                5
-              ]
+              "zone-pair service-policy type inspect" : "5"
             }
           },
           "zone security" : {
             "z1" : {
-              "zone-pair security source" : [
-                4
-              ]
+              "zone-pair security source" : "4"
             },
             "z2" : {
-              "zone-pair security destination" : [
-                4
-              ]
+              "zone-pair security destination" : "4"
             }
           }
         },
         "configs/colon_in_vrf" : {
           "route-map" : {
             "RMT_PBI" : {
-              "bgp redistribute connected route-map" : [
-                6
-              ]
+              "bgp redistribute connected route-map" : "6"
             }
           }
         },
         "configs/community_list_named" : {
           "community-list" : {
             "COMM_LIST_NAME" : {
-              "route-map set community additive" : [
-                10
-              ]
+              "route-map set community additive" : "10"
             }
           },
           "ipv4 prefix-list" : {
             "PFX_LIST" : {
-              "route-map match ipv4 prefix-list" : [
-                9
-              ]
+              "route-map match ipv4 prefix-list" : "9"
             }
           }
         },
         "configs/community_name_numbers" : {
           "community-list" : {
             "9999-RRR" : {
-              "route-map match community-list" : [
-                7
-              ]
+              "route-map match community-list" : "7"
             }
           }
         },
         "configs/community_name_numbers_dos" : {
           "community-list" : {
             "9999-RRR" : {
-              "route-map match community-list" : [
-                7
-              ]
+              "route-map match community-list" : "7"
             }
           }
         },
         "configs/cumulus_nclu" : {
           "abstract interface" : {
             "lo" : {
-              "route-map match interface" : [
-                80
-              ]
+              "route-map match interface" : "80"
             },
             "swp1" : {
-              "bgp neighbor interface" : [
-                37
-              ]
+              "bgp neighbor interface" : "37"
             },
             "swp2" : {
-              "bgp neighbor interface" : [
-                38
-              ]
+              "bgp neighbor interface" : "38"
             },
             "swp3" : {
-              "bgp neighbor interface" : [
-                39,
-                40
-              ]
+              "bgp neighbor interface" : "39-40"
             }
           },
           "bond" : {
             "bond1" : {
-              "bond self-reference" : [
-                15
-              ]
+              "bond self-reference" : "15"
             },
             "bond2" : {
-              "bond self-reference" : [
-                17
-              ]
+              "bond self-reference" : "17"
             }
           },
           "interface" : {
             "bond1.4094" : {
-              "net add interface" : [
-                20,
-                28,
-                29,
-                30,
-                31
-              ]
+              "net add interface" : "20,28-31"
             },
             "eth0" : {
-              "net add interface" : [
-                7
-              ]
+              "net add interface" : "7"
             },
             "swp1" : {
-              "bond slave" : [
-                15
-              ],
-              "net add interface" : [
-                6,
-                8
-              ]
+              "bond slave" : "15",
+              "net add interface" : "6,8"
             },
             "swp2" : {
-              "bond slave" : [
-                15
-              ],
-              "net add interface" : [
-                6,
-                9,
-                10
-              ]
+              "bond slave" : "15",
+              "net add interface" : "6,9-10"
             },
             "swp3" : {
-              "bond slave" : [
-                15
-              ],
-              "net add interface" : [
-                6
-              ]
+              "bond slave" : "15",
+              "net add interface" : "6"
             },
             "swp4" : {
-              "bond slave" : [
-                15
-              ]
+              "bond slave" : "15"
             },
             "swp5" : {
-              "bond slave" : [
-                15
-              ]
+              "bond slave" : "15"
             },
             "swp6" : {
-              "bond slave" : [
-                15
-              ]
+              "bond slave" : "15"
             },
             "swp7" : {
-              "bond slave" : [
-                15
-              ]
+              "bond slave" : "15"
             },
             "swp8" : {
-              "bond slave" : [
-                15
-              ]
+              "bond slave" : "15"
             }
           },
           "loopback" : {
             "lo" : {
-              "loopback self-reference" : [
-                11,
-                12,
-                13
-              ]
+              "loopback self-reference" : "11-13"
             }
           },
           "route-map" : {
             "rm1" : {
-              "bgp ipv4 unicast redistribute connected route-map" : [
-                42
-              ]
+              "bgp ipv4 unicast redistribute connected route-map" : "42"
             }
           },
           "vlan" : {
             "vlan4" : {
-              "vlan self-reference" : [
-                88,
-                89,
-                90,
-                91,
-                92,
-                93
-              ]
+              "vlan self-reference" : "88-93"
             }
           },
           "vrf" : {
             "mgmt" : {
-              "interface clag backup-ip vrf" : [
-                28
-              ],
-              "interface vrf" : [
-                7
-              ],
-              "vrf self-reference" : [
-                94,
-                95,
-                97
-              ]
+              "interface clag backup-ip vrf" : "28",
+              "interface vrf" : "7",
+              "vrf self-reference" : "94-95,97"
             },
             "vrf1" : {
-              "bgp vrf" : [
-                52,
-                53,
-                54,
-                55,
-                56,
-                57
-              ],
-              "vlan vrf" : [
-                92
-              ],
-              "vrf self-reference" : [
-                96,
-                97,
-                114,
-                115
-              ]
+              "bgp vrf" : "52-57",
+              "vlan vrf" : "92",
+              "vrf self-reference" : "96-97,114-115"
             }
           },
           "vxlan" : {
             "vni10001" : {
-              "vxlan self-reference" : [
-                99
-              ]
+              "vxlan self-reference" : "99"
             },
             "vni10004" : {
-              "vxlan self-reference" : [
-                105
-              ]
+              "vxlan self-reference" : "105"
             }
           }
         },
         "configs/cumulus_nclu_bgp" : {
           "vrf" : {
             "vrf1" : {
-              "bgp vrf" : [
-                8
-              ]
+              "bgp vrf" : "8"
             }
           }
         },
         "configs/cumulus_nclu_bgp_no_remote_as" : {
           "vrf" : {
             "vrf1" : {
-              "bgp vrf" : [
-                8
-              ]
+              "bgp vrf" : "8"
             }
           }
         },
         "configs/cumulus_nclu_bgp_no_router_id" : {
           "loopback" : {
             "lo" : {
-              "loopback self-reference" : [
-                6
-              ]
+              "loopback self-reference" : "6"
             }
           }
         },
         "configs/cumulus_nclu_bgp_no_router_id_or_loopback_ip" : {
           "loopback" : {
             "lo" : {
-              "loopback self-reference" : [
-                6
-              ]
+              "loopback self-reference" : "6"
             }
           }
         },
         "configs/cumulus_nclu_bond" : {
           "bond" : {
             "AGG" : {
-              "bond self-reference" : [
-                5
-              ]
+              "bond self-reference" : "5"
             },
             "otherbond" : {
-              "bond self-reference" : [
-                8
-              ]
+              "bond self-reference" : "8"
             }
           },
           "interface" : {
             "swp1" : {
-              "bond slave" : [
-                5
-              ]
+              "bond slave" : "5"
             },
             "swp10" : {
-              "bond slave" : [
-                5
-              ]
+              "bond slave" : "5"
             },
             "swp2" : {
-              "bond slave" : [
-                5
-              ]
+              "bond slave" : "5"
             },
             "swp3" : {
-              "bond slave" : [
-                5
-              ]
+              "bond slave" : "5"
             },
             "swp3s0" : {
-              "bond slave" : [
-                8
-              ]
+              "bond slave" : "8"
             },
             "swp4" : {
-              "bond slave" : [
-                5
-              ]
+              "bond slave" : "5"
             },
             "swp5" : {
-              "bond slave" : [
-                5
-              ]
+              "bond slave" : "5"
             },
             "swp6" : {
-              "bond slave" : [
-                5
-              ]
+              "bond slave" : "5"
             },
             "swp7" : {
-              "bond slave" : [
-                5
-              ]
+              "bond slave" : "5"
             },
             "swp8" : {
-              "bond slave" : [
-                5
-              ]
+              "bond slave" : "5"
             },
             "swp9" : {
-              "bond slave" : [
-                5
-              ]
+              "bond slave" : "5"
             }
           }
         },
         "configs/cumulus_nclu_interface" : {
           "interface" : {
             "swp1" : {
-              "net add interface" : [
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                19
-              ]
+              "net add interface" : "6-17,19"
             },
             "swp1s2" : {
-              "net add interface" : [
-                21
-              ]
+              "net add interface" : "21"
             }
           }
         },
         "configs/cumulus_nclu_invalid_bonds" : {
           "vrf" : {
             "vrf1" : {
-              "vrf self-reference" : [
-                8
-              ]
+              "vrf self-reference" : "8"
             }
           },
           "vxlan" : {
             "v1" : {
-              "vxlan self-reference" : [
-                18
-              ]
+              "vxlan self-reference" : "18"
             }
           }
         },
         "configs/cumulus_nclu_invalid_interfaces" : {
           "bond" : {
             "bond1" : {
-              "bond self-reference" : [
-                6
-              ]
+              "bond self-reference" : "6"
             }
           },
           "vrf" : {
             "vrf1" : {
-              "vrf self-reference" : [
-                16
-              ]
+              "vrf self-reference" : "16"
             }
           },
           "vxlan" : {
             "v1" : {
-              "vxlan self-reference" : [
-                19
-              ]
+              "vxlan self-reference" : "19"
             }
           }
         },
         "configs/cumulus_nclu_invalid_vrfs" : {
           "bond" : {
             "bond1" : {
-              "bond self-reference" : [
-                8
-              ]
+              "bond self-reference" : "8"
             }
           },
           "interface" : {
             "swp1" : {
-              "bond slave" : [
-                8
-              ]
+              "bond slave" : "8"
             }
           },
           "vxlan" : {
             "vx1" : {
-              "vxlan self-reference" : [
-                16
-              ]
+              "vxlan self-reference" : "16"
             }
           }
         },
         "configs/cumulus_nclu_invalid_vxlans" : {
           "bond" : {
             "bond1" : {
-              "bond self-reference" : [
-                8
-              ]
+              "bond self-reference" : "8"
             }
           },
           "interface" : {
             "swp0" : {
-              "bond slave" : [
-                8
-              ]
+              "bond slave" : "8"
             }
           },
           "vrf" : {
             "vrf1" : {
-              "vrf self-reference" : [
-                11
-              ]
+              "vrf self-reference" : "11"
             }
           }
         },
         "configs/cumulus_nclu_stp" : {
           "bond" : {
             "bond1" : {
-              "bond self-reference" : [
-                12
-              ]
+              "bond self-reference" : "12"
             }
           },
           "interface" : {
             "swp1" : {
-              "bond slave" : [
-                12
-              ],
-              "net add interface" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10
-              ]
+              "bond slave" : "12",
+              "net add interface" : "5-10"
             }
           }
         },
         "configs/eos_mlag" : {
           "interface" : {
             "Port-Channel1" : {
-              "interface" : [
-                9
-              ],
-              "mlag configuration peer-link" : [
-                21
-              ]
+              "interface" : "9",
+              "mlag configuration peer-link" : "21"
             },
             "Port-Channel2" : {
-              "interface" : [
-                13
-              ]
+              "interface" : "13"
             },
             "Vlan4094" : {
-              "mlag configuration local-interface" : [
-                19
-              ]
+              "mlag configuration local-interface" : "19"
             }
           }
         },
         "configs/eos_trunk_group" : {
           "interface" : {
             "Port-Channel1" : {
-              "interface" : [
-                34
-              ]
+              "interface" : "34"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_imish_malformed" : {
           "bgp neighbor" : {
             "2::2" : {
-              "bgp neighbor self-reference" : [
-                20
-              ]
+              "bgp neighbor self-reference" : "20"
             },
             "3.3.3.3" : {
-              "bgp neighbor self-reference" : [
-                17
-              ]
+              "bgp neighbor self-reference" : "17"
             }
           },
           "bgp process" : {
             "1" : {
-              "bgp process self-reference" : [
-                15
-              ]
+              "bgp process self-reference" : "15"
             }
           },
           "peer-group" : {
             "undefined-peer-group" : {
-              "neighbor peer-group" : [
-                18
-              ]
+              "neighbor peer-group" : "18"
             }
           },
           "route-map" : {
             "rm1" : {
-              "bgp neighbor address-family ipv6 route-map out" : [
-                21
-              ],
-              "neighbor peer-group route-map out" : [
-                22
-              ]
+              "bgp neighbor address-family ipv6 route-map out" : "21",
+              "neighbor peer-group route-map out" : "22"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_cm" : {
           "device" : {
             "/Common/f5_bigip_structured_cm" : {
-              "device-group device" : [
-                124,
-                132,
-                140
-              ],
-              "trust-domain ca-device" : [
-                176
-              ]
+              "device-group device" : "124,132,140",
+              "trust-domain ca-device" : "176"
             },
             "/Common/f5_bigip_structured_cm2" : {
-              "device-group device" : [
-                125,
-                133
-              ],
-              "trust-domain ca-device" : [
-                176
-              ]
+              "device-group device" : "125,133",
+              "trust-domain ca-device" : "176"
             }
           },
           "device-group" : {
             "/Common/device_trust_group" : {
-              "trust-domain trust-group" : [
-                180
-              ]
+              "trust-domain trust-group" : "180"
             }
           },
           "ha-group" : {
             "/Common/t1" : {
-              "traffic-group ha-group" : [
-                168
-              ]
+              "traffic-group ha-group" : "168"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_ltm" : {
           "monitor" : {
             "/Common/SOME_MONITOR" : {
-              "pool monitor" : [
-                33
-              ]
+              "pool monitor" : "33"
             }
           },
           "node" : {
             "/Common/bar" : {
-              "pool member" : [
-                28
-              ]
+              "pool member" : "28"
             },
             "/Common/foo" : {
-              "pool member" : [
-                23
-              ]
+              "pool member" : "23"
             }
           },
           "persistence" : {
             "/Common/SOME_PROFILE" : {
-              "virtual persist persistence" : [
-                97
-              ]
+              "virtual persist persistence" : "97"
             }
           },
           "pool" : {
             "/Common/SOME_POOL" : {
-              "virtual pool" : [
-                101
-              ]
+              "virtual pool" : "101"
             }
           },
           "profile" : {
             "/Common/P1" : {
-              "virtual profile" : [
-                103
-              ]
+              "virtual profile" : "103"
             },
             "/Common/P2" : {
-              "virtual profile" : [
-                104
-              ]
+              "virtual profile" : "104"
             },
             "/Common/P3" : {
-              "virtual profile" : [
-                105
-              ]
+              "virtual profile" : "105"
             }
           },
           "profile server-ssl" : {
             "/Common/SOME_SSL_PROFILE" : {
-              "monitor https ssl-profile" : [
-                166
-              ]
+              "monitor https ssl-profile" : "166"
             }
           },
           "rule" : {
             "/Common/SOME_RULE1" : {
-              "virtual rules rule" : [
-                109
-              ]
+              "virtual rules rule" : "109"
             }
           },
           "snat" : {
             "/Common/SOME_SNAT" : {
-              "snat self-reference" : [
-                67
-              ]
+              "snat self-reference" : "67"
             }
           },
           "snat-translation" : {
             "/Common/192.0.2.5" : {
-              "snatpool members member" : [
-                85
-              ]
+              "snatpool members member" : "85"
             },
             "/Common/192.0.2.6" : {
-              "snatpool members member" : [
-                86
-              ]
+              "snatpool members member" : "86"
             }
           },
           "snatpool" : {
             "/Common/SOME_SNATPOOL" : {
-              "snat snatpool" : [
-                71
-              ],
-              "virtual source-address-translation pool" : [
-                113
-              ]
+              "snat snatpool" : "71",
+              "virtual source-address-translation pool" : "113"
             }
           },
           "virtual" : {
             "/Common/SOME_VIRTUAL" : {
-              "virtual self-reference" : [
-                89
-              ]
+              "virtual self-reference" : "89"
             }
           },
           "virtual-address" : {
             "/Common/192.0.2.7" : {
-              "virtual destination" : [
-                90
-              ]
+              "virtual destination" : "90"
             }
           },
           "vlan" : {
             "/Common/MY_VLAN" : {
-              "virtual vlans vlan" : [
-                120
-              ]
+              "virtual vlans vlan" : "120"
             },
             "/Common/SOME_VLAN" : {
-              "snat vlans vlan" : [
-                74
-              ]
+              "snat vlans vlan" : "74"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_malformed" : {
           "route" : {
             "/Common/bad_gw" : {
-              "route self-reference" : [
-                15
-              ]
+              "route self-reference" : "15"
             },
             "/Common/missing_gw" : {
-              "route self-reference" : [
-                11
-              ]
+              "route self-reference" : "11"
             },
             "/Common/missing_network" : {
-              "route self-reference" : [
-                30
-              ]
+              "route self-reference" : "30"
             },
             "/Common/mixed_protocols1" : {
-              "route self-reference" : [
-                20
-              ]
+              "route self-reference" : "20"
             },
             "/Common/mixed_protocols2" : {
-              "route self-reference" : [
-                25
-              ]
+              "route self-reference" : "25"
             }
           },
           "self" : {
             "/Common/self1" : {
-              "self self-reference" : [
-                7
-              ]
+              "self self-reference" : "7"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_net" : {
           "interface" : {
             "1.0" : {
-              "interface self-reference" : [
-                8
-              ]
+              "interface self-reference" : "8"
             },
             "2.0" : {
-              "trunk interfaces interface" : [
-                67
-              ]
+              "trunk interfaces interface" : "67"
             },
             "3.0" : {
-              "trunk interfaces interface" : [
-                68
-              ]
+              "trunk interfaces interface" : "68"
             }
           },
           "route" : {
             "/Common/route1" : {
-              "route self-reference" : [
-                34
-              ]
+              "route self-reference" : "34"
             }
           },
           "self" : {
             "/Common/MYSELF" : {
-              "self self-reference" : [
-                28
-              ]
+              "self self-reference" : "28"
             },
             "/Common/MYSELF6" : {
-              "self self-reference" : [
-                38
-              ]
+              "self self-reference" : "38"
             }
           },
           "vlan" : {
             "/Common/MYVLAN" : {
-              "self vlan" : [
-                32,
-                40
-              ]
+              "self vlan" : "32,40"
             }
           },
           "vlan member interface" : {
             "1.0" : {
-              "vlan interface" : [
-                78
-              ]
+              "vlan interface" : "78"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_net_routing_bgp" : {
           "bgp neighbor" : {
             "192.0.2.1" : {
-              "bgp neighbor self-reference" : [
-                42
-              ]
+              "bgp neighbor self-reference" : "42"
             },
             "dead:beef::1" : {
-              "bgp neighbor self-reference" : [
-                20
-              ]
+              "bgp neighbor self-reference" : "20"
             }
           },
           "bgp process" : {
             "/Common/my_bgp" : {
-              "bgp process self-reference" : [
-                7
-              ]
+              "bgp process self-reference" : "7"
             }
           },
           "route-map" : {
             "/Common/MY_IPV4_OUT" : {
-              "bgp neighbor address-family ipv6 route-map out" : [
-                52
-              ]
+              "bgp neighbor address-family ipv6 route-map out" : "52"
             },
             "/Common/MY_IPV6_OUT" : {
-              "bgp neighbor address-family ipv6 route-map out" : [
-                33
-              ]
+              "bgp neighbor address-family ipv6 route-map out" : "33"
             },
             "/Common/MY_KERNEL_OUT" : {
-              "bgp address-family redistribute kernel route-map" : [
-                12
-              ]
+              "bgp address-family redistribute kernel route-map" : "12"
             }
           },
           "vlan" : {
             "SOME_VLAN" : {
-              "bgp neighbor update-source" : [
-                40,
-                63
-              ]
+              "bgp neighbor update-source" : "40,63"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_net_routing_route_map" : {
           "prefix-list" : {
             "/Common/MY_PREFIX_LIST" : {
-              "route-map match ipv4 address prefix-list" : [
-                14
-              ]
+              "route-map match ipv4 address prefix-list" : "14"
             },
             "/Common/MY_PREFIX_LIST2" : {
-              "route-map match ipv4 address prefix-list" : [
-                29
-              ]
+              "route-map match ipv4 address prefix-list" : "29"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_sys_ha_group" : {
           "pool" : {
             "/Common/p1" : {
-              "ha-group pool" : [
-                10
-              ]
+              "ha-group pool" : "10"
             },
             "/Common/p2" : {
-              "ha-group pool" : [
-                13
-              ]
+              "ha-group pool" : "13"
             }
           },
           "trunk" : {
             "t1" : {
-              "ha-group trunk" : [
-                16
-              ]
+              "ha-group trunk" : "16"
             },
             "t2" : {
-              "ha-group trunk" : [
-                19
-              ]
+              "ha-group trunk" : "19"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_with_imish" : {
           "IMISH interface" : {
             "lo" : {
-              "IMISH interface self-reference" : [
-                13
-              ]
+              "IMISH interface self-reference" : "13"
             },
             "tmm" : {
-              "IMISH interface self-reference" : [
-                15
-              ]
+              "IMISH interface self-reference" : "15"
             },
             "us1" : {
-              "bgp neighbor update-source" : [
-                56
-              ]
+              "bgp neighbor update-source" : "56"
             },
             "vlan_active" : {
-              "IMISH interface self-reference" : [
-                17
-              ]
+              "IMISH interface self-reference" : "17"
             },
             "vlan_passive" : {
-              "IMISH interface self-reference" : [
-                20
-              ],
-              "router ospf passive-interface" : [
-                28
-              ]
+              "IMISH interface self-reference" : "20",
+              "router ospf passive-interface" : "28"
             }
           },
           "access-list" : {
             "acl1" : {
-              "route-map match ip address" : [
-                63
-              ]
+              "route-map match ip address" : "63"
             }
           },
           "bgp neighbor" : {
             "10.0.0.1" : {
-              "bgp neighbor self-reference" : [
-                52
-              ]
+              "bgp neighbor self-reference" : "52"
             },
             "1:2:3:4:5:6:7::" : {
-              "bgp neighbor self-reference" : [
-                47
-              ]
+              "bgp neighbor self-reference" : "47"
             },
             "1:2:3:4:5:6:9.8.7.6" : {
-              "bgp neighbor self-reference" : [
-                51
-              ]
+              "bgp neighbor self-reference" : "51"
             },
             "1:2:3::" : {
-              "bgp neighbor self-reference" : [
-                45
-              ]
+              "bgp neighbor self-reference" : "45"
             },
             "1:2:3::4:5:6" : {
-              "bgp neighbor self-reference" : [
-                46
-              ]
+              "bgp neighbor self-reference" : "46"
             },
             "1:2::3:4.5.6.7" : {
-              "bgp neighbor self-reference" : [
-                50
-              ]
+              "bgp neighbor self-reference" : "50"
             },
             "::1:2:3:4:5:6" : {
-              "bgp neighbor self-reference" : [
-                48
-              ]
+              "bgp neighbor self-reference" : "48"
             },
             "::1:2:3:4:5:6:7" : {
-              "bgp neighbor self-reference" : [
-                49
-              ]
+              "bgp neighbor self-reference" : "49"
             }
           },
           "bgp process" : {
             "65500" : {
-              "bgp process self-reference" : [
-                32
-              ]
+              "bgp process self-reference" : "32"
             }
           },
           "peer-group" : {
             "pg1" : {
-              "neighbor peer-group" : [
-                55
-              ]
+              "neighbor peer-group" : "55"
             }
           },
           "prefix-list" : {
             "pl1" : {
-              "route-map match ipv4 address prefix-list" : [
-                64
-              ]
+              "route-map match ipv4 address prefix-list" : "64"
             }
           },
           "route-map" : {
             "rm1" : {
-              "router bgp redistribute kernel route-map" : [
-                58
-              ]
+              "router bgp redistribute kernel route-map" : "58"
             }
           },
           "router ospf" : {
             "65001" : {
-              "router ospf self-reference" : [
-                26
-              ]
+              "router ospf self-reference" : "26"
             }
           }
         },
         "configs/foundry_bgp" : {
           "interface" : {
             "Loopback1" : {
-              "update-source interface" : [
-                16
-              ]
+              "update-source interface" : "16"
             }
           }
         },
         "configs/foundry_interface" : {
           "interface" : {
             "Ethernet1/15" : {
-              "interface" : [
-                5
-              ]
+              "interface" : "5"
             }
           }
         },
         "configs/foundry_misc" : {
           "interface" : {
             "Ethernet13/10" : {
-              "ip route next-hop interface" : [
-                39
-              ]
+              "ip route next-hop interface" : "39"
             }
           },
           "ipv4 acl" : {
             "blib" : {
-              "ssh ipv4 access-list" : [
-                31
-              ]
+              "ssh ipv4 access-list" : "31"
             }
           },
           "ipv6 acl" : {
             "blob" : {
-              "ssh ipv6 access-list" : [
-                32
-              ]
+              "ssh ipv6 access-list" : "32"
             }
           }
         },
         "configs/gh-2658-juniper-vrf-import-export.cfg" : {
           "bgp group" : {
             "overlay" : {
-              "bgp group neighbor" : [
-                149,
-                150,
-                151,
-                152
-              ]
+              "bgp group neighbor" : "149-152"
             },
             "underlay" : {
-              "bgp group neighbor" : [
-                126,
-                129,
-                132
-              ]
+              "bgp group neighbor" : "126,129,132"
             }
           },
           "interface" : {
             "fxp0" : {
-              "interface" : [
-                75
-              ]
+              "interface" : "75"
             },
             "fxp0.0" : {
-              "interface" : [
-                76
-              ]
+              "interface" : "76"
             },
             "irb" : {
-              "interface" : [
-                82
-              ]
+              "interface" : "82"
             },
             "irb.100" : {
-              "interface" : [
-                83
-              ]
+              "interface" : "83"
             },
             "lo0" : {
-              "interface" : [
-                91
-              ]
+              "interface" : "91"
             },
             "lo0.0" : {
-              "interface" : [
-                92
-              ],
-              "policy-statement from interface" : [
-                163
-              ],
-              "routing-instances vtep-source-interface" : [
-                201
-              ]
+              "interface" : "92",
+              "policy-statement from interface" : "163",
+              "routing-instances vtep-source-interface" : "201"
             },
             "lo0.1" : {
-              "interface" : [
-                97
-              ],
-              "routing-instance interface" : [
-                198
-              ]
+              "interface" : "97",
+              "routing-instance interface" : "198"
             },
             "xe-0/0/2" : {
-              "interface" : [
-                53
-              ]
+              "interface" : "53"
             },
             "xe-0/0/2.0" : {
-              "interface" : [
-                54
-              ]
+              "interface" : "54"
             },
             "xe-0/0/3" : {
-              "interface" : [
-                60
-              ]
+              "interface" : "60"
             },
             "xe-0/0/3.0" : {
-              "interface" : [
-                61
-              ]
+              "interface" : "61"
             },
             "xe-0/0/4" : {
-              "interface" : [
-                67
-              ]
+              "interface" : "67"
             },
             "xe-0/0/4.0" : {
-              "interface" : [
-                69
-              ]
+              "interface" : "69"
             }
           },
           "policy-statement" : {
             "export-loopback" : {
-              "bgp export policy-statement" : [
-                120
-              ]
+              "bgp export policy-statement" : "120"
             },
             "fabric" : {
-              "routing-instance vrf-import" : [
-                203
-              ]
+              "routing-instance vrf-import" : "203"
             },
             "lbpp" : {
-              "forwarding-table export policy-statement" : [
-                112
-              ]
+              "forwarding-table export policy-statement" : "112"
             }
           }
         },
         "configs/host2" : {
           "interface" : {
             "Ethernet0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             },
             "Ethernet1" : {
-              "interface" : [
-                7
-              ]
+              "interface" : "7"
             }
           }
         },
         "configs/interface_exit" : {
           "interface" : {
             "Vlan303" : {
-              "interface" : [
-                17
-              ]
+              "interface" : "17"
             },
             "Vlan803" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           }
         },
         "configs/interface_name" : {
           "interface" : {
             "FastEthernet12/13" : {
-              "interface" : [
-                3
-              ]
+              "interface" : "3"
             },
             "HundredGigE0/6/0/8" : {
-              "interface" : [
-                10
-              ]
+              "interface" : "10"
             },
             "Port-Channel1" : {
-              "interface" : [
-                7
-              ]
+              "interface" : "7"
             },
             "Vlan100" : {
-              "interface" : [
-                5
-              ]
+              "interface" : "5"
             }
           }
         },
         "configs/interface_sdr" : {
           "interface" : {
             "Loopback0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           }
         },
         "configs/ios_bgp" : {
           "ipv6 prefix-list" : {
             "VPNV6_PL" : {
-              "bgp inbound ipv6 prefix-list" : [
-                11
-              ]
+              "bgp inbound ipv6 prefix-list" : "11"
             }
           },
           "route-map" : {
             "ADVERTISE_MAP" : {
-              "bgp address-family aggregate-address advertise-map" : [
-                5
-              ]
+              "bgp address-family aggregate-address advertise-map" : "5"
             },
             "EXIST_MAP" : {
-              "bgp neighbor advertise-map exist-map" : [
-                5
-              ]
+              "bgp neighbor advertise-map exist-map" : "5"
             }
           },
           "undeclared bgp peer" : {
             "1.2.3.4" : {
-              "bgp neighbor without remote-as" : [
-                5
-              ]
+              "bgp neighbor without remote-as" : "5"
             }
           },
           "undeclared bgp peer-group" : {
             "UNDEFINED_PEER_GROUP" : {
-              "bgp peer-group referenced before defined" : [
-                8
-              ]
+              "bgp peer-group referenced before defined" : "8"
             }
           }
         },
         "configs/ios_interface" : {
           "interface" : {
             "GigabitEthernet1/0/1" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           },
           "policy-map" : {
             "FOOBAR" : {
-              "interface service-policy" : [
-                5
-              ]
+              "interface service-policy" : "5"
             }
           }
         },
         "configs/ios_interface_eigrp_settings" : {
           "interface" : {
             "Ethernet0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           }
         },
         "configs/ios_interface_ip_autentication" : {
           "interface" : {
             "Ethernet0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           }
         },
         "configs/ios_interface_ip_tcp" : {
           "interface" : {
             "Ethernet0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           }
         },
         "configs/ios_standby" : {
           "interface" : {
             "Vlan1000" : {
-              "interface" : [
-                5
-              ]
+              "interface" : "5"
             }
           },
           "track" : {
             "1" : {
-              "interface standby track" : [
-                12
-              ]
+              "interface standby track" : "12"
             }
           }
         },
         "configs/ios_xe_bgp" : {
           "bgp template peer-policy" : {
             "FOO-BAR_BAZ:QUX" : {
-              "inherited BGP peer-policy" : [
-                13
-              ]
+              "inherited BGP peer-policy" : "13"
             }
           },
           "bgp template peer-session" : {
             "FOO-BAR:BAZ" : {
-              "inherited BGP peer-session" : [
-                12
-              ]
+              "inherited BGP peer-session" : "12"
             }
           },
           "route-map" : {
             "MAP" : {
-              "bgp inbound route-map" : [
-                6
-              ]
+              "bgp inbound route-map" : "6"
             }
           }
         },
         "configs/ios_xr_bgp" : {
           "route-policy" : {
             "ADDITIONAL_PATHS_POLICY" : {
-              "bgp additional-paths selection route-policy" : [
-                9
-              ]
+              "bgp additional-paths selection route-policy" : "9"
             },
             "AGGREGATE_POLICY" : {
-              "aggregate-address route-policy" : [
-                11
-              ]
+              "aggregate-address route-policy" : "11"
             }
           }
         },
         "configs/ios_xr_bgp_neighbor_group" : {
           "bgp neighbor-group" : {
             "BGPMonitor" : {
-              "bgp use neighbor-group" : [
-                34
-              ]
+              "bgp use neighbor-group" : "34"
             },
             "foobar-iBGP_border_ipv4" : {
-              "bgp use neighbor-group" : [
-                88
-              ]
+              "bgp use neighbor-group" : "88"
             },
             "foobar-iBGP_ipv4" : {
-              "bgp use neighbor-group" : [
-                79,
-                84
-              ]
+              "bgp use neighbor-group" : "79,84"
             }
           },
           "bgp session-group" : {
             "CIAO" : {
-              "bgp use session-group" : [
-                95
-              ]
+              "bgp use session-group" : "95"
             },
             "bippety" : {
-              "bgp use session-group" : [
-                35
-              ]
+              "bgp use session-group" : "35"
             },
             "blabber" : {
-              "bgp use session-group" : [
-                18
-              ]
+              "bgp use session-group" : "18"
             },
             "excellect-group" : {
-              "bgp use session-group" : [
-                89
-              ]
+              "bgp use session-group" : "89"
             }
           },
           "interface" : {
             "Loopback0" : {
-              "update-source interface" : [
-                23,
-                37,
-                49,
-                59,
-                70
-              ]
+              "update-source interface" : "23,37,49,59,70"
             }
           },
           "route-policy" : {
             "advertise_fooey_dc_and_isp_routes_ipv4" : {
-              "bgp neighbor route-policy out" : [
-                26,
-                30
-              ]
+              "bgp neighbor route-policy out" : "26,30"
             },
             "advertise_fooey_routes_only" : {
-              "bgp neighbor route-policy out" : [
-                40
-              ]
+              "bgp neighbor route-policy out" : "40"
             },
             "deny_bgp_routes" : {
-              "bgp neighbor route-policy in" : [
-                25,
-                29
-              ]
+              "bgp neighbor route-policy in" : "25,29"
             },
             "deny_default_network_ipv4" : {
-              "bgp neighbor route-policy out" : [
-                61
-              ]
+              "bgp neighbor route-policy out" : "61"
             }
           }
         },
         "configs/ios_xr_multicast" : {
           "ipv4 access-list" : {
             "MSDP_filter" : {
-              "msdp peer sa-list" : [
-                30,
-                31,
-                47,
-                48
-              ]
+              "msdp peer sa-list" : "30-31,47-48"
             }
           }
         },
         "configs/ios_xr_multipart" : {
           "ipv4 access-list" : {
             "GNS-VTY-ACCESS" : {
-              "ssh ipv4 access-list" : [
-                31
-              ]
+              "ssh ipv4 access-list" : "31"
             }
           }
         },
         "configs/ios_xr_ospf" : {
           "interface" : {
             "Bundle-Ether101" : {
-              "router ospf area interface" : [
-                18
-              ]
+              "router ospf area interface" : "18"
             },
             "Bundle-Ether103" : {
-              "router ospf area interface" : [
-                24
-              ]
+              "router ospf area interface" : "24"
             },
             "Bundle-Ether201" : {
-              "router ospf area interface" : [
-                28
-              ]
+              "router ospf area interface" : "28"
             },
             "HundredGigE0/2/0/0.292" : {
-              "router ospf area interface" : [
-                42
-              ]
+              "router ospf area interface" : "42"
             },
             "HundredGigE0/2/0/3" : {
-              "router ospf area interface" : [
-                44
-              ]
+              "router ospf area interface" : "44"
             },
             "Loopback0" : {
-              "router ospf area interface" : [
-                33
-              ]
+              "router ospf area interface" : "33"
             },
             "TenGigE0/0/0/2" : {
-              "router ospf area interface" : [
-                51
-              ]
+              "router ospf area interface" : "51"
             },
             "TenGigE0/0/0/4" : {
-              "router ospf area interface" : [
-                36
-              ]
+              "router ospf area interface" : "36"
             },
             "TenGigE0/0/0/5" : {
-              "router ospf area interface" : [
-                39
-              ]
+              "router ospf area interface" : "39"
             }
           }
         },
         "configs/ios_xr_route_policy" : {
           "as-path-set" : {
             "chill-as-path" : {
-              "route-policy as-path in" : [
-                124
-              ]
+              "route-policy as-path in" : "124"
             },
             "chill_aspath_141_deny" : {
-              "route-policy as-path in" : [
-                130
-              ]
+              "route-policy as-path in" : "130"
             },
             "chill_aspath_141_permit" : {
-              "route-policy as-path in" : [
-                144
-              ]
+              "route-policy as-path in" : "144"
             },
             "chill_aspath_142_permit" : {
-              "route-policy as-path in" : [
-                146
-              ]
+              "route-policy as-path in" : "146"
             },
             "xo-deny-as" : {
-              "route-policy as-path in" : [
-                91
-              ]
+              "route-policy as-path in" : "91"
             }
           },
           "community-set" : {
             "CF_fooey_Associates-chillmap" : {
-              "route-policy community matches-any" : [
-                146
-              ]
+              "route-policy community matches-any" : "146"
             },
             "DC_AT_CHILL" : {
-              "route-policy community matches-any" : [
-                151
-              ]
+              "route-policy community matches-any" : "151"
             },
             "EBGP-CUST-EXT" : {
-              "route-policy community matches-any" : [
-                99
-              ]
+              "route-policy community matches-any" : "99"
             },
             "EBGP-CUST-NOEXP-PEER-NA" : {
-              "route-policy community matches-any" : [
-                89
-              ]
+              "route-policy community matches-any" : "89"
             },
             "barbar_to_fooey_community_ipv4" : {
-              "route-policy set community" : [
-                53
-              ]
+              "route-policy set community" : "53"
             },
             "blackhole-all" : {
-              "route-policy community matches-any" : [
-                108,
-                159
-              ]
+              "route-policy community matches-any" : "108,159"
             },
             "blackhole-isp" : {
-              "route-policy community matches-any" : [
-                111
-              ]
+              "route-policy community matches-any" : "111"
             },
             "chillmap" : {
-              "route-policy community matches-any" : [
-                142
-              ]
+              "route-policy community matches-any" : "142"
             },
             "community_5555" : {
-              "route-policy community matches-any" : [
-                34
-              ],
-              "route-policy delete community [not] in" : [
-                35
-              ]
+              "route-policy community matches-any" : "34",
+              "route-policy delete community [not] in" : "35"
             },
             "fooey_blackhole_community" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             },
             "fooey_routes_community" : {
-              "route-policy community matches-any" : [
-                17
-              ]
+              "route-policy community matches-any" : "17"
             },
             "scenes_No_Export" : {
-              "route-policy community matches-any" : [
-                121
-              ]
+              "route-policy community matches-any" : "121"
             },
             "to-peers-backbone" : {
-              "route-policy community matches-any" : [
-                138
-              ]
+              "route-policy community matches-any" : "138"
             },
             "wrn-expanded" : {
-              "route-policy community matches-any" : [
-                130,
-                144
-              ]
+              "route-policy community matches-any" : "130,144"
             },
             "wrn-squelch-40027" : {
-              "route-policy community matches-any" : [
-                127
-              ]
+              "route-policy community matches-any" : "127"
             }
           },
           "prefix-set" : {
             "EBGP-PEER-BOGONS" : {
-              "route-policy prefix-set" : [
-                79
-              ]
+              "route-policy prefix-set" : "79"
             },
             "EBGP-PEER-OTHER-UNDESIRABLES" : {
-              "route-policy prefix-set" : [
-                79
-              ]
+              "route-policy prefix-set" : "79"
             },
             "EBGP-PEER-TOO-SPECIFIC" : {
-              "route-policy prefix-set" : [
-                81
-              ]
+              "route-policy prefix-set" : "81"
             },
             "barbar_blackhole_routes" : {
-              "route-policy prefix-set" : [
-                6,
-                52
-              ]
+              "route-policy prefix-set" : "6,52"
             },
             "barbar_networks_ipv4" : {
-              "route-policy prefix-set" : [
-                52
-              ]
+              "route-policy prefix-set" : "52"
             },
             "barbar_networks_ipv6" : {
-              "route-policy prefix-set" : [
-                22
-              ]
+              "route-policy prefix-set" : "22"
             },
             "bippetyboppety_ipv4" : {
-              "route-policy prefix-set" : [
-                45,
-                52
-              ]
+              "route-policy prefix-set" : "45,52"
             },
             "local-peer-aggregates" : {
-              "route-policy prefix-set" : [
-                69
-              ]
+              "route-policy prefix-set" : "69"
             },
             "null" : {
-              "route-policy prefix-set" : [
-                115
-              ]
+              "route-policy prefix-set" : "115"
             },
             "remote-router-loopbacks" : {
-              "route-policy prefix-set" : [
-                67
-              ]
+              "route-policy prefix-set" : "67"
             }
           },
           "route-policy" : {
             "bbbb" : {
-              "route-policy apply" : [
-                29
-              ]
+              "route-policy apply" : "29"
             }
           }
         },
         "configs/ios_xr_router_static" : {
           "interface" : {
             "GigabitEthernet0/2/1/5.290" : {
-              "router static route" : [
-                17
-              ]
+              "router static route" : "17"
             },
             "Null0" : {
-              "router static route" : [
-                7,
-                10,
-                11,
-                12,
-                13,
-                15,
-                16
-              ]
+              "router static route" : "7,10-13,15-16"
             },
             "TenGigE0/0/2/3" : {
-              "router static route" : [
-                8
-              ]
+              "router static route" : "8"
             }
           }
         },
         "configs/ios_xr_ssh" : {
           "ipv4 access-list" : {
             "ACL99" : {
-              "ssh ipv4 access-list" : [
-                7
-              ]
+              "ssh ipv4 access-list" : "7"
             }
           },
           "ipv6 access-list" : {
             "ipv6-vty-acl" : {
-              "ssh ipv6 access-list" : [
-                7
-              ]
+              "ssh ipv6 access-list" : "7"
             }
           }
         },
         "configs/juniper-interfaces" : {
           "interface" : {
             "xe-0/0/0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             },
             "xe-0/0/0:0" : {
-              "interface" : [
-                4,
-                5,
-                15
-              ]
+              "interface" : "4-5,15"
             },
             "xe-0/0/0:0.0" : {
-              "interface" : [
-                5,
-                15
-              ],
-              "ospf area interface" : [
-                17
-              ]
+              "interface" : "5,15",
+              "ospf area interface" : "17"
             }
           }
         },
         "configs/juniper-tcpflags" : {
           "firewall filter term" : {
             "foo bar" : {
-              "firewall filter term" : [
-                4
-              ]
+              "firewall filter term" : "4"
             }
           }
         },
         "configs/juniper_as_path_group" : {
           "as-path-group as-path" : {
             "AS_PATH_REGEX_NAME1" : {
-              "as-path-group as-path" : [
-                5
-              ]
+              "as-path-group as-path" : "5"
             },
             "AS_PATH_REGEX_NAME2" : {
-              "as-path-group as-path" : [
-                6
-              ]
+              "as-path-group as-path" : "6"
             }
           }
         },
         "configs/juniper_bgp" : {
           "bgp group" : {
             "someinternalipv4group" : {
-              "bgp group neighbor" : [
-                33,
-                34
-              ]
+              "bgp group neighbor" : "33-34"
             },
             "someinternalipv6group" : {
-              "bgp group neighbor" : [
-                42
-              ]
+              "bgp group neighbor" : "42"
             },
             "someipv4bgpgroup" : {
-              "bgp group neighbor" : [
-                15,
-                16,
-                17
-              ]
+              "bgp group neighbor" : "15-17"
             },
             "someipv6bgpgroup" : {
-              "bgp group neighbor" : [
-                25
-              ]
+              "bgp group neighbor" : "25"
             }
           },
           "policy-statement" : {
             "someexportpolicy" : {
-              "bgp export policy-statement" : [
-                10,
-                21,
-                28,
-                37
-              ]
+              "bgp export policy-statement" : "10,21,28,37"
             },
             "someimportpolicy" : {
-              "bgp import policy-statement" : [
-                13,
-                23,
-                30,
-                39
-              ]
+              "bgp import policy-statement" : "13,23,30,39"
             }
           }
         },
         "configs/juniper_bgp_allow" : {
           "bgp group" : {
             "GROUP" : {
-              "bgp group allow" : [
-                8
-              ]
+              "bgp group allow" : "8"
             }
           }
         },
         "configs/juniper_bgp_authentication" : {
           "authentication-key-chain" : {
             "bgp-auth" : {
-              "authentication-key-chains policy" : [
-                10
-              ]
+              "authentication-key-chains policy" : "10"
             },
             "bgp-auth1" : {
-              "authentication-key-chains policy" : [
-                23
-              ]
+              "authentication-key-chains policy" : "23"
             }
           },
           "bgp group" : {
             "ext" : {
-              "bgp group neighbor" : [
-                8
-              ]
+              "bgp group neighbor" : "8"
             },
             "ext1" : {
-              "bgp group neighbor" : [
-                22
-              ]
+              "bgp group neighbor" : "22"
             }
           }
         },
         "configs/juniper_bgp_enforce_fist_as" : {
           "bgp group" : {
             "MYGROUP" : {
-              "bgp group neighbor" : [
-                7
-              ]
+              "bgp group neighbor" : "7"
             }
           }
         },
         "configs/juniper_firewall" : {
           "firewall filter term" : {
             "ISP-INBOUND-L2 ALLOW-ARP" : {
-              "firewall filter term" : [
-                47
-              ]
+              "firewall filter term" : "47"
             },
             "blah blorp" : {
-              "firewall filter term" : [
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                35,
-                36
-              ]
+              "firewall filter term" : "5-28,35-36"
             },
             "blah prefix-list" : {
-              "firewall filter term" : [
-                30
-              ]
+              "firewall filter term" : "30"
             },
             "blah some term" : {
-              "firewall filter term" : [
-                32
-              ]
+              "firewall filter term" : "32"
             },
             "blah t2" : {
-              "firewall filter term" : [
-                38
-              ]
+              "firewall filter term" : "38"
             },
             "blah t3" : {
-              "firewall filter term" : [
-                40
-              ]
+              "firewall filter term" : "40"
             },
             "blah6 blorp6" : {
-              "firewall filter term" : [
-                42,
-                43,
-                44
-              ]
+              "firewall filter term" : "42-44"
             },
             "f1 t1" : {
-              "firewall filter term" : [
-                4
-              ]
+              "firewall filter term" : "4"
             },
             "ip_options t1" : {
-              "firewall filter term" : [
-                48,
-                49,
-                50,
-                51,
-                52,
-                53,
-                54,
-                55
-              ]
+              "firewall filter term" : "48-55"
             }
           },
           "routing-instance" : {
             "OTHER_INSTANCE" : {
-              "firewall filter then routing-instance" : [
-                38
-              ]
+              "firewall filter then routing-instance" : "38"
             }
           }
         },
         "configs/juniper_forwarding_options" : {
           "dhcp-relay server-group" : {
             "site-dhcp" : {
-              "dhcp relay group active-server-group" : [
-                8,
-                13
-              ]
+              "dhcp relay group active-server-group" : "8,13"
             },
             "test2" : {
-              "dhcp relay group active-server-group" : [
-                9,
-                17
-              ]
+              "dhcp relay group active-server-group" : "9,17"
             }
           },
           "interface" : {
             "et-0/0/10.0" : {
-              "fowarding-options dhcp-relay group interface" : [
-                15
-              ]
+              "fowarding-options dhcp-relay group interface" : "15"
             },
             "ge-0/2/5.0" : {
-              "fowarding-options dhcp-relay group interface" : [
-                18
-              ]
+              "fowarding-options dhcp-relay group interface" : "18"
             },
             "xe-1/0/0.0" : {
-              "fowarding-options dhcp-relay group interface" : [
-                10
-              ]
+              "fowarding-options dhcp-relay group interface" : "10"
             }
           }
         },
         "configs/juniper_interfaces" : {
           "interface" : {
             "ae0" : {
-              "interface" : [
-                5
-              ]
+              "interface" : "5"
             },
             "ae0.0" : {
-              "interface" : [
-                5
-              ]
+              "interface" : "5"
             },
             "fab0" : {
-              "interface" : [
-                6
-              ]
+              "interface" : "6"
             },
             "ge-0/0/0" : {
-              "interface" : [
-                7
-              ]
+              "interface" : "7"
             },
             "ge-0/0/1" : {
-              "routing-instance interface" : [
-                24
-              ]
+              "routing-instance interface" : "24"
             },
             "ge-1/0/0" : {
-              "interface" : [
-                8
-              ]
+              "interface" : "8"
             },
             "ge-2/0/0" : {
-              "interface" : [
-                9,
-                10
-              ]
+              "interface" : "9-10"
             },
             "ge-2/0/0.0" : {
-              "interface" : [
-                9
-              ]
+              "interface" : "9"
             },
             "ge-2/0/0.1" : {
-              "interface" : [
-                10
-              ]
+              "interface" : "10"
             },
             "ge-3/0/0" : {
-              "interface" : [
-                11
-              ]
+              "interface" : "11"
             },
             "ge-3/0/0.0" : {
-              "interface" : [
-                11
-              ]
+              "interface" : "11"
             },
             "ge-4/0/0" : {
-              "interface" : [
-                12
-              ]
+              "interface" : "12"
             },
             "ge-4/0/0.0" : {
-              "interface" : [
-                12
-              ]
+              "interface" : "12"
             },
             "ge-5/0/0" : {
-              "interface" : [
-                13
-              ]
+              "interface" : "13"
             },
             "ge-5/0/0.0" : {
-              "interface" : [
-                13
-              ]
+              "interface" : "13"
             },
             "irb" : {
-              "interface" : [
-                16,
-                17,
-                18,
-                19
-              ]
+              "interface" : "16-19"
             },
             "irb.5" : {
-              "interface" : [
-                16,
-                17,
-                18,
-                19
-              ]
+              "interface" : "16-19"
             },
             "vme" : {
-              "interface" : [
-                22
-              ]
+              "interface" : "22"
             },
             "vme.0" : {
-              "interface" : [
-                22
-              ]
+              "interface" : "22"
             },
             "xe-0/0/0:0" : {
-              "interface" : [
-                14,
-                15
-              ]
+              "interface" : "14-15"
             },
             "xe-0/0/0:0.0" : {
-              "interface" : [
-                15
-              ]
+              "interface" : "15"
             },
             "xe-0/0/5:0" : {
-              "interface" : [
-                20
-              ]
+              "interface" : "20"
             },
             "xe-0/0/5:0.0" : {
-              "interface" : [
-                20
-              ]
+              "interface" : "20"
             },
             "xe-0/0/6" : {
-              "interface" : [
-                21
-              ]
+              "interface" : "21"
             }
           },
           "vlan" : {
             "bippetyboppety" : {
-              "interface vlan" : [
-                20
-              ]
+              "interface vlan" : "20"
             }
           }
         },
         "configs/juniper_isis" : {
           "interface" : {
             "ge-0/0/0" : {
-              "interface" : [
-                6
-              ]
+              "interface" : "6"
             },
             "ge-0/0/0.0" : {
-              "interface" : [
-                6
-              ],
-              "isis interface" : [
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14
-              ]
+              "interface" : "6",
+              "isis interface" : "8-14"
             }
           }
         },
         "configs/juniper_misc" : {
           "interface" : {
             "lo0.0" : {
-              "routing-instances vtep-source-interface" : [
-                9
-              ]
+              "routing-instances vtep-source-interface" : "9"
             }
           }
         },
         "configs/juniper_nat" : {
           "interface" : {
             "ge-0/0/0" : {
-              "interface" : [
-                33
-              ]
+              "interface" : "33"
             },
             "ge-0/0/0.0" : {
-              "interface" : [
-                33
-              ],
-              "security zones security-zone interfaces" : [
-                34
-              ]
+              "interface" : "33",
+              "security zones security-zone interfaces" : "34"
             }
           }
         },
         "configs/juniper_ospf" : {
           "interface" : {
             "ae16.0" : {
-              "ospf area interface" : [
-                18,
-                19,
-                20,
-                21,
-                23,
-                24
-              ]
+              "ospf area interface" : "18-21,23-24"
             },
             "xe-0/0/1.0" : {
-              "ospf area interface" : [
-                16
-              ]
+              "ospf area interface" : "16"
             },
             "xe-0/0/20:0.0" : {
-              "ospf area interface" : [
-                4,
-                5,
-                6,
-                7
-              ]
+              "ospf area interface" : "4-7"
             },
             "xe-0/0/21:0.0" : {
-              "ospf area interface" : [
-                8
-              ]
+              "ospf area interface" : "8"
             }
           }
         },
         "configs/juniper_ospf_disable" : {
           "interface" : {
             "ge-0/0/0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             },
             "ge-0/0/0.0" : {
-              "interface" : [
-                4
-              ],
-              "ospf area interface" : [
-                6
-              ]
+              "interface" : "4",
+              "ospf area interface" : "6"
             }
           }
         },
         "configs/juniper_policy_statement" : {
           "as-path" : {
             "ORIGINATED_IN_65535" : {
-              "policy-statement from as-path" : [
-                35
-              ]
+              "policy-statement from as-path" : "35"
             }
           },
           "as-path-group" : {
             "AS_PATH_GROUP" : {
-              "policy-statement from as-path-group" : [
-                4
-              ]
+              "policy-statement from as-path-group" : "4"
             }
           },
           "routing-instance" : {
             "FORWARDING" : {
-              "policy-statement from instance" : [
-                17
-              ]
+              "policy-statement from instance" : "17"
             }
           }
         },
         "configs/juniper_relay" : {
           "dhcp-relay server-group" : {
             "site-dhcp" : {
-              "dhcp relay group active-server-group" : [
-                5,
-                6
-              ]
+              "dhcp relay group active-server-group" : "5-6"
             }
           },
           "interface" : {
             "irb.10" : {
-              "fowarding-options dhcp-relay group interface" : [
-                7
-              ]
+              "fowarding-options dhcp-relay group interface" : "7"
             },
             "irb.20" : {
-              "fowarding-options dhcp-relay group interface" : [
-                8
-              ]
+              "fowarding-options dhcp-relay group interface" : "8"
             }
           }
         },
         "configs/juniper_reth_interfaces" : {
           "interface" : {
             "ge-0/0/0" : {
-              "interface" : [
-                4,
-                5
-              ]
+              "interface" : "4-5"
             },
             "ge-0/0/0.0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             },
             "ge-0/0/1" : {
-              "interface" : [
-                6,
-                7
-              ]
+              "interface" : "6-7"
             },
             "ge-0/0/1.0" : {
-              "interface" : [
-                6
-              ]
+              "interface" : "6"
             },
             "reth0" : {
-              "interface" : [
-                8
-              ]
+              "interface" : "8"
             },
             "reth0.3" : {
-              "interface" : [
-                8
-              ]
+              "interface" : "8"
             }
           }
         },
         "configs/juniper_rib_groups" : {
           "bgp group" : {
             "BGP_GROUP" : {
-              "bgp group neighbor" : [
-                16,
-                19,
-                22,
-                25
-              ]
+              "bgp group neighbor" : "16,19,22,25"
             }
           },
           "rib-group" : {
             "bgp-rib-group" : {
-              "bgp family inet unicast rib-group" : [
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25
-              ]
+              "bgp family inet unicast rib-group" : "14-25"
             },
             "interface-routes-rib" : {
-              "routing-options interface-routes" : [
-                3,
-                4
-              ]
+              "routing-options interface-routes" : "3-4"
             }
           }
         },
         "configs/juniper_routing_options" : {
           "policy-statement" : {
             "AGGREGATE_ROUTE_POLICY" : {
-              "aggregate route policy" : [
-                9
-              ]
+              "aggregate route policy" : "9"
             },
             "POLICY" : {
-              "routing-options instance-import" : [
-                17
-              ]
+              "routing-options instance-import" : "17"
             }
           }
         },
         "configs/juniper_routing_policy" : {
           "interface" : {
             "ge-0/0/0" : {
-              "interface" : [
-                4,
-                5
-              ]
+              "interface" : "4-5"
             },
             "ge-0/0/0.0" : {
-              "interface" : [
-                4,
-                5
-              ],
-              "policy-statement from interface" : [
-                7
-              ]
+              "interface" : "4-5",
+              "policy-statement from interface" : "7"
             },
             "ge-0/0/0.99" : {
-              "policy-statement from interface" : [
-                9
-              ]
+              "policy-statement from interface" : "9"
             }
           }
         },
         "configs/juniper_security" : {
           "address-book" : {
             "notglobalAttached" : {
-              "address-book attach zone" : [
-                10
-              ]
+              "address-book attach zone" : "10"
             }
           },
           "ike proposal" : {
             "PROPOSAL" : {
-              "ike policy ike proposal" : [
-                14
-              ]
+              "ike policy ike proposal" : "14"
             }
           },
           "security policy" : {
             "zone~A~to~zone~B" : {
-              "security policy" : [
-                19,
-                20,
-                21,
-                22
-              ]
+              "security policy" : "19-22"
             },
             "~GLOBAL_SECURITY_POLICY~" : {
-              "security policy" : [
-                16,
-                17
-              ]
+              "security policy" : "16-17"
             }
           },
           "security policy term" : {
             "zone~A~to~zone~B 123-4" : {
-              "security policy term" : [
-                19,
-                20,
-                21,
-                22
-              ]
+              "security policy term" : "19-22"
             },
             "~GLOBAL_SECURITY_POLICY~ p1" : {
-              "security policy term" : [
-                16,
-                17
-              ]
+              "security policy term" : "16-17"
             }
           }
         },
         "configs/juniper_snmp" : {
           "prefix-list" : {
             "bippetyboo" : {
-              "snmp community prefix-list" : [
-                5
-              ]
+              "snmp community prefix-list" : "5"
             }
           }
         },
         "configs/juniper_system" : {
           "logical-system" : {
             "ls905" : {
-              "security-profile logical-system" : [
-                21
-              ]
+              "security-profile logical-system" : "21"
             }
           }
         },
         "configs/juniper_vlan" : {
           "interface" : {
             "vlan.30" : {
-              "vlan l3-interface" : [
-                6
-              ]
+              "vlan l3-interface" : "6"
             },
             "vlan.40" : {
-              "vlan l3-interface" : [
-                8
-              ]
+              "vlan l3-interface" : "8"
             },
             "xe-0/0/0" : {
-              "interface" : [
-                10,
-                11,
-                12,
-                13,
-                14
-              ]
+              "interface" : "10-14"
             },
             "xe-0/0/0.0" : {
-              "interface" : [
-                10,
-                11,
-                12,
-                13,
-                14
-              ]
+              "interface" : "10-14"
             }
           },
           "vlan" : {
             "VLAN30" : {
-              "interface vlan" : [
-                11
-              ]
+              "interface vlan" : "11"
             },
             "VLAN40" : {
-              "interface vlan" : [
-                12
-              ]
+              "interface vlan" : "12"
             }
           }
         },
         "configs/mos_interface" : {
           "interface" : {
             "Ethernet1" : {
-              "interface" : [
-                6
-              ]
+              "interface" : "6"
             },
             "Ethernet2" : {
-              "interface" : [
-                9
-              ]
+              "interface" : "9"
             },
             "Management1" : {
-              "interface" : [
-                16
-              ]
+              "interface" : "16"
             },
             "ap1" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           }
         },
         "configs/named_and_numbered_lists" : {
           "ipv4 acl" : {
             "1" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "2" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "4" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "456def" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "5" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "95qrs5" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "a4" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "abc123" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             }
           }
         },
         "configs/nxos/nxos_bgp" : {
           "bgp template peer" : {
             "PEER_BLLF" : {
-              "bgp neighbor inherit peer" : [
-                39
-              ]
+              "bgp neighbor inherit peer" : "39"
             }
           },
           "class-map type control-plane" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "default-out-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "route-map" : {
             "BLIB" : {
-              "bgp address-family [IPv6] network route-map" : [
-                24
-              ]
+              "bgp address-family [IPv6] network route-map" : "24"
             },
             "BLIBB" : {
-              "bgp address-family network route-map" : [
-                21
-              ]
+              "bgp address-family network route-map" : "21"
             },
             "BLOBB" : {
-              "bgp address-family redistribute route-map" : [
-                18
-              ]
+              "bgp address-family redistribute route-map" : "18"
             },
             "EG_CCC" : {
-              "bgp neighbor address-family route-map out" : [
-                34
-              ]
+              "bgp neighbor address-family route-map out" : "34"
             },
             "IN_BBB" : {
-              "bgp neighbor address-family route-map in" : [
-                33
-              ]
+              "bgp neighbor address-family route-map in" : "33"
             }
           },
           "vrf" : {
             "default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "management" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           }
         },
         "configs/nxos/nxos_interface" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                6
-              ]
+              "interface" : "6"
             },
             "Ethernet0/1" : {
-              "interface" : [
-                15
-              ]
+              "interface" : "15"
             }
           },
           "nve" : {
             "nve1" : {
-              "interface nve" : [
-                12
-              ]
+              "interface nve" : "12"
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "default-out-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "vrf" : {
             "default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "management" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           }
         },
         "configs/nxos/nxos_misc" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "default-out-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "vrf" : {
             "default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "management" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           }
         },
         "configs/nxos/nxos_ntp" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "default-out-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "vrf" : {
             "default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "management" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           }
         },
         "configs/nxos/nxos_ospf" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "interface" : {
             "Ethernet0/0" : {
-              "interface" : [
-                9
-              ]
+              "interface" : "9"
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "default-out-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "route-map" : {
             "RM_OSPF_DIRECT" : {
-              "router ospf redistribute route-map" : [
-                27,
-                32
-              ]
+              "router ospf redistribute route-map" : "27,32"
             },
             "RM_OSPF_STATIC" : {
-              "router ospf redistribute route-map" : [
-                28
-              ]
+              "router ospf redistribute route-map" : "28"
             }
           },
           "router ospf" : {
             "1" : {
-              "interface ip router ospf" : [
-                13
-              ],
-              "router ospf" : [
-                23,
-                38
-              ]
+              "interface ip router ospf" : "13",
+              "router ospf" : "23,38"
             },
             "100" : {
-              "router ospf" : [
-                34
-              ]
+              "router ospf" : "34"
             },
             "ignored" : {
-              "router ospf" : [
-                18,
-                30
-              ]
+              "router ospf" : "18,30"
             }
           },
           "vrf" : {
             "OTHER" : {
-              "interface vrf member" : [
-                12
-              ]
+              "interface vrf member" : "12"
             },
             "default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "management" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           }
         },
         "configs/nxos/nxos_route_map_continue" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "default-out-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "route-map entry" : {
             "foobar 10" : {
-              "route-map entry" : [
-                6
-              ]
+              "route-map entry" : "6"
             },
             "foobar 100" : {
-              "route-map continue" : [
-                34
-              ],
-              "route-map entry" : [
-                37
-              ]
+              "route-map continue" : "34",
+              "route-map entry" : "37"
             },
             "foobar 110" : {
-              "route-map entry" : [
-                40
-              ]
+              "route-map entry" : "40"
             },
             "foobar 120" : {
-              "route-map continue" : [
-                39,
-                41
-              ],
-              "route-map entry" : [
-                43
-              ]
+              "route-map continue" : "39,41",
+              "route-map entry" : "43"
             },
             "foobar 130" : {
-              "route-map continue" : [
-                45
-              ],
-              "route-map entry" : [
-                47
-              ]
+              "route-map continue" : "45",
+              "route-map entry" : "47"
             },
             "foobar 140" : {
-              "route-map continue" : [
-                49
-              ],
-              "route-map entry" : [
-                51
-              ]
+              "route-map continue" : "49",
+              "route-map entry" : "51"
             },
             "foobar 150" : {
-              "route-map continue" : [
-                53
-              ],
-              "route-map entry" : [
-                55
-              ]
+              "route-map continue" : "53",
+              "route-map entry" : "55"
             },
             "foobar 160" : {
-              "route-map continue" : [
-                57
-              ],
-              "route-map entry" : [
-                59
-              ]
+              "route-map continue" : "57",
+              "route-map entry" : "59"
             },
             "foobar 170" : {
-              "route-map continue" : [
-                61
-              ],
-              "route-map entry" : [
-                63
-              ]
+              "route-map continue" : "61",
+              "route-map entry" : "63"
             },
             "foobar 180" : {
-              "route-map continue" : [
-                65
-              ],
-              "route-map entry" : [
-                67
-              ]
+              "route-map continue" : "65",
+              "route-map entry" : "67"
             },
             "foobar 190" : {
-              "route-map continue" : [
-                69
-              ],
-              "route-map entry" : [
-                71
-              ]
+              "route-map continue" : "69",
+              "route-map entry" : "71"
             },
             "foobar 20" : {
-              "route-map entry" : [
-                8
-              ]
+              "route-map entry" : "8"
             },
             "foobar 200" : {
-              "route-map continue" : [
-                73
-              ],
-              "route-map entry" : [
-                75
-              ]
+              "route-map continue" : "73",
+              "route-map entry" : "75"
             },
             "foobar 210" : {
-              "route-map continue" : [
-                77
-              ],
-              "route-map entry" : [
-                79
-              ]
+              "route-map continue" : "77",
+              "route-map entry" : "79"
             },
             "foobar 220" : {
-              "route-map continue" : [
-                81
-              ],
-              "route-map entry" : [
-                83
-              ]
+              "route-map continue" : "81",
+              "route-map entry" : "83"
             },
             "foobar 230" : {
-              "route-map entry" : [
-                86
-              ]
+              "route-map entry" : "86"
             },
             "foobar 240" : {
-              "route-map continue" : [
-                85
-              ],
-              "route-map entry" : [
-                87
-              ]
+              "route-map continue" : "85",
+              "route-map entry" : "87"
             },
             "foobar 250" : {
-              "route-map continue" : [
-                89
-              ],
-              "route-map entry" : [
-                91
-              ]
+              "route-map continue" : "89",
+              "route-map entry" : "91"
             },
             "foobar 260" : {
-              "route-map continue" : [
-                93
-              ],
-              "route-map entry" : [
-                95
-              ]
+              "route-map continue" : "93",
+              "route-map entry" : "95"
             },
             "foobar 270" : {
-              "route-map continue" : [
-                97
-              ],
-              "route-map entry" : [
-                99
-              ]
+              "route-map continue" : "97",
+              "route-map entry" : "99"
             },
             "foobar 280" : {
-              "route-map continue" : [
-                101
-              ],
-              "route-map entry" : [
-                103
-              ]
+              "route-map continue" : "101",
+              "route-map entry" : "103"
             },
             "foobar 290" : {
-              "route-map continue" : [
-                105
-              ],
-              "route-map entry" : [
-                107
-              ]
+              "route-map continue" : "105",
+              "route-map entry" : "107"
             },
             "foobar 30" : {
-              "route-map entry" : [
-                10
-              ]
+              "route-map entry" : "10"
             },
             "foobar 300" : {
-              "route-map continue" : [
-                109
-              ],
-              "route-map entry" : [
-                111
-              ]
+              "route-map continue" : "109",
+              "route-map entry" : "111"
             },
             "foobar 310" : {
-              "route-map continue" : [
-                112
-              ],
-              "route-map entry" : [
-                114
-              ]
+              "route-map continue" : "112",
+              "route-map entry" : "114"
             },
             "foobar 40" : {
-              "route-map entry" : [
-                13
-              ]
+              "route-map entry" : "13"
             },
             "foobar 50" : {
-              "route-map continue" : [
-                12
-              ],
-              "route-map entry" : [
-                14
-              ]
+              "route-map continue" : "12",
+              "route-map entry" : "14"
             },
             "foobar 60" : {
-              "route-map continue" : [
-                15
-              ],
-              "route-map entry" : [
-                17
-              ]
+              "route-map continue" : "15",
+              "route-map entry" : "17"
             },
             "foobar 70" : {
-              "route-map continue" : [
-                19
-              ],
-              "route-map entry" : [
-                22
-              ]
+              "route-map continue" : "19",
+              "route-map entry" : "22"
             },
             "foobar 80" : {
-              "route-map continue" : [
-                24
-              ],
-              "route-map entry" : [
-                27
-              ]
+              "route-map continue" : "24",
+              "route-map entry" : "27"
             },
             "foobar 90" : {
-              "route-map continue" : [
-                29
-              ],
-              "route-map entry" : [
-                32
-              ]
+              "route-map continue" : "29",
+              "route-map entry" : "32"
             }
           },
           "vrf" : {
             "default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "management" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           }
         },
         "configs/nxos/nxos_ssh" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "default-out-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "vrf" : {
             "default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "management" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           }
         },
         "configs/nxos/nxos_system" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "policy-map type network-qos" : {
             "jumbo" : {
-              "system qos service-policy type network-qos" : [
-                11
-              ]
+              "system qos service-policy type network-qos" : "11"
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "built-in structure" : [
-                0
-              ],
-              "system qos service-policy type queuing" : [
-                9
-              ]
+              "built-in structure" : "0",
+              "system qos service-policy type queuing" : "9"
             },
             "default-out-policy" : {
-              "built-in structure" : [
-                0
-              ],
-              "system qos service-policy type queuing" : [
-                10
-              ]
+              "built-in structure" : "0",
+              "system qos service-policy type queuing" : "10"
             }
           },
           "vrf" : {
             "default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "management" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           }
         },
         "configs/nxos/nxos_vrf" : {
           "class-map type control-plane" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type network-qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type qos" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "class-map type queuing" : {
             "class-default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "policy-map type queuing" : {
             "default-in-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "default-out-policy" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           },
           "vrf" : {
             "default" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             },
             "management" : {
-              "built-in structure" : [
-                0
-              ]
+              "built-in structure" : "0"
             }
           }
         },
         "configs/palo_alto/applications" : {
           "application-group or application or none" : {
             "ssh~panorama" : {
-              "application-group members" : [
-                17
-              ]
+              "application-group members" : "17"
             },
             "ssl~panorama" : {
-              "application-group members" : [
-                17
-              ]
+              "application-group members" : "17"
             }
           }
         },
         "configs/palo_alto/nat" : {
           "address-like" : {
             "ADDR1~panorama" : {
-              "rulebase nat rules source-translation" : [
-                42
-              ]
+              "rulebase nat rules source-translation" : "42"
             },
             "DST_1~panorama" : {
-              "rulebase nat rules destination" : [
-                47
-              ]
+              "rulebase nat rules destination" : "47"
             },
             "DST_2~panorama" : {
-              "rulebase nat rules destination" : [
-                47
-              ]
+              "rulebase nat rules destination" : "47"
             },
             "DST_NAME~panorama" : {
-              "rulebase nat rules destination" : [
-                36
-              ]
+              "rulebase nat rules destination" : "36"
             },
             "SRC_1~panorama" : {
-              "rulebase nat rules source" : [
-                46
-              ]
+              "rulebase nat rules source" : "46"
             },
             "SRC_2~panorama" : {
-              "rulebase nat rules source" : [
-                46
-              ]
+              "rulebase nat rules source" : "46"
             },
             "SRC_NAME~panorama" : {
-              "rulebase nat rules source" : [
-                35,
-                60
-              ]
+              "rulebase nat rules source" : "35,60"
             }
           },
           "address-like or none" : {
             "1.1.1.0/24~panorama" : {
-              "rulebase nat rules destination-translation" : [
-                20
-              ]
+              "rulebase nat rules destination-translation" : "20"
             },
             "1.1.1.1~panorama" : {
-              "rulebase nat rules source-translation" : [
-                42
-              ]
+              "rulebase nat rules source-translation" : "42"
             },
             "2.2.2.0/24~panorama" : {
-              "rulebase nat rules source-translation" : [
-                24,
-                42
-              ]
+              "rulebase nat rules source-translation" : "24,42"
             },
             "3.3.3.3-4.4.4.4~panorama" : {
-              "rulebase nat rules source-translation" : [
-                42
-              ]
+              "rulebase nat rules source-translation" : "42"
             },
             "any~panorama" : {
-              "rulebase nat rules destination" : [
-                30
-              ],
-              "rulebase nat rules source" : [
-                29
-              ]
+              "rulebase nat rules destination" : "30",
+              "rulebase nat rules source" : "29"
             }
           },
           "nat rule" : {
             "MISSING_DESTINATION~panorama" : {
-              "rulebase nat rules" : [
-                57
-              ]
+              "rulebase nat rules" : "57"
             },
             "MISSING_FROM~panorama" : {
-              "rulebase nat rules" : [
-                50
-              ]
+              "rulebase nat rules" : "50"
             },
             "MISSING_SOURCE~panorama" : {
-              "rulebase nat rules" : [
-                53
-              ]
+              "rulebase nat rules" : "53"
             },
             "MISSING_TO~panorama" : {
-              "rulebase nat rules" : [
-                49
-              ]
+              "rulebase nat rules" : "49"
             },
             "RULE_1~panorama" : {
-              "rulebase nat rules" : [
-                18
-              ]
+              "rulebase nat rules" : "18"
             },
             "RULE_2~panorama" : {
-              "rulebase nat rules" : [
-                32
-              ]
+              "rulebase nat rules" : "32"
             },
             "RULE_3~panorama" : {
-              "rulebase nat rules" : [
-                38
-              ]
+              "rulebase nat rules" : "38"
             }
           },
           "zone" : {
             "FROM_1~panorama" : {
-              "rulebase nat rules from" : [
-                45
-              ]
+              "rulebase nat rules from" : "45"
             },
             "FROM_2~panorama" : {
-              "rulebase nat rules from" : [
-                45
-              ]
+              "rulebase nat rules from" : "45"
             },
             "FROM_ZONE~panorama" : {
-              "rulebase nat rules from" : [
-                34,
-                55,
-                59
-              ]
+              "rulebase nat rules from" : "34,55,59"
             },
             "TO_ZONE~panorama" : {
-              "rulebase nat rules to" : [
-                27,
-                33,
-                39,
-                51,
-                54,
-                58
-              ]
+              "rulebase nat rules to" : "27,33,39,51,54,58"
             }
           }
         },
         "configs/palo_alto/virtual-routers" : {
           "interface" : {
             "dummy" : {
-              "virtual-router interface" : [
-                27
-              ]
+              "virtual-router interface" : "27"
             }
           },
           "virtual-router" : {
             "vr1" : {
-              "virtual-router self-reference" : [
-                12
-              ]
+              "virtual-router self-reference" : "12"
             },
             "vr2" : {
-              "static-route nexthop next-vr" : [
-                19
-              ],
-              "virtual-router self-reference" : [
-                26
-              ]
+              "static-route nexthop next-vr" : "19",
+              "virtual-router self-reference" : "26"
             }
           }
         },
         "configs/palo_alto/zones" : {
           "interface" : {
             "ethernet1/1" : {
-              "vsys import interface" : [
-                32
-              ],
-              "zone network layer3" : [
-                43
-              ]
+              "vsys import interface" : "32",
+              "zone network layer3" : "43"
             },
             "ethernet1/2" : {
-              "vsys import interface" : [
-                32
-              ],
-              "zone network layer3" : [
-                48
-              ]
+              "vsys import interface" : "32",
+              "zone network layer3" : "48"
             },
             "ethernet1/3" : {
-              "vsys import interface" : [
-                32
-              ],
-              "zone network layer3" : [
-                53
-              ]
+              "vsys import interface" : "32",
+              "zone network layer3" : "53"
             },
             "ethernet1/4" : {
-              "vsys import interface" : [
-                32
-              ],
-              "zone network layer3" : [
-                58
-              ]
+              "vsys import interface" : "32",
+              "zone network layer3" : "58"
             }
           },
           "zone" : {
             "zl2~vsys10" : {
-              "zone network layer2" : [
-                43
-              ]
+              "zone network layer2" : "43"
             },
             "zl3~vsys10" : {
-              "zone network layer3" : [
-                48
-              ]
+              "zone network layer3" : "48"
             },
             "ztap~vsys10" : {
-              "zone network tap" : [
-                53
-              ]
+              "zone network tap" : "53"
             },
             "zvirtual-wire~vsys10" : {
-              "zone network virtual-wire" : [
-                58
-              ]
+              "zone network virtual-wire" : "58"
             }
           }
         },
         "configs/pim" : {
           "interface" : {
             "Loopback1" : {
-              "interface" : [
-                25
-              ]
+              "interface" : "25"
             }
           }
         },
         "configs/prefix_list_ipv4" : {
           "ipv4 prefix-list" : {
             "default" : {
-              "route-map match ipv4 prefix-list" : [
-                10
-              ]
+              "route-map match ipv4 prefix-list" : "10"
             }
           }
         },
         "configs/route_policy_as_path" : {
           "community-set" : {
             "13979:90" : {
-              "route-policy set community" : [
-                8
-              ]
+              "route-policy set community" : "8"
             },
             "SOCAL-USERS" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             }
           },
           "prefix-set" : {
             "CENIC_DC_Internal" : {
-              "route-policy prefix-set" : [
-                26
-              ]
+              "route-policy prefix-set" : "26"
             },
             "classful_default" : {
-              "route-policy prefix-set" : [
-                15
-              ]
+              "route-policy prefix-set" : "15"
             }
           }
         },
         "configs/route_policy_igp_cost" : {
           "community-set" : {
             "DC_AT_MEMBERS" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             },
             "DC_CF_COMMODITY_PEER" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             },
             "DC_CF_ISP" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             },
             "HPR_CF_RE_PEER" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             },
             "No_Export" : {
-              "route-policy community matches-any" : [
-                8
-              ]
+              "route-policy community matches-any" : "8"
             }
           }
         },
         "configs/route_policy_metric_type" : {
           "community-set" : {
             "No_Export" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             }
           },
           "prefix-set" : {
             "DC_Internal" : {
-              "route-policy prefix-set" : [
-                8
-              ]
+              "route-policy prefix-set" : "8"
             }
           }
         },
         "configs/route_policy_param" : {
           "community-set" : {
             "blackhole-all" : {
-              "route-policy community matches-any" : [
-                14
-              ]
+              "route-policy community matches-any" : "14"
             }
           },
           "prefix-set" : {
             "$cust_v4_pfx" : {
-              "route-policy prefix-set" : [
-                6
-              ]
+              "route-policy prefix-set" : "6"
             }
           }
         },
         "configs/switchport_range" : {
           "interface" : {
             "FastEthernet0/1" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           }
         },
         "configs/underscore_variable" : {
           "ipv4 prefix-list" : {
             "ABC_DEF" : {
-              "route-map match ipv4 prefix-list" : [
-                5
-              ]
+              "route-map match ipv4 prefix-list" : "5"
             },
             "_GHI" : {
-              "route-map match ipv4 prefix-list" : [
-                5
-              ]
+              "route-map match ipv4 prefix-list" : "5"
             }
           }
         },
         "configs/variables" : {
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           },
           "ipv4 acl" : {
             "ABC_def.gh_vlan789_out_20000101" : {
-              "interface outgoing ip access-list" : [
-                5
-              ]
+              "interface outgoing ip access-list" : "5"
             }
           }
         },
         "configs/variables_dos" : {
           "interface" : {
             "FastEthernet0/0" : {
-              "interface" : [
-                4
-              ]
+              "interface" : "4"
             }
           },
           "ipv4 acl" : {
             "ABC_def.gh_vlan789_out_20000101" : {
-              "interface outgoing ip access-list" : [
-                5
-              ]
+              "interface outgoing ip access-list" : "5"
             }
           }
         },
         "configs/vlan_access_map2" : {
           "undeclared bgp peer" : {
             "10.10.212.233" : {
-              "bgp neighbor without remote-as" : [
-                19
-              ]
+              "bgp neighbor without remote-as" : "19"
             }
           }
         }
@@ -89324,2253 +87247,1499 @@
         "configs/arista_bgp" : {
           "bgp peer-group" : {
             "UNDEFINED_PEER_GROUP" : {
-              "bgp neighbor peer-group" : [
-                12
-              ]
+              "bgp neighbor peer-group" : "12"
             }
           },
           "route-map" : {
             "UNDEFINED_MAP" : {
-              "bgp redistribute ospfv3 route-map" : [
-                14
-              ]
+              "bgp redistribute ospfv3 route-map" : "14"
             }
           }
         },
         "configs/arista_interface" : {
           "policy-map" : {
             "pbr-pmap" : {
-              "interface service-policy" : [
-                10
-              ]
+              "interface service-policy" : "10"
             },
             "qos-pmap" : {
-              "interface service-policy" : [
-                11
-              ]
+              "interface service-policy" : "11"
             }
           },
           "standard ipv4 access-list" : {
             "some_acl" : {
-              "interface ip multicast boundary" : [
-                9
-              ]
+              "interface ip multicast boundary" : "9"
             }
           }
         },
         "configs/arista_misc" : {
           "ipv4 acl" : {
             "abc" : {
-              "management telnet ip access-group" : [
-                41
-              ]
+              "management telnet ip access-group" : "41"
             }
           }
         },
         "configs/asa_acl" : {
           "object-group network" : {
             "drawbridge_hosts" : {
-              "extended access-list network object-group" : [
-                9
-              ]
+              "extended access-list network object-group" : "9"
             }
           }
         },
         "configs/asa_interface" : {
           "policy-map" : {
             "some-interface-policy" : {
-              "service-policy interface policy" : [
-                8
-              ]
+              "service-policy interface policy" : "8"
             }
           }
         },
         "configs/asa_nat" : {
           "interface" : {
             "inside" : {
-              "object nat real interface" : [
-                16,
-                17,
-                18,
-                19
-              ],
-              "twice nat real interface" : [
-                7,
-                8,
-                9
-              ]
+              "object nat real interface" : "16-19",
+              "twice nat real interface" : "7-9"
             },
             "outside" : {
-              "object nat mapped interface" : [
-                16,
-                17,
-                18,
-                20
-              ],
-              "twice nat mapped interface" : [
-                7,
-                8,
-                9
-              ]
+              "object nat mapped interface" : "16-18,20",
+              "twice nat mapped interface" : "7-9"
             }
           },
           "object network" : {
             "interface" : {
-              "twice nat mapped destination network object" : [
-                8
-              ],
-              "twice nat mapped source network object" : [
-                8
-              ]
+              "twice nat mapped destination network object" : "8",
+              "twice nat mapped source network object" : "8"
             },
             "net1" : {
-              "twice nat real source network object" : [
-                8,
-                9,
-                11,
-                12,
-                13
-              ]
+              "twice nat real source network object" : "8-9,11-13"
             },
             "net2" : {
-              "twice nat mapped source network object" : [
-                9,
-                11,
-                12,
-                13
-              ],
-              "twice nat real destination network object" : [
-                8
-              ]
+              "twice nat mapped source network object" : "9,11-13",
+              "twice nat real destination network object" : "8"
             },
             "net3" : {
-              "twice nat mapped destination network object" : [
-                11
-              ]
+              "twice nat mapped destination network object" : "11"
             },
             "net4" : {
-              "twice nat real destination network object" : [
-                11
-              ]
+              "twice nat real destination network object" : "11"
             },
             "source-mapped" : {
-              "object nat mapped source network object" : [
-                18,
-                22,
-                23
-              ]
+              "object nat mapped source network object" : "18,22-23"
             }
           }
         },
         "configs/bgp_address_family" : {
           "interface" : {
             "Loopback0" : {
-              "update-source interface" : [
-                14
-              ]
+              "update-source interface" : "14"
             }
           },
           "route-map" : {
             "as1_to_as2" : {
-              "bgp outbound route-map" : [
-                26
-              ]
+              "bgp outbound route-map" : "26"
             },
             "as1_to_as3" : {
-              "bgp outbound route-map" : [
-                28
-              ]
+              "bgp outbound route-map" : "28"
             },
             "as2_to_as1" : {
-              "bgp inbound route-map" : [
-                27
-              ]
+              "bgp inbound route-map" : "27"
             },
             "as3_to_as1" : {
-              "bgp inbound route-map" : [
-                29
-              ]
+              "bgp inbound route-map" : "29"
             }
           },
           "undeclared bgp peer" : {
             "13.16.3.16" : {
-              "bgp neighbor without remote-as" : [
-                17
-              ]
+              "bgp neighbor without remote-as" : "17"
             }
           }
         },
         "configs/bgp_default_originate_policy" : {
           "route-policy" : {
             "EBGP_CUST_FULL_v4" : {
-              "bgp neighbor route-policy out" : [
-                14
-              ]
+              "bgp neighbor route-policy out" : "14"
             },
             "cust_v4_in" : {
-              "bgp neighbor route-policy in" : [
-                12
-              ]
+              "bgp neighbor route-policy in" : "12"
             }
           }
         },
         "configs/bgp_foundry" : {
           "route-map" : {
             "from_ucr" : {
-              "bgp inbound route-map" : [
-                10
-              ]
+              "bgp inbound route-map" : "10"
             },
             "tag-bbone-prefixes" : {
-              "bgp ipv4 network statement route-map" : [
-                15
-              ]
+              "bgp ipv4 network statement route-map" : "15"
             }
           }
         },
         "configs/bgp_route_policy" : {
           "bgp neighbor-group" : {
             "EBGP-PEER-SVL-PNI" : {
-              "bgp use neighbor-group" : [
-                20
-              ]
+              "bgp use neighbor-group" : "20"
             }
           },
           "route-policy" : {
             "EBGP-PEER-AS11164-SVL-PNI-IN" : {
-              "bgp neighbor route-policy in" : [
-                24
-              ]
+              "bgp neighbor route-policy in" : "24"
             },
             "EBGP-PEER-AS11164-SVL-PNI-OUT" : {
-              "bgp neighbor route-policy out" : [
-                26
-              ]
+              "bgp neighbor route-policy out" : "26"
             }
           }
         },
         "configs/cadant_bgp" : {
           "interface" : {
             "Loopback15" : {
-              "update-source interface" : [
-                12,
-                17
-              ]
+              "update-source interface" : "12,17"
             }
           },
           "route-map" : {
             "blarp" : {
-              "bgp outbound route-map" : [
-                28
-              ]
+              "bgp outbound route-map" : "28"
             },
             "blerp" : {
-              "bgp outbound ipv6 route-map" : [
-                35
-              ]
+              "bgp outbound ipv6 route-map" : "35"
             }
           }
         },
         "configs/cadant_interface" : {
           "ipv4/6 acl" : {
             "fleep-acl" : {
-              "interface ip inband access-group" : [
-                130
-              ]
+              "interface ip inband access-group" : "130"
             }
           },
           "ipv6 acl" : {
             "bar-filter" : {
-              "interface ipv6 traffic-filter out" : [
-                86
-              ]
+              "interface ipv6 traffic-filter out" : "86"
             },
             "foo-filter" : {
-              "interface ipv6 traffic-filter in" : [
-                85
-              ]
+              "interface ipv6 traffic-filter in" : "85"
             }
           }
         },
         "configs/cadant_isis" : {
           "ipv4/6 acl" : {
             "blah-acl-99" : {
-              "router isis distribute-list acl" : [
-                15
-              ]
+              "router isis distribute-list acl" : "15"
             },
             "blah-ipv6-access-list" : {
-              "router isis distribute-list acl" : [
-                20
-              ]
+              "router isis distribute-list acl" : "20"
             }
           }
         },
         "configs/cadant_misc" : {
           "interface" : {
             "Loopback0" : {
-              "ntp source-interface" : [
-                80
-              ],
-              "tacacs source-interface" : [
-                94
-              ]
+              "ntp source-interface" : "80",
+              "tacacs source-interface" : "94"
             }
           }
         },
         "configs/cadant_rip" : {
           "ipv4/6 acl" : {
             "blah-std-acl" : {
-              "router rip distribute-list" : [
-                6
-              ]
+              "router rip distribute-list" : "6"
             }
           }
         },
         "configs/cadant_route_map" : {
           "ipv4 prefix-list" : {
             "bar-prefix-list" : {
-              "route-map match ipv4 prefix-list" : [
-                6
-              ]
+              "route-map match ipv4 prefix-list" : "6"
             }
           },
           "ipv6 prefix-list" : {
             "baz-ipv6-prefix-list" : {
-              "route-map match ipv6 prefix-list" : [
-                10
-              ]
+              "route-map match ipv6 prefix-list" : "10"
             }
           }
         },
         "configs/cadant_snmp" : {
           "interface" : {
             "Loopback0" : {
-              "snmp-server source-interface" : [
-                18
-              ]
+              "snmp-server source-interface" : "18"
             }
           },
           "ipv4 acl" : {
             "52" : {
-              "snmp server community ipv4 acl" : [
-                7
-              ]
+              "snmp server community ipv4 acl" : "7"
             }
           }
         },
         "configs/cisco_additional_paths" : {
           "undeclared bgp peer" : {
             "1.2.3.4" : {
-              "bgp neighbor without remote-as" : [
-                8,
-                9
-              ]
+              "bgp neighbor without remote-as" : "8-9"
             }
           }
         },
         "configs/cisco_bgp" : {
           "as-path access-list" : {
             "40" : {
-              "bgp neighbor filter-list access-list" : [
-                18
-              ]
+              "bgp neighbor filter-list access-list" : "18"
             }
           },
           "bgp template peer-policy" : {
             "p2" : {
-              "inherited BGP peer-policy" : [
-                36
-              ]
+              "inherited BGP peer-policy" : "36"
             },
             "p310" : {
-              "inherited BGP peer-policy" : [
-                37
-              ]
+              "inherited BGP peer-policy" : "37"
             }
           },
           "route-map" : {
             "abcdefg" : {
-              "bgp redistribute static route-map" : [
-                33
-              ]
+              "bgp redistribute static route-map" : "33"
             },
             "blah" : {
-              "bgp redistribute rip route-map" : [
-                34
-              ]
+              "bgp redistribute rip route-map" : "34"
             },
             "bloop" : {
-              "bgp redistribute connected route-map" : [
-                28
-              ]
+              "bgp redistribute connected route-map" : "28"
             }
           },
           "undeclared bgp peer" : {
             "10.0.0.1" : {
-              "bgp neighbor without remote-as" : [
-                39,
-                40,
-                41,
-                42
-              ]
+              "bgp neighbor without remote-as" : "39-42"
             },
             "10.20.2.2" : {
-              "bgp neighbor without remote-as" : [
-                10
-              ]
+              "bgp neighbor without remote-as" : "10"
             },
             "192.168.3.2" : {
-              "bgp neighbor without remote-as" : [
-                14
-              ]
+              "bgp neighbor without remote-as" : "14"
             },
             "192.168.4.2" : {
-              "bgp neighbor without remote-as" : [
-                18
-              ]
+              "bgp neighbor without remote-as" : "18"
             }
           }
         },
         "configs/cisco_cable" : {
           "cable service-class" : {
             "barfoo" : {
-              "cable qos enforce-rule service-class" : [
-                77
-              ]
+              "cable qos enforce-rule service-class" : "77"
             },
             "foobar" : {
-              "cable qos enforce-rule service-class" : [
-                78
-              ]
+              "cable qos enforce-rule service-class" : "78"
             }
           },
           "depi-tunnel" : {
             "depitun0" : {
-              "controller rf-channel depi-tunnel" : [
-                124
-              ]
+              "controller rf-channel depi-tunnel" : "124"
             }
           },
           "l2tp-class" : {
             "l2tpclass1" : {
-              "depi-tunnel l2tp-class" : [
-                140
-              ]
+              "depi-tunnel l2tp-class" : "140"
             }
           }
         },
         "configs/cisco_control_plane" : {
           "policy-map" : {
             "copp-policy" : {
-              "control-plane service-policy input" : [
-                5
-              ]
+              "control-plane service-policy input" : "5"
             },
             "copp-policy-out" : {
-              "control-plane service-policy output" : [
-                6
-              ]
+              "control-plane service-policy output" : "6"
             }
           }
         },
         "configs/cisco_crypto" : {
           "crypto ipsec transform-set" : {
             "bleep" : {
-              "crypto map ipsec-isakmp transform-set" : [
-                227
-              ]
+              "crypto map ipsec-isakmp transform-set" : "227"
             },
             "hijklmnop" : {
-              "ipsec profile set transform-set" : [
-                160
-              ]
+              "ipsec profile set transform-set" : "160"
             },
             "mytransformset" : {
-              "crypto map ipsec-isakmp transform-set" : [
-                246
-              ]
+              "crypto map ipsec-isakmp transform-set" : "246"
             }
           },
           "crypto isakmp profile" : {
             "myisakmpprofile" : {
-              "crypto map ipsec-isakmp isakmp-profile" : [
-                242
-              ]
+              "crypto map ipsec-isakmp isakmp-profile" : "242"
             },
             "someOtherprofile" : {
-              "ipsec profile set isakmp-profile" : [
-                163
-              ]
+              "ipsec profile set isakmp-profile" : "163"
             }
           },
           "crypto keyring" : {
             "VRF:MMS:RMT:UPM:1143" : {
-              "isakmp profile keyring" : [
-                191
-              ]
+              "isakmp profile keyring" : "191"
             }
           },
           "crypto-dynamic-map-set" : {
             "bippety" : {
-              "crypto map ipsec-isakmp crypto-dynamic-map-set" : [
-                229
-              ]
+              "crypto map ipsec-isakmp crypto-dynamic-map-set" : "229"
             }
           },
           "ipv4/6 acl" : {
             "myvpnacl" : {
-              "crypto map ipsec-isakmp acl" : [
-                240
-              ]
+              "crypto map ipsec-isakmp acl" : "240"
             },
             "someacl" : {
-              "crypto map ipsec-isakmp acl" : [
-                224
-              ],
-              "crypto map match address" : [
-                232
-              ]
+              "crypto map ipsec-isakmp acl" : "224",
+              "crypto map match address" : "232"
             }
           }
         },
         "configs/cisco_domain" : {
           "interface" : {
             "Loopback666" : {
-              "domain lookup source-interface" : [
-                5
-              ]
+              "domain lookup source-interface" : "5"
             }
           }
         },
         "configs/cisco_eigrp" : {
           "interface" : {
             "FastEthernet0/1" : {
-              "eigrp passive-interface" : [
-                147
-              ]
+              "eigrp passive-interface" : "147"
             },
             "GigabitEthernet1/5/3" : {
-              "eigrp passive-interface" : [
-                27
-              ]
+              "eigrp passive-interface" : "27"
             },
             "GigabitEthernet2/5/3" : {
-              "eigrp passive-interface" : [
-                28
-              ]
+              "eigrp passive-interface" : "28"
             },
             "Port-channel34" : {
-              "eigrp passive-interface" : [
-                29
-              ]
+              "eigrp passive-interface" : "29"
             },
             "Port-channel35" : {
-              "eigrp passive-interface" : [
-                30
-              ]
+              "eigrp passive-interface" : "30"
             }
           },
           "route-map" : {
             "BGP_TO_EIGRP" : {
-              "eigrp redistribute bgp route-map" : [
-                35
-              ]
+              "eigrp redistribute bgp route-map" : "35"
             },
             "CONNECTED_TO_EIGRP" : {
-              "eigrp redistribute connected route-map" : [
-                36
-              ]
+              "eigrp redistribute connected route-map" : "36"
             },
             "EIGRP_TO_EIGRP" : {
-              "eigrp redistribute eigrp route-map" : [
-                37
-              ]
+              "eigrp redistribute eigrp route-map" : "37"
             },
             "ISIS_TO_EIGRP" : {
-              "eigrp redistribute isis route-map" : [
-                38
-              ]
+              "eigrp redistribute isis route-map" : "38"
             },
             "OSPF_TO_EIGRP" : {
-              "eigrp redistribute ospf route-map" : [
-                39
-              ]
+              "eigrp redistribute ospf route-map" : "39"
             },
             "RIP_TO_EIGRP" : {
-              "eigrp redistribute rip route-map" : [
-                40
-              ]
+              "eigrp redistribute rip route-map" : "40"
             },
             "STATIC_TO_EIGRP" : {
-              "eigrp redistribute static route-map" : [
-                41
-              ]
+              "eigrp redistribute static route-map" : "41"
             }
           }
         },
         "configs/cisco_interface" : {
           "ipv4 acl" : {
             "167" : {
-              "interface ip verify access-list" : [
-                129
-              ]
+              "interface ip verify access-list" : "129"
             },
             "310-systems" : {
-              "interface outgoing ip access-list" : [
-                137
-              ]
+              "interface outgoing ip access-list" : "137"
             },
             "ag1" : {
-              "interface incoming ip access-list" : [
-                56
-              ]
+              "interface incoming ip access-list" : "56"
             },
             "ag2" : {
-              "interface outgoing ip access-list" : [
-                57
-              ]
+              "interface outgoing ip access-list" : "57"
             }
           },
           "ipv4/6 acl" : {
             "1" : {
-              "interface igmp access-group acl" : [
-                80
-              ]
+              "interface igmp access-group acl" : "80"
             },
             "hpaccesslist" : {
-              "interface igmp host-proxy access-list" : [
-                82
-              ]
+              "interface igmp host-proxy access-list" : "82"
             }
           },
           "route-map" : {
             "SITEMAP" : {
-              "interface ip vrf sitemap" : [
-                135
-              ]
+              "interface ip vrf sitemap" : "135"
             },
             "eigrp-leak-map" : {
-              "interface summary-address eigrp leak-map" : [
-                125
-              ]
+              "interface summary-address eigrp leak-map" : "125"
             }
           },
           "zone security" : {
             "z1" : {
-              "interface zone-member security" : [
-                279
-              ]
+              "interface zone-member security" : "279"
             }
           }
         },
         "configs/cisco_ip" : {
           "ipv4/6 acl" : {
             "wccp-cachelist" : {
-              "ip wccp group-list" : [
-                11
-              ]
+              "ip wccp group-list" : "11"
             },
             "wccp-redir" : {
-              "ip wccp redirect-list" : [
-                11
-              ]
+              "ip wccp redirect-list" : "11"
             }
           }
         },
         "configs/cisco_ip_route" : {
           "interface" : {
             "Dialer1" : {
-              "ip route next-hop interface" : [
-                14
-              ]
+              "ip route next-hop interface" : "14"
             },
             "Dialer2" : {
-              "ip route next-hop interface" : [
-                15
-              ]
+              "ip route next-hop interface" : "15"
             },
             "GigabitEthernet3/0/0.212" : {
-              "ip route next-hop interface" : [
-                6
-              ]
+              "ip route next-hop interface" : "6"
             },
             "Loopback66" : {
-              "ip route next-hop interface" : [
-                12
-              ]
+              "ip route next-hop interface" : "12"
             },
             "Loopback99" : {
-              "ip route next-hop interface" : [
-                13
-              ]
+              "ip route next-hop interface" : "13"
             },
             "POS5/3:10" : {
-              "ip route next-hop interface" : [
-                10
-              ]
+              "ip route next-hop interface" : "10"
             },
             "Serial5/0:2" : {
-              "ip route next-hop interface" : [
-                7
-              ]
+              "ip route next-hop interface" : "7"
             },
             "Serial5/1:5" : {
-              "ip route next-hop interface" : [
-                9
-              ]
+              "ip route next-hop interface" : "9"
             }
           }
         },
         "configs/cisco_isis" : {
           "route-map" : {
             "connected-to-isis" : {
-              "isis redistribute connected route-map" : [
-                66
-              ]
+              "isis redistribute connected route-map" : "66"
             },
             "connected-to-isis-v6" : {
-              "isis redistribute connected route-map" : [
-                69
-              ]
+              "isis redistribute connected route-map" : "69"
             },
             "static-to-bgp" : {
-              "isis redistribute static route-map" : [
-                61
-              ]
+              "isis redistribute static route-map" : "61"
             }
           }
         },
         "configs/cisco_line" : {
           "ipv4 acl" : {
             "40" : {
-              "line access-class list" : [
-                6,
-                26
-              ]
+              "line access-class list" : "6,26"
             },
             "99" : {
-              "line access-class list" : [
-                56
-              ]
+              "line access-class list" : "56"
             },
             "vty-acl" : {
-              "line access-class list" : [
-                22
-              ]
+              "line access-class list" : "22"
             }
           },
           "ipv6 acl" : {
             "ipv6-vty-acl" : {
-              "line access-class ipv6 list" : [
-                61
-              ]
+              "line access-class ipv6 list" : "61"
             }
           }
         },
         "configs/cisco_misc" : {
           "class-map" : {
             "ICMP-cmap" : {
-              "policy-map class" : [
-                206
-              ]
+              "policy-map class" : "206"
             },
             "TCP-cmap" : {
-              "policy-map class" : [
-                208
-              ]
+              "policy-map class" : "208"
             },
             "inspection_default" : {
-              "policy-map class" : [
-                195
-              ]
+              "policy-map class" : "195"
             }
           },
           "ipv4/6 acl" : {
             "cops-acl" : {
-              "cops listener access-list" : [
-                42
-              ]
+              "cops listener access-list" : "42"
             }
           }
         },
         "configs/cisco_ntp" : {
           "interface" : {
             "Loopback0" : {
-              "ntp source-interface" : [
-                7
-              ]
+              "ntp source-interface" : "7"
             }
           },
           "ipv4 acl" : {
             "ntp-peer-group" : {
-              "ntp access-group" : [
-                4
-              ]
+              "ntp access-group" : "4"
             }
           }
         },
         "configs/cisco_ospf" : {
           "ipv4 prefix-list" : {
             "plin" : {
-              "router ospf distribute-list prefix in" : [
-                56
-              ]
+              "router ospf distribute-list prefix in" : "56"
             },
             "plout" : {
-              "router ospf distribute-list prefix out" : [
-                57
-              ]
+              "router ospf distribute-list prefix out" : "57"
             }
           },
           "ipv4/6 acl" : {
             "aclin" : {
-              "router ospf distribute-list in" : [
-                53,
-                54
-              ]
+              "router ospf distribute-list in" : "53-54"
             },
             "aclout" : {
-              "router ospf distribute-list out" : [
-                55
-              ]
+              "router ospf distribute-list out" : "55"
             }
           },
           "route-map" : {
             "DEFAULT_ORIGINATE_OSPF" : {
-              "ospf default-originate route-map" : [
-                47
-              ]
+              "ospf default-originate route-map" : "47"
             },
             "DIRECT_OSPF" : {
-              "ospf redistribute connected route-map" : [
-                68
-              ]
+              "ospf redistribute connected route-map" : "68"
             },
             "eigrp-ospf-route-map" : {
-              "ospf redistribute eigrp route-map" : [
-                69
-              ]
+              "ospf redistribute eigrp route-map" : "69"
             },
             "rmin" : {
-              "router ospf distribute-list route-map in" : [
-                58
-              ]
+              "router ospf distribute-list route-map in" : "58"
             },
             "rmout" : {
-              "router ospf distribute-list route-map out" : [
-                59
-              ]
+              "router ospf distribute-list route-map out" : "59"
             }
           }
         },
         "configs/cisco_ospf_ipv6" : {
           "ipv6 prefix-list" : {
             "SWITCHLAN" : {
-              "ipv6 router ospf distribute-list prefix-list in" : [
-                14
-              ]
+              "ipv6 router ospf distribute-list prefix-list in" : "14"
             },
             "SWITCHLAN-OUT" : {
-              "ipv6 router ospf distribute-list prefix-list out" : [
-                15
-              ]
+              "ipv6 router ospf distribute-list prefix-list out" : "15"
             }
           }
         },
         "configs/cisco_pim" : {
           "ipv4 acl" : {
             "foobar" : {
-              "pim rp-address" : [
-                7
-              ]
+              "pim rp-address" : "7"
             },
             "foobarmap" : {
-              "pim rp-address" : [
-                8
-              ]
+              "pim rp-address" : "8"
             }
           }
         },
         "configs/cisco_qos" : {
           "acl" : {
             "boop" : {
-              "class-map access-group" : [
-                20
-              ]
+              "class-map access-group" : "20"
             },
             "boop2" : {
-              "class-map access-list" : [
-                21
-              ]
+              "class-map access-list" : "21"
             }
           },
           "class-map" : {
             "MY_CLASS_1" : {
-              "policy-map event class" : [
-                129
-              ]
+              "policy-map event class" : "129"
             },
             "MY_CLASS_2" : {
-              "policy-map event class" : [
-                131
-              ]
+              "policy-map event class" : "131"
             },
             "bippetyboo-drop" : {
-              "policy-map class" : [
-                50
-              ]
+              "policy-map class" : "50"
             },
             "bippetyboo-ndrop" : {
-              "policy-map class" : [
-                66
-              ]
+              "policy-map class" : "66"
             },
             "bippetyboo-ndrop-fcoe" : {
-              "policy-map class" : [
-                62
-              ]
+              "policy-map class" : "62"
             },
             "bleefee" : {
-              "policy-map class" : [
-                102
-              ]
+              "policy-map class" : "102"
             },
             "bleefee2" : {
-              "policy-map class" : [
-                107
-              ]
+              "policy-map class" : "107"
             },
             "blerf" : {
-              "policy-map class" : [
-                98
-              ]
+              "policy-map class" : "98"
             },
             "c-bleeb-drop" : {
-              "policy-map class" : [
-                109
-              ]
+              "policy-map class" : "109"
             },
             "c-bleeb-ndrop-fcoe" : {
-              "policy-map class" : [
-                114
-              ]
+              "policy-map class" : "114"
             },
             "c-foob-drop" : {
-              "policy-map class" : [
-                81
-              ]
+              "policy-map class" : "81"
             },
             "c-foob-ndrop" : {
-              "policy-map class" : [
-                93
-              ]
+              "policy-map class" : "93"
             },
             "c-foob-ndrop-fcoe" : {
-              "policy-map class" : [
-                89
-              ]
+              "policy-map class" : "89"
             },
             "fffoooddd" : {
-              "policy-map class" : [
-                72
-              ]
+              "policy-map class" : "72"
             },
             "floop" : {
-              "policy-map class" : [
-                119
-              ]
+              "policy-map class" : "119"
             }
           },
           "class-map type inspect" : {
             "cinspect" : {
-              "policy-map type inspect class type inspect" : [
-                43
-              ]
+              "policy-map type inspect class type inspect" : "43"
             }
           },
           "policy-map" : {
             "prioritize_backbone" : {
-              "policy-map class service-policy" : [
-                74
-              ]
+              "policy-map class service-policy" : "74"
             }
           },
           "service-template" : {
             "DEF" : {
-              "class-map activate-service-template" : [
-                9
-              ]
+              "class-map activate-service-template" : "9"
             },
             "GHI" : {
-              "class-map service-template" : [
-                10
-              ]
+              "class-map service-template" : "10"
             },
             "my_TEMPLATE_NAME" : {
-              "policy-map event class activate" : [
-                130
-              ]
+              "policy-map event class activate" : "130"
             }
           }
         },
         "configs/cisco_rip" : {
           "ipv4/6 acl" : {
             "some-ACL" : {
-              "router rip distribute-list" : [
-                10,
-                11,
-                12,
-                13
-              ]
+              "router rip distribute-list" : "10-13"
             }
           }
         },
         "configs/cisco_route_map" : {
           "as-path access-list" : {
             "AS_PATH_UNDEF" : {
-              "route-map match as-path access-list" : [
-                57
-              ]
+              "route-map match as-path access-list" : "57"
             }
           },
           "ipv4 acl" : {
             "test" : {
-              "route-map match ipv4 access-list" : [
-                26
-              ]
+              "route-map match ipv4 access-list" : "26"
             }
           },
           "ipv4 prefix-list" : {
             "bobble" : {
-              "route-map match ipv4 prefix-list" : [
-                36
-              ]
+              "route-map match ipv4 prefix-list" : "36"
             },
             "hpr-connector-subnets" : {
-              "route-map match ipv4 prefix-list" : [
-                10
-              ]
+              "route-map match ipv4 prefix-list" : "10"
             }
           }
         },
         "configs/cisco_snmp" : {
           "interface" : {
             "Loopback0" : {
-              "snmp-server source-interface" : [
-                89
-              ]
+              "snmp-server source-interface" : "89"
             },
             "Vlan1" : {
-              "snmp-server source-interface" : [
-                91
-              ]
+              "snmp-server source-interface" : "91"
             },
             "mgmt0" : {
-              "snmp-server source-interface" : [
-                90
-              ]
+              "snmp-server source-interface" : "90"
             }
           },
           "ipv4 acl" : {
             "1" : {
-              "snmp server community ipv4 acl" : [
-                9
-              ]
+              "snmp server community ipv4 acl" : "9"
             },
             "2" : {
-              "snmp server community ipv4 acl" : [
-                8,
-                10
-              ]
+              "snmp server community ipv4 acl" : "8,10"
             },
             "50" : {
-              "snmp-server group v3 access" : [
-                69
-              ]
+              "snmp-server group v3 access" : "69"
             },
             "customer-snmp" : {
-              "snmp server community ipv4 acl" : [
-                14
-              ]
+              "snmp server community ipv4 acl" : "14"
             },
             "dummyacl" : {
-              "snmp server community ipv4 acl" : [
-                13
-              ]
+              "snmp server community ipv4 acl" : "13"
             },
             "snmp-acl" : {
-              "snmp server community ipv4 acl" : [
-                7,
-                11
-              ]
+              "snmp server community ipv4 acl" : "7,11"
             },
             "snmp-arpa-acl" : {
-              "snmp server community ipv4 acl" : [
-                12
-              ]
+              "snmp server community ipv4 acl" : "12"
             },
             "to-VTY" : {
-              "snmp server community ipv4 acl" : [
-                16
-              ]
+              "snmp server community ipv4 acl" : "16"
             }
           },
           "ipv4/6 acl" : {
             "8" : {
-              "snmp server file transfer acl" : [
-                67
-              ],
-              "snmp server tftp-server list" : [
-                94
-              ]
+              "snmp server file transfer acl" : "67",
+              "snmp server tftp-server list" : "94"
             }
           },
           "ipv6 acl" : {
             "dummyacl" : {
-              "snmp server community ipv6 acl" : [
-                15
-              ]
+              "snmp server community ipv6 acl" : "15"
             },
             "snmp6" : {
-              "snmp-server group v3 access ipv6" : [
-                70
-              ]
+              "snmp-server group v3 access ipv6" : "70"
             },
             "to-VTY" : {
-              "snmp server community ipv6 acl" : [
-                16
-              ]
+              "snmp server community ipv6 acl" : "16"
             }
           }
         },
         "configs/cisco_track" : {
           "interface" : {
             "GigabitEthernet0/0" : {
-              "track interface" : [
-                4
-              ]
+              "track interface" : "4"
             },
             "GigabitEthernet0/1" : {
-              "track interface" : [
-                5
-              ]
+              "track interface" : "5"
             }
           }
         },
         "configs/cisco_vrrp" : {
           "interface" : {
             "GigabitEthernet0/0/0/19" : {
-              "router vrrp interface" : [
-                16
-              ]
+              "router vrrp interface" : "16"
             },
             "ManagementEthernet0/RSP0/CPU0/0" : {
-              "router vrrp interface" : [
-                26
-              ]
+              "router vrrp interface" : "26"
             },
             "ManagementEthernet0/RSP1/CPU0/0" : {
-              "router vrrp interface" : [
-                28
-              ]
+              "router vrrp interface" : "28"
             }
           }
         },
         "configs/cisco_zone" : {
           "policy-map type inspect" : {
             "p1" : {
-              "zone-pair service-policy type inspect" : [
-                5
-              ]
+              "zone-pair service-policy type inspect" : "5"
             }
           }
         },
         "configs/colon_in_vrf" : {
           "route-map" : {
             "RMT_PBI" : {
-              "bgp redistribute connected route-map" : [
-                6
-              ]
+              "bgp redistribute connected route-map" : "6"
             }
           }
         },
         "configs/eos_mlag" : {
           "interface" : {
             "Vlan4094" : {
-              "mlag configuration local-interface" : [
-                19
-              ]
+              "mlag configuration local-interface" : "19"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_imish_malformed" : {
           "route-map" : {
             "rm1" : {
-              "bgp neighbor address-family ipv6 route-map out" : [
-                21
-              ],
-              "neighbor peer-group route-map out" : [
-                22
-              ]
+              "bgp neighbor address-family ipv6 route-map out" : "21",
+              "neighbor peer-group route-map out" : "22"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_cm" : {
           "ha-group" : {
             "/Common/t1" : {
-              "traffic-group ha-group" : [
-                168
-              ]
+              "traffic-group ha-group" : "168"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_ltm" : {
           "monitor" : {
             "/Common/SOME_MONITOR" : {
-              "pool monitor" : [
-                33
-              ]
+              "pool monitor" : "33"
             }
           },
           "node" : {
             "/Common/bar" : {
-              "pool member" : [
-                28
-              ]
+              "pool member" : "28"
             },
             "/Common/foo" : {
-              "pool member" : [
-                23
-              ]
+              "pool member" : "23"
             }
           },
           "persistence" : {
             "/Common/SOME_PROFILE" : {
-              "virtual persist persistence" : [
-                97
-              ]
+              "virtual persist persistence" : "97"
             }
           },
           "pool" : {
             "/Common/SOME_POOL" : {
-              "virtual pool" : [
-                101
-              ]
+              "virtual pool" : "101"
             }
           },
           "profile" : {
             "/Common/P1" : {
-              "virtual profile" : [
-                103
-              ]
+              "virtual profile" : "103"
             },
             "/Common/P2" : {
-              "virtual profile" : [
-                104
-              ]
+              "virtual profile" : "104"
             },
             "/Common/P3" : {
-              "virtual profile" : [
-                105
-              ]
+              "virtual profile" : "105"
             }
           },
           "profile server-ssl" : {
             "/Common/SOME_SSL_PROFILE" : {
-              "monitor https ssl-profile" : [
-                166
-              ]
+              "monitor https ssl-profile" : "166"
             }
           },
           "snat-translation" : {
             "/Common/192.0.2.5" : {
-              "snatpool members member" : [
-                85
-              ]
+              "snatpool members member" : "85"
             },
             "/Common/192.0.2.6" : {
-              "snatpool members member" : [
-                86
-              ]
+              "snatpool members member" : "86"
             }
           },
           "virtual-address" : {
             "/Common/192.0.2.7" : {
-              "virtual destination" : [
-                90
-              ]
+              "virtual destination" : "90"
             }
           },
           "vlan" : {
             "/Common/MY_VLAN" : {
-              "virtual vlans vlan" : [
-                120
-              ]
+              "virtual vlans vlan" : "120"
             },
             "/Common/SOME_VLAN" : {
-              "snat vlans vlan" : [
-                74
-              ]
+              "snat vlans vlan" : "74"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_net_routing_bgp" : {
           "route-map" : {
             "/Common/MY_IPV4_OUT" : {
-              "bgp neighbor address-family ipv6 route-map out" : [
-                52
-              ]
+              "bgp neighbor address-family ipv6 route-map out" : "52"
             },
             "/Common/MY_IPV6_OUT" : {
-              "bgp neighbor address-family ipv6 route-map out" : [
-                33
-              ]
+              "bgp neighbor address-family ipv6 route-map out" : "33"
             },
             "/Common/MY_KERNEL_OUT" : {
-              "bgp address-family redistribute kernel route-map" : [
-                12
-              ]
+              "bgp address-family redistribute kernel route-map" : "12"
             }
           },
           "vlan" : {
             "SOME_VLAN" : {
-              "bgp neighbor update-source" : [
-                40,
-                63
-              ]
+              "bgp neighbor update-source" : "40,63"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_net_routing_route_map" : {
           "prefix-list" : {
             "/Common/MY_PREFIX_LIST" : {
-              "route-map match ipv4 address prefix-list" : [
-                14
-              ]
+              "route-map match ipv4 address prefix-list" : "14"
             },
             "/Common/MY_PREFIX_LIST2" : {
-              "route-map match ipv4 address prefix-list" : [
-                29
-              ]
+              "route-map match ipv4 address prefix-list" : "29"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_sys_ha_group" : {
           "pool" : {
             "/Common/p1" : {
-              "ha-group pool" : [
-                10
-              ]
+              "ha-group pool" : "10"
             },
             "/Common/p2" : {
-              "ha-group pool" : [
-                13
-              ]
+              "ha-group pool" : "13"
             }
           }
         },
         "configs/f5_bigip/f5_bigip_structured_with_imish" : {
           "IMISH interface" : {
             "us1" : {
-              "bgp neighbor update-source" : [
-                56
-              ]
+              "bgp neighbor update-source" : "56"
             }
           }
         },
         "configs/foundry_bgp" : {
           "interface" : {
             "Loopback1" : {
-              "update-source interface" : [
-                16
-              ]
+              "update-source interface" : "16"
             }
           }
         },
         "configs/foundry_misc" : {
           "interface" : {
             "Ethernet13/10" : {
-              "ip route next-hop interface" : [
-                39
-              ]
+              "ip route next-hop interface" : "39"
             }
           },
           "ipv4 acl" : {
             "blib" : {
-              "ssh ipv4 access-list" : [
-                31
-              ]
+              "ssh ipv4 access-list" : "31"
             }
           },
           "ipv6 acl" : {
             "blob" : {
-              "ssh ipv6 access-list" : [
-                32
-              ]
+              "ssh ipv6 access-list" : "32"
             }
           }
         },
         "configs/ios_bgp" : {
           "ipv6 prefix-list" : {
             "VPNV6_PL" : {
-              "bgp inbound ipv6 prefix-list" : [
-                11
-              ]
+              "bgp inbound ipv6 prefix-list" : "11"
             }
           },
           "route-map" : {
             "ADVERTISE_MAP" : {
-              "bgp address-family aggregate-address advertise-map" : [
-                5
-              ]
+              "bgp address-family aggregate-address advertise-map" : "5"
             },
             "EXIST_MAP" : {
-              "bgp neighbor advertise-map exist-map" : [
-                5
-              ]
+              "bgp neighbor advertise-map exist-map" : "5"
             }
           },
           "undeclared bgp peer" : {
             "1.2.3.4" : {
-              "bgp neighbor without remote-as" : [
-                5
-              ]
+              "bgp neighbor without remote-as" : "5"
             }
           },
           "undeclared bgp peer-group" : {
             "UNDEFINED_PEER_GROUP" : {
-              "bgp peer-group referenced before defined" : [
-                8
-              ]
+              "bgp peer-group referenced before defined" : "8"
             }
           }
         },
         "configs/ios_interface" : {
           "policy-map" : {
             "FOOBAR" : {
-              "interface service-policy" : [
-                5
-              ]
+              "interface service-policy" : "5"
             }
           }
         },
         "configs/ios_standby" : {
           "track" : {
             "1" : {
-              "interface standby track" : [
-                12
-              ]
+              "interface standby track" : "12"
             }
           }
         },
         "configs/ios_xe_bgp" : {
           "bgp template peer-policy" : {
             "FOO-BAR_BAZ:QUX" : {
-              "inherited BGP peer-policy" : [
-                13
-              ]
+              "inherited BGP peer-policy" : "13"
             }
           },
           "bgp template peer-session" : {
             "FOO-BAR:BAZ" : {
-              "inherited BGP peer-session" : [
-                12
-              ]
+              "inherited BGP peer-session" : "12"
             }
           },
           "route-map" : {
             "MAP" : {
-              "bgp inbound route-map" : [
-                6
-              ]
+              "bgp inbound route-map" : "6"
             }
           }
         },
         "configs/ios_xr_bgp" : {
           "route-policy" : {
             "ADDITIONAL_PATHS_POLICY" : {
-              "bgp additional-paths selection route-policy" : [
-                9
-              ]
+              "bgp additional-paths selection route-policy" : "9"
             },
             "AGGREGATE_POLICY" : {
-              "aggregate-address route-policy" : [
-                11
-              ]
+              "aggregate-address route-policy" : "11"
             }
           }
         },
         "configs/ios_xr_bgp_neighbor_group" : {
           "bgp session-group" : {
             "CIAO" : {
-              "bgp use session-group" : [
-                95
-              ]
+              "bgp use session-group" : "95"
             },
             "bippety" : {
-              "bgp use session-group" : [
-                35
-              ]
+              "bgp use session-group" : "35"
             },
             "blabber" : {
-              "bgp use session-group" : [
-                18
-              ]
+              "bgp use session-group" : "18"
             },
             "excellect-group" : {
-              "bgp use session-group" : [
-                89
-              ]
+              "bgp use session-group" : "89"
             }
           },
           "interface" : {
             "Loopback0" : {
-              "update-source interface" : [
-                23,
-                37,
-                49,
-                59,
-                70
-              ]
+              "update-source interface" : "23,37,49,59,70"
             }
           },
           "route-policy" : {
             "advertise_fooey_dc_and_isp_routes_ipv4" : {
-              "bgp neighbor route-policy out" : [
-                26,
-                30
-              ]
+              "bgp neighbor route-policy out" : "26,30"
             },
             "advertise_fooey_routes_only" : {
-              "bgp neighbor route-policy out" : [
-                40
-              ]
+              "bgp neighbor route-policy out" : "40"
             },
             "deny_bgp_routes" : {
-              "bgp neighbor route-policy in" : [
-                25,
-                29
-              ]
+              "bgp neighbor route-policy in" : "25,29"
             },
             "deny_default_network_ipv4" : {
-              "bgp neighbor route-policy out" : [
-                61
-              ]
+              "bgp neighbor route-policy out" : "61"
             }
           }
         },
         "configs/ios_xr_multicast" : {
           "ipv4 access-list" : {
             "MSDP_filter" : {
-              "msdp peer sa-list" : [
-                30,
-                31,
-                47,
-                48
-              ]
+              "msdp peer sa-list" : "30-31,47-48"
             }
           }
         },
         "configs/ios_xr_multipart" : {
           "ipv4 access-list" : {
             "GNS-VTY-ACCESS" : {
-              "ssh ipv4 access-list" : [
-                31
-              ]
+              "ssh ipv4 access-list" : "31"
             }
           }
         },
         "configs/ios_xr_ospf" : {
           "interface" : {
             "Bundle-Ether101" : {
-              "router ospf area interface" : [
-                18
-              ]
+              "router ospf area interface" : "18"
             },
             "Bundle-Ether103" : {
-              "router ospf area interface" : [
-                24
-              ]
+              "router ospf area interface" : "24"
             },
             "Bundle-Ether201" : {
-              "router ospf area interface" : [
-                28
-              ]
+              "router ospf area interface" : "28"
             },
             "HundredGigE0/2/0/0.292" : {
-              "router ospf area interface" : [
-                42
-              ]
+              "router ospf area interface" : "42"
             },
             "HundredGigE0/2/0/3" : {
-              "router ospf area interface" : [
-                44
-              ]
+              "router ospf area interface" : "44"
             },
             "Loopback0" : {
-              "router ospf area interface" : [
-                33
-              ]
+              "router ospf area interface" : "33"
             },
             "TenGigE0/0/0/2" : {
-              "router ospf area interface" : [
-                51
-              ]
+              "router ospf area interface" : "51"
             },
             "TenGigE0/0/0/4" : {
-              "router ospf area interface" : [
-                36
-              ]
+              "router ospf area interface" : "36"
             },
             "TenGigE0/0/0/5" : {
-              "router ospf area interface" : [
-                39
-              ]
+              "router ospf area interface" : "39"
             }
           }
         },
         "configs/ios_xr_route_policy" : {
           "as-path-set" : {
             "chill-as-path" : {
-              "route-policy as-path in" : [
-                124
-              ]
+              "route-policy as-path in" : "124"
             },
             "chill_aspath_141_deny" : {
-              "route-policy as-path in" : [
-                130
-              ]
+              "route-policy as-path in" : "130"
             },
             "chill_aspath_141_permit" : {
-              "route-policy as-path in" : [
-                144
-              ]
+              "route-policy as-path in" : "144"
             },
             "chill_aspath_142_permit" : {
-              "route-policy as-path in" : [
-                146
-              ]
+              "route-policy as-path in" : "146"
             },
             "xo-deny-as" : {
-              "route-policy as-path in" : [
-                91
-              ]
+              "route-policy as-path in" : "91"
             }
           },
           "community-set" : {
             "CF_fooey_Associates-chillmap" : {
-              "route-policy community matches-any" : [
-                146
-              ]
+              "route-policy community matches-any" : "146"
             },
             "DC_AT_CHILL" : {
-              "route-policy community matches-any" : [
-                151
-              ]
+              "route-policy community matches-any" : "151"
             },
             "EBGP-CUST-EXT" : {
-              "route-policy community matches-any" : [
-                99
-              ]
+              "route-policy community matches-any" : "99"
             },
             "EBGP-CUST-NOEXP-PEER-NA" : {
-              "route-policy community matches-any" : [
-                89
-              ]
+              "route-policy community matches-any" : "89"
             },
             "barbar_to_fooey_community_ipv4" : {
-              "route-policy set community" : [
-                53
-              ]
+              "route-policy set community" : "53"
             },
             "blackhole-all" : {
-              "route-policy community matches-any" : [
-                108,
-                159
-              ]
+              "route-policy community matches-any" : "108,159"
             },
             "blackhole-isp" : {
-              "route-policy community matches-any" : [
-                111
-              ]
+              "route-policy community matches-any" : "111"
             },
             "chillmap" : {
-              "route-policy community matches-any" : [
-                142
-              ]
+              "route-policy community matches-any" : "142"
             },
             "community_5555" : {
-              "route-policy community matches-any" : [
-                34
-              ],
-              "route-policy delete community [not] in" : [
-                35
-              ]
+              "route-policy community matches-any" : "34",
+              "route-policy delete community [not] in" : "35"
             },
             "fooey_blackhole_community" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             },
             "fooey_routes_community" : {
-              "route-policy community matches-any" : [
-                17
-              ]
+              "route-policy community matches-any" : "17"
             },
             "scenes_No_Export" : {
-              "route-policy community matches-any" : [
-                121
-              ]
+              "route-policy community matches-any" : "121"
             },
             "to-peers-backbone" : {
-              "route-policy community matches-any" : [
-                138
-              ]
+              "route-policy community matches-any" : "138"
             },
             "wrn-expanded" : {
-              "route-policy community matches-any" : [
-                130,
-                144
-              ]
+              "route-policy community matches-any" : "130,144"
             },
             "wrn-squelch-40027" : {
-              "route-policy community matches-any" : [
-                127
-              ]
+              "route-policy community matches-any" : "127"
             }
           },
           "prefix-set" : {
             "EBGP-PEER-BOGONS" : {
-              "route-policy prefix-set" : [
-                79
-              ]
+              "route-policy prefix-set" : "79"
             },
             "EBGP-PEER-OTHER-UNDESIRABLES" : {
-              "route-policy prefix-set" : [
-                79
-              ]
+              "route-policy prefix-set" : "79"
             },
             "EBGP-PEER-TOO-SPECIFIC" : {
-              "route-policy prefix-set" : [
-                81
-              ]
+              "route-policy prefix-set" : "81"
             },
             "barbar_blackhole_routes" : {
-              "route-policy prefix-set" : [
-                6,
-                52
-              ]
+              "route-policy prefix-set" : "6,52"
             },
             "barbar_networks_ipv4" : {
-              "route-policy prefix-set" : [
-                52
-              ]
+              "route-policy prefix-set" : "52"
             },
             "barbar_networks_ipv6" : {
-              "route-policy prefix-set" : [
-                22
-              ]
+              "route-policy prefix-set" : "22"
             },
             "bippetyboppety_ipv4" : {
-              "route-policy prefix-set" : [
-                45,
-                52
-              ]
+              "route-policy prefix-set" : "45,52"
             },
             "local-peer-aggregates" : {
-              "route-policy prefix-set" : [
-                69
-              ]
+              "route-policy prefix-set" : "69"
             },
             "null" : {
-              "route-policy prefix-set" : [
-                115
-              ]
+              "route-policy prefix-set" : "115"
             },
             "remote-router-loopbacks" : {
-              "route-policy prefix-set" : [
-                67
-              ]
+              "route-policy prefix-set" : "67"
             }
           },
           "route-policy" : {
             "bbbb" : {
-              "route-policy apply" : [
-                29
-              ]
+              "route-policy apply" : "29"
             }
           }
         },
         "configs/ios_xr_router_static" : {
           "interface" : {
             "GigabitEthernet0/2/1/5.290" : {
-              "router static route" : [
-                17
-              ]
+              "router static route" : "17"
             },
             "TenGigE0/0/2/3" : {
-              "router static route" : [
-                8
-              ]
+              "router static route" : "8"
             }
           }
         },
         "configs/ios_xr_ssh" : {
           "ipv4 access-list" : {
             "ACL99" : {
-              "ssh ipv4 access-list" : [
-                7
-              ]
+              "ssh ipv4 access-list" : "7"
             }
           },
           "ipv6 access-list" : {
             "ipv6-vty-acl" : {
-              "ssh ipv6 access-list" : [
-                7
-              ]
+              "ssh ipv6 access-list" : "7"
             }
           }
         },
         "configs/juniper_bgp" : {
           "policy-statement" : {
             "someexportpolicy" : {
-              "bgp export policy-statement" : [
-                10,
-                21,
-                28,
-                37
-              ]
+              "bgp export policy-statement" : "10,21,28,37"
             },
             "someimportpolicy" : {
-              "bgp import policy-statement" : [
-                13,
-                23,
-                30,
-                39
-              ]
+              "bgp import policy-statement" : "13,23,30,39"
             }
           }
         },
         "configs/juniper_bgp_authentication" : {
           "authentication-key-chain" : {
             "bgp-auth1" : {
-              "authentication-key-chains policy" : [
-                23
-              ]
+              "authentication-key-chains policy" : "23"
             }
           }
         },
         "configs/juniper_forwarding_options" : {
           "dhcp-relay server-group" : {
             "site-dhcp" : {
-              "dhcp relay group active-server-group" : [
-                8,
-                13
-              ]
+              "dhcp relay group active-server-group" : "8,13"
             }
           },
           "interface" : {
             "et-0/0/10.0" : {
-              "fowarding-options dhcp-relay group interface" : [
-                15
-              ]
+              "fowarding-options dhcp-relay group interface" : "15"
             },
             "ge-0/2/5.0" : {
-              "fowarding-options dhcp-relay group interface" : [
-                18
-              ]
+              "fowarding-options dhcp-relay group interface" : "18"
             },
             "xe-1/0/0.0" : {
-              "fowarding-options dhcp-relay group interface" : [
-                10
-              ]
+              "fowarding-options dhcp-relay group interface" : "10"
             }
           }
         },
         "configs/juniper_interfaces" : {
           "interface" : {
             "ge-0/0/1" : {
-              "routing-instance interface" : [
-                24
-              ]
+              "routing-instance interface" : "24"
             }
           },
           "vlan" : {
             "bippetyboppety" : {
-              "interface vlan" : [
-                20
-              ]
+              "interface vlan" : "20"
             }
           }
         },
         "configs/juniper_misc" : {
           "interface" : {
             "lo0.0" : {
-              "routing-instances vtep-source-interface" : [
-                9
-              ]
+              "routing-instances vtep-source-interface" : "9"
             }
           }
         },
         "configs/juniper_ospf" : {
           "interface" : {
             "ae16.0" : {
-              "ospf area interface" : [
-                18,
-                19,
-                20,
-                21,
-                23,
-                24
-              ]
+              "ospf area interface" : "18-21,23-24"
             },
             "xe-0/0/1.0" : {
-              "ospf area interface" : [
-                16
-              ]
+              "ospf area interface" : "16"
             },
             "xe-0/0/20:0.0" : {
-              "ospf area interface" : [
-                4,
-                5,
-                6,
-                7
-              ]
+              "ospf area interface" : "4-7"
             },
             "xe-0/0/21:0.0" : {
-              "ospf area interface" : [
-                8
-              ]
+              "ospf area interface" : "8"
             }
           }
         },
         "configs/juniper_policy_statement" : {
           "routing-instance" : {
             "FORWARDING" : {
-              "policy-statement from instance" : [
-                17
-              ]
+              "policy-statement from instance" : "17"
             }
           }
         },
         "configs/juniper_relay" : {
           "interface" : {
             "irb.10" : {
-              "fowarding-options dhcp-relay group interface" : [
-                7
-              ]
+              "fowarding-options dhcp-relay group interface" : "7"
             },
             "irb.20" : {
-              "fowarding-options dhcp-relay group interface" : [
-                8
-              ]
+              "fowarding-options dhcp-relay group interface" : "8"
             }
           }
         },
         "configs/juniper_routing_policy" : {
           "interface" : {
             "ge-0/0/0.99" : {
-              "policy-statement from interface" : [
-                9
-              ]
+              "policy-statement from interface" : "9"
             }
           }
         },
         "configs/juniper_snmp" : {
           "prefix-list" : {
             "bippetyboo" : {
-              "snmp community prefix-list" : [
-                5
-              ]
+              "snmp community prefix-list" : "5"
             }
           }
         },
         "configs/juniper_system" : {
           "logical-system" : {
             "ls905" : {
-              "security-profile logical-system" : [
-                21
-              ]
+              "security-profile logical-system" : "21"
             }
           }
         },
         "configs/juniper_vlan" : {
           "interface" : {
             "vlan.30" : {
-              "vlan l3-interface" : [
-                6
-              ]
+              "vlan l3-interface" : "6"
             },
             "vlan.40" : {
-              "vlan l3-interface" : [
-                8
-              ]
+              "vlan l3-interface" : "8"
             }
           }
         },
         "configs/named_and_numbered_lists" : {
           "ipv4 acl" : {
             "1" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "2" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "4" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "456def" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "5" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "95qrs5" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "a4" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             },
             "abc123" : {
-              "route-map match ipv4 access-list" : [
-                5
-              ]
+              "route-map match ipv4 access-list" : "5"
             }
           }
         },
         "configs/nxos/nxos_bgp" : {
           "route-map" : {
             "BLIB" : {
-              "bgp address-family [IPv6] network route-map" : [
-                24
-              ]
+              "bgp address-family [IPv6] network route-map" : "24"
             },
             "BLIBB" : {
-              "bgp address-family network route-map" : [
-                21
-              ]
+              "bgp address-family network route-map" : "21"
             },
             "BLOBB" : {
-              "bgp address-family redistribute route-map" : [
-                18
-              ]
+              "bgp address-family redistribute route-map" : "18"
             },
             "EG_CCC" : {
-              "bgp neighbor address-family route-map out" : [
-                34
-              ]
+              "bgp neighbor address-family route-map out" : "34"
             },
             "IN_BBB" : {
-              "bgp neighbor address-family route-map in" : [
-                33
-              ]
+              "bgp neighbor address-family route-map in" : "33"
             }
           }
         },
         "configs/nxos/nxos_ospf" : {
           "route-map" : {
             "RM_OSPF_DIRECT" : {
-              "router ospf redistribute route-map" : [
-                27,
-                32
-              ]
+              "router ospf redistribute route-map" : "27,32"
             },
             "RM_OSPF_STATIC" : {
-              "router ospf redistribute route-map" : [
-                28
-              ]
+              "router ospf redistribute route-map" : "28"
             }
           }
         },
         "configs/nxos/nxos_system" : {
           "policy-map type network-qos" : {
             "jumbo" : {
-              "system qos service-policy type network-qos" : [
-                11
-              ]
+              "system qos service-policy type network-qos" : "11"
             }
           }
         },
         "configs/palo_alto/nat" : {
           "zone" : {
             "FROM_1~panorama" : {
-              "rulebase nat rules from" : [
-                45
-              ]
+              "rulebase nat rules from" : "45"
             },
             "FROM_2~panorama" : {
-              "rulebase nat rules from" : [
-                45
-              ]
+              "rulebase nat rules from" : "45"
             },
             "FROM_ZONE~panorama" : {
-              "rulebase nat rules from" : [
-                34,
-                55,
-                59
-              ]
+              "rulebase nat rules from" : "34,55,59"
             },
             "TO_ZONE~panorama" : {
-              "rulebase nat rules to" : [
-                27,
-                33,
-                39,
-                51,
-                54,
-                58
-              ]
+              "rulebase nat rules to" : "27,33,39,51,54,58"
             }
           }
         },
         "configs/palo_alto/virtual-routers" : {
           "interface" : {
             "dummy" : {
-              "virtual-router interface" : [
-                27
-              ]
+              "virtual-router interface" : "27"
             }
           }
         },
         "configs/route_policy_as_path" : {
           "community-set" : {
             "13979:90" : {
-              "route-policy set community" : [
-                8
-              ]
+              "route-policy set community" : "8"
             },
             "SOCAL-USERS" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             }
           },
           "prefix-set" : {
             "CENIC_DC_Internal" : {
-              "route-policy prefix-set" : [
-                26
-              ]
+              "route-policy prefix-set" : "26"
             },
             "classful_default" : {
-              "route-policy prefix-set" : [
-                15
-              ]
+              "route-policy prefix-set" : "15"
             }
           }
         },
         "configs/route_policy_igp_cost" : {
           "community-set" : {
             "DC_AT_MEMBERS" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             },
             "DC_CF_COMMODITY_PEER" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             },
             "DC_CF_ISP" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             },
             "HPR_CF_RE_PEER" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             },
             "No_Export" : {
-              "route-policy community matches-any" : [
-                8
-              ]
+              "route-policy community matches-any" : "8"
             }
           }
         },
         "configs/route_policy_metric_type" : {
           "community-set" : {
             "No_Export" : {
-              "route-policy community matches-any" : [
-                6
-              ]
+              "route-policy community matches-any" : "6"
             }
           },
           "prefix-set" : {
             "DC_Internal" : {
-              "route-policy prefix-set" : [
-                8
-              ]
+              "route-policy prefix-set" : "8"
             }
           }
         },
         "configs/route_policy_param" : {
           "community-set" : {
             "blackhole-all" : {
-              "route-policy community matches-any" : [
-                14
-              ]
+              "route-policy community matches-any" : "14"
             }
           },
           "prefix-set" : {
             "$cust_v4_pfx" : {
-              "route-policy prefix-set" : [
-                6
-              ]
+              "route-policy prefix-set" : "6"
             }
           }
         },
         "configs/underscore_variable" : {
           "ipv4 prefix-list" : {
             "ABC_DEF" : {
-              "route-map match ipv4 prefix-list" : [
-                5
-              ]
+              "route-map match ipv4 prefix-list" : "5"
             },
             "_GHI" : {
-              "route-map match ipv4 prefix-list" : [
-                5
-              ]
+              "route-map match ipv4 prefix-list" : "5"
             }
           }
         },
         "configs/variables" : {
           "ipv4 acl" : {
             "ABC_def.gh_vlan789_out_20000101" : {
-              "interface outgoing ip access-list" : [
-                5
-              ]
+              "interface outgoing ip access-list" : "5"
             }
           }
         },
         "configs/variables_dos" : {
           "ipv4 acl" : {
             "ABC_def.gh_vlan789_out_20000101" : {
-              "interface outgoing ip access-list" : [
-                5
-              ]
+              "interface outgoing ip access-list" : "5"
             }
           }
         },
         "configs/vlan_access_map2" : {
           "undeclared bgp peer" : {
             "10.10.212.233" : {
-              "bgp neighbor without remote-as" : [
-                19
-              ]
+              "bgp neighbor without remote-as" : "19"
             }
           }
         }


### PR DESCRIPTION
Changing from `SortedSet<Integer>` to `IntegerSpace` is a dramatic reduction in storage, especially for definition lines. In one large network, halfway through parsing there were about 60M objects in memory, of which 34M were in `DefinedStructureInfo`.

By using `IntegerSpace` instead, we reduce sets to ranges and dramatically cut down on the number of objects maintained. Only internal storage changes - see ViModel diffs. Question answers stay the same.