### PR TITLE
IOSXE: recognize vasi left/right as valid interface prefixes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -316,6 +316,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
           .put("TwentyFiveGigE", "TwentyFiveGigE")
           .put("TwentyFiveGigabitEthernet", "TwentyFiveGigE")
           .put("TwoGigabitEthernet", "TwoGigabitEthernet")
+          .put("vasileft", "vasileft")
+          .put("vasiright", "vasiright")
           .put("ve", "VirtualEthernet")
           .put("VirtualEthernet", "VirtualEthernet")
           .put("Virtual-Template", "Virtual-Template")

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -6275,4 +6275,11 @@ public final class CiscoGrammarTest {
         outside,
         equalTo(new FirewallSessionInterfaceInfo(true, ImmutableSet.of("outside"), null, null)));
   }
+
+  @Test
+  public void testVasiInterface() throws IOException {
+    Configuration c = parseConfig("iosxe-vasi-interface");
+    assertThat(c, hasInterface("vasileft1", hasAddress("1.1.1.2/31")));
+    assertThat(c, hasInterface("vasiright1", hasAddress("1.1.1.3/31")));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/iosxe-vasi-interface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/iosxe-vasi-interface
@@ -1,0 +1,9 @@
+!
+hostname iosxe-vasi-interface
+!
+interface vasileft1
+  description left
+  ip address 1.1.1.2/31
+interface vasiright1
+  description right
+  ip address 1.1.1.3/31


### PR DESCRIPTION
Used for cross-vrf nat on IOS XE: https://www.cisco.com/c/en/us/support/docs/ip/network-address-translation-nat/200255-Configure-VRF-Aware-Software-Infrastruct.html