### PR TITLE
PAN: switch to custom insert-order data structure for security rules

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/InsertOrderedMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/InsertOrderedMap.java
@@ -60,7 +60,7 @@ public class InsertOrderedMap<K, V> implements Map<K, V>, Serializable {
   /**
    * See {@link Map#containsKey}, with the exception that this rejects {@code null} values.
    *
-   * @throws IllegalArgumentException if the key is {@code null}
+   * @throws IllegalArgumentException if the value is {@code null}
    */
   @Override
   public boolean containsValue(Object value) {
@@ -84,7 +84,7 @@ public class InsertOrderedMap<K, V> implements Map<K, V>, Serializable {
    * Insert a new value into the map, at the end. See {@link Map#get}, with the exception that this
    * rejects {@code null} keys
    *
-   * @throws IllegalArgumentException if the key is {@code null}
+   * @throws IllegalArgumentException if the key or value is {@code null}
    */
   @Override
   @Nullable
@@ -175,24 +175,30 @@ public class InsertOrderedMap<K, V> implements Map<K, V>, Serializable {
   }
 
   /**
-   * Move the given key prior the the pivot key
+   * Move the given key prior to the pivot key. Moving a key before itself has no effect.
    *
    * @throws IllegalArgumentException if either key does not exist
    */
   public void moveBefore(K key, K pivot) {
     int pivotIndex = _keyList.indexOf(pivot);
     checkArgument(pivotIndex != -1, String.format("Key %s does not exist in the map", pivot));
+    if (key.equals(pivot)) {
+      return;
+    }
     moveTo(key, pivotIndex);
   }
 
   /**
-   * Move the given key immediately after the pivot key
+   * Move the given key immediately after the pivot key. Moving a key after itself has no effect.
    *
    * @throws IllegalArgumentException if either key does not exist
    */
   public void moveAfter(K key, K pivot) {
     int pivotIndex = _keyList.indexOf(pivot);
     checkArgument(pivotIndex != -1, String.format("Key %s does not exist in the map", pivot));
+    if (key.equals(pivot)) {
+      return;
+    }
     moveTo(key, pivotIndex + 1);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/InsertOrderedMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/collections/InsertOrderedMap.java
@@ -1,0 +1,258 @@
+package org.batfish.datamodel.collections;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.io.Serializable;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * A (mostly) insert-ordered {@link Map} implementation. Similar to {@link LinkedHashMap}, but in
+ * addition provides APIs for inserting at the front of the map or re-ordering keys: {@link
+ * #putFirst(K, V)}, {@link #moveBefore(K, K)}, {@link #moveAfter(K, K)}
+ *
+ * <p>Note: this implementation rejects {@code null} keys and values by throwing an {@link
+ * IllegalArgumentException}. This implementation is also <b>not</b> thread-safe.
+ */
+@ParametersAreNonnullByDefault
+public class InsertOrderedMap<K, V> implements Map<K, V>, Serializable {
+
+  /** Create a new empty map */
+  public InsertOrderedMap() {
+    _map = new HashMap<>(1);
+    _keyList = new LinkedList<>();
+  }
+
+  public InsertOrderedMap(Map<K, V> other) {
+    this();
+    putAll(other);
+  }
+
+  @Override
+  public int size() {
+    return _map.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return _map.isEmpty();
+  }
+
+  /** See {@link Map#containsKey}, with the exception that this rejects {@code null} keys */
+  @Override
+  public boolean containsKey(Object key) {
+    checkArgument(key != null, "Key must be nonnull");
+    return _map.containsKey(key);
+  }
+
+  /**
+   * See {@link Map#containsKey}, with the exception that this rejects {@code null} values.
+   *
+   * @throws IllegalArgumentException if the key is {@code null}
+   */
+  @Override
+  public boolean containsValue(Object value) {
+    checkArgument(value != null, "Value must be nonnull");
+    return _map.containsValue(value);
+  }
+
+  /**
+   * See {@link Map#get}, with the exception that this rejects {@code null} keys
+   *
+   * @throws IllegalArgumentException if the key is {@code null}
+   */
+  @Override
+  @Nullable
+  public V get(Object key) {
+    checkArgument(key != null, "Key must be nonnull");
+    return _map.get(key);
+  }
+
+  /**
+   * Insert a new value into the map, at the end. See {@link Map#get}, with the exception that this
+   * rejects {@code null} keys
+   *
+   * @throws IllegalArgumentException if the key is {@code null}
+   */
+  @Override
+  @Nullable
+  public V put(K key, V value) {
+    checkArgument(key != null && value != null, "Keys and values must be nonnull");
+    V ret = putIntoMapClearFromKeyList(key, value);
+    _keyList.add(key);
+    return ret;
+  }
+
+  /** Insert a value at the front of the map. See {@link #put(K, V)} for return value semantics. */
+  @Nullable
+  public V putFirst(K key, V value) {
+    V ret = putIntoMapClearFromKeyList(key, value);
+    _keyList.add(0, key);
+    return ret;
+  }
+
+  /** See {@link Map#remove}, with the exception that this rejects {@code null} keys */
+  @Override
+  public V remove(@Nullable Object key) {
+    checkArgument(key != null, "Key must be nonnull");
+    _keyList.remove(key);
+    return _map.remove(key);
+  }
+
+  @Override
+  public void putAll(Map<? extends K, ? extends V> m) {
+    for (Entry<? extends K, ? extends V> entry : m.entrySet()) {
+      put(entry.getKey(), entry.getValue());
+    }
+  }
+
+  @Override
+  public void clear() {
+    _map.clear();
+    _keyList.clear();
+  }
+
+  /** Returns and immutable copy of the key set. Map iteration order is reflected in the set. */
+  @Override
+  @Nonnull
+  public Set<K> keySet() {
+    return ImmutableSet.copyOf(_keyList);
+  }
+
+  /**
+   * Returns and immutable copy of the map values. Map iteration order is reflected in the
+   * collection.
+   */
+  @Override
+  public Collection<V> values() {
+    ImmutableList.Builder<V> valuesBuilder = ImmutableList.builder();
+    for (K k : _keyList) {
+      valuesBuilder.add(_map.get(k));
+    }
+    return valuesBuilder.build();
+  }
+
+  /**
+   * Returns an immutable copy of the entry set. Map iteration order is reflected in the collection.
+   */
+  @Override
+  public Set<Entry<K, V>> entrySet() {
+    ImmutableSet.Builder<Entry<K, V>> valuesBuilder = ImmutableSet.builder();
+    for (K k : _keyList) {
+      valuesBuilder.add(new SimpleEntry<>(k, _map.get(k)));
+    }
+    return valuesBuilder.build();
+  }
+
+  /**
+   * Move the given key to the beginning of the map
+   *
+   * @throws IllegalArgumentException if the key does not exist
+   */
+  public void moveFirst(K key) {
+    moveTo(key, 0);
+  }
+
+  /**
+   * Move the given key to the end of the map
+   *
+   * @throws IllegalArgumentException if the key does not exist
+   */
+  public void moveLast(K key) {
+    moveTo(key, size());
+  }
+
+  /**
+   * Move the given key prior the the pivot key
+   *
+   * @throws IllegalArgumentException if either key does not exist
+   */
+  public void moveBefore(K key, K pivot) {
+    int pivotIndex = _keyList.indexOf(pivot);
+    checkArgument(pivotIndex != -1, String.format("Key %s does not exist in the map", pivot));
+    moveTo(key, pivotIndex);
+  }
+
+  /**
+   * Move the given key immediately after the pivot key
+   *
+   * @throws IllegalArgumentException if either key does not exist
+   */
+  public void moveAfter(K key, K pivot) {
+    int pivotIndex = _keyList.indexOf(pivot);
+    checkArgument(pivotIndex != -1, String.format("Key %s does not exist in the map", pivot));
+    moveTo(key, pivotIndex + 1);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_keyList, _map);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (!(obj instanceof InsertOrderedMap)) {
+      return false;
+    }
+    InsertOrderedMap<?, ?> that = (InsertOrderedMap<?, ?>) obj;
+    if (!_keyList.equals(that._keyList)) {
+      return false;
+    }
+    for (K k : keySet()) {
+      if (!get(k).equals(that.get(k))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /////////////////////////
+  // Private implementation
+
+  private final Map<K, V> _map;
+  private final List<K> _keyList;
+
+  /**
+   * Put a new value in the map. If the value already existed for a given key, remove it from the
+   * key list.
+   */
+  @Nullable
+  private V putIntoMapClearFromKeyList(K key, @Nonnull V value) {
+    V ret = _map.put(key, value);
+    if (ret != null) {
+      // A value has been replaced
+      _keyList.remove(key);
+    }
+    return ret;
+  }
+
+  /**
+   * Move a given key to a given index
+   *
+   * @throws IllegalArgumentException if the {@code key} does not exist
+   */
+  private void moveTo(K key, int index) {
+    checkArgument(_keyList.contains(key), String.format("Key %s does not exist in the map", key));
+    _keyList.remove(key);
+    if (index == size()) {
+      _keyList.add(key);
+    } else {
+      _keyList.add(index, key);
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/collections/InsertOrderedMapTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/collections/InsertOrderedMapTest.java
@@ -149,6 +149,15 @@ public class InsertOrderedMapTest {
     assertThat(_testMap.keySet(), contains("key2", "key1"));
   }
 
+  @Test
+  public void testMoveBeforeSameKey() {
+    _testMap.put("key1", "value");
+    _testMap.put("key2", "value2");
+    // This should have no effect
+    _testMap.moveBefore("key1", "key1");
+    assertThat(_testMap.keySet(), contains("key1", "key2"));
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testMoveBeforeRejectNonExistentKey() {
     _testMap.put("key1", "value");
@@ -167,6 +176,15 @@ public class InsertOrderedMapTest {
     _testMap.put("key2", "value");
     _testMap.moveAfter("key1", "key2");
     assertThat(_testMap.keySet(), contains("key2", "key1"));
+  }
+
+  @Test
+  public void testMoveAfterSameKey() {
+    _testMap.put("key1", "value");
+    _testMap.put("key2", "value2");
+    // This should have no effect
+    _testMap.moveAfter("key1", "key1");
+    assertThat(_testMap.keySet(), contains("key1", "key2"));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/collections/InsertOrderedMapTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/collections/InsertOrderedMapTest.java
@@ -1,0 +1,209 @@
+package org.batfish.datamodel.collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.testing.EqualsTester;
+import java.util.AbstractMap.SimpleEntry;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests of {@link InsertOrderedMap} */
+public class InsertOrderedMapTest {
+
+  private InsertOrderedMap<String, String> _testMap;
+
+  @Before
+  public void setUp() {
+    _testMap = new InsertOrderedMap<>();
+  }
+
+  @Test
+  public void testIsEmptyOnCreation() {
+    assertTrue(_testMap.isEmpty());
+  }
+
+  @Test
+  public void testPut() {
+    _testMap.put("key", "value");
+    assertThat(_testMap.get("key"), equalTo("value"));
+  }
+
+  @Test
+  public void testPutAsReplace() {
+    _testMap.put("key", "value");
+    _testMap.put("key2", "value2");
+    _testMap.put("key", "newValue");
+    // Expect new value at key; key moves to the end of the map.
+    assertThat(_testMap.get("key"), equalTo("newValue"));
+    assertThat(_testMap.keySet(), contains("key2", "key"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPutRejectsNullKey() {
+    _testMap.put(null, "value");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPutRejectsNullValue() {
+    _testMap.put("key", null);
+  }
+
+  @Test
+  public void testPutAll() {
+    _testMap.putAll(ImmutableSortedMap.of("a", "1", "b", "2", "c", "3"));
+    assertThat(_testMap.keySet(), contains("a", "b", "c"));
+  }
+
+  @Test
+  public void testRemove() {
+    String key = "key";
+    _testMap.put(key, "value");
+    _testMap.remove(key);
+    assertTrue(_testMap.isEmpty());
+    // removing again should simply return null.
+    assertThat(_testMap.remove(key), nullValue());
+  }
+
+  @Test
+  public void testClear() {
+    _testMap.put("key", "value");
+    _testMap.clear();
+    assertTrue(_testMap.isEmpty());
+  }
+
+  @Test
+  public void tetKeySetIterationOrder() {
+    _testMap.put("first", "1");
+    _testMap.put("second", "2");
+    _testMap.put("last", "3");
+    assertThat(_testMap.keySet(), contains("first", "second", "last"));
+  }
+
+  @Test
+  public void testValuesIterationOrder() {
+    _testMap.put("first", "1");
+    _testMap.put("second", "2");
+    _testMap.put("last", "3");
+    assertThat(_testMap.values(), contains("1", "2", "3"));
+  }
+
+  @Test
+  public void tetEntrySetIterationOrder() {
+    _testMap.put("first", "1");
+    _testMap.put("second", "2");
+    _testMap.put("last", "3");
+    assertThat(
+        _testMap.entrySet(),
+        contains(
+            new SimpleEntry<>("first", "1"),
+            new SimpleEntry<>("second", "2"),
+            new SimpleEntry<>("last", "3")));
+  }
+
+  @Test
+  public void testPutFirst() {
+    _testMap.put("key", "value");
+    _testMap.putFirst("first", "1");
+    assertThat(_testMap.keySet(), contains("first", "key"));
+  }
+
+  @Test
+  public void testMoveFirst() {
+    _testMap.put("key1", "value");
+    _testMap.put("key2", "value");
+    _testMap.put("key3", "value");
+    _testMap.moveFirst("key3");
+    assertThat(_testMap.keySet(), contains("key3", "key1", "key2"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMoveFirstRejectNonexistent() {
+    _testMap.moveFirst("key3");
+  }
+
+  @Test
+  public void testMoveLast() {
+    _testMap.put("key1", "value");
+    _testMap.put("key2", "value");
+    _testMap.put("key3", "value");
+    _testMap.moveLast("key1");
+    assertThat(_testMap.keySet(), contains("key2", "key3", "key1"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMoveLastRejectNonexistent() {
+    _testMap.moveLast("key3");
+  }
+
+  @Test
+  public void testMoveBefore() {
+    _testMap.put("key1", "value");
+    _testMap.put("key2", "value2");
+    _testMap.moveBefore("key2", "key1");
+    assertThat(_testMap.keySet(), contains("key2", "key1"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMoveBeforeRejectNonExistentKey() {
+    _testMap.put("key1", "value");
+    _testMap.moveBefore("notThere", "key1");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMoveBeforeRejectNonExistentPivot() {
+    _testMap.put("key1", "value");
+    _testMap.moveBefore("key1", "notThere");
+  }
+
+  @Test
+  public void testMoveAfter() {
+    _testMap.put("key1", "value");
+    _testMap.put("key2", "value");
+    _testMap.moveAfter("key1", "key2");
+    assertThat(_testMap.keySet(), contains("key2", "key1"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMoveAfterRejectNonExistentKey() {
+    _testMap.put("key1", "value");
+    _testMap.moveAfter("notThere", "key1");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMoveAfterRejectNonExistentPivot() {
+    _testMap.put("key1", "value");
+    _testMap.moveAfter("key1", "notThere");
+  }
+
+  @Test
+  public void testEquals() {
+    _testMap.put("first", "val1");
+    _testMap.put("second", "val2");
+    InsertOrderedMap<String, String> shouldEqual = new InsertOrderedMap<>();
+    shouldEqual.put("first", "val1");
+    shouldEqual.put("second", "val2");
+    InsertOrderedMap<String, String> m1 = new InsertOrderedMap<>();
+    m1.put("first", "val1");
+    InsertOrderedMap<String, String> m2 = new InsertOrderedMap<>();
+    m2.put("second", "val2");
+    m2.put("first", "val1");
+    new EqualsTester()
+        .addEqualityGroup(_testMap, _testMap, shouldEqual)
+        .addEqualityGroup(m1)
+        .addEqualityGroup(m2)
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    _testMap.put("key1", "value");
+    assertThat(SerializationUtils.clone(_testMap), equalTo(_testMap));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -122,6 +122,7 @@ import org.batfish.datamodel.acl.TrueExpr;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily.Builder;
+import org.batfish.datamodel.collections.InsertOrderedMap;
 import org.batfish.datamodel.flow.TransformationStep.TransformationType;
 import org.batfish.datamodel.ospf.NssaSettings;
 import org.batfish.datamodel.ospf.OspfArea;
@@ -2426,9 +2427,9 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     targetPostNat.clear();
     targetPostNat.putAll(postRulebaseNat);
     // Security post
-    // Note: using LinkedHashMaps to preserve insertion order
+    // Note: using InsertOrderedMap to preserve insertion order
     Map<String, SecurityRule> postRulebaseSecurity =
-        new LinkedHashMap<>(source.getPostRulebase().getSecurityRules());
+        new InsertOrderedMap<>(source.getPostRulebase().getSecurityRules());
     Map<String, SecurityRule> targetPostSecurity = target.getPostRulebase().getSecurityRules();
     postRulebaseSecurity.putAll(targetPostSecurity);
     targetPostSecurity.clear();

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Rulebase.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Rulebase.java
@@ -4,17 +4,18 @@ import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import org.batfish.datamodel.collections.InsertOrderedMap;
 
 /** Represents a rulebase within a {@link Vsys} or in panorama policy */
 public class Rulebase implements Serializable {
 
   // Note: these are LinkedHashMaps to preserve insertion order.
   @Nonnull private final Map<String, NatRule> _natRules;
-  @Nonnull private final Map<String, SecurityRule> _securityRules;
+  @Nonnull private final InsertOrderedMap<String, SecurityRule> _securityRules;
 
   public Rulebase() {
     _natRules = new LinkedHashMap<>();
-    _securityRules = new LinkedHashMap<>();
+    _securityRules = new InsertOrderedMap<>();
   }
 
   /** Get map of {@code NatRule} name to {@code NatRule}; preserves insertion order. */
@@ -25,7 +26,7 @@ public class Rulebase implements Serializable {
 
   /** Get map of {@code SecurityRule} name to {@code SecurityRule}; preserves insertion order. */
   @Nonnull
-  public Map<String, SecurityRule> getSecurityRules() {
+  public InsertOrderedMap<String, SecurityRule> getSecurityRules() {
     return _securityRules;
   }
 }


### PR DESCRIPTION
* Implement a LinkedHashMap-like Map with extra APIs for reordering keys
* Use it in PAN configuration. Lays groundwork for supporting moving of security rules