### PR TITLE
bazel: annotate some of the larger test suites as high-cpu

### DIFF
--- a/projects/batfish/BUILD
+++ b/projects/batfish/BUILD
@@ -104,6 +104,7 @@ junit_tests(
     resources = [
         "//projects/batfish/src/test/resources",
     ],
+    tags = ["cpu:4"],
     deps = [
         ":batfish",
         ":batfish_testlib",

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BUILD
@@ -27,6 +27,10 @@ junit_tests(
     resources = [
         "//projects/batfish/src/test/resources",
     ],
+    runtime_deps = [
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+    ],
     deps = [
         ":testlib",
         "//projects/batfish",
@@ -41,8 +45,4 @@ junit_tests(
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",
     ],
-    runtime_deps = [
-        "@maven//:org_apache_logging_log4j_log4j_core",
-        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
-    ]
 )

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/BUILD
@@ -11,9 +11,14 @@ junit_tests(
         "**/*Test.java",
     ]),
     resources = [
+        "//projects/batfish/src/test/resources:log4j_config",
         "//projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs",
         "//projects/batfish/src/test/resources/org/batfish/grammar/arista/testrigs",
-        "//projects/batfish/src/test/resources:log4j_config",
+    ],
+    tags = ["cpu:4"],
+    runtime_deps = [
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
     ],
     deps = [
         "//projects/batfish",
@@ -30,8 +35,4 @@ junit_tests(
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",
     ],
-     runtime_deps = [
-        "@maven//:org_apache_logging_log4j_log4j_core",
-        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
-    ]
 )

--- a/projects/batfish/src/test/java/org/batfish/grammar/aws/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/aws/BUILD
@@ -13,6 +13,7 @@ junit_tests(
     resources = [
         "//projects/batfish/src/test/resources/org/batfish/grammar/aws/testrigs",
     ],
+    tags = ["cpu:4"],
     deps = [
         "//projects/batfish",
         "//projects/batfish:batfish_testlib",

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/BUILD
@@ -14,6 +14,7 @@ junit_tests(
         "//projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs",
         "//projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs",
     ],
+    tags = ["cpu:4"],
     deps = [
         "//projects/batfish",
         "//projects/batfish:batfish_testlib",

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/BUILD
@@ -11,11 +11,16 @@ junit_tests(
         "**/*Test.java",
     ]),
     resources = [
+        "//projects/batfish/src/test/resources:log4j_config",
         "//projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/bgp",
         "//projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/ospf",
         "//projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/snapshots/runtime_data",
         "//projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs",
-        "//projects/batfish/src/test/resources:log4j_config",
+    ],
+    tags = ["cpu:4"],
+    runtime_deps = [
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
     ],
     deps = [
         "//projects/batfish",
@@ -32,8 +37,4 @@ junit_tests(
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",
     ],
-    runtime_deps = [
-        "@maven//:org_apache_logging_log4j_log4j_core",
-        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
-    ]
 )

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/BUILD
@@ -13,6 +13,7 @@ junit_tests(
     resources = [
         "//projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs",
     ],
+    tags = ["cpu:4"],
     deps = [
         "//projects/batfish",
         "//projects/batfish:batfish_testlib",

--- a/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/f5_bigip_imish/BUILD
@@ -11,9 +11,14 @@ junit_tests(
         "**/*Test.java",
     ]),
     resources = [
+        "//projects/batfish/src/test/resources:log4j_config",
         "//projects/batfish/src/test/resources/org/batfish/grammar/f5_bigip_imish/snapshots",
         "//projects/batfish/src/test/resources/org/batfish/grammar/f5_bigip_imish/testconfigs",
-        "//projects/batfish/src/test/resources:log4j_config",
+    ],
+    runtime_deps = [
+        "@maven//:org_apache_logging_log4j_log4j_core",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+        "@maven//:org_mockito_mockito_inline",
     ],
     deps = [
         "//projects/batfish",
@@ -28,10 +33,5 @@ junit_tests(
         "@maven//:org_antlr_antlr4_runtime",
         "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",
-    ],
-    runtime_deps = [
-            "@maven//:org_mockito_mockito_inline",
-            "@maven//:org_apache_logging_log4j_log4j_core",
-                    "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
     ],
 )

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/BUILD
@@ -26,6 +26,7 @@ junit_tests(
         "//projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs",
         "//projects/batfish/src/test/resources/org/batfish/grammar/juniper/testrigs",
     ],
+    tags = ["cpu:4"],
     deps = [
         ":testlib",
         "//projects/batfish",

--- a/projects/batfish/src/test/java/org/batfish/grammar/juniper/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/juniper/BUILD
@@ -13,6 +13,7 @@ junit_tests(
     resources = [
         "//projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs",
     ],
+    tags = ["cpu:4"],
     deps = [
         "//projects/batfish",
         "//projects/batfish-common-protocol:common",

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/BUILD
@@ -14,6 +14,7 @@ junit_tests(
         "//projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/snapshots",
         "//projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs",
     ],
+    tags = ["cpu:4"],
     deps = [
         "//projects/batfish",
         "//projects/batfish:batfish_testlib",

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/BUILD
@@ -11,13 +11,13 @@ junit_tests(
         "**/*Test*.java",
     ]),
     resources = [
-        "//projects/batfish/src/test/resources/org/batfish/representation/aws",
         "//projects/batfish/src/test/resources:log4j_config",
-        ],
+        "//projects/batfish/src/test/resources/org/batfish/representation/aws",
+    ],
     runtime_deps = [
-        "@maven//:org_mockito_mockito_inline",
         "@maven//:org_apache_logging_log4j_log4j_core",
-                "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+        "@maven//:org_apache_logging_log4j_log4j_slf4j_impl",
+        "@maven//:org_mockito_mockito_inline",
     ],
     deps = [
         "//projects/batfish",


### PR DESCRIPTION
This will hopefully prevent timeouts when running many intensive
tests in parallel.

Also run buildifier.