### PR TITLE
NXOS: Support EIGRP network statements

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_eigrp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_eigrp.g4
@@ -105,12 +105,19 @@ recaf_ipv6
 
 recaf_common
 :
-  recaf_router_id
+  recaf_network
+  | recaf_router_id
+;
+
+recaf_network
+:
+  NETWORK network = ip_prefix NEWLINE
 ;
 
 recaf_router_id
 :
-  ROUTER_ID id = ip_address NEWLINE
+  // EIGRP keyword here is undocumented, but apparently works for backwards compatibility.
+  EIGRP? ROUTER_ID id = ip_address NEWLINE
 ;
 
 recaf4_redistribute

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_eigrp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_eigrp.g4
@@ -105,8 +105,15 @@ recaf_ipv6
 
 recaf_common
 :
-  recaf_network
+  recaf_eigrp
+  | recaf_network
   | recaf_router_id
+;
+
+recaf_eigrp
+:
+  // EIGRP keyword here is undocumented, but apparently works for backwards compatibility.
+  EIGRP recaf_router_id
 ;
 
 recaf_network
@@ -116,8 +123,7 @@ recaf_network
 
 recaf_router_id
 :
-  // EIGRP keyword here is undocumented, but apparently works for backwards compatibility.
-  EIGRP? ROUTER_ID id = ip_address NEWLINE
+  ROUTER_ID id = ip_address NEWLINE
 ;
 
 recaf4_redistribute

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -4176,6 +4176,11 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   }
 
   @Override
