### PR TITLE
JunOS: rework SRX cross-zone-policy

### DIFF
--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_security
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_security
@@ -24,3 +24,8 @@ set security policies from-zone A to-zone B policy 123-4 then trace
 set security zones security-zone ZONE-protocols host-inbound-traffic protocols all
 set security zones security-zone ZONE-system-services host-inbound-traffic system-services all
 #
+set interfaces xe-0/0/0 unit 0 family inet address 1.2.3.4/24
+set security zones security-zone A interfaces xe-0/0/0.0
+set interfaces xe-1/0/0 unit 0 family inet address 2.3.4.5/24
+set security zones security-zone B interfaces xe-1/0/0.0
+#

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -63991,6 +63991,124 @@
             "lifetimeSeconds" : 28800
           }
         },
+        "interfaces" : {
+          "xe-0/0/0" : {
+            "name" : "xe-0/0/0",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-0/0/0"
+            ],
+            "mtu" : 1500,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "xe-0/0/0.0" : {
+            "name" : "xe-0/0/0.0",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allPrefixes" : [
+              "1.2.3.4/24"
+            ],
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-0/0/0.0"
+            ],
+            "firewallSessionInterfaceInfo" : {
+              "fibLookup" : false,
+              "sessionInterfaces" : [
+                "xe-0/0/0.0"
+              ]
+            },
+            "mtu" : 1500,
+            "preTransformationOutgoingFilter" : "~SECURITY_POLICIES_TO~xe-0/0/0.0",
+            "prefix" : "1.2.3.4/24",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOGICAL",
+            "vrf" : "default",
+            "zone" : "A"
+          },
+          "xe-1/0/0" : {
+            "name" : "xe-1/0/0",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-1/0/0"
+            ],
+            "mtu" : 1500,
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "default"
+          },
+          "xe-1/0/0.0" : {
+            "name" : "xe-1/0/0.0",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allPrefixes" : [
+              "2.3.4.5/24"
+            ],
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E10,
+            "declaredNames" : [
+              "xe-1/0/0.0"
+            ],
+            "firewallSessionInterfaceInfo" : {
+              "fibLookup" : false,
+              "sessionInterfaces" : [
+                "xe-1/0/0.0"
+              ]
+            },
+            "mtu" : 1500,
+            "preTransformationOutgoingFilter" : "~SECURITY_POLICIES_TO~xe-1/0/0.0",
+            "prefix" : "2.3.4.5/24",
+            "proxyArp" : false,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "LOGICAL",
+            "vrf" : "default",
+            "zone" : "B"
+          }
+        },
         "ipAccessLists" : {
           "zone~A~to~zone~B" : {
             "lines" : [
@@ -64004,7 +64122,10 @@
                       "class" : "org.batfish.datamodel.acl.TrueExpr"
                     },
                     {
-                      "class" : "org.batfish.datamodel.acl.MatchSrcInterface"
+                      "class" : "org.batfish.datamodel.acl.MatchSrcInterface",
+                      "srcInterfaces" : [
+                        "xe-0/0/0.0"
+                      ]
                     }
                   ]
                 },
@@ -65013,6 +65134,146 @@
             "name" : "~INBOUND_ZONE_FILTER~ZONE-system-services",
             "sourceName" : "~INBOUND_ZONE_FILTER~ZONE-system-services",
             "sourceType" : "firewall filter"
