### PR TITLE
FRR: update routemap semantics

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/Statements.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/Statements.java
@@ -126,8 +126,12 @@ public enum Statements {
             if (environment.getIntermediateBgpAttributes() == null) {
               BgpRoute.Builder<?, ?> bgpRouteBuilder = (Builder<?, ?>) environment.getOutputRoute();
               AbstractRoute or = environment.getOriginalRoute();
-              environment.setIntermediateBgpAttributes(
-                  bgpRouteBuilder.newBuilder().setMetric(or.getMetric()).setTag(or.getTag()));
+              Builder<?, ?> intermediateBgpAttributes =
+                  bgpRouteBuilder.newBuilder().setMetric(or.getMetric()).setTag(or.getTag());
+              if (or instanceof BgpRoute) {
+                intermediateBgpAttributes.setCommunities(((BgpRoute<?, ?>) or).getCommunities());
+              }
+              environment.setIntermediateBgpAttributes(intermediateBgpAttributes);
             }
           }
           break;

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapConvertor.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/RouteMapConvertor.java
@@ -59,6 +59,9 @@ class RouteMapConvertor {
     String currentRoutingPolicyName = _routeMap.getName();
 
     ImmutableList.Builder<Statement> currentRoutingPolicyStatements = ImmutableList.builder();
+    currentRoutingPolicyStatements.add(
+        Statements.SetReadIntermediateBgpAttributes.toStaticStatement(),
+        Statements.SetWriteIntermediateBgpAttributes.toStaticStatement());
     for (RouteMapEntry currentEntry : _routeMap.getEntries().values()) {
       int currentSequence = currentEntry.getNumber();
       if (_continueTargets.contains(currentSequence)) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
@@ -382,6 +382,33 @@ public class CumulusConcatenatedGrammarTest {
   }
 
   @Test
+  public void testSetCommunityContinue() throws IOException {
+    Ip origNextHopIp = Ip.parse("192.0.2.254");
+    Bgpv4Route base =
+        Bgpv4Route.builder()
+            .setAsPath(AsPath.ofSingletonAsSets(2L))
+            .setOriginatorIp(Ip.ZERO)
+            .setOriginType(OriginType.INCOMPLETE)
+            .setProtocol(RoutingProtocol.BGP)
+            .setNextHopIp(origNextHopIp)
+            .setNetwork(Prefix.parse("10.20.30.0/31"))
+            .setTag(0L)
+            .build();
+    Configuration c = parseConfig("set_community_additive_continue");
+    RoutingPolicy rp1 = c.getRoutingPolicies().get("RM_SET_ADDITIVE_TEST_1");
+    Bgpv4Route inRoute =
+        base.toBuilder().setCommunities(ImmutableSet.of(StandardCommunity.of(4, 4))).build();
+    Bgpv4Route outputRoute1 = processRouteIn(rp1, inRoute);
+    assertThat(
+        outputRoute1.getCommunities().getCommunities(),
+        containsInAnyOrder(
+            StandardCommunity.of(2, 2),
+            StandardCommunity.of(3, 3),
+            StandardCommunity.of(4, 4),
+            StandardCommunity.of(7, 7)));
+  }
+
+  @Test
   public void testSetMetric() throws IOException {
     Ip origNextHopIp = Ip.parse("192.0.2.254");
     Bgpv4Route base =

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/set_community_additive_continue
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/set_community_additive_continue
@@ -1,0 +1,30 @@
+set_community_additive_continue
+# This file describes the network interfaces
+
+iface eth0
+ address 10.20.30.0/31
+
+### end /etc/network/interfaces
+
+# ports.conf --
+
+### start of frr.conf
+frr version
+agentx
+!
+router bgp 12345
+ bgp router-id 1.2.3.4
+ address-family ipv4 unicast
+  network 10.20.0.0/16
+ exit-address-family
+!
+route-map RM_SET_ADDITIVE_TEST_1 permit 1
+ set community 2:2 3:3 additive
+ on-match next
+
+route-map RM_SET_ADDITIVE_TEST_1 permit 2
+ set community 7:7 additive
+!
+line vty
+!
+!### end frr.conf

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -30742,6 +30742,14 @@
             "name" : "rm1",
             "statements" : [
               {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "SetReadIntermediateBgpAttributes"
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "SetWriteIntermediateBgpAttributes"
+              },
+              {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",


### PR DESCRIPTION
In FRR, matching/setting is done on the "in-flight" intermediate route, not the original route. Update route map conversion accordingly