### PR TITLE
fix npe due to stale listing during GC: computeExpungeBeforeDate

### DIFF
--- a/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
+++ b/projects/coordinator/src/main/java/org/batfish/coordinator/WorkMgr.java
@@ -224,6 +224,13 @@ public class WorkMgr extends AbstractCoordinator {
               network, snapshot, Throwables.getStackTraceAsString(e));
           continue;
         }
+        if (metadata == null) {
+          _logger.debugf(
+              "computeExpungeBeforeDate: network or snapshot removed between listing and metadata"
+                  + " fetching: network '%s', snapshot '%s'",
+              network, snapshot);
+          continue;
+        }
         builder.add(metadata.getCreationTimestamp());
       }
     }


### PR DESCRIPTION
Handle case where after listing snapshots of a network but before
fetching snapshot metadata, network or snapshot has been removed.