### PR TITLE
Dataplane: remove configurations

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/DataPlane.java
@@ -15,8 +15,6 @@ public interface DataPlane extends Serializable {
   /** Return routes in the EVPN RIB on each node/VRF */
   Table<String, String, Set<EvpnRoute<?, ?>>> getEvpnRoutes();
 
-  Map<String, Configuration> getConfigurations();
-
   /** Return a {@link Fib} for each node/VRF */
   Map<String, Map<String, Fib>> getFibs();
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockDataPlane.java
@@ -15,7 +15,6 @@ public class MockDataPlane implements DataPlane {
 
   public static class Builder {
     @Nonnull private Table<String, String, Set<Bgpv4Route>> _bgpRoutes;
-    @Nonnull private Map<String, Configuration> _configurations;
     @Nonnull private Table<String, String, Set<EvpnRoute<?, ?>>> _evpnRoutes;
     @Nonnull private Map<String, Map<String, Fib>> _fibs;
     @Nullable private ForwardingAnalysis _forwardingAnalysis;
@@ -27,7 +26,6 @@ public class MockDataPlane implements DataPlane {
 
     private Builder() {
       _bgpRoutes = HashBasedTable.create();
-      _configurations = ImmutableMap.of();
       _evpnRoutes = HashBasedTable.create();
       _fibs = ImmutableMap.of();
       _ribs = ImmutableSortedMap.of();
@@ -40,11 +38,6 @@ public class MockDataPlane implements DataPlane {
 
     public Builder setBgpRoutes(@Nonnull Table<String, String, Set<Bgpv4Route>> bgpRoutes) {
       _bgpRoutes = bgpRoutes;
-      return this;
-    }
-
-    public Builder setConfigs(Map<String, Configuration> configs) {
-      _configurations = configs;
       return this;
     }
 
@@ -80,7 +73,6 @@ public class MockDataPlane implements DataPlane {
   }
 
   @Nonnull private Table<String, String, Set<Bgpv4Route>> _bgpRoutes;
-  @Nonnull private final Map<String, Configuration> _configurations;
   @Nonnull private Table<String, String, Set<EvpnRoute<?, ?>>> _evpnRoutes;
   @Nonnull private final Map<String, Map<String, Fib>> _fibs;
   @Nullable private final ForwardingAnalysis _forwardingAnalysis;
@@ -93,7 +85,6 @@ public class MockDataPlane implements DataPlane {
 
   private MockDataPlane(Builder builder) {
     _bgpRoutes = builder._bgpRoutes;
-    _configurations = builder._configurations;
     _evpnRoutes = builder._evpnRoutes;
     _fibs = builder._fibs;
     _forwardingAnalysis = builder._forwardingAnalysis;
@@ -129,12 +120,6 @@ public class MockDataPlane implements DataPlane {
   @Override
   public SortedMap<String, SortedMap<String, GenericRib<AnnotatedRoute<AbstractRoute>>>> getRibs() {
     return _ribs;
-  }
-
-  @Nonnull
-  @Override
-  public Map<String, Configuration> getConfigurations() {
-    return _configurations;
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
@@ -1,9 +1,11 @@
 package org.batfish.dataplane;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import org.batfish.common.plugin.TracerouteEngine;
+import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Topology;
@@ -15,17 +17,26 @@ import org.batfish.dataplane.traceroute.TracerouteEngineImplContext;
 public final class TracerouteEngineImpl implements TracerouteEngine {
   private final DataPlane _dataPlane;
   private final Topology _topology;
+  private final Map<String, Configuration> _configurations;
 
-  public TracerouteEngineImpl(DataPlane dataPlane, Topology topology) {
+  public TracerouteEngineImpl(
+      DataPlane dataPlane, Topology topology, Map<String, Configuration> configurations) {
     _dataPlane = dataPlane;
     _topology = topology;
+    _configurations = configurations;
   }
 
   @Override
   public SortedMap<Flow, List<TraceAndReverseFlow>> computeTracesAndReverseFlows(
       Set<Flow> flows, Set<FirewallSessionTraceInfo> sessions, boolean ignoreFilters) {
     return new TracerouteEngineImplContext(
-            _dataPlane, _topology, sessions, flows, _dataPlane.getFibs(), ignoreFilters)
+            _dataPlane,
+            _topology,
+            sessions,
+            flows,
+            _dataPlane.getFibs(),
+            ignoreFilters,
+            _configurations)
         .buildTracesAndReturnFlows();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -158,7 +158,7 @@ class IncrementalBdpEngine {
 
           TracerouteEngine trEngCurrentL3Topogy =
               new TracerouteEngineImpl(
-                  partialDataplane, currentTopologyContext.getLayer3Topology());
+                  partialDataplane, currentTopologyContext.getLayer3Topology(), configurations);
 
           // Update topologies
           LOGGER.info("Updating dynamic topologies");
@@ -215,7 +215,7 @@ class IncrementalBdpEngine {
                   ipVrfOwners,
                   false,
                   true,
-                  new TracerouteEngineImpl(partialDataplane, newLayer3Topology),
+                  new TracerouteEngineImpl(partialDataplane, newLayer3Topology, configurations),
                   initialTopologyContext.getLayer2Topology().orElse(null));
           TopologyContext newTopologyContext =
               currentTopologyContext

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -51,15 +51,6 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
     }
   }
 
-  private final class ConfigurationsSupplier
-      implements Serializable, Supplier<Map<String, Configuration>> {
-
-    @Override
-    public Map<String, Configuration> get() {
-      return computeConfigurations();
-    }
-  }
-
   private final class FibsSupplier
       implements Serializable, Supplier<Map<String, Map<String, Fib>>> {
 
@@ -81,9 +72,6 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
   public static Builder builder() {
     return new Builder();
   }
-
-  private final Supplier<Map<String, Configuration>> _configurations =
-      Suppliers.memoize(new ConfigurationsSupplier());
 
   private final Supplier<Map<String, Map<String, Fib>>> _fibs =
       Suppliers.memoize(new FibsSupplier());
@@ -127,7 +115,7 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
   }
 
   private ForwardingAnalysis computeForwardingAnalysis() {
-    Map<String, Configuration> configs = getConfigurations();
+    Map<String, Configuration> configs = computeConfigurations();
     return new ForwardingAnalysisImpl(
         configs, getFibs(), _layer3Topology, computeLocationInfo(configs));
   }
@@ -193,11 +181,6 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
       }
     }
     return result;
-  }
-
-  @Override
-  public Map<String, Configuration> getConfigurations() {
-    return _configurations.get();
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteEngineImplContext.java
@@ -45,7 +45,6 @@ import org.batfish.datamodel.flow.TraceAndReverseFlow;
  */
 public class TracerouteEngineImplContext {
   private final Map<String, Configuration> _configurations;
-  private final DataPlane _dataPlane;
   private final Multimap<NodeInterfacePair, FirewallSessionTraceInfo> _sessionsByIngressInterface;
   private final Map<String, Multimap<String, FirewallSessionTraceInfo>> _sessionsByOriginatingVrf;
   private final Map<String, Map<String, Fib>> _fibs;
@@ -60,13 +59,13 @@ public class TracerouteEngineImplContext {
       Set<FirewallSessionTraceInfo> sessions,
       Set<Flow> flows,
       Map<String, Map<String, Fib>> fibs,
-      boolean ignoreFilters) {
-    _configurations = dataPlane.getConfigurations();
-    _dataPlane = dataPlane;
+      boolean ignoreFilters,
+      Map<String, Configuration> configurations) {
+    _configurations = configurations;
     _flows = flows;
     _fibs = fibs;
     _ignoreFilters = ignoreFilters;
-    _forwardingAnalysis = _dataPlane.getForwardingAnalysis();
+    _forwardingAnalysis = dataPlane.getForwardingAnalysis();
     _sessionsByIngressInterface = buildSessionsByIngressInterface(sessions);
     _sessionsByOriginatingVrf = buildSessionsByOriginatingVrf(sessions);
     _topology = topology;

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1757,7 +1757,9 @@ public class Batfish extends PluginConsumer implements IBatfish {
   @Override
   public TracerouteEngine getTracerouteEngine(NetworkSnapshot snapshot) {
     return new TracerouteEngineImpl(
-        loadDataPlane(snapshot), _topologyProvider.getLayer3Topology(snapshot));
+        loadDataPlane(snapshot),
+        _topologyProvider.getLayer3Topology(snapshot),
+        loadConfigurations(snapshot));
   }
 
   /** Function that processes an interface blacklist across all configurations */

--- a/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/TracerouteEngineTest.java
@@ -124,7 +124,8 @@ public class TracerouteEngineTest {
 
     // Compute flow traces
     SortedMap<Flow, List<Trace>> traces =
-        new TracerouteEngineImpl(dp, batfish.getTopologyProvider().getLayer3Topology(snapshot))
+        new TracerouteEngineImpl(
+                dp, batfish.getTopologyProvider().getLayer3Topology(snapshot), configs)
             .computeTraces(ImmutableSet.of(flow1, flow2), false);
 
     assertThat(traces, hasEntry(equalTo(flow1), contains(hasDisposition(NO_ROUTE))));
@@ -174,7 +175,8 @@ public class TracerouteEngineTest {
             .setDstIp(parse("10.0.0.2"))
             .build();
     List<Trace> traces =
-        new TracerouteEngineImpl(dp, batfish.getTopologyProvider().getLayer3Topology(snapshot))
+        new TracerouteEngineImpl(
+                dp, batfish.getTopologyProvider().getLayer3Topology(snapshot), configurations)
             .computeTraces(ImmutableSet.of(flow), false)
             .get(flow);
 
@@ -350,15 +352,15 @@ public class TracerouteEngineTest {
     Configuration.Builder cb =
         nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
     Configuration c1 = cb.build();
-    Batfish batfish =
-        BatfishTestUtils.getBatfish(ImmutableSortedMap.of(c1.getHostname(), c1), _tempFolder);
+    ImmutableSortedMap<String, Configuration> configs = ImmutableSortedMap.of(c1.getHostname(), c1);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _tempFolder);
     NetworkSnapshot snapshot = batfish.getSnapshot();
     batfish.computeDataPlane(snapshot);
     DataPlane dp = batfish.loadDataPlane(snapshot);
 
     _thrown.expect(IllegalArgumentException.class);
     _thrown.expectMessage("Node missingNode is not in the network");
-    new TracerouteEngineImpl(dp, batfish.getTopologyProvider().getLayer3Topology(snapshot))
+    new TracerouteEngineImpl(dp, batfish.getTopologyProvider().getLayer3Topology(snapshot), configs)
         .computeTraces(ImmutableSet.of(builder().setIngressNode("missingNode").build()), false);
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -504,7 +504,7 @@ public class IncrementalDataPlanePluginTest {
             initiator,
             listener,
             source,
-            new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology())));
+            new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
   @Test
@@ -538,7 +538,7 @@ public class IncrementalDataPlanePluginTest {
             initiator,
             listener,
             source,
-            new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology())));
+            new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
   @Test
@@ -572,7 +572,7 @@ public class IncrementalDataPlanePluginTest {
             initiator,
             listener,
             source,
-            new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology())));
+            new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
   @Test
@@ -608,7 +608,7 @@ public class IncrementalDataPlanePluginTest {
             initiator,
             listener,
             source,
-            new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology())));
+            new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
   @Test
@@ -644,7 +644,7 @@ public class IncrementalDataPlanePluginTest {
             initiator,
             listener,
             source,
-            new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology())));
+            new TracerouteEngineImpl(dp, result._topologies.getLayer3Topology(), configs)));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -143,14 +143,16 @@ public final class FlowTracerTest {
 
     List<TraceAndReverseFlow> traces = new ArrayList<>();
 
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
-            MockDataPlane.builder().setConfigs(ImmutableMap.of(c.getHostname(), c)).build(),
+            MockDataPlane.builder().build(),
             Topology.EMPTY,
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(),
-            false);
+            false,
+            configs);
     FlowTracer flowTracer = initialFlowTracer(ctxt, c.getHostname(), null, flow, traces::add);
     flowTracer.buildDeniedTrace(DENIED_IN);
     assertThat(
@@ -178,14 +180,16 @@ public final class FlowTracerTest {
     FirewallSessionTraceInfo sessionInfo =
         new FirewallSessionTraceInfo(
             "hostname", Accept.INSTANCE, ImmutableSet.of(), dummySessionFlow, null);
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
-            MockDataPlane.builder().setConfigs(ImmutableMap.of(c.getHostname(), c)).build(),
+            MockDataPlane.builder().build(),
             Topology.EMPTY,
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(),
-            false);
+            false,
+            configs);
     FlowTracer flowTracer =
         new FlowTracer(
             ctxt,
@@ -235,11 +239,11 @@ public final class FlowTracerTest {
     Interface ingressIface =
         nf.interfaceBuilder().setOwner(c).setVrf(vrf).setName(flow.getIngressInterface()).build();
 
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
     // Accepting interface should be the one that owns the dst IP, not necessarily ingress interface
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
             MockDataPlane.builder()
-                .setConfigs(ImmutableMap.of(c.getHostname(), c))
                 .setForwardingAnalysis(
                     MockForwardingAnalysis.builder()
                         .setAcceptedIps(
@@ -255,7 +259,8 @@ public final class FlowTracerTest {
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(),
-            false);
+            false,
+            configs);
     List<TraceAndReverseFlow> traces = new ArrayList<>();
     FlowTracer flowTracer =
         new FlowTracer(
@@ -379,12 +384,13 @@ public final class FlowTracerTest {
             .setDstPort(dstPort)
             .build();
 
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
+
     // Accepting interface should be the one that owns the dst IP
     String acceptingIfaceName = "acceptingIface";
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
             MockDataPlane.builder()
-                .setConfigs(ImmutableMap.of(c.getHostname(), c))
                 .setForwardingAnalysis(
                     MockForwardingAnalysis.builder()
                         .setAcceptedIps(
@@ -399,7 +405,8 @@ public final class FlowTracerTest {
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(),
-            false);
+            false,
+            configs);
     List<TraceAndReverseFlow> traces = new ArrayList<>();
     FlowTracer flowTracer =
         new FlowTracer(
@@ -468,10 +475,11 @@ public final class FlowTracerTest {
             flowMatchingNewSession,
             null);
 
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
+
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
             MockDataPlane.builder()
-                .setConfigs(ImmutableMap.of(c.getHostname(), c))
                 .setForwardingAnalysis(
                     MockForwardingAnalysis.builder()
                         .setAcceptedIps(
@@ -484,7 +492,8 @@ public final class FlowTracerTest {
             ImmutableSet.of(),
             ImmutableMap.of(
                 c.getHostname(), ImmutableMap.of(vrf.getName(), MockFib.builder().build())),
-            false);
+            false,
+            configs);
 
     {
       // Return flow matches session
@@ -584,14 +593,17 @@ public final class FlowTracerTest {
                                     .build())))))
             .build();
 
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
+
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
-            MockDataPlane.builder().setConfigs(ImmutableMap.of(c.getHostname(), c)).build(),
+            MockDataPlane.builder().build(),
             Topology.EMPTY,
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(hostname, ImmutableMap.of(srcVrfName, srcFib)),
-            false);
+            false,
+            configs);
     FlowTracer flowTracer = initialFlowTracer(ctxt, hostname, null, flow, traces::add);
     flowTracer.fibLookup(dstIp, hostname, srcFib);
     List<TraceAndReverseFlow> finalTraces = traces.build();
@@ -647,14 +659,16 @@ public final class FlowTracerTest {
                         new FibEntry(FibNullRoute.INSTANCE, ImmutableList.of(nullRoute)))))
             .build();
     List<TraceAndReverseFlow> traces = new ArrayList<>();
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
-            MockDataPlane.builder().setConfigs(ImmutableMap.of(c.getHostname(), c)).build(),
+            MockDataPlane.builder().build(),
             Topology.EMPTY,
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(hostname, ImmutableMap.of(srcVrfName, srcFib, nextVrfName, nextFib)),
-            false);
+            false,
+            configs);
     FlowTracer flowTracer = initialFlowTracer(ctxt, hostname, null, flow, traces::add);
     flowTracer.fibLookup(dstIp, hostname, srcFib);
 
