### PR TITLE
bdp: optimize to run fewer topology iterations

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -274,7 +274,6 @@ final class IncrementalBdpEngine {
       // Generate the answers from the computation, compute final FIBs
       // TODO: Properly finalize topologies, IpOwners, etc.
       LOGGER.info("Finalizing dataplane");
-      computeFibs(nodes);
       answerElement.setVersion(BatfishVersion.getVersionStatic());
       IncrementalDataPlane finalDataplane =
           IncrementalDataPlane.builder()

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -34,7 +34,6 @@ import org.batfish.common.plugin.DataPlanePlugin.ComputeDataPlaneResult;
 import org.batfish.common.plugin.TracerouteEngine;
 import org.batfish.common.topology.IpOwners;
 import org.batfish.common.topology.Layer2Topology;
-import org.batfish.common.topology.TopologyUtil;
 import org.batfish.common.topology.TunnelTopology;
 import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.BgpAdvertisement;
@@ -48,10 +47,8 @@ import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.eigrp.EigrpTopology;
 import org.batfish.datamodel.eigrp.EigrpTopologyUtils;
 import org.batfish.datamodel.ipsec.IpsecTopology;
-import org.batfish.datamodel.isis.IsisTopology;
 import org.batfish.datamodel.ospf.OspfTopology;
 import org.batfish.datamodel.vxlan.VxlanTopology;
-import org.batfish.datamodel.vxlan.VxlanTopologyUtils;
 import org.batfish.dataplane.TracerouteEngineImpl;
 import org.batfish.dataplane.ibdp.schedule.IbdpSchedule;
 import org.batfish.dataplane.ibdp.schedule.IbdpSchedule.Schedule;
@@ -75,9 +72,112 @@ final class IncrementalBdpEngine {
     _settings = settings;
   }
 
+  /**
+   * Performs the iterative step in dataplane computations as topology changes.
+   *
+   * <p>The {@code currentTopologyContext} contains the connectivity learned so far in the network,
+   * specifically for things like VXLAN, BGP, and others, and {@code nodes} contains the current
+   * routing and forwarding tables.
+   *
+   * <p>Given these inputs, primarily the current Layer3 topology, the possible edges for each other
+   * topology (obtained from {@code initialTopologyContext}) are pruned down based on which sessions
+   * can be established given the current L3 topology and dataplane state. The resulting {@code
+   * TopologyContext} for the next iteration of dataplane is returned.
+   */
+  private TopologyContext nextTopologyContext(
+      TopologyContext currentTopologyContext,
+      SortedMap<String, Node> nodes,
+      TopologyContext initialTopologyContext,
+      NetworkConfigurations networkConfigurations,
+      Map<Ip, Map<String, Set<String>>> ipVrfOwners) {
+    // Force re-init of partial dataplane. Re-inits forwarding analysis, etc.
+    computeFibs(nodes);
+    PartialDataplane partialDataplane =
+        PartialDataplane.builder()
+            .setNodes(nodes)
+            .setLayer3Topology(currentTopologyContext.getLayer3Topology())
+            .build();
+
+    Map<String, Configuration> configurations = networkConfigurations.getMap();
+    TracerouteEngine trEngCurrentL3Topology =
+        new TracerouteEngineImpl(
+            partialDataplane, currentTopologyContext.getLayer3Topology(), configurations);
+
+    // Update topologies
+    LOGGER.info("Updating dynamic topologies");
+
+    // IPsec
+    LOGGER.info("Updating IPsec topology");
+    // Note: this uses the initial context since it is pruning down the potential edges initially
+    // established.
+    IpsecTopology newIpsecTopology =
+        retainReachableIpsecEdges(
+            initialTopologyContext.getIpsecTopology(), configurations, trEngCurrentL3Topology);
+
+    // VXLAN
+    LOGGER.info("Updating VXLAN topology");
+    VxlanTopology newVxlanTopology =
+        prunedVxlanTopology(
+            computeVxlanTopology(partialDataplane.getLayer2Vnis()),
+            configurations,
+            trEngCurrentL3Topology);
+    // Layer-2
+    LOGGER.info("Updating Layer 2 topology");
+    Optional<Layer2Topology> newLayer2Topology =
+        initialTopologyContext // not updated across rounds
+            .getLayer1LogicalTopology()
+            .map(l1 -> computeLayer2Topology(l1, newVxlanTopology, configurations));
+
+    // Tunnel topology
+    LOGGER.info("Updating Tunnel topology");
+    TunnelTopology newTunnelTopology =
+        pruneUnreachableTunnelEdges(
+            initialTopologyContext.getTunnelTopology(), // like IPsec, pruning initial tunnels
+            networkConfigurations,
+            trEngCurrentL3Topology);
+
+    // Layer-3
+    LOGGER.info("Updating Layer 3 topology");
+    Topology newLayer3Topology =
+        computeLayer3Topology(
+            computeRawLayer3Topology(
+                initialTopologyContext.getRawLayer1PhysicalTopology(), // not updated across rounds
+                initialTopologyContext.getLayer1LogicalTopology(), // not updated across rounds
+                newLayer2Topology,
+                configurations),
+            // Overlay edges consist of "plain" tunnels and IPSec tunnels
+            Sets.union(toEdgeSet(newIpsecTopology, configurations), newTunnelTopology.asEdgeSet()));
+
+    // EIGRP topology
+    LOGGER.info("Updating EIGRP topology");
+    EigrpTopology newEigrpTopology =
+        EigrpTopologyUtils.initEigrpTopology(configurations, newLayer3Topology);
+
+    // Initialize BGP topology
+    LOGGER.info("Updating BGP topology");
+    BgpTopology newBgpTopology =
+        initBgpTopology(
+            configurations,
+            ipVrfOwners,
+            false,
+            true,
+            new TracerouteEngineImpl(partialDataplane, newLayer3Topology, configurations),
+            newLayer2Topology.orElse(null));
+    return currentTopologyContext
+        .toBuilder()
+        .setBgpTopology(newBgpTopology)
+        .setLayer2Topology(newLayer2Topology)
+        .setLayer3Topology(newLayer3Topology)
+        .setVxlanTopology(newVxlanTopology)
+        .setIpsecTopology(newIpsecTopology)
+        .setTunnelTopology(newTunnelTopology)
+        .setEigrpTopology(newEigrpTopology)
+        .build();
+  }
+
   ComputeDataPlaneResult computeDataPlane(
       Map<String, Configuration> configurations,
-      TopologyContext callerTopologyContext,
+      TopologyContext initialTopologyContext,
       Set<BgpAdvertisement> externalAdverts) {
     Span span = GlobalTracer.get().buildSpan("Compute Data Plane").start();
     try (Scope scope = GlobalTracer.get().scopeManager().activate(span)) {
@@ -87,19 +187,6 @@ final class IncrementalBdpEngine {
 
       // TODO: switch to topologies and owners from TopologyProvider
       Map<Ip, Map<String, Set<String>>> ipVrfOwners = new IpOwners(configurations).getIpVrfOwners();
-
-      TopologyContext initialTopologyContext =
-          callerTopologyContext
-              .toBuilder()
-              .setEigrpTopology(
-                  EigrpTopologyUtils.initEigrpTopology(
-                      configurations, callerTopologyContext.getLayer3Topology()))
-              .setIsisTopology(
-                  IsisTopology.initIsisTopology(
-                      configurations, callerTopologyContext.getLayer3Topology()))
-              .setVxlanTopology(VxlanTopologyUtils.computeVxlanTopology(configurations))
-              .setTunnelTopology(TopologyUtil.computeInitialTunnelTopology(configurations))
-              .build();
 
       // Generate our nodes, keyed by name, sorted for determinism
       SortedMap<String, Node> nodes =
@@ -133,10 +220,17 @@ final class IncrementalBdpEngine {
       }
 
       /*
-       * Perform a fixed-point computation.
+       * Perform a fixed-point computation, in which every round the topology is updated based
+       * on what we have learned in the previous round.
        */
+      TopologyContext currentTopologyContext =
+          nextTopologyContext(
+              initialTopologyContext /* current is just initial */,
+              nodes,
+              initialTopologyContext,
+              networkConfigurations,
+              ipVrfOwners);
       int topologyIterations = 0;
-      TopologyContext currentTopologyContext = initialTopologyContext;
       boolean converged = false;
       while (!converged && topologyIterations++ < MAX_TOPOLOGY_ITERATIONS) {
         Span iterSpan =
@@ -145,98 +239,24 @@ final class IncrementalBdpEngine {
         try (Scope iterScope = GlobalTracer.get().scopeManager().activate(iterSpan)) {
           assert iterScope != null; // avoid unused warning
 
-          // Force re-init of partial dataplane. Re-inits forwarding analysis, etc.
-          computeFibs(nodes);
-          PartialDataplane partialDataplane =
-              PartialDataplane.builder()
-                  .setNodes(nodes)
-                  .setLayer3Topology(currentTopologyContext.getLayer3Topology())
-                  .build();
-
-          TracerouteEngine trEngCurrentL3Topogy =
-              new TracerouteEngineImpl(
-                  partialDataplane, currentTopologyContext.getLayer3Topology(), configurations);
-
-          // Update topologies
-          LOGGER.info("Updating dynamic topologies");
-          // IPsec
-          LOGGER.info("Updating IPsec topology");
-          IpsecTopology newIpsecTopology =
-              retainReachableIpsecEdges(
-                  initialTopologyContext.getIpsecTopology(), configurations, trEngCurrentL3Topogy);
-          // VXLAN
-          LOGGER.info("Updating VXLAN topology");
-          VxlanTopology newVxlanTopology =
-              prunedVxlanTopology(
-                  computeVxlanTopology(partialDataplane.getLayer2Vnis()),
-                  configurations,
-                  trEngCurrentL3Topogy);
-          // Layer-2
-          LOGGER.info("Updating Layer 2 topology");
-          Optional<Layer2Topology> newLayer2Topology =
-              currentTopologyContext
-                  .getLayer1LogicalTopology()
-                  .map(l1 -> computeLayer2Topology(l1, newVxlanTopology, configurations));
-
-          // Tunnel topology
-          LOGGER.info("Updating Tunnel topology");
-          TunnelTopology newTunnelTopology =
-              pruneUnreachableTunnelEdges(
-                  initialTopologyContext.getTunnelTopology(),
-                  networkConfigurations,
-                  trEngCurrentL3Topogy);
-
-          // Layer-3
-          LOGGER.info("Updating Layer 3 topology");
-          Topology newLayer3Topology =
-              computeLayer3Topology(
-                  computeRawLayer3Topology(
-                      initialTopologyContext.getRawLayer1PhysicalTopology(),
-                      initialTopologyContext.getLayer1LogicalTopology(),
-                      newLayer2Topology,
-                      configurations),
-                  // Overlay edges consist of "plain" tunnels and IPSec tunnels
-                  Sets.union(
-                      toEdgeSet(newIpsecTopology, configurations), newTunnelTopology.asEdgeSet()));
-
-          // EIGRP topology
-          LOGGER.info("Updating EIGRP topology");
-          EigrpTopology newEigrpTopology =
-              EigrpTopologyUtils.initEigrpTopology(configurations, newLayer3Topology);
-
-          // Initialize BGP topology
-          LOGGER.info("Updating BGP topology");
-          BgpTopology newBgpTopology =
-              initBgpTopology(
-                  configurations,
-                  ipVrfOwners,
-                  false,
-                  true,
-                  new TracerouteEngineImpl(partialDataplane, newLayer3Topology, configurations),
-                  initialTopologyContext.getLayer2Topology().orElse(null));
-          TopologyContext newTopologyContext =
-              currentTopologyContext
-                  .toBuilder()
-                  .setBgpTopology(newBgpTopology)
-                  .setLayer2Topology(newLayer2Topology)
-                  .setLayer3Topology(newLayer3Topology)
-                  .setVxlanTopology(newVxlanTopology)
-                  .setIpsecTopology(newIpsecTopology)
-                  .setTunnelTopology(newTunnelTopology)
-                  .setEigrpTopology(newEigrpTopology)
-                  .build();
-
           boolean isOscillating =
               computeNonMonotonicPortionOfDataPlane(
-                  nodes, answerElement, newTopologyContext, networkConfigurations);
+                  nodes, answerElement, currentTopologyContext, networkConfigurations);
           if (isOscillating) {
             // If we are oscillating here, network has no stable solution.
             LOGGER.error("Network has no stable solution");
             throw new BdpOscillationException("Network has no stable solution");
           }
 
-          converged = currentTopologyContext.equals(newTopologyContext);
-          currentTopologyContext = newTopologyContext;
+          TopologyContext nextTopologyContext =
+              nextTopologyContext(
+                  currentTopologyContext,
+                  nodes,
+                  initialTopologyContext,
+                  networkConfigurations,
+                  ipVrfOwners);
+          converged = currentTopologyContext.equals(nextTopologyContext);
+          currentTopologyContext = nextTopologyContext;
         } finally {
           iterSpan.finish();
         }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlanePlugin.java
@@ -10,6 +10,7 @@ import org.batfish.common.topology.TopologyProvider;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.answers.IncrementalBdpAnswerElement;
+import org.batfish.datamodel.isis.IsisTopology;
 
 /** A batfish plugin that registers the Incremental Batfish Data Plane (ibdp) Engine. */
 @AutoService(Plugin.class)
@@ -30,11 +31,15 @@ public final class IncrementalDataPlanePlugin extends DataPlanePlugin {
     TopologyContext topologyContext =
         TopologyContext.builder()
             .setIpsecTopology(topologyProvider.getInitialIpsecTopology(snapshot))
+            .setIsisTopology(
+                IsisTopology.initIsisTopology(
+                    configurations, topologyProvider.getInitialLayer3Topology(snapshot)))
             .setLayer1LogicalTopology(topologyProvider.getLayer1LogicalTopology(snapshot))
             .setLayer2Topology(topologyProvider.getInitialLayer2Topology(snapshot))
             .setLayer3Topology(topologyProvider.getInitialLayer3Topology(snapshot))
             .setOspfTopology(topologyProvider.getInitialOspfTopology(snapshot))
             .setRawLayer1PhysicalTopology(topologyProvider.getRawLayer1PhysicalTopology(snapshot))
+            .setTunnelTopology(topologyProvider.getInitialTunnelTopology(snapshot))
             .build();
 
     ComputeDataPlaneResult answer =

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -44,6 +44,7 @@ import org.batfish.datamodel.isis.IsisInterfaceMode;
 import org.batfish.datamodel.isis.IsisInterfaceSettings;
 import org.batfish.datamodel.isis.IsisLevelSettings;
 import org.batfish.datamodel.isis.IsisProcess;
+import org.batfish.datamodel.isis.IsisTopology;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -171,7 +172,10 @@ public class IsisTest {
     return (IbdpResult)
         engine.computeDataPlane(
             configurations,
-            TopologyContext.builder().setLayer3Topology(topology).build(),
+            TopologyContext.builder()
+                .setLayer3Topology(topology)
+                .setIsisTopology(IsisTopology.initIsisTopology(configurations, topology))
+                .build(),
             Collections.emptySet());
   }
 
@@ -452,7 +456,10 @@ public class IsisTest {
     return (IbdpResult)
         engine.computeDataPlane(
             configurations,
-            TopologyContext.builder().setLayer3Topology(topology).build(),
+            TopologyContext.builder()
+                .setLayer3Topology(topology)
+                .setIsisTopology(IsisTopology.initIsisTopology(configurations, topology))
+                .build(),
             Collections.emptySet());
   }
 
@@ -638,7 +645,10 @@ public class IsisTest {
     return (IncrementalDataPlane)
         engine.computeDataPlane(
                 configurations,
-                TopologyContext.builder().setLayer3Topology(topology).build(),
+                TopologyContext.builder()
+                    .setLayer3Topology(topology)
+                    .setIsisTopology(IsisTopology.initIsisTopology(configurations, topology))
+                    .build(),
                 Collections.emptySet())
             ._dataPlane;
   }

--- a/tests/basic/genDp.ref
+++ b/tests/basic/genDp.ref
@@ -11,8 +11,7 @@
         "6" : 74,
         "7" : 76,
         "8" : 76,
-        "9" : 76,
-        "10" : 76
+        "9" : 76
       },
       "bgpMultipathRibRoutesByIteration" : {
         "1" : 24,
@@ -23,10 +22,9 @@
         "6" : 118,
         "7" : 120,
         "8" : 120,
-        "9" : 120,
-        "10" : 120
+        "9" : 120
       },
-      "dependentRoutesIterations" : 10,
+      "dependentRoutesIterations" : 9,
       "mainRibRoutesByIteration" : {
         "1" : 209,
         "2" : 265,
@@ -36,8 +34,7 @@
         "6" : 337,
         "7" : 339,
         "8" : 339,
-        "9" : 339,
-        "10" : 339
+        "9" : 339
       },
       "ospfInternalIterations" : 3,
       "version" : "0.36.0",


### PR DESCRIPTION
No need to run extra routing iterations if the topology didn't change.