### PR TITLE
PAN: parse virtual router ECMP, stop warning

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -118,6 +118,11 @@ AGGREGATE_MED
     'aggregate-med'
 ;
 
+ALGORITHM
+:
+    'algorithm'
+;
+
 ALLOW
 :
     'allow'
@@ -416,6 +421,11 @@ DYNAMIC_IP_AND_PORT
 EBGP
 :
     'ebgp'
+;
+
+ECMP
+:
+    'ecmp'
 ;
 
 EGP
@@ -836,6 +846,11 @@ LOOPBACK
 MATCH
 :
     'match'
+;
+
+MAX_PATH
+:
+    'max-path'
 ;
 
 MD5

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_virtual_router.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_virtual_router.g4
@@ -101,7 +101,7 @@ vr_ecmp
 
 vr_ecmp_enable
 :
-    ENABLE (YES | NO)
+    ENABLE yes_or_no
 ;
 
 vr_interface

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_virtual_router.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_virtual_router.g4
@@ -22,6 +22,7 @@ vr_definition
     name = variable
     (
         vr_admin_dists
+        | vr_ecmp
         | vr_interface
         | vr_protocol
         | vr_routing_table
@@ -86,6 +87,21 @@ vrad_static
 vrad_static_ipv6
 :
     STATIC_IPV6 ad = protocol_ad
+;
+
+vr_ecmp
+:
+    ECMP
+    (
+       ALGORITHM null_rest_of_line
+       | MAX_PATH UINT8 // only 2,3,4 are allowed
+       | vr_ecmp_enable
+    )
+;
+
+vr_ecmp_enable
+:
+    ENABLE (YES | NO)
 ;
 
 vr_interface

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -320,6 +320,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Variable_listContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Variable_list_itemContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Vlan_tagContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Vr_definitionContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Vr_ecmp_enableContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Vr_interfaceContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Vr_routing_tableContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Vrad_ebgpContext;
@@ -1842,6 +1843,13 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitVr_definition(Vr_definitionContext ctx) {
     _currentVirtualRouter = null;
+  }
+
+  @Override
+  public void exitVr_ecmp_enable(Vr_ecmp_enableContext ctx) {
+    if (ctx.NO() != null) {
+      warn(ctx, "Disabling of ECMP for IGP is not supported");
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -1847,7 +1847,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void exitVr_ecmp_enable(Vr_ecmp_enableContext ctx) {
-    if (ctx.NO() != null) {
+    if (!toBoolean(ctx.yes_or_no())) {
       warn(ctx, "Disabling of ECMP for IGP is not supported");
     }
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -3650,4 +3650,11 @@ public final class PaloAltoGrammarTest {
     // Non /32 address should not be associated with loopback
     assertThat(interfaces2.get(eth_lo).getConcreteAddress(), nullValue());
   }
+
+  @Test
+  public void testVirtualRouterEcmp() {
+    String hostname = "virtual-router-ecmp";
+    // Do not crash (i.e., no warnings generated)
+    PaloAltoConfiguration c = parsePaloAltoConfig(hostname);
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -3655,6 +3655,6 @@ public final class PaloAltoGrammarTest {
   public void testVirtualRouterEcmp() {
     String hostname = "virtual-router-ecmp";
     // Do not crash (i.e., no warnings generated)
-    PaloAltoConfiguration c = parsePaloAltoConfig(hostname);
+    parsePaloAltoConfig(hostname);
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/virtual-router-ecmp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/virtual-router-ecmp
@@ -1,0 +1,5 @@
+#RANCID-CONTENT-TYPE: paloalto
+set deviceconfig system hostname virtual-router-ecmp
+set network virtual-router VR ecmp enable yes
+set network virtual-router VR ecmp max-path 4
+set network virtual-router VR ecmp algorithm ip-hash use-port yes


### PR DESCRIPTION
ECMP being on is very common, and is our default. So do not warn to reduce
user confusion.
Only warn if ECMP is explicitly disabled for IGP, which we do not support in VI.