### PR TITLE
Juniper GroupWildcard: treat carat like ! in a character class

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/GroupWildcardTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/GroupWildcardTest.java
@@ -41,5 +41,6 @@ public class GroupWildcardTest {
     assertThat(toJavaRegex("[!a-c]"), equalTo("[^a-c]"));
     assertThat(toJavaRegex("[!qwerty]"), equalTo("[^qwerty]"));
     assertThat(toJavaRegex("test[!4]"), equalTo("test[^4]"));
+    assertThat(toJavaRegex("*[^/][^0]"), equalTo(".*[^/][^0]"));
   }
 }


### PR DESCRIPTION
Juniper documentation says that ! means character class negation and does not mention ^,
but open sources users have used ^ successfully.

Fix #6059.