### PR TITLE
BGP RIBs: enable backup routes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -224,7 +224,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             bestPathTieBreaker,
             _process.getMultipathEbgp() ? null : 1,
             multiPathMatchMode,
-            false,
+            true,
             clusterListAsIgpCost);
     _ibgpv4Rib =
         new Bgpv4Rib(
@@ -232,7 +232,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             bestPathTieBreaker,
             _process.getMultipathIbgp() ? null : 1,
             multiPathMatchMode,
-            false,
+            true,
             clusterListAsIgpCost);
     _bgpv4Rib =
         new Bgpv4Rib(
@@ -240,7 +240,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             bestPathTieBreaker,
             _process.getMultipathEbgp() || _process.getMultipathIbgp() ? null : 1,
             multiPathMatchMode,
-            false,
+            true,
             clusterListAsIgpCost);
     _bgpv4DeltaBuilder = RibDelta.builder();
 


### PR DESCRIPTION
Enabling backup routes helps us handle networks where there is temporary flap and best routes get withdrawn (and thus must be replaced by previously-seen not-withdrawn routes)