### PR TITLE
JunOS: keep the original filter and term names during conversion

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/JuniperConfigurationTest.java
@@ -753,8 +753,9 @@ public class JuniperConfigurationTest {
     JuniperConfiguration config = createConfig();
     FwTerm term = new FwTerm("term");
     term.getThens().add(FwThenAccept.INSTANCE);
-    List<FwTerm> terms = ImmutableList.of(term);
-    IpAccessList acl = config.fwTermsToIpAccessList("acl", terms, null, FIREWALL_FILTER);
+    ConcreteFirewallFilter filter = new ConcreteFirewallFilter("acl", Family.INET);
+    filter.getTerms().put(term.getName(), term);
+    IpAccessList acl = config.fwTermsToIpAccessList("acl", filter, null, FIREWALL_FILTER);
 
     assertThat(acl.getLines(), hasSize(1));
 

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -65337,7 +65337,7 @@
                       "text" : "123-4",
                       "vendorStructureId" : {
                         "filename" : "configs/juniper_security",
-                        "structureName" : "~zone~A~to~zone~B~pure 123-4",
+                        "structureName" : "zone~A~to~zone~B 123-4",
                         "structureType" : "security policy term"
                       }
                     }
@@ -65346,7 +65346,7 @@
               }
             ],
             "name" : "~zone~A~to~zone~B~pure",
-            "sourceName" : "~zone~A~to~zone~B~pure",
+            "sourceName" : "zone~A~to~zone~B",
             "sourceType" : "security policy"
           }
         },


### PR DESCRIPTION
This make sure that tracing and source metadata are correct even when
producing an ACL with a different output name,