### PR TITLE
NXOS route-maps: match interface and match vlan

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -5859,6 +5859,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
           names.add(name);
         });
     _currentRouteMapEntry.setMatchInterface(new RouteMapMatchInterface(names.build()));
+    warn(ctx, "Route-map match interface is not supported and will be ignored.");
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -3275,8 +3275,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
             // Matches any routes that have their next hop out one of the configured interfaces.
             // https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/6-x/unicast/configuration/guide/l3_cli_nxos/l3_rpm.html
             // TODO: Implement MatchNextHopInterface/Ip
-            // TODO: ignore shutdown/blacklisted interfaces?
-            // TODO: HSRP addresses? Only if elected?
+            // https://github.com/batfish/batfish/issues/6502
             return BooleanExprs.TRUE;
           }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -6146,11 +6146,12 @@ public final class CiscoNxosGrammarTest {
     }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("match_interface");
-      assertRoutingPolicyDeniesRoute(rp, base);
-      Bgpv4Route routeConnected = base.toBuilder().setNetwork(Prefix.parse("192.0.2.1/24")).build();
-      assertRoutingPolicyPermitsRoute(rp, routeConnected);
-      Bgpv4Route routeDirect = base.toBuilder().setNetwork(Prefix.parse("192.0.2.1/32")).build();
-      assertRoutingPolicyPermitsRoute(rp, routeDirect);
+      // TODO Should deny base route after implementing next hop matching (right now permits all)
+      assertRoutingPolicyPermitsRoute(rp, base);
+      Bgpv4Route routeNextHopIp = base.toBuilder().setNextHopIp(Ip.parse("192.0.2.1")).build();
+      assertRoutingPolicyPermitsRoute(rp, routeNextHopIp);
+      Bgpv4Route routeNextHopIface = base.toBuilder().setNextHopInterface("loopback0").build();
+      assertRoutingPolicyPermitsRoute(rp, routeNextHopIface);
     }
     // Skip match ip address - not relevant to routing
     {
@@ -6291,36 +6292,9 @@ public final class CiscoNxosGrammarTest {
       assertRoutingPolicyPermitsRoute(rp, route);
     }
     {
+      // match vlan is for pbr, doesn't apply for toBooleanExpr
       RoutingPolicy rp = c.getRoutingPolicies().get("match_vlan");
-      assertRoutingPolicyDeniesRoute(rp, base);
-      {
-        Bgpv4Route routeConnected =
-            base.toBuilder().setNetwork(Prefix.parse("10.0.1.1/24")).build();
-        assertRoutingPolicyPermitsRoute(rp, routeConnected);
-        Bgpv4Route routeDirect = base.toBuilder().setNetwork(Prefix.parse("10.0.1.1/32")).build();
-        assertRoutingPolicyPermitsRoute(rp, routeDirect);
-      }
-      {
-        Bgpv4Route routeConnected =
-            base.toBuilder().setNetwork(Prefix.parse("10.0.2.1/24")).build();
-        assertRoutingPolicyDeniesRoute(rp, routeConnected);
-        Bgpv4Route routeDirect = base.toBuilder().setNetwork(Prefix.parse("10.0.2.1/32")).build();
-        assertRoutingPolicyDeniesRoute(rp, routeDirect);
-      }
-      {
-        Bgpv4Route routeConnected =
-            base.toBuilder().setNetwork(Prefix.parse("10.0.3.1/24")).build();
-        assertRoutingPolicyPermitsRoute(rp, routeConnected);
-        Bgpv4Route routeDirect = base.toBuilder().setNetwork(Prefix.parse("10.0.3.1/32")).build();
-        assertRoutingPolicyPermitsRoute(rp, routeDirect);
-      }
-      {
-        Bgpv4Route routeConnected =
-            base.toBuilder().setNetwork(Prefix.parse("10.0.4.1/24")).build();
-        assertRoutingPolicyPermitsRoute(rp, routeConnected);
-        Bgpv4Route routeDirect = base.toBuilder().setNetwork(Prefix.parse("10.0.4.1/32")).build();
-        assertRoutingPolicyPermitsRoute(rp, routeDirect);
-      }
+      assertRoutingPolicyPermitsRoute(rp, base);
     }
 
     // sets

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -6146,8 +6146,9 @@ public final class CiscoNxosGrammarTest {
     }
     {
       RoutingPolicy rp = c.getRoutingPolicies().get("match_interface");
-      // TODO Should deny base route after implementing next hop matching (right now permits all)
-      assertRoutingPolicyPermitsRoute(rp, base);
+      // TODO Should deny base route after implementing next hop matching (right now permits all).
+      //  https://github.com/batfish/batfish/issues/6502
+      //      assertRoutingPolicyDeniesRoute(rp, base);
       Bgpv4Route routeNextHopIp = base.toBuilder().setNextHopIp(Ip.parse("192.0.2.1")).build();
       assertRoutingPolicyPermitsRoute(rp, routeNextHopIp);
       Bgpv4Route routeNextHopIface = base.toBuilder().setNextHopInterface("loopback0").build();


### PR DESCRIPTION
Both of these route-map statements were incorrectly implemented.
- match interface should [match any routes that have their next hop out one of the configured interfaces](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/6-x/unicast/configuration/guide/l3_cli_nxos/l3_rpm.html)
- match vlan is [PBR-specific and has no effect on route import/export](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/sw/nx-os/unicast/configuration/guide/b-7k-Cisco-Nexus-7000-Series-NX-OS-Unicast-Routing-Configuration-Guide-Release/n7k_unicast_config_pbr.html)