### PR TITLE
EIGRP: move admin cost computation out of dataplane

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpProcess.java
@@ -16,7 +16,9 @@ import java.util.function.Function;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.RoutingProtocol;
 
 /** Represents an EIGRP process on a router */
 @ParametersAreNonnullByDefault
@@ -26,24 +28,32 @@ public final class EigrpProcess implements Serializable {
   private static final String PROP_MODE = "eigrpMode";
   private static final String PROP_NEIGHBORS = "neighbors";
   private static final String PROP_ROUTER_ID = "routerId";
+  private static final String PROP_INTERNAL_ADMIN_COST = "internalAdminCost";
+  private static final String PROP_EXTERNAL_ADMIN_COST = "externalAdminCost";
 
   private final long _asn;
   @Nullable private final String _exportPolicy;
   @Nonnull private final EigrpProcessMode _mode;
   @Nonnull private SortedMap<String, EigrpNeighborConfig> _neighbors;
   @Nonnull private final Ip _routerId;
+  private final int _internalAdminCost;
+  private final int _externalAdminCost;
 
   private EigrpProcess(
       long asn,
       @Nullable String exportPolicy,
       EigrpProcessMode mode,
       Ip routerId,
-      Map<String, EigrpNeighborConfig> neighbors) {
+      Map<String, EigrpNeighborConfig> neighbors,
+      int internalAdminCost,
+      int externalAdminCost) {
     _asn = asn;
     _exportPolicy = exportPolicy;
     _mode = mode;
     _neighbors = ImmutableSortedMap.copyOf(neighbors);
     _routerId = routerId;
+    _internalAdminCost = internalAdminCost;
+    _externalAdminCost = externalAdminCost;
   }
 
   @JsonCreator
@@ -52,12 +62,22 @@ public final class EigrpProcess implements Serializable {
       @Nullable @JsonProperty(PROP_EXPORT_POLICY) String exportPolicy,
       @Nullable @JsonProperty(PROP_MODE) EigrpProcessMode mode,
       @Nullable @JsonProperty(PROP_NEIGHBORS) Map<String, EigrpNeighborConfig> neighbors,
-      @Nullable @JsonProperty(PROP_ROUTER_ID) Ip routerId) {
+      @Nullable @JsonProperty(PROP_ROUTER_ID) Ip routerId,
+      @Nullable @JsonProperty(PROP_INTERNAL_ADMIN_COST) Integer internalAdminCost,
+      @Nullable @JsonProperty(PROP_EXTERNAL_ADMIN_COST) Integer externalAdminCost) {
     checkArgument(asn != null, "Missing %s", PROP_ASN);
     checkArgument(mode != null, "Missing %s", PROP_MODE);
     checkArgument(routerId != null, "Missing %s", PROP_ROUTER_ID);
+    checkArgument(internalAdminCost != null, "Missing %s", PROP_INTERNAL_ADMIN_COST);
+    checkArgument(externalAdminCost != null, "Missing %s", PROP_EXTERNAL_ADMIN_COST);
     return new EigrpProcess(
-        asn, exportPolicy, mode, routerId, firstNonNull(neighbors, ImmutableMap.of()));
+        asn,
+        exportPolicy,
+        mode,
+        routerId,
+        firstNonNull(neighbors, ImmutableMap.of()),
+        internalAdminCost,
+        externalAdminCost);
   }
 
   public static Builder builder() {
@@ -101,6 +121,14 @@ public final class EigrpProcess implements Serializable {
     return _mode;
   }
 
+  public int getInternalAdminCost() {
+    return _internalAdminCost;
+  }
+
+  public int getExternalAdminCost() {
+    return _externalAdminCost;
+  }
+
   /** Add an {@link EigrpNeighborConfig} to this EIGRP process */
   public void addNeighbor(EigrpNeighborConfig neighborConfig) {
     _neighbors =
@@ -136,12 +164,15 @@ public final class EigrpProcess implements Serializable {
         && Objects.equals(_exportPolicy, that._exportPolicy)
         && _mode == that._mode
         && _neighbors == that._neighbors
-        && _routerId.equals(that._routerId);
+        && _routerId.equals(that._routerId)
+        && _internalAdminCost == that._internalAdminCost
+        && _externalAdminCost == that._externalAdminCost;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_asn, _exportPolicy, _mode, _routerId, _neighbors);
+    return Objects.hash(
+        _asn, _exportPolicy, _mode, _routerId, _neighbors, _internalAdminCost, _externalAdminCost);
   }
 
   public static class Builder {
@@ -150,6 +181,9 @@ public final class EigrpProcess implements Serializable {
     @Nullable private EigrpProcessMode _mode;
     @Nullable private Map<String, EigrpNeighborConfig> _neighbors;
     @Nullable private Ip _routerId;
+    // The defaults are consistent across cisco variants
+    private int _internalAdminCost = 90;
+    private int _externalAdminCost = 170;
 
     private Builder() {}
 
@@ -159,7 +193,13 @@ public final class EigrpProcess implements Serializable {
       checkArgument(_mode != null, "Missing %s", PROP_MODE);
       checkArgument(_routerId != null, "Missing %s", PROP_ROUTER_ID);
       return new EigrpProcess(
-          _asn, _exportPolicy, _mode, _routerId, firstNonNull(_neighbors, ImmutableMap.of()));
+          _asn,
+          _exportPolicy,
+          _mode,
+          _routerId,
+          firstNonNull(_neighbors, ImmutableMap.of()),
+          _internalAdminCost,
+          _externalAdminCost);
     }
 
     @Nonnull
@@ -189,6 +229,26 @@ public final class EigrpProcess implements Serializable {
     public Builder setMode(EigrpProcessMode mode) {
       _mode = mode;
       return this;
+    }
+
+    public Builder setInternalAdminCost(int internalAdminCost) {
+      _internalAdminCost = internalAdminCost;
+      return this;
+    }
+
+    public Builder setExternalAdminCost(int externalAdminCost) {
+      _externalAdminCost = externalAdminCost;
+      return this;
+    }
+
+    /**
+     * Sets {@link #setInternalAdminCost(int)} and {@link #setExternalAdminCost(int)} to default
+     * EIGRP administrative costs for the given {@link ConfigurationFormat}.
+     */
+    @Nonnull
+    public Builder setAdminCostsToVendorDefaults(@Nonnull ConfigurationFormat format) {
+      return setInternalAdminCost(RoutingProtocol.EIGRP.getDefaultAdministrativeCost(format))
+          .setExternalAdminCost(RoutingProtocol.EIGRP_EX.getDefaultAdministrativeCost(format));
     }
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -68,9 +68,6 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
   /** Our AS number */
   private final long _asn;
 
-  private final int _defaultExternalAdminCost;
-  private final int _defaultInternalAdminCost;
-
   // RIBs and RIB deltas
 
   /** Helper RIB containing EIGRP external paths */
@@ -109,10 +106,6 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
   EigrpRoutingProcess(final EigrpProcess process, final String vrfName, final Configuration c) {
     _process = process;
     _asn = process.getAsn();
-    _defaultExternalAdminCost =
-        RoutingProtocol.EIGRP_EX.getDefaultAdministrativeCost(c.getConfigurationFormat());
-    _defaultInternalAdminCost =
-        RoutingProtocol.EIGRP.getDefaultAdministrativeCost(c.getConfigurationFormat());
     _externalRib = new EigrpExternalRib();
     _internalRib = new EigrpInternalRib();
     _rib = new EigrpRib();
@@ -309,7 +302,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
       EigrpMetric newMetric = connectingInterfaceMetric.add(route.getEigrpMetric());
       EigrpInternalRoute transformedRoute =
           EigrpInternalRoute.builder()
-              .setAdmin(_defaultInternalAdminCost)
+              .setAdmin(_process.getInternalAdminCost())
               .setEigrpMetric(newMetric)
               .setNetwork(route.getNetwork())
               .setNextHopIp(nextHopIp)
@@ -328,7 +321,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
     // TODO: simplify all this later. Copied from old code
     RibDelta.Builder<EigrpExternalRoute> deltaBuilder = RibDelta.builder();
     EigrpExternalRoute.Builder routeBuilder = EigrpExternalRoute.builder();
-    routeBuilder.setAdmin(_defaultExternalAdminCost).setProcessAsn(_asn);
+    routeBuilder.setAdmin(_process.getExternalAdminCost()).setProcessAsn(_asn);
 
     _incomingExternalRoutes.forEach(
         (edge, queue) -> {
@@ -535,7 +528,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
     if (!exportPolicy.process(potentialExportRoute, outputRouteBuilder, _process, Direction.OUT)) {
       return null;
     }
-    outputRouteBuilder.setAdmin(_defaultExternalAdminCost);
+    outputRouteBuilder.setAdmin(_process.getExternalAdminCost());
     if (unannotatedPotentialRoute instanceof EigrpExternalRoute) {
       EigrpExternalRoute externalRoute = (EigrpExternalRoute) unannotatedPotentialRoute;
       outputRouteBuilder.setDestinationAsn(externalRoute.getDestinationAsn());

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -23628,6 +23628,8 @@
                 "asn" : 5,
                 "eigrpMode" : "CLASSIC",
                 "exportPolicy" : "~EIGRP_EXPORT_POLICY:default:5~",
+                "externalAdminCost" : 170,
+                "internalAdminCost" : 90,
                 "routerId" : "100.1.1.1"
               }
             }


### PR DESCRIPTION
This should be determined (and possibly overridden) in parsing/conversion stages