### PR TITLE
IpOwners: only consider HSRP interfaces with L3 addresses

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
@@ -306,7 +306,10 @@ public final class IpOwners {
                 candidates = Collections.newSetFromMap(new IdentityHashMap<>());
                 hsrpGroups.put(ip, groupNum, candidates);
               }
-              candidates.add(i);
+              if (i.getConcreteAddress() != null) {
+                // Only interfaces that have IP addresses are considered valid.
+                candidates.add(i);
+              }
             });
   }
 
@@ -327,6 +330,10 @@ public final class IpOwners {
               assert groupNum != null;
               Set<Interface> candidates = cell.getValue();
               assert candidates != null;
+              if (candidates.isEmpty()) {
+                // No interfaces can actually be the master for this group.
+                return;
+              }
               /*
                * Compare priorities first. If tied, break tie based on highest interface IP.
                */

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
@@ -192,7 +192,11 @@ public class IpOwnersTest {
   @Test
   public void testExtractHsrp() {
     Table<Ip, Integer, Set<Interface>> groups = HashBasedTable.create();
-    Interface i = Interface.builder().setName("name").build();
+    Interface i =
+        Interface.builder()
+            .setName("name")
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
+            .build();
     extractHsrp(groups, i);
     assertTrue(groups.isEmpty());
 
@@ -217,8 +221,18 @@ public class IpOwnersTest {
             .build();
 
     Table<Ip, Integer, Set<Interface>> groups = HashBasedTable.create();
-    Interface i1 = Interface.builder().setOwner(c1).setName("i1").build();
-    Interface i2 = Interface.builder().setOwner(c2).setName("i2").build();
+    Interface i1 =
+        Interface.builder()
+            .setOwner(c1)
+            .setName("i1")
+            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
+            .build();
+    Interface i2 =
+        Interface.builder()
+            .setOwner(c2)
+            .setName("i2")
+            .setAddress(ConcreteInterfaceAddress.parse("2.3.4.5/24"))
+            .build();
 
     Ip ip = Ip.parse("1.1.1.1");
     i1.setHsrpGroups(

--- a/tests/parsing-tests/networks/unit-tests/configs/ios_standby
+++ b/tests/parsing-tests/networks/unit-tests/configs/ios_standby
@@ -11,4 +11,12 @@ interface Vlan 1000
  standby 1001 timers msec 500 2                                                                                                                                                                                   
  standby 1001 track 1 decrement 20
 !
-
+interface Vlan 1001
+ standby version 2
+ standby 1001 authentication 012345678901234567890123456789012345678
+ standby 1001 ip 1.2.3.4
+ standby 1001 preempt
+ standby 1001 priority 105
+ standby 1001 timers msec 500 2
+ standby 1001 track 1 decrement 20
+!

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -2928,7 +2928,8 @@
         "Lines" : {
           "filename" : "configs/ios_standby",
           "lines" : [
-            12
+            12,
+            21
           ]
         }
       },

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -36517,6 +36517,48 @@
             "type" : "VLAN",
             "vlan" : 1000,
             "vrf" : "default"
+          },
+          "Vlan1001" : {
+            "name" : "Vlan1001",
+            "active" : false,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E9,
+            "declaredNames" : [
+              "Vlan1001"
+            ],
+            "hsrpGroups" : {
+              "1001" : {
+                "authentication" : "9d02ca801b026e21590248fb1578fe959b68a16cccdb0005917dce66a40c5f78",
+                "groupNumber" : 1001,
+                "helloTime" : 500,
+                "holdTime" : 2000,
+                "ip" : "1.2.3.4",
+                "preempt" : true,
+                "priority" : 105,
+                "trackActions" : {
+                  "1" : {
+                    "class" : "org.batfish.datamodel.tracking.DecrementPriority",
+                    "subtrahend" : 20
+                  }
+                }
+              }
+            },
+            "hsrpVersion" : "2",
+            "mtu" : 1500,
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "VLAN",
+            "vlan" : 1001,
+            "vrf" : "default"
           }
         },
         "vendorFamily" : {

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -52822,6 +52822,83 @@
             "                  DECREMENT:'decrement'",
             "                  subtrahend = DEC:'20'))))",
             "          NEWLINE:'\\n'))))",
+            "  (stanza",
+            "    (s_interface",
+            "      INTERFACE:'interface'",
+            "      iname = (interface_name",
+            "        name_prefix_alpha = M_Interface_PREFIX:'Vlan'  <== mode:M_Interface",
+            "        (range",
+            "          (subrange",
+            "            low = DEC:'1001'  <== mode:M_Interface)))",
+            "      NEWLINE:'\\n'  <== mode:M_Interface",
+            "      (if_inner",
+            "        (if_standby",
+            "          STANDBY:'standby'",
+            "          (standby_version",
+            "            VERSION:'version'",
+            "            version = (variable_permissive",
+            "              DEC:'2'))",
+            "          NEWLINE:'\\n'))",
+            "      (if_inner",
+            "        (if_standby",
+            "          STANDBY:'standby'",
+            "          (standby_group",
+            "            group = DEC:'1001'",
+            "            (standby_group_authentication",
+            "              AUTHENTICATION:'authentication'",
+            "              auth = (variable",
+            "                DEC:'012345678901234567890123456789012345678'  <== mode:M_Authentication)))",
+            "          NEWLINE:'\\n'))",
+            "      (if_inner",
+            "        (if_standby",
+            "          STANDBY:'standby'",
+            "          (standby_group",
+            "            group = DEC:'1001'",
+            "            (standby_group_ip",
+            "              IP:'ip'",
+            "              ip = IP_ADDRESS:'1.2.3.4'))",
+            "          NEWLINE:'\\n'))",
+            "      (if_inner",
+            "        (if_standby",
+            "          STANDBY:'standby'",
+            "          (standby_group",
+            "            group = DEC:'1001'",
+            "            (standby_group_preempt",
+            "              PREEMPT:'preempt'))",
+            "          NEWLINE:'\\n'))",
+            "      (if_inner",
+            "        (if_standby",
+            "          STANDBY:'standby'",
+            "          (standby_group",
+            "            group = DEC:'1001'",
+            "            (standby_group_priority",
+            "              PRIORITY:'priority'",
+            "              priority = DEC:'105'))",
+            "          NEWLINE:'\\n'))",
+            "      (if_inner",
+            "        (if_standby",
+            "          STANDBY:'standby'",
+            "          (standby_group",
+            "            group = DEC:'1001'",
+            "            (standby_group_timers",
+            "              TIMERS:'timers'",
+            "              MSEC:'msec'",
+            "              hello_ms = DEC:'500'",
+            "              hold_sec = DEC:'2'))",
+            "          NEWLINE:'\\n'))",
+            "      (if_inner",
+            "        (if_standby",
+            "          STANDBY:'standby'",
+            "          (standby_group",
+            "            group = DEC:'1001'",
+            "            (standby_group_track",
+            "              TRACK:'track'",
+            "              group = DEC:'1'",
+            "              (track_action",
+            "                (track_action_decrement",
+            "                  DECREMENT:'decrement'",
+            "                  subtrahend = DEC:'20'))))",
+            "          NEWLINE:'\\n'))))",
             "  EOF:<EOF>)"
           ]
         },
@@ -80913,6 +80990,10 @@
             "Vlan1000" : {
               "definitionLines" : "5-12",
               "numReferrers" : 1
+            },
+            "Vlan1001" : {
+              "definitionLines" : "14-21",
+              "numReferrers" : 1
             }
           }
         },
@@ -86949,12 +87030,18 @@
               "interface" : [
                 5
               ]
+            },
+            "Vlan1001" : {
+              "interface" : [
+                14
+              ]
             }
           },
           "track" : {
             "1" : {
               "interface standby track" : [
-                12
+                12,
+                21
               ]
             }
           }
@@ -90953,7 +91040,8 @@
           "track" : {
             "1" : {
               "interface standby track" : [
-                12
+                12,
+                21
               ]
             }
           }


### PR DESCRIPTION
https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst3750x_3560x/software/release/12-2_55_se/configuration/guide/3750xscg/swhsrp.html

> All Layer 3 interfaces must have IP addresses assigned to them.

Downstream code in IpOwners chooses an HSRP master with tiebreak
based on L3 IPs, which could crash in some scenarios (multiple
interfaces with equal priority, at least one of which had no
IP.)