### PR TITLE
Cisco-style: stop warning about OSPF settings on interface not in an area

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -2367,32 +2367,27 @@ public final class AristaConfiguration extends VendorConfiguration {
         });
 
     /*
-     * Another pass over interfaces to push final settings to VI interfaces and issue final warnings
-     * (e.g. has OSPF settings but no associated OSPF process)
+     * Another pass over interfaces to push final settings to VI interfaces.
+     * (e.g. has OSPF settings but no associated OSPF process, common in show run all)
      */
     _interfaces.forEach(
         (ifaceName, vsIface) -> {
           org.batfish.datamodel.Interface iface = c.getAllInterfaces().get(ifaceName);
           if (iface == null) {
             // Should never get here
-          } else {
-            // Conversion of interface OSPF settings usually occurs per area
-            // If the iface does not have an area, then need warn and convert settings here instead
-            if (iface.getOspfAreaName() == null) {
-              // Not part of an OSPF area
-              if (vsIface.getOspfArea() != null
-                  || vsIface.getOspfCost() != null
-                  || vsIface.getOspfPassive() != null
-                  || vsIface.getOspfNetworkType() != null
-                  || vsIface.getOspfDeadInterval() != null
-                  || vsIface.getOspfHelloInterval() != null) {
-                _w.redFlag(
-                    "Interface: '"
-                        + ifaceName
-                        + "' contains OSPF settings, but there is no corresponding OSPF area (or process)");
-                finalizeInterfaceOspfSettings(iface, vsIface, null, null);
-              }
-            }
+            return;
+          } else if (iface.getOspfAreaName() != null) {
+            // Already configured
+            return;
+          }
+          // Not part of an OSPF area, but has settings
+          if (vsIface.getOspfArea() != null
+              || vsIface.getOspfCost() != null
+              || vsIface.getOspfPassive() != null
+              || vsIface.getOspfNetworkType() != null
+              || vsIface.getOspfDeadInterval() != null
+              || vsIface.getOspfHelloInterval() != null) {
+            finalizeInterfaceOspfSettings(iface, vsIface, null, null);
           }
         });
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3355,10 +3355,9 @@ public final class CiscoConfiguration extends VendorConfiguration {
             newVrf.setBgpProcess(newBgpProcess);
           }
         });
