### PR TITLE
EnumSetSpecifier: distinguish between unspecified and empty

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/NodePropertySpecifierTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/questions/NodePropertySpecifierTest.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.questions;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
@@ -34,5 +35,11 @@ public class NodePropertySpecifierTest {
     assertThat(
         new NodePropertySpecifier(firstTwoProperties).getMatchingProperties(),
         containsInAnyOrder(prop1, prop2));
+  }
+
+  @Test
+  public void testRegexNoMatch() {
+    NodePropertySpecifier spec = NodePropertySpecifier.create("/no-matching-properties/");
+    assertThat(spec.getMatchingProperties(), empty());
   }
 }


### PR DESCRIPTION
We have documented `properties='/no-such-property/'` as a way to get just
the key of the properties. However, we broke this when we reimplemented
the EnumSetSpecifier. Add a test, then fix it by making EnumSetValues
understand the difference between unspecified and empty. Only
unspecified should default to everything.