### PR TITLE
Batfish: unusableVlanShutdown should only count active interfaces

### DIFF
--- a/projects/batfish/BUILD
+++ b/projects/batfish/BUILD
@@ -19,6 +19,7 @@ java_library(
     runtime_deps = [
         "//projects/question",
         "@maven//:io_jaegertracing_jaeger_thrift",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
     ],
     deps = [
         "//projects/batfish-common-protocol:common",

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -880,7 +880,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
       Integer vlanNumber = null;
       // Populate vlanInterface and nonVlanInterfaces, and initialize
       // vlanMemberCounts:
-      for (Interface iface : c.getAllInterfaces().values()) {
+      for (Interface iface : c.getActiveInterfaces().values()) {
         if ((iface.getInterfaceType() == InterfaceType.VLAN)
             && ((vlanNumber = CommonUtil.getInterfaceVlanNumber(iface.getName())) != null)) {
           vlanInterfaces.put(vlanNumber, iface);

--- a/projects/batfish/src/test/java/org/batfish/main/VlanInterfacesTest.java
+++ b/projects/batfish/src/test/java/org/batfish/main/VlanInterfacesTest.java
@@ -1,0 +1,40 @@
+package org.batfish.main;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+import org.batfish.common.plugin.IBatfish;
+import org.batfish.datamodel.Configuration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class VlanInterfacesTest {
+  private static final String TESTCONFIGS_PREFIX = "org/batfish/main/testconfigs/";
+  @Rule public TemporaryFolder _folder = new TemporaryFolder();
+
+  private Configuration parseConfig(String hostname) {
+    try {
+      IBatfish batfish =
+          BatfishTestUtils.getBatfishForTextConfigs(_folder, TESTCONFIGS_PREFIX + hostname);
+      Map<String, Configuration> configs = batfish.loadConfigurations(batfish.getSnapshot());
+      assertThat(configs, hasKey(hostname.toLowerCase()));
+      return configs.get(hostname.toLowerCase());
+    } catch (IOException e) {
+      throw new AssertionError("Failed to parse " + hostname, e);
+    }
+  }
+
+  /** Tests Batfish#disableUnusableVlanInterfaces. */
+  @Test
+  public void testDisableUnusableInterfaces() {
+    Configuration c = parseConfig("vlan");
+    assertThat(
+        c.getAllInterfaces().keySet(),
+        containsInAnyOrder("Ethernet1", "Ethernet2", "Vlan1", "Vlan2"));
+    assertThat(c.getActiveInterfaces().keySet(), containsInAnyOrder("Ethernet1", "Vlan1"));
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/vlan
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/vlan
@@ -1,0 +1,19 @@
+!RANCID-CONTENT-TYPE: cisco
+hostname vlan
+!
+interface Vlan1
+  no shutdown
+!
+interface Ethernet1
+  no shutdown
+  switchport mode access
+  switchport access vlan 1
+!
+interface Vlan2
+  no shutdown
+!
+interface Ethernet2
+  shutdown
+  switchport mode access
+  switchport access vlan 2
+!


### PR DESCRIPTION
If an interface is shutdown, it will not keep a Vlan up. (The autostate flag is
still supported below).