### PR TITLE
NXOS port-channel subinterfaces: bind correctly

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -17,7 +17,6 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.batfish.datamodel.routing_policy.Common.generateGenerationPolicy;
 import static org.batfish.datamodel.routing_policy.Common.matchDefaultRoute;
 import static org.batfish.datamodel.routing_policy.Common.suppressSummarizedPrefixes;
-import static org.batfish.representation.cisco_nxos.CiscoNxosInterfaceType.PORT_CHANNEL;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureUsage.CLASS_MAP_CP_MATCH_ACCESS_GROUP;
 import static org.batfish.representation.cisco_nxos.Conversions.getVrfForL3Vni;
 import static org.batfish.representation.cisco_nxos.Conversions.inferRouterId;
@@ -1865,7 +1864,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     newIfaceBuilder.setAutoState(iface.getAutostate());
 
     CiscoNxosInterfaceType type = iface.getType();
-    newIfaceBuilder.setType(toInterfaceType(type, parent != null));
+    InterfaceType viType = toInterfaceType(type, parent != null);
+    newIfaceBuilder.setType(viType);
 
     Optional<InterfaceRuntimeData> runtimeData =
         Optional.ofNullable(_hostname)
@@ -1921,8 +1921,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
       _portChannelMembers.put(portChannel, ifaceName);
     }
 
-    // port-channels
-    if (type == PORT_CHANNEL) {
+    // port-channels (and not port-channel subinterfaces)
+    if (viType == InterfaceType.AGGREGATED) {
       Collection<String> members = _portChannelMembers.get(ifaceName);
       newIfaceBuilder.setChannelGroupMembers(members);
       newIfaceBuilder.setDependencies(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -5808,6 +5808,20 @@ public final class CiscoNxosGrammarTest {
   }
 
   @Test
+  public void testPortChannelSubinterfaceConversion() throws IOException {
+    String hostname = "port_channel_subinterface";
+    Configuration c = parseConfig(hostname);
+    org.batfish.datamodel.Interface iface = c.getAllInterfaces().get("port-channel1.1");
+    assertThat(iface, isActive());
+    assertThat(iface, hasInterfaceType(InterfaceType.AGGREGATE_CHILD));
+    // Should inherit bandwidth from parent portchannel
+    assertThat(iface, hasBandwidth(200E6));
+    assertThat(
+        iface, hasDependencies(contains(new Dependency("port-channel1", DependencyType.BIND))));
+    assertThat(iface, hasChannelGroupMembers(empty()));
+  }
+
+  @Test
   public void testRipParsing() throws IOException {
     parseConfig("nxos_rip");
     // don't crash.

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/port_channel_subinterface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/port_channel_subinterface
@@ -1,0 +1,24 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname port_channel_subinterface
+!
+
+! port-channel with active members:
+! - shutdown = false (default)
+! - active = true
+! - each member has bandwidth 100Mbits (unit is kilobits)
+interface port-channel1
+!
+interface Ethernet1/1
+  channel-group 1
+  bandwidth 100000
+!
+interface Ethernet1/2
+  channel-group 1
+  bandwidth 100000
+!
+
+! port-channel subinterface
+interface port-channel1.1
+  no shutdown
+!


### PR DESCRIPTION
Port-channel subinterface dependencies were accidentally getting overwritten in conversion code intended to apply only to port-channels (not subinterfaces).