### PR TITLE
Support for EIGRP inbound filtering in dataplane

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -1,6 +1,5 @@
 package org.batfish.dataplane.ibdp;
 
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 import static org.batfish.common.util.CollectionUtil.toImmutableSortedMap;
 import static org.batfish.common.util.CollectionUtil.toOrderedHashCode;
@@ -272,88 +271,134 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
   @Nonnull
   private RibDelta<EigrpInternalRoute> processInternalRoutes(NetworkConfigurations nc) {
     // TODO: simplify all this later. Copied from old code
-    Builder<EigrpInternalRoute> builder = RibDelta.builder();
+    Builder<EigrpInternalRoute> deltaBuilder = RibDelta.builder();
     _incomingInternalRoutes.forEach(
-        (edge, queue) -> {
-          processInternalRoutesFromNeighbor(nc, builder, edge, queue);
-        });
-    return builder.build();
+        (edge, queue) -> processInternalRoutesFromNeighbor(nc, deltaBuilder, edge, queue));
+    return deltaBuilder.build();
   }
 
   private void processInternalRoutesFromNeighbor(
       NetworkConfigurations nc,
-      Builder<EigrpInternalRoute> builder,
+      Builder<EigrpInternalRoute> deltaBuilder,
       EigrpEdge edge,
       Queue<RouteAdvertisement<EigrpInternalRoute>> queue) {
+    Interface remoteIface = edge.getNode1().getInterface(nc);
+    assert remoteIface.getEigrp() != null;
+    Ip nextHopIp = remoteIface.getConcreteAddress().getIp();
     EigrpMetric connectingInterfaceMetric = edge.getNode2().getInterfaceSettings(nc).getMetric();
-    Interface neighborInterface = edge.getNode1().getInterface(nc);
-    Ip nextHopIp = neighborInterface.getConcreteAddress().getIp();
+    @Nullable
+    RoutingPolicy importPolicy =
+        Optional.ofNullable(remoteIface.getEigrp().getImportPolicy())
+            .map(_configuration.getRoutingPolicies()::get)
+            .orElse(null);
     while (!queue.isEmpty()) {
       RouteAdvertisement<EigrpInternalRoute> ra = queue.remove();
       EigrpInternalRoute route = ra.getRoute();
-      EigrpMetric newMetric = connectingInterfaceMetric.add(route.getEigrpMetric());
-      EigrpInternalRoute transformedRoute =
-          EigrpInternalRoute.builder()
-              .setAdmin(_process.getInternalAdminCost())
-              .setEigrpMetric(newMetric)
-              .setNetwork(route.getNetwork())
-              .setNextHopIp(nextHopIp)
-              .setProcessAsn(_asn)
-              .build();
+      Optional<EigrpInternalRoute> transformedRoute =
+          transformAndFilterInternalRouteFromNeighbor(
+              route, connectingInterfaceMetric, nextHopIp, importPolicy);
+      if (!transformedRoute.isPresent()) {
+        continue;
+      }
       if (!ra.isWithdrawn()) {
-        builder.from(_internalRib.mergeRouteGetDelta(transformedRoute));
+        deltaBuilder.from(_internalRib.mergeRouteGetDelta(transformedRoute.get()));
       } else {
-        builder.from(_internalRib.removeRouteGetDelta(transformedRoute));
+        deltaBuilder.from(_internalRib.removeRouteGetDelta(transformedRoute.get()));
       }
     }
   }
 
