### PR TITLE
NX-OS: fixup to #6462

### DIFF
--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_route_map_exhaustive
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_route_map_exhaustive
@@ -1,0 +1,21 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_route_map_exhaustive
+!
+ip community-list standard cl20 seq 1 permit 0:2
+!
+route-map RM deny 10
+ match tag 1
+ set tag 10
+ continue 20
+route-map RM permit 20
+ match community cl20
+ set community 0:20
+ continue 30
+route-map RM deny 30
+ match metric 3
+ set metric 10
+route-map RM permit 40
+ set local-preference 40
+ description Done
+!

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -74493,7 +74493,7 @@
                 "trueStatements" : [
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionReject"
+                    "type" : "ReturnFalse"
                   }
                 ]
               },
@@ -74510,7 +74510,7 @@
                 "trueStatements" : [
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetLocalDefaultActionReject"
+                    "type" : "ReturnFalse"
                   }
                 ]
               },
@@ -74552,7 +74552,7 @@
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "SetLocalDefaultActionReject"
+                "type" : "ReturnFalse"
               }
             ]
           },
@@ -75287,7 +75287,7 @@
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "SetLocalDefaultActionReject"
+                "type" : "ReturnFalse"
               }
             ]
           },
@@ -75834,7 +75834,7 @@
             "statements" : [
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "SetLocalDefaultActionAccept"
+                "type" : "ReturnTrue"
               },
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",


### PR DESCRIPTION
Non-continue terms need to terminate, not change default action.
Otherwise, a subsequent match could mess things up.

Add an exhaust~ing~ive test. Note I had to mix the actions, so decided
that it's okay that half the tests don't really test pre-matches.