@@ -725,14 +739,17 @@ public final class FlowTracerTest {
                             new FibNextVrf(vrf1Name), ImmutableList.of(vrf2NextVrfRoute)))))
             .build();
     List<TraceAndReverseFlow> traces = new ArrayList<>();
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
+
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
-            MockDataPlane.builder().setConfigs(ImmutableMap.of(c.getHostname(), c)).build(),
+            MockDataPlane.builder().build(),
             Topology.EMPTY,
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(hostname, ImmutableMap.of(vrf1Name, fib1, vrf2Name, fib2)),
-            false);
+            false,
+            configs);
     FlowTracer flowTracer = initialFlowTracer(ctxt, hostname, null, flow, traces::add);
     flowTracer.fibLookup(dstIp, hostname, fib1);
 
@@ -814,6 +831,7 @@ public final class FlowTracerTest {
                                     .setNextHopIp(Ip.parse("2.3.4.5"))
                                     .build())))))
             .build();
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
 
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
@@ -827,13 +845,13 @@ public final class FlowTracerTest {
                                     srcVrf.getName(),
                                     ImmutableMap.of("iface1", dstIp.toIpSpace()))))
                         .build())
-                .setConfigs(ImmutableMap.of(c.getHostname(), c))
                 .build(),
             Topology.EMPTY,
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(hostname, ImmutableMap.of(srcVrfName, srcFib)),
-            false);
+            false,
+            configs);
     FlowTracer flowTracer = initialFlowTracer(ctxt, hostname, null, flow, traces::add);
     flowTracer.fibLookup(dstIp, hostname, srcFib);
     List<TraceAndReverseFlow> finalTraces = traces.build();
