### PR TITLE
PAN: parse and extract security group tags

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_rulebase.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_rulebase.g4
@@ -87,6 +87,7 @@ srs_definition
         | srs_source_user
         | srs_target
         | srs_to
+        | srs_tag
     )?
 ;
 
@@ -188,6 +189,11 @@ srs_source
 srs_source_user
 :
     SOURCE_USER ANY // only support user any so far
+;
+
+srs_tag
+:
+    TAG tags = variable_list
 ;
 
 srs_target

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -299,6 +299,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Srs_negate_sourceContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Srs_rule_typeContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Srs_serviceContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Srs_sourceContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Srs_tagContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Srs_toContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_descriptionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_portContext;
@@ -2690,6 +2691,14 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
         type = ADDRESS_LIKE;
       }
       referenceStructure(type, uniqueName, SECURITY_RULE_SOURCE, getLine(var.start));
+    }
+  }
+
+  @Override
+  public void exitSrs_tag(Srs_tagContext ctx) {
+    for (Variable_list_itemContext var : variables(ctx.variable_list())) {
+      String tag = getText(var);
+      _currentSecurityRule.getTags().add(tag);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/SecurityRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/SecurityRule.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.palo_alto;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.SortedSet;
@@ -51,6 +52,8 @@ public final class SecurityRule implements Serializable {
   // Rule type
   @Nullable private RuleType _ruleType;
 
+  @Nonnull private final List<String> _tags;
+
   public SecurityRule(String name, Vsys vsys) {
     _action = LineAction.DENY;
     _applications = new TreeSet<>();
@@ -62,6 +65,7 @@ public final class SecurityRule implements Serializable {
     _source = new LinkedList<>();
     _negateSource = false;
     _to = new TreeSet<>();
+    _tags = new ArrayList<>(1);
     _name = name;
     _vsys = vsys;
   }
@@ -129,6 +133,11 @@ public final class SecurityRule implements Serializable {
   @Nonnull
   public SortedSet<String> getTo() {
     return _to;
+  }
+
+  @Nonnull
+  public List<String> getTags() {
+    return _tags;
   }
 
   @Nonnull

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -3671,4 +3671,18 @@ public final class PaloAltoGrammarTest {
         c.getVirtualSystems().get("MY_VSYS").getRulebase().getSecurityRules().keySet(),
         contains("RULE7", "RULE6"));
   }
+
+  @Test
+  public void testSecurityRuleTag() {
+    String hostname = "security-rule-tag";
+    PaloAltoConfiguration c = parsePaloAltoConfig(hostname);
+    assertThat(
+        c.getVirtualSystems()
+            .get(DEFAULT_VSYS_NAME)
+            .getRulebase()
+            .getSecurityRules()
+            .get("RULE1")
+            .getTags(),
+        contains("TAG"));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/security-rule-tag
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/security-rule-tag
@@ -1,0 +1,8 @@
+#RANCID-CONTENT-TYPE: paloalto
+set deviceconfig system hostname security-rule-tag
+
+set rulebase security rules RULE1 from any
+set rulebase security rules RULE1 to [ z1 z2 ]
+set rulebase security rules RULE1 source any
+set rulebase security rules RULE1 destination any
+set rulebase security rules RULE1 tag TAG


### PR DESCRIPTION
While not strictly necessary for analysis, this is QOL improvement that trims down potentially hundreds of parse warnings.

Docs:
https://knowledgebase.paloaltonetworks.com/KCSArticleDetail\?id\=kA10g000000ClEnCAK\#:\~:text\=Creating%20Tags,inbound%20rule%20and%20click%20OK.