### PR TITLE
Cisco: cleanup unused code in redistribution policy

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpRedistributionPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpRedistributionPolicy.java
@@ -10,7 +10,7 @@ public class BgpRedistributionPolicy extends RedistributionPolicy implements Ser
   private Long _metric;
 
   public BgpRedistributionPolicy(RoutingProtocol sourceProtocol) {
-    super(sourceProtocol, RoutingProtocol.BGP);
+    super(sourceProtocol);
   }
 
   public Long getMetric() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/EigrpRedistributionPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/EigrpRedistributionPolicy.java
@@ -13,7 +13,7 @@ public class EigrpRedistributionPolicy extends RedistributionPolicy {
   private @Nullable EigrpMetricValues _metric;
 
   public EigrpRedistributionPolicy(RoutingProtocol sourceProtocol) {
-    super(sourceProtocol, RoutingProtocol.EIGRP);
+    super(sourceProtocol);
   }
 
   @Nullable

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/IsisRedistributionPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/IsisRedistributionPolicy.java
@@ -21,7 +21,7 @@ public class IsisRedistributionPolicy extends RedistributionPolicy {
   private Prefix _summaryPrefix;
 
   public IsisRedistributionPolicy(RoutingProtocol sourceProtocol) {
-    super(sourceProtocol, RoutingProtocol.ISIS_ANY);
+    super(sourceProtocol);
   }
 
   public IsisLevel getLevel() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/OspfRedistributionPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/OspfRedistributionPolicy.java
@@ -20,7 +20,7 @@ public class OspfRedistributionPolicy extends RedistributionPolicy {
   private Long _tag;
 
   public OspfRedistributionPolicy(RoutingProtocol sourceProtocol) {
-    super(sourceProtocol, RoutingProtocol.OSPF);
+    super(sourceProtocol);
   }
 
   public Long getMetric() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RedistributionPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RedistributionPolicy.java
@@ -7,22 +7,15 @@ import org.batfish.datamodel.RoutingProtocol;
 
 public abstract class RedistributionPolicy implements Serializable {
 
-  protected final RoutingProtocol _destinationProtocol;
-
   protected String _routeMap;
 
   protected final RoutingProtocol _sourceProtocol;
 
   protected final Map<String, Object> _specialAttributes;
 
-  public RedistributionPolicy(RoutingProtocol sourceProtocol, RoutingProtocol destinationProtocol) {
+  public RedistributionPolicy(RoutingProtocol sourceProtocol) {
     _sourceProtocol = sourceProtocol;
-    _destinationProtocol = destinationProtocol;
     _specialAttributes = new TreeMap<>();
-  }
-
-  public RoutingProtocol getDestinationProtocol() {
-    return _destinationProtocol;
   }
 
   public String getRouteMap() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/RipRedistributionPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/RipRedistributionPolicy.java
@@ -13,7 +13,7 @@ public class RipRedistributionPolicy extends RedistributionPolicy {
   private Long _metric;
 
   public RipRedistributionPolicy(RoutingProtocol sourceProtocol) {
-    super(sourceProtocol, RoutingProtocol.RIP);
+    super(sourceProtocol);
   }
 
   public Long getMetric() {


### PR DESCRIPTION
Destination protocol doesn't serve any purpose, that's already encoded in the type of policy.