@@ -883,16 +901,18 @@ public final class FlowTracerTest {
     Transformation transformation =
         when(matchDst(new IpSpaceReference("ips"))).apply(assignDestinationIp(ip3, ip3)).build();
 
+    ImmutableMap<String, Configuration> configs =
+        ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2);
+
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
-            MockDataPlane.builder()
-                .setConfigs(ImmutableMap.of(c1.getHostname(), c1, c2.getHostname(), c2))
-                .build(),
+            MockDataPlane.builder().build(),
             Topology.EMPTY,
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(),
-            false);
+            false,
+            configs);
     Flow.Builder fb =
         Flow.builder()
             .setIngressNode(c1.getHostname())
@@ -1155,14 +1175,17 @@ public final class FlowTracerTest {
             .setIngressVrf(vrf.getName())
             .build();
 
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
+
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
-            MockDataPlane.builder().setConfigs(ImmutableMap.of(c.getHostname(), c)).build(),
+            MockDataPlane.builder().build(),
             Topology.EMPTY,
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(),
-            false);
+            false,
+            configs);
 
     List<TraceAndReverseFlow> traces = new ArrayList<>();
     FlowTracer flowTracer =
@@ -1368,14 +1391,17 @@ public final class FlowTracerTest {
             .setIngressVrf(vrf.getName())
             .build();
 
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
+
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
-            MockDataPlane.builder().setConfigs(ImmutableMap.of(c.getHostname(), c)).build(),
+            MockDataPlane.builder().build(),
             Topology.EMPTY,
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(),
-            false);
+            false,
+            configs);
     String node = c.getHostname();
     Configuration currentConfig = ctxt.getConfigurations().get(node);
     Stack<Breadcrumb> breadcrumbs = new Stack<>();
