### PR TITLE
PAN: support for "move rulebase security" commands

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -98,6 +98,11 @@ AES_256_GCM
     'aes-256-gcm'
 ;
 
+AFTER
+:
+    'after'
+;
+
 AGGREGATE
 :
     'aggregate'
@@ -198,6 +203,11 @@ AUTO
     'auto'
 ;
 
+BEFORE
+:
+    'before'
+;
+
 BFD
 :
     'bfd'
@@ -216,6 +226,11 @@ BOTH
 BOTNET
 :
     'botnet'
+;
+
+BOTTOM
+:
+    'bottom'
 ;
 
 BROADCAST
@@ -888,6 +903,11 @@ MGT_CONFIG
     'mgt-config'
 ;
 
+MOVE
+:
+    'move'
+;
+
 MTU
 :
     'mtu'
@@ -1491,6 +1511,11 @@ TIMEZONE
 TO
 :
     'to'
+;
+
+TOP
+:
+    'top'
 ;
 
 TRANSFERS_FILES

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoParser.g4
@@ -37,10 +37,20 @@ options {
 palo_alto_configuration
 :
     (
-        set_line
+        move_line
+        | set_line
         /* TODO: delete line, etc. */
         | newline
     )+ EOF
+;
+
+move_line
+:
+   MOVE
+   (
+      m_vsys
+      | m_rulebase
+   )
 ;
 
 newline

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_common.g4
@@ -10,6 +10,14 @@ bgp_asn
     uint32
 ;
 
+move_action
+:
+    AFTER name = variable
+    | BEFORE name = variable
+    | BOTTOM
+    | TOP
+;
+
 null_rest_of_line
 :
     ~NEWLINE*

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_rulebase.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_rulebase.g4
@@ -8,6 +8,31 @@ options {
     tokenVocab = PaloAltoLexer;
 }
 
+m_rulebase
+:
+    RULEBASE m_rulebase_inner
+;
+
+m_post_rulebase
+:
+    POST_RULEBASE m_rulebase_inner
+;
+
+m_pre_rulebase
+:
+    PRE_RULEBASE m_rulebase_inner
+;
+
+m_rulebase_inner
+:
+    mr_security
+;
+
+mr_security
+:
+    SECURITY RULES name = variable action = move_action
+;
+
 s_rulebase
 :
     RULEBASE rulebase_inner

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_vsys.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_vsys.g4
@@ -6,6 +6,12 @@ options {
     tokenVocab = PaloAltoLexer;
 }
 
+m_vsys
+:
+    VSYS name = variable
+    m_rulebase
+;
+
 s_vsys
 :
     VSYS s_vsys_definition?

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -3659,4 +3659,16 @@ public final class PaloAltoGrammarTest {
     // Do not crash (i.e., no warnings generated)
     parsePaloAltoConfig(hostname);
   }
+
+  @Test
+  public void testSecurityRuleMove() {
+    String hostname = "move-rulebase-security";
+    PaloAltoConfiguration c = parsePaloAltoConfig(hostname);
+    assertThat(
+        c.getVirtualSystems().get(DEFAULT_VSYS_NAME).getRulebase().getSecurityRules().keySet(),
+        contains("RULE3", "RULE4", "RULE1", "RULE5", "RULE2"));
+    assertThat(
+        c.getVirtualSystems().get("MY_VSYS").getRulebase().getSecurityRules().keySet(),
+        contains("RULE7", "RULE6"));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/move-rulebase-security
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/move-rulebase-security
@@ -1,0 +1,69 @@
+#RANCID-CONTENT-TYPE: paloalto
+set deviceconfig system hostname move-rulebase-security
+
+set rulebase security rules RULE1 from any
+set rulebase security rules RULE1 to [ z1 z2 ]
+set rulebase security rules RULE1 source any
+set rulebase security rules RULE1 source-user any
+set rulebase security rules RULE1 destination any
+set rulebase security rules RULE1 service "SERVICE1"
+set rulebase security rules RULE1 application any
+set rulebase security rules RULE1 action deny
+
+set rulebase security rules RULE2 from any
+set rulebase security rules RULE2 to [ z1 z2 ]
+set rulebase security rules RULE2 source [ 2.2.2.2 ]
+set rulebase security rules RULE2 negate-source yes
+set rulebase security rules RULE2 destination [ 1.1.1.2 1.1.4.2 ]
+set rulebase security rules RULE2 service any
+set rulebase security rules RULE2 application any
+set rulebase security rules RULE2 action allow
+
+set rulebase security rules RULE3 from any
+set rulebase security rules RULE3 to any
+set rulebase security rules RULE3 source any
+set rulebase security rules RULE3 destination any
+set rulebase security rules RULE3 service any
+set rulebase security rules RULE3 application any
+set rulebase security rules RULE3 action deny
+
+set rulebase security rules RULE4 from any
+set rulebase security rules RULE4 to any
+set rulebase security rules RULE4 source any
+set rulebase security rules RULE4 destination any
+set rulebase security rules RULE4 service any
+set rulebase security rules RULE4 application any
+set rulebase security rules RULE4 action deny
+
+set rulebase security rules RULE5 from any
+set rulebase security rules RULE5 to any
+set rulebase security rules RULE5 source any
+set rulebase security rules RULE5 destination any
+set rulebase security rules RULE5 service any
+set rulebase security rules RULE5 application any
+set rulebase security rules RULE5 action deny
+
+move rulebase security rules RULE3 top
+move rulebase security rules RULE4 before RULE2
+move rulebase security rules RULE1 after RULE4
+move rulebase security rules RULE2 bottom
+
+# Final order of rules after moves: 3,4,1,5,2
+
+set vsys MY_VSYS rulebase security rules RULE6 from any
+set vsys MY_VSYS rulebase security rules RULE6 to any
+set vsys MY_VSYS rulebase security rules RULE6 source any
+set vsys MY_VSYS rulebase security rules RULE6 destination any
+set vsys MY_VSYS rulebase security rules RULE6 service any
+set vsys MY_VSYS rulebase security rules RULE6 application any
+set vsys MY_VSYS rulebase security rules RULE6 action deny
+
+set vsys MY_VSYS rulebase security rules RULE7 from any
+set vsys MY_VSYS rulebase security rules RULE7 to any
+set vsys MY_VSYS rulebase security rules RULE7 source any
+set vsys MY_VSYS rulebase security rules RULE7 destination any
+set vsys MY_VSYS rulebase security rules RULE7 service any
+set vsys MY_VSYS rulebase security rules RULE7 application any
+set vsys MY_VSYS rulebase security rules RULE7 action deny
+
+move vsys MY_VSYS rulebase security rules RULE7 before RULE6


### PR DESCRIPTION
Allows moving security rules to top/bottom or before/after a specific rule
Also supports pre/post rulebases