### PR TITLE
CommunityMatchExprEvaluators: rewrite streams as loops

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunityMatchExprEvaluator.java
@@ -65,13 +65,23 @@ public final class CommunityMatchExprEvaluator
   @Override
   public @Nonnull Boolean visitCommunityMatchAll(
       CommunityMatchAll communityMatchAll, Community arg) {
-    return communityMatchAll.getExprs().stream().allMatch(expr -> expr.accept(this, arg));
+    for (CommunityMatchExpr expr : communityMatchAll.getExprs()) {
+      if (!expr.accept(this, arg)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override
   public @Nonnull Boolean visitCommunityMatchAny(
       CommunityMatchAny communityMatchAny, Community arg) {
-    return communityMatchAny.getExprs().stream().anyMatch(expr -> expr.accept(this, arg));
+    for (CommunityMatchExpr expr : communityMatchAny.getExprs()) {
+      if (expr.accept(this, arg)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override


### PR DESCRIPTION
Streams are actually fairly expensive over small sets, as is the common
case for these use cases.