### PR TITLE
BGP ribs: do not merge routes with unreachable next hops

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
@@ -1,5 +1,6 @@
 package org.batfish.dataplane.rib;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRoute;
@@ -7,7 +8,10 @@ import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.BgpTieBreaker;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.GenericRibReadOnly;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
+import org.batfish.datamodel.Route;
+import org.batfish.datamodel.RoutingProtocol;
 
 /** BGPv4-specific RIB implementation */
 @ParametersAreNonnullByDefault
@@ -27,5 +31,29 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
         multipathEquivalentAsPathMatchMode,
         withBackups,
         clusterListAsIgpCost);
+  }
+
+  @Nonnull
+  @Override
+  public RibDelta<Bgpv4Route> mergeRouteGetDelta(Bgpv4Route route) {
+    Ip nextHopIp = route.getNextHopIp();
+    /*
+      Do not merge routes for which next hop is not reachable.
+      However, due to some complications with how we create routes, we must skip this check for:
+      - routes with link-local address as next hop (i.e., next-hop interface is set to something)
+      - routes with Ip.AUTO as next hop or protocol AGGREGATE (for locally-generated routes/aggregates)
+    */
+    if (Route.UNSET_NEXT_HOP_INTERFACE.equals(route.getNextHopInterface())
+        && !nextHopIp.equals(Ip.AUTO)
+        && route.getProtocol() != RoutingProtocol.AGGREGATE
+        && _mainRib != null
+        && _mainRib.longestPrefixMatch(nextHopIp).isEmpty()) {
+      /*
+      TODO: when backups are enabled again, we should probably put this in as a backup
+         and then return empty delta
+      */
+      return RibDelta.empty();
+    }
+    return super.mergeRouteGetDelta(route);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpNextHopUnchangedTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpNextHopUnchangedTest.java
@@ -184,7 +184,22 @@ public class BgpNextHopUnchangedTest {
             .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
             .build();
     Vrf r3Vrf = _nf.vrfBuilder().setName(DEFAULT_VRF_NAME).setOwner(r3).setOwner(r3).build();
-    _nf.interfaceBuilder().setName("r3_r2").setAddress(_r3Addr1).setVrf(r3Vrf).setOwner(r3).build();
+    Interface i3 =
+        _nf.interfaceBuilder()
+            .setName("r3_r2")
+            .setAddress(_r3Addr1)
+            .setVrf(r3Vrf)
+            .setOwner(r3)
+            .build();
+    // Static route required, otherwise IBGP routes from r1 won't be accepted (no reach. to nexthop
+    // ip)
+    r3Vrf.setStaticRoutes(
+        ImmutableSortedSet.of(
+            StaticRoute.builder()
+                .setNetwork(_r1Addr1.getPrefix())
+                .setAdmin(1)
+                .setNextHopInterface(i3.getName())
+                .build()));
     BgpProcess bgpProcessR3 = _bgpProcessBuilder.setRouterId(_routerId3).setVrf(r3Vrf).build();
     _nf.bgpNeighborBuilder()
         .setLocalIp(_r3Addr1.getIp())

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
@@ -47,19 +47,12 @@ import org.junit.Test;
 public class RouteReflectionTest {
 
   private static final Prefix AS1_PREFIX = Prefix.parse("1.0.0.0/8");
-
   private static final Prefix AS3_PREFIX = Prefix.parse("3.0.0.0/8");
-
   private static final int EDGE_PREFIX_LENGTH = 24;
-
   private static final String EDGE1_NAME = "edge1";
-
   private static final String EDGE2_NAME = "edge2";
-
   private static final String RR_NAME = "rr";
-
   private static final String RR1_NAME = "rr1";
-
   private static final String RR2_NAME = "rr2";
 
   private static <T extends AbstractRoute> void assertIbgpRoute(
@@ -84,21 +77,13 @@ public class RouteReflectionTest {
   }
 
   private BgpAdvertisement.Builder _ab;
-
   private Configuration.Builder _cb;
-
   private RoutingPolicy.Builder _defaultExportPolicyBuilder;
-
   private Interface.Builder _ib;
-
   private BgpActivePeerConfig.Builder _nb;
-
   private NetworkFactory _nf;
-
   private RoutingPolicy.Builder _nullExportPolicyBuilder;
-
   private BgpProcess.Builder _pb;
-
   private Vrf.Builder _vb;
 
   /*
@@ -128,7 +113,8 @@ public class RouteReflectionTest {
     StaticRoute.Builder sb = StaticRoute.builder().setAdministrativeCost(1);
     vEdge1.setStaticRoutes(
         ImmutableSortedSet.of(
-            sb.setNextHopIp(rrEdge1IfaceIp).setNetwork(rrLoopbackIp.toPrefix()).build()));
+            sb.setNextHopIp(rrEdge1IfaceIp).setNetwork(rrLoopbackIp.toPrefix()).build(),
+            sb.setNextHopIp(rrEdge1IfaceIp).setNetwork(as3PeeringIp.toPrefix()).build()));
     BgpProcess edge1Proc = _pb.setRouterId(edge1LoopbackIp).setVrf(vEdge1).build();
     RoutingPolicy edge1EbgpExportPolicy = _nullExportPolicyBuilder.setOwner(edge1).build();
     _nb.setBgpProcess(edge1Proc)
@@ -160,7 +146,9 @@ public class RouteReflectionTest {
     vRr.setStaticRoutes(
         ImmutableSortedSet.of(
             sb.setNextHopIp(edge1IbgpIfaceIp).setNetwork(edge1LoopbackIp.toPrefix()).build(),
-            sb.setNextHopIp(edge2IbgpIfaceIp).setNetwork(edge2LoopbackIp.toPrefix()).build()));
+            sb.setNextHopIp(edge2IbgpIfaceIp).setNetwork(edge2LoopbackIp.toPrefix()).build(),
+            sb.setNextHopIp(edge1IbgpIfaceIp).setNetwork(as1PeeringIp.toPrefix()).build(),
+            sb.setNextHopIp(edge2IbgpIfaceIp).setNetwork(as3PeeringIp.toPrefix()).build()));
     BgpProcess rrProc = _pb.setRouterId(rrLoopbackIp).setVrf(vRr).build();
     RoutingPolicy rrExportPolicy = _defaultExportPolicyBuilder.setOwner(rr).build();
     Builder ipv4AfBuilder =
@@ -192,7 +180,8 @@ public class RouteReflectionTest {
     _ib.setAddress(ConcreteInterfaceAddress.create(edge2IbgpIfaceIp, EDGE_PREFIX_LENGTH)).build();
     vEdge2.setStaticRoutes(
         ImmutableSortedSet.of(
-            sb.setNextHopIp(rrEdge2IfaceIp).setNetwork(rrLoopbackIp.toPrefix()).build()));
+            sb.setNextHopIp(rrEdge2IfaceIp).setNetwork(rrLoopbackIp.toPrefix()).build(),
+            sb.setNextHopIp(rrEdge2IfaceIp).setNetwork(as1PeeringIp.toPrefix()).build()));
     BgpProcess edge2Proc = _pb.setRouterId(edge2LoopbackIp).setVrf(vEdge2).build();
     RoutingPolicy edge2EbgpExportPolicy = _nullExportPolicyBuilder.setOwner(edge2).build();
     _nb.setBgpProcess(edge2Proc)
@@ -300,7 +289,8 @@ public class RouteReflectionTest {
     vRr1.setStaticRoutes(
         ImmutableSortedSet.of(
             sb.setNextHopIp(edge1IbgpIfaceIp).setNetwork(edge1LoopbackIp.toPrefix()).build(),
-            sb.setNextHopIp(rr2IbgpIfaceIp).setNetwork(rr2LoopbackIp.toPrefix()).build()));
+            sb.setNextHopIp(rr2IbgpIfaceIp).setNetwork(rr2LoopbackIp.toPrefix()).build(),
+            sb.setNextHopIp(rr2IbgpIfaceIp).setNetwork(as1PeeringIp.toPrefix()).build()));
     BgpProcess rr1Proc = _pb.setRouterId(rr1LoopbackIp).setVrf(vRr1).build();
     RoutingPolicy rr1ExportPolicy = _defaultExportPolicyBuilder.setOwner(rr1).build();
     _nb.setBgpProcess(rr1Proc)
@@ -326,7 +316,8 @@ public class RouteReflectionTest {
     _ib.setAddress(ConcreteInterfaceAddress.create(rr2IbgpIfaceIp, EDGE_PREFIX_LENGTH)).build();
     vRr2.setStaticRoutes(
         ImmutableSortedSet.of(
-            sb.setNextHopIp(rr1Rr2IfaceIp).setNetwork(rr1LoopbackIp.toPrefix()).build()));
+            sb.setNextHopIp(rr1Rr2IfaceIp).setNetwork(rr1LoopbackIp.toPrefix()).build(),
+            sb.setNextHopIp(rr1Rr2IfaceIp).setNetwork(as1PeeringIp.toPrefix()).build()));
     BgpProcess rr2Proc = _pb.setRouterId(rr2LoopbackIp).setVrf(vRr2).build();
     RoutingPolicy edge2IbgpExportPolicy = _defaultExportPolicyBuilder.setOwner(rr2).build();
 


### PR DESCRIPTION
Because that's how BGP actually works.

https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/iproute_bgp/configuration/xe-3s/irg-xe-3s-book/bgp-support-for-next-hop-address-tracking.html