@@ -1426,14 +1452,17 @@ public final class FlowTracerTest {
             .setIngressVrf(v1.getName())
             .build();
 
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c1.getHostname(), c1);
+
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
-            MockDataPlane.builder().setConfigs(ImmutableMap.of(c1.getHostname(), c1)).build(),
+            MockDataPlane.builder().build(),
             Topology.EMPTY,
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(),
-            false);
+            false,
+            configs);
     FlowTracer flowTracer =
         initialFlowTracer(ctxt, c1.getHostname(), null, flow, traceAndReverseFlow -> {});
 
@@ -1489,17 +1518,17 @@ public final class FlowTracerTest {
                     ImmutableMap.of(
                         vrf.getName(), ImmutableMap.of(iface.getName(), dstIp.toIpSpace()))))
             .build();
+    ImmutableMap<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
+
     TracerouteEngineImplContext ctxt =
         new TracerouteEngineImplContext(
-            MockDataPlane.builder()
-                .setConfigs(ImmutableMap.of(c.getHostname(), c))
-                .setForwardingAnalysis(forwardingAnalysis)
-                .build(),
+            MockDataPlane.builder().setForwardingAnalysis(forwardingAnalysis).build(),
             Topology.EMPTY,
             ImmutableSet.of(),
             ImmutableSet.of(),
             ImmutableMap.of(),
-            false);
+            false,
+            configs);
 
     // There's a sanity check in FlowTracer constructor that requires there to be a PolicyStep or
     // TransformationStep if the current and original flows don't match. Doesn't matter if this

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -1346,12 +1346,13 @@ public class TracerouteEngineImplTest {
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(true, ImmutableSet.of(i2Name), null, null))
         .build();
