### PR TITLE
PAN: parse and ignore application-override

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -163,6 +163,11 @@ APPLICATION_GROUP
     'application-group'
 ;
 
+APPLICATION_OVERRIDE
+:
+    'application-override'
+;
+
 AREA
 :
     'area'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_rulebase.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_rulebase.g4
@@ -50,8 +50,14 @@ s_pre_rulebase
 
 rulebase_inner
 :
-    sr_nat
+    sr_application_override
+    | sr_nat
     | sr_security
+;
+
+sr_application_override
+:
+    APPLICATION_OVERRIDE null_rest_of_line
 ;
 
 sr_security

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -275,6 +275,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Snsg_display_nameContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snsg_zone_definitionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snsgi_interfaceContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Snsgzn_layer3Context;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Sr_application_overrideContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Src_or_dst_list_itemContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Srespr_devicesContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Sresprd_hostnameContext;
@@ -1847,6 +1848,12 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
       _currentDeviceGroup.addVsys(getText(ctx.device), _currentDeviceGroupVsys);
     }
     _currentDeviceGroupVsys = null;
+  }
+
+  @Override
+  public void exitSr_application_override(Sr_application_overrideContext ctx) {
+    // application-override only affects App-ID, so Batfish ignores it
+    // TODO: maybe surface a warning to user? but don't spam on every line.
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -3742,4 +3742,11 @@ public final class PaloAltoGrammarTest {
             .get(Prefix.parse("120.120.120.120/32"))
             .getEbgpMultihop());
   }
+
+  @Test
+  public void testApplicationOverride() {
+    String hostname = "application-override";
+    // Don't crash
+    parsePaloAltoConfig(hostname);
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/application-override
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/application-override
@@ -1,0 +1,3 @@
+#RANCID-CONTENT-TYPE: paloalto
+set deviceconfig system hostname application-override
+set config devices localhost.localdomain vsys vsys1 rulebase application-override rules FOO from FOO-OTHER


### PR DESCRIPTION
This doesn't affect our analysis (it only affects App-ID/DPI), but can generate so may parse warnings, it drowns any useful info out. 