### PR TITLE
IOS XR: policy map parsing

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
@@ -2621,6 +2621,11 @@ DCE_MODE
    'dce-mode'
 ;
 
+DEACTIVATE
+:
+   'deactivate'
+;
+
 DEAD_INTERVAL
 :
    'dead-interval'
@@ -3211,6 +3216,11 @@ DISCARD_ROUTE
    'discard-route'
 ;
 
+DISCONNECT
+:
+   'disconnect'
+;
+
 DISCOVERED_AP_CNT
 :
    'discovered-ap-cnt'
@@ -3276,9 +3286,19 @@ DO
    'do'
 ;
 
+DO_ALL
+:
+   'do-all'
+;
+
 DO_UNTIL_FAILURE
 :
    'do-until-failure'
+;
+
+DO_UNTIL_SUCCESS
+:
+   'do-until-success'
 ;
 
 DOD_HOST_PROHIBITED
@@ -3539,6 +3559,11 @@ DYNAMIC_MCAST_OPTIMIZATION
 DYNAMIC_MCAST_OPTIMIZATION_THRESH
 :
    'dynamic-mcast-optimization-thresh'
+;
+
+DYNAMIC_TEMPLATE
+:
+   'dynamic-template'
 ;
 
 E164
@@ -8672,6 +8697,11 @@ PERCENT_LITERAL
    'percent'
 ;
 
+PERFORMANCE_TRAFFIC
+:
+   'performance-traffic'
+;
+
 PERIODIC
 :
    'periodic'
@@ -10669,6 +10699,11 @@ SET_OVERLOAD_BIT
    'set-overload-bit'
 ;
 
+SET_TIMER
+:
+   'set-timer'
+;
+
 SETUP
 :
    'setup'
@@ -11334,6 +11369,11 @@ STOP_ONLY
 STOP_RECORD
 :
    'stop-record'
+;
+
+STOP_TIMER
+:
+   'stop-timer'
 ;
 
 STOPBITS
@@ -12044,6 +12084,11 @@ TRACKING_PRIORITY_INCREMENT
 TRADITIONAL
 :
    'traditional'
+;
+
+TRAFFIC
+:
+   'traffic'
 ;
 
 TRAFFIC_ENG

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrParser.g4
@@ -3552,7 +3552,6 @@ stanza
    | s_passwd
    | s_phone_proxy
    | s_policy_map
-   | s_policy_map_ios
    | s_privilege
    | s_process_max_time
    | s_qos_mapping

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_qos.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_qos.g4
@@ -667,24 +667,24 @@ pm_end_policy_map
    END_POLICY_MAP NEWLINE
 ;
 
-pm_event
+pmtcs_event
 :
    EVENT null_rest_of_line
    (
-      pm_event_class
+      pmtcse_class
    )*
 ;
 
-pm_event_class
+pmtcse_class
 :
    CLASS
    (
       CLASS_DEFAULT
       | TYPE CONTROL SUBSCRIBER classname = variable
    )
-   pmec_do?
+   pmtcsec_do?
    NEWLINE
-   pmec_tail*
+   pmtcsec_tail*
 ;
 
 pm_ios_inspect
@@ -760,8 +760,6 @@ pm_parameters
 pm_tail
 :
   pm_class
-  | pm_end_policy_map
-  | pm_event
   | pm_null
   | pm_parameters
 ;
@@ -813,14 +811,14 @@ pmcp_null
    ) null_rest_of_line
 ;
 
-pmec_do
+pmtcsec_do
 :
   DO_ALL
   | DO_UNTIL_FAILURE
   | DO_UNTIL_SUCCESS
 ;
 
-pmec_tail
+pmtcsec_tail
 :
   DEC
   (
@@ -845,6 +843,11 @@ pmp_null
       | PROTOCOL_VIOLATION
       | TCP_INSPECTION
    ) null_rest_of_line
+;
+
+pmtcs_tail
+:
+  pmtcs_event
 ;
 
 qm_null
