### PR TITLE
IOS: stop explicitly listing reference types for concrete structures

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3528,96 +3528,25 @@ public final class CiscoConfiguration extends VendorConfiguration {
         CiscoStructureUsage.ROUTE_MAP_MATCH_IPV6_PREFIX_LIST);
 
     // mark references to route-maps
-    markConcreteStructure(
-        CiscoStructureType.ROUTE_MAP,
-        CiscoStructureUsage.BGP_ADVERTISE_MAP_EXIST_MAP,
-        CiscoStructureUsage.BGP_AGGREGATE_ATTRIBUTE_MAP,
-        CiscoStructureUsage.BGP_AGGREGATE_MATCH_MAP,
-        CiscoStructureUsage.BGP_DEFAULT_ORIGINATE_ROUTE_MAP,
-        CiscoStructureUsage.BGP_INBOUND_ROUTE_MAP,
-        CiscoStructureUsage.BGP_INBOUND_ROUTE6_MAP,
-        CiscoStructureUsage.BGP_NEIGHBOR_REMOTE_AS_ROUTE_MAP,
-        CiscoStructureUsage.BGP_NETWORK_ORIGINATION_ROUTE_MAP,
-        CiscoStructureUsage.BGP_NETWORK6_ORIGINATION_ROUTE_MAP,
-        CiscoStructureUsage.BGP_OUTBOUND_ROUTE_MAP,
-        CiscoStructureUsage.BGP_OUTBOUND_ROUTE6_MAP,
-        CiscoStructureUsage.BGP_REDISTRIBUTE_ATTACHED_HOST_MAP,
-        CiscoStructureUsage.BGP_REDISTRIBUTE_CONNECTED_MAP,
-        CiscoStructureUsage.BGP_REDISTRIBUTE_DYNAMIC_MAP,
-        CiscoStructureUsage.BGP_REDISTRIBUTE_ISIS_MAP,
-        CiscoStructureUsage.BGP_REDISTRIBUTE_OSPF_MAP,
-        CiscoStructureUsage.BGP_REDISTRIBUTE_OSPFV3_MAP,
-        CiscoStructureUsage.BGP_REDISTRIBUTE_RIP_MAP,
-        CiscoStructureUsage.BGP_REDISTRIBUTE_STATIC_MAP,
-        CiscoStructureUsage.BGP_ROUTE_MAP_ADVERTISE,
-        CiscoStructureUsage.BGP_ROUTE_MAP_UNSUPPRESS,
-        CiscoStructureUsage.BGP_VRF_AGGREGATE_ROUTE_MAP,
-        CiscoStructureUsage.EIGRP_DISTRIBUTE_LIST_ROUTE_MAP_IN,
-        CiscoStructureUsage.EIGRP_DISTRIBUTE_LIST_ROUTE_MAP_OUT,
-        CiscoStructureUsage.EIGRP_REDISTRIBUTE_BGP_MAP,
-        CiscoStructureUsage.EIGRP_REDISTRIBUTE_CONNECTED_MAP,
-        CiscoStructureUsage.EIGRP_REDISTRIBUTE_EIGRP_MAP,
-        CiscoStructureUsage.EIGRP_REDISTRIBUTE_ISIS_MAP,
-        CiscoStructureUsage.EIGRP_REDISTRIBUTE_OSPF_MAP,
-        CiscoStructureUsage.EIGRP_REDISTRIBUTE_RIP_MAP,
-        CiscoStructureUsage.EIGRP_REDISTRIBUTE_STATIC_MAP,
-        CiscoStructureUsage.EIGRP_STUB_LEAK_MAP,
-        CiscoStructureUsage.INTERFACE_IP_VRF_SITEMAP,
-        CiscoStructureUsage.INTERFACE_POLICY_ROUTING_MAP,
-        CiscoStructureUsage.INTERFACE_SUMMARY_ADDRESS_EIGRP_LEAK_MAP,
-        CiscoStructureUsage.ISIS_REDISTRIBUTE_CONNECTED_MAP,
-        CiscoStructureUsage.ISIS_REDISTRIBUTE_STATIC_MAP,
-        CiscoStructureUsage.OSPF_DEFAULT_ORIGINATE_ROUTE_MAP,
-        CiscoStructureUsage.OSPF_DISTRIBUTE_LIST_ROUTE_MAP_IN,
-        CiscoStructureUsage.OSPF_DISTRIBUTE_LIST_ROUTE_MAP_OUT,
-        CiscoStructureUsage.OSPF_REDISTRIBUTE_BGP_MAP,
-        CiscoStructureUsage.OSPF_REDISTRIBUTE_CONNECTED_MAP,
-        CiscoStructureUsage.OSPF_REDISTRIBUTE_EIGRP_MAP,
-        CiscoStructureUsage.OSPF_REDISTRIBUTE_STATIC_MAP,
-        CiscoStructureUsage.OSPF_PREFIX_PRIORITY_MAP,
-        CiscoStructureUsage.PIM_ACCEPT_REGISTER_ROUTE_MAP,
-        CiscoStructureUsage.RIP_DEFAULT_ORIGINATE_ROUTE_MAP,
-        CiscoStructureUsage.RIP_REDISTRIBUTE_BGP_MAP,
-        CiscoStructureUsage.RIP_REDISTRIBUTE_CONNECTED_MAP,
-        CiscoStructureUsage.RIP_REDISTRIBUTE_STATIC_MAP,
-        CiscoStructureUsage.VRF_DEFINITION_ADDRESS_FAMILY_EXPORT_MAP);
+    markConcreteStructure(CiscoStructureType.ROUTE_MAP);
 
     // Cable
