### PR TITLE
IOS: tweak default interface delay inference

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1909,7 +1909,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
     EigrpMetricValues values =
         EigrpMetricValues.builder()
             .setDelay(
-                firstNonNull(iface.getDelay(), Interface.getDefaultDelay(iface.getName(), _vendor)))
+                firstNonNull(
+                    iface.getDelay(), Interface.getDefaultDelay(iface.getName(), _vendor, bw)))
             .setBandwidth(bw)
             .build();
     if (mode == EigrpProcessMode.CLASSIC) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1965,6 +1965,11 @@ public final class CiscoGrammarTest {
         hasInterface(
             "Tunnel0",
             hasEigrp(EigrpInterfaceSettingsMatchers.hasEigrpMetric(hasDelay(50_000_000_000L)))));
+    assertThat(
+        c,
+        hasInterface(
+            "PortChannel1",
+            hasEigrp(EigrpInterfaceSettingsMatchers.hasEigrpMetric(hasDelay(10_000_000L)))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -1968,7 +1968,7 @@ public final class CiscoGrammarTest {
     assertThat(
         c,
         hasInterface(
-            "PortChannel1",
+            "Port-channel1",
             hasEigrp(EigrpInterfaceSettingsMatchers.hasEigrpMetric(hasDelay(10_000_000L)))));
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-delay
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-delay
@@ -10,7 +10,7 @@ interface GigabitEthernet0/1
  no shutdown
  delay 1000
 !
-interface PortChannel1
+interface Port-channel1
  ip address 10.0.3.1 255.255.255.0
  no shutdown
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-delay
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-interface-delay
@@ -10,6 +10,10 @@ interface GigabitEthernet0/1
  no shutdown
  delay 1000
 !
+interface PortChannel1
+ ip address 10.0.3.1 255.255.255.0
+ no shutdown
+!
 interface FastEthernet0/1
  ip address 10.0.2.1 255.255.255.0
  no shutdown


### PR DESCRIPTION
Handle the most common portchannel cases. Not a perfect solution (we may need to move this to snapshot post-processing as well) but a good enough stop-gap fix.