### PR TITLE
FilterQuestionUtils: make it use TEST_FILTERS FlowPreference

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -241,9 +241,8 @@ public class BDDPacket {
     if (bdd.isZero()) {
       return Optional.empty();
     }
-    BDD representativeBDD =
-        BDDRepresentativePicker.pickRepresentative(
-            bdd, _flowConstraintGeneratorSupplier.get().generateFlowPreference(preference));
+
+    BDD representativeBDD = getFlowBDD(bdd, preference);
 
     if (representativeBDD.isZero()) {
       // Should not be possible if the preference is well-formed.
@@ -251,6 +250,22 @@ public class BDDPacket {
     }
 
     return Optional.of(getRepresentativeFlow(representativeBDD));
+  }
+
+  /**
+   * Restrict a BDD according to a given flow preference.
+   *
+   * @param bdd a BDD representing a set of packet headers
+   * @param preference a FlowPreference representing flow preference
+   * @return A BDD restricted to more preferred flows. Note that the return value is NOT a full
+   *     assignment.
+   */
+  public @Nonnull BDD getFlowBDD(BDD bdd, FlowPreference preference) {
+    if (bdd.isZero()) {
+      return bdd;
+    }
+    return BDDRepresentativePicker.pickRepresentative(
+        bdd, _flowConstraintGeneratorSupplier.get().generateFlowPreference(preference));
   }
 
   /**

--- a/projects/question/src/main/java/org/batfish/question/FilterQuestionUtils.java
+++ b/projects/question/src/main/java/org/batfish/question/FilterQuestionUtils.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDFlowConstraintGenerator.FlowPreference;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.datamodel.Configuration;
@@ -92,7 +93,7 @@ public final class FilterQuestionUtils {
     if (bdd.isZero()) {
       return Optional.empty();
     }
-    BDD assignment = bdd.fullSatOne();
+    BDD assignment = pkt.getFlowBDD(bdd, FlowPreference.TESTFILTER).fullSatOne();
     return Optional.of(
         pkt.getRepresentativeFlow(assignment)
             .setIngressNode(hostname)

--- a/projects/question/src/test/java/org/batfish/question/FilterQuestionUtilsTest.java
+++ b/projects/question/src/test/java/org/batfish/question/FilterQuestionUtilsTest.java
@@ -1,0 +1,28 @@
+package org.batfish.question;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+import org.batfish.common.bdd.BDDPacket;
+import org.batfish.common.bdd.BDDSourceManager;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.Ip;
+import org.junit.Test;
+
+public class FilterQuestionUtilsTest {
+  @Test
+  public void testGetFlowWithPreference() {
+    BDDPacket pkt = new BDDPacket();
+    Optional<Flow> maybeFlow =
+        FilterQuestionUtils.getFlow(
+            pkt, BDDSourceManager.empty(pkt), "foo", pkt.getFactory().one());
+    assertTrue(maybeFlow.isPresent());
+    Flow flow = maybeFlow.get();
+    assertThat(flow.getSrcIp(), not(equalTo(Ip.ZERO)));
+    assertThat(flow.getDstIp(), not(equalTo(Ip.ZERO)));
+    assertThat(flow.getIpProtocol().number(), not(equalTo(0)));
+  }
+}


### PR DESCRIPTION
Before it was only using fullSatOne, which leads to all zero bits.

To make this work I had to add a new API that preserves the BDD post-restriction, so that
caller can set the interface from the same assignment as the flow builder.