### PR TITLE
BgpAdvertisements: Tolerant to missing values

### DIFF
--- a/networks/example/live-with-bgp-announcements/external_bgp_announcements.json
+++ b/networks/example/live-with-bgp-announcements/external_bgp_announcements.json
@@ -4,7 +4,6 @@
       "type" : "ebgp_sent",
       "network" : "4.0.0.0/8",
       "nextHopIp" : "10.14.22.4",
-      "srcNode" : "neighbor",
       "srcIp" : "10.14.22.4",
       "dstNode" : "as1border2",
       "dstIp" : "10.14.22.1",
@@ -15,7 +14,6 @@
       "originatorIp" : "0.0.0.0",
       "asPath" : [ [ 1239 ], [7018, 7019]],
       "communities" : [ 262145 ],
-      "srcVrf":"default",
       "dstVrf":"default",
       "clusterList":[]
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpAdvertisement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpAdvertisement.java
@@ -379,7 +379,7 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
     if (ret != 0) {
       return ret;
     }
-    ret = nullSafeCompareTo(_srcNode, _dstNode);
+    ret = nullSafeCompareTo(_srcNode, rhs._srcNode);
     if (ret != 0) {
       return ret;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpAdvertisement.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpAdvertisement.java
@@ -2,10 +2,12 @@ package org.batfish.datamodel;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
@@ -13,6 +15,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.SortedSet;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.bgp.community.Community;
 
@@ -229,7 +232,7 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
   private static final String PROP_TYPE = "type";
   private static final String PROP_WEIGHT = "weight";
 
-  public static final int UNSET_LOCAL_PREFERENCE = 0;
+  public static final long UNSET_LOCAL_PREFERENCE = 0;
 
   public static final Ip UNSET_ORIGINATOR_IP = Ip.AUTO;
 
@@ -261,7 +264,7 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
 
   private final Ip _srcIp;
 
-  private final String _srcNode;
+  @Nullable private final String _srcNode;
 
   private final RoutingProtocol _srcProtocol;
 
@@ -294,42 +297,38 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
     checkArgument(type != null, "type must be specified for BgpAdvertisement");
     checkArgument(network != null, "network must be specified for BgpAdvertisement");
     checkArgument(nextHopIp != null, "nextHopIp must be specified for BgpAdvertisement");
-    checkArgument(srcNode != null, "srcNode must be specified for BgpAdvertisement");
-    checkArgument(srcVrf != null, "srcVrf must be specified for BgpAdvertisement");
     checkArgument(srcIp != null, "srcIp must be specified for BgpAdvertisement");
     checkArgument(dstNode != null, "dstNode must be specified for BgpAdvertisement");
-    checkArgument(dstVrf != null, "dstVrf must be specified for BgpAdvertisement");
     checkArgument(dstIp != null, "dstIp must be specified for BgpAdvertisement");
     checkArgument(srcProtocol != null, "srcProtocol must be specified for BgpAdvertisement");
     checkArgument(originType != null, "originType must be specified for BgpAdvertisement");
-    checkArgument(originatorIp != null, "originatorIp must be specified for BgpAdvertisement");
     checkArgument(asPath != null, "asPath must be specified for BgpAdvertisement");
     return new BgpAdvertisement(
         type,
         network,
         nextHopIp,
         srcNode,
-        srcVrf,
+        firstNonNull(srcVrf, DEFAULT_VRF_NAME),
         srcIp,
         dstNode,
-        dstVrf,
+        firstNonNull(dstVrf, DEFAULT_VRF_NAME),
         dstIp,
         srcProtocol,
         originType,
-        firstNonNull(localPreference, 100L),
+        firstNonNull(localPreference, UNSET_LOCAL_PREFERENCE),
         firstNonNull(med, 0L),
-        originatorIp,
+        firstNonNull(originatorIp, UNSET_ORIGINATOR_IP),
         asPath,
         firstNonNull(communities, ImmutableSortedSet.of()),
         firstNonNull(clusterList, ImmutableSortedSet.of()),
-        firstNonNull(weight, 0));
+        firstNonNull(weight, UNSET_WEIGHT));
   }
 
   public BgpAdvertisement(
       @Nonnull BgpAdvertisementType type,
       @Nonnull Prefix network,
       @Nonnull Ip nextHopIp,
-      @Nonnull String srcNode,
+      @Nullable String srcNode,
       @Nonnull String srcVrf,
       @Nonnull Ip srcIp,
       @Nonnull String dstNode,
@@ -347,7 +346,7 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
     _type = type;
     _network = network;
     _nextHopIp = nextHopIp;
-    _srcNode = srcNode.toLowerCase(); // canonicalize node name
+    _srcNode = srcNode == null ? null : srcNode.toLowerCase(); // canonicalize node name
     _srcVrf = srcVrf;
     _srcIp = srcIp;
     _dstNode = dstNode.toLowerCase(); // canonicalize node name
@@ -368,6 +367,11 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
     return new Builder();
   }
 
