### PR TITLE
NXOS EIGRP: Avoid spurious warning

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1999,6 +1999,10 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
       Ip ifaceIp = ((ConcreteInterfaceAddress) newIface.getAddress()).getIp();
       for (Entry<String, EigrpProcessConfiguration> e : _eigrpProcesses.entrySet()) {
         EigrpProcessConfiguration process = e.getValue();
+        if (eigrpProcess == process) {
+          // already matched this one based on interface's process tag
+          continue;
+        }
         EigrpVrfConfiguration eigrpVrf = process.getVrf(vrfName);
         if (eigrpVrf != null
             && Stream.of(eigrpVrf.getV4AddressFamily(), eigrpVrf.getVrfIpv4AddressFamily())


### PR DESCRIPTION
If an interface is configured to match a given EIGRP process (with `ip router eigrp TAG`) and that same EIGRP process is also configured to include the interface (via a network statement), we were generating a spurious warning that the interface matches multiple EIGRP processes.