### PR TITLE
Arista: improve route-map parsing on older EOS

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/Legacy_routemap.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/Legacy_routemap.g4
@@ -208,7 +208,8 @@ rm_stanza
 
 route_map_stanza
 :
-   ROUTE_MAP name = variable rmt = access_list_action num = DEC NEWLINE
+   // Both action and number are optional but number must come with action
+   ROUTE_MAP name = variable (rmt = access_list_action (num = DEC)?)? NEWLINE
    rm_stanza*
 ;
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
@@ -3717,8 +3717,8 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
     String name = ctx.name.getText();
     RouteMap routeMap = _configuration.getRouteMaps().computeIfAbsent(name, RouteMap::new);
     _currentRouteMap = routeMap;
-    int num = toInteger(ctx.num);
-    LineAction action = toLineAction(ctx.rmt);
+    int num = ctx.num != null ? toInteger(ctx.num) : 10;
+    LineAction action = ctx.rmt != null ? toLineAction(ctx.rmt) : LineAction.PERMIT;
     RouteMapClause clause = _currentRouteMap.getClauses().get(num);
     if (clause == null) {
       clause = new RouteMapClause(action, name, num);
@@ -3730,6 +3730,8 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
               "Route map '%s' already contains clause numbered '%d'. Duplicate clause will be"
                   + " merged with original clause.",
               _currentRouteMap.getName(), num));
+      // Yes, action can change if the line is reconfigured.
+      clause.setAction(action);
     }
     _currentRouteMapClause = clause;
     _configuration.defineStructure(ROUTE_MAP, name, ctx);

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/RouteMapClause.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/RouteMapClause.java
@@ -3,11 +3,12 @@ package org.batfish.representation.arista;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.LineAction;
 
 public class RouteMapClause implements Serializable {
 
-  private LineAction _action;
+  private @Nonnull LineAction _action;
 
   private RouteMapContinue _continueLine;
 
@@ -21,7 +22,7 @@ public class RouteMapClause implements Serializable {
 
   private List<RouteMapSetLine> _setList;
 
-  public RouteMapClause(LineAction action, String name, int num) {
+  public RouteMapClause(@Nonnull LineAction action, String name, int num) {
     _action = action;
     _mapName = name;
     _seqNum = num;
@@ -37,7 +38,7 @@ public class RouteMapClause implements Serializable {
     _setList.add(line);
   }
 
-  public LineAction getAction() {
+  public @Nonnull LineAction getAction() {
     return _action;
   }
 
@@ -63,6 +64,10 @@ public class RouteMapClause implements Serializable {
 
   public List<RouteMapSetLine> getSetList() {
     return _setList;
+  }
+
+  public void setAction(@Nonnull LineAction action) {
+    _action = action;
   }
 
   public void setContinueLine(RouteMapContinue continueLine) {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/route_map
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/route_map
@@ -4,3 +4,15 @@ hostname route_map
 !
 route-map map1 permit 1
  set local-preference 4294967295
+!
+! The below was reported on Batfish Slack. It's for an older version of EOS: 4.20.7
+route-map DANAIL_PETROV_20201103
+  match ip address prefix-list PL_DANAIL_PETROV_20201103
+  set community 12345:54321
+!
+route-map ACTION_CHANGES permit 10
+  match ip address prefix-list SOME_PL
+!
+route-map ACTION_CHANGES deny
+  set community 12345:54321
+!


### PR DESCRIPTION
As reported by @dannypetrov, EOS 4.20.7 does not include action/line number
in output (in at least some cases). The new tests are based on behavior during
that discussion.