### PR TITLE
Remove spurious node from L1 topology in test

### DIFF
--- a/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/evpn-type5-routes/layer1_topology.json
+++ b/projects/batfish/src/test/resources/org/batfish/dataplane/testrigs/evpn-type5-routes/layer1_topology.json
@@ -103,16 +103,6 @@
     {
       "node1": {
         "hostname": "Leaf1",
-        "interfaceName": "swp21"
-      },
-      "node2": {
-        "hostname": "pc10",
-        "interfaceName": "e0"
-      }
-    },
-    {
-      "node1": {
-        "hostname": "Leaf1",
         "interfaceName": "swp25"
       },
       "node2": {


### PR DESCRIPTION
The test where this topology is being used is not cleaning the topology, which creates NPEs downstream. 