### PR TITLE
IOS: update EIGRP redistribution policies

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpProcess.java
@@ -32,7 +32,7 @@ public final class EigrpProcess implements Serializable {
   private static final String PROP_EXTERNAL_ADMIN_COST = "externalAdminCost";
 
   private final long _asn;
-  @Nullable private final String _exportPolicy;
+  @Nullable private final String _redistributionPolicy;
   @Nonnull private final EigrpProcessMode _mode;
   @Nonnull private SortedMap<String, EigrpNeighborConfig> _neighbors;
   @Nonnull private final Ip _routerId;
@@ -48,7 +48,7 @@ public final class EigrpProcess implements Serializable {
       int internalAdminCost,
       int externalAdminCost) {
     _asn = asn;
-    _exportPolicy = exportPolicy;
+    _redistributionPolicy = exportPolicy;
     _mode = mode;
     _neighbors = ImmutableSortedMap.copyOf(neighbors);
     _routerId = routerId;
@@ -96,8 +96,8 @@ public final class EigrpProcess implements Serializable {
    */
   @Nullable
   @JsonProperty(PROP_EXPORT_POLICY)
-  public String getExportPolicy() {
-    return _exportPolicy;
+  public String getRedistributionPolicy() {
+    return _redistributionPolicy;
   }
 
   /** @return All EIGRP neighbors in this process */
@@ -161,7 +161,7 @@ public final class EigrpProcess implements Serializable {
     }
     EigrpProcess that = (EigrpProcess) o;
     return _asn == that._asn
-        && Objects.equals(_exportPolicy, that._exportPolicy)
+        && Objects.equals(_redistributionPolicy, that._redistributionPolicy)
         && _mode == that._mode
         && _neighbors == that._neighbors
         && _routerId.equals(that._routerId)
@@ -172,7 +172,13 @@ public final class EigrpProcess implements Serializable {
   @Override
   public int hashCode() {
     return Objects.hash(
-        _asn, _exportPolicy, _mode, _routerId, _neighbors, _internalAdminCost, _externalAdminCost);
+        _asn,
+        _redistributionPolicy,
+        _mode,
+        _routerId,
+        _neighbors,
+        _internalAdminCost,
+        _externalAdminCost);
   }
 
   public static class Builder {
@@ -209,7 +215,7 @@ public final class EigrpProcess implements Serializable {
     }
 
     @Nonnull
-    public Builder setExportPolicy(@Nullable String exportPolicy) {
+    public Builder setRedistributionPolicy(@Nullable String exportPolicy) {
       _exportPolicy = exportPolicy;
       return this;
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/EigrpTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/EigrpTopologyUtilsTest.java
@@ -66,10 +66,10 @@ public class EigrpTopologyUtilsTest {
     vrf.addEigrpProcess(
         EigrpProcess.builder()
             .setAsNumber(1L)
-            .setExportPolicy("ep")
+            .setRedistributionPolicy("ep")
             .setMode(EigrpProcessMode.NAMED)
             .setRouterId(Ip.parse("1.1.1.1"))
-            .setExportPolicy("policy")
+            .setRedistributionPolicy("policy")
             .build());
 
     EigrpTopologyUtils.initNeighborConfigs(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -1394,27 +1394,6 @@ public class CiscoConversions {
   }
 
   /**
-   * Given a list of {@link If} statements, sets the false statements of every {@link If} to an
-   * empty list and adds a rule at the end to allow EIGRP from provided ownAsn.
-   */
-  static List<If> clearFalseStatementsAndAddMatchOwnAsn(List<If> redistributeIfs, long ownAsn) {
-    List<Statement> emptyFalseStatements = ImmutableList.of();
-    List<If> redistributeIfsWithEmptyFalse =
-        redistributeIfs.stream()
-            .map(
-                redistributionStatement ->
-                    new If(
-                        redistributionStatement.getGuard(),
-                        redistributionStatement.getTrueStatements(),
-                        emptyFalseStatements))
-            .collect(Collectors.toList());
-
-    redistributeIfsWithEmptyFalse.add(ifToAllowEigrpToOwnAsn(ownAsn));
-
-    return ImmutableList.copyOf(redistributeIfsWithEmptyFalse);
-  }
-
-  /**
    * Inserts an {@link If} generated from the provided distributeList to the beginning of
    * existingStatements and creates a {@link RoutingPolicy} from the result
    */

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -1075,12 +1075,12 @@ public class CiscoConversions {
      * Route redistribution modifies the configuration structure, so do this last to avoid having to
      * clean up configuration if another conversion step fails
      */
-    String eigrpExportPolicyName = "~EIGRP_EXPORT_POLICY:" + vrfName + ":" + proc.getAsn() + "~";
-    RoutingPolicy eigrpExportPolicy = new RoutingPolicy(eigrpExportPolicyName, c);
-    c.getRoutingPolicies().put(eigrpExportPolicyName, eigrpExportPolicy);
-    newProcess.setExportPolicy(eigrpExportPolicyName);
+    String redistributionPolicyName = "~EIGRP_EXPORT_POLICY:" + vrfName + ":" + proc.getAsn() + "~";
+    RoutingPolicy redistributionPolicy = new RoutingPolicy(redistributionPolicyName, c);
+    c.getRoutingPolicies().put(redistributionPolicyName, redistributionPolicy);
+    newProcess.setRedistributionPolicy(redistributionPolicyName);
 
-    eigrpExportPolicy
+    redistributionPolicy
         .getStatements()
         .addAll(
             eigrpRedistributionPoliciesToStatements(
@@ -1091,7 +1091,7 @@ public class CiscoConversions {
 
   /** Creates an {@link If} statement to allow EIGRP routes redistributed from supplied localAsn */
   @Nonnull
-  private static If ifToAllowEigrpToOwnAsn(long localAsn) {
+  static If ifToAllowEigrpToOwnAsn(long localAsn) {
     return new If(
         new Conjunction(
             ImmutableList.of(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
@@ -1449,7 +1449,7 @@ public class CiscoXrConversions {
     String eigrpExportPolicyName = "~EIGRP_EXPORT_POLICY:" + vrfName + ":" + proc.getAsn() + "~";
     RoutingPolicy eigrpExportPolicy = new RoutingPolicy(eigrpExportPolicyName, c);
     c.getRoutingPolicies().put(eigrpExportPolicyName, eigrpExportPolicy);
-    newProcess.setExportPolicy(eigrpExportPolicyName);
+    newProcess.setRedistributionPolicy(eigrpExportPolicyName);
 
     eigrpExportPolicy
         .getStatements()

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -2727,23 +2727,24 @@ public final class CiscoGrammarTest {
             .setValues(EigrpMetricValues.builder().setBandwidth(1d).setDelay(1d).build())
             .build();
 
-    // Test redistribution policy
+    // Test redistribution policy allows redistribution from router EIGRP 2
     RoutingPolicy redistrPolicy =
         c.getRoutingPolicies().get(eigrpProcess1.getRedistributionPolicy());
-    redistrPolicy.process(
-        EigrpExternalRoute.builder()
-            .setNetwork(Prefix.parse("172.21.30.0/24"))
-            .setEigrpMetric(metric)
-            .setProcessAsn(2L)
-            .setDestinationAsn(5L)
-            .build(),
-        EigrpExternalRoute.builder(),
-        eigrpProcess1,
-        Direction.IN);
+    assertTrue(
+        redistrPolicy.process(
+            EigrpExternalRoute.builder()
+                .setNetwork(Prefix.parse("172.21.30.0/24"))
+                .setEigrpMetric(metric)
+                .setProcessAsn(2L)
+                .setDestinationAsn(5L)
+                .build(),
+            EigrpExternalRoute.builder(),
+            eigrpProcess1,
+            Direction.IN));
 
     RoutingPolicy routingPolicy = c.getRoutingPolicies().get(distListPolicyName);
 
-    // a route redistributed from router EIGRP 2 and allowed by distribute list
+    // a route (previously) redistributed from router EIGRP 2 and allowed by distribute list
     assertTrue(
         routingPolicy.process(
             EigrpExternalRoute.builder()
@@ -2754,7 +2755,7 @@ public final class CiscoGrammarTest {
                 .build(),
             EigrpExternalRoute.builder(),
             Direction.OUT));
-    // a route redistributed from router EIGRP 2 and denied by distribute list
+    // a route (previously) redistributed from router EIGRP 2 and denied by distribute list
     assertFalse(
         routingPolicy.process(
             EigrpExternalRoute.builder()
@@ -2765,7 +2766,7 @@ public final class CiscoGrammarTest {
                 .build(),
             EigrpExternalRoute.builder(),
             Direction.OUT));
-    // a route redistributed internally from router EIGRP 1 and allowed by distribute list
+    // an internal route sent from router EIGRP 1 and allowed by distribute list
     assertTrue(
         routingPolicy.process(
             EigrpInternalRoute.builder()
@@ -2776,8 +2777,7 @@ public final class CiscoGrammarTest {
             EigrpExternalRoute.builder(),
             Direction.OUT));
     // a route matching distribute list but does not have the correct ASN so falls through till the
-    // end and
-    // gets rejected
+    // end and gets rejected
     assertFalse(
         routingPolicy.process(
             EigrpExternalRoute.builder()

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -2761,7 +2761,7 @@ public final class CiscoGrammarTest {
             EigrpExternalRoute.builder()
                 .setNetwork(Prefix.parse("172.21.31.0/24"))
                 .setEigrpMetric(metric)
-                .setProcessAsn(2L)
+                .setProcessAsn(1L)
                 .setDestinationAsn(5L)
                 .build(),
             EigrpExternalRoute.builder(),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1729,7 +1729,7 @@ public final class CiscoGrammarTest {
     assertThat(c, hasDefaultVrf(hasEigrpProcesses(hasKey(1L))));
     assertThat(c, hasDefaultVrf(hasEigrpProcesses(hasKey(2L))));
     String exportPolicyName =
-        c.getVrfs().get(DEFAULT_VRF_NAME).getEigrpProcesses().get(2L).getExportPolicy();
+        c.getVrfs().get(DEFAULT_VRF_NAME).getEigrpProcesses().get(2L).getRedistributionPolicy();
     assertThat(exportPolicyName, notNullValue());
     RoutingPolicy routingPolicy = c.getRoutingPolicies().get(exportPolicyName);
     assertThat(routingPolicy, notNullValue());
@@ -1774,7 +1774,7 @@ public final class CiscoGrammarTest {
     assertThat(c, hasDefaultVrf(hasEigrpProcesses(hasKey(asn))));
     org.batfish.datamodel.eigrp.EigrpProcess eigrpProcess =
         c.getVrfs().get(DEFAULT_VRF_NAME).getEigrpProcesses().get(asn);
-    String exportPolicyName = eigrpProcess.getExportPolicy();
+    String exportPolicyName = eigrpProcess.getRedistributionPolicy();
     assertThat(exportPolicyName, notNullValue());
     RoutingPolicy routingPolicy = c.getRoutingPolicies().get(exportPolicyName);
     assertThat(routingPolicy, notNullValue());
@@ -2697,16 +2697,12 @@ public final class CiscoGrammarTest {
 
     String distListPolicyName = "~EIGRP_EXPORT_POLICY_default_1_GigabitEthernet0/0";
 
+    org.batfish.datamodel.eigrp.EigrpProcess eigrpProcess1 =
+        c.getDefaultVrf().getEigrpProcesses().get(1L);
     assertThat(
-        c.getDefaultVrf()
-            .getEigrpProcesses()
-            .get(1L)
-            .getNeighbors()
-            .get("GigabitEthernet0/0")
-            .getExportPolicy(),
+        eigrpProcess1.getNeighbors().get("GigabitEthernet0/0").getExportPolicy(),
         equalTo(distListPolicyName));
 
-    BooleanExpr matchAsn2 = new MatchProcessAsn(2L);
     BooleanExpr matchAsn1 = new MatchProcessAsn(1L);
     BooleanExpr matchEigrp = new MatchProtocol(RoutingProtocol.EIGRP, RoutingProtocol.EIGRP_EX);
 
@@ -2720,28 +2716,40 @@ public final class CiscoGrammarTest {
                 ImmutableList.of(),
                 ImmutableList.of(Statements.ExitReject.toStaticStatement())),
             new If(
-                new Conjunction(ImmutableList.of(matchAsn2, matchEigrp)),
-                ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
-                ImmutableList.of()),
-            new If(
                 new Conjunction(ImmutableList.of(matchEigrp, matchAsn1)),
                 ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
                 ImmutableList.of(Statements.ExitReject.toStaticStatement())));
 
     assertThat(c.getRoutingPolicies().get(distListPolicyName).getStatements(), equalTo(statements));
 
-    RoutingPolicy routingPolicy = c.getRoutingPolicies().get(distListPolicyName);
     EigrpMetric metric =
         WideMetric.builder()
             .setValues(EigrpMetricValues.builder().setBandwidth(1d).setDelay(1d).build())
             .build();
+
+    // Test redistribution policy
+    RoutingPolicy redistrPolicy =
+        c.getRoutingPolicies().get(eigrpProcess1.getRedistributionPolicy());
+    redistrPolicy.process(
+        EigrpExternalRoute.builder()
+            .setNetwork(Prefix.parse("172.21.30.0/24"))
+            .setEigrpMetric(metric)
+            .setProcessAsn(2L)
+            .setDestinationAsn(5L)
+            .build(),
+        EigrpExternalRoute.builder(),
+        eigrpProcess1,
+        Direction.IN);
+
+    RoutingPolicy routingPolicy = c.getRoutingPolicies().get(distListPolicyName);
+
     // a route redistributed from router EIGRP 2 and allowed by distribute list
     assertTrue(
         routingPolicy.process(
             EigrpExternalRoute.builder()
                 .setNetwork(Prefix.parse("172.21.30.0/24"))
                 .setEigrpMetric(metric)
-                .setProcessAsn(2L)
+                .setProcessAsn(1L)
                 .setDestinationAsn(5L)
                 .build(),
             EigrpExternalRoute.builder(),


### PR DESCRIPTION
Switch from a per-neighbor redistribution to a global redistribution model.

Goal: stop "baking in" the EIGRP process _redistribution_ policy into a per-neighbor _filtering_ policy. This is/was a legacy way of doing things, and in this case we can easily fix it for one vendor before propagating the pattern to other vendors (like NXOS).

In dataplane code: execute redistribution policy on redistribution and keep the resulting routes (both in the the RIB and as a delta). Per neighbor policies now only execute the filtering (e.g., defined via distribute lists). This is a potential speedup because we do not process the same route N times (where N is number of neighbors)

In vendor code (Cisco IOS specifically): stop inlining export policy into neighbor policies. We already had infrastructure for process-global policy, it was just unused.

Note: I did include 1 rename exportPolicy -> redistributionPolicy; my hope is this should make it easier to reason about the code changes.