### PR TITLE
FRR: BgpNeighbor RemoteAs fixup

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpIpNeighbor.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpIpNeighbor.java
@@ -5,17 +5,14 @@ import org.batfish.datamodel.Ip;
 
 /** BGP neighbor identified by an IPv4 peer address */
 public class BgpIpNeighbor extends BgpNeighbor {
-  private Ip _peerIp;
+  private final @Nonnull Ip _peerIp;
 
-  public BgpIpNeighbor(String name) {
+  public BgpIpNeighbor(String name, Ip ip) {
     super(name);
-  }
-
-  public Ip getPeerIp() {
-    return _peerIp;
-  }
-
-  public void setPeerIp(@Nonnull Ip ip) {
     _peerIp = ip;
+  }
+
+  public @Nonnull Ip getPeerIp() {
+    return _peerIp;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpNeighbor.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpNeighbor.java
@@ -2,19 +2,103 @@ package org.batfish.representation.cumulus;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.BgpPeerConfig;
+import org.batfish.datamodel.LongSpace;
 
 /** Parent for all BGP neighbors. */
 public abstract class BgpNeighbor implements Serializable {
+  public static class RemoteAs implements Serializable {
+    @Nullable final Long _asn;
+    @Nonnull final RemoteAsType _type;
+
+    public static RemoteAs explicit(long asn) {
+      return new RemoteAs(asn, RemoteAsType.EXPLICIT);
+    }
+
+    public static RemoteAs external() {
+      return new RemoteAs(null, RemoteAsType.EXTERNAL);
+    }
+
+    public static RemoteAs internal() {
+      return new RemoteAs(null, RemoteAsType.INTERNAL);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof RemoteAs)) {
+        return false;
+      }
+      RemoteAs remoteAs = (RemoteAs) o;
+      return Objects.equals(_asn, remoteAs._asn) && _type == remoteAs._type;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_asn, _type);
+    }
+
+    /**
+     * Returns the remote AS values for this remote AS configuration with the given local ASN, or
+     * {@link LongSpace#EMPTY} if {@code localAs} is required to compute the AS values but is {@code
+     * null}.
+     */
+    public @Nonnull LongSpace getRemoteAs(@Nullable Long localAs) {
+      if (_type == RemoteAsType.EXPLICIT) {
+        assert _asn != null;
+        return LongSpace.of(_asn);
+      } else if (localAs == null) {
+        // For either INTERNAL or EXTERNAL, we need to know the local AS to implement this.
+        return LongSpace.EMPTY;
+      } else if (_type == RemoteAsType.EXTERNAL) {
+        // Everything but the local ASN.
+        return BgpPeerConfig.ALL_AS_NUMBERS.difference(LongSpace.of(localAs));
+      } else {
+        assert _type == RemoteAsType.INTERNAL;
+        return LongSpace.of(localAs);
+      }
+    }
+
+    /**
+     * Returns {@code true} if this remote AS is known to be different from the given {@code
+     * localAs}, and {@code false} otherwise.
+     *
+     * <p>Returns {@code false} when the result is unknown, aka, when {@code localAs} is {@code
+     * null} and this is an explicitly numbered peer.
+     */
+    public boolean isKnownEbgp(@Nullable Long localAs) {
+      return _type == RemoteAsType.EXTERNAL
+          || _type == RemoteAsType.EXPLICIT && localAs != null && !localAs.equals(_asn);
+    }
+
+    /**
+     * Returns {@code true} if this remote AS is known to be the same as the given {@code localAs},
+     * and {@code false} otherwise.
+     *
+     * <p>Returns {@code false} when the result is unknown, aka, when {@code localAs} is {@code
+     * null} and this is an explicitly numbered peer.
+     */
+    public boolean isKnownIbgp(@Nullable Long localAs) {
+      return _type == RemoteAsType.INTERNAL
+          || _type == RemoteAsType.EXPLICIT && localAs != null && localAs.equals(_asn);
+    }
+
+    private RemoteAs(@Nullable Long asn, RemoteAsType type) {
+      _asn = asn;
+      _type = type;
+    }
+  }
 
   private final @Nonnull String _name;
   private @Nullable String _description;
   private @Nullable String _peerGroup;
 
   // Inheritable properties
-  private @Nullable Long _remoteAs;
-  private @Nullable RemoteAsType _remoteAsType;
+  private @Nullable RemoteAs _remoteAs;
   private @Nullable BgpNeighborIpv4UnicastAddressFamily _ipv4UnicastAddressFamily;
   private @Nullable BgpNeighborL2vpnEvpnAddressFamily _l2vpnEvpnAddressFamily;
   private @Nullable Long _ebgpMultihop;
@@ -72,20 +156,12 @@ public abstract class BgpNeighbor implements Serializable {
     _peerGroup = peerGroup;
   }
 
-  /**
-   * Returns explicit remote-as number when {@link #getRemoteAsType} is {@link
-   * RemoteAsType#EXPLICIT}, or else {@code null}.
-   */
   public @Nullable Long getLocalAs() {
     return _localAs;
   }
 
-  public @Nullable Long getRemoteAs() {
+  public @Nullable RemoteAs getRemoteAs() {
     return _remoteAs;
-  }
-
-  public @Nullable RemoteAsType getRemoteAsType() {
-    return _remoteAsType;
   }
 
   public @Nullable Long getEbgpMultihop() {
@@ -100,12 +176,8 @@ public abstract class BgpNeighbor implements Serializable {
     _localAs = localAs;
   }
 
-  public void setRemoteAs(@Nullable Long remoteAs) {
+  public void setRemoteAs(@Nullable RemoteAs remoteAs) {
     _remoteAs = remoteAs;
-  }
-
-  public void setRemoteAsType(@Nullable RemoteAsType remoteAsType) {
-    _remoteAsType = remoteAsType;
   }
 
   protected void inheritFrom(@Nonnull Map<String, BgpNeighbor> peers) {
@@ -131,10 +203,8 @@ public abstract class BgpNeighbor implements Serializable {
       _ebgpMultihop = other.getEbgpMultihop();
     }
 
-    if (_remoteAsType == null) {
-      // These properties are coupled, but remoteAsType will be non-null if they have been set.
+    if (_remoteAs == null) {
       _remoteAs = other.getRemoteAs();
-      _remoteAsType = other.getRemoteAsType();
     }
 
     if (_ipv4UnicastAddressFamily == null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -61,7 +61,6 @@ import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LinkLocalAddress;
-import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.Mlag;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.OriginType;
@@ -483,6 +482,19 @@ public final class CumulusConversions {
       localAs = bgpVrf.getAutonomousSystem();
     }
 
+    if (neighbor.getRemoteAs() == null) {
+      w.redFlag(
+          "Skipping BGP neighbor " + neighbor.getName() + ": missing remote-as configuration");
+      return;
+    }
+    if (neighbor.getRemoteAs().getRemoteAs(localAs).isEmpty()) {
+      w.redFlag(
+          "Skipping BGP neighbor "
+              + neighbor.getName()
+              + ": unable to determine remote-as without local-as configured");
+      return;
+    }
+
     if (neighbor instanceof BgpInterfaceNeighbor) {
       BgpInterfaceNeighbor interfaceNeighbor = (BgpInterfaceNeighbor) neighbor;
       addInterfaceBgpNeighbor(c, vsConfig, interfaceNeighbor, localAs, bgpVrf, viBgpProcess, w);
@@ -503,11 +515,6 @@ public final class CumulusConversions {
       BgpVrf bgpVrf,
       org.batfish.datamodel.BgpProcess newProc,
       Warnings w) {
-    if (neighbor.getRemoteAs() == null && neighbor.getRemoteAsType() == null) {
-      w.redFlag("Skipping invalidly configured BGP peer " + neighbor.getName());
-      return;
-    }
-
     BgpPeerConfig.Builder<?, ?> peerConfigBuilder;
 
     // if an interface neighbor has only one address and that address is a /31, it gets treated as
@@ -515,9 +522,12 @@ public final class CumulusConversions {
     Interface viIface = c.getAllInterfaces().get(neighbor.getName());
     Optional<Ip> inferredIp = inferPeerIp(viIface);
     if (inferredIp.isPresent()) {
+      InterfaceAddress localAddress = viIface.getAddress();
+      // consequence of inferredIp
+      assert localAddress instanceof ConcreteInterfaceAddress;
       peerConfigBuilder =
           BgpActivePeerConfig.builder()
-              .setLocalIp(((ConcreteInterfaceAddress) viIface.getAddress()).getIp())
+              .setLocalIp(((ConcreteInterfaceAddress) localAddress).getIp())
               .setPeerAddress(inferredIp.get());
     } else {
       peerConfigBuilder =
@@ -539,19 +549,21 @@ public final class CumulusConversions {
       org.batfish.datamodel.BgpProcess newProc,
       BgpPeerConfig.Builder<?, ?> peerConfigBuilder,
       Warnings w) {
+    assert neighbor.getRemoteAs() != null; // precondition
 
-    RoutingPolicy exportRoutingPolicy = computeBgpNeighborExportRoutingPolicy(c, neighbor, bgpVrf);
+    RoutingPolicy exportRoutingPolicy =
+        computeBgpNeighborExportRoutingPolicy(c, neighbor, bgpVrf, localAs);
     @Nullable
     RoutingPolicy importRoutingPolicy = computeBgpNeighborImportRoutingPolicy(c, neighbor, bgpVrf);
 
     peerConfigBuilder
         .setBgpProcess(newProc)
-        .setClusterId(inferClusterId(bgpVrf, newProc.getRouterId(), neighbor))
+        .setClusterId(inferClusterId(bgpVrf, newProc.getRouterId(), neighbor, localAs))
         .setConfederation(bgpVrf.getConfederationId())
         .setDescription(neighbor.getDescription())
         .setGroup(neighbor.getPeerGroup())
         .setLocalAs(localAs)
-        .setRemoteAsns(computeRemoteAsns(neighbor, localAs))
+        .setRemoteAsns(neighbor.getRemoteAs().getRemoteAs(localAs))
         .setEbgpMultihop(neighbor.getEbgpMultihop() != null)
         .setGeneratedRoutes(
             bgpDefaultOriginate(neighbor) ? ImmutableSet.of(GENERATED_DEFAULT_ROUTE) : null)
@@ -619,12 +631,6 @@ public final class CumulusConversions {
       BgpVrf bgpVrf,
       org.batfish.datamodel.BgpProcess newProc,
       Warnings w) {
-    if (neighbor.getPeerIp() == null
-        || (neighbor.getRemoteAs() == null && neighbor.getRemoteAsType() == null)) {
-      w.redFlag("Skipping invalidly configured BGP peer " + neighbor.getName());
-      return;
-    }
-
     BgpActivePeerConfig.Builder peerConfigBuilder =
         BgpActivePeerConfig.builder()
             .setLocalIp(
@@ -639,7 +645,7 @@ public final class CumulusConversions {
 
   @Nonnull
   private static RoutingPolicy computeBgpNeighborExportRoutingPolicy(
-      Configuration c, BgpNeighbor neighbor, BgpVrf bgpVrf) {
+      Configuration c, BgpNeighbor neighbor, BgpVrf bgpVrf, @Nullable Long localAs) {
     String vrfName = bgpVrf.getVrfName();
 
     RoutingPolicy.Builder peerExportPolicy =
@@ -663,7 +669,7 @@ public final class CumulusConversions {
     }
 
     BooleanExpr peerExportConditions = computePeerExportConditions(neighbor, bgpVrf);
-    List<Statement> acceptStmts = getAcceptStatements(neighbor, bgpVrf);
+    List<Statement> acceptStmts = getAcceptStatements(neighbor, bgpVrf, localAs);
 
     peerExportPolicy.addStatement(
         new If(
@@ -761,9 +767,10 @@ public final class CumulusConversions {
         : new Conjunction(ImmutableList.of(commonCondition, peerCondition));
   }
 
-  private static List<Statement> getAcceptStatements(BgpNeighbor neighbor, BgpVrf bgpVrf) {
+  private static List<Statement> getAcceptStatements(
+      BgpNeighbor neighbor, BgpVrf bgpVrf, @Nullable Long localAs) {
     ImmutableList.Builder<Statement> acceptStatements = ImmutableList.builder();
-    SetNextHop setNextHop = getSetNextHop(neighbor, bgpVrf);
+    SetNextHop setNextHop = getSetNextHop(neighbor, localAs);
     SetMetric setMaxMedMetric = getSetMaxMedMetric(bgpVrf);
 
     if (setNextHop != null) {
@@ -792,18 +799,19 @@ public final class CumulusConversions {
   }
 
   @VisibleForTesting
-  static @Nullable SetNextHop getSetNextHop(BgpNeighbor neighbor, BgpVrf bgpVrf) {
-    if (neighbor.getRemoteAs() == null || bgpVrf.getAutonomousSystem() == null) {
+  static @Nullable SetNextHop getSetNextHop(BgpNeighbor neighbor, @Nullable Long localAs) {
+    if (neighbor.getRemoteAs() == null || localAs == null) {
       return null;
     }
 
-    boolean isIBgp = neighbor.getRemoteAs().equals(bgpVrf.getAutonomousSystem());
     // TODO: Need to handle dynamic neighbors.
     boolean nextHopSelf =
         Optional.ofNullable(neighbor.getIpv4UnicastAddressFamily())
             .map(BgpNeighborIpv4UnicastAddressFamily::getNextHopSelf)
             .orElse(false);
 
+    // Note that since localAs != null, this is authoritative.
+    boolean isIBgp = neighbor.getRemoteAs().isKnownIbgp(localAs);
     if (isIBgp) {
       // Check for "force".
       // TODO: Handle v6 AFI.
@@ -1025,22 +1033,6 @@ public final class CumulusConversions {
   private static boolean bgpDefaultOriginate(BgpNeighbor neighbor) {
     return neighbor.getIpv4UnicastAddressFamily() != null
         && Boolean.TRUE.equals(neighbor.getIpv4UnicastAddressFamily().getDefaultOriginate());
-  }
-
-  @Nonnull
-  private static LongSpace computeRemoteAsns(BgpNeighbor neighbor, @Nullable Long localAs) {
-    if (neighbor.getRemoteAsType() == RemoteAsType.EXPLICIT) {
-      Long remoteAs = neighbor.getRemoteAs();
-      return remoteAs == null ? LongSpace.EMPTY : LongSpace.of(remoteAs);
-    } else if (localAs == null) {
-      return LongSpace.EMPTY;
-    } else if (neighbor.getRemoteAsType() == RemoteAsType.EXTERNAL) {
-      return BgpPeerConfig.ALL_AS_NUMBERS.difference(LongSpace.of(localAs));
-    } else if (neighbor.getRemoteAsType() == RemoteAsType.INTERNAL) {
-      return LongSpace.of(localAs);
-    }
-    throw new IllegalArgumentException(
-        String.format("Invalid remote-as type: %s", neighbor.getRemoteAsType()));
   }
 
   @Nullable
@@ -1343,9 +1335,11 @@ public final class CumulusConversions {
    */
   @VisibleForTesting
   @Nullable
-  static Long inferClusterId(final BgpVrf bgpVrf, final Ip routerId, final BgpNeighbor neighbor) {
+  static Long inferClusterId(
+      final BgpVrf bgpVrf, final Ip routerId, final BgpNeighbor neighbor, @Nullable Long localAs) {
+    assert neighbor.getRemoteAs() != null; // precondition
     // Do not set cluster Id if peer is eBGP
-    if (!Objects.equals(neighbor.getRemoteAs(), bgpVrf.getAutonomousSystem())) {
+    if (neighbor.getRemoteAs().isKnownEbgp(localAs)) {
       return null;
     }
     // Return clusterId if set in the config, otherwise return routerId as default.

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -10,9 +10,6 @@ import static org.batfish.representation.cumulus.CumulusStructureType.IP_AS_PATH
 import static org.batfish.representation.cumulus.CumulusStructureType.IP_COMMUNITY_LIST;
 import static org.batfish.representation.cumulus.CumulusStructureUsage.ROUTE_MAP_MATCH_AS_PATH;
 import static org.batfish.representation.cumulus.CumulusStructureUsage.ROUTE_MAP_MATCH_COMMUNITY_LIST;
-import static org.batfish.representation.cumulus.RemoteAsType.EXPLICIT;
-import static org.batfish.representation.cumulus.RemoteAsType.EXTERNAL;
-import static org.batfish.representation.cumulus.RemoteAsType.INTERNAL;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -75,6 +72,7 @@ import org.batfish.main.TestrigText;
 import org.batfish.representation.cumulus.BgpInterfaceNeighbor;
 import org.batfish.representation.cumulus.BgpIpNeighbor;
 import org.batfish.representation.cumulus.BgpNeighbor;
+import org.batfish.representation.cumulus.BgpNeighbor.RemoteAs;
 import org.batfish.representation.cumulus.BgpNeighborSourceAddress;
 import org.batfish.representation.cumulus.BgpNeighborSourceInterface;
 import org.batfish.representation.cumulus.BgpNetwork;
@@ -616,7 +614,7 @@ public class CumulusFrrGrammarTest {
     assertThat(neighbors.keySet(), contains("foo"));
     BgpNeighbor foo = neighbors.get("foo");
     assertThat(foo, isA(BgpPeerGroupNeighbor.class));
-    assertThat(foo.getRemoteAs(), equalTo(2L));
+    assertThat(foo.getRemoteAs(), equalTo(RemoteAs.explicit(2L)));
   }
 
   @Test
@@ -640,8 +638,7 @@ public class CumulusFrrGrammarTest {
     Map<String, BgpNeighbor> neighbors = _frr.getBgpProcess().getDefaultVrf().getNeighbors();
     assertThat(neighbors.keySet(), contains("n"));
     BgpNeighbor foo = neighbors.get("n");
-    assertThat(foo.getRemoteAsType(), equalTo(EXPLICIT));
-    assertThat(foo.getRemoteAs(), equalTo(2L));
+    assertThat(foo.getRemoteAs(), equalTo(RemoteAs.explicit(2)));
   }
 
   @Test
@@ -650,8 +647,7 @@ public class CumulusFrrGrammarTest {
     Map<String, BgpNeighbor> neighbors = _frr.getBgpProcess().getDefaultVrf().getNeighbors();
     assertThat(neighbors.keySet(), contains("n"));
     BgpNeighbor foo = neighbors.get("n");
-    assertThat(foo.getRemoteAsType(), equalTo(EXTERNAL));
-    assertNull(foo.getRemoteAs());
+    assertThat(foo.getRemoteAs(), equalTo(RemoteAs.external()));
   }
 
   @Test
@@ -660,8 +656,7 @@ public class CumulusFrrGrammarTest {
     Map<String, BgpNeighbor> neighbors = _frr.getBgpProcess().getDefaultVrf().getNeighbors();
     assertThat(neighbors.keySet(), contains("n"));
     BgpNeighbor foo = neighbors.get("n");
-    assertThat(foo.getRemoteAsType(), equalTo(INTERNAL));
-    assertNull(foo.getRemoteAs());
+    assertThat(foo.getRemoteAs(), equalTo(RemoteAs.internal()));
   }
 
   @Test
@@ -680,7 +675,7 @@ public class CumulusFrrGrammarTest {
     assertThat(neighbors.keySet(), contains("1.2.3.4"));
     BgpNeighbor neighbor = neighbors.get("1.2.3.4");
     assertThat(neighbor, isA(BgpIpNeighbor.class));
-    assertThat(neighbor.getRemoteAs(), equalTo(2L));
+    assertThat(neighbor.getRemoteAs(), equalTo(RemoteAs.explicit(2L)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -132,6 +132,7 @@ import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
 import org.batfish.representation.cumulus.BgpL2vpnEvpnAddressFamily;
 import org.batfish.representation.cumulus.BgpNeighbor;
+import org.batfish.representation.cumulus.BgpNeighbor.RemoteAs;
 import org.batfish.representation.cumulus.BgpProcess;
 import org.batfish.representation.cumulus.BgpRedistributionPolicy;
 import org.batfish.representation.cumulus.BgpVrf;
@@ -141,7 +142,6 @@ import org.batfish.representation.cumulus.CumulusNcluConfiguration;
 import org.batfish.representation.cumulus.CumulusRoutingProtocol;
 import org.batfish.representation.cumulus.CumulusStructureType;
 import org.batfish.representation.cumulus.Interface;
-import org.batfish.representation.cumulus.RemoteAsType;
 import org.batfish.representation.cumulus.RouteMap;
 import org.batfish.representation.cumulus.RouteMapMatchInterface;
 import org.batfish.representation.cumulus.StaticRoute;
@@ -468,8 +468,8 @@ public final class CumulusNcluGrammarTest {
     assertThat("Ensure interface neighbor has correct name", in.getName(), equalTo("swp1"));
     assertThat(
         "Ensure interface uses correct remote-as type",
-        in.getRemoteAsType(),
-        equalTo(RemoteAsType.EXTERNAL));
+        in.getRemoteAs(),
+        equalTo(RemoteAs.external()));
 
     // l2vpn evpn route activation and reflector settings
     assertTrue(
@@ -1646,6 +1646,7 @@ public final class CumulusNcluGrammarTest {
 
     BgpUnnumberedPeerConfig vrf2BgpPeer =
         c.getVrfs().get("vrf2").getBgpProcess().getInterfaceNeighbors().get("swp2");
+    assertThat(vrf2BgpPeer, notNullValue());
     assertThat(vrf2BgpPeer.getIpv4UnicastAddressFamily(), notNullValue());
     assertThat(vrf2BgpPeer.getEvpnAddressFamily(), nullValue());
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/BgpNeighborTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/BgpNeighborTest.java
@@ -3,10 +3,15 @@ package org.batfish.representation.cumulus;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.LongSpace;
 import org.batfish.representation.cumulus.BgpNeighbor.RemoteAs;
 import org.junit.Test;
 
@@ -66,5 +71,66 @@ public final class BgpNeighborTest {
       assertThat(leaf.getL2vpnEvpnAddressFamily().getRouteReflectorClient(), equalTo(Boolean.TRUE));
       assertThat(leaf.getRemoteAs(), equalTo(RemoteAs.explicit(8)));
     }
+  }
+
+  @Test
+  public void testRemoteAsEquals() {
+    new EqualsTester()
+        .addEqualityGroup(1)
+        .addEqualityGroup(RemoteAs.explicit(5), RemoteAs.explicit(5))
+        .addEqualityGroup(RemoteAs.explicit(7))
+        .addEqualityGroup(RemoteAs.internal())
+        .addEqualityGroup(RemoteAs.external())
+        .testEquals();
+  }
+
+  @Test
+  public void testRemoteAsExplicit() {
+    RemoteAs explicit5 = RemoteAs.explicit(5);
+    // remoteAs should always resolve to 5
+    assertThat(explicit5.getRemoteAs(null), equalTo(LongSpace.of(5)));
+    assertThat(explicit5.getRemoteAs(7L), equalTo(LongSpace.of(5)));
+    // Only 5 is known iBGP
+    assertFalse(explicit5.isKnownIbgp(4L));
+    assertTrue(explicit5.isKnownIbgp(5L));
+    assertFalse(explicit5.isKnownIbgp(6L));
+    // All but 5 are known eBGP
+    assertTrue(explicit5.isKnownEbgp(4L));
+    assertFalse(explicit5.isKnownEbgp(5L));
+    assertTrue(explicit5.isKnownEbgp(6L));
+    // Neither is known with null
+    assertFalse(explicit5.isKnownIbgp(null));
+    assertFalse(explicit5.isKnownEbgp(null));
+  }
+
+  @Test
+  public void testRemoteAsExternal() {
+    RemoteAs external = RemoteAs.external();
+    // RemoteAS is anything but argument, empty for null.
+    assertThat(external.getRemoteAs(null), equalTo(LongSpace.EMPTY));
+    assertThat(
+        external.getRemoteAs(5L),
+        equalTo(BgpPeerConfig.ALL_AS_NUMBERS.difference(LongSpace.of(5))));
+    // Never known iBGP
+    assertFalse(external.isKnownIbgp(null));
+    assertFalse(external.isKnownIbgp(5L));
+    // Always known eBGP
+    assertTrue(external.isKnownEbgp(null));
+    assertTrue(external.isKnownEbgp(5L));
+  }
+
+  @Test
+  public void testRemoteAsInternal() {
+    RemoteAs internal = RemoteAs.internal();
+    // RemoteAS is same as argument, empty for null.
+    assertThat(internal.getRemoteAs(null), equalTo(LongSpace.EMPTY));
+    assertThat(internal.getRemoteAs(5L), equalTo(LongSpace.of(5)));
+    assertThat(internal.getRemoteAs(7L), equalTo(LongSpace.of(7)));
+    // Always known iBGP
+    assertTrue(internal.isKnownIbgp(null));
+    assertTrue(internal.isKnownIbgp(5L));
+    // Never known eBGP
+    assertFalse(internal.isKnownEbgp(null));
+    assertFalse(internal.isKnownEbgp(5L));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/BgpNeighborTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/BgpNeighborTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import org.batfish.datamodel.Ip;
+import org.batfish.representation.cumulus.BgpNeighbor.RemoteAs;
 import org.junit.Test;
 
 /** Test of {@link BgpNeighbor} and subclasses. */
@@ -24,11 +25,10 @@ public final class BgpNeighborTest {
     BgpNeighborL2vpnEvpnAddressFamily pgL2vpn = new BgpNeighborL2vpnEvpnAddressFamily();
     pgL2vpn.setRouteReflectorClient(true);
     pg.setL2vpnEvpnAddressFamily(pgL2vpn);
-    pg.setRemoteAs(8L);
-    pg.setRemoteAsType(RemoteAsType.EXPLICIT);
+    pg.setRemoteAs(RemoteAs.explicit(8));
     {
       // all props set, inherit nothing
-      BgpIpNeighbor leaf = new BgpIpNeighbor("leaf");
+      BgpIpNeighbor leaf = new BgpIpNeighbor("leaf", Ip.parse("1.2.3.4"));
       leaf.setBgpNeighborSource(new BgpNeighborSourceAddress(Ip.ZERO));
       leaf.setDescription("leaf desc");
       leaf.setEbgpMultihop(1L);
@@ -39,7 +39,7 @@ public final class BgpNeighborTest {
       leafL2vpn.setRouteReflectorClient(false);
       leaf.setL2vpnEvpnAddressFamily(leafL2vpn);
       leaf.setPeerGroup("pg");
-      leaf.setRemoteAsType(RemoteAsType.EXTERNAL);
+      leaf.setRemoteAs(RemoteAs.external());
 
       leaf.inheritFrom(ImmutableMap.of("pg", pg));
 
@@ -50,12 +50,11 @@ public final class BgpNeighborTest {
       assertThat(
           leaf.getL2vpnEvpnAddressFamily().getRouteReflectorClient(), not(equalTo(Boolean.TRUE)));
       assertThat(leaf.getPeerGroup(), equalTo("pg"));
-      assertThat(leaf.getRemoteAs(), nullValue());
-      assertThat(leaf.getRemoteAsType(), equalTo(RemoteAsType.EXTERNAL));
+      assertThat(leaf.getRemoteAs(), equalTo(RemoteAs.external()));
     }
     {
       // no props set, inherit everything applicable
-      BgpIpNeighbor leaf = new BgpIpNeighbor("leaf");
+      BgpIpNeighbor leaf = new BgpIpNeighbor("leaf", Ip.parse("1.2.3.4"));
       leaf.setPeerGroup("pg");
       leaf.inheritFrom(ImmutableMap.of("pg", pg));
 
@@ -65,8 +64,7 @@ public final class BgpNeighborTest {
       assertThat(leaf.getEbgpMultihop(), equalTo(5L));
       assertThat(leaf.getIpv4UnicastAddressFamily().getNextHopSelf(), equalTo(Boolean.TRUE));
       assertThat(leaf.getL2vpnEvpnAddressFamily().getRouteReflectorClient(), equalTo(Boolean.TRUE));
-      assertThat(leaf.getRemoteAs(), equalTo(8L));
-      assertThat(leaf.getRemoteAsType(), equalTo(RemoteAsType.EXPLICIT));
+      assertThat(leaf.getRemoteAs(), equalTo(RemoteAs.explicit(8)));
     }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConcatenatedConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConcatenatedConfigurationTest.java
@@ -275,6 +275,7 @@ public class CumulusConcatenatedConfigurationTest {
 
     BgpProcess bgpProc = new BgpProcess();
     BgpVrf bgpVrf = new BgpVrf(DEFAULT_VRF_NAME);
+    bgpVrf.setAutonomousSystem(65000L);
     BgpNeighbor neighbpr = new BgpInterfaceNeighbor("swp2");
     neighbpr.setRemoteAs(RemoteAs.external());
     frrConfiguration.setBgpProcess(bgpProc);

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConcatenatedConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConcatenatedConfigurationTest.java
@@ -27,6 +27,7 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
+import org.batfish.representation.cumulus.BgpNeighbor.RemoteAs;
 import org.batfish.representation.cumulus.CumulusPortsConfiguration.PortSettings;
 import org.junit.Test;
 
@@ -275,7 +276,7 @@ public class CumulusConcatenatedConfigurationTest {
     BgpProcess bgpProc = new BgpProcess();
     BgpVrf bgpVrf = new BgpVrf(DEFAULT_VRF_NAME);
     BgpNeighbor neighbpr = new BgpInterfaceNeighbor("swp2");
-    neighbpr.setRemoteAsType(RemoteAsType.EXTERNAL);
+    neighbpr.setRemoteAs(RemoteAs.external());
     frrConfiguration.setBgpProcess(bgpProc);
     bgpProc.getVrfs().put(DEFAULT_VRF_NAME, bgpVrf);
     bgpVrf.getNeighbors().put(neighbpr.getName(), neighbpr);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testconfigs/cumulus_nclu_evpn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_nclu/testconfigs/cumulus_nclu_evpn
@@ -23,6 +23,7 @@ net add vxlan vni10002 bridge access 2
 
 # VNIs for vrf1
 net add vrf vrf1 vni 10004
+net add bgp vrf vrf1 autonomous-system 65500
 net add bgp vrf vrf1 router-id 192.0.1.1
 net add vxlan vni10004 vxlan id 10004
 net add vxlan vni10004 vxlan local-tunnelip 192.0.2.14
@@ -36,6 +37,7 @@ net add vxlan vni10005 bridge access 5
 
 # VNIs for vrf6
 net add vrf vrf6 vni 10006
+net add bgp vrf vrf6 autonomous-system 65500
 net add bgp vrf vrf6 router-id 192.0.1.1
 ## advertise ipv4 unicast must appear in the tenant VRF config to take effect
 net add bgp vrf vrf6 l2vpn evpn advertise ipv4 unicast
@@ -46,6 +48,7 @@ net add vxlan vni10006 bridge access 6
 # Unrelated to EVPN vrf
 net add vrf vrf2
 net add interface swp2 vrf vrf2
+net add bgp vrf vrf2 autonomous-system 65500
 net add bgp vrf vrf2 router-id 192.0.2.2
 net add bgp vrf vrf2 neighbor swp2 interface remote-as external
 

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -34505,6 +34505,7 @@
                 },
                 "swp2" : {
                   "class" : "org.batfish.datamodel.BgpUnnumberedPeerConfig",
+                  "clusterId" : 3221225986,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
                   "enforceFirstAs" : false,
@@ -34880,6 +34881,7 @@
               "neighbors" : {
                 "1.1.1.2/32" : {
                   "class" : "org.batfish.datamodel.BgpActivePeerConfig",
+                  "clusterId" : 0,
                   "defaultMetric" : 0,
                   "ebgpMultihop" : false,
                   "enforceFirstAs" : false,

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -92183,11 +92183,11 @@
           "Red flags" : [
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Skipping invalidly configured BGP peer 1.1.1.1"
+              "text" : "Skipping BGP neighbor 1.1.1.1: missing remote-as configuration"
             },
             {
               "tag" : "MISCELLANEOUS",
-              "text" : "Skipping invalidly configured BGP peer 1.1.1.2"
+              "text" : "Skipping BGP neighbor 1.1.1.2: missing remote-as configuration"
             }
           ]
         },


### PR DESCRIPTION
* Create one class to encapsulate the different types of remote-as configuration
* Simplify conversion code
* Fix a few places that vrf local-as was used as local-as (it can be overridden per neighbor)
* Don't convert neighbors where remote-as set is empty, and fix a test that needed it
* BgpIpNeighbor: make the IP mandatory
* Improve and centralize warnings (removing the invalid peerIp warning)