### PR TITLE
NXOS: support VRF nameservers

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_vrf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_vrf.g4
@@ -73,6 +73,7 @@ vc_ip
   IP
   (
     ip_route
+    | ip_name_server
     | vc_ip_null
   )
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -189,7 +189,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.Table;
 import com.google.common.primitives.Ints;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -432,6 +431,7 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Maximum_pathsContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Monitor_session_destinationContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Monitor_session_source_interfaceContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Monitor_session_source_vlanContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Name_serverContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.No_sysds_shutdownContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.No_sysds_switchportContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Ntp_serverContext;
@@ -742,6 +742,7 @@ import org.batfish.representation.cisco_nxos.Layer3Options;
 import org.batfish.representation.cisco_nxos.LiteralIpAddressSpec;
 import org.batfish.representation.cisco_nxos.LiteralPortSpec;
 import org.batfish.representation.cisco_nxos.LoggingServer;
+import org.batfish.representation.cisco_nxos.NameServer;
 import org.batfish.representation.cisco_nxos.NtpServer;
 import org.batfish.representation.cisco_nxos.Nve;
 import org.batfish.representation.cisco_nxos.Nve.HostReachabilityProtocol;
@@ -2015,19 +2016,17 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
 
   @Override
   public void exitIp_name_server(Ip_name_serverContext ctx) {
-    String vrf;
+    String useVrf = null;
     if (ctx.vrf != null) {
       Optional<String> vrfOrErr = toString(ctx, ctx.vrf);
       if (!vrfOrErr.isPresent()) {
         return;
       }
-      vrf = vrfOrErr.get();
-    } else {
-      vrf = DEFAULT_VRF_NAME;
+      useVrf = vrfOrErr.get();
     }
-    List<String> existingServers =
-        _c.getIpNameServersByUseVrf().computeIfAbsent(vrf, v -> new LinkedList<>());
-    ctx.servers.stream().map(ParserRuleContext::getText).forEach(existingServers::add);
+    for (Name_serverContext server : ctx.servers) {
+      _currentVrf.addNameServer(new NameServer(getFullText(server), useVrf));
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -400,7 +400,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   private final @Nonnull Map<String, IpAsPathAccessList> _ipAsPathAccessLists;
   private final @Nonnull Map<String, IpCommunityList> _ipCommunityLists;
   private @Nullable String _ipDomainName;
-  private Map<String, List<String>> _ipNameServersByUseVrf;
   private final @Nonnull Map<String, IpPrefixList> _ipPrefixLists;
   private final @Nonnull Map<String, Ipv6AccessList> _ipv6AccessLists;
   private final @Nonnull Map<String, Ipv6PrefixList> _ipv6PrefixLists;
@@ -435,7 +434,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     _ipAccessLists = new HashMap<>();
     _ipAsPathAccessLists = new HashMap<>();
     _ipCommunityLists = new HashMap<>();
-    _ipNameServersByUseVrf = new HashMap<>();
     _ipPrefixLists = new HashMap<>();
     _ipv6AccessLists = new HashMap<>();
     _ipv6PrefixLists = new HashMap<>();
@@ -1029,8 +1027,10 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
   private void convertIpNameServers() {
     _c.setDnsServers(
-        _ipNameServersByUseVrf.values().stream()
+        _vrfs.values().stream()
+            .map(Vrf::getNameServers)
             .flatMap(Collection::stream)
+            .map(NameServer::getName)
             .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder())));
   }
 
@@ -1439,10 +1439,6 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
   public @Nullable String getIpDomainName() {
     return _ipDomainName;
-  }
-
-  public @Nonnull Map<String, List<String>> getIpNameServersByUseVrf() {
-    return _ipNameServersByUseVrf;
   }
 
   public @Nonnull Map<String, IpPrefixList> getIpPrefixLists() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/NameServer.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/NameServer.java
