### PR TITLE
Juniper: fix handling of "all" interface in OSPF area config

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -2860,6 +2860,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     name = ctx.name.getText();
     _currentRoutingInstance =
         _currentLogicalSystem.getRoutingInstances().computeIfAbsent(name, RoutingInstance::new);
+    _currentRoutingInstance.getGlobalMasterInterface().setParent(_currentMasterInterface);
     _configuration.defineFlattenedStructure(ROUTING_INSTANCE, name, ctx, _parser);
   }
 
@@ -5106,6 +5107,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void exitRi_interface(Ri_interfaceContext ctx) {
     Interface iface = initInterface(ctx.id);
     iface.setRoutingInstance(_currentRoutingInstance.getName());
+    iface.setParent(_currentRoutingInstance.getGlobalMasterInterface());
     _configuration.referenceStructure(
         INTERFACE, iface.getName(), ROUTING_INSTANCE_INTERFACE, getLine(ctx.id.getStop()));
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5784,4 +5784,16 @@ public final class FlatJuniperGrammarTest {
         hasInterface(
             "et-0/0/0.0", hasAllowedVlans(equalTo(IntegerSpace.of(Range.closed(1, 4094))))));
   }
+
+  /**
+   * Test that interfaces inherit OSPF properties from the virtual master interface inside a routing
+   * instance
+   */
+  @Test
+  public void testOspfInterfaceAllInRoutingInstanceInheritance() {
+    String hostname = "ospf-area-interface-all";
+    Configuration c = parseConfig(hostname);
+    assertThat(c, hasInterface("ge-0/0/0.0", hasOspfCost(equalTo(111))));
+    assertThat(c, hasInterface("ge-0/0/1.0", hasOspfCost(equalTo(111))));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-area-interface-all
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/ospf-area-interface-all
@@ -1,0 +1,10 @@
+#
+set system host-name ospf-area-interface-all
+#
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/31
+set interfaces ge-0/0/1 unit 0 family inet address 10.0.1.2/31
+#
+set routing-instances ri instance-type forwarding
+set routing-instances ri interface ge-0/0/0.0
+set routing-instances ri interface ge-0/0/1.0
+set routing-instances ri protocols ospf area 0 interface all metric 111


### PR DESCRIPTION
Previously we did not correctly inherit from the routing instance's master interface.
This inserts that interface into the inheritance tree.

Note this does not attempt to fix inheritance for fields that should be
inherited, but are not.