+  @VisibleForTesting
+  static int nullSafeCompareTo(@Nullable String left, @Nullable String right) {
+    return left == null ? right == null ? 0 : -1 : right == null ? 1 : left.compareTo(right);
+  }
+
   @Override
   public int compareTo(BgpAdvertisement rhs) {
     int ret;
@@ -375,7 +379,7 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
     if (ret != 0) {
       return ret;
     }
-    ret = _srcNode.compareTo(rhs._srcNode);
+    ret = nullSafeCompareTo(_srcNode, _dstNode);
     if (ret != 0) {
       return ret;
     }
@@ -503,7 +507,7 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
     if (!_srcIp.equals(other._srcIp)) {
       return false;
     }
-    if (!_srcNode.equals(other._srcNode)) {
+    if (!Objects.equals(_srcNode, other._srcNode)) {
       return false;
     }
     if (_srcProtocol != other._srcProtocol) {
@@ -587,6 +591,7 @@ public class BgpAdvertisement implements Comparable<BgpAdvertisement>, Serializa
   }
 
   @JsonProperty(PROP_SRC_NODE)
+  @Nullable
   public String getSrcNode() {
     return _srcNode;
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpAdvertisementTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpAdvertisementTest.java
@@ -1,12 +1,21 @@
 package org.batfish.datamodel;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.batfish.common.util.Resources.readResource;
+import static org.batfish.datamodel.BgpAdvertisement.UNSET_LOCAL_PREFERENCE;
+import static org.batfish.datamodel.BgpAdvertisement.UNSET_ORIGINATOR_IP;
+import static org.batfish.datamodel.BgpAdvertisement.UNSET_WEIGHT;
 import static org.batfish.datamodel.BgpAdvertisement.nullSafeCompareTo;
+import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.BgpAdvertisement.BgpAdvertisementType;
+import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.junit.Test;
 
 public class BgpAdvertisementTest {
@@ -47,5 +56,37 @@ public class BgpAdvertisementTest {
     assertThat(nullSafeCompareTo(null, "a"), equalTo(-1));
     assertThat(nullSafeCompareTo("a", null), equalTo(1));
     assertThat(nullSafeCompareTo("a", "b"), equalTo("a".compareTo("b")));
+  }
+
+  /** Test that optional fields are handled properly in the json creator */
+  @Test
+  public void testCreateMissingValues() throws JsonProcessingException {
+    String input =
+        readResource("org/batfish/datamodel/bgp-advertisement-missing-fields.json", UTF_8);
+    BgpAdvertisement advertisement =
+        BatfishObjectMapper.mapper().readValue(input, BgpAdvertisement.class);
+
+    assertThat(
+        advertisement,
+        equalTo(
+            new BgpAdvertisement(
+                BgpAdvertisementType.EBGP_SENT,
+                Prefix.parse("4.0.0.0/8"),
+                Ip.parse("10.14.22.4"),
+                null,
+                DEFAULT_VRF_NAME,
+                Ip.parse("10.14.22.4"),
+                "as1border2",
+                "default",
+                Ip.parse("10.14.22.1"),
+                RoutingProtocol.AGGREGATE,
+                OriginType.EGP,
+                UNSET_LOCAL_PREFERENCE,
+                0L,
+                UNSET_ORIGINATOR_IP,
+                AsPath.of(AsSet.of(1239)),
+                ImmutableSortedSet.of(StandardCommunity.of(262145)),
+                ImmutableSortedSet.of(),
+                UNSET_WEIGHT)));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpAdvertisementTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpAdvertisementTest.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel;
 
+import static org.batfish.datamodel.BgpAdvertisement.nullSafeCompareTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -38,5 +39,13 @@ public class BgpAdvertisementTest {
     // don't canonicalize VRFs
     assertThat(advert.getSrcVrf(), equalTo("srcVrf"));
     assertThat(advert.getDstVrf(), equalTo("dstVrf"));
+  }
+
+  @Test
+  public void testNullSafeCompareTo() {
+    assertThat(nullSafeCompareTo(null, null), equalTo(0));
+    assertThat(nullSafeCompareTo(null, "a"), equalTo(-1));
+    assertThat(nullSafeCompareTo("a", null), equalTo(1));
+    assertThat(nullSafeCompareTo("a", "b"), equalTo("a".compareTo("b")));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpAdvertisementTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/BgpAdvertisementTest.java
@@ -89,4 +89,49 @@ public class BgpAdvertisementTest {
                 ImmutableSortedSet.of(),
                 UNSET_WEIGHT)));
   }
+
+  @Test
+  public void testCompareTo() {
+    BgpAdvertisement left =
+        new BgpAdvertisement(
+            BgpAdvertisementType.EBGP_SENT,
+            Prefix.parse("4.0.0.0/8"),
+            Ip.parse("10.14.22.4"),
+            null,
+            DEFAULT_VRF_NAME,
+            Ip.parse("10.14.22.4"),
+            "as1border2",
+            "default",
+            Ip.parse("10.14.22.1"),
+            RoutingProtocol.AGGREGATE,
+            OriginType.EGP,
+            UNSET_LOCAL_PREFERENCE,
+            0L,
+            UNSET_ORIGINATOR_IP,
+            AsPath.of(AsSet.of(1239)),
+            ImmutableSortedSet.of(StandardCommunity.of(262145)),
+            ImmutableSortedSet.of(),
+            UNSET_WEIGHT);
+    BgpAdvertisement right =
+        new BgpAdvertisement(
+            BgpAdvertisementType.EBGP_SENT,
+            Prefix.parse("4.0.0.0/8"),
+            Ip.parse("10.14.22.4"),
+            null,
+            DEFAULT_VRF_NAME,
+            Ip.parse("10.14.22.4"),
+            "as1border2",
+            "default",
+            Ip.parse("10.14.22.1"),
+            RoutingProtocol.AGGREGATE,
+            OriginType.EGP,
+            UNSET_LOCAL_PREFERENCE,
+            0L,
+            UNSET_ORIGINATOR_IP,
+            AsPath.of(AsSet.of(1239)),
+            ImmutableSortedSet.of(StandardCommunity.of(262145)),
+            ImmutableSortedSet.of(),
+            UNSET_WEIGHT);
+    assertThat(left.compareTo(right), equalTo(0));
+  }
 }

--- a/projects/batfish-common-protocol/src/test/resources/org/batfish/datamodel/bgp-advertisement-missing-fields.json
+++ b/projects/batfish-common-protocol/src/test/resources/org/batfish/datamodel/bgp-advertisement-missing-fields.json
@@ -1,0 +1,14 @@
+{
+  "type" : "ebgp_sent",
+  "network" : "4.0.0.0/8",
+  "nextHopIp" : "10.14.22.4",
+  "srcIp" : "10.14.22.4",
+  "dstNode" : "as1border2",
+  "dstIp" : "10.14.22.1",
+  "srcProtocol" : "AGGREGATE",
+  "originType" : "egp",
+  "asPath" : [ [ 1239 ] ],
+  "communities" : [ 262145 ],
+  "dstVrf":"default",
+  "clusterList":[]
+}


### PR DESCRIPTION
https://github.com/batfish/batfish/pull/6373 enforced all fields in the class to be non-empty (as expected by the compareTo/equals) implementations. That broke users who were relying on not requiring specification of unnecessary fields. This PR relaxes the non-null checks for some fields by filling in defaults and makes compareTo/equals handle null values where they may appear.