### PR TITLE
PAN: Parse and ignore application statements

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -323,6 +323,11 @@ DEAD_COUNTS
     'dead-counts'
 ;
 
+DEFAULT
+:
+    'default'
+;
+
 DEFAULT_GATEWAY
 :
     'default-gateway'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_application.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_application.g4
@@ -15,13 +15,44 @@ s_application_definition
 :
     name = variable
     (
-        sapp_description
+        sapp_category
+        | sapp_default_port
+        | sapp_description
+        | sapp_risk
+        | sapp_subcategory
+        | sapp_technology
     )?
+;
+
+sapp_category
+:
+    CATEGORY null_rest_of_line
+;
+
+sapp_default_port
+:
+    DEFAULT PORT null_rest_of_line
 ;
 
 sapp_description
 :
     DESCRIPTION description = value
+;
+
+sapp_risk
+:
+// 1-5
+  RISK uint8
+;
+
+sapp_subcategory
+:
+  SUBCATEGORY null_rest_of_line
+;
+
+sapp_technology
+:
+  TECHNOLOGY null_rest_of_line
 ;
 
 s_application_group

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_application.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_application.g4
@@ -15,13 +15,25 @@ s_application_definition
 :
     name = variable
     (
-        sapp_category
-        | sapp_default_port
-        | sapp_description
-        | sapp_risk
-        | sapp_subcategory
-        | sapp_technology
+        sapp_description
+        | sapp_ignored
     )?
+;
+
+sapp_description
+:
+    DESCRIPTION description = value
+;
+
+sapp_ignored
+:
+    (
+    sapp_category
+    | sapp_default_port
+    | sapp_risk
+    | sapp_subcategory
+    | sapp_technology
+)
 ;
 
 sapp_category
@@ -32,11 +44,6 @@ sapp_category
 sapp_default_port
 :
     DEFAULT PORT null_rest_of_line
-;
-
-sapp_description
-:
-    DESCRIPTION description = value
 ;
 
 sapp_risk

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -3164,7 +3164,7 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       _filedWarningApplicationStatementIgnored = true;
       warn(
           ctx,
-          "Application statements are not supported. Application effects will not be modeled.");
+          "Application definitions only affect App-ID, so Batfish ignores custom application definitions.");
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -226,7 +226,12 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_descriptionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_staticContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_tagContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sagd_filterContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_categoryContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_default_portContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_descriptionContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_riskContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_subcategoryContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_technologyContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sappg_definitionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sappg_membersContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sdg_descriptionContext;
@@ -437,6 +442,9 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   private PaloAltoCombinedParser _parser;
   private final String _text;
   private final Warnings _w;
+
+  /** Should file at most one warning about ignored application statements */
+  private boolean _filedWarningApplicationStatementIgnored = false;
 
   private AddressGroup _currentAddressGroup;
   private AddressObject _currentAddressObject;
@@ -1600,8 +1608,33 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   }
 
   @Override
+  public void exitSapp_category(Sapp_categoryContext ctx) {
+    fileWarningApplicationStatementIgnored(ctx);
+  }
+
+  @Override
+  public void exitSapp_default_port(Sapp_default_portContext ctx) {
+    fileWarningApplicationStatementIgnored(ctx);
+  }
+
+  @Override
   public void exitSapp_description(Sapp_descriptionContext ctx) {
     _currentApplication.setDescription(getText(ctx.description));
+  }
+
+  @Override
+  public void exitSapp_risk(Sapp_riskContext ctx) {
+    fileWarningApplicationStatementIgnored(ctx);
+  }
+
+  @Override
+  public void exitSapp_subcategory(Sapp_subcategoryContext ctx) {
+    fileWarningApplicationStatementIgnored(ctx);
+  }
+
+  @Override
+  public void exitSapp_technology(Sapp_technologyContext ctx) {
+    fileWarningApplicationStatementIgnored(ctx);
   }
 
   @Override