+          },
+          "~SECURITY_POLICIES_TO~xe-0/0/0.0" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.OriginatingFromDevice"
+                },
+                "name" : "HOST_OUTBOUND",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched Juniper semantics on traffic originated from device"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "~GLOBAL_SECURITY_POLICY~",
+                "name" : "Match global security policy",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched "
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$LinkFragment",
+                      "text" : "global security policy",
+                      "vendorStructureId" : {
+                        "filename" : "configs/juniper_security",
+                        "structureName" : "~GLOBAL_SECURITY_POLICY~",
+                        "structureType" : "security policy"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "DEFAULT_POLICY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched default policy"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~SECURITY_POLICIES_TO~xe-0/0/0.0"
+          },
+          "~SECURITY_POLICIES_TO~xe-1/0/0.0" : {
+            "lines" : [
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.OriginatingFromDevice"
+                },
+                "name" : "HOST_OUTBOUND",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched Juniper semantics on traffic originated from device"
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "zone~A~to~zone~B",
+                "name" : "Match security policy from zone A to zone B",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched "
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$LinkFragment",
+                      "text" : "security policy from zone A to zone B",
+                      "vendorStructureId" : {
+                        "filename" : "configs/juniper_security",
+                        "structureName" : "zone~A~to~zone~B",
+                        "structureType" : "security policy"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.AclAclLine",
+                "aclName" : "~GLOBAL_SECURITY_POLICY~",
+                "name" : "Match global security policy",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched "
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$LinkFragment",
+                      "text" : "global security policy",
+                      "vendorStructureId" : {
+                        "filename" : "configs/juniper_security",
+                        "structureName" : "~GLOBAL_SECURITY_POLICY~",
+                        "structureType" : "security policy"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
+                },
+                "name" : "DEFAULT_POLICY",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched default policy"
+                    }
+                  ]
+                }
+              }
+            ],
+            "name" : "~SECURITY_POLICIES_TO~xe-1/0/0.0"
           }
         },
         "ipSpaceMetadata" : {

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -64116,18 +64116,7 @@
                 "class" : "org.batfish.datamodel.ExprAclLine",
                 "action" : "PERMIT",
                 "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
-                  "conjuncts" : [
-                    {
-                      "class" : "org.batfish.datamodel.acl.TrueExpr"
-                    },
-                    {
-                      "class" : "org.batfish.datamodel.acl.MatchSrcInterface",
-                      "srcInterfaces" : [
-                        "xe-0/0/0.0"
-                      ]
-                    }
-                  ]
+                  "class" : "org.batfish.datamodel.acl.TrueExpr"
                 },
                 "name" : "123-4",
                 "traceElement" : {
@@ -65200,27 +65189,25 @@
                 "class" : "org.batfish.datamodel.ExprAclLine",
                 "action" : "PERMIT",
                 "matchCondition" : {
-                  "class" : "org.batfish.datamodel.acl.OriginatingFromDevice"
-                },
-                "name" : "HOST_OUTBOUND",
-                "traceElement" : {
-                  "fragments" : [
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
                     {
-                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched Juniper semantics on traffic originated from device"
+                      "class" : "org.batfish.datamodel.acl.MatchSrcInterface",
+                      "srcInterfaces" : [
+                        "xe-0/0/0.0"
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.PermittedByAcl",
+                      "aclName" : "zone~A~to~zone~B"
                     }
                   ]
-                }
-              },
-              {
-                "class" : "org.batfish.datamodel.AclAclLine",
-                "aclName" : "zone~A~to~zone~B",
-                "name" : "Match security policy from zone A to zone B",
+                },
                 "traceElement" : {
                   "fragments" : [
                     {
                       "class" : "org.batfish.datamodel.TraceElement$TextFragment",
-                      "text" : "Matched "
+                      "text" : "Permitted by "
                     },
                     {
                       "class" : "org.batfish.datamodel.TraceElement$LinkFragment",
@@ -65230,6 +65217,58 @@
                         "structureName" : "zone~A~to~zone~B",
                         "structureType" : "security policy"
                       }
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "DENY",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.AndMatchExpr",
+                  "conjuncts" : [
+                    {
+                      "class" : "org.batfish.datamodel.acl.MatchSrcInterface",
+                      "srcInterfaces" : [
+                        "xe-0/0/0.0"
+                      ]
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.acl.PermittedByAcl",
+                      "aclName" : "zone~A~to~zone~B"
+                    }
+                  ]
+                },
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Denied by "
+                    },
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$LinkFragment",
+                      "text" : "security policy from zone A to zone B",
+                      "vendorStructureId" : {
+                        "filename" : "configs/juniper_security",
+                        "structureName" : "zone~A~to~zone~B",
+                        "structureType" : "security policy"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "class" : "org.batfish.datamodel.ExprAclLine",
+                "action" : "PERMIT",
+                "matchCondition" : {
+                  "class" : "org.batfish.datamodel.acl.OriginatingFromDevice"
+                },
+                "name" : "HOST_OUTBOUND",
+                "traceElement" : {
+                  "fragments" : [
+                    {
+                      "class" : "org.batfish.datamodel.TraceElement$TextFragment",
+                      "text" : "Matched Juniper semantics on traffic originated from device"
                     }
                   ]
                 }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -67714,6 +67714,94 @@
             "                    (hib_system_service",
             "                      ALL:'all')))))))))",
             "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_interfaces",
+            "            INTERFACES:'interfaces'",
+            "            (int_named",
+            "              (interface_id",
+            "                name = INTERFACE_NAME:'xe-0/0/0'  <== mode:M_Interface)",
+            "              (i_unit",
+            "                UNIT:'unit'",
+            "                num = DEC:'0'",
+            "                (i_common",
+            "                  (i_family",
+            "                    FAMILY:'family'",
+            "                    (if_inet",
+            "                      INET:'inet'",
+            "                      (ifi_address",
+            "                        ADDRESS:'address'",
+            "                        IP_PREFIX:'1.2.3.4/24'))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_security",
+            "            SECURITY:'security'",
+            "            (se_zones",
+            "              ZONES:'zones'",
+            "              (sez_security_zone",
+            "                SECURITY_ZONE:'security-zone'",
+            "                (zone",
+            "                  name = (variable",
+            "                    text = VARIABLE:'A'))",
+            "                (sezs_interfaces",
+            "                  INTERFACES:'interfaces'",
+            "                  (interface_id",
+            "                    name = INTERFACE_NAME:'xe-0/0/0'  <== mode:M_Interface",
+            "                    PERIOD:'.'",
+            "                    unit = DEC:'0')",
+            "                  (apply))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_interfaces",
+            "            INTERFACES:'interfaces'",
+            "            (int_named",
+            "              (interface_id",
+            "                name = INTERFACE_NAME:'xe-1/0/0'  <== mode:M_Interface)",
+            "              (i_unit",
+            "                UNIT:'unit'",
+            "                num = DEC:'0'",
+            "                (i_common",
+            "                  (i_family",
+            "                    FAMILY:'family'",
+            "                    (if_inet",
+            "                      INET:'inet'",
+            "                      (ifi_address",
+            "                        ADDRESS:'address'",
+            "                        IP_PREFIX:'2.3.4.5/24'))))))))))",
+            "    NEWLINE:'\\n')",
+            "  (set_line",
+            "    SET:'set'",
+            "    (set_line_tail",
+            "      (statement",
+            "        (s_common",
+            "          (s_security",
+            "            SECURITY:'security'",
+            "            (se_zones",
+            "              ZONES:'zones'",
+            "              (sez_security_zone",
+            "                SECURITY_ZONE:'security-zone'",
+            "                (zone",
+            "                  name = (variable",
+            "                    text = VARIABLE:'B'))",
+            "                (sezs_interfaces",
+            "                  INTERFACES:'interfaces'",
+            "                  (interface_id",
+            "                    name = INTERFACE_NAME:'xe-1/0/0'  <== mode:M_Interface",
+            "                    PERIOD:'.'",
+            "                    unit = DEC:'0')",
+            "                  (apply))))))))",
+            "    NEWLINE:'\\n')",
             "  EOF:<EOF>)"
           ]
         },
