### PR TITLE
CumulusNclu: be robust to bad interface neighbor

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_nclu/CumulusNcluConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_nclu/CumulusNcluConfigurationBuilder.java
@@ -775,6 +775,7 @@ public class CumulusNcluConfigurationBuilder extends CumulusNcluParserBaseListen
           String.format(
               "Cannot create BGP neighbor for illegal abstract interface name '%s' in: %s",
               _currentBgpNeighborName, getFullText(ctx)));
+      _currentBgpNeighbor = new BgpPeerGroupNeighbor("dummy");
       return;
     }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -559,6 +559,12 @@ public final class CumulusNcluGrammarTest {
   }
 
   @Test
+  public void testBgpInvalidInterfaceNeighbor() throws IOException {
+    CumulusNcluConfiguration c = parseVendorConfig("cumulus_nclu_bgp_invalid_interface_neighbor");
+    assertThat(c.getBgpProcess().getDefaultVrf().getNeighbors(), anEmptyMap());
+  }
+
+  @Test
   public void testBgpIpNeighbor() throws IOException {
     Configuration c = parseConfig("cumulus_nclu_bgp_ip_neighbor");
     long internalAs = 65500L;

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testconfigs/cumulus_nclu_bgp_invalid_interface_neighbor
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testconfigs/cumulus_nclu_bgp_invalid_interface_neighbor
@@ -1,0 +1,8 @@
+net del all
+#
+net add hostname cumulus_nclu_bgp_invalid_interface_neighbor
+#
+net add bgp autonomous-system 65500
+net add bgp neighbor NOT_AN_IFACE_NAME interface remote-as 5
+#
+net commit


### PR DESCRIPTION
By creating a dummy neighbor, we prevent crashes handling the rest of the line.