+  @VisibleForTesting
+  Optional<EigrpInternalRoute> transformAndFilterInternalRouteFromNeighbor(
+      EigrpInternalRoute route,
+      EigrpMetric connectingInterfaceMetric,
+      Ip nextHopIp,
+      @Nullable RoutingPolicy importPolicy) {
+
+    EigrpMetric newMetric = connectingInterfaceMetric.add(route.getEigrpMetric());
+    EigrpInternalRoute.Builder outputRouteBuilder =
+        EigrpInternalRoute.builder()
+            .setAdmin(_process.getInternalAdminCost())
+            .setEigrpMetric(newMetric)
+            .setNetwork(route.getNetwork())
+            .setNextHopIp(nextHopIp)
+            .setProcessAsn(_asn);
+    return filterRouteOnImport(route, outputRouteBuilder, importPolicy);
+  }
+
+  /** Run an EIGRP route though the given import policy */
+  @VisibleForTesting
+  <B extends EigrpRoute.Builder<B, R>, R extends EigrpRoute> Optional<R> filterRouteOnImport(
+      R route, B outputBuilder, @Nullable RoutingPolicy policy) {
+    if (policy == null) {
+      return Optional.of(outputBuilder.build());
+    }
+    boolean allowed = policy.process(route, outputBuilder, _process, Direction.IN);
+    return allowed ? Optional.of(outputBuilder.build()) : Optional.empty();
+  }
+
   @Nonnull
   private RibDelta<EigrpExternalRoute> processExternalRoutes(NetworkConfigurations nc) {
-    // TODO: simplify all this later. Copied from old code
     RibDelta.Builder<EigrpExternalRoute> deltaBuilder = RibDelta.builder();
-    EigrpExternalRoute.Builder routeBuilder = EigrpExternalRoute.builder();
-    routeBuilder.setAdmin(_process.getExternalAdminCost()).setProcessAsn(_asn);
-
     _incomingExternalRoutes.forEach(
-        (edge, queue) -> {
-          processExternalRoutesFromNeighbor(nc, deltaBuilder, routeBuilder, edge, queue);
-        });
-
+        (edge, queue) -> processExternalRoutesFromNeighbor(nc, deltaBuilder, edge, queue));
     return deltaBuilder.build();
   }
 
   private void processExternalRoutesFromNeighbor(
       NetworkConfigurations nc,
       Builder<EigrpExternalRoute> deltaBuilder,
-      EigrpExternalRoute.Builder routeBuilder,
       EigrpEdge edge,
       Queue<RouteAdvertisement<EigrpExternalRoute>> queue) {
-    Interface nextHopIntf = edge.getNode1().getInterface(nc);
-    Interface connectingIntf = edge.getNode2().getInterface(nc);
+    Interface remoteIface = edge.getNode1().getInterface(nc);
+    assert remoteIface.getEigrp() != null;
+    Interface localIface = edge.getNode2().getInterface(nc);
+    assert localIface.getEigrp() != null;
 
-    // Edge nodes must have EIGRP configuration
-    checkState(connectingIntf.getEigrp() != null);
-
-    EigrpMetric connectingIntfMetric = connectingIntf.getEigrp().getMetric();
-
-    routeBuilder.setNextHopIp(nextHopIntf.getConcreteAddress().getIp());
     while (queue.peek() != null) {
       RouteAdvertisement<EigrpExternalRoute> routeAdvert = queue.remove();
       EigrpExternalRoute neighborRoute = routeAdvert.getRoute();
-      EigrpMetric metric = connectingIntfMetric.add(neighborRoute.getEigrpMetric());
-      routeBuilder
-          .setDestinationAsn(neighborRoute.getDestinationAsn())
-          .setEigrpMetric(metric)
-          .setNetwork(neighborRoute.getNetwork());
-      EigrpExternalRoute transformedRoute = routeBuilder.build();
 
+      @Nullable
+      RoutingPolicy importPolicy =
+          Optional.ofNullable(localIface.getEigrp().getImportPolicy())
+              .map(_configuration.getRoutingPolicies()::get)
+              .orElse(null);
+      Optional<EigrpExternalRoute> transformedRoute =
+          transformAndFilterExternalRouteFromNeighbor(
+              neighborRoute,
+              localIface.getEigrp().getMetric(),
+              remoteIface.getConcreteAddress().getIp(),
+              importPolicy);
+      if (!transformedRoute.isPresent()) {
+        continue;
+      }
       if (!routeAdvert.isWithdrawn()) {
-        deltaBuilder.from(_externalRib.mergeRouteGetDelta(transformedRoute));
+        deltaBuilder.from(_externalRib.mergeRouteGetDelta(transformedRoute.get()));
       } else {
-        deltaBuilder.from(_externalRib.removeRouteGetDelta(transformedRoute));
+        deltaBuilder.from(_externalRib.removeRouteGetDelta(transformedRoute.get()));
       }
     }
+  }
+
+  @Nonnull
+  @VisibleForTesting
+  Optional<EigrpExternalRoute> transformAndFilterExternalRouteFromNeighbor(
+      EigrpExternalRoute route,
+      EigrpMetric connectingIntfMetric,
+      Ip nextHopIp,
+      @Nullable RoutingPolicy importPolicy) {
+    EigrpMetric newMetric = connectingIntfMetric.add(route.getEigrpMetric());
+
+    EigrpExternalRoute.Builder routeBuilder =
+        EigrpExternalRoute.builder()
+            .setAdmin(_process.getExternalAdminCost())
+            .setProcessAsn(_asn)
+            .setNextHopIp(nextHopIp)
+            .setDestinationAsn(route.getDestinationAsn())
+            .setEigrpMetric(newMetric)
+            .setNetwork(route.getNetwork());
+    return filterRouteOnImport(route, routeBuilder, importPolicy);
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -39,6 +39,7 @@ import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.eigrp.EigrpEdge;
+import org.batfish.datamodel.eigrp.EigrpInterfaceSettings;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.eigrp.EigrpNeighborConfig;
 import org.batfish.datamodel.eigrp.EigrpNeighborConfigId;
@@ -285,10 +286,11 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
     Interface remoteIface = edge.getNode1().getInterface(nc);
     assert remoteIface.getEigrp() != null;
     Ip nextHopIp = remoteIface.getConcreteAddress().getIp();
-    EigrpMetric connectingInterfaceMetric = edge.getNode2().getInterfaceSettings(nc).getMetric();
+    EigrpInterfaceSettings localEigrpIface = edge.getNode2().getInterfaceSettings(nc);
+    EigrpMetric connectingInterfaceMetric = localEigrpIface.getMetric();
     @Nullable
     RoutingPolicy importPolicy =
-        Optional.ofNullable(remoteIface.getEigrp().getImportPolicy())
+        Optional.ofNullable(localEigrpIface.getImportPolicy())
             .map(_configuration.getRoutingPolicies()::get)
             .orElse(null);
     while (!queue.isEmpty()) {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpRoutingProcessTest.java
@@ -1,13 +1,26 @@
 package org.batfish.dataplane.ibdp;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
 import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.EigrpExternalRoute;
+import org.batfish.datamodel.EigrpInternalRoute;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.eigrp.ClassicMetric;
+import org.batfish.datamodel.eigrp.EigrpMetricValues;
 import org.batfish.datamodel.eigrp.EigrpProcess;
 import org.batfish.datamodel.eigrp.EigrpProcessMode;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.dataplane.rib.RibDelta;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,11 +28,20 @@ import org.junit.Test;
 /** Tests of {@link EigrpRoutingProcess} */
 public class EigrpRoutingProcessTest {
 
+  Configuration _c;
   EigrpProcess _process;
   EigrpRoutingProcess _routingProcess;
+  private EigrpExternalRoute.Builder _externalRouteBuilder;
+  private EigrpInternalRoute.Builder _internalRouteBuilder;
+  private ClassicMetric _ifaceMetric;
 
   @Before
   public void setUp() {
+    _c =
+        Configuration.builder()
+            .setHostname("c1")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
     _process =
         EigrpProcess.builder()
             .setAsNumber(1)
@@ -29,6 +51,43 @@ public class EigrpRoutingProcessTest {
     _routingProcess =
         new EigrpRoutingProcess(
             _process, "vrf", new Configuration("host", ConfigurationFormat.CISCO_IOS));
+    _ifaceMetric =
+        ClassicMetric.builder()
+            .setValues(
+                EigrpMetricValues.builder()
+                    .setBandwidth(1)
+                    .setDelay(2)
+                    .setReliability(3)
+                    .setEffectiveBandwidth(4)
+                    .setMtu(5)
+                    .build())
+            .build();
+    ClassicMetric metric =
+        ClassicMetric.builder()
+            .setValues(
+                EigrpMetricValues.builder()
+                    .setBandwidth(1)
+                    .setDelay(2)
+                    .setReliability(3)
+                    .setEffectiveBandwidth(4)
+                    .setMtu(5)
+                    .build())
+            .build();
+    _externalRouteBuilder =
+        EigrpExternalRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setAdmin(222)
+            .setProcessAsn(1L)
+            .setNextHopIp(Ip.parse("1.1.1.1"))
+            .setDestinationAsn(2L)
+            .setEigrpMetric(metric);
+    _internalRouteBuilder =
+        EigrpInternalRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setAdmin(222)
+            .setProcessAsn(1L)
+            .setNextHopIp(Ip.parse("1.1.1.1"))
+            .setEigrpMetric(metric);
   }
 
   @Test
@@ -42,5 +101,78 @@ public class EigrpRoutingProcessTest {
                     .setNextHopInterface("Eth0")
                     .build(),
                 "vrf")));
+  }
+
+  @Test
+  public void testTransformAndFilterExternalRouteFromNeighborBlocked() {
+    RoutingPolicy rp =
+        RoutingPolicy.builder()
+            .setName("rp")
+            .setOwner(_c)
+            .setStatements(ImmutableList.of(Statements.ExitReject.toStaticStatement()))
+            .build();
+    EigrpExternalRoute routeIn = _externalRouteBuilder.build();
+    assertFalse(
+        _routingProcess
+            .transformAndFilterExternalRouteFromNeighbor(
+                routeIn, _ifaceMetric, Ip.parse("9.9.9.9"), rp)
+            .isPresent());
+  }
+
+  @Test
+  public void testTransformAndFilterExternalRouteFromNeighborAllowed() {
+    RoutingPolicy rp =
+        RoutingPolicy.builder()
+            .setName("rp")
+            .setOwner(_c)
+            .setStatements(ImmutableList.of(Statements.ExitAccept.toStaticStatement()))
+            .build();
+    EigrpExternalRoute routeIn = _externalRouteBuilder.build();
+
+    Ip ip = Ip.parse("9.9.9.9");
+    Optional<EigrpExternalRoute> maybeRoute =
+        _routingProcess.transformAndFilterExternalRouteFromNeighbor(routeIn, _ifaceMetric, ip, rp);
+    assertTrue(maybeRoute.isPresent());
+    EigrpExternalRoute route = maybeRoute.get();
+    assertThat(route.getNextHopIp(), equalTo(ip));
+    assertThat(route.getAdministrativeCost(), equalTo(_process.getExternalAdminCost()));
+    assertThat(route.getEigrpMetric(), equalTo(routeIn.getEigrpMetric().add(_ifaceMetric)));
+    assertThat(route.getProcessAsn(), equalTo(_process.getAsn()));
+  }
+
+  @Test
+  public void testTransformAndFilterInternalRouteFromNeighborBlocked() {
+    RoutingPolicy rp =
+        RoutingPolicy.builder()
+            .setName("rp")
+            .setOwner(_c)
+            .setStatements(ImmutableList.of(Statements.ExitReject.toStaticStatement()))
+            .build();
+    EigrpExternalRoute routeIn = _externalRouteBuilder.build();
+    assertFalse(
+        _routingProcess
+            .transformAndFilterExternalRouteFromNeighbor(
+                routeIn, _ifaceMetric, Ip.parse("9.9.9.9"), rp)
+            .isPresent());
+  }
+
+  @Test
+  public void testTransformAndFilterInternalRouteFromNeighborAllowed() {
+    RoutingPolicy rp =
+        RoutingPolicy.builder()
+            .setName("rp")
+            .setOwner(_c)
+            .setStatements(ImmutableList.of(Statements.ExitAccept.toStaticStatement()))
+            .build();
+    EigrpInternalRoute routeIn = _internalRouteBuilder.build();
+    Ip ip = Ip.parse("9.9.9.9");
+    Optional<EigrpInternalRoute> maybeRoute =
+        _routingProcess.transformAndFilterInternalRouteFromNeighbor(routeIn, _ifaceMetric, ip, rp);
+    assertTrue(maybeRoute.isPresent());
+    EigrpInternalRoute route = maybeRoute.get();
+    assertThat(route.getNextHopIp(), equalTo(ip));
+    assertThat(route.getAdministrativeCost(), equalTo(_process.getInternalAdminCost()));
+    assertThat(route.getEigrpMetric(), equalTo(routeIn.getEigrpMetric().add(_ifaceMetric)));
+    assertThat(route.getProcessAsn(), equalTo(_process.getAsn()));
   }
 }


### PR DESCRIPTION
Execute neighbor import policies during dataplane computation.

Among other things a I tried to clean up things a little bit (and standardize external/internal route processing) but I tried not to go too far so deferring any additional/larger cleanup.