@@ -918,19 +921,23 @@ s_policy_map
 :
    POLICY_MAP
    (
+      mapname = variable NEWLINE pm_tail*
+      |
       TYPE
       (
-          ACCOUNTING
-          | CONTROL SUBSCRIBER
-          | PBR
-          | PERFORMANCE_TRAFFIC
-          | QOS
-          | REDIRECT
-          | TRAFFIC
+          CONTROL SUBSCRIBER mapname = variable NEWLINE pmtcs_tail
+          |
+          (
+              ACCOUNTING
+              | PBR
+              | PERFORMANCE_TRAFFIC
+              | QOS
+              | REDIRECT
+              | TRAFFIC
+          ) mapname = variable NEWLINE pm_tail*
       )
-   )?
-   mapname = variable NEWLINE
-   pm_tail*
+   )
+   pm_end_policy_map?
 ;
 
 s_policy_map_ios

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_qos.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_qos.g4
@@ -677,25 +677,14 @@ pm_event
 
 pm_event_class
 :
-   DEC CLASS
+   CLASS
    (
-      ALWAYS
-      | classname = variable
-   ) DO_UNTIL_FAILURE NEWLINE
-   (
-      DEC
-      (
-         ACTIVATE SERVICE_TEMPLATE stname = variable
-         | AUTHENTICATE
-         | AUTHENTICATION_RESTART
-         | AUTHORIZE
-         | CLEAR_SESSION
-         | PAUSE
-         | RESTRICT
-         | RESUME
-         | TERMINATE
-      ) null_rest_of_line
-   )*
+      CLASS_DEFAULT
+      | TYPE CONTROL SUBSCRIBER classname = variable
+   )
+   pmec_do?
+   NEWLINE
+   pmec_tail*
 ;
 
 pm_ios_inspect
@@ -768,6 +757,15 @@ pm_parameters
    )*
 ;
 
+pm_tail
+:
+  pm_class
+  | pm_end_policy_map
+  | pm_event
+  | pm_null
+  | pm_parameters
+;
+
 pmc_null
 :
    NO?
@@ -813,6 +811,28 @@ pmcp_null
       | EXCEED_ACTION
       | VIOLATE_ACTION
    ) null_rest_of_line
+;
+
+pmec_do
+:
+  DO_ALL
+  | DO_UNTIL_FAILURE
+  | DO_UNTIL_SUCCESS
+;
+
+pmec_tail
+:
+  DEC
+  (
+     ACTIVATE DYNAMIC_TEMPLATE dtname = variable
+     | AUTHENTICATE
+     | AUTHORIZE
+     | DEACTIVATE
+     | DISCONNECT
+     | MONITOR
+     | SET_TIMER
+     | STOP_TIMER
+  ) null_rest_of_line
 ;
 
 pmp_null
@@ -898,34 +918,19 @@ s_policy_map
 :
    POLICY_MAP
    (
-      variable_policy_map_header
-      |
+      TYPE
       (
-         TYPE variable variable variable
+          ACCOUNTING
+          | CONTROL SUBSCRIBER
+          | PBR
+          | PERFORMANCE_TRAFFIC
+          | QOS
+          | REDIRECT
+          | TRAFFIC
       )
-      |
-      (
-         TYPE
-         (
-            CONTROL_PLANE
-            | NETWORK_QOS
-            | PBR
-            | QUEUEING
-            | QUEUING
-            | QOS
-         ) mapname = variable
-         (
-            TEMPLATE template = variable
-         )?
-      )
-   ) NEWLINE
-   (
-      pm_class
-      | pm_end_policy_map
-      | pm_event
-      | pm_null
-      | pm_parameters
-   )*
+   )?
+   mapname = variable NEWLINE
+   pm_tail*
 ;
 
 s_policy_map_ios

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_qos.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_qos.g4
@@ -687,59 +687,6 @@ pmtcse_class
    pmtcsec_tail*
 ;
 
