### PR TITLE
IOS: better parsing for VRF definition

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoParser.g4
@@ -1883,6 +1883,22 @@ vrfd_af_export
    NEWLINE
 ;
 
+vrfd_af_import
+:
+   IMPORT
+   vrfd_af_import_map
+;
+
+vrfd_af_import_map
+:
+   MAP name = variable NEWLINE
+;
+
+vrfd_af_route_target
+:
+   ROUTE_TARGET type = both_export_import rt = route_target NEWLINE
+;
+
 vrfd_af_null
 :
    NO?
@@ -3401,6 +3417,7 @@ s_vrf_definition
       vrfd_address_family
       | vrfd_description
       | vrfd_rd
+      | vrfd_route_target
       | vrfd_null
    )*
    (
@@ -4634,62 +4651,6 @@ vpn_null
    ) null_rest_of_line
 ;
 
-vrfc_address_family
-:
-   ADDRESS_FAMILY (IPV4 | IPV6) UNICAST NEWLINE
-   (
-      vrfc_route_target
-   )*
-;
-
-vrfc_ip_route
-:
-   IP ROUTE ip_route_tail
-;
-
-vrfc_rd
-:
-   RD (AUTO | route_distinguisher) NEWLINE
-;
-
-vrfc_route_target
-:
-   ROUTE_TARGET (IMPORT | EXPORT | BOTH) (AUTO | route_target) EVPN? NEWLINE
-;
-
-vrfc_shutdown
-:
-   NO? SHUTDOWN NEWLINE
-;
-
-vrfc_vni
-:
-   VNI vni = DEC NEWLINE
-;
-
-
-vrfc_null
-:
-   NO?
-   (
-      (
-         IP
-         (
-            AMT
-            | AUTO_DISCARD
-            | DOMAIN_LIST
-            | DOMAIN_NAME
-            | IGMP
-            | MROUTE
-            | MSDP
-            | NAME_SERVER
-            | PIM
-         )
-      )
-      | MDT
-   ) null_rest_of_line
-;
-
 vrfd_address_family
 :
    ADDRESS_FAMILY
@@ -4706,7 +4667,9 @@ vrfd_address_family
    )? NEWLINE
    (
       vrfd_af_export
+      | vrfd_af_import
       | vrfd_af_null
+      | vrfd_af_route_target
    )*
    (
       EXIT_ADDRESS_FAMILY NEWLINE
@@ -4723,12 +4686,16 @@ vrfd_rd
    RD (AUTO | rd = route_distinguisher) NEWLINE
 ;
 
+vrfd_route_target
+:
+   ROUTE_TARGET type = both_export_import rt = route_target NEWLINE
+;
+
 vrfd_null
 :
    NO?
    (
       AUTO_IMPORT
-      | ROUTE_TARGET
    ) null_rest_of_line
 ;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_common.g4
@@ -26,6 +26,13 @@ bgp_asn
     | asn4b = FLOAT // DEC.DEC , but this lexes as FLOAT
 ;
 
+both_export_import
+:
+  BOTH
+  | EXPORT
+  | IMPORT
+;
+
 community
 :
    ACCEPT_OWN

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ignored.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_ignored.g4
@@ -456,7 +456,6 @@ null_inner
       | PROVISION
       | RANDOM
       | RANDOM_DETECT
-      | RD
       | REACT
       | REAL
       | RECEIVE
@@ -471,7 +470,6 @@ null_inner
       | RETRIES
       | REVISION
       | RING
-      | ROUTE_TARGET
       | RP_ADDRESS
       | SA_FILTER
       | SATELLITE
@@ -861,11 +859,9 @@ null_single
       | QUIT
       | RADIUS_COMMON_PW
       | RADIUS_SERVER
-      | RD
       | RESOURCE
       | RESOURCE_POOL
       | NO ROUTE
-      | ROUTE_TARGET
       | RTR
       | SAT
       | SCHEDULE

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -986,12 +986,10 @@ import org.batfish.grammar.cisco.CiscoParser.Viafv_preemptContext;
 import org.batfish.grammar.cisco.CiscoParser.Viafv_priorityContext;
 import org.batfish.grammar.cisco.CiscoParser.Vlan_idContext;
 import org.batfish.grammar.cisco.CiscoParser.Vrf_block_rb_stanzaContext;
-import org.batfish.grammar.cisco.CiscoParser.Vrfc_rdContext;
-import org.batfish.grammar.cisco.CiscoParser.Vrfc_route_targetContext;
-import org.batfish.grammar.cisco.CiscoParser.Vrfc_shutdownContext;
-import org.batfish.grammar.cisco.CiscoParser.Vrfc_vniContext;
 import org.batfish.grammar.cisco.CiscoParser.Vrfd_af_exportContext;
 import org.batfish.grammar.cisco.CiscoParser.Vrfd_descriptionContext;
+import org.batfish.grammar.cisco.CiscoParser.Vrfd_rdContext;
+import org.batfish.grammar.cisco.CiscoParser.Vrfd_route_targetContext;
 import org.batfish.grammar.cisco.CiscoParser.Vrrp_interfaceContext;
 import org.batfish.grammar.cisco.CiscoParser.Wccp_idContext;
 import org.batfish.grammar.cisco.CiscoParser.Zp_service_policy_inspectContext;
@@ -3535,37 +3533,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
       username = unquote(ctx.quoted_user.getText());
     }
     _currentUser = _configuration.getCf().getUsers().computeIfAbsent(username, User::new);
