### PR TITLE
IOS: better support for EIGRP distribute-lists

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpInterfaceSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpInterfaceSettings.java
@@ -95,7 +95,7 @@ public class EigrpInterfaceSettings implements Serializable {
     return _exportPolicy;
   }
 
-  /** @return Name of the export policy for this interface if there is any */
+  /** @return Name of the import policy for this interface if there is any */
   @Nullable
   @JsonProperty(PROP_IMPORT_POLICY)
   public String getImportPolicy() {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpInterfaceSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpInterfaceSettings.java
@@ -16,12 +16,14 @@ public class EigrpInterfaceSettings implements Serializable {
   private static final String PROP_ASN = "asn";
   private static final String PROP_ENABLED = "enabled";
   private static final String PROP_EXPORT_POLICY = "exportPolicy";
+  private static final String PROP_IMPORT_POLICY = "importPolicy";
   private static final String PROP_METRIC = "metric";
   private static final String PROP_PASSIVE = "passive";
 
   private final long _asn;
   private final boolean _enabled;
   @Nullable private final String _exportPolicy;
+  @Nullable private final String _importPolicy;
   @Nonnull private final EigrpMetric _metric;
   private final boolean _passive;
 
@@ -29,11 +31,13 @@ public class EigrpInterfaceSettings implements Serializable {
       long asn,
       boolean enabled,
       @Nullable String exportPolicy,
+      @Nullable String importPolicy,
       @Nonnull EigrpMetric metric,
       boolean passive) {
     _asn = asn;
     _enabled = enabled;
     _exportPolicy = exportPolicy;
+    _importPolicy = importPolicy;
     _metric = metric;
     _passive = passive;
   }
@@ -43,11 +47,12 @@ public class EigrpInterfaceSettings implements Serializable {
       @Nullable @JsonProperty(PROP_ASN) Long asn,
       @JsonProperty(PROP_ENABLED) boolean enabled,
       @Nullable @JsonProperty(PROP_EXPORT_POLICY) String exportPolicy,
+      @Nullable @JsonProperty(PROP_IMPORT_POLICY) String importPolicy,
       @Nullable @JsonProperty(PROP_METRIC) EigrpMetric metric,
       @JsonProperty(PROP_PASSIVE) boolean passive) {
     checkArgument(asn != null, "Missing %s", PROP_ASN);
     checkArgument(metric != null, "Missing %s", PROP_METRIC);
-    return new EigrpInterfaceSettings(asn, enabled, exportPolicy, metric, passive);
+    return new EigrpInterfaceSettings(asn, enabled, exportPolicy, importPolicy, metric, passive);
   }
 
   public static Builder builder() {
@@ -66,6 +71,7 @@ public class EigrpInterfaceSettings implements Serializable {
     return Objects.equals(_asn, rhs._asn)
         && (_enabled == rhs._enabled)
         && Objects.equals(_exportPolicy, rhs._exportPolicy)
+        && Objects.equals(_importPolicy, rhs._importPolicy)
         && _metric.equals(rhs._metric)
         && _passive == rhs._passive;
   }
@@ -84,8 +90,16 @@ public class EigrpInterfaceSettings implements Serializable {
 
   /** @return Name of the export policy for this interface if there is any */
   @Nullable
+  @JsonProperty(PROP_EXPORT_POLICY)
   public String getExportPolicy() {
     return _exportPolicy;
+  }
+
+  /** @return Name of the export policy for this interface if there is any */
+  @Nullable
+  @JsonProperty(PROP_IMPORT_POLICY)
+  public String getImportPolicy() {
+    return _importPolicy;
   }
 
   /** @return The interface metric */
@@ -103,7 +117,7 @@ public class EigrpInterfaceSettings implements Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_asn, _enabled, _exportPolicy, _metric, _passive);
+    return Objects.hash(_asn, _enabled, _exportPolicy, _importPolicy, _metric, _passive);
   }
 
   public static class Builder {
@@ -111,6 +125,7 @@ public class EigrpInterfaceSettings implements Serializable {
     @Nullable private Long _asn;
     private boolean _enabled;
     @Nullable private String _exportPolicy;
+    @Nullable private String _importPolicy;
     @Nullable private EigrpMetric _metric;
     private boolean _passive;
 
@@ -120,7 +135,8 @@ public class EigrpInterfaceSettings implements Serializable {
     public EigrpInterfaceSettings build() {
       checkArgument(_asn != null, "Missing %s", PROP_ASN);
       checkArgument(_metric != null, "Missing %s", PROP_METRIC);
-      return new EigrpInterfaceSettings(_asn, _enabled, _exportPolicy, _metric, _passive);
+      return new EigrpInterfaceSettings(
+          _asn, _enabled, _exportPolicy, _importPolicy, _metric, _passive);
     }
 
     public Builder setAsn(@Nullable Long asn) {
@@ -135,6 +151,11 @@ public class EigrpInterfaceSettings implements Serializable {
 
     public Builder setExportPolicy(@Nullable String exportPolicy) {
       _exportPolicy = exportPolicy;
+      return this;
+    }
+
+    public Builder setImportPolicy(@Nullable String importPolicy) {
+      _importPolicy = importPolicy;
       return this;
     }
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_eigrp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_eigrp.g4
@@ -333,6 +333,7 @@ rec_address_family_null
 rec_address_family_tail
 :
    re_autonomous_system
+   | re_distribute_list
    | re_default_metric
    | re_eigrp
    | re_network

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1886,11 +1886,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
   }
 
   public static String eigrpNeighborImportPolicyName(String ifaceName, String vrfName, Long asn) {
-    return String.format("~EIGRP_IMPORT_POLICY_%s_%s_%s", vrfName, asn, ifaceName);
+    return String.format("~EIGRP_IMPORT_POLICY_%s_%s_%s~", vrfName, asn, ifaceName);
   }
 
   public static String eigrpNeighborExportPolicyName(String ifaceName, String vrfName, Long asn) {
-    return String.format("~EIGRP_EXPORT_POLICY_%s_%s_%s", vrfName, asn, ifaceName);
+    return String.format("~EIGRP_EXPORT_POLICY_%s_%s_%s~", vrfName, asn, ifaceName);
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -1093,7 +1093,7 @@ public class CiscoConversions {
     return newProcess.build();
   }
 
-  /** Creates an {@link BooleanExpr} statement that matches EIGRP routes with a given ASN */
+  /** Creates a {@link BooleanExpr} statement that matches EIGRP routes with a given ASN */
   @Nonnull
   static BooleanExpr matchOwnAsn(long localAsn) {
     return new Conjunction(
@@ -1395,7 +1395,7 @@ public class CiscoConversions {
   }
 
   /**
-   * Generate a EIGRP policy from the provided {@param distributeLists} and any additional {@param
+   * Generate an EIGRP policy from the provided {@param distributeLists} and any additional {@param
    * extraConditions} that must be true for the policy to permit the route
    *
    * <p>Note that the list of distribute lists is allowed to have {@code null} elements (those will

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -1093,16 +1093,13 @@ public class CiscoConversions {
     return newProcess.build();
   }
 
-  /** Creates an {@link If} statement to allow EIGRP routes redistributed from supplied localAsn */
+  /** Creates an {@link BooleanExpr} statement that matches EIGRP routes with a given ASN */
   @Nonnull
-  static If ifToAllowEigrpToOwnAsn(long localAsn) {
-    return new If(
-        new Conjunction(
-            ImmutableList.of(
-                new MatchProtocol(RoutingProtocol.EIGRP, RoutingProtocol.EIGRP_EX),
-                new MatchProcessAsn(localAsn))),
-        ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
-        ImmutableList.of(Statements.ExitReject.toStaticStatement()));
+  static BooleanExpr matchOwnAsn(long localAsn) {
+    return new Conjunction(
+        ImmutableList.of(
+            new MatchProtocol(RoutingProtocol.EIGRP, RoutingProtocol.EIGRP_EX),
+            new MatchProcessAsn(localAsn)));
   }
 
   /**
@@ -1398,30 +1395,38 @@ public class CiscoConversions {
   }
 
   /**
-   * Inserts an {@link If} generated from the provided distributeList to the beginning of
-   * existingStatements and creates a {@link RoutingPolicy} from the result
+   * Generate a EIGRP policy from the provided {@param distributeLists} and any additional {@param
+   * extraConditions} that must be true for the policy to permit the route
+   *
+   * <p>Note that the list of distribute lists is allowed to have {@code null} elements (those will
+   * be skipped). Invalid (e.g., non-existent) distribute lists will be skipped as well.
    */
-  static RoutingPolicy insertDistributeListFilterAndGetPolicy(
+  static RoutingPolicy generateEigrpPolicy(
       @Nonnull Configuration c,
       @Nonnull CiscoConfiguration vsConfig,
-      @Nullable DistributeList distributeList,
-      @Nonnull List<If> existingStatements,
+      @Nonnull List<DistributeList> distributeLists,
+      @Nonnull List<BooleanExpr> extraConditions,
       @Nonnull String name) {
-    ImmutableList.Builder<Statement> combinedStatments = ImmutableList.builder();
-    if (distributeList != null && sanityCheckEigrpDistributeList(c, distributeList, vsConfig)) {
-      combinedStatments.add(
-          new If(
-              new MatchPrefixSet(
-                  DestinationNetwork.instance(),
-                  new NamedPrefixSet(distributeList.getFilterName())),
-              ImmutableList.of(),
-              ImmutableList.of(Statements.ExitReject.toStaticStatement())));
+    ImmutableList.Builder<BooleanExpr> matchesBuilder = ImmutableList.builder();
+    for (DistributeList distributeList : distributeLists) {
+      if (distributeList == null || !sanityCheckEigrpDistributeList(c, distributeList, vsConfig)) {
+        continue;
+      }
+      matchesBuilder.add(
+          new MatchPrefixSet(
+              DestinationNetwork.instance(), new NamedPrefixSet(distributeList.getFilterName())));
     }
-    combinedStatments.addAll(existingStatements);
+    matchesBuilder.addAll(extraConditions);
+
     return RoutingPolicy.builder()
         .setOwner(c)
         .setName(name)
-        .setStatements(combinedStatments.build())
+        .setStatements(
+            ImmutableList.of(
+                new If(
+                    new Conjunction(matchesBuilder.build()),
+                    ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
+                    ImmutableList.of(Statements.ExitReject.toStaticStatement()))))
         .build();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/EigrpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/EigrpProcess.java
@@ -26,6 +26,9 @@ public class EigrpProcess implements Serializable {
   private final EigrpProcessMode _mode;
   private final Set<IpWildcard> _wildcardNetworks;
   private final Set<Prefix> _networks;
+  @Nullable private DistributeList _inboundGlobalDistributeList;
+  @Nullable private DistributeList _outboundGlobalDistributeList;
+  @Nonnull private Map<String, DistributeList> _inboundInterfaceDistributeLists;
   @Nonnull private Map<String, DistributeList> _outboundInterfaceDistributeLists;
   private final Map<RoutingProtocol, EigrpRedistributionPolicy> _redistributionPolicies;
   private final @Nonnull String _vrfName;
@@ -44,7 +47,8 @@ public class EigrpProcess implements Serializable {
     _interfacePassiveStatus = new TreeMap<>();
     _mode = mode;
     _networks = new TreeSet<>();
-    _outboundInterfaceDistributeLists = new HashMap<>();
+    _inboundInterfaceDistributeLists = new HashMap<>(0);
+    _outboundInterfaceDistributeLists = new HashMap<>(0);
     _redistributionPolicies = new EnumMap<>(RoutingProtocol.class);
     _vrfName = vrfName;
     _wildcardNetworks = new TreeSet<>();
@@ -118,6 +122,30 @@ public class EigrpProcess implements Serializable {
 
   public Set<Prefix> getNetworks() {
     return _networks;
+  }
+
+  @Nullable
+  public DistributeList getInboundGlobalDistributeList() {
+    return _inboundGlobalDistributeList;
+  }
+
+  public void setInboundGlobalDistributeList(@Nullable DistributeList inboundGlobalDistributeList) {
+    _inboundGlobalDistributeList = inboundGlobalDistributeList;
+  }
+
+  @Nullable
+  public DistributeList getOutboundGlobalDistributeList() {
+    return _outboundGlobalDistributeList;
+  }
+
+  public void setOutboundGlobalDistributeList(
+      @Nullable DistributeList outboundGlobalDistributeList) {
+    _outboundGlobalDistributeList = outboundGlobalDistributeList;
+  }
+
+  @Nonnull
+  public Map<String, DistributeList> getInboundInterfaceDistributeLists() {
+    return _inboundInterfaceDistributeLists;
   }
 
   @Nonnull

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -377,12 +377,10 @@ import org.batfish.datamodel.ospf.OspfProcess;
 import org.batfish.datamodel.ospf.StubType;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
-import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
 import org.batfish.datamodel.routing_policy.expr.Conjunction;
 import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
 import org.batfish.datamodel.routing_policy.expr.LiteralCommunityConjunction;
 import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
-import org.batfish.datamodel.routing_policy.expr.MatchProcessAsn;
 import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
 import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
 import org.batfish.datamodel.routing_policy.statement.If;
@@ -2721,12 +2719,6 @@ public final class CiscoGrammarTest {
     assertThat(
         eigrpProcess1.getNeighbors().get("GigabitEthernet0/0").getExportPolicy(),
         equalTo(distListPolicyName));
-
-    BooleanExpr matchAsn1 = new MatchProcessAsn(1L);
-    BooleanExpr matchEigrp = new MatchProtocol(RoutingProtocol.EIGRP, RoutingProtocol.EIGRP_EX);
-
-    BooleanExpr exprForDistributeList =
-        new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet("2"));
 
     EigrpMetric metric =
         WideMetric.builder()

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -178,6 +178,8 @@ import static org.batfish.representation.cisco.CiscoConfiguration.computeProtoco
 import static org.batfish.representation.cisco.CiscoConfiguration.computeServiceObjectAclName;
 import static org.batfish.representation.cisco.CiscoConfiguration.computeServiceObjectGroupAclName;
 import static org.batfish.representation.cisco.CiscoConfiguration.computeZonePairAclName;
+import static org.batfish.representation.cisco.CiscoConfiguration.eigrpNeighborExportPolicyName;
+import static org.batfish.representation.cisco.CiscoConfiguration.eigrpNeighborImportPolicyName;
 import static org.batfish.representation.cisco.CiscoIosDynamicNat.computeDynamicDestinationNatAclName;
 import static org.batfish.representation.cisco.CiscoStructureType.ACCESS_LIST;
 import static org.batfish.representation.cisco.CiscoStructureType.BFD_TEMPLATE;
@@ -350,6 +352,7 @@ import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.eigrp.ClassicMetric;
+import org.batfish.datamodel.eigrp.EigrpInterfaceSettings;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
 import org.batfish.datamodel.eigrp.EigrpNeighborConfig;
@@ -384,7 +387,6 @@ import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
 import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetEigrpMetric;
-import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.trace.TraceTree;
 import org.batfish.datamodel.tracking.DecrementPriority;
@@ -2726,19 +2728,6 @@ public final class CiscoGrammarTest {
     BooleanExpr exprForDistributeList =
         new MatchPrefixSet(DestinationNetwork.instance(), new NamedPrefixSet("2"));
 
-    List<Statement> statements =
-        ImmutableList.of(
-            new If(
-                exprForDistributeList,
-                ImmutableList.of(),
-                ImmutableList.of(Statements.ExitReject.toStaticStatement())),
-            new If(
-                new Conjunction(ImmutableList.of(matchEigrp, matchAsn1)),
-                ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
-                ImmutableList.of(Statements.ExitReject.toStaticStatement())));
-
-    assertThat(c.getRoutingPolicies().get(distListPolicyName).getStatements(), equalTo(statements));
-
     EigrpMetric metric =
         WideMetric.builder()
             .setValues(EigrpMetricValues.builder().setBandwidth(1d).setDelay(1d).build())
@@ -2837,21 +2826,11 @@ public final class CiscoGrammarTest {
 
     ParseVendorConfigurationAnswerElement pvcae =
         batfish.loadParseVendorConfigurationAnswerElement(batfish.getSnapshot());
-
-    assertThat(
-        pvcae,
-        hasParseWarning(
-            filename, containsString("Inbound distribute-list is not supported for EIGRP")));
-    assertThat(
-        pvcae,
-        hasParseWarning(
-            filename, containsString("Global distribute-list not supported for EIGRP")));
-
     assertThat(
         pvcae,
         hasParseWarning(
             filename,
-            containsString("Prefix lists in distribute-list are not supported for EIGRP")));
+            containsString("Gateway prefix lists in distribute-list are not supported for EIGRP")));
     assertThat(
         pvcae,
         hasParseWarning(
@@ -2860,6 +2839,87 @@ public final class CiscoGrammarTest {
         pvcae,
         hasParseWarning(
             filename, containsString("Route maps in distribute-list are not supported for EIGRP")));
+  }
+
+  @Test
+  public void testIosEigrpDistributeListWithPrefixListExtraction() {
+    String hostname = "ios-eigrp-distribute-list-prefix-list";
+    CiscoConfiguration vc = parseCiscoConfig(hostname, ConfigurationFormat.CISCO_IOS);
+    EigrpProcess proc = vc.getDefaultVrf().getEigrpProcesses().get(1L);
+    assertThat(
+        proc.getInboundGlobalDistributeList(),
+        equalTo(new DistributeList("PL_IN", DistributeListFilterType.PREFIX_LIST)));
+    assertThat(
+        proc.getOutboundGlobalDistributeList(),
+        equalTo(new DistributeList("PL_OUT", DistributeListFilterType.PREFIX_LIST)));
+    String ifaceName = "GigabitEthernet0/0";
+    assertThat(
+        proc.getInboundInterfaceDistributeLists(),
+        hasEntry(
+            ifaceName, new DistributeList("PL_IN_IFACE", DistributeListFilterType.PREFIX_LIST)));
+    assertThat(
+        proc.getOutboundInterfaceDistributeLists(),
+        hasEntry(
+            ifaceName, new DistributeList("PL_OUT_IFACE", DistributeListFilterType.PREFIX_LIST)));
+  }
+
+  @Test
+  public void testIosEigrpDistributeListWithPrefixListConversion() throws IOException {
+    String hostname = "ios-eigrp-distribute-list-prefix-list";
+    Configuration c = parseConfig(hostname);
+    String ifaceName = "GigabitEthernet0/0";
+    EigrpInterfaceSettings eigrpSettings = c.getAllInterfaces().get(ifaceName).getEigrp();
+    String importPolicyName = eigrpNeighborImportPolicyName(ifaceName, DEFAULT_VRF_NAME, 1L);
+    assertThat(eigrpSettings.getImportPolicy(), equalTo(importPolicyName));
+    String exportPolicyName = eigrpNeighborExportPolicyName(ifaceName, DEFAULT_VRF_NAME, 1L);
+    assertThat(eigrpSettings.getExportPolicy(), equalTo(exportPolicyName));
+
+    Map<String, RoutingPolicy> policies = c.getRoutingPolicies();
+    EigrpInternalRoute.Builder builder =
+        EigrpInternalRoute.builder()
+            .setAdmin(90)
+            .setEigrpMetric(
+                ClassicMetric.builder()
+                    .setValues(EigrpMetricValues.builder().setBandwidth(2e9).setDelay(4e5).build())
+                    .build())
+            .setProcessAsn(1L);
+    RoutingPolicy importPolicy = policies.get(importPolicyName);
+    // Allow routes permitted by both prefix lists
+    assertTrue(
+        importPolicy.process(
+            builder.setNetwork(Prefix.parse("1.1.1.1/31")).build(),
+            EigrpInternalRoute.builder(),
+            Direction.IN));
+    // Block others
+    assertFalse(
+        importPolicy.process(
+            builder.setNetwork(Prefix.parse("1.1.1.1/26")).build(),
+            EigrpInternalRoute.builder(),
+            Direction.IN));
+    assertFalse(
+        importPolicy.process(
+            builder.setNetwork(Prefix.parse("5.5.5.5/31")).build(),
+            EigrpInternalRoute.builder(),
+            Direction.IN));
+
+    RoutingPolicy exportPolicy = policies.get(exportPolicyName);
+    // Allow routes permitted by both prefix lists
+    assertTrue(
+        exportPolicy.process(
+            builder.setNetwork(Prefix.parse("2.2.2.2/30")).build(),
+            EigrpInternalRoute.builder(),
+            Direction.OUT));
+    // Block others
+    assertFalse(
+        exportPolicy.process(
+            builder.setNetwork(Prefix.parse("2.2.2.2/26")).build(),
+            EigrpInternalRoute.builder(),
+            Direction.OUT));
+    assertFalse(
+        exportPolicy.process(
+            builder.setNetwork(Prefix.parse("5.5.5.5/30")).build(),
+            EigrpInternalRoute.builder(),
+            Direction.OUT));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-eigrp-distribute-list-prefix-list
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-eigrp-distribute-list-prefix-list
@@ -8,11 +8,14 @@ ip prefix-list PL_OUT_IFACE permit 2.2.2.0/24 ge 30
 !
 interface GigabitEthernet0/0
  ip address 2.2.2.2 255.255.255.0
+interface GigabitEthernet1/0
+ ip address 3.3.3.3 255.255.255.0
 !
 router eigrp 1
   distribute-list prefix PL_IN in
   distribute-list prefix PL_OUT out
   distribute-list prefix PL_IN_IFACE in GigabitEthernet0/0
   distribute-list prefix PL_OUT_IFACE out GigabitEthernet0/0
-  network 2.2.2.2 0.0.0.255
+  network 2.2.2.0 0.0.0.255
+  network 3.3.3.0 0.0.0.255
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-eigrp-distribute-list-prefix-list
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-eigrp-distribute-list-prefix-list
@@ -1,0 +1,18 @@
+!
+hostname ios-eigrp-distribute-list-prefix-list
+!
+ip prefix-list PL_IN permit 1.1.1.0/24 ge 24
+ip prefix-list PL_IN_IFACE permit 1.1.1.0/24 ge 30
+ip prefix-list PL_OUT permit 2.2.2.0/24 ge 24
+ip prefix-list PL_OUT_IFACE permit 2.2.2.0/24 ge 30
+!
+interface GigabitEthernet0/0
+ ip address 2.2.2.2 255.255.255.0
+!
+router eigrp 1
+  distribute-list prefix PL_IN in
+  distribute-list prefix PL_OUT out
+  distribute-list prefix PL_IN_IFACE in GigabitEthernet0/0
+  distribute-list prefix PL_OUT_IFACE out GigabitEthernet0/0
+  network 2.2.2.2 0.0.0.255
+!


### PR DESCRIPTION
Support both inbound/outbound, both global/per interface
Support distribute lists that reference prefix lists in addition to ACLs

Note: EIGRP import policies not yet plumbed through to dataplane