### PR TITLE
Location: subclasses should have different hashes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceLinkLocation.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceLinkLocation.java
@@ -3,7 +3,6 @@ package org.batfish.specifier;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /** Identifies the {@link Location} of the link of an interface in the network. */
@@ -55,7 +54,7 @@ public final class InterfaceLinkLocation implements Location {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_interfaceName, _nodeName);
+    return 31 * 31 * getClass().hashCode() + 31 * _interfaceName.hashCode() + _nodeName.hashCode();
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceLocation.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/specifier/InterfaceLocation.java
@@ -52,7 +52,7 @@ public final class InterfaceLocation implements Location {
 
   @Override
   public int hashCode() {
-    return 31 * _interfaceName.hashCode() + _nodeName.hashCode();
+    return 31 * 31 * getClass().hashCode() + 31 * _interfaceName.hashCode() + _nodeName.hashCode();
   }
 
   @Override


### PR DESCRIPTION
This is basically similar to batfish/batfish#3855: hash codes should not be the same even if the two fields are.