@@ -81719,6 +81807,24 @@
               "numReferrers" : 1
             }
           },
+          "interface" : {
+            "xe-0/0/0" : {
+              "definitionLines" : "27",
+              "numReferrers" : 1
+            },
+            "xe-0/0/0.0" : {
+              "definitionLines" : "27",
+              "numReferrers" : 2
+            },
+            "xe-1/0/0" : {
+              "definitionLines" : "29",
+              "numReferrers" : 1
+            },
+            "xe-1/0/0.0" : {
+              "definitionLines" : "29",
+              "numReferrers" : 2
+            }
+          },
           "security policy" : {
             "zone~A~to~zone~B" : {
               "definitionLines" : "19-22",
@@ -88020,6 +88126,34 @@
             "PROPOSAL" : {
               "ike policy ike proposal" : [
                 14
+              ]
+            }
+          },
+          "interface" : {
+            "xe-0/0/0" : {
+              "interface" : [
+                27
+              ]
+            },
+            "xe-0/0/0.0" : {
+              "interface" : [
+                27
+              ],
+              "security zones security-zone interfaces" : [
+                28
+              ]
+            },
+            "xe-1/0/0" : {
+              "interface" : [
+                29
+              ]
+            },
+            "xe-1/0/0.0" : {
+              "interface" : [
+                29
+              ],
+              "security zones security-zone interfaces" : [
+                30
               ]
             }
           },


### PR DESCRIPTION
We want to be able to analyze the pure-packet-header
parts of the cross-zone policy. To support this, move the
"matchSourceInterface in from-zone" part of the filter
from inside the zone~A~to~zone~B filter to the parent.

The traces change a little, for the better. Instead of "Matched
cross-zone policy", it's now "Permitted by .." and "Denied by ..".

Additionally, since from-zone junos-host is a real thing, moved the
"permit from junos-host" term to after cross-zone policy evaluation.