@@ -1,0 +1,56 @@
+package org.batfish.representation.cisco_nxos;
+
+import com.google.common.base.MoreObjects;
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * Name server configuration. Contains ipv4 or ipv6 address of the nameserver, and what VRF to use
+ * for fallback name resolution.
+ */
+@ParametersAreNonnullByDefault
+public final class NameServer implements Serializable {
+
+  public NameServer(String name, @Nullable String useVrf) {
+    _ip = name;
+    _useVrf = useVrf;
+  }
+
+  public String getName() {
+    return _ip;
+  }
+
+  /** VRF to use for fallback name resolution */
+  @Nullable
+  public String getUseVrf() {
+    return _useVrf;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof NameServer)) {
+      return false;
+    }
+    NameServer that = (NameServer) o;
+    return _ip.equals(that._ip) && Objects.equals(_useVrf, that._useVrf);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_ip, _useVrf);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("ip", _ip).add("useVrf", _useVrf).toString();
+  }
+
+  @Nonnull private final String _ip;
+  @Nullable private final String _useVrf;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Vrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Vrf.java
@@ -3,7 +3,9 @@ package org.batfish.representation.cisco_nxos;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -22,6 +24,7 @@ public final class Vrf implements Serializable {
     _name = name;
     _id = id;
     _addressFamilies = new HashMap<>();
+    _nameServers = new ArrayList<>(1);
     _staticRoutes = HashMultimap.create();
   }
 
@@ -43,6 +46,19 @@ public final class Vrf implements Serializable {
    */
   public int getId() {
     return _id;
+  }
+
+  @Nonnull
+  public List<NameServer> getNameServers() {
+    return _nameServers;
+  }
+
+  public void addNameServer(@Nonnull NameServer server) {
+    if (_nameServers.contains(server)) {
+      // Do not add duplicates
+      return;
+    }
+    _nameServers.add(server);
   }
 
   public @Nullable RouteDistinguisherOrAuto getRd() {
@@ -80,6 +96,7 @@ public final class Vrf implements Serializable {
   private final Map<AddressFamily, VrfAddressFamily> _addressFamilies;
   private final @Nonnull String _name;
   private final int _id;
+  @Nonnull private final List<NameServer> _nameServers;
   private @Nullable RouteDistinguisherOrAuto _rd;
   private boolean _shutdown;
   private final Multimap<Prefix, StaticRoute> _staticRoutes;

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -291,6 +291,7 @@ import org.batfish.representation.cisco_nxos.Lacp;
 import org.batfish.representation.cisco_nxos.Layer3Options;
 import org.batfish.representation.cisco_nxos.LiteralIpAddressSpec;
 import org.batfish.representation.cisco_nxos.LiteralPortSpec;
+import org.batfish.representation.cisco_nxos.NameServer;
 import org.batfish.representation.cisco_nxos.NtpServer;
 import org.batfish.representation.cisco_nxos.Nve;
 import org.batfish.representation.cisco_nxos.Nve.HostReachabilityProtocol;
@@ -3969,7 +3970,8 @@ public final class CiscoNxosGrammarTest {
 
     assertThat(
         c.getDnsServers(),
-        containsInAnyOrder("192.0.2.1", "192.0.2.2", "192.0.2.3", "dead:beef::1"));
+        containsInAnyOrder(
+            "192.0.2.1", "192.0.2.2", "192.0.2.3", "dead:beef::1", "192.0.2.99", "192.0.2.100"));
   }
 
   @Test
@@ -3978,13 +3980,18 @@ public final class CiscoNxosGrammarTest {
     CiscoNxosConfiguration vc = parseVendorConfig(hostname);
 
     assertThat(
-        vc.getIpNameServersByUseVrf(),
-        equalTo(
-            ImmutableMap.of(
-                DEFAULT_VRF_NAME,
-                ImmutableList.of("192.0.2.2", "192.0.2.1", "dead:beef::1"),
-                "management",
-                ImmutableList.of("192.0.2.3"))));
+        vc.getDefaultVrf().getNameServers(),
+        contains(
+            new NameServer("192.0.2.2", null),
+            new NameServer("192.0.2.1", null),
+            new NameServer("dead:beef::1", null),
+            new NameServer("192.0.2.3", MANAGEMENT_VRF_NAME)));
+    assertThat(
+        vc.getVrfs().get("other_vrf").getNameServers(),
+        contains(
+            new NameServer("192.0.2.99", MANAGEMENT_VRF_NAME),
+            new NameServer("192.0.2.100", null)));
+    assertThat(vc.getVrfs().get(MANAGEMENT_VRF_NAME).getNameServers(), empty());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ip_name_server
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_ip_name_server
@@ -7,3 +7,7 @@ ip name-server 192.0.2.2
 ip name-server 192.0.2.1 dead:beef::1
 
 ip name-server 192.0.2.3 use-vrf management
+
+vrf context other_vrf
+  ip name-server 192.0.2.99 use-vrf management
+  ip name-server 192.0.2.100


### PR DESCRIPTION
Main goal: keep parser context. Secondary goal: actually plumb through so that DNS sever verification works