### PR TITLE
pre-commit: use pass_filenames false on global checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
         entry: ./tools/fix_java_format.sh --diff
         language: script
         files: '\.java$'
+        pass_filenames: false  # this is a global check, only run it once
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:


### PR DESCRIPTION
Otherwise, pre-commit will take the list of changed files and try to run
multiple invocations in parallel, which will be doing redundant work.