### PR TITLE
Some tests: print logs

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BUILD
@@ -41,4 +41,8 @@ junit_tests(
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",
     ],
+    runtime_deps = [
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+    ]
 )

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/BUILD
@@ -13,6 +13,7 @@ junit_tests(
     resources = [
         "//projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs",
         "//projects/batfish/src/test/resources/org/batfish/grammar/arista/testrigs",
+        "//projects/batfish/src/test/resources:log4j_config",
     ],
     deps = [
         "//projects/batfish",
@@ -29,4 +30,8 @@ junit_tests(
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",
     ],
+     runtime_deps = [
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+    ]
 )

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/BUILD
@@ -15,6 +15,7 @@ junit_tests(
         "//projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/ospf",
         "//projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/snapshots/runtime_data",
         "//projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs",
+        "//projects/batfish/src/test/resources:log4j_config",
     ],
     deps = [
         "//projects/batfish",
@@ -31,4 +32,8 @@ junit_tests(
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",
     ],
+    runtime_deps = [
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+    ]
 )

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/BUILD
@@ -13,6 +13,7 @@ junit_tests(
     resources = [
         "//projects/batfish/src/test/resources/org/batfish/grammar/f5_bigip_imish/snapshots",
         "//projects/batfish/src/test/resources/org/batfish/grammar/f5_bigip_imish/testconfigs",
+        "//projects/batfish/src/test/resources:log4j_config",
     ],
     deps = [
         "//projects/batfish",
@@ -27,5 +28,10 @@ junit_tests(
         "@maven//:org_antlr_antlr4_runtime",
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",
+    ],
+    runtime_deps = [
+            "@maven//:org_mockito_mockito_inline",
+            "@maven//:org_apache_logging_log4j_log4j_core",
+                    "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
     ],
 )

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/BUILD
@@ -10,9 +10,14 @@ junit_tests(
     srcs = glob([
         "**/*Test*.java",
     ]),
-    resources = ["//projects/batfish/src/test/resources/org/batfish/representation/aws"],
+    resources = [
+        "//projects/batfish/src/test/resources/org/batfish/representation/aws",
+        "//projects/batfish/src/test/resources:log4j_config",
+        ],
     runtime_deps = [
         "@maven//:org_mockito_mockito_inline",
+        "@maven//:org_apache_logging_log4j_log4j_core",
+                "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
     ],
     deps = [
         "//projects/batfish",

--- a/projects/batfish/src/test/resources/BUILD
+++ b/projects/batfish/src/test/resources/BUILD
@@ -7,3 +7,8 @@ filegroup(
     name = "resources",
     srcs = glob(["**"]),
 )
+
+filegroup(
+    name = "log4j_config",
+    srcs = ["log4j2.properties"],
+)

--- a/projects/batfish/src/test/resources/log4j2.properties
+++ b/projects/batfish/src/test/resources/log4j2.properties
@@ -1,0 +1,12 @@
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+# loglevel, line number, message newline
+appender.console.layout.pattern=%p %l %m%n
+logger.bflogger.name=org.batfish.common.BatfishLogger
+logger.bflogger.level=error
+logger.bflogger.additivity=false
+logger.bflogger.appenderRef.stdout.ref=STDOUT
+# Update this to whatever log level you desire while debugging tests
+rootLogger.level=error
+rootLogger.appenderRef.stdout.ref=STDOUT


### PR DESCRIPTION
For some batfish package tests, quite useful to enable logs in tests. Helped me debug a whole bunch. By default log level error, but folks can change locally as required.