-    markConcreteStructure(
-        CiscoStructureType.DEPI_CLASS, CiscoStructureUsage.DEPI_TUNNEL_DEPI_CLASS);
-    markConcreteStructure(
-        CiscoStructureType.DEPI_TUNNEL,
-        CiscoStructureUsage.CONTROLLER_DEPI_TUNNEL,
-        CiscoStructureUsage.DEPI_TUNNEL_PROTECT_TUNNEL);
-    markConcreteStructure(
-        CiscoStructureType.DOCSIS_POLICY, CiscoStructureUsage.DOCSIS_GROUP_DOCSIS_POLICY);
-    markConcreteStructure(
-        CiscoStructureType.DOCSIS_POLICY_RULE,
-        CiscoStructureUsage.DOCSIS_POLICY_DOCSIS_POLICY_RULE);
+    markConcreteStructure(CiscoStructureType.DEPI_CLASS);
+    markConcreteStructure(CiscoStructureType.DEPI_TUNNEL);
+    markConcreteStructure(CiscoStructureType.DOCSIS_POLICY);
+    markConcreteStructure(CiscoStructureType.DOCSIS_POLICY_RULE);
     markConcreteStructure(
         CiscoStructureType.SERVICE_CLASS, CiscoStructureUsage.QOS_ENFORCE_RULE_SERVICE_CLASS);
 
     // L2tp
-    markConcreteStructure(
-        CiscoStructureType.L2TP_CLASS, CiscoStructureUsage.DEPI_TUNNEL_L2TP_CLASS);
+    markConcreteStructure(CiscoStructureType.L2TP_CLASS);
 
     // Crypto, Isakmp, and IPSec
