### PR TITLE
ibdp: stop using batfish logger

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
@@ -50,8 +50,7 @@ public class IncrementalDataPlanePlugin extends DataPlanePlugin {
   protected void dataPlanePluginInitialize() {
     _engine =
         new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(_batfish.getSettingsConfiguration()),
-            _batfish.getLogger());
+            new IncrementalDataPlaneSettings(_batfish.getSettingsConfiguration()));
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/FixedPointTopologyTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/FixedPointTopologyTest.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.plugin.DataPlanePlugin.ComputeDataPlaneResult;
 import org.batfish.common.topology.Layer1Edge;
 import org.batfish.common.topology.Layer1Topology;
@@ -184,10 +183,7 @@ public final class FixedPointTopologyTest {
   @Test
   public void testFixedPointVxlanTopology() {
     Map<String, Configuration> configs = generateVxlanConfigs();
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_DEBUG, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
     TopologyContext callerTopologyContext = getCallerTopologyContext(configs);
 
     // Initially there should be no VXLAN tunnel
@@ -373,10 +369,7 @@ public final class FixedPointTopologyTest {
             .setIpsecTopology(getIpsecTopology(false))
             .setLayer3Topology(layer3Topology)
             .build();
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_DEBUG, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
 
     ComputeDataPlaneResult dp =
         engine.computeDataPlane(configurations, topologyContext, ImmutableSet.of());
@@ -403,10 +396,7 @@ public final class FixedPointTopologyTest {
             .setIpsecTopology(getIpsecTopology(false))
             .setLayer3Topology(layer3Topology)
             .build();
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_DEBUG, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
 
     ComputeDataPlaneResult dp =
         engine.computeDataPlane(configurations, topologyContext, ImmutableSet.of());
@@ -432,10 +422,7 @@ public final class FixedPointTopologyTest {
             .setIpsecTopology(getIpsecTopology(false))
             .setLayer3Topology(layer3Topology)
             .build();
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_DEBUG, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
 
     ComputeDataPlaneResult dp =
         engine.computeDataPlane(configurations, topologyContext, ImmutableSet.of());
@@ -476,10 +463,7 @@ public final class FixedPointTopologyTest {
             .setIpsecTopology(getIpsecTopology(true))
             .setLayer3Topology(layer3Topology)
             .build();
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_DEBUG, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
 
     ComputeDataPlaneResult dp =
         engine.computeDataPlane(configurations, topologyContext, ImmutableSet.of());

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePluginTest.java
@@ -32,7 +32,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.SerializationUtils;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.DataPlanePlugin;
 import org.batfish.common.plugin.DataPlanePlugin.ComputeDataPlaneResult;
@@ -365,8 +364,7 @@ public class IncrementalDataPlanePluginTest {
     IncrementalBdpEngine engine =
         new IncrementalBdpEngine(
             // TODO: parametrize settings with different schedules
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_DEBUG, false));
+            new IncrementalDataPlaneSettings());
     Topology topology = new Topology(Collections.emptySortedSet());
     ComputeDataPlaneResult dp =
         engine.computeDataPlane(
@@ -399,10 +397,7 @@ public class IncrementalDataPlanePluginTest {
             .build();
     vrf.getStaticRoutes().add(sr);
     Map<String, Configuration> configs = ImmutableMap.of(c.getHostname(), c);
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_DEBUG, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
     ComputeDataPlaneResult dp =
         engine.computeDataPlane(configs, TopologyContext.builder().build(), Collections.emptySet());
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.Set;
 import java.util.SortedMap;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.topology.TopologyUtil;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
@@ -167,10 +166,7 @@ public class IsisTest {
 
     SortedMap<String, Configuration> configurations =
         ImmutableSortedMap.of(r1.getHostname(), r1, r2.getHostname(), r2);
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_OUTPUT, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
     Topology topology = TopologyUtil.synthesizeL3Topology(configurations);
     return (IbdpResult)
         engine.computeDataPlane(
@@ -451,10 +447,7 @@ public class IsisTest {
             r4,
             r5.getHostname(),
             r5);
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_OUTPUT, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
     Topology topology = TopologyUtil.synthesizeL3Topology(configurations);
     return (IbdpResult)
         engine.computeDataPlane(
@@ -640,10 +633,7 @@ public class IsisTest {
     SortedMap<String, Configuration> configurations =
         ImmutableSortedMap.of(
             r1.getHostname(), r1, r2.getHostname(), r2, r3.getHostname(), r3, r4.getHostname(), r4);
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_OUTPUT, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
     Topology topology = TopologyUtil.synthesizeL3Topology(configurations);
     return (IncrementalDataPlane)
         engine.computeDataPlane(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfTest.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.topology.TopologyUtil;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
@@ -345,10 +344,7 @@ public class OspfTest {
             .put(c3.getHostname(), c3)
             .put(c4.getHostname(), c4)
             .build();
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_OUTPUT, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
     OspfTopologyUtils.initNeighborConfigs(NetworkConfigurations.of(configurations));
     Topology topology = TopologyUtil.synthesizeL3Topology(configurations);
     IncrementalDataPlane dp =
@@ -585,10 +581,7 @@ public class OspfTest {
             .put(r5.getHostname(), r5)
             .put(r6.getHostname(), r6)
             .build();
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_OUTPUT, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
     OspfTopologyUtils.initNeighborConfigs(NetworkConfigurations.of(configurations));
     Topology topology = TopologyUtil.synthesizeL3Topology(configurations);
     IncrementalDataPlane dp =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/RouteReflectionTest.java
@@ -13,7 +13,6 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Set;
 import java.util.SortedMap;
-import org.batfish.common.BatfishLogger;
 import org.batfish.common.plugin.DataPlanePlugin.ComputeDataPlaneResult;
 import org.batfish.common.topology.TopologyUtil;
 import org.batfish.datamodel.AbstractRoute;
@@ -217,10 +216,7 @@ public class RouteReflectionTest {
             .put(rr.getHostname(), rr)
             .put(edge2.getHostname(), edge2)
             .build();
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_OUTPUT, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
     Topology topology = TopologyUtil.synthesizeL3Topology(configurations);
     ComputeDataPlaneResult dpResult =
         engine.computeDataPlane(
@@ -348,10 +344,7 @@ public class RouteReflectionTest {
             .put(rr1.getHostname(), rr1)
             .put(rr2.getHostname(), rr2)
             .build();
-    IncrementalBdpEngine engine =
-        new IncrementalBdpEngine(
-            new IncrementalDataPlaneSettings(),
-            new BatfishLogger(BatfishLogger.LEVELSTR_OUTPUT, false));
+    IncrementalBdpEngine engine = new IncrementalBdpEngine(new IncrementalDataPlaneSettings());
     Topology topology = TopologyUtil.synthesizeL3Topology(configurations);
     IncrementalDataPlane dp =
         (IncrementalDataPlane)


### PR DESCRIPTION
Minor cleanup, since we have the ability to log well with log4j now.