-pm_ios_inspect
-:
-   INSPECT name = variable_permissive NEWLINE
-   (
-      pm_iosi_class_default
-      | pm_iosi_class_type_inspect
-   )*
-;
-
-pm_iosi_class_default
-:
-   CLASS CLASS_DEFAULT NEWLINE
-   (
-      pi_iosicd_drop
-      | pi_iosicd_pass
-   )*
-;
-
-pm_iosi_class_type_inspect
-:
-   CLASS TYPE INSPECT name = variable NEWLINE
-   (
-      pm_iosict_drop
-      | pm_iosict_inspect
-      | pm_iosict_pass
-   )*
-;
-
-pi_iosicd_drop
-:
-   DROP LOG? NEWLINE
-;
-
-pi_iosicd_pass
-:
-   PASS NEWLINE
-;
-
-pm_iosict_drop
-:
-   DROP LOG? NEWLINE
-;
-
-pm_iosict_inspect
-:
-   INSPECT NEWLINE
-;
-
-pm_iosict_pass
-:
-   PASS NEWLINE
-;
-
 pm_null
 :
    NO?
@@ -938,11 +885,6 @@ s_policy_map
       )
    )
    pm_end_policy_map?
-;
-
-s_policy_map_ios
-:
-   POLICY_MAP TYPE pm_ios_inspect
 ;
 
 s_qos_mapping

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_qos.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_qos.g4
@@ -641,30 +641,62 @@ os_service
    SERVICE service_specifier NEWLINE
 ;
 
-pm_class
-:
-   num = DEC? CLASS
-   (
-      TYPE
-      (
-         CONTROL_PLANE
-         | NETWORK_QOS
-         | PBR
-         | QOS
-         | QUEUING
-      ) name = variable_permissive
-      | name = variable_permissive
-   ) NEWLINE
-   (
-      pmc_null
-      | pmc_police
-      | pmc_service_policy
-   )*
-;
-
 pm_end_policy_map
 :
    END_POLICY_MAP NEWLINE
+;
+
+pm_type_accounting
+:
+   TYPE ACCOUNTING mapname = variable NEWLINE
+   pm_type_null_tail*
+;
+
+pm_type_null_tail
+:
+     (
+         CLASS
+         | DESCRIPTION
+     )  null_rest_of_line
+;
+
+pm_type_control_subscriber
+:
+   TYPE CONTROL SUBSCRIBER mapname = variable NEWLINE
+   (
+      pmtcs_event
+      | pm_type_null_tail
+   )*
+;
+
+pm_type_pbr
+:
+   TYPE PBR mapname = variable NEWLINE
+   pm_type_null_tail*
+;
+
+pm_type_performance_traffic
+:
+   TYPE PERFORMANCE_TRAFFIC mapname = variable NEWLINE
+   pm_type_null_tail*
+;
+
+pm_type_qos
+:
+   (TYPE QOS)? mapname = variable NEWLINE
+   pm_type_null_tail*
+;
+
+pm_type_redirect
+:
+   TYPE REDIRECT mapname = variable NEWLINE
+   pm_type_null_tail*
+;
+
+pm_type_traffic
+:
+   TYPE TRAFFIC mapname = variable NEWLINE
+   pm_type_null_tail*
 ;
 
 pmtcs_event
@@ -687,77 +719,6 @@ pmtcse_class
    pmtcsec_tail*
 ;
 
