### PR TITLE
Set portchannel subinterfaces' EIGRP bandwidths

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpTopologyUtils.java
@@ -130,7 +130,9 @@ public class EigrpTopologyUtils {
             if (iface.getConcreteAddress() == null
                 || iface.getEigrp() == null
                 || !iface.getEigrp().getEnabled()
-                || iface.getEigrp().getAsn() != proc.getAsn()) {
+                || iface.getEigrp().getAsn() != proc.getAsn()
+                // this shouldn't happen, but if it does, ignore the interface
+                || iface.getEigrp().getMetric().getValues().getBandwidth() == null) {
               continue;
             }
             // TODO: check if secondary addresses also participate in EIGRP neighbor relationships

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpTopologyUtils.java
@@ -130,10 +130,7 @@ public class EigrpTopologyUtils {
             if (iface.getConcreteAddress() == null
                 || iface.getEigrp() == null
                 || !iface.getEigrp().getEnabled()
-                || iface.getEigrp().getAsn() != proc.getAsn()
-                // TODO EIGRP bandwidth should be guaranteed nonnull. Remove this when portchannel
-                //  subinterfaces correctly set EIGRP bandwidth.
-                || iface.getEigrp().getMetric().getValues().getBandwidth() == null) {
+                || iface.getEigrp().getAsn() != proc.getAsn()) {
               continue;
             }
             // TODO: check if secondary addresses also participate in EIGRP neighbor relationships

--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1788,10 +1788,11 @@ public class Batfish extends PluginConsumer implements IBatfish {
   private void postProcessEigrpCosts(Map<String, Configuration> configurations) {
     configurations.values().stream()
         .flatMap(c -> c.getAllInterfaces().values().stream())
-        // Recalculate EIGRP metrics now that bandwidths are accurate
         .filter(
             iface ->
-                iface.getInterfaceType() == InterfaceType.AGGREGATED && iface.getEigrp() != null)
+                iface.getEigrp() != null
+                    && (iface.getInterfaceType() == InterfaceType.AGGREGATED
+                        || iface.getInterfaceType() == InterfaceType.AGGREGATE_CHILD))
         .forEach(
             iface -> {
               EigrpMetricValues metricValues = iface.getEigrp().getMetric().getValues();


### PR DESCRIPTION
Depends on the invariant that portchannel subinterfaces all have nonnull bandwidths after `Batfish.postProcessAggregatedInterfaces()`, so this shouldn't be merged until after #6417.