-  }
-
-  @Override
-  public void exitVrfc_rd(Vrfc_rdContext ctx) {
-    if (ctx.AUTO() == null) {
-      currentVrf().setRouteDistinguisher(toRouteDistinguisher(ctx.route_distinguisher()));
-    }
-  }
-
-  @Override
-  public void exitVrfc_route_target(Vrfc_route_targetContext ctx) {
-    ExtendedCommunity rt = ctx.AUTO() != null ? null : toRouteTarget(ctx.route_target());
-    if (ctx.IMPORT() != null || ctx.BOTH() != null) {
-      currentVrf().setRouteImportTarget(rt);
-    }
-    if (ctx.EXPORT() != null || ctx.BOTH() != null) {
-      currentVrf().setRouteExportTarget(rt);
-    }
-  }
-
-  @Override
-  public void exitVrfc_shutdown(Vrfc_shutdownContext ctx) {
-    if (ctx.NO() == null) {
-      todo(ctx);
-    }
-    currentVrf().setShutdown(ctx.NO() != null);
-  }
-
-  @Override
-  public void exitVrfc_vni(Vrfc_vniContext ctx) {
-    currentVrf().setVni(toInteger(ctx.vni));
   }
 
   @Override
@@ -8649,6 +8616,20 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitS_vrf_definition(S_vrf_definitionContext ctx) {
     _currentVrf = Configuration.DEFAULT_VRF_NAME;
+  }
+
+  @Override
+  public void exitVrfd_rd(Vrfd_rdContext ctx) {
+    currentVrf().setRouteDistinguisher(toRouteDistinguisher(ctx.rd));
+  }
+
+  @Override
+  public void exitVrfd_route_target(Vrfd_route_targetContext ctx) {
+    if (ctx.type.BOTH() != null || ctx.type.IMPORT() != null) {
+      currentVrf().setRouteImportTarget(toRouteTarget(ctx.rt));
+    } else if (ctx.type.BOTH() != null || ctx.type.EXPORT() != null) {
+      currentVrf().setRouteExportTarget(toRouteTarget(ctx.rt));
+    }
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -345,7 +345,9 @@ import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.bgp.BgpConfederation;
 import org.batfish.datamodel.bgp.BgpTopologyUtils;
+import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.Community;
+import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.eigrp.ClassicMetric;
 import org.batfish.datamodel.eigrp.EigrpMetric;
@@ -3453,9 +3455,18 @@ public final class CiscoGrammarTest {
   }
 
   @Test
-  public void testIosVrfDefinition() throws IOException {
-    // Don't crash
-    parseConfig("ios-vrf-definition");
+  public void testIosVrfDefinition() {
+    CiscoConfiguration vc = parseCiscoConfig("ios-vrf-definition", ConfigurationFormat.CISCO_IOS);
+    assertThat(
+        vc.getVrfs().get("vrf1").getRouteDistinguisher(),
+        equalTo(RouteDistinguisher.from(1111, 11L)));
+    assertThat(
+        vc.getVrfs().get("vrf1").getRouteImportTarget(),
+        equalTo(ExtendedCommunity.target(2222, 22)));
+    assertThat(
+        vc.getVrfs().get("vrf1").getRouteExportTarget(),
+        equalTo(ExtendedCommunity.target(2222, 23)));
+    // TODO: extract (and test) RD/RT config at address family level
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -3453,6 +3453,12 @@ public final class CiscoGrammarTest {
   }
 
   @Test
+  public void testIosVrfDefinition() throws IOException {
+    // Don't crash
+    parseConfig("ios-vrf-definition");
+  }
+
+  @Test
   public void testIosZoneSecurity() throws IOException {
     String hostname = "ios-zone-security";
     String filename = "configs/" + hostname;

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-vrf-definition
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-vrf-definition
@@ -1,0 +1,19 @@
+!
+hostname ios-vrf-definition
+!
+route-map RT_MAP permit 10
+!
+vrf definition vrf1
+   rd 1111:11
+   route-target both 2222:21
+   route-target import 2222:22
+   route-target export 2222:23
+   address-family ipv4
+      import map RT_MAP
+      export map RT_MAP
+      export ipv4 unicast 500 map RT_MAP
+      route-target both 3333:31
+      route-target import 3333:32
+      route-target export 3333:33
+   exit-address-family
+!


### PR DESCRIPTION
* Remove old unused grammar
* Parse RD/RT with custom rules instead of null rules

`vfc_*` rules (I believe) were left over from pre-NXOS split days.
No conversion necessary (yet) since we do not support VPNv4/MPLS address family.