### PR TITLE
Cisco IOS: improve ospf->bgp redistribution, support matching on route types

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_common.g4
@@ -258,12 +258,12 @@ null_rest_of_line
 ospf_route_type
 :
    (
-      EXTERNAL DEC?
+      EXTERNAL type = DEC?
    )
    | INTERNAL
    |
    (
-      NSSA_EXTERNAL DEC?
+      NSSA_EXTERNAL type = DEC?
    )
 ;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpRedistributionPolicy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpRedistributionPolicy.java
@@ -6,6 +6,7 @@ import org.batfish.datamodel.RoutingProtocol;
 public class BgpRedistributionPolicy extends RedistributionPolicy implements Serializable {
 
   public static final String OSPF_PROCESS_NUMBER = "OSPF_PROCESS_NUMBER";
+  public static final String OSPF_ROUTE_TYPES = "OSPF_ROUTE_TYPES";
 
   private Long _metric;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1373,7 +1373,17 @@ public final class CiscoConfiguration extends VendorConfiguration {
       BooleanExpr weInterior = BooleanExprs.TRUE;
       Conjunction exportOspfConditions = new Conjunction();
       exportOspfConditions.setComment("Redistribute OSPF routes into BGP");
-      exportOspfConditions.getConjuncts().add(new MatchProtocol(RoutingProtocol.OSPF));
+      exportOspfConditions
+          .getConjuncts()
+          .add(
+              firstNonNull(
+                  (MatchProtocol)
+                      redistributeOspfPolicy
+                          .getSpecialAttributes()
+                          .get(BgpRedistributionPolicy.OSPF_ROUTE_TYPES),
+                  // No match type means internal routes only, at least on IOS.
+                  // https://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/5242-bgp-ospf-redis.html#redistributionofonlyospfinternalroutesintobgp
+                  new MatchProtocol(RoutingProtocol.OSPF, RoutingProtocol.OSPF_IA)));
       String mapName = redistributeOspfPolicy.getRouteMap();
       if (mapName != null) {
         RouteMap redistributeOspfRouteMap = _routeMaps.get(mapName);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-redistribute-ospf
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-redistribute-ospf
@@ -1,0 +1,8 @@
+!
+hostname ios-bgp-redistribute-ospf-match-various
+!
+route-map ospf2bgp permit 10
+
+router bgp 1
+  redistribute ospf
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-redistribute-ospf-match-internal
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-redistribute-ospf-match-internal
@@ -1,0 +1,8 @@
+!
+hostname ios-bgp-redistribute ospf
+!
+route-map ospf2bgp permit 10
+
+router bgp 1
+  redistribute ospf 1 match internal
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-redistribute-ospf-match-various
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-bgp-redistribute-ospf-match-various
@@ -1,0 +1,8 @@
+!
+hostname ios-bgp-redistribute-ospf-match-various
+!
+route-map ospf2bgp permit 10
+
+router bgp 1
+  redistribute ospf 1 metric 10000 match internal external 1 external 2 route-map ospf2bgp
+!

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -22402,7 +22402,8 @@
                         {
                           "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
                           "protocols" : [
-                            "ospf"
+                            "ospf",
+                            "ospfIA"
                           ]
                         },
                         {

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -275,27 +275,6 @@
       },
       {
         "Filename" : "configs/cisco_bgp",
-        "Line" : 30,
-        "Text" : "redistribute ospf abc",
-        "Parser_Context" : "[redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/cisco_bgp",
-        "Line" : 31,
-        "Text" : "redistribute ospf 2",
-        "Parser_Context" : "[redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/cisco_bgp",
-        "Line" : 32,
-        "Text" : "redistribute ospf 2 vrf vrf1",
-        "Parser_Context" : "[redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
-        "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/cisco_bgp",
         "Line" : 40,
         "Text" : "unsuppress-map UNSUPP-MAP",
         "Parser_Context" : "[unsuppress_map_bgp_tail bgp_tail neighbor_flat_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
@@ -1507,10 +1486,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 209 results",
+      "notes" : "Found 206 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 209
+      "numResults" : 206
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -77068,24 +77068,6 @@
               "Text" : "bgp redistribute-internal"
             },
             {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 30,
-              "Parser_Context" : "[redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
-              "Text" : "redistribute ospf abc"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 31,
-              "Parser_Context" : "[redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
-              "Text" : "redistribute ospf 2"
-            },
-            {
-              "Comment" : "This feature is not currently supported",
-              "Line" : 32,
-              "Parser_Context" : "[redistribute_ospf_bgp_tail bgp_tail router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",
-              "Text" : "redistribute ospf 2 vrf vrf1"
-            },
-            {
               "Comment" : "BGP unusuppress-map is not currently supported",
               "Line" : 40,
               "Parser_Context" : "[unsuppress_map_bgp_tail bgp_tail neighbor_flat_rb_stanza router_bgp_stanza_tail router_bgp_stanza stanza cisco_configuration]",


### PR DESCRIPTION
This fixes 3 bugs:
1. A spurious warning since `ctx.MATCH()` is a list and always non-null
2. Adds support for matching specific route types in redistribute statement
3. Not specifying match types means redistributing both OSPF and OSPF_IA, not just OSPF (intra-area)

I'm aware this is a subpar solution and we need to make VS datamodel for redistribution more NXOS-like, but wasn't going to overhaul a lot of the VS model to unblock this bug fix.