### PR TITLE
Arista: port NX-OS route-map logic

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -2463,14 +2463,12 @@ public class AristaGrammarTest {
               .build());
     }
     {
-      assert true;
-      // TODO(PR#6465) true false false -> 10, 40
-      //      Bgpv4Route after = processRouteIn(rm, base.toBuilder().setTag(1L).build());
-      //      assertThat(after.getTag(), equalTo(10L));
-      //      assertThat(after.getCommunities(),
-      // not(equalTo(CommunitySet.of(StandardCommunity.of(20)))));
-      //      assertThat(after.getMetric(), not(equalTo(30L)));
-      //      assertThat(after.getLocalPreference(), equalTo(40L));
+      // true false false -> 10, 40
+      Bgpv4Route after = processRouteIn(rm, base.toBuilder().setTag(1L).build());
+      assertThat(after.getTag(), equalTo(10L));
+      assertThat(after.getCommunities(), not(equalTo(CommunitySet.of(StandardCommunity.of(20)))));
+      assertThat(after.getMetric(), not(equalTo(30L)));
+      assertThat(after.getLocalPreference(), equalTo(40L));
     }
     {
       // true false true -> 10, 30
@@ -2478,20 +2476,18 @@ public class AristaGrammarTest {
           rm, base.toBuilder().setTag(1L).setNetwork(Prefix.parse("1.2.3.4/32")).build());
     }
     {
-      assert true;
-      //      // TODO(PR#6465) true true false -> 10, 20, 40
-      //      Bgpv4Route after =
-      //          processRouteIn(
-      //              rm,
-      //              base.toBuilder()
-      //                  .setTag(1L)
-      //                  .setCommunities(CommunitySet.of(StandardCommunity.of(2)))
-      //                  .build());
-      //      assertThat(after.getTag(), equalTo(10L));
-      //      assertThat(after.getCommunities(),
-      // equalTo(CommunitySet.of(StandardCommunity.of(20))));
-      //      assertThat(after.getMetric(), not(equalTo(30L)));
-      //      assertThat(after.getLocalPreference(), equalTo(40L));
+      // true true false -> 10, 20, 40
+      Bgpv4Route after =
+          processRouteIn(
+              rm,
+              base.toBuilder()
+                  .setTag(1L)
+                  .setCommunities(CommunitySet.of(StandardCommunity.of(2)))
+                  .build());
+      assertThat(after.getTag(), equalTo(10L));
+      assertThat(after.getCommunities(), equalTo(CommunitySet.of(StandardCommunity.of(20))));
+      assertThat(after.getMetric(), not(equalTo(30L)));
+      assertThat(after.getLocalPreference(), equalTo(40L));
     }
     {
       // true true true -> 10, 20, 30

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -18642,8 +18642,53 @@
             "name" : "ROUTE_MAP",
             "statements" : [
               {
-                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                "type" : "ReturnFalse"
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ExitReject"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                      "type" : "CallExprContext"
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnFalse"
+                      }
+                    ]
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
+                  "calledPolicyName" : "~ROUTE_MAP~SEQ:10~"
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ExitAccept"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                      "type" : "CallExprContext"
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "ReturnTrue"
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -18669,6 +18714,23 @@
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
                 "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~ROUTE_MAP~SEQ:10~" : {
+            "name" : "~ROUTE_MAP~SEQ:10~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "SetLocalDefaultActionReject"
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnLocalDefaultAction"
               }
             ]
           }


### PR DESCRIPTION
Prior to this PR, Arista modeled route-maps as nested structures, so that if
there were N terms, those terms would go into a recursive structure that was N
terms deep. For large N (hundreds+) this can cause recursion limits in Java,
e.g., in walking the route-map or in serializing it to disk.

Fix this by adopting (nearly verbatim) the logic from NX-OS.

Validated by existing unit tests + Batfish Enterprise compare view: routes are
the same before and after in many real networks.