@@ -3147,6 +3180,15 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     } else {
       String msg = String.format("Unrecognized Line: %d: %s", line, lineText);
       _w.redFlag(msg + " SUBSEQUENT LINES MAY NOT BE PROCESSED CORRECTLY");
+    }
+  }
+
+  private void fileWarningApplicationStatementIgnored(ParserRuleContext ctx) {
+    if (!_filedWarningApplicationStatementIgnored) {
+      _filedWarningApplicationStatementIgnored = true;
+      warn(
+          ctx,
+          "Application statements are not supported. Application effects will not be modeled.");
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -3164,7 +3164,8 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       _filedWarningApplicationStatementIgnored = true;
       warn(
           ctx,
-          "Application definitions only affect App-ID, so Batfish ignores custom application definitions.");
+          "Application definitions only affect App-ID, so Batfish ignores custom application"
+              + " definitions.");
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -226,12 +226,8 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_descriptionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_staticContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sag_tagContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sagd_filterContext;
-import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_categoryContext;
-import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_default_portContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_descriptionContext;
-import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_riskContext;
-import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_subcategoryContext;
-import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_technologyContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sapp_ignoredContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sappg_definitionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sappg_membersContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sdg_descriptionContext;
@@ -1608,32 +1604,12 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   }
 
   @Override
-  public void exitSapp_category(Sapp_categoryContext ctx) {
-    fileWarningApplicationStatementIgnored(ctx);
-  }
-
-  @Override
-  public void exitSapp_default_port(Sapp_default_portContext ctx) {
-    fileWarningApplicationStatementIgnored(ctx);
-  }
-
-  @Override
   public void exitSapp_description(Sapp_descriptionContext ctx) {
     _currentApplication.setDescription(getText(ctx.description));
   }
 
   @Override
-  public void exitSapp_risk(Sapp_riskContext ctx) {
-    fileWarningApplicationStatementIgnored(ctx);
-  }
-
-  @Override
-  public void exitSapp_subcategory(Sapp_subcategoryContext ctx) {
-    fileWarningApplicationStatementIgnored(ctx);
-  }
-
-  @Override
-  public void exitSapp_technology(Sapp_technologyContext ctx) {
+  public void exitSapp_ignored(Sapp_ignoredContext ctx) {
     fileWarningApplicationStatementIgnored(ctx);
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -101,6 +101,7 @@ import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
@@ -123,6 +124,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -136,6 +138,7 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warning;
 import org.batfish.common.Warnings;
+import org.batfish.common.Warnings.ParseWarning;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.IpSpaceToBDD;
 import org.batfish.common.plugin.IBatfish;
@@ -699,6 +702,20 @@ public final class PaloAltoGrammarTest {
     assertThat(applications.get("app2").getDescription(), equalTo("this is a description"));
     assertThat(
         applications.get("app w spaces").getDescription(), equalTo("this is another description"));
+  }
+
+  @Test
+  public void testApplicationsIgnoredStatements() {
+    PaloAltoConfiguration c = parsePaloAltoConfig("application-ignored");
+
+    // Make sure the configured applications were discovered
+    assertThat(
+        c.getVirtualSystems().get(DEFAULT_VSYS_NAME).getApplications().keySet(), contains("APP1"));
+    assertThat(c.getVirtualSystems().get("vsys2").getApplications().keySet(), contains("APP2"));
+
+    // Should result in only one warning
+    ParseWarning warning = Iterables.getOnlyElement(c.getWarnings().getParseWarnings());
+    assertThat(warning.getComment(), containsStringIgnoringCase("application"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/application-ignored
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/application-ignored
@@ -1,0 +1,9 @@
+set deviceconfig system hostname application-ignored
+
+# Config should only have 1 parse warning for ignored application statements.
+set application APP1 default port tcp/1025
+set application APP1 category foo
+set application APP1 subcategory bar
+set application APP1 technology baz
+set application APP1 risk 1
+set vsys vsys2 application APP2 category spam


### PR DESCRIPTION
Parses and ignores the following statements in the `s_application_definition` context:
- `default port tcp/1025`
- `category foo`
- `subcategory bar`
- `technology baz`
- `risk 1`

If any such statements appear anywhere in a config, a single umbrella parse warning will be generated (rather than a warning for every such line).