### PR TITLE
VendorFormatConfigDetector: tweak NX-OS boot related lines

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/VendorConfigurationFormatDetector.java
@@ -51,7 +51,9 @@ public final class VendorConfigurationFormatDetector {
   private static final Pattern NEXUS_COMMIT_LINE_PATTERN = Pattern.compile("(?m)^ *commit *$");
   private static final Pattern NEXUS_FEATURE_LINE_PATTERN =
       Pattern.compile("(?m)^\\s*(no\\s*)?feature\\s+[^\\s+].*$");
-  private static final Pattern NEXUS_BOOTFLASH_PATTERN = Pattern.compile("bootflash:(n\\d+|nxos)");
+  private static final Pattern NEXUS_BOOT_NXOS_PATTERN = Pattern.compile("boot nxos");
+  private static final Pattern NEXUS_BOOTFLASH_PATTERN =
+      Pattern.compile("bootflash:(n\\d+|/?nxos)");
 
   // checkJuniper patterns
   private static final Pattern FLAT_JUNIPER_HOSTNAME_DECLARATION_PATTERN =
@@ -147,7 +149,9 @@ public final class VendorConfigurationFormatDetector {
     if (checkCiscoXr() == ConfigurationFormat.CISCO_IOS_XR) {
       return ConfigurationFormat.CISCO_IOS_XR;
     }
-    if (fileTextMatches(NEXUS_FEATURE_LINE_PATTERN) || fileTextMatches(NEXUS_BOOTFLASH_PATTERN)) {
+    if (fileTextMatches(NEXUS_BOOT_NXOS_PATTERN)
+        || fileTextMatches(NEXUS_FEATURE_LINE_PATTERN)
+        || fileTextMatches(NEXUS_BOOTFLASH_PATTERN)) {
       return ConfigurationFormat.CISCO_NX;
     }
     if (fileTextMatches(CISCO_LIKE_PATTERN)

--- a/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/VendorConfigurationFormatDetectorTest.java
@@ -130,9 +130,10 @@ public class VendorConfigurationFormatDetectorTest {
   public void testNxos() {
     String n7000 = "boot system bootflash:n7000-s2-dk9.7.2.1.D1.1.bin sup-2 \n";
     String nxos = "boot nxos bootflash:nxos.7.0.3.I4.7.bin \n";
+    String nxosVirtual = "boot nxos bootflash:/nxos.9.2.3.bin\n";
     String rancid = "!RANCID-CONTENT-TYPE: cisco-nx\n";
 
-    for (String fileText : ImmutableList.of(n7000, nxos, rancid)) {
+    for (String fileText : ImmutableList.of(n7000, nxos, nxosVirtual, rancid)) {
       assertThat(identifyConfigurationFormat(fileText), equalTo(CISCO_NX));
     }
   }


### PR DESCRIPTION
'boot nxos' ought to be a dead giveaway
for a 'bootflash:' line, there may be a '/' before the filename