### PR TITLE
RoutingPolicy: don't build deep unions

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -132,7 +131,11 @@ public class RoutingPolicy implements Serializable {
   public Set<String> computeSources(
       Set<String> parentSources, Map<String, RoutingPolicy> routingPolicies, Warnings w) {
     if (_sources == null) {
-      Set<String> newParentSources = Sets.union(parentSources, ImmutableSet.of(_name));
+      Set<String> newParentSources =
+          ImmutableSet.<String>builderWithExpectedSize(parentSources.size() + 1)
+              .addAll(parentSources)
+              .add(_name)
+              .build();
       ImmutableSet.Builder<String> childSources = ImmutableSet.builder();
       childSources.add(_name);
       for (Statement statement : _statements) {


### PR DESCRIPTION
In very long routing policies, especially when they have lots of
continue statements, we might compile them into fairly complicated
structures with Call statements. Sets.union is a shallow operation that
never coalesces, so it seems plausible that building a deep union will
cause stack overflows on containment checks.

To fix this, materialize the sets as we go. This should not in practice
be very expensive unless we are in a case that would cause a stack
overflow with the prior approach.