-    Batfish batfish = BatfishTestUtils.getBatfish(ImmutableSortedMap.of(hostname, c), _tempFolder);
+    SortedMap<String, Configuration> configs = ImmutableSortedMap.of(hostname, c);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _tempFolder);
     NetworkSnapshot snapshot = batfish.getSnapshot();
     batfish.computeDataPlane(snapshot);
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
 
-    TracerouteEngineImpl te = new TracerouteEngineImpl(dp, Topology.EMPTY);
+    TracerouteEngineImpl te = new TracerouteEngineImpl(dp, Topology.EMPTY, configs);
     List<TraceAndReverseFlow> forwardTraces =
         te.computeTracesAndReverseFlows(ImmutableSet.of(flow), false).get(flow);
 
@@ -1422,12 +1423,13 @@ public class TracerouteEngineImplTest {
                 .setNetwork(Prefix.ZERO)
                 .setNextVrf(vrf1.getName())
                 .build());
-    Batfish batfish = BatfishTestUtils.getBatfish(ImmutableSortedMap.of(hostname, c), _tempFolder);
+    SortedMap<String, Configuration> configs = ImmutableSortedMap.of(hostname, c);
+    Batfish batfish = BatfishTestUtils.getBatfish(configs, _tempFolder);
     NetworkSnapshot snapshot = batfish.getSnapshot();
     batfish.computeDataPlane(snapshot);
     DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
 
