### PR TITLE
CI: don't fail build if codecov is down

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -164,4 +164,5 @@ cat <<EOF
           download:
             - "workspace/**/jacoco.exec"
             - "workspace/allinone.jar"
+    soft_fail: true
 EOF


### PR DESCRIPTION
Over the weekend, codecov was down and all our builds failed. Let this step
soft-fail.

```
+ bash /dev/fd/63 -t 59baa5fe-139e-4aef-80a7-b40bfaa3fc67
++ curl -s https://codecov.io/bash
/dev/fd/63: line 2: syntax error near unexpected token `<'
/dev/fd/63: line 2: `<html><head>'
```