### PR TITLE
BDDPacket: when converting to Flow, constrain to sane packets

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -1,5 +1,6 @@
 package org.batfish.common.bdd;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.common.bdd.BDDInteger.makeFromIndex;
 import static org.batfish.common.bdd.BDDUtils.swapPairing;
 
@@ -20,6 +21,7 @@ import org.batfish.common.BatfishException;
 import org.batfish.common.bdd.BDDFlowConstraintGenerator.FlowPreference;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.Prefix;
 
 /**
@@ -94,6 +96,7 @@ public class BDDPacket {
   private final BDDPairing _swapSourceAndDestinationPairing;
   private final IpSpaceToBDD _dstIpSpaceToBDD;
   private final IpSpaceToBDD _srcIpSpaceToBDD;
+  private final @Nonnull BDD _saneFlow;
 
   // Generating flow preference for representative flow picking
   private final Supplier<BDDFlowConstraintGenerator> _flowConstraintGeneratorSupplier =
@@ -167,6 +170,8 @@ public class BDDPacket {
 
     _dstIpSpaceToBDD = new MemoizedIpSpaceToBDD(_dstIp, ImmutableMap.of());
     _srcIpSpaceToBDD = new MemoizedIpSpaceToBDD(_srcIp, ImmutableMap.of());
+
+    _saneFlow = saneIpFlow();
   }
 
   /*
@@ -238,15 +243,16 @@ public class BDDPacket {
    * @return A Flow.Builder for a representative of the set, if it's non-empty
    */
   public Optional<Flow.Builder> getFlow(BDD bdd, FlowPreference preference) {
-    if (bdd.isZero()) {
+    BDD saneBDD = bdd.and(_saneFlow);
+    if (saneBDD.isZero()) {
       return Optional.empty();
     }
 
-    BDD representativeBDD = getFlowBDD(bdd, preference);
+    BDD representativeBDD = getFlowBDD(saneBDD, preference);
 
     if (representativeBDD.isZero()) {
       // Should not be possible if the preference is well-formed.
-      return Optional.of(getRepresentativeFlow(bdd));
+      return Optional.of(getRepresentativeFlow(saneBDD));
     }
 
     return Optional.of(getRepresentativeFlow(representativeBDD));
@@ -261,11 +267,12 @@ public class BDDPacket {
    *     assignment.
    */
   public @Nonnull BDD getFlowBDD(BDD bdd, FlowPreference preference) {
-    if (bdd.isZero()) {
-      return bdd;
+    BDD saneBDD = bdd.and(_saneFlow);
+    if (saneBDD.isZero()) {
+      return saneBDD;
     }
     return BDDRepresentativePicker.pickRepresentative(
-        bdd, _flowConstraintGeneratorSupplier.get().generateFlowPreference(preference));
+        saneBDD, _flowConstraintGeneratorSupplier.get().generateFlowPreference(preference));
   }
 
   /**
@@ -280,8 +287,16 @@ public class BDDPacket {
     return getFlow(bdd, FlowPreference.DEBUGGING);
   }
 
-  public Flow.Builder getRepresentativeFlow(BDD bdd) {
-    return getFromFromAssignment(bdd.minAssignmentBits());
+  /**
+   * Returns a {@link Flow.Builder} corresponding to one assignment of the given {@link BDD}.
+   *
+   * @throws IllegalArgumentException if there are no assignments of the given {@link BDD} that
+   *     correspond to valid L3 flows.
+   */
+  public @Nonnull Flow.Builder getRepresentativeFlow(BDD bdd) {
+    BDD saneBDD = bdd.and(_saneFlow);
+    checkArgument(!saneBDD.isZero(), "The input set of flows does not contain any valid flows");
+    return getFromFromAssignment(saneBDD.minAssignmentBits());
   }
 
   public Flow.Builder getFromFromAssignment(BitSet bits) {
@@ -451,6 +466,18 @@ public class BDDPacket {
         && _dscp.equals(other._dscp)
         && _ecn.equals(other._ecn)
         && _fragmentOffset.equals(other._fragmentOffset);
+  }
+
+  /**
+   * Returns a BDD representing known constraints on all sane IP flows. For example, all IP Packets
+   * are at least 20 bytes long, and all TCP packets are at least 40 bytes.
+   */
+  private BDD saneIpFlow() {
+    BDD ipPacketsAreAtLeast20Long = _packetLength.geq(20);
+    BDD validIcmp = _ipProtocol.value(IpProtocol.ICMP).impWith(_packetLength.geq(64));
+    BDD validUdp = _ipProtocol.value(IpProtocol.UDP).impWith(_packetLength.geq(28));
+    BDD validTcp = _ipProtocol.value(IpProtocol.TCP).impWith(_packetLength.geq(40));
+    return BDDOps.andNull(ipPacketsAreAtLeast20Long, validIcmp, validTcp, validUdp);
   }
 
   public BDD restrict(BDD bdd, Prefix pfx) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
@@ -59,6 +59,23 @@ public class BDDPacketTest {
   }
 
   @Test
+  public void testGetFlow_not_sane() {
+    BDDPacket pkt = new BDDPacket();
+    BDDPacketLength length = pkt.getPacketLength();
+    BDDIpProtocol protocol = pkt.getIpProtocol();
+    assertThat(pkt.getFlow(length.value(19)), equalTo(Optional.empty()));
+    assertThat(
+        pkt.getFlow(length.value(27).and(protocol.value(IpProtocol.UDP))),
+        equalTo(Optional.empty()));
+    assertThat(
+        pkt.getFlow(length.value(39).and(protocol.value(IpProtocol.TCP))),
+        equalTo(Optional.empty()));
+    assertThat(
+        pkt.getFlow(length.value(63).and(protocol.value(IpProtocol.ICMP))),
+        equalTo(Optional.empty()));
+  }
+
+  @Test
   public void testGetFlow_ICMP() {
     BDDPacket pkt = new BDDPacket();
     Ip dstIp = Ip.parse("123.45.78.0");


### PR DESCRIPTION
IP packets and L4 protocols have some constraints. E.g., all IP packets are at
least 20 bytes. Enforce these constraints.