-    markConcreteStructure(
-        CiscoStructureType.CRYPTO_DYNAMIC_MAP_SET,
-        CiscoStructureUsage.CRYPTO_MAP_IPSEC_ISAKMP_CRYPTO_DYNAMIC_MAP_SET);
-    markConcreteStructure(
-        CiscoStructureType.ISAKMP_PROFILE,
-        CiscoStructureUsage.ISAKMP_PROFILE_SELF_REF,
-        CiscoStructureUsage.CRYPTO_MAP_IPSEC_ISAKMP_ISAKMP_PROFILE,
-        CiscoStructureUsage.IPSEC_PROFILE_ISAKMP_PROFILE);
-    markConcreteStructure(
-        CiscoStructureType.ISAKMP_POLICY, CiscoStructureUsage.ISAKMP_POLICY_SELF_REF);
-    markConcreteStructure(
-        CiscoStructureType.IPSEC_PROFILE, CiscoStructureUsage.TUNNEL_PROTECTION_IPSEC_PROFILE);
-    markConcreteStructure(
-        CiscoStructureType.IPSEC_TRANSFORM_SET,
-        CiscoStructureUsage.CRYPTO_MAP_IPSEC_ISAKMP_TRANSFORM_SET,
-        CiscoStructureUsage.IPSEC_PROFILE_TRANSFORM_SET);
+    markConcreteStructure(CiscoStructureType.CRYPTO_DYNAMIC_MAP_SET);
+    markConcreteStructure(CiscoStructureType.ISAKMP_PROFILE);
+    markConcreteStructure(CiscoStructureType.ISAKMP_POLICY);
+    markConcreteStructure(CiscoStructureType.IPSEC_PROFILE);
+    markConcreteStructure(CiscoStructureType.IPSEC_TRANSFORM_SET);
     markConcreteStructure(CiscoStructureType.KEYRING, CiscoStructureUsage.ISAKMP_PROFILE_KEYRING);
     markConcreteStructure(
         CiscoStructureType.NAMED_RSA_PUB_KEY, CiscoStructureUsage.NAMED_RSA_PUB_KEY_SELF_REF);

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -115,6 +115,54 @@
         }
       },
       {
+        "File_Name" : "configs/aruba_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "\"",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/aruba_crypto",
+          "lines" : [
+            5
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/aruba_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "bar",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/aruba_crypto",
+          "lines" : [
+            5
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/aruba_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "baz",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/aruba_crypto",
+          "lines" : [
+            5
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/aruba_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "foo",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/aruba_crypto",
+          "lines" : [
+            5
+          ]
+        }
+      },
+      {
         "File_Name" : "configs/asa_acl",
         "Struct_Type" : "object-group network",
         "Ref_Name" : "drawbridge_hosts",
@@ -843,6 +891,140 @@
           "filename" : "configs/cisco_control_plane",
           "lines" : [
             6
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/cisco_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "ESP-3DES-MD5-trans",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/cisco_crypto",
+          "lines" : [
+            101
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/cisco_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "ESP-3DES-SHA",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/cisco_crypto",
+          "lines" : [
+            101,
+            105,
+            111
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/cisco_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "ESP-3DES-SHA-TRANS",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/cisco_crypto",
+          "lines" : [
+            101
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/cisco_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "ESP-AES-128-MD5",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/cisco_crypto",
+          "lines" : [
+            105
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/cisco_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "ESP-AES-128-SHA",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/cisco_crypto",
+          "lines" : [
+            105
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/cisco_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "ESP-AES-192-MD5",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/cisco_crypto",
+          "lines" : [
+            105
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/cisco_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "ESP-AES-192-SHA",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/cisco_crypto",
+          "lines" : [
+            105
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/cisco_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "ESP-AES-256-MD5",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/cisco_crypto",
+          "lines" : [
+            105
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/cisco_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "ESP-AES-256-SHA",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/cisco_crypto",
+          "lines" : [
+            105
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/cisco_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "ESP-DES-MD5",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/cisco_crypto",
+          "lines" : [
+            105
+          ]
+        }
+      },
+      {
+        "File_Name" : "configs/cisco_crypto",
+        "Struct_Type" : "crypto ipsec transform-set",
+        "Ref_Name" : "ESP-DES-SHA",
+        "Context" : "crypto dynamic-map transform-set",
+        "Lines" : {
+          "filename" : "configs/cisco_crypto",
+          "lines" : [
+            105
           ]
         }
       },
@@ -4228,10 +4410,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 343 results",
+      "notes" : "Found 358 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 343
+      "numResults" : 358
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -565,18 +565,6 @@
       },
       {
         "Structure_Type" : "crypto ipsec transform-set",
-        "Structure_Name" : "ESP-3DES-MD5",
-        "Source_Lines" : {
-          "filename" : "configs/cisco_crypto",
-          "lines" : [
-            168,
-            169,
-            170
-          ]
-        }
-      },
-      {
-        "Structure_Type" : "crypto ipsec transform-set",
         "Structure_Name" : "IPSEC_AES_256",
         "Source_Lines" : {
           "filename" : "configs/cisco_crypto",
@@ -3930,10 +3918,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 265 results",
+      "notes" : "Found 264 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 265
+      "numResults" : 264
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -79262,7 +79262,7 @@
           "crypto ipsec transform-set" : {
             "ESP-3DES-MD5" : {
               "definitionLines" : "168-170",
-              "numReferrers" : 0
+              "numReferrers" : 3
             },
             "IPSEC_AES_256" : {
               "definitionLines" : "171",
@@ -89372,6 +89372,30 @@
             }
           }
         },
+        "configs/aruba_crypto" : {
+          "crypto ipsec transform-set" : {
+            "\"" : {
+              "crypto dynamic-map transform-set" : [
+                5
+              ]
+            },
+            "bar" : {
+              "crypto dynamic-map transform-set" : [
+                5
+              ]
+            },
+            "baz" : {
+              "crypto dynamic-map transform-set" : [
+                5
+              ]
+            },
+            "foo" : {
+              "crypto dynamic-map transform-set" : [
+                5
+              ]
+            }
+          }
+        },
         "configs/asa_acl" : {
           "object-group network" : {
             "drawbridge_hosts" : {
@@ -89781,6 +89805,63 @@
         },
         "configs/cisco_crypto" : {
           "crypto ipsec transform-set" : {
+            "ESP-3DES-MD5-trans" : {
+              "crypto dynamic-map transform-set" : [
+                101
+              ]
+            },
+            "ESP-3DES-SHA" : {
+              "crypto dynamic-map transform-set" : [
+                101,
+                105,
+                111
+              ]
+            },
+            "ESP-3DES-SHA-TRANS" : {
+              "crypto dynamic-map transform-set" : [
+                101
+              ]
+            },
+            "ESP-AES-128-MD5" : {
+              "crypto dynamic-map transform-set" : [
+                105
+              ]
+            },
+            "ESP-AES-128-SHA" : {
+              "crypto dynamic-map transform-set" : [
+                105
+              ]
+            },
+            "ESP-AES-192-MD5" : {
+              "crypto dynamic-map transform-set" : [
+                105
+              ]
+            },
+            "ESP-AES-192-SHA" : {
+              "crypto dynamic-map transform-set" : [
+                105
+              ]
+            },
+            "ESP-AES-256-MD5" : {
+              "crypto dynamic-map transform-set" : [
+                105
+              ]
+            },
+            "ESP-AES-256-SHA" : {
+              "crypto dynamic-map transform-set" : [
+                105
+              ]
+            },
+            "ESP-DES-MD5" : {
+              "crypto dynamic-map transform-set" : [
+                105
+              ]
+            },
+            "ESP-DES-SHA" : {
+              "crypto dynamic-map transform-set" : [
+                105
+              ]
+            },
             "bleep" : {
               "crypto map ipsec-isakmp transform-set" : [
                 227


### PR DESCRIPTION
Listing reference types explicitly is important for structures that can be used
with abstract references, aka, ip access-list which can often refer to one of
half a dozen types. It's not necessary for things like route-map or crypto
constructs that are not referenced in an ambiguous way.

Remove this listing, and hey, find a bug or two on the way.