### PR TITLE
Arista: don't bail on miscellaneous extra output

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/Legacy_acl.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/Legacy_acl.g4
@@ -217,9 +217,13 @@ extended_access_list_null_tail
          access_list_action protocol access_list_ip_range port_specifier?
          access_list_ip_range port_specifier? REFLECT
       )
+      | COUNTERS
       | DYNAMIC
       | EVALUATE
+      | FRAGMENT_RULES
       | MENU
+      | NO COUNTERS
+      | NO STATISTICS
       | REMARK
       | STATISTICS
    ) null_rest_of_line
@@ -924,7 +928,9 @@ standard_access_list_null_tail
       )? num = DEC
    )?
    (
-      FRAGMENT_RULES
+      COUNTERS
+      | FRAGMENT_RULES
+      | NO COUNTERS
       | NO STATISTICS
       | REMARK
       | STATISTICS

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -1790,8 +1790,9 @@ public class AristaGrammarTest {
   @Test
   public void testParseAclShowRunAll() {
     Configuration c = parseConfig("arista_acl_show_run_all");
-    // Tests that the ACL parses.
+    // Tests that the ACLs parse.
     assertThat(c, hasIpAccessList("SOME_ACL", hasLines(hasSize(1))));
+    assertThat(c, hasIpAccessList("SOME_EXT_ACL", hasLines(hasSize(1))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_acl_show_run_all
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_acl_show_run_all
@@ -3,6 +3,17 @@
 hostname arista_acl_show_run_all
 !
 ip access-list standard SOME_ACL
+   counters per-entry
+   no counters per-entry
+   statistics per-entry
    no statistics per-entry
    fragment-rules
    10 permit 192.0.2.0/24
+!
+ip access-list SOME_EXT_ACL
+   counters per-entry
+   no counters per-entry
+   statistics per-entry
+   no statistics per-entry
+   fragment-rules
+   10 permit tcp any any eq ssh https


### PR DESCRIPTION
Both standard and extended ACLs, in some versions of EOS, will show lines like
`[no] statistics per-entry` or its version-dependent counter-part `counters`.