### PR TITLE
NXOS EIGRP conversion tweaks

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -114,12 +114,12 @@ import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.acl.PermittedByAcl;
 import org.batfish.datamodel.bgp.community.Community;
+import org.batfish.datamodel.eigrp.ClassicMetric;
 import org.batfish.datamodel.eigrp.EigrpInterfaceSettings;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
 import org.batfish.datamodel.eigrp.EigrpProcess;
 import org.batfish.datamodel.eigrp.EigrpProcessMode;
-import org.batfish.datamodel.eigrp.WideMetric;
 import org.batfish.datamodel.isis.IsisMetricType;
 import org.batfish.datamodel.ospf.NssaSettings;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
@@ -856,7 +856,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                     vrfConfig.getDistanceExternal(),
                     EigrpProcessConfiguration.DEFAULT_DISTANCE_EXTERNAL))
             .setRouterId(routerId);
-    proc.setMode(vrfConfig.getAsn() != null ? EigrpProcessMode.CLASSIC : EigrpProcessMode.NAMED);
+    proc.setMode(EigrpProcessMode.CLASSIC);
     if (v.getEigrpProcesses().containsKey(Long.valueOf(asn))) {
       // TODO: figure out what this does and handle it.
       _w.redFlag(
@@ -2096,11 +2096,10 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
             .orElse(null);
     EigrpMetricValues values =
         EigrpMetricValues.builder()
-            .setDelay(delayTensOfMicroseconds * 10e7) // convert to picoseconds
+            .setDelay(delayTensOfMicroseconds * 1e7) // convert to picoseconds
             .setBandwidth(bw)
             .build();
-    // TODO Can NXOS use ClassicMetric?
-    return WideMetric.builder().setValues(values).build();
+    return ClassicMetric.builder().setValues(values).build();
   }
 
   private @Nonnull InterfaceType toInterfaceType(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -7741,8 +7741,8 @@ public final class CiscoNxosGrammarTest {
       EigrpInterfaceSettings eigrp = iface.getEigrp();
       assertNotNull(eigrp);
       assertThat(eigrp.getMetric().getValues().getBandwidth(), equalTo(300L));
-      // EIGRP metric values have delay in ps (10e-12); config has it in tens of µs (10e-5)
-      assertThat(eigrp.getMetric().getValues().getDelay(), equalTo((long) (400 * 10e7)));
+      // EIGRP metric values have delay in ps (1e-12); config has it in tens of µs (1e-5)
+      assertThat(eigrp.getMetric().getValues().getDelay(), equalTo((long) (400 * 1e7)));
       assertTrue(eigrp.getPassive());
     }
     {
@@ -7763,7 +7763,7 @@ public final class CiscoNxosGrammarTest {
           eigrp.getMetric().getValues().getBandwidth(), equalTo(defaultBw.longValue() / 1000));
       assertThat(
           eigrp.getMetric().getValues().getDelay(),
-          equalTo((long) (defaultDelayTensOfMicroseconds(CiscoNxosInterfaceType.ETHERNET) * 10e7)));
+          equalTo((long) (defaultDelayTensOfMicroseconds(CiscoNxosInterfaceType.ETHERNET) * 1e7)));
       assertFalse(eigrp.getPassive());
     }
   }


### PR DESCRIPTION
* Fix the order of magnitute delay bug. ten million is 1e7
* Switch to classic metric, remove todo. Wide metrics require a special command `metrics version 64bit`, we can add support for that later