### PR TITLE
XR: fix a crash in ExtcommunitySetRt

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_extcommunity_set.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_extcommunity_set.g4
@@ -13,26 +13,32 @@ s_extcommunity_set
 
 extcommunity_set_rt
 :
-  RT name = variable NEWLINE extcommunity_set_rt_elem_list END_SET NEWLINE
+  RT name = variable NEWLINE
+  lines = extcommunity_set_rt_elem_lines
+  END_SET NEWLINE
 ;
 
-extcommunity_set_rt_elem_list
+// The lines can be:
+// * empty (handled in "Comments only")
+// * comments, anywhere
+// * one or more communities
+//
+// If there are more than one community, every community but the last one
+// has a comma at the end of the line. But comments may be intermixed.
+extcommunity_set_rt_elem_lines
 :
-// no elements
-
-   |
-   (
-      (
-         (
-            elems += extcommunity_set_rt_elem COMMA
-         )
-         | hash_comment
-      ) NEWLINE
-   )*
-   (
-      elems += extcommunity_set_rt_elem
-      | hash_comment
-   ) NEWLINE
+  // Comments only
+  (hash_comment NEWLINE)*
+  |
+  // One or more communities, with comments mixed in
+  (
+    // leading comments or not-last elements
+    ((hash_comment | elems += extcommunity_set_rt_elem COMMA) NEWLINE)*
+    // last element
+    elems += extcommunity_set_rt_elem NEWLINE
+    // trailing comments
+    (hash_comment NEWLINE)*
+  )
 ;
 
 extcommunity_set_rt_elem

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/ExtcommunitySetRt.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/ExtcommunitySetRt.java
@@ -2,6 +2,7 @@ package org.batfish.representation.cisco_xr;
 
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -12,13 +13,20 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 @ParametersAreNonnullByDefault
 public final class ExtcommunitySetRt implements Serializable {
+  public ExtcommunitySetRt() {
+    _elements = new ArrayList<>(1);
+  }
 
   public ExtcommunitySetRt(List<ExtcommunitySetRtElem> elements) {
     _elements = ImmutableList.copyOf(elements);
   }
 
+  public void addElement(@Nonnull ExtcommunitySetRtElem element) {
+    _elements.add(element);
+  }
+
   public @Nonnull List<ExtcommunitySetRtElem> getElements() {
-    return _elements;
+    return ImmutableList.copyOf(_elements);
   }
 
   private final @Nonnull List<ExtcommunitySetRtElem> _elements;


### PR DESCRIPTION
As always, parents should almost never call into their children's context.

Fixes batfish/batfish#6302. Note that the actual code inside that issue is wrong, the second number
has to be between 1 and 65535.