### PR TITLE
Fix error initing EIGRP for portchannel subinterfaces

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpTopologyUtils.java
@@ -130,7 +130,10 @@ public class EigrpTopologyUtils {
             if (iface.getConcreteAddress() == null
                 || iface.getEigrp() == null
                 || !iface.getEigrp().getEnabled()
-                || iface.getEigrp().getAsn() != proc.getAsn()) {
+                || iface.getEigrp().getAsn() != proc.getAsn()
+                // TODO EIGRP bandwidth should be guaranteed nonnull. Remove this when portchannel
+                //  subinterfaces correctly set EIGRP bandwidth.
+                || iface.getEigrp().getMetric().getValues().getBandwidth() == null) {
               continue;
             }
             // TODO: check if secondary addresses also participate in EIGRP neighbor relationships

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1877,7 +1877,10 @@ public final class CiscoConfiguration extends VendorConfiguration {
             .map(bandwidth -> bandwidth.longValue() / 1000) // convert to kbps
             .orElse(null);
     // Bandwidth can be null for port-channels (will be calculated later).
-    assert bw != null || computeInterfaceType(iface.getName(), _vendor) == InterfaceType.AGGREGATED;
+    if (bw == null) {
+      InterfaceType ifaceType = computeInterfaceType(iface.getName(), _vendor);
+      assert ifaceType == InterfaceType.AGGREGATED || ifaceType == InterfaceType.AGGREGATE_CHILD;
+    }
     EigrpMetricValues values =
         EigrpMetricValues.builder()
             .setDelay(


### PR DESCRIPTION
* Allow portchannel subinterfaces to have null EIGRP bandwidth
* Prevent creation of EIGRP neighbors for interfaces with null EIGRP bandwidth

Work is in progress to correctly set EIGRP bandwidth for portchannel subinterfaces, at which point we will once again have the invariant that all interfaces with EIGRP have nonnull EIGRP bandwidths, so we'll be able to undo the second bullet point.