### PR TITLE
FRR: fix NPE in routemaps for non-bgp routes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/Statements.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/Statements.java
@@ -117,7 +117,9 @@ public enum Statements {
           break;
 
         case SetReadIntermediateBgpAttributes:
-          environment.setReadFromIntermediateBgpAttributes(true);
+          if (environment.getOutputRoute() instanceof BgpRoute.Builder<?, ?>) {
+            environment.setReadFromIntermediateBgpAttributes(true);
+          }
           break;
 
         case SetWriteIntermediateBgpAttributes:

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
@@ -3,6 +3,7 @@ package org.batfish.grammar.cumulus_concatenated;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.batfish.common.util.Resources.readResource;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasHostname;
+import static org.batfish.datamodel.routing_policy.Environment.Direction.OUT;
 import static org.batfish.main.BatfishTestUtils.TEST_SNAPSHOT;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
 import static org.batfish.representation.cumulus.CumulusConversions.computeBgpGenerationPolicyName;
@@ -43,10 +44,12 @@ import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.OriginType;
+import org.batfish.datamodel.OspfExternalType2Route;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
@@ -771,5 +774,16 @@ public class CumulusConcatenatedGrammarTest {
     Long neighbor_iface_local_as =
         defaultVrf.getBgpProcess().getInterfaceNeighbors().get("bond2").getLocalAs();
     assertThat(neighbor_iface_local_as, equalTo(10L));
+  }
+
+  @Test
+  public void testRouteMapMatchTagNonBgp() throws IOException {
+    Configuration c = parseConfig("frr-match-tag-non-bgp");
+    RoutingPolicy policy = c.getRoutingPolicies().get("SET_METRIC");
+    // Don't crash
+    policy.process(
+        new ConnectedRoute(Prefix.parse("1.1.1.0/24"), "iface"),
+        OspfExternalType2Route.builder(),
+        OUT);
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/frr-match-tag-non-bgp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/frr-match-tag-non-bgp
@@ -1,0 +1,22 @@
+frr-match-tag-non-bgp
+# This file describes the network interfaces
+auto lo
+iface lo inet loopback
+
+auto swp1
+iface swp1
+
+# ports.conf --
+frr version
+frr defaults datacenter
+!
+interface lo
+ ip address 2.2.2.2/32
+ ip ospf area 0
+!
+! This should not crash on non-bgp routes
+route-map SET_METRIC permit 10
+ match tag 100
+ set metric 20
+!
+end


### PR DESCRIPTION
This is unlikely to correctly capture FRR semantics until we overhaul routing policy, but at least will prevent crashes.