### PR TITLE
Juniper: bgp descriptions

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
@@ -76,9 +76,7 @@ public class BgpGroup implements Serializable {
       if (_clusterId == null) {
         _clusterId = _parent._clusterId;
       }
-      if (_description == null) {
-        _description = _parent._description;
-      }
+      // Deliberately do not inherit description
       if (_disable == null) {
         _disable = _parent._disable;
       }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -443,6 +443,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
         neighbor =
             BgpActivePeerConfig.builder().setPeerAddress(prefix.getStartIp()).setRemoteAs(remoteAs);
       }
+      neighbor.setDescription(ig.getDescription());
 
       // route reflection
       Ip declaredClusterId = ig.getClusterId();

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -209,6 +209,7 @@ import org.batfish.datamodel.AclAclLine;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.AnnotatedRoute;
+import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpProcess;
 import org.batfish.datamodel.Bgpv4Route;
@@ -893,6 +894,16 @@ public final class FlatJuniperGrammarTest {
     assertThat(
         bgpProcess.getActiveNeighbors().get(Prefix.parse("1.1.1.1/32")).getConfederationAsn(),
         equalTo(7L));
+  }
+
+  @Test
+  public void testBgpDescription() {
+    Configuration c = parseConfig("bgp-description");
+    Map<Prefix, BgpActivePeerConfig> neighbors =
+        c.getDefaultVrf().getBgpProcess().getActiveNeighbors();
+    assertThat(neighbors, hasKeys(Prefix.parse("1.2.3.4/32"), Prefix.parse("2.3.4.5/32")));
+    assertThat(neighbors.get(Prefix.parse("1.2.3.4/32")).getDescription(), equalTo("N"));
+    assertThat(neighbors.get(Prefix.parse("2.3.4.5/32")).getDescription(), nullValue());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-confederation
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-confederation
@@ -6,5 +6,5 @@ set routing-options autonomous-system 1
 set routing-options confederation 5 members 65001
 set routing-options confederation 5 members 65002
 set routing-options confederation 7 members 65003
-# Need at least one valid peer for converions to kick in
+# Need at least one valid peer for conversions to kick in
 set protocols bgp group GROUP neighbor 1.1.1.1 peer-as 2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-confederation
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-confederation
@@ -6,5 +6,5 @@ set routing-options autonomous-system 1
 set routing-options confederation 5 members 65001
 set routing-options confederation 5 members 65002
 set routing-options confederation 7 members 65003
-# Need at least one valid peer for conversions to kick in
+# Need at least one valid peer for converions to kick in
 set protocols bgp group GROUP neighbor 1.1.1.1 peer-as 2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-description
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-description
@@ -1,0 +1,8 @@
+#
+set system host-name bgp-description
+#
+set routing-options autonomous-system 1
+set protocols bgp group G description G
+set protocols bgp group G neighbor 1.2.3.4 description N
+# neighbor 2.3.4.5 does NOT inherit the description from G
+set protocols bgp group G neighbor 2.3.4.5


### PR DESCRIPTION
1. Add a VI test
2. Set them in VI
3. Stop inheriting description