### PR TITLE
TracerouteEngine: add an interface that exposes the TraceDag

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/TracerouteEngine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/TracerouteEngine.java
@@ -3,9 +3,11 @@ package org.batfish.common.plugin;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
+import org.batfish.common.traceroute.TraceDag;
 import org.batfish.common.util.CollectionUtil;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
@@ -57,5 +59,9 @@ public interface TracerouteEngine {
    * @return {@link SortedMap} of {@link Flow Flows} to {@link List} of {@link Trace Traces}
    */
   SortedMap<Flow, List<TraceAndReverseFlow>> computeTracesAndReverseFlows(
+      Set<Flow> flows, Set<FirewallSessionTraceInfo> sessions, boolean ignoreFilters);
+
+  /** Computes {@link Trace TraceDag} for a {@link Set} of forward {@link Flow Flows}. */
+  Map<Flow, TraceDag> computeTraceDags(
       Set<Flow> flows, Set<FirewallSessionTraceInfo> sessions, boolean ignoreFilters);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/TracerouteEngine.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/plugin/TracerouteEngine.java
@@ -61,7 +61,7 @@ public interface TracerouteEngine {
   SortedMap<Flow, List<TraceAndReverseFlow>> computeTracesAndReverseFlows(
       Set<Flow> flows, Set<FirewallSessionTraceInfo> sessions, boolean ignoreFilters);
 
-  /** Computes {@link Trace TraceDag} for a {@link Set} of forward {@link Flow Flows}. */
+  /** Computes {@link TraceDag} for a {@link Set} of forward {@link Flow Flows}. */
   Map<Flow, TraceDag> computeTraceDags(
       Set<Flow> flows, Set<FirewallSessionTraceInfo> sessions, boolean ignoreFilters);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/traceroute/TraceDag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/traceroute/TraceDag.java
@@ -1,18 +1,6 @@
 package org.batfish.common.traceroute;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.collect.ImmutableList;
-import java.util.List;
-import java.util.Stack;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
-import org.batfish.datamodel.Flow;
-import org.batfish.datamodel.FlowDisposition;
-import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
-import org.batfish.datamodel.flow.Hop;
-import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
 
 /**
@@ -20,118 +8,17 @@ import org.batfish.datamodel.flow.TraceAndReverseFlow;
  * the DAG from a root to a leaf is a valid {@link TraceAndReverseFlow trace}, i.e. one that {@link
  * org.batfish.common.plugin.TracerouteEngine} would create.
  */
-public class TraceDag {
-  /** A node in the DAG contains everything needed to reconstruct traces through the node. */
-  public static final class Node {
-    private final Hop _hop;
-    private final @Nullable FirewallSessionTraceInfo _firewallSessionTraceInfo;
-    private final @Nullable FlowDisposition _flowDisposition;
-    private final @Nullable Flow _returnFlow;
-    private final List<Integer> _successors;
+public interface TraceDag {
 
-    public Node(
-        Hop hop,
-        @Nullable FirewallSessionTraceInfo firewallSessionTraceInfo,
-        @Nullable FlowDisposition flowDisposition,
-        @Nullable Flow returnFlow,
-        List<Integer> successors) {
-      checkArgument(
-          (flowDisposition != null && flowDisposition.isSuccessful()) == (returnFlow != null),
-          "returnFlow is present iff disposition is successful");
-      _hop = hop;
-      _firewallSessionTraceInfo = firewallSessionTraceInfo;
-      _flowDisposition = flowDisposition;
-      _returnFlow = returnFlow;
-      _successors = ImmutableList.copyOf(successors);
-    }
-  }
+  /** Returns the number of edges in the DAG. */
+  int countEdges();
 
-  private final List<Node> _nodes;
-  private final List<Integer> _rootIds;
+  /** Returns the number of nodes in the DAG. */
+  int countNodes();
 
-  public TraceDag(List<Node> nodes, List<Integer> rootIds) {
-    _nodes = nodes;
-    _rootIds = rootIds;
-  }
+  /** Returns the number of traces, aka the number of paths through the DAG. */
+  int size();
 
-  public int size() {
-    return new SizeComputer().size();
-  }
-
-  /** Efficiently compute the number of traces in the DAG. */
-  private class SizeComputer {
-    private final Integer[] _cache;
-
-    SizeComputer() {
-      _cache = new Integer[_nodes.size()];
-    }
-
-    int size(int nodeId) {
-      @Nullable Integer cachedSize = _cache[nodeId];
-      if (cachedSize != null) {
-        return cachedSize;
-      }
-      Node node = _nodes.get(nodeId);
-      if (node._successors.isEmpty()) {
-        // leaf
-        _cache[nodeId] = 1;
-      } else {
-        _cache[nodeId] = node._successors.stream().mapToInt(this::size).sum();
-      }
-      return _cache[nodeId];
-    }
-
-    int size() {
-      return _rootIds.stream().mapToInt(this::size).sum();
-    }
-  }
-
-  private Stream<TraceAndReverseFlow> getTraces(
-      List<Hop> hopsInput, List<FirewallSessionTraceInfo> sessionsInput, int rootId) {
-    Node node = _nodes.get(rootId);
-
-    List<Hop> hops =
-        ImmutableList.<Hop>builderWithExpectedSize(hopsInput.size() + 1)
-            .addAll(hopsInput)
-            .add(node._hop)
-            .build();
-
-    List<FirewallSessionTraceInfo> sessions;
-    FirewallSessionTraceInfo firewallSessionTraceInfo = node._firewallSessionTraceInfo;
-    if (firewallSessionTraceInfo != null) {
-      sessions =
-          ImmutableList.<FirewallSessionTraceInfo>builderWithExpectedSize(sessionsInput.size() + 1)
-              .addAll(sessionsInput)
-              .add(firewallSessionTraceInfo)
-              .build();
-    } else {
-      sessions = sessionsInput;
-    }
-
-    List<Integer> successors = node._successors;
-    if (successors.isEmpty()) {
-      FlowDisposition disposition =
-          checkNotNull(node._flowDisposition, "failed to determine disposition from hop");
-      Trace trace = new Trace(disposition, hops);
-      return Stream.of(new TraceAndReverseFlow(trace, node._returnFlow, sessions));
-    } else {
-      return successors.stream().flatMap(successorId -> getTraces(hops, sessions, successorId));
-    }
-  }
-
-  public int countEdges() {
-    return _nodes.stream().map(node -> node._successors).mapToInt(List::size).sum();
-  }
-
-  public int countNodes() {
-    return _nodes.size();
-  }
-
-  private Stream<TraceAndReverseFlow> getTraces(int rootId) {
-    return getTraces(ImmutableList.of(), new Stack<>(), rootId);
-  }
-
-  public Stream<TraceAndReverseFlow> getTraces() {
-    return _rootIds.stream().flatMap(this::getTraces);
-  }
+  /** Returns a stream of the {@link TraceAndReverseFlow} corresponding to the traces in this DAG */
+  Stream<TraceAndReverseFlow> getTraces();
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/traceroute/TraceDag.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/traceroute/TraceDag.java
@@ -1,4 +1,4 @@
-package org.batfish.dataplane.traceroute;
+package org.batfish.common.traceroute;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -18,7 +18,7 @@ import org.batfish.datamodel.flow.TraceAndReverseFlow;
 /**
  * A DAG representation of a collection of {@link TraceAndReverseFlow traces}. Every path through
  * the DAG from a root to a leaf is a valid {@link TraceAndReverseFlow trace}, i.e. one that {@link
- * FlowTracer} would create.
+ * org.batfish.common.plugin.TracerouteEngine} would create.
  */
 public class TraceDag {
   /** A node in the DAG contains everything needed to reconstruct traces through the node. */
@@ -119,11 +119,11 @@ public class TraceDag {
     }
   }
 
-  int countEdges() {
+  public int countEdges() {
     return _nodes.stream().map(node -> node._successors).mapToInt(List::size).sum();
   }
 
-  int countNodes() {
+  public int countNodes() {
     return _nodes.size();
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/traceroute/TraceDagImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/traceroute/TraceDagImpl.java
@@ -1,0 +1,141 @@
+package org.batfish.common.traceroute;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Stack;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.FlowDisposition;
+import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
+import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.Trace;
+import org.batfish.datamodel.flow.TraceAndReverseFlow;
+
+/**
+ * A DAG representation of a collection of {@link TraceAndReverseFlow traces}. Every path through
+ * the DAG from a root to a leaf is a valid {@link TraceAndReverseFlow trace}, i.e. one that {@link
+ * org.batfish.common.plugin.TracerouteEngine} would create.
+ */
+public final class TraceDagImpl implements TraceDag {
+  /** A node in the DAG contains everything needed to reconstruct traces through the node. */
+  public static final class Node {
+    private final Hop _hop;
+    private final @Nullable FirewallSessionTraceInfo _firewallSessionTraceInfo;
+    private final @Nullable FlowDisposition _flowDisposition;
+    private final @Nullable Flow _returnFlow;
+    private final List<Integer> _successors;
+
+    public Node(
+        Hop hop,
+        @Nullable FirewallSessionTraceInfo firewallSessionTraceInfo,
+        @Nullable FlowDisposition flowDisposition,
+        @Nullable Flow returnFlow,
+        List<Integer> successors) {
+      checkArgument(
+          (flowDisposition != null && flowDisposition.isSuccessful()) == (returnFlow != null),
+          "returnFlow is present iff disposition is successful");
+      _hop = hop;
+      _firewallSessionTraceInfo = firewallSessionTraceInfo;
+      _flowDisposition = flowDisposition;
+      _returnFlow = returnFlow;
+      _successors = ImmutableList.copyOf(successors);
+    }
+  }
+
+  private final List<Node> _nodes;
+  private final List<Integer> _rootIds;
+
+  public TraceDagImpl(List<Node> nodes, List<Integer> rootIds) {
+    _nodes = nodes;
+    _rootIds = rootIds;
+  }
+
+  @Override
+  public int size() {
+    return new SizeComputer().size();
+  }
+
+  /** Efficiently compute the number of traces in the DAG. */
+  private class SizeComputer {
+    private final Integer[] _cache;
+
+    SizeComputer() {
+      _cache = new Integer[_nodes.size()];
+    }
+
+    int size(int nodeId) {
+      @Nullable Integer cachedSize = _cache[nodeId];
+      if (cachedSize != null) {
+        return cachedSize;
+      }
+      Node node = _nodes.get(nodeId);
+      if (node._successors.isEmpty()) {
+        // leaf
+        _cache[nodeId] = 1;
+      } else {
+        _cache[nodeId] = node._successors.stream().mapToInt(this::size).sum();
+      }
+      return _cache[nodeId];
+    }
+
+    int size() {
+      return _rootIds.stream().mapToInt(this::size).sum();
+    }
+  }
+
+  private Stream<TraceAndReverseFlow> getTraces(
+      List<Hop> hopsInput, List<FirewallSessionTraceInfo> sessionsInput, int rootId) {
+    Node node = _nodes.get(rootId);
+
+    List<Hop> hops =
+        ImmutableList.<Hop>builderWithExpectedSize(hopsInput.size() + 1)
+            .addAll(hopsInput)
+            .add(node._hop)
+            .build();
+
+    List<FirewallSessionTraceInfo> sessions;
+    FirewallSessionTraceInfo firewallSessionTraceInfo = node._firewallSessionTraceInfo;
+    if (firewallSessionTraceInfo != null) {
+      sessions =
+          ImmutableList.<FirewallSessionTraceInfo>builderWithExpectedSize(sessionsInput.size() + 1)
+              .addAll(sessionsInput)
+              .add(firewallSessionTraceInfo)
+              .build();
+    } else {
+      sessions = sessionsInput;
+    }
+
+    List<Integer> successors = node._successors;
+    if (successors.isEmpty()) {
+      FlowDisposition disposition =
+          checkNotNull(node._flowDisposition, "failed to determine disposition from hop");
+      Trace trace = new Trace(disposition, hops);
+      return Stream.of(new TraceAndReverseFlow(trace, node._returnFlow, sessions));
+    } else {
+      return successors.stream().flatMap(successorId -> getTraces(hops, sessions, successorId));
+    }
+  }
+
+  @Override
+  public int countEdges() {
+    return _nodes.stream().map(node -> node._successors).mapToInt(List::size).sum();
+  }
+
+  @Override
+  public int countNodes() {
+    return _nodes.size();
+  }
+
+  private Stream<TraceAndReverseFlow> getTraces(int rootId) {
+    return getTraces(ImmutableList.of(), new Stack<>(), rootId);
+  }
+
+  @Override
+  public Stream<TraceAndReverseFlow> getTraces() {
+    return _rootIds.stream().flatMap(this::getTraces);
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/vxlan/VxlanTopologyUtils.java
@@ -27,7 +27,7 @@ import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.flow.Hop;
-import org.batfish.datamodel.flow.Trace;
+import org.batfish.datamodel.flow.TraceAndReverseFlow;
 
 /** Utility class for computing {@link VxlanTopology} instances from network data. */
 public final class VxlanTopologyUtils {
@@ -236,8 +236,11 @@ public final class VxlanTopologyUtils {
             .setSrcPort(NamedPort.EPHEMERAL_LOWEST.number())
             .setDstPort(udpPort)
             .build();
-    List<Trace> traces = tracerouteEngine.computeTraces(ImmutableSet.of(flow), false).get(flow);
-    return traces.stream()
+    return tracerouteEngine
+        .computeTraceDags(ImmutableSet.of(flow), ImmutableSet.of(), false)
+        .get(flow)
+        .getTraces()
+        .map(TraceAndReverseFlow::getTrace)
         .anyMatch(
             trace -> {
               List<Hop> hops = trace.getHops();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/traceroute/TraceDagImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/traceroute/TraceDagImplTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.batfish.common.traceroute.TraceDag.Node;
+import org.batfish.common.traceroute.TraceDagImpl.Node;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.Ip;
@@ -24,7 +24,7 @@ import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
 import org.junit.Test;
 
-public class TraceDagTest {
+public class TraceDagImplTest {
   private static final Flow TEST_FLOW =
       Flow.builder().setDstIp(Ip.parse("1.1.1.1")).setIngressNode("src").build();
 
@@ -51,8 +51,8 @@ public class TraceDagTest {
     Node nodeC1 = new Node(hopC1, null, FlowDisposition.ACCEPTED, c1ReturnFlow, ImmutableList.of());
     Node nodeC2 = new Node(hopC2, null, FlowDisposition.ACCEPTED, c2ReturnFlow, ImmutableList.of());
     Node nodeC3 = new Node(hopC3, null, FlowDisposition.NO_ROUTE, null, ImmutableList.of());
-    TraceDag dag =
-        new TraceDag(
+    TraceDagImpl dag =
+        new TraceDagImpl(
             ImmutableList.of(nodeA, nodeB1, nodeB2, nodeC1, nodeC2, nodeC3), ImmutableList.of(0));
     List<TraceAndReverseFlow> traces = dag.getTraces().collect(Collectors.toList());
     assertThat(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/traceroute/TraceDagTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/traceroute/TraceDagTest.java
@@ -1,8 +1,8 @@
-package org.batfish.dataplane.traceroute;
+package org.batfish.common.traceroute;
 
-import static org.batfish.dataplane.traceroute.HopTestUtils.acceptedHop;
-import static org.batfish.dataplane.traceroute.HopTestUtils.forwardedHop;
-import static org.batfish.dataplane.traceroute.HopTestUtils.noRouteHop;
+import static org.batfish.datamodel.flow.HopTestUtils.acceptedHop;
+import static org.batfish.datamodel.flow.HopTestUtils.forwardedHop;
+import static org.batfish.datamodel.flow.HopTestUtils.noRouteHop;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.batfish.common.traceroute.TraceDag.Node;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.Ip;
@@ -21,7 +22,6 @@ import org.batfish.datamodel.flow.OriginatingSessionScope;
 import org.batfish.datamodel.flow.SessionMatchExpr;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
-import org.batfish.dataplane.traceroute.TraceDag.Node;
 import org.junit.Test;
 
 public class TraceDagTest {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/HopTestUtils.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/HopTestUtils.java
@@ -1,23 +1,15 @@
-package org.batfish.dataplane.traceroute;
+package org.batfish.datamodel.flow;
 
 import com.google.common.collect.ImmutableList;
 import org.batfish.datamodel.collections.NodeInterfacePair;
-import org.batfish.datamodel.flow.EnterInputIfaceStep;
 import org.batfish.datamodel.flow.EnterInputIfaceStep.EnterInputIfaceStepDetail;
-import org.batfish.datamodel.flow.ExitOutputIfaceStep;
 import org.batfish.datamodel.flow.ExitOutputIfaceStep.ExitOutputIfaceStepDetail;
-import org.batfish.datamodel.flow.Hop;
-import org.batfish.datamodel.flow.InboundStep;
 import org.batfish.datamodel.flow.InboundStep.InboundStepDetail;
-import org.batfish.datamodel.flow.LoopStep;
-import org.batfish.datamodel.flow.RoutingStep;
 import org.batfish.datamodel.flow.RoutingStep.RoutingStepDetail;
-import org.batfish.datamodel.flow.Step;
-import org.batfish.datamodel.flow.StepAction;
 import org.batfish.datamodel.pojo.Node;
 
 /** Utilities for building {@link Hop hops} and {@link Step steps} for testing. */
-final class HopTestUtils {
+public final class HopTestUtils {
   private static EnterInputIfaceStep enterInputIfaceStep(String node) {
     return EnterInputIfaceStep.builder()
         .setAction(StepAction.RECEIVED)
@@ -30,7 +22,7 @@ final class HopTestUtils {
   }
 
   /** Create a Hop with StepAction Forwarded. */
-  static Hop acceptedHop(String node) {
+  public static Hop acceptedHop(String node) {
     return new Hop(
         new Node(node),
         ImmutableList.of(
@@ -39,7 +31,7 @@ final class HopTestUtils {
   }
 
   /** Create a Hop with StepAction Forwarded. */
-  static Hop forwardedHop(String node) {
+  public static Hop forwardedHop(String node) {
     return new Hop(
         new Node(node),
         ImmutableList.of(
@@ -57,11 +49,11 @@ final class HopTestUtils {
                 .build()));
   }
 
-  static Hop loopHop(String node) {
+  public static Hop loopHop(String node) {
     return new Hop(new Node(node), ImmutableList.of(enterInputIfaceStep(node), LoopStep.INSTANCE));
   }
 
-  static Hop noRouteHop(String node) {
+  public static Hop noRouteHop(String node) {
     return new Hop(
         new Node(node),
         ImmutableList.of(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
@@ -36,6 +36,7 @@ import java.util.SortedMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.batfish.common.plugin.TracerouteEngine;
+import org.batfish.common.traceroute.TraceDag;
 import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
@@ -96,6 +97,12 @@ public final class VxlanTopologyUtilsTest {
 
     @Override
     public SortedMap<Flow, List<TraceAndReverseFlow>> computeTracesAndReverseFlows(
+        Set<Flow> flows, Set<FirewallSessionTraceInfo> sessions, boolean ignoreFilters) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<Flow, TraceDag> computeTraceDags(
         Set<Flow> flows, Set<FirewallSessionTraceInfo> sessions, boolean ignoreFilters) {
       throw new UnsupportedOperationException();
     }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
@@ -21,19 +21,17 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Table;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.MutableGraph;
-import java.util.Comparator;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import org.batfish.common.plugin.TracerouteEngine;
 import org.batfish.common.traceroute.TraceDag;
@@ -63,7 +61,21 @@ public final class VxlanTopologyUtilsTest {
 
   private static class TestTracerouteEngine implements TracerouteEngine {
 
-    private final Map<String, List<Trace>> _results;
+    private final Map<String, List<TraceAndReverseFlow>> _results;
+
+    /** Builds a fake {@link TraceAndReverseFlow} for the given result. */
+    private static TraceAndReverseFlow resultToTarf(TestTracerouteEngineResult result) {
+      Trace forwardTrace =
+          new Trace(
+              result._accept ? FlowDisposition.ACCEPTED : FlowDisposition.DENIED_OUT,
+              result._addHop
+                  ? ImmutableList.of(new Hop(new Node(result._receivingNode), ImmutableList.of()))
+                  : ImmutableList.of());
+      return new TraceAndReverseFlow(
+          forwardTrace,
+          result._accept ? Flow.builder().setIngressNode(result._receivingNode).build() : null,
+          ImmutableSet.of());
+    }
 
     private TestTracerouteEngine(Map<String, TestTracerouteEngineResult> results) {
       _results =
@@ -71,28 +83,12 @@ public final class VxlanTopologyUtilsTest {
               .collect(
                   ImmutableMap.toImmutableMap(
                       Entry::getKey,
-                      resultEntry ->
-                          ImmutableList.of(
-                              new Trace(
-                                  resultEntry.getValue()._accept
-                                      ? FlowDisposition.ACCEPTED
-                                      : FlowDisposition.DENIED_OUT,
-                                  resultEntry.getValue()._addHop
-                                      ? ImmutableList.of(
-                                          new Hop(
-                                              new Node(resultEntry.getValue()._receivingNode),
-                                              ImmutableList.of()))
-                                      : ImmutableList.of()))));
+                      resultEntry -> ImmutableList.of(resultToTarf(resultEntry.getValue()))));
     }
 
     @Override
     public SortedMap<Flow, List<Trace>> computeTraces(Set<Flow> flows, boolean ignoreFilters) {
-      return flows.stream()
-          .collect(
-              ImmutableSortedMap.toImmutableSortedMap(
-                  Comparator.naturalOrder(),
-                  Function.<Flow>identity(),
-                  flow -> _results.get(flow.getIngressNode())));
+      throw new UnsupportedOperationException();
     }
 
     @Override
@@ -104,7 +100,35 @@ public final class VxlanTopologyUtilsTest {
     @Override
     public Map<Flow, TraceDag> computeTraceDags(
         Set<Flow> flows, Set<FirewallSessionTraceInfo> sessions, boolean ignoreFilters) {
-      throw new UnsupportedOperationException();
+      return flows.stream()
+          .map(
+              flow -> {
+                List<TraceAndReverseFlow> result = _results.get(flow.getIngressNode());
+                TraceDag dag =
+                    new TraceDag() {
+                      @Override
+                      public int countEdges() {
+                        throw new UnsupportedOperationException();
+                      }
+
+                      @Override
+                      public int countNodes() {
+                        throw new UnsupportedOperationException();
+                      }
+
+                      @Override
+                      public int size() {
+                        throw new UnsupportedOperationException();
+                      }
+
+                      @Override
+                      public Stream<TraceAndReverseFlow> getTraces() {
+                        return result.stream();
+                      }
+                    };
+                return new SimpleEntry<>(flow, dag);
+              })
+          .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/DagTraceRecorder.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/DagTraceRecorder.java
@@ -20,6 +20,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.traceroute.TraceDag;
+import org.batfish.common.traceroute.TraceDagImpl;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.flow.Hop;
@@ -37,7 +38,7 @@ public class DagTraceRecorder implements TraceRecorder {
   }
 
   /**
-   * The key used to lookup Nodes in a TraceDag.
+   * The key used to lookup Nodes in a TraceDagImpl.
    *
    * <p>TODO: implement equals/hashCode for {@link Hop} instead of using JSON.
    */
@@ -210,8 +211,8 @@ public class DagTraceRecorder implements TraceRecorder {
           && _forbiddenBreadcrumbs.stream().noneMatch(breadcrumbs::contains);
     }
 
-    /** Convert a {@link Node} to a {@link TraceDag.Node}. */
-    private int buildTraceDagNode(Map<Node, Integer> cache, List<TraceDag.Node> traceDagNodes) {
+    /** Convert a {@link Node} to a {@link TraceDagImpl.Node}. */
+    private int buildTraceDagNode(Map<Node, Integer> cache, List<TraceDagImpl.Node> traceDagNodes) {
       @Nullable Integer nodeId = cache.get(this);
       if (nodeId != null) {
         return nodeId;
@@ -226,7 +227,7 @@ public class DagTraceRecorder implements TraceRecorder {
       nodeId = traceDagNodes.size();
       cache.put(this, nodeId);
       traceDagNodes.add(
-          new TraceDag.Node(
+          new TraceDagImpl.Node(
               hopInfo.getHop(),
               hopInfo.getFirewallSessionTraceInfo(),
               hopInfo.getDisposition(),
@@ -284,11 +285,11 @@ public class DagTraceRecorder implements TraceRecorder {
       buildRoot();
     }
     Map<Node, Integer> nodeIds = new HashMap<>();
-    List<TraceDag.Node> dagNodes = new ArrayList<>(_nodeMap.size());
+    List<TraceDagImpl.Node> dagNodes = new ArrayList<>(_nodeMap.size());
     List<Integer> rootIds =
         _roots.stream()
             .map(root -> root.buildTraceDagNode(nodeIds, dagNodes))
             .collect(ImmutableList.toImmutableList());
-    return _builtTraceDag = new TraceDag(dagNodes, rootIds);
+    return _builtTraceDag = new TraceDagImpl(dagNodes, rootIds);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/DagTraceRecorder.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/DagTraceRecorder.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.traceroute.TraceDag;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.flow.Hop;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/HopInfo.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/HopInfo.java
@@ -3,6 +3,7 @@ package org.batfish.dataplane.traceroute;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import javax.annotation.Nullable;
+import org.batfish.common.traceroute.TraceDag;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/HopInfo.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/HopInfo.java
@@ -3,13 +3,15 @@ package org.batfish.dataplane.traceroute;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import javax.annotation.Nullable;
-import org.batfish.common.traceroute.TraceDag;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
 import org.batfish.datamodel.flow.Hop;
 
-/** Records information about a {@link Hop trace hop} needed to build a {@link TraceDag}. */
+/**
+ * Records information about a {@link Hop trace hop} needed to build a {@link
+ * org.batfish.common.traceroute.TraceDag}.
+ */
 public final class HopInfo {
   private final Hop _hop;
   // Flow as it entered the hop

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/BUILD
@@ -5,20 +5,6 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-java_library(
-    name = "testlib",
-    srcs = ["HopTestUtils.java"],
-    deps = [
-        "//projects/batfish",
-        "//projects/batfish-common-protocol:common",
-        "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
-        "@maven//:com_google_code_findbugs_jsr305",
-        "@maven//:com_google_guava_guava",
-        "@maven//:junit_junit",
-        "@maven//:org_hamcrest_hamcrest",
-    ],
-)
-
 junit_tests(
     name = "tests",
     srcs = glob([
@@ -33,7 +19,6 @@ junit_tests(
         "//projects/batfish-common-protocol:common",
         "//projects/batfish-common-protocol:common_testlib",
         "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
-        "//projects/batfish/src/test/java/org/batfish/dataplane/traceroute:testlib",
         "//projects/bdd",
         "@maven//:com_fasterxml_jackson_core_jackson_core",
         "@maven//:com_google_code_findbugs_jsr305",

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/DagTraceRecorderTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/DagTraceRecorderTest.java
@@ -13,10 +13,12 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
+import org.batfish.common.traceroute.TraceDag;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.HopTestUtils;
 import org.batfish.dataplane.traceroute.DagTraceRecorder.NodeKey;
 import org.junit.Test;
 

--- a/projects/question/src/test/java/org/batfish/question/traceroute/MockTracerouteEngine.java
+++ b/projects/question/src/test/java/org/batfish/question/traceroute/MockTracerouteEngine.java
@@ -14,6 +14,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import org.batfish.common.plugin.TracerouteEngine;
+import org.batfish.common.traceroute.TraceDag;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
@@ -54,5 +55,11 @@ public final class MockTracerouteEngine implements TracerouteEngine {
         .collect(
             ImmutableSortedMap.toImmutableSortedMap(
                 Ordering.natural(), Entry::getKey, Entry::getValue));
+  }
+
+  @Override
+  public Map<Flow, TraceDag> computeTraceDags(
+      Set<Flow> flows, Set<FirewallSessionTraceInfo> sessions, boolean ignoreFilters) {
+    throw new UnsupportedOperationException();
   }
 }


### PR DESCRIPTION
Not all users want the full list of traces. We may want to do other things, such as looking for any path, or randomly sampling the paths, or looking for a particular hop.

* Convert TraceDag into an interface
* Move it to common, along with tests and some utilities that are of common code.
* Add an interface to expose TraceDag in TracerouteEngine
* As an example, update one caller and its tests.