-pm_null
-:
-   NO?
-   (
-      CIR
-      | DESCRIPTION
-   ) null_rest_of_line
-;
-
-pm_parameters
-:
-   PARAMETERS NEWLINE
-   (
-      pmp_null
-   )*
-;
-
-pm_tail
-:
-  pm_class
-  | pm_null
-  | pm_parameters
-;
-
-pmc_null
-:
-   NO?
-   (
-      BANDWIDTH
-      | CONGESTION_CONTROL
-      | DBL
-      | DROP
-      | FAIR_QUEUE
-      | INSPECT
-      | MTU
-      | PASS
-      | PAUSE
-      | PRIORITY
-      | QUEUE_BUFFERS
-      | QUEUE_LIMIT
-      | RANDOM_DETECT
-      | SET
-      | SHAPE
-      | TRUST
-      | USER_STATISTICS
-   ) null_rest_of_line
-;
-
-pmc_police
-:
-   POLICE null_rest_of_line
-   (
-      pmcp_null
-   )*
-;
-
-pmc_service_policy
-:
-   SERVICE_POLICY name = variable NEWLINE
-;
-
-pmcp_null
-:
-   NO?
-   (
-      CONFORM_ACTION
-      | EXCEED_ACTION
-      | VIOLATE_ACTION
-   ) null_rest_of_line
-;
-
 pmtcsec_do
 :
   DO_ALL
@@ -769,32 +730,27 @@ pmtcsec_tail
 :
   DEC
   (
-     ACTIVATE DYNAMIC_TEMPLATE dtname = variable
-     | AUTHENTICATE
-     | AUTHORIZE
-     | DEACTIVATE
-     | DISCONNECT
-     | MONITOR
-     | SET_TIMER
-     | STOP_TIMER
-  ) null_rest_of_line
+     pmtcsec_activate
+     | pmtcsec_null
+  )
 ;
 
-pmp_null
+pmtcsec_activate
 :
-   NO?
-   (
-      ID_MISMATCH
-      | ID_RANDOMIZATION
-      | MESSAGE_LENGTH
-      | PROTOCOL_VIOLATION
-      | TCP_INSPECTION
-   ) null_rest_of_line
+  ACTIVATE DYNAMIC_TEMPLATE dtname = variable NEWLINE
 ;
 
-pmtcs_tail
+pmtcsec_null
 :
-  pmtcs_event
+  (
+   AUTHENTICATE
+   | AUTHORIZE
+   | DEACTIVATE
+   | DISCONNECT
+   | MONITOR
+   | SET_TIMER
+   | STOP_TIMER
+) null_rest_of_line
 ;
 
 qm_null
@@ -868,21 +824,13 @@ s_policy_map
 :
    POLICY_MAP
    (
-      mapname = variable NEWLINE pm_tail*
-      |
-      TYPE
-      (
-          CONTROL SUBSCRIBER mapname = variable NEWLINE pmtcs_tail
-          |
-          (
-              ACCOUNTING
-              | PBR
-              | PERFORMANCE_TRAFFIC
-              | QOS
-              | REDIRECT
-              | TRAFFIC
-          ) mapname = variable NEWLINE pm_tail*
-      )
+      pm_type_accounting
+      | pm_type_control_subscriber
+      | pm_type_pbr
+      | pm_type_performance_traffic
+      | pm_type_qos
+      | pm_type_redirect
+      | pm_type_traffic
    )
    pm_end_policy_map?
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -658,14 +658,14 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Pim_rp_candidateContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pim_send_rp_announceContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pim_spt_thresholdContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_classContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_event_classContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_ios_inspectContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_iosi_class_type_inspectContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_iosict_dropContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_iosict_inspectContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_iosict_passContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pmc_service_policyContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.Pmec_tailContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Pmtcse_classContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Pmtcsec_tailContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.PortContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Port_specifierContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Prefix_list_bgp_tailContext;
@@ -6096,7 +6096,7 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   }
 
   @Override