+  public void exitRecaf_network(CiscoNxosParser.Recaf_networkContext ctx) {
+    _currentEigrpVrfIpAf.addNetwork(toPrefix(ctx.network));
+  }
+
+  @Override
   public void exitRecaf4_redistribute(Recaf4_redistributeContext ctx) {
     Optional<RoutingProtocolInstance> rpiOrError =
         toRoutingProtocolInstance(ctx, ctx.routing_instance_v4());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1991,8 +1991,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     String processTag = iface.getEigrp();
     EigrpProcessConfiguration eigrpProcess = _eigrpProcesses.get(processTag);
     if (iface.getAddress() != null) {
-      // check if this iface is included in an EIGRP process via a network statement
-      // TODO: Determine whether we should also be checking secondary addresses
+      // Check if this iface is included in an EIGRP process via a network statement.
+      // (Secondary addresses do not count for network statement inclusion.)
       Ip ifaceIp = iface.getAddress().getAddress().getIp();
       for (Entry<String, EigrpProcessConfiguration> e : _eigrpProcesses.entrySet()) {
         EigrpProcessConfiguration process = e.getValue();
@@ -2004,8 +2004,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                 .anyMatch(network -> network.containsIp(ifaceIp))) {
           // Found a process on interface
           if (eigrpProcess != null) {
-            // Cisco does not recommend running multiple EIGRP autonomous systems on the same
-            // interface
+            // TODO Support interfaces with multiple EIGRP processes
             _w.redFlag(
                 String.format(
                     "Interface %s matches multiple EIGRP processes. Only process %s will be used.",

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/EigrpVrfIpAddressFamilyConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/EigrpVrfIpAddressFamilyConfiguration.java
@@ -1,12 +1,16 @@
 package org.batfish.representation.cisco_nxos;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.Prefix;
 
 /**
  * Represents the EIGRP configuration for IPv4 or IPv6 address families at the VRF level.
@@ -17,7 +21,12 @@ import javax.annotation.Nullable;
 public abstract class EigrpVrfIpAddressFamilyConfiguration implements Serializable {
 
   public EigrpVrfIpAddressFamilyConfiguration() {
+    _networks = new HashSet<>();
     _redistributionPolicies = new HashMap<>();
+  }
+
+  public final @Nonnull Set<Prefix> getNetworks() {
+    return ImmutableSet.copyOf(_networks);
   }
 
   /** Return all redistribution policies. */
@@ -39,10 +48,15 @@ public abstract class EigrpVrfIpAddressFamilyConfiguration implements Serializab
     return _redistributionPolicies.get(protocol);
   }
 
+  public final void addNetwork(Prefix network) {
+    _networks.add(network);
+  }
+
   /** Set the redistribution policy for the given instance. */
   public final void setRedistributionPolicy(RoutingProtocolInstance instance, String routeMap) {
     _redistributionPolicies.put(instance, new RedistributionPolicy(instance, routeMap));
   }
 
+  private final Set<Prefix> _networks;
   private final Map<RoutingProtocolInstance, RedistributionPolicy> _redistributionPolicies;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/InterfaceAddressWithAttributes.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/InterfaceAddressWithAttributes.java
@@ -8,16 +8,16 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.InterfaceAddress;
 
 /** Describes the configuration for an IP address assigned to an {@link Interface}. */
 @ParametersAreNonnullByDefault
 public final class InterfaceAddressWithAttributes implements Serializable {
-  public InterfaceAddressWithAttributes(ConcreteInterfaceAddress address) {
+  public InterfaceAddressWithAttributes(InterfaceAddress address) {
     _address = address;
   }
 
-  public @Nonnull ConcreteInterfaceAddress getAddress() {
+  public @Nonnull InterfaceAddress getAddress() {
     return _address;
   }
 
@@ -41,7 +41,7 @@ public final class InterfaceAddressWithAttributes implements Serializable {
   ///// Private implementation details         /////
   //////////////////////////////////////////////////
 
-  private final @Nonnull ConcreteInterfaceAddress _address;
+  private final @Nonnull InterfaceAddress _address;
   private int _routePreference;
   private long _tag;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/InterfaceAddressWithAttributes.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/InterfaceAddressWithAttributes.java
@@ -8,16 +8,16 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.InterfaceAddress;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 
 /** Describes the configuration for an IP address assigned to an {@link Interface}. */
 @ParametersAreNonnullByDefault
 public final class InterfaceAddressWithAttributes implements Serializable {
-  public InterfaceAddressWithAttributes(InterfaceAddress address) {
+  public InterfaceAddressWithAttributes(ConcreteInterfaceAddress address) {
     _address = address;
   }
 
-  public @Nonnull InterfaceAddress getAddress() {
+  public @Nonnull ConcreteInterfaceAddress getAddress() {
     return _address;
   }
 
@@ -41,7 +41,7 @@ public final class InterfaceAddressWithAttributes implements Serializable {
   ///// Private implementation details         /////
   //////////////////////////////////////////////////
 
-  private final @Nonnull InterfaceAddress _address;
+  private final @Nonnull ConcreteInterfaceAddress _address;
   private int _routePreference;
   private long _tag;
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_eigrp_network_statements
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_eigrp_network_statements
@@ -1,0 +1,59 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_eigrp_network_statements
+!
+feature eigrp
+!
+interface Ethernet1/1
+  ip address 10.10.10.1/24
+!
+interface Ethernet1/2
+  ip address 11.11.11.1/24
+!
+interface Ethernet1/3
+  vrf member VRF1
+  ip address 12.12.12.1/24
+!
+interface Ethernet1/4
+  vrf member VRF1
+  ip address 13.13.13.1/24
+!
+interface Ethernet1/5
+  vrf member VRF1
+  ip address 14.14.14.1/24
+!
+vrf context VRF1
+  ! defined so it will be converted
+!
+vrf context VRF2
+  ! defined so it will be converted
+!
+!
+! Should have Ethernet1/1
+router eigrp 1
+  network 10.10.10.0/24
+!
+! Should have Ethernet1/2
+router eigrp 2
+  address-family ipv4 unicast
+    network 11.11.0.0/16
+!
+! Should have Ethernet1/3
+router eigrp 3
+  vrf VRF1
+    network 12.12.12.0/30
+!
+! Should have Ethernet1/4
+router eigrp 4
+  vrf VRF1
+    address-family ipv4 unicast
+      network 13.13.13.1/32
+!
+! Should not match Ethernet1/5, which is in vrf VRF1 with address 14.14.14.1/24.
+router eigrp 5
+  network 14.14.14.0/24
+  vrf VRF2
+    network 14.14.14.0/24
+  vrf VRF1
+    network 14.14.14.2/32
+!


### PR DESCRIPTION
Supports (largely undocumented) NX-OS EIGRP network statement syntax for adding interfaces to an EIGRP process. The standard way is to declare EIGRP process in the interface stanza:
```
interface Ethernet1/1
  ip address 1.1.1.1/24
  ip router eigrp 1
```
But it can alternatively be done from the EIGRP stanza using a network statement:
```
router eigrp 1
  network 1.1.1.0/30
```
Network statements will add all interfaces with interface addresses in the network into the EIGRP process. They can appear at the top level of `config-router` (implying default VRF), within a VRF stanza (`config-router-vrf`), or in either of those places within an address-family stanza (`config-router-af`).