### PR TITLE
NXOS: fixup bgp allowas-in extraction

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -3781,12 +3781,9 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     /*
     Default value for allowas-in, if unspecified, is 3
     https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/7-x/command_references/configuration_commands/b_Using_N9K_Config_Commands/b_N9K_Bookmap_chapter_00.html#wp2015222148
-     */
-    _currentBgpVrfNeighborAddressFamily.setAllowAsIn(
-        ctx.num == null
-            ? 3
-            // if new value is invalid, keep old value
-            : toInteger(ctx, ctx.num).orElse(_currentBgpVrfNeighborAddressFamily.getAllowAsIn()));
+    */
+    Optional<Integer> value = ctx.num == null ? Optional.of(3) : toInteger(ctx, ctx.num);
+    value.ifPresent(_currentBgpVrfNeighborAddressFamily::setAllowAsIn);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -3783,7 +3783,10 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/7-x/command_references/configuration_commands/b_Using_N9K_Config_Commands/b_N9K_Bookmap_chapter_00.html#wp2015222148
      */
     _currentBgpVrfNeighborAddressFamily.setAllowAsIn(
-        ctx.num == null ? 3 : toInteger(ctx, ctx.num).orElse(null));
+        ctx.num == null
+            ? 3
+            // if new value is invalid, keep old value
+            : toInteger(ctx, ctx.num).orElse(_currentBgpVrfNeighborAddressFamily.getAllowAsIn()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -268,6 +268,7 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4udp_port_specContex
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4udp_port_spec_literalContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4udp_port_spec_port_groupContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Acllal4udp_source_portContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Allowas_in_max_occurrencesContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.As_path_regexContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Banner_execContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Banner_motdContext;
@@ -813,6 +814,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     implements BatfishListener {
 
   private static final IntegerSpace BANDWIDTH_RANGE = IntegerSpace.of(Range.closed(1, 100_000_000));
+  private static final IntegerSpace BGP_ALLOWAS_IN = IntegerSpace.of(Range.closed(1, 10));
   private static final LongSpace BGP_ASN_RANGE = LongSpace.of(Range.closed(1L, 4294967295L));
   private static final IntegerSpace BGP_EBGP_MULTIHOP_TTL_RANGE =
       IntegerSpace.of(Range.closed(2, 255));
@@ -3776,10 +3778,12 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
 
   @Override
   public void exitRb_n_af_allowas_in(Rb_n_af_allowas_inContext ctx) {
-    if (ctx.num != null) {
-      todo(ctx);
-    }
-    _currentBgpVrfNeighborAddressFamily.setAllowAsIn(true);
+    /*
+    Default value for allowas-in, if unspecified, is 3
+    https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/7-x/command_references/configuration_commands/b_Using_N9K_Config_Commands/b_N9K_Bookmap_chapter_00.html#wp2015222148
+     */
+    _currentBgpVrfNeighborAddressFamily.setAllowAsIn(
+        ctx.num == null ? 3 : toInteger(ctx, ctx.num).orElse(null));
   }
 
   @Override
@@ -6334,6 +6338,11 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   private @Nonnull Optional<Integer> toInteger(
       ParserRuleContext messageCtx, Tcp_flags_maskContext ctx) {
     return toIntegerInSpace(messageCtx, ctx, TCP_FLAGS_MASK_RANGE, "tcp-flags-mask");
+  }
+
+  private Optional<Integer> toInteger(
+      ParserRuleContext messageCtx, Allowas_in_max_occurrencesContext ctx) {
+    return toIntegerInSpace(messageCtx, ctx, BGP_ALLOWAS_IN, "bgp allowas-in");
   }
 
   private int toInteger(Tcp_port_numberContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/BgpVrfNeighborAddressFamilyConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/BgpVrfNeighborAddressFamilyConfiguration.java
@@ -19,11 +19,11 @@ public final class BgpVrfNeighborAddressFamilyConfiguration implements Serializa
   }
 
   @Nullable
-  public Boolean getAllowAsIn() {
+  public Integer getAllowAsIn() {
     return _allowAsIn;
   }
 
-  public void setAllowAsIn(@Nullable Boolean allowAsIn) {
+  public void setAllowAsIn(@Nullable Integer allowAsIn) {
     _allowAsIn = allowAsIn;
   }
 
@@ -139,7 +139,7 @@ public final class BgpVrfNeighborAddressFamilyConfiguration implements Serializa
     _suppressInactive = suppressInactive;
   }
 
-  private @Nullable Boolean _allowAsIn;
+  private @Nullable Integer _allowAsIn;
   private @Nullable Boolean _asOverride;
   private @Nullable Boolean _defaultOriginate;
   private @Nullable String _defaultOriginateMap;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -710,7 +710,7 @@ final class Conversions {
       BgpVrfNeighborAddressFamilyConfiguration naf, boolean inheritedSupressInactive) {
     return AddressFamilyCapabilities.builder()
         .setAdvertiseInactive(!firstNonNull(naf.getSuppressInactive(), inheritedSupressInactive))
-        .setAllowLocalAsIn(firstNonNull(naf.getAllowAsIn(), Boolean.FALSE))
+        .setAllowLocalAsIn(firstNonNull(naf.getAllowAsIn(), 0) > 0)
         .setAllowRemoteAsOut(firstNonNull(naf.getDisablePeerAsCheck(), Boolean.FALSE))
         .setSendCommunity(firstNonNull(naf.getSendCommunityStandard(), Boolean.FALSE))
         .setSendExtendedCommunity(firstNonNull(naf.getSendCommunityExtended(), Boolean.FALSE))

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -7543,4 +7543,37 @@ public final class CiscoNxosGrammarTest {
   public void testWordLexing() {
     assertThat(parseVendorConfig("nxos_word"), notNullValue());
   }
+
+  @Test
+  public void testBgpAllowAsInExtraction() {
+    String hostname = "nxos_bgp_allowas_in";
+    CiscoNxosConfiguration vc = parseVendorConfig(hostname);
+    assertThat(
+        vc.getBgpGlobalConfiguration()
+            .getVrfs()
+            .get(DEFAULT_VRF_NAME)
+            .getNeighbors()
+            .get(Ip.parse("1.1.1.1"))
+            .getIpv4UnicastAddressFamily()
+            .getAllowAsIn(),
+        equalTo(3));
+    assertThat(
+        vc.getBgpGlobalConfiguration()
+            .getVrfs()
+            .get(DEFAULT_VRF_NAME)
+            .getNeighbors()
+            .get(Ip.parse("2.2.2.2"))
+            .getIpv4UnicastAddressFamily()
+            .getAllowAsIn(),
+        equalTo(2));
+    assertThat(
+        vc.getBgpGlobalConfiguration()
+            .getVrfs()
+            .get(DEFAULT_VRF_NAME)
+            .getNeighbors()
+            .get(Ip.parse("3.3.3.3"))
+            .getIpv4UnicastAddressFamily()
+            .getAllowAsIn(),
+        nullValue());
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_bgp_allowas_in
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_bgp_allowas_in
@@ -1,0 +1,18 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_bgp_allowas_in
+feature bgp
+!
+router bgp 1
+  neighbor 1.1.1.1
+      remote-as 2
+      address-family ipv4 unicast
+          allowas-in
+  neighbor 2.2.2.2
+      remote-as 2
+      address-family ipv4 unicast
+          allowas-in 2
+  neighbor 3.3.3.3
+      remote-as 2
+      address-family ipv4 unicast
+!


### PR DESCRIPTION
Stop warning that the feature is unsupported; plumb though full extraction, convert to the best of VI abilities