-
     /*
-     * Another pass over interfaces to push final settings to VI interfaces and issue final warnings
-     * (e.g. has OSPF settings but no associated OSPF process)
+     * Another pass over interfaces to push final settings to VI interfaces.
+     * (e.g. has OSPF settings but no associated OSPF process, common in show run all)
      */
     _interfaces.forEach(
         (key, vsIface) -> {
@@ -3367,24 +3366,19 @@ public final class CiscoConfiguration extends VendorConfiguration {
           org.batfish.datamodel.Interface iface = c.getAllInterfaces().get(ifaceName);
           if (iface == null) {
             // Should never get here
-          } else {
-            // Conversion of interface OSPF settings usually occurs per area
-            // If the iface does not have an area, then need warn and convert settings here instead
-            if (iface.getOspfAreaName() == null) {
-              // Not part of an OSPF area
-              if (vsIface.getOspfArea() != null
-                  || vsIface.getOspfCost() != null
-                  || vsIface.getOspfPassive() != null
-                  || vsIface.getOspfNetworkType() != null
-                  || vsIface.getOspfDeadInterval() != null
-                  || vsIface.getOspfHelloInterval() != null) {
-                _w.redFlag(
-                    "Interface: '"
-                        + ifaceName
-                        + "' contains OSPF settings, but there is no corresponding OSPF area (or process)");
-                finalizeInterfaceOspfSettings(iface, vsIface, null, null);
-              }
-            }
+            return;
+          } else if (iface.getOspfAreaName() != null) {
+            // Already configured
+            return;
+          }
+          // Not part of an OSPF area, but has settings
+          if (vsIface.getOspfArea() != null
+              || vsIface.getOspfCost() != null
+              || vsIface.getOspfPassive() != null
+              || vsIface.getOspfNetworkType() != null
+              || vsIface.getOspfDeadInterval() != null
+              || vsIface.getOspfHelloInterval() != null) {
+            finalizeInterfaceOspfSettings(iface, vsIface, null, null);
           }
         });
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -2456,29 +2456,27 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
         });
 
     /*
-     * Another pass over interfaces to push final settings to VI interfaces and issue final warnings
-     * (e.g. has OSPF settings but no associated OSPF process)
+     * Another pass over interfaces to push final settings to VI interfaces.
+     * (e.g. has OSPF settings but no associated OSPF process, common in show run all)
      */
     _interfaces.forEach(
         (ifaceName, vsIface) -> {
           org.batfish.datamodel.Interface iface = c.getAllInterfaces().get(ifaceName);
-          assert iface != null;
-          // Conversion of interface OSPF settings usually occurs per area
-          // If the iface does not have an area, then need warn and convert settings here instead
-          if (iface.getOspfAreaName() == null) {
-            // Not part of an OSPF area
-            if (vsIface.getOspfArea() != null
-                || vsIface.getOspfCost() != null
-                || vsIface.getOspfPassive() != null
-                || vsIface.getOspfNetworkType() != null
-                || vsIface.getOspfDeadInterval() != null
-                || vsIface.getOspfHelloInterval() != null) {
-              _w.redFlag(
-                  "Interface: '"
-                      + ifaceName
-                      + "' contains OSPF settings, but there is no corresponding OSPF area (or process)");
-              finalizeInterfaceOspfSettings(iface, vsIface, null, null);
-            }
+          if (iface == null) {
+            // Should never get here
+            return;
+          } else if (iface.getOspfAreaName() != null) {
+            // Already configured
+            return;
+          }
+          // Not part of an OSPF area, but has settings
+          if (vsIface.getOspfArea() != null
+              || vsIface.getOspfCost() != null
+              || vsIface.getOspfPassive() != null
+              || vsIface.getOspfNetworkType() != null
+              || vsIface.getOspfDeadInterval() != null
+              || vsIface.getOspfHelloInterval() != null) {
+            finalizeInterfaceOspfSettings(iface, vsIface, null, null);
           }
         });
 

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -78451,7 +78451,7 @@
         "cisco_flow" : "PASSED",
         "cisco_hardware" : "PASSED",
         "cisco_hsrp" : "PASSED",
-        "cisco_interface" : "WARNINGS",
+        "cisco_interface" : "PASSED",
         "cisco_ios_neighbor" : "PASSED",
         "cisco_ip" : "PASSED",
         "cisco_ip_nat" : "PASSED",
@@ -78470,9 +78470,9 @@
         "cisco_multicast" : "PASSED",
         "cisco_ntp" : "PASSED",
         "cisco_ospf" : "WARNINGS",
-        "cisco_ospf_ipv6" : "WARNINGS",
+        "cisco_ospf_ipv6" : "PASSED",
         "cisco_ospf_multi_process" : "PASSED",
-        "cisco_ospfv3" : "WARNINGS",
+        "cisco_ospfv3" : "PASSED",
         "cisco_pim" : "PASSED",
         "cisco_platform" : "PASSED",
         "cisco_privilege" : "PASSED",
@@ -91681,18 +91681,6 @@
             }
           ]
         },
-        "cisco_interface" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface: 'Ethernet0' contains OSPF settings, but there is no corresponding OSPF area (or process)"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface: 'inside' contains OSPF settings, but there is no corresponding OSPF area (or process)"
-            }
-          ]
-        },
         "cisco_ospf" : {
           "Red flags" : [
             {
@@ -91702,26 +91690,6 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "OSPF process default:1 in cisco_ospf uses distribute-list of type ACCESS_LIST, only prefix-lists are supported in dist-lists by Batfish"
-            },
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface: 'Ethernet1/0' contains OSPF settings, but there is no corresponding OSPF area (or process)"
-            }
-          ]
-        },
-        "cisco_ospf_ipv6" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface: 'Ethernet0/0' contains OSPF settings, but there is no corresponding OSPF area (or process)"
-            }
-          ]
-        },
-        "cisco_ospfv3" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Interface: 'Ethernet0/0' contains OSPF settings, but there is no corresponding OSPF area (or process)"
             }
           ]
         },


### PR DESCRIPTION
This is apparently really common behavior - show run all on many vendors
will include OSPF defaults. So this is not an indication of a likely
misconfiguration.