### PR TITLE
PAN: parse and extract service tags

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_service.g4
@@ -19,6 +19,7 @@ s_service_definition
         | sserv_port
         | sserv_protocol
         | sserv_source_port
+        | sserv_tag
     )*
 ;
 
@@ -45,4 +46,9 @@ sserv_protocol
 sserv_source_port
 :
     SOURCE_PORT variable_port_list
+;
+
+sserv_tag
+:
+    TAG tags = variable_list
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -305,6 +305,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_descriptionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_portContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_protocolContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_source_portContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sserv_tagContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sservgrp_membersContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.St_commentsContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.St_descriptionContext;
@@ -2778,6 +2779,13 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
         assert item.range != null;
         _currentService.addSourcePorts(new SubRange(getText(item.range)));
       }
+    }
+  }
+
+  @Override
+  public void enterSserv_tag(Sserv_tagContext ctx) {
+    for (Variable_list_itemContext tag : variables(ctx.tags)) {
+      _currentService.addTag(getText(tag));
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Service.java
@@ -4,6 +4,8 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeServiceGroupMemberAclName;
 
 import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -93,16 +95,16 @@ public final class Service implements ServiceGroupMember {
 
   private final String _name;
   @Nullable private String _description;
-
   @Nullable private IpProtocol _protocol;
-
   @Nonnull private IntegerSpace _sourcePorts;
   @Nonnull private IntegerSpace _ports;
+  @Nonnull private final List<String> _tags;
 
   public Service(String name) {
     _name = name;
     _ports = IntegerSpace.EMPTY;
     _sourcePorts = IntegerSpace.EMPTY;
+    _tags = new ArrayList<>(1);
   }
 
   @Nullable
@@ -142,6 +144,15 @@ public final class Service implements ServiceGroupMember {
 
   public void setProtocol(IpProtocol protocol) {
     _protocol = protocol;
+  }
+
+  @Nonnull
+  public List<String> getTags() {
+    return _tags;
+  }
+
+  public void addTag(String tag) {
+    _tags.add(tag);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Service.java
@@ -4,8 +4,8 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.representation.palo_alto.PaloAltoConfiguration.computeServiceGroupMemberAclName;
 
 import com.google.common.collect.ImmutableList;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -98,13 +98,13 @@ public final class Service implements ServiceGroupMember {
   @Nullable private IpProtocol _protocol;
   @Nonnull private IntegerSpace _sourcePorts;
   @Nonnull private IntegerSpace _ports;
-  @Nonnull private final List<String> _tags;
+  @Nonnull private final Set<String> _tags;
 
   public Service(String name) {
     _name = name;
     _ports = IntegerSpace.EMPTY;
     _sourcePorts = IntegerSpace.EMPTY;
-    _tags = new ArrayList<>(1);
+    _tags = new HashSet<>();
   }
 
   @Nullable
@@ -147,7 +147,7 @@ public final class Service implements ServiceGroupMember {
   }
 
   @Nonnull
-  public List<String> getTags() {
+  public Set<String> getTags() {
     return _tags;
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -2607,6 +2607,17 @@ public final class PaloAltoGrammarTest {
     IpAccessList sg1 = c.getIpAccessLists().get(serviceGroup1AclName);
     AclLine line1 = sg1.getLines().get(0);
     assertThat(line1.getName(), equalTo(service1.getSourceName()));
+
+    // Verify VS tags
+    PaloAltoConfiguration vsConfig = parsePaloAltoConfig(hostname);
+    assertThat(
+        vsConfig
+            .getVirtualSystems()
+            .get(DEFAULT_VSYS_NAME)
+            .getServices()
+            .get("SERVICE 4")
+            .getTags(),
+        contains("TAG"));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/service
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/service
@@ -4,6 +4,7 @@ set service SERVICE1 protocol tcp port 1
 set service SERVICE2 protocol udp source-port 4,5-9
 set service SERVICE3 protocol udp port 5,6 source-port 9,10
 set service "SERVICE 4" protocol sctp
+set service "SERVICE 4" tag TAG
 
 set service-group SG1 members [ SERVICE1 SERVICE2 ]
 set service-group "SG 2" members [ SG1 SERVICE_UNDEFINED ]


### PR DESCRIPTION
This does not affect analysis, but is a QOL improvement that can trim down a number of parse warnings