### PR TITLE
NXOS: parse more EIGRP interface properties

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
@@ -1255,6 +1255,8 @@ EIGRP
       case KEY_CHAIN:
         pushMode(M_TwoWords);
         break;
+      case HELLO_INTERVAL:
+      case HOLD_TIME:
       case MODE:
       case REDISTRIBUTE:
       case ROUTER:
@@ -1715,6 +1717,11 @@ HEX_UINT32
 HMM
 :
   'hmm'
+;
+
+HOLD_TIME
+:
+  'hold-time'
 ;
 
 HOST

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
@@ -388,6 +388,8 @@ i_ip
     | i_ip_address
     | i_ip_authentication
     | i_ip_dhcp
+    | i_ip_hello_interval
+    | i_ip_hold_time
     | i_ip_forward
     | i_ip_igmp
     | i_ip_null
@@ -467,6 +469,16 @@ i_ip_dhcp_relay
 i_ip_forward
 :
   FORWARD NEWLINE
+;
+
+i_ip_hello_interval
+:
+  HELLO_INTERVAL EIGRP router_eigrp_process_tag time = uint16 NEWLINE
+;
+
+i_ip_hold_time
+:
+  HOLD_TIME EIGRP router_eigrp_process_tag time = uint16 NEWLINE
 ;
 
 i_ip_igmp

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -7613,4 +7613,18 @@ public final class CiscoNxosGrammarTest {
             .getAllowAsIn(),
         nullValue());
   }
+
+  @Test
+  public void testInterfaceEigrpPropertiesExtraction() {
+    String hostname = "nxos_interface_eigrp";
+    // Don't crash. TODO: turn into full test
+    parseVendorConfig(hostname);
+  }
+
+  @Test
+  public void testInterfaceEigrpPropertiesConversion() throws IOException {
+    String hostname = "nxos_interface_eigrp";
+    // Don't crash. TODO: turn into full test
+    parseConfig(hostname);
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_eigrp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_eigrp
@@ -1,0 +1,10 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_interface_eigrp
+!
+feature eigrp
+
+interface Ethernet1/1
+  ip address 192.0.2.2/24
+  ip hold-time eigrp 1 100
+  ip hello-interval eigrp 1 200


### PR DESCRIPTION
At this time only hello-interval and hold-time and leave placeholder tests for proper extraction and conversion of other properties