-  public void exitPm_event_class(Pm_event_classContext ctx) {
+  public void exitPmtcse_class(Pmtcse_classContext ctx) {
     if (ctx.classname != null) {
       _configuration.referenceStructure(
           CLASS_MAP, ctx.classname.getText(), POLICY_MAP_EVENT_CLASS, ctx.getStart().getLine());
@@ -6104,7 +6104,7 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   }
 
   @Override
-  public void exitPmec_tail(Pmec_tailContext ctx) {
+  public void exitPmtcsec_tail(Pmtcsec_tailContext ctx) {
     if (ctx.dtname != null) {
       _configuration.referenceStructure(
           DYNAMIC_TEMPLATE,

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -18,6 +18,7 @@ import static org.batfish.representation.cisco_xr.CiscoXrStructureType.CLASS_MAP
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.COMMUNITY_SET;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.CRYPTO_DYNAMIC_MAP_SET;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.CRYPTO_MAP_SET;
+import static org.batfish.representation.cisco_xr.CiscoXrStructureType.DYNAMIC_TEMPLATE;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.EXTCOMMUNITY_SET_RT;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.ICMP_TYPE_OBJECT_GROUP;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.INSPECT_CLASS_MAP;
@@ -664,6 +665,7 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_iosict_dropContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_iosict_inspectContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_iosict_passContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pmc_service_policyContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Pmec_tailContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.PortContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Port_specifierContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Prefix_list_bgp_tailContext;
@@ -3005,10 +3007,8 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   @Override
   public void enterS_policy_map(S_policy_mapContext ctx) {
     // TODO: do something with this.
-    if (ctx.variable_policy_map_header() != null) {
-      String name = ctx.variable_policy_map_header().getText();
-      _configuration.defineStructure(POLICY_MAP, name, ctx);
-    }
+    String name = ctx.mapname.getText();
+    _configuration.defineStructure(POLICY_MAP, name, ctx);
   }
 
   @Override
@@ -6101,12 +6101,16 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
       _configuration.referenceStructure(
           CLASS_MAP, ctx.classname.getText(), POLICY_MAP_EVENT_CLASS, ctx.getStart().getLine());
     }
-    if (ctx.stname != null) {
+  }
+
+  @Override
+  public void exitPmec_tail(Pmec_tailContext ctx) {
+    if (ctx.dtname != null) {
       _configuration.referenceStructure(
-          SERVICE_TEMPLATE,
-          ctx.stname.getText(),
+          DYNAMIC_TEMPLATE,
+          ctx.dtname.getText(),
           POLICY_MAP_EVENT_CLASS_ACTIVATE,
-          ctx.stname.getStart().getLine());
+          ctx.dtname.getStart().getLine());
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -143,8 +143,6 @@ import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.PIM_RP_A
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.PIM_RP_CANDIDATE_ACL;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.PIM_SEND_RP_ANNOUNCE_ACL;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.PIM_SPT_THRESHOLD_ACL;
-import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.POLICY_MAP_CLASS;
-import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.POLICY_MAP_CLASS_SERVICE_POLICY;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.POLICY_MAP_EVENT_CLASS;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.POLICY_MAP_EVENT_CLASS_ACTIVATE;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureUsage.PROTOCOL_OBJECT_GROUP_GROUP_OBJECT;
@@ -653,10 +651,15 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Pim_rp_announce_filterContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pim_rp_candidateContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pim_send_rp_announceContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pim_spt_thresholdContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_classContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.Pmc_service_policyContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_type_accountingContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_type_control_subscriberContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_type_pbrContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_type_performance_trafficContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_type_qosContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_type_redirectContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Pm_type_trafficContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Pmtcse_classContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.Pmtcsec_tailContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Pmtcsec_activateContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.PortContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Port_specifierContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Prefix_list_bgp_tailContext;
@@ -769,7 +772,6 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.S_loggingContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.S_mac_access_listContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.S_mac_access_list_extendedContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.S_ntpContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.S_policy_mapContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.S_router_ospfContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.S_router_ripContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.S_serviceContext;
@@ -2642,6 +2644,54 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   }
 
   @Override
+  public void enterPm_type_accounting(Pm_type_accountingContext ctx) {
+    String name = ctx.mapname.getText();
+    _configuration.defineStructure(POLICY_MAP, name, ctx);
+    warn(ctx, "Policy map of type accounting is not supported");
+  }
+
+  @Override
+  public void enterPm_type_control_subscriber(Pm_type_control_subscriberContext ctx) {
+    String name = ctx.mapname.getText();
+    _configuration.defineStructure(POLICY_MAP, name, ctx);
+  }
+
+  @Override
+  public void enterPm_type_pbr(Pm_type_pbrContext ctx) {
+    String name = ctx.mapname.getText();
+    _configuration.defineStructure(POLICY_MAP, name, ctx);
+    warn(ctx, "Policy map of type pbr is not supported");
+  }
+
+  @Override
+  public void enterPm_type_performance_traffic(Pm_type_performance_trafficContext ctx) {
+    String name = ctx.mapname.getText();
+    _configuration.defineStructure(POLICY_MAP, name, ctx);
+    warn(ctx, "Policy map of type performance-traffic is not supported");
+  }
+
+  @Override
+  public void enterPm_type_qos(Pm_type_qosContext ctx) {
+    String name = ctx.mapname.getText();
+    _configuration.defineStructure(POLICY_MAP, name, ctx);
+    warn(ctx, "Policy map of type qos is not supported");
+  }
+
+  @Override
+  public void enterPm_type_redirect(Pm_type_redirectContext ctx) {
+    String name = ctx.mapname.getText();
+    _configuration.defineStructure(POLICY_MAP, name, ctx);
+    warn(ctx, "Policy map of type redirect is not supported");
+  }
+
+  @Override
+  public void enterPm_type_traffic(Pm_type_trafficContext ctx) {
+    String name = ctx.mapname.getText();
+    _configuration.defineStructure(POLICY_MAP, name, ctx);
+    warn(ctx, "Policy map of type traffic is not supported");
+  }
+
+  @Override
   public void enterRo_area(Ro_areaContext ctx) {
     long area;
     if (ctx.area_int != null) {
@@ -2986,13 +3036,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
     if (_configuration.getCf().getNtp() == null) {
       _configuration.getCf().setNtp(new Ntp());
     }
-  }
-
-  @Override
-  public void enterS_policy_map(S_policy_mapContext ctx) {
-    // TODO: do something with this.
-    String name = ctx.mapname.getText();
-    _configuration.defineStructure(POLICY_MAP, name, ctx);
   }
 
   @Override
@@ -6052,26 +6095,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   }
 
   @Override
-  public void enterPm_class(Pm_classContext ctx) {
-    // TODO: do something with this.
-    // should be something like _currentPolicyMapClass = ...
-    String name = ctx.name.getText();
-    _configuration.referenceStructure(CLASS_MAP, name, POLICY_MAP_CLASS, ctx.getStart().getLine());
-    if ("class-default".equals(name)) {
-      // This is a hack because there's an implicit class named "class-default" and we don't want
-      // a false positive undefined reference.
-      _configuration.defineSingleLineStructure(
-          CLASS_MAP, "class-default", ctx.getStart().getLine());
-    }
-  }
-
-  @Override
-  public void exitPm_class(Pm_classContext ctx) {
-    // TODO: do something with this.
-    // should be something like _currentPolicyMapClass = null.
-  }
-
-  @Override
   public void exitPmtcse_class(Pmtcse_classContext ctx) {
     if (ctx.classname != null) {
       _configuration.referenceStructure(
@@ -6080,23 +6103,12 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   }
 
   @Override
-  public void exitPmtcsec_tail(Pmtcsec_tailContext ctx) {
-    if (ctx.dtname != null) {
-      _configuration.referenceStructure(
-          DYNAMIC_TEMPLATE,
-          ctx.dtname.getText(),
-          POLICY_MAP_EVENT_CLASS_ACTIVATE,
-          ctx.dtname.getStart().getLine());
-    }
-  }
-
-  @Override
-  public void exitPmc_service_policy(Pmc_service_policyContext ctx) {
+  public void exitPmtcsec_activate(Pmtcsec_activateContext ctx) {
     _configuration.referenceStructure(
-        POLICY_MAP,
-        ctx.name.getText(),
-        POLICY_MAP_CLASS_SERVICE_POLICY,
-        ctx.name.getStart().getLine());
+        DYNAMIC_TEMPLATE,
+        ctx.dtname.getText(),
+        POLICY_MAP_EVENT_CLASS_ACTIVATE,
+        ctx.dtname.getStart().getLine());
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -905,8 +905,6 @@ import org.batfish.representation.cisco_xr.InspectClassMapMatch;
 import org.batfish.representation.cisco_xr.InspectClassMapMatchAccessGroup;
 import org.batfish.representation.cisco_xr.InspectClassMapMatchProtocol;
 import org.batfish.representation.cisco_xr.InspectClassMapProtocol;
-import org.batfish.representation.cisco_xr.InspectPolicyMap;
-import org.batfish.representation.cisco_xr.InspectPolicyMapInspectClass;
 import org.batfish.representation.cisco_xr.Interface;
 import org.batfish.representation.cisco_xr.IpBgpPeerGroup;
 import org.batfish.representation.cisco_xr.IpsecProfile;
@@ -1299,10 +1297,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   private ServiceObjectGroup _currentServiceObjectGroup;
 
   private InspectClassMap _currentInspectClassMap;
-
-  private InspectPolicyMap _currentInspectPolicyMap;
-
-  private InspectPolicyMapInspectClass _currentInspectPolicyMapInspectClass;
 
   private Integer _currentHsrpGroup;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrStructureType.java
@@ -16,6 +16,7 @@ public enum CiscoXrStructureType implements StructureType {
   COMMUNITY_SET("community-set"),
   CRYPTO_DYNAMIC_MAP_SET("crypto-dynamic-map-set"),
   CRYPTO_MAP_SET("crypto-map-set"),
+  DYNAMIC_TEMPLATE("dynamic-template"),
   EXTCOMMUNITY_SET_RT("extcommunity-set rt"),
   ICMP_TYPE_OBJECT("object icmp-type"),
   ICMP_TYPE_OBJECT_GROUP("object-group icmp-type"),

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrStructureType.java
@@ -21,7 +21,6 @@ public enum CiscoXrStructureType implements StructureType {
   ICMP_TYPE_OBJECT("object icmp-type"),
   ICMP_TYPE_OBJECT_GROUP("object-group icmp-type"),
   INSPECT_CLASS_MAP("class-map type inspect"),
-  INSPECT_POLICY_MAP("policy-map type inspect"),
   INTERFACE("interface"),
   IP_ACCESS_LIST("ipv4/6 acl"),
   IPSEC_PROFILE("crypto ipsec profile"),

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrStructureUsage.java
@@ -55,7 +55,6 @@ public enum CiscoXrStructureUsage implements StructureUsage {
   FAILOVER_LINK_INTERFACE("failover link interface"),
   ICMP_TYPE_OBJECT_GROUP_GROUP_OBJECT("object-group icmp-type group-object"),
   INSPECT_CLASS_MAP_MATCH_ACCESS_GROUP("class-map type inspect match access-group"),
-  INSPECT_POLICY_MAP_INSPECT_CLASS("policy-map type inspect class type inspect"),
   INTERFACE_BFD_TEMPLATE("interface bfd template"),
   INTERFACE_IGMP_ACCESS_GROUP_ACL("interface igmp access-group acl"),
   INTERFACE_IGMP_HOST_PROXY_ACCESS_LIST("interface igmp host-proxy access-list"),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -14,6 +14,8 @@ import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
 import static org.batfish.representation.cisco_xr.CiscoXrConfiguration.computeCommunitySetMatchAnyName;
 import static org.batfish.representation.cisco_xr.CiscoXrConfiguration.computeCommunitySetMatchEveryName;
 import static org.batfish.representation.cisco_xr.CiscoXrConfiguration.computeExtcommunitySetRtName;
+import static org.batfish.representation.cisco_xr.CiscoXrStructureType.CLASS_MAP;
+import static org.batfish.representation.cisco_xr.CiscoXrStructureType.POLICY_MAP;
 import static org.batfish.representation.cisco_xr.CiscoXrStructureType.PREFIX_SET;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -731,5 +733,21 @@ public final class XrGrammarTest {
     assertTrue(bgpRpOut.process(permittedRoute, Bgpv4Route.builder(), Direction.OUT));
     assertTrue(bgpRpOut.process(permittedRoute2, Bgpv4Route.builder(), Direction.OUT));
     assertFalse(bgpRpOut.process(rejectedRoute, Bgpv4Route.builder(), Direction.OUT));
+  }
+
+  @Test
+  public void testPolicyMap() {
+    String hostname = "policy-map";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    Configuration c = batfish.loadConfigurations(batfish.getSnapshot()).get(hostname);
+
+    ConvertConfigurationAnswerElement ccae =
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
+    String filename = "configs/" + hostname;
+
+    assertThat(ccae, hasNumReferrers(filename, POLICY_MAP, "POLICY-MAP", 1));
+    assertThat(ccae, hasNumReferrers(filename, CLASS_MAP, "PPP", 1));
+
+    assertThat(ccae, hasNumReferrers(filename, POLICY_MAP, "PM", 0));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -739,7 +739,6 @@ public final class XrGrammarTest {
   public void testPolicyMap() {
     String hostname = "policy-map";
     Batfish batfish = getBatfishForConfigurationNames(hostname);
-    Configuration c = batfish.loadConfigurations(batfish.getSnapshot()).get(hostname);
 
     ConvertConfigurationAnswerElement ccae =
         batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/policy-map
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/policy-map
@@ -1,0 +1,29 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+hostname policy-map
+!
+class-map type control subscriber match-any PPP
+ match protocol ppp
+ end-class-map
+!
+policy-map type control subscriber POLICY-MAP
+ event session-start match-first
+  class type control subscriber PPP do-until-failure
+   10 activate dynamic-template TEMPLATE1
+  !
+  class class_default
+  class type control subscriber CM do-all
+  class type control subscriber CM do-until-success
+ !
+end-policy-map
+!
+interface Bundle-Ether1.1
+ service-policy type control subscriber POLICY-MAP
+!
+! other policy-map definitions
+policy-map PM
+policy-map type accounting PM
+policy-map type pbr PM
+policy-map type performance-traffic PM
+policy-map type qos PM
+policy-map type redirect PM
+policy-map type traffic PM

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/policy-map
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/policy-map
@@ -10,7 +10,7 @@ policy-map type control subscriber POLICY-MAP
   class type control subscriber PPP do-until-failure
    10 activate dynamic-template TEMPLATE1
   !
-  class class_default
+  class class-default
   class type control subscriber CM do-all
   class type control subscriber CM do-until-success
  !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/policy-map
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/policy-map
@@ -11,10 +11,10 @@ policy-map type control subscriber POLICY-MAP
    10 activate dynamic-template TEMPLATE1
   !
   class class-default
-  class type control subscriber CM do-all
-  class type control subscriber CM do-until-success
+  class type control subscriber PPP do-all
+  class type control subscriber PPP do-until-success
  !
-end-policy-map
+! end-policy-map
 !
 interface Bundle-Ether1.1
  service-policy type control subscriber POLICY-MAP


### PR DESCRIPTION
Fixes #6348 

Looks like we had copied over qos parsing from uber-cisco-parser to the xr-parser. The syntax in the two worlds appear quite different (and there were no tests for qos parsing in XR).  This PR 1) adds parsing for the policy-map syntax in the issue and fleshes out the neighborhood, and 2) removes the `s_policy_map_ios_inspect` which doesn't appear valid for XR. 