### PR TITLE
EIGRP portchannel bandwidth: fixup scaling

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/main/Batfish.java
+++ b/projects/batfish/src/main/java/org/batfish/main/Batfish.java
@@ -1800,7 +1800,7 @@ public class Batfish extends PluginConsumer implements IBatfish {
                 // only set bandwidth if it's not explicitly configured for EIGRP
                 Double bw = iface.getBandwidth();
                 assert bw != null; // all bandwidths should be finalized at this point
-                metricValues.setBandwidth(bw.longValue());
+                metricValues.setBandwidth(bw.longValue() / 1000); // convert to kbps
               }
             });
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1732,7 +1732,7 @@ public final class CiscoGrammarTest {
         portChannel23,
         hasEigrp(
             EigrpInterfaceSettingsMatchers.hasEigrpMetric(
-                EigrpMetricMatchers.hasBandwidth(expectedBw))));
+                EigrpMetricMatchers.hasBandwidth(expectedBw / 1000)))); // scale to kbps
   }
 
   /**


### PR DESCRIPTION
We forgot to scale down to kbps when inheriting.