### PR TITLE
NXOS: parse more ip sla constructs

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
@@ -1567,6 +1567,11 @@ FRAGMENTS
   'fragments'
 ;
 
+FREQUENCY
+:
+  'frequency'
+;
+
 FTP_DATA
 :
   'ftp-data'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosParser.g4
@@ -248,11 +248,15 @@ ip_sla_entry
 :
   (
     DNS
+    | FREQUENCY
     | HTTP
     | ICMP_ECHO
     | TCP_CONNECT
+    | THRESHOLD
+    | TIMEOUT
     | UDP_ECHO
     | UDP_JITTER
+    | VRF
   ) null_rest_of_line
 ;
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ip_sla
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ip_sla
@@ -9,6 +9,10 @@ ip sla 30
   tcp-connect 1.1.1.1 5555 control enable
   udp-echo example.com 45555 control disable source-ip 2.2.2.2 source-port 5555
   udp-jitter example.com 5555 codec g729a codec-numpackets 8888 codec-size 67 advantage-factor 3 control enable source-ip 1.1.1.1 source-port 4444
+  vrf ext
+  threshold 1000
+  timeout 1000
+  frequency 2
 ip sla schedule 30 life forever start-time now
 ip sla reaction-trigger 45 46
 ip sla reaction-configuration 30 react connectionLoss threshold-type consecutive 3 action-type triggerOnly


### PR DESCRIPTION
The "vrf x" was really tripping up our parser; Added other keywords while at it