### PR TITLE
NXOS iface conversion: Use EIGRP VRF ASN if process ASN not present

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -2020,14 +2020,12 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
       }
     }
     if (eigrpProcess != null) {
-      // TODO Does EigrpVrfConfiguration ASN take precedence over EigrpProcessConfiguration ASN?
-      Integer asn = eigrpProcess.getAsn();
-      if (asn == null) {
-        asn =
-            Optional.ofNullable(eigrpProcess.getVrf(vrfName))
-                .map(EigrpVrfConfiguration::getAsn)
-                .orElse(null);
-      }
+      // Find process ASN for this interface. If an ASN is explicitly configured for the interface's
+      // VRF, it takes precedence over process ASN (which is just process tag interpreted as ASN).
+      Integer asn =
+          Optional.ofNullable(eigrpProcess.getVrf(vrfName))
+              .map(EigrpVrfConfiguration::getAsn)
+              .orElse(eigrpProcess.getAsn());
       if (asn != null) {
         String importPolicyName = eigrpNeighborImportPolicyName(ifaceName, vrfName, asn);
         String exportPolicyName = eigrpNeighborExportPolicyName(ifaceName, vrfName, asn);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -7957,6 +7957,7 @@ public final class CiscoNxosGrammarTest {
     {
       // Interface with custom EIGRP BW, delay, passive-interface
       Interface iface = vc.getInterfaces().get("Ethernet1/1");
+      assertThat(iface.getEigrp(), equalTo("1"));
       assertThat(iface.getEigrpBandwidth(), equalTo(300));
       assertThat(iface.getEigrpDelay(), equalTo(400));
       assertTrue(iface.getEigrpPassive());
@@ -7964,6 +7965,7 @@ public final class CiscoNxosGrammarTest {
     {
       // Interface with no custom EIGRP configurations
       Interface iface = vc.getInterfaces().get("Ethernet1/2");
+      assertThat(iface.getEigrp(), equalTo("EIGRP2"));
       assertNull(iface.getEigrpBandwidth());
       assertNull(iface.getEigrpDelay());
       assertFalse(iface.getEigrpPassive());
@@ -7999,10 +8001,11 @@ public final class CiscoNxosGrammarTest {
     }
     {
       /*
+      router eigrp EIGRP2
+        autonomous-system 2
       interface Ethernet1/2
-        vrf member VRF
         ip address 192.0.3.2/24
-        ip router eigrp 1
+        ip router eigrp EIGRP2
        */
       String ifaceName = "Ethernet1/2";
       org.batfish.datamodel.Interface iface = c.getAllInterfaces().get(ifaceName);
@@ -8010,6 +8013,7 @@ public final class CiscoNxosGrammarTest {
       assertThat(iface.getBandwidth(), equalTo(defaultBw));
       EigrpInterfaceSettings eigrp = iface.getEigrp();
       assertNotNull(eigrp);
+      assertThat(eigrp.getAsn(), equalTo(2L));
       // EIGRP metric values have bandwidth in kb/s; VI config has it in bits/s
       assertThat(
           eigrp.getMetric().getValues().getBandwidth(), equalTo(defaultBw.longValue() / 1000));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -8022,6 +8022,33 @@ public final class CiscoNxosGrammarTest {
           equalTo((long) (defaultDelayTensOfMicroseconds(CiscoNxosInterfaceType.ETHERNET) * 1e7)));
       assertFalse(eigrp.getPassive());
     }
+    {
+      /*
+      router eigrp 3
+        autonomous-system 4
+      interface Ethernet1/3
+        ip address 192.0.3.3/24
+        ip router eigrp 3
+       */
+      // Since Ethernet1/3 is in the default vrf, autononomous-system 4 should override process tag
+      String ifaceName = "Ethernet1/3";
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get(ifaceName);
+      assertThat(iface.getEigrp().getAsn(), equalTo(4L));
+    }
+    {
+      /*
+      router eigrp 3
+        autonomous-system 4
+      interface Ethernet1/4
+        vrf member VRF
+        ip address 192.0.3.4/24
+        ip router eigrp 3
+       */
+      // Since Ethernet1/4 is not in the default vrf, autononomous-system 4 should be ignored
+      String ifaceName = "Ethernet1/4";
+      org.batfish.datamodel.Interface iface = c.getAllInterfaces().get(ifaceName);
+      assertThat(iface.getEigrp().getAsn(), equalTo(3L));
+    }
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_eigrp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_eigrp
@@ -13,6 +13,9 @@ router eigrp 1
 router eigrp EIGRP2
   autonomous-system 2
 !
+router eigrp 3
+  autonomous-system 4
+!
 interface Ethernet1/1
   vrf member VRF
   ip address 192.0.2.2/24
@@ -28,3 +31,12 @@ interface Ethernet1/1
 interface Ethernet1/2
   ip address 192.0.3.2/24
   ip router eigrp EIGRP2
+!
+interface Ethernet1/3
+  ip address 192.0.3.3/24
+  ip router eigrp 3
+!
+interface Ethernet1/4
+  vrf member VRF
+  ip address 192.0.3.4/24
+  ip router eigrp 3

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_eigrp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_eigrp
@@ -10,6 +10,9 @@ vrf context VRF
 router eigrp 1
   ! defined so it will be converted
 !
+router eigrp EIGRP2
+  autonomous-system 2
+!
 interface Ethernet1/1
   vrf member VRF
   ip address 192.0.2.2/24
@@ -23,6 +26,5 @@ interface Ethernet1/1
   ip passive-interface eigrp 1
 !
 interface Ethernet1/2
-  vrf member VRF
   ip address 192.0.3.2/24
-  ip router eigrp 1
+  ip router eigrp EIGRP2


### PR DESCRIPTION
An EIGRP process configuration can specify its ASN in two ways. It can be set directly in the router EIGRP line:
```
! ASN is 1
router eigrp 1
```
Or it can be set on a per-VRF basis using `autonomous-system` (no VRF specified means default VRF):
```
! ASN is 2 for default VRF
router eigrp EIGRP_PROC
  autonomous-system 2
```
In the latter case, we were failing to propagate the ASN to EIGRP interfaces during conversion, which meant those interfaces didn't have EIGRP in the VI model and thus couldn't establish EIGRP edges.

With this PR, the sample configs in #4684 establish an EIGRP edge.