### PR TITLE
BDDPacket: increase the size of the initial number of nodes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -34,7 +34,7 @@ public class BDDPacket {
    * will reduce time spent garbage collecting for large computations, but will waste memory for
    * smaller ones.
    */
-  private static final int JFACTORY_INITIAL_NODE_TABLE_SIZE = 10000;
+  private static final int JFACTORY_INITIAL_NODE_TABLE_SIZE = 1_000_000;
 
   /*
    * The ratio of node table size to node cache size to preserve when resizing. The default


### PR DESCRIPTION
1M is only 8MB of pointers, and even our example network gets there
for some questions.