-    TracerouteEngineImpl te = new TracerouteEngineImpl(dp, Topology.EMPTY);
+    TracerouteEngineImpl te = new TracerouteEngineImpl(dp, Topology.EMPTY, configs);
     List<TraceAndReverseFlow> forwardTraces =
         te.computeTracesAndReverseFlows(ImmutableSet.of(flow), false).get(flow);
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoBidirectionalBehaviorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoBidirectionalBehaviorTest.java
@@ -80,7 +80,10 @@ public final class PaloAltoBidirectionalBehaviorTest {
     NetworkSnapshot snapshot = batfish.getSnapshot();
     batfish.computeDataPlane(snapshot);
     DataPlane dp = batfish.loadDataPlane(snapshot);
-    return new TracerouteEngineImpl(dp, batfish.getTopologyProvider().getLayer3Topology(snapshot));
+    return new TracerouteEngineImpl(
+        dp,
+        batfish.getTopologyProvider().getLayer3Topology(snapshot),
+        batfish.loadConfigurations(snapshot));
   }
 
   private void assertForwardDropped(String hostname) throws IOException {

--- a/projects/question/src/test/java/org/batfish/question/vxlanproperties/VxlanVniPropertiesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/vxlanproperties/VxlanVniPropertiesAnswererTest.java
@@ -162,7 +162,6 @@ public final class VxlanVniPropertiesAnswererTest {
 
     @Override
     public DataPlane loadDataPlane(NetworkSnapshot snapshot) {
-      SortedMap<String, Configuration> configs = loadConfigurations(snapshot);
       HashBasedTable<String, String, Set<Layer2Vni>> vnis = HashBasedTable.create();
       vnis.put(
           "hostname",
@@ -195,7 +194,7 @@ public final class VxlanVniPropertiesAnswererTest {
                   .setUdpPort(1234)
                   .setBumTransportMethod(BumTransportMethod.MULTICAST_GROUP)
                   .build()));
-      return MockDataPlane.builder().setConfigs(configs).setVniSettings(vnis).build();
+      return MockDataPlane.builder().setVniSettings(vnis).build();
     }
 
     @Override


### PR DESCRIPTION
DP should not be the source of truth for configurations.
This also should unblock some follow-up optimizations where we do not serialize Nodes to disk