### PR TITLE
bdp: stop exposing map of virtual routers

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -531,7 +531,9 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
               } else {
                 // Merge into our sibling VRF corresponding to the VNI
                 BgpRoutingProcess bgpRoutingProcess =
-                    n.getVirtualRouters().get(vniVrf.getName()).getBgpRoutingProcess();
+                    n.getVirtualRouter(vniVrf.getName())
+                        .map(VirtualRouter::getBgpRoutingProcess)
+                        .orElse(null);
                 checkArgument(
                     bgpRoutingProcess != null,
                     "Missing bgp process for vrf %s, node %s",
@@ -733,8 +735,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
               rib ->
                   nodes
                       .get(_c.getHostname())
-                      .getVirtualRouters()
-                      .get(rib.getVrfName())
+                      .getVirtualRouterOrThrow(rib.getVrfName())
                       .enqueueCrossVrfRoutes(
                           new CrossVrfEdgeId(_vrfName, rib.getRibName()),
                           perNeighborDeltaForRibGroups.build().getActions(),
@@ -1658,8 +1659,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     BgpRoutingProcess proc =
         allNodes
             .get(id.getHostname())
-            .getVirtualRouters()
-            .get(id.getVrfName())
+            .getVirtualRouterOrThrow(id.getVrfName())
             .getBgpRoutingProcess();
     assert proc != null; // Otherwise our computation is really wrong
     return proc;
@@ -1669,7 +1669,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   @Nonnull
   private BgpRoutingProcess getVrfProcess(String vrf, Map<String, Node> allNodes) {
     BgpRoutingProcess proc =
-        allNodes.get(_c.getHostname()).getVirtualRouters().get(vrf).getBgpRoutingProcess();
+        allNodes.get(_c.getHostname()).getVirtualRouterOrThrow(vrf).getBgpRoutingProcess();
     assert proc != null;
     return proc;
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/DataplaneUtil.java
@@ -39,8 +39,8 @@ public final class DataplaneUtil {
         nodeEntry ->
             toImmutableMap(
                 nodeEntry.getValue().getVirtualRouters(),
-                Entry::getKey,
-                vrfEntry -> vrfEntry.getValue().getFib()));
+                VirtualRouter::getName,
+                VirtualRouter::getFib));
   }
 
   static ForwardingAnalysis computeForwardingAnalysis(
@@ -58,8 +58,8 @@ public final class DataplaneUtil {
         nodeEntry ->
             toImmutableSortedMap(
                 nodeEntry.getValue().getVirtualRouters(),
-                Entry::getKey,
-                vrfEntry -> vrfEntry.getValue().getMainRib()));
+                VirtualRouter::getName,
+                VirtualRouter::getMainRib));
   }
 
   @Nonnull
@@ -70,8 +70,8 @@ public final class DataplaneUtil {
         (hostname, node) ->
             node.getVirtualRouters()
                 .forEach(
-                    (vrfName, vr) -> {
-                      table.put(hostname, vrfName, vr.getBgpRoutes());
+                    vr -> {
+                      table.put(hostname, vr.getName(), vr.getBgpRoutes());
                     }));
     return table.build();
   }
@@ -83,8 +83,8 @@ public final class DataplaneUtil {
         (hostname, node) ->
             node.getVirtualRouters()
                 .forEach(
-                    (vrfName, vr) -> {
-                      table.put(hostname, vrfName, vr.getEvpnRoutes());
+                    vr -> {
+                      table.put(hostname, vr.getName(), vr.getEvpnRoutes());
                     }));
     return table.build();
   }
@@ -93,9 +93,8 @@ public final class DataplaneUtil {
   static Table<String, String, Set<Layer2Vni>> computeVniSettings(Map<String, Node> nodes) {
     ImmutableTable.Builder<String, String, Set<Layer2Vni>> result = ImmutableTable.builder();
     for (Node node : nodes.values()) {
-      for (Entry<String, VirtualRouter> vr : node.getVirtualRouters().entrySet()) {
-        result.put(
-            node.getConfiguration().getHostname(), vr.getKey(), vr.getValue().getLayer2Vnis());
+      for (VirtualRouter vr : node.getVirtualRouters()) {
+        result.put(node.getConfiguration().getHostname(), vr.getName(), vr.getLayer2Vnis());
       }
     }
     return result.build();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -605,9 +605,8 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
   private static EigrpRoutingProcess getNeighborEigrpProcess(
       Map<String, Node> allNodes, EigrpEdge edge, long asn) {
     return Optional.ofNullable(allNodes.get(edge.getNode1().getHostname()))
-        .map(Node::getVirtualRouters)
-        .map(vrs -> vrs.get(edge.getNode1().getVrf()))
-        .map(vrf -> vrf.getEigrpProcess(asn))
+        .map(n -> n.getVirtualRouterOrThrow(edge.getNode1().getVrf()))
+        .map(vr -> vr.getEigrpProcess(asn))
         .orElseThrow(
             () -> new IllegalStateException("Cannot find EigrpProcess for " + edge.getNode1()));
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalBdpEngine.java
@@ -212,7 +212,7 @@ final class IncrementalBdpEngine {
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(
                 vr -> vr.initForEgpComputationBeforeTopologyLoop(externalAdverts, ipVrfOwners));
       } finally {
@@ -323,7 +323,7 @@ final class IncrementalBdpEngine {
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(VirtualRouter::activateStaticRoutes);
       } finally {
         nhIpSpan.finish();
@@ -340,7 +340,7 @@ final class IncrementalBdpEngine {
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(VirtualRouter::recomputeGeneratedRoutes);
       } finally {
         genRoutesSpan.finish();
@@ -355,12 +355,12 @@ final class IncrementalBdpEngine {
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(vr -> vr.eigrpIteration(allNodes));
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(VirtualRouter::mergeEigrpRoutesToMainRib);
       } finally {
         eigrpSpan.finish();
@@ -375,7 +375,7 @@ final class IncrementalBdpEngine {
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(vr -> vr.initIsisExports(iteration, allNodes, networkConfigurations));
       } finally {
         isisSpan.finish();
@@ -399,7 +399,7 @@ final class IncrementalBdpEngine {
           nodes
               .values()
               .parallelStream()
-              .flatMap(n -> n.getVirtualRouters().values().stream())
+              .flatMap(n -> n.getVirtualRouters().stream())
               .forEach(
                   vr -> {
                     Entry<RibDelta<IsisRoute>, RibDelta<IsisRoute>> p =
@@ -423,12 +423,12 @@ final class IncrementalBdpEngine {
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(vr -> vr.ospfIteration(allNodes));
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(VirtualRouter::mergeOspfRoutesToMainRib);
       } finally {
         span.finish();
@@ -455,7 +455,7 @@ final class IncrementalBdpEngine {
           .forEach(
               n -> {
                 // Execute one round of bgp route propagation
-                n.getVirtualRouters().values().forEach(vr -> vr.bgpIteration(allNodes));
+                n.getVirtualRouters().forEach(vr -> vr.bgpIteration(allNodes));
               });
     } finally {
       span.finish();
@@ -471,8 +471,7 @@ final class IncrementalBdpEngine {
       nodes
           .values()
           .parallelStream()
-          .forEach(
-              n -> n.getVirtualRouters().values().forEach(VirtualRouter::initBgpAggregateRoutes));
+          .forEach(n -> n.getVirtualRouters().forEach(VirtualRouter::initBgpAggregateRoutes));
     } finally {
       genSpan.finish();
     }
@@ -488,7 +487,7 @@ final class IncrementalBdpEngine {
       nodes
           .values()
           .parallelStream()
-          .flatMap(n -> n.getVirtualRouters().values().stream())
+          .flatMap(n -> n.getVirtualRouters().stream())
           .forEach(VirtualRouter::mergeBgpRoutesToMainRib);
 
     } finally {
@@ -505,7 +504,7 @@ final class IncrementalBdpEngine {
       nodes
           .values()
           .parallelStream()
-          .flatMap(n -> n.getVirtualRouters().values().stream())
+          .flatMap(n -> n.getVirtualRouters().stream())
           .forEach(VirtualRouter::queueCrossVrfImports);
     } finally {
       span.finish();
@@ -521,7 +520,7 @@ final class IncrementalBdpEngine {
       nodes
           .values()
           .parallelStream()
-          .flatMap(n -> n.getVirtualRouters().values().stream())
+          .flatMap(n -> n.getVirtualRouters().stream())
           .forEach(VirtualRouter::processCrossVrfRoutes);
     } finally {
       span.finish();
@@ -541,7 +540,7 @@ final class IncrementalBdpEngine {
       nodes
           .values()
           .parallelStream()
-          .flatMap(n -> n.getVirtualRouters().values().stream())
+          .flatMap(n -> n.getVirtualRouters().stream())
           .forEach(VirtualRouter::computeFib);
     } finally {
       span.finish();
@@ -578,7 +577,7 @@ final class IncrementalBdpEngine {
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(vr -> vr.initForIgpComputation(topologyContext));
       } finally {
         initializeSpan.finish();
@@ -599,7 +598,7 @@ final class IncrementalBdpEngine {
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(
                 vr -> {
                   importRib(vr.getMainRib(), vr._independentRib);
@@ -648,7 +647,7 @@ final class IncrementalBdpEngine {
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(vr -> vr.initForEgpComputationWithNewTopology(topologyContext));
       } finally {
         initializationSpan.finish();
@@ -697,7 +696,7 @@ final class IncrementalBdpEngine {
             nodes
                 .values()
                 .parallelStream()
-                .flatMap(n -> n.getVirtualRouters().values().parallelStream())
+                .flatMap(n -> n.getVirtualRouters().parallelStream())
                 .forEach(VirtualRouter::reinitForNewIteration);
           } finally {
             depRoutesspan.finish();
@@ -715,7 +714,7 @@ final class IncrementalBdpEngine {
           try (Scope redistscope = GlobalTracer.get().scopeManager().activate(redistributeSpan)) {
             assert redistscope != null; // avoid unused warning
             nodes.values().stream()
-                .flatMap(n -> n.getVirtualRouters().values().stream())
+                .flatMap(n -> n.getVirtualRouters().stream())
                 .forEach(VirtualRouter::redistribute);
 
             // Handle cross-VRF leaking here too.
@@ -740,7 +739,7 @@ final class IncrementalBdpEngine {
           nodes
               .values()
               .parallelStream()
-              .flatMap(n -> n.getVirtualRouters().values().stream())
+              .flatMap(n -> n.getVirtualRouters().stream())
               .forEach(VirtualRouter::endOfEgpRound);
 
           /*
@@ -792,7 +791,7 @@ final class IncrementalBdpEngine {
       return nodes
           .values()
           .parallelStream()
-          .flatMap(n -> n.getVirtualRouters().values().stream())
+          .flatMap(n -> n.getVirtualRouters().stream())
           .anyMatch(VirtualRouter::isDirty);
     } finally {
       span.finish();
@@ -814,7 +813,7 @@ final class IncrementalBdpEngine {
       return nodes
           .values()
           .parallelStream()
-          .flatMap(node -> node.getVirtualRouters().values().stream())
+          .flatMap(node -> node.getVirtualRouters().stream())
           .mapToInt(VirtualRouter::computeIterationHashCode)
           .sum();
     } finally {
@@ -830,21 +829,21 @@ final class IncrementalBdpEngine {
       assert scope != null; // avoid unused warning
       int numBgpBestPathRibRoutes =
           nodes.values().stream()
-              .flatMap(n -> n.getVirtualRouters().values().stream())
+              .flatMap(n -> n.getVirtualRouters().stream())
               .mapToInt(VirtualRouter::getNumBgpBestPaths)
               .sum();
       ae.getBgpBestPathRibRoutesByIteration()
           .put(dependentRoutesIterations, numBgpBestPathRibRoutes);
       int numBgpMultipathRibRoutes =
           nodes.values().stream()
-              .flatMap(n -> n.getVirtualRouters().values().stream())
+              .flatMap(n -> n.getVirtualRouters().stream())
               .mapToInt(VirtualRouter::getNumBgpPaths)
               .sum();
       ae.getBgpMultipathRibRoutesByIteration()
           .put(dependentRoutesIterations, numBgpMultipathRibRoutes);
       int numMainRibRoutes =
           nodes.values().stream()
-              .flatMap(n -> n.getVirtualRouters().values().stream())
+              .flatMap(n -> n.getVirtualRouters().stream())
               .mapToInt(vr -> vr.getMainRib().getTypedRoutes().size())
               .sum();
       ae.getMainRibRoutesByIteration().put(dependentRoutesIterations, numMainRibRoutes);
@@ -904,20 +903,20 @@ final class IncrementalBdpEngine {
           scheduleNodes
               .values()
               .parallelStream()
-              .flatMap(n -> n.getVirtualRouters().values().stream())
+              .flatMap(n -> n.getVirtualRouters().stream())
               .forEach(virtualRouter -> virtualRouter.ospfIteration(allNodes));
 
           scheduleNodes
               .values()
               .parallelStream()
-              .flatMap(n -> n.getVirtualRouters().values().stream())
+              .flatMap(n -> n.getVirtualRouters().stream())
               .forEach(VirtualRouter::mergeOspfRoutesToMainRib);
         }
         dirty =
             allNodes
                 .values()
                 .parallelStream()
-                .flatMap(n -> n.getVirtualRouters().values().stream())
+                .flatMap(n -> n.getVirtualRouters().stream())
                 .flatMap(vr -> vr.getOspfProcesses().values().stream())
                 .anyMatch(OspfRoutingProcess::isDirty);
       } finally {
@@ -952,7 +951,7 @@ final class IncrementalBdpEngine {
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(
                 vr -> {
                   if (vr.propagateRipInternalRoutes(nodes, topology)) {
@@ -972,7 +971,7 @@ final class IncrementalBdpEngine {
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(VirtualRouter::unstageRipInternalRoutes);
       } finally {
         unstageSpan.finish();
@@ -987,7 +986,7 @@ final class IncrementalBdpEngine {
         nodes
             .values()
             .parallelStream()
-            .flatMap(n -> n.getVirtualRouters().values().stream())
+            .flatMap(n -> n.getVirtualRouters().stream())
             .forEach(
                 vr -> {
                   importRib(vr._ripRib, vr._ripInternalRib);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/IncrementalDataPlane.java
@@ -144,7 +144,7 @@ public final class IncrementalDataPlane implements Serializable, DataPlane {
         nodeEntry ->
             toImmutableSortedMap(
                 nodeEntry.getValue().getVirtualRouters(),
-                Entry::getKey,
-                vrfEntry -> vrfEntry.getValue().getPrefixTracer().summarize()));
+                VirtualRouter::getName,
+                vr -> vr.getPrefixTracer().summarize()));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -429,8 +429,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
       OspfNeighborConfigId ospfNeighborId, Map<String, Node> allNodes) {
     return allNodes
         .get(ospfNeighborId.getHostname())
-        .getVirtualRouters()
-        .get(ospfNeighborId.getVrfName())
+        .getVirtualRouterOrThrow(ospfNeighborId.getVrfName())
         .getOspfProcesses()
         .get(ospfNeighborId.getProcName());
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -187,7 +187,7 @@ public class BgpRoutingProcessTest {
 
     Node node = new Node(_c);
     BgpRoutingProcess defaultProc =
-        node.getVirtualRouters().get(DEFAULT_VRF_NAME).getBgpRoutingProcess();
+        node.getVirtualRouterOrThrow(DEFAULT_VRF_NAME).getBgpRoutingProcess();
 
     // Test
     defaultProc.initLocalEvpnRoutes(node);
@@ -209,8 +209,7 @@ public class BgpRoutingProcessTest {
                 .build()));
     // Sibling VRF, for vni2
     assertThat(
-        node.getVirtualRouters()
-            .get("vrf2")
+        node.getVirtualRouterOrThrow("vrf2")
             .getBgpRoutingProcess()
             .getUpdatesForMainRib()
             .getRoutesStream()
@@ -407,7 +406,7 @@ public class BgpRoutingProcessTest {
 
     Node node = new Node(_c);
     BgpRoutingProcess routingProcNode1 =
-        node.getVirtualRouters().get(DEFAULT_VRF_NAME).getBgpRoutingProcess();
+        node.getVirtualRouterOrThrow(DEFAULT_VRF_NAME).getBgpRoutingProcess();
 
     /////////// Node 2
 
@@ -439,7 +438,7 @@ public class BgpRoutingProcessTest {
     bgp2.getActiveNeighbors().put(localIp.toPrefix(), node2Peer);
     Node node2 = new Node(c2);
     BgpRoutingProcess routingProcNode2 =
-        node2.getVirtualRouters().get(DEFAULT_VRF_NAME).getBgpRoutingProcess();
+        node2.getVirtualRouterOrThrow(DEFAULT_VRF_NAME).getBgpRoutingProcess();
     routingProcNode2.initialize(node2);
 
     /*

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/IsisTest.java
@@ -188,13 +188,13 @@ public class IsisTest {
     Prefix r2LoopbackPrefix = R2_LOOPBACK_IP.toPrefix();
 
     Set<IsisRoute> r1L1RibRoutes =
-        dp.getNodes().get(R1).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
+        dp.getNodes().get(R1).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
     Set<IsisRoute> r2L1RibRoutes =
-        dp.getNodes().get(R2).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
+        dp.getNodes().get(R2).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
     Set<IsisRoute> r1L2RibRoutes =
-        dp.getNodes().get(R1).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL2Rib.getTypedRoutes();
+        dp.getNodes().get(R1).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL2Rib.getTypedRoutes();
     Set<IsisRoute> r2L2RibRoutes =
-        dp.getNodes().get(R2).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL2Rib.getTypedRoutes();
+        dp.getNodes().get(R2).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL2Rib.getTypedRoutes();
 
     // L1 RIBs lack the other's loopback, but have default route (see VirtualRouter.initIsisImports)
     assertThat(
@@ -247,13 +247,13 @@ public class IsisTest {
     Prefix r2LoopbackPrefix = R2_LOOPBACK_IP.toPrefix();
 
     Set<IsisRoute> r1L1RibRoutes =
-        dp.getNodes().get(R1).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
+        dp.getNodes().get(R1).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
     Set<IsisRoute> r2L1RibRoutes =
-        dp.getNodes().get(R2).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
+        dp.getNodes().get(R2).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getTypedRoutes();
     Set<IsisRoute> r1L2RibRoutes =
-        dp.getNodes().get(R1).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL2Rib.getTypedRoutes();
+        dp.getNodes().get(R1).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL2Rib.getTypedRoutes();
     Set<IsisRoute> r2L2RibRoutes =
-        dp.getNodes().get(R2).getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL2Rib.getTypedRoutes();
+        dp.getNodes().get(R2).getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL2Rib.getTypedRoutes();
 
     // L1 RIBs have the other's loopback and default route (see VirtualRouter.initIsisImports)
     assertThat(
@@ -514,14 +514,14 @@ public class IsisTest {
 
     // Assert r1/r2 have empty l1 rib
     assertThat(
-        dp.getNodes().get("r1").getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes(),
+        dp.getNodes().get("r1").getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes(),
         empty());
     assertThat(
-        dp.getNodes().get("r2").getVirtualRouters().get(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes(),
+        dp.getNodes().get("r2").getVirtualRouterOrThrow(DEFAULT_VRF_NAME)._isisL1Rib.getRoutes(),
         empty());
 
     // Assert r3 has disjoint l1/l2 ribs
-    VirtualRouter r3Vr = dp.getNodes().get("r3").getVirtualRouters().get(DEFAULT_VRF_NAME);
+    VirtualRouter r3Vr = dp.getNodes().get("r3").getVirtualRouterOrThrow(DEFAULT_VRF_NAME);
     assertThat(
         Sets.intersection(r3Vr._isisL1Rib.getRoutes(), r3Vr._isisL2Rib.getRoutes()), empty());
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -110,12 +110,12 @@ public class VirtualRouterTest {
 
   private static VirtualRouter makeF5VirtualRouter(String hostname) {
     Node n = TestUtils.makeF5Router(hostname);
-    return n.getVirtualRouters().get(DEFAULT_VRF_NAME);
+    return n.getVirtualRouterOrThrow(DEFAULT_VRF_NAME);
   }
 
   private static VirtualRouter makeIosVirtualRouter(String hostname) {
     Node n = TestUtils.makeIosRouter(hostname);
-    return n.getVirtualRouters().get(DEFAULT_VRF_NAME);
+    return n.getVirtualRouterOrThrow(DEFAULT_VRF_NAME);
   }
 
   private static Set<AbstractRoute> makeOneRouteOfEveryType() {
@@ -566,7 +566,7 @@ public class VirtualRouterTest {
 
     Map<String, VirtualRouter> vrs =
         nodes.values().stream()
-            .map(n -> n.getVirtualRouters().get(DEFAULT_VRF_NAME))
+            .map(n -> n.getVirtualRouterOrThrow(DEFAULT_VRF_NAME))
             .collect(
                 ImmutableMap.toImmutableMap(
                     vr -> vr.getConfiguration().getHostname(), Function.identity()));
@@ -599,8 +599,7 @@ public class VirtualRouterTest {
     BgpTopology bgpTopology2 =
         initBgpTopology(configs, new IpOwners(configs).getIpVrfOwners(), false, null);
     for (Node n : nodes.values()) {
-      n.getVirtualRouters()
-          .get(DEFAULT_VRF_NAME)
+      n.getVirtualRouterOrThrow(DEFAULT_VRF_NAME)
           .initForEgpComputationWithNewTopology(
               TopologyContext.builder()
                   .setBgpTopology(bgpTopology2)
@@ -663,7 +662,7 @@ public class VirtualRouterTest {
         ImmutableMap.of(c1.getHostname(), new Node(c1), c2.getHostname(), new Node(c2));
     Map<String, VirtualRouter> vrs =
         nodes.values().stream()
-            .map(n -> n.getVirtualRouters().get(DEFAULT_VRF_NAME))
+            .map(n -> n.getVirtualRouterOrThrow(DEFAULT_VRF_NAME))
             .collect(
                 ImmutableMap.toImmutableMap(
                     vr -> vr.getConfiguration().getHostname(), Function.identity()));
@@ -757,8 +756,8 @@ public class VirtualRouterTest {
 
     // Create a Node based on the configuration and get its VirtualRouters
     Node n = new Node(c);
-    VirtualRouter vrWithRoutes = n.getVirtualRouters().get(vrfWithRoutesName);
-    VirtualRouter emptyVr = n.getVirtualRouters().get(emptyVrfName);
+    VirtualRouter vrWithRoutes = n.getVirtualRouterOrThrow(vrfWithRoutesName);
+    VirtualRouter emptyVr = n.getVirtualRouterOrThrow(emptyVrfName);
 
     // Create routes of every type and inject them into vrWithRoutes' main RIB and main RIB delta
     Set<AnnotatedRoute<AbstractRoute>> annotatedRoutes =


### PR DESCRIPTION
* In `Node` have `getVirtualRouters` (collection) and `getVirtualRouter(name)`
  to avoid iterating over maps where we don't need them. Makes the code simpler to read, IMO.
* Introduce  `getVirtualRouterOrThrow(name)` any time we expect VR to
  exist that throws with a meaningful message instead of an NPE

No DP functionality changes.