### PR TITLE
Speed up Layer 2 topology computation

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/InterfacesByVlanRange.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/InterfacesByVlanRange.java
@@ -1,0 +1,122 @@
+package org.batfish.common.topology;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.TreeRangeMap;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.IntegerSpace;
+
+/**
+ * Internal implementation detail of Layer2 topology computation, performed in {@link TopologyUtil}.
+ * Keeps track of a mapping between VLAN ranges to a set of interfaces which allow those VLANs.
+ *
+ * <p>This implementation
+ *
+ * <ul>
+ *   <li>Assumes all interfaces are on the same node (only tracks interface names)
+ *   <li>Does not care about switchport modes, only overlapping VLANs
+ * </ul>
+ */
+@ParametersAreNonnullByDefault
+class InterfacesByVlanRange {
+
+  /** Create a new mapping of VLAN ranges to interfaces */
+  static InterfacesByVlanRange create() {
+    return new InterfacesByVlanRange();
+  }
+
+  /** See {@link #add(Range, Collection) } */
+  public void add(int vlan, String iface) {
+    add(Range.singleton(vlan), iface);
+  }
+
+  /** See {@link #add(Range, Collection)} */
+  public void add(Range<Integer> vlans, String iface) {
+    add(vlans, ImmutableSet.of(iface));
+  }
+
+  /**
+   * Add a new range with the given collection of interfaces. If the given range intersects with
+   * existing ranges, new ranges will be created, with the intersection(s) being mapped to the union
+   * of existing and provided interfaces.
+   */
+  public void add(Range<Integer> vlans, Collection<String> interfaces) {
+    if (vlans.isEmpty() || interfaces.isEmpty()) {
+      return;
+    }
+    _ranges.merge(
+        vlans,
+        ImmutableSet.copyOf(interfaces),
+        (a, b) -> ImmutableSet.<String>builder().addAll(a).addAll(b).build());
+  }
+
+  /** Return the mapping of all ranges to sets of interfaces as an unmodifiable map */
+  @Nonnull
+  public Map<Range<Integer>, Set<String>> asMap() {
+    return _ranges.asMapOfRanges();
+  }
+
+  /** Return the set of interfaces for a given VLAN, or an empty set. */
+  @Nonnull
+  public Set<String> get(int vlan) {
+    return firstNonNull(_ranges.get(vlan), ImmutableSet.of());
+  }
+
+  /** Return the range matching given VLAN, or {@code null} if no match is present. */
+  @Nullable
+  public Range<Integer> getRange(int vlan) {
+    Entry<Range<Integer>, Set<String>> entry = _ranges.getEntry(vlan);
+    return entry == null ? null : entry.getKey();
+  }
+
+  /**
+   * Intersect the VLAN ranges given an interface on this node with the allowed VLAN space of some
+   * other interface on a (potentially different) node.
+   *
+   * <p>Example: Ranges 10-20 and 30-40 exist, mapped to Eth1.
+   *
+   * <ul>
+   *   <li>Calling intersect with Eth2 as interface name will produce empty set
+   *   <li>Calling intersect with Eth1 and VLAN range 50-60 will produce empty set
+   *   <li>Calling intersect with Eth1 and VLAN range 15-35 will produce a set containing ranges
+   *       10-15 and 30-35
+   * </ul>
+   *
+   * @param interfaceName the name of the interface <b>that is assumed to already be in this map</b>
+   * @param otherVlanSpace the VLAN range of some other, foreign interface (whose name does not
+   *     matter)
+   */
+  @Nonnull
+  public Set<Range<Integer>> intersect(String interfaceName, IntegerSpace otherVlanSpace) {
+    ImmutableSet.Builder<Range<Integer>> builder = ImmutableSet.builder();
+    for (Range<Integer> otherRange : otherVlanSpace.getRanges()) {
+      _ranges
+          .subRangeMap(otherRange)
+          .asMapOfRanges()
+          .forEach(
+              (intersectedRange, interfaceSet) -> {
+                if (interfaceSet.contains(interfaceName)) {
+                  builder.add(intersectedRange);
+                }
+              });
+    }
+    return builder.build();
+  }
+
+  // Private implementation
+
+  private final RangeMap<Integer, Set<String>> _ranges;
+
+  private InterfacesByVlanRange() {
+    _ranges = TreeRangeMap.create();
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer2Node.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer2Node.java
@@ -1,72 +1,57 @@
 package org.batfish.common.topology;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static java.util.Objects.requireNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Range;
 import java.io.Serializable;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class Layer2Node implements Comparable<Layer2Node>, Serializable {
+public final class Layer2Node implements Serializable {
   private static final String PROP_HOSTNAME = "hostname";
   private static final String PROP_INTERFACE_NAME = "interfaceName";
+  // For backwards compatibility
   private static final String PROP_SWITCHPORT_VLAN_ID = "switchportVlanId";
+  private static final String PROP_SWITCHPORT_VLAN_RANGE = "switchportVlanRange";
 
   @JsonCreator
   private static @Nonnull Layer2Node create(
-      @JsonProperty(PROP_HOSTNAME) String hostname,
-      @JsonProperty(PROP_INTERFACE_NAME) String interfaceName,
-      @JsonProperty(PROP_SWITCHPORT_VLAN_ID) Integer switchportVlanId) {
-    return new Layer2Node(
-        requireNonNull(hostname), requireNonNull(interfaceName), switchportVlanId);
+      @JsonProperty(PROP_HOSTNAME) @Nullable String hostname,
+      @JsonProperty(PROP_INTERFACE_NAME) @Nullable String interfaceName,
+      @JsonProperty(PROP_SWITCHPORT_VLAN_ID) Integer switchportVlanId,
+      @JsonProperty(PROP_SWITCHPORT_VLAN_RANGE) Range<Integer> switchportVlanRange) {
+    checkArgument(hostname != null, String.format("Missing %s", PROP_HOSTNAME));
+    checkArgument(hostname != null, String.format("Missing %s", PROP_INTERFACE_NAME));
+    @Nullable Range<Integer> range = null;
+    if (switchportVlanRange != null) {
+      range = switchportVlanRange;
+    } else if (switchportVlanId != null) {
+      range = Range.closed(switchportVlanId, switchportVlanId);
+    }
+    return new Layer2Node(hostname, interfaceName, range);
   }
 
   private final @Nonnull String _hostname;
-
   private final @Nonnull String _interfaceName;
+  private final @Nullable Range<Integer> _switchportVlanRange;
 
-  private final @Nullable Integer _switchportVlanId;
-
-  public Layer2Node(@Nonnull Layer1Node layer1Node, @Nullable Integer vlanId) {
-    _hostname = layer1Node.getHostname();
-    _interfaceName = layer1Node.getInterfaceName();
-    _switchportVlanId = vlanId;
+  public Layer2Node(@Nonnull Layer1Node layer1Node, @Nullable Range<Integer> vlanRange) {
+    this(layer1Node.getHostname(), layer1Node.getInterfaceName(), vlanRange);
   }
 
   public Layer2Node(
-      @Nonnull String hostname, @Nonnull String interfaceName, @Nullable Integer vlanId) {
+      @Nonnull String hostname, @Nonnull String interfaceName, @Nullable Range<Integer> vlanRange) {
     _hostname = hostname;
     _interfaceName = interfaceName;
-    _switchportVlanId = vlanId;
+    _switchportVlanRange = vlanRange;
   }
 
-  @Override
-  public int compareTo(@Nonnull Layer2Node o) {
-    // compareTo is hot for some networks, so inlining the comparator is worth it
-    if (this == o) {
-      return 0;
-    }
-    int r = _hostname.compareTo(o._hostname);
-    if (r != 0) {
-      return r;
-    }
-    r = _interfaceName.compareTo(o._interfaceName);
-    if (r != 0) {
-      return r;
-    }
-    if (_switchportVlanId == null && o._switchportVlanId == null) {
-      return 0;
-    }
-    if (_switchportVlanId == null) {
-      return -1;
-    }
-    if (o._switchportVlanId == null) {
-      return 1;
-    }
-    return _switchportVlanId.compareTo(o._switchportVlanId);
+  public Layer2Node(@Nonnull String hostname, @Nonnull String interfaceName, int vlan) {
+    this(hostname, interfaceName, Range.singleton(vlan));
   }
 
   @Override
@@ -80,7 +65,7 @@ public final class Layer2Node implements Comparable<Layer2Node>, Serializable {
     Layer2Node rhs = (Layer2Node) obj;
     return _hostname.equals(rhs._hostname)
         && _interfaceName.equals(rhs._interfaceName)
-        && Objects.equals(_switchportVlanId, rhs._switchportVlanId);
+        && Objects.equals(_switchportVlanRange, rhs._switchportVlanRange);
   }
 
   @JsonProperty(PROP_HOSTNAME)
@@ -93,16 +78,17 @@ public final class Layer2Node implements Comparable<Layer2Node>, Serializable {
     return _interfaceName;
   }
 
-  @JsonProperty(PROP_SWITCHPORT_VLAN_ID)
-  public @Nullable Integer getSwitchportVlanId() {
-    return _switchportVlanId;
+  @JsonProperty(PROP_SWITCHPORT_VLAN_RANGE)
+  @Nullable
+  public Range<Integer> getSwitchportVlanRange() {
+    return _switchportVlanRange;
   }
 
   @Override
   public int hashCode() {
     int ret = _hashCode;
     if (ret == 0) {
-      ret = Objects.hash(_hostname, _interfaceName, _switchportVlanId);
+      ret = Objects.hash(_hostname, _interfaceName, _switchportVlanRange);
       _hashCode = ret;
     }
     return ret;
@@ -114,7 +100,7 @@ public final class Layer2Node implements Comparable<Layer2Node>, Serializable {
         .omitNullValues()
         .add(PROP_HOSTNAME, _hostname)
         .add(PROP_INTERFACE_NAME, _interfaceName)
-        .add(PROP_SWITCHPORT_VLAN_ID, _switchportVlanId)
+        .add(PROP_SWITCHPORT_VLAN_RANGE, _switchportVlanRange)
         .toString();
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer2Topology.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/Layer2Topology.java
@@ -12,6 +12,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -125,7 +126,8 @@ public final class Layer2Topology {
                   if (domain.isEmpty()) {
                     return Stream.of();
                   }
-                  Layer2Node repr = domain.stream().max(Layer2Node::compareTo).get();
+                  Layer2Node repr =
+                      domain.stream().max(Comparator.comparingInt(Layer2Node::hashCode)).get();
                   return domain.stream().map(node -> Maps.immutableEntry(node, repr));
                 })
             .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue)));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -98,7 +98,7 @@ public final class TopologyUtil {
                 node1,
                 node1Ranges.getRange(i1.getNativeVlan()),
                 node2,
-                node2Ranges.getRange(i1.getNativeVlan())));
+                node2Ranges.getRange(i2.getNativeVlan())));
       }
     } else if (i1Tag != null) {
       // i1 is a tagged layer-3 interface, and the other side is a trunk. The only possible edge is

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/TopologyUtil.java
@@ -10,12 +10,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.google.common.graph.EndpointPair;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +34,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.plugin.TracerouteEngine;
 import org.batfish.common.topology.TunnelTopology.Builder;
-import org.batfish.common.util.CollectionUtil;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DeviceModel;
@@ -66,47 +67,75 @@ public final class TopologyUtil {
 
   // Precondition: at least one of i1 and i2 is a trunk
   private static void addLayer2TrunkEdges(
-      Interface i1, Interface i2, Consumer<Layer2Edge> edges, Layer1Node node1, Layer1Node node2) {
+      Interface i1,
+      Interface i2,
+      Consumer<Layer2Edge> edges,
+      Layer1Node node1,
+      Layer1Node node2,
+      Map<String, InterfacesByVlanRange> vlanRangesPerNode) {
     Integer i1Tag = i1.getEncapsulationVlan();
     Integer i2Tag = i2.getEncapsulationVlan();
+    InterfacesByVlanRange node1Ranges = vlanRangesPerNode.get(node1.getHostname());
+    InterfacesByVlanRange node2Ranges = vlanRangesPerNode.get(node2.getHostname());
     if (i1.getSwitchportMode() == SwitchportMode.TRUNK
         && i2.getSwitchportMode() == SwitchportMode.TRUNK) {
-      // Both sides are trunks, so add edges from n1,v to n2,v for all shared VLANs.
-      i1.getAllowedVlans().stream()
-          .forEach(
-              vlan -> {
-                if (Objects.equals(i1.getNativeVlan(), vlan) && trunkWithNativeVlanAllowed(i2)) {
-                  // This frame will not be tagged by i1, and i2 accepts untagged frames.
-                  edges.accept(new Layer2Edge(node1, vlan, node2, vlan, null /* untagged */));
-                } else if (i2.getAllowedVlans().contains(vlan)) {
-                  // This frame will be tagged by i1 and we can directly check whether i2 allows.
-                  edges.accept(new Layer2Edge(node1, vlan, node2, vlan, vlan));
-                }
-              });
+      /*
+        Both sides are trunks, so add edges from n1,vlan_range to n2,vlan_range for all shared VLANs.
+
+        While singleton VLAN ranges are guaranteed to have been correctly pre-computed per node
+        in the previous steps, additional logic is needed to correctly intersect two
+        cross-node VLAN ranges (otherwise we will create edges between non-existent vertices)
+      */
+
+      for (Range<Integer> sharedRange : node1Ranges.intersect(i1.getName(), i2.getAllowedVlans())) {
+        // This frame will be tagged by i1 and we can directly check whether i2 allows.
+        edges.accept(new Layer2Edge(node1, sharedRange, node2, sharedRange));
+      }
+      if (i1.getNativeVlan() != null && trunkWithNativeVlanAllowed(i2)) {
+        // This frame will not be tagged by i1, and i2 accepts untagged frames.
+        edges.accept(
+            new Layer2Edge(
+                node1,
+                node1Ranges.getRange(i1.getNativeVlan()),
+                node2,
+                node2Ranges.getRange(i1.getNativeVlan())));
+      }
     } else if (i1Tag != null) {
       // i1 is a tagged layer-3 interface, and the other side is a trunk. The only possible edge is
       // i2 receiving frames for a non-native allowed vlan.
       if (!i1Tag.equals(i2.getNativeVlan()) && i2.getAllowedVlans().contains(i1Tag)) {
-        edges.accept(new Layer2Edge(node1, null, node2, i1Tag, i1Tag));
+        edges.accept(new Layer2Edge(node1, null, node2, node2Ranges.getRange(i1Tag)));
       }
     } else if (i2Tag != null) {
       // i1 is a trunk, and the other side is a tagged layer-3 interface. The only possible edge is
       // i2 receiving frames for from a non-native allowed vlan of i1.
       if (!i2Tag.equals(i1.getNativeVlan()) && i1.getAllowedVlans().contains(i2Tag)) {
-        edges.accept(new Layer2Edge(node1, i2Tag, node2, null, i2Tag));
+        edges.accept(new Layer2Edge(node1, node1Ranges.getRange(i2Tag), node2, null));
       }
     } else if (trunkWithNativeVlanAllowed(i1)) {
       // i1 is a trunk, but the other side is not and does not use tags. The only edge that will
       // come up is i2 receiving untagged packets.
       Integer node2VlanId =
           i2.getSwitchportMode() == SwitchportMode.ACCESS ? i2.getAccessVlan() : null;
-      edges.accept(new Layer2Edge(node1, i1.getNativeVlan(), node2, node2VlanId, null));
+      assert i1.getNativeVlan() != null; // invariant of trunkWithNativeVlanAllowed
+      edges.accept(
+          new Layer2Edge(
+              node1,
+              node1Ranges.getRange(i1.getNativeVlan()),
+              node2,
+              node2VlanId == null ? null : node2Ranges.getRange(node2VlanId)));
     } else if (trunkWithNativeVlanAllowed(i2)) {
       // i1 is not a trunk and does not use tags, but the other side is a trunk. The only edge that
       // will come up is the other side receiving untagged packets and treating them as native VLAN.
       Integer node1VlanId =
           i1.getSwitchportMode() == SwitchportMode.ACCESS ? i1.getAccessVlan() : null;
-      edges.accept(new Layer2Edge(node1, node1VlanId, node2, i2.getNativeVlan(), null));
+      assert i2.getNativeVlan() != null; // invariant of trunkWithNativeVlanAllowed
+      edges.accept(
+          new Layer2Edge(
+              node1,
+              node1VlanId == null ? null : node1Ranges.getRange(node1VlanId),
+              node2,
+              node2Ranges.getRange(i2.getNativeVlan())));
     }
   }
 
@@ -156,7 +185,8 @@ public final class TopologyUtil {
       @Nonnull Layer1Edge layer1Edge,
       @Nonnull Map<String, Configuration> configurations,
       @Nonnull Consumer<Layer2Edge> edges,
-      Map<Layer1Node, Set<Layer1Node>> parentChildrenMap) {
+      Map<Layer1Node, Set<Layer1Node>> parentChildrenMap,
+      Map<String, InterfacesByVlanRange> vlanRangesPerNode) {
     Layer1Node node1 = layer1Edge.getNode1();
     Layer1Node node2 = layer1Edge.getNode2();
 
@@ -171,13 +201,17 @@ public final class TopologyUtil {
                     .forEach(
                         node2Child ->
                             tryComputeLayer2EdgesForLayer1ChildEdge(
-                                new Layer1Edge(node1Child, node2Child), configurations, edges)));
+                                new Layer1Edge(node1Child, node2Child),
+                                configurations,
+                                edges,
+                                vlanRangesPerNode)));
   }
 
   private static void tryComputeLayer2EdgesForLayer1ChildEdge(
       Layer1Edge layer1MappedEdge,
       Map<String, Configuration> configurations,
-      Consumer<Layer2Edge> edges) {
+      Consumer<Layer2Edge> edges,
+      Map<String, InterfacesByVlanRange> vlanRangesPerNode) {
     Layer1Node node1 = layer1MappedEdge.getNode1();
     Layer1Node node2 = layer1MappedEdge.getNode2();
     Interface i1 = getInterface(node1, configurations);
@@ -188,7 +222,7 @@ public final class TopologyUtil {
     }
     if (i1.getSwitchportMode() == SwitchportMode.TRUNK
         || i2.getSwitchportMode() == SwitchportMode.TRUNK) {
-      addLayer2TrunkEdges(i1, i2, edges, node1, node2);
+      addLayer2TrunkEdges(i1, i2, edges, node1, node2, vlanRangesPerNode);
     } else if (i1.getEncapsulationVlan() != null || i2.getEncapsulationVlan() != null) {
       // Both interfaces are tagged Layer3 interfaces
       tryAddLayer2TaggedNonTrunkEdge(i1, i2, edges, node1, node2);
@@ -197,7 +231,12 @@ public final class TopologyUtil {
           i1.getSwitchportMode() == SwitchportMode.ACCESS ? i1.getAccessVlan() : null;
       Integer node2VlanId =
           i2.getSwitchportMode() == SwitchportMode.ACCESS ? i2.getAccessVlan() : null;
-      edges.accept(new Layer2Edge(node1, node1VlanId, node2, node2VlanId, null));
+      edges.accept(
+          new Layer2Edge(
+              node1,
+              node1VlanId == null ? null : Range.singleton(node1VlanId),
+              node2,
+              node2VlanId == null ? null : Range.singleton(node2VlanId)));
     }
   }
 
@@ -209,7 +248,7 @@ public final class TopologyUtil {
     if (i1Tag == null || i2Tag == null || !i1Tag.equals(i2Tag)) {
       return;
     }
-    edges.accept(new Layer2Edge(node1, null, node2, null, i1Tag));
+    edges.accept(new Layer2Edge(node1, null, node2, null));
   }
 
   @VisibleForTesting
@@ -219,42 +258,29 @@ public final class TopologyUtil {
 
   @VisibleForTesting
   static void computeLayer2SelfEdges(
-      @Nonnull Configuration config, @Nonnull Consumer<Layer2Edge> edges) {
+      @Nonnull Configuration config,
+      InterfacesByVlanRange switchportsByVlan,
+      @Nonnull Consumer<Layer2Edge> edges) {
+
     String hostname = config.getHostname();
-    Map<Integer, ImmutableList.Builder<String>> switchportsByVlanBuilder = new HashMap<>();
-    config.getAllInterfaces().values().stream()
-        .filter(Interface::getActive)
-        .forEach(
-            i -> {
-              if (i.getSwitchportMode() == SwitchportMode.TRUNK) {
-                i.getAllowedVlans().stream()
-                    .forEach(
-                        vlan ->
-                            switchportsByVlanBuilder
-                                .computeIfAbsent(vlan, n -> ImmutableList.builder())
-                                .add(i.getName()));
-              } else if (i.getSwitchportMode() == SwitchportMode.ACCESS
-                  && i.getAccessVlan() != null) {
-                switchportsByVlanBuilder
-                    .computeIfAbsent(i.getAccessVlan(), n -> ImmutableList.builder())
-                    .add(i.getName());
-              }
-            });
+
     // Note that since the L2 model is transitive, we only need add a single spanning tree rather
     // than all O(N^2) edges to get complete connectivity for all interfaces on the same switchport.
     // Additionally, edges need not be added symmetrically.
-    Map<Integer, List<String>> switchportsByVlan =
-        CollectionUtil.toImmutableMap(
-            switchportsByVlanBuilder, Entry::getKey, e -> e.getValue().build());
-    switchportsByVlan.forEach(
-        (vlanId, interfaceNames) -> {
-          String firstInterface = interfaceNames.get(0);
-          Layer2Node firstNode = new Layer2Node(hostname, firstInterface, vlanId);
-          for (String otherInterface : interfaceNames.subList(1, interfaceNames.size())) {
-            Layer2Node otherNode = new Layer2Node(hostname, otherInterface, vlanId);
-            edges.accept(new Layer2Edge(firstNode, otherNode, null));
-          }
-        });
+    switchportsByVlan
+        .asMap()
+        .forEach(
+            (vlanRange, interfaceNames) -> {
+              assert !interfaceNames.isEmpty();
+              Iterator<String> iterator = interfaceNames.iterator();
+              String firstInterface = iterator.next();
+              Layer2Node firstNode = new Layer2Node(hostname, firstInterface, vlanRange);
+              while (iterator.hasNext()) {
+                String otherInterface = iterator.next();
+                Layer2Node otherNode = new Layer2Node(hostname, otherInterface, vlanRange);
+                edges.accept(new Layer2Edge(firstNode, otherNode));
+              }
+            });
     Map<Integer, Layer2Vni> vniSettingsByVlan =
         config.getVrfs().values().stream()
             .flatMap(vrf -> vrf.getLayer2Vnis().values().stream())
@@ -274,8 +300,7 @@ public final class TopologyUtil {
                   .ifPresent(
                       vniName ->
                           edges.accept(
-                              new Layer2Edge(
-                                  hostname, irbName, null, hostname, vniName, null, null)));
+                              new Layer2Edge(hostname, irbName, null, hostname, vniName, null)));
             });
     // Link each VNI to switchports in same VLAN
     vniSettingsByVlan.forEach(
@@ -286,24 +311,40 @@ public final class TopologyUtil {
         });
   }
 
+  @Nonnull
+  private static InterfacesByVlanRange computeInterfacesByVlan(@Nonnull Configuration config) {
+    InterfacesByVlanRange ifacesByVlan = InterfacesByVlanRange.create();
+    for (Interface i : config.getActiveInterfaces().values()) {
+      if (i.getSwitchportMode() == SwitchportMode.TRUNK) {
+        i.getAllowedVlans()
+            .getRanges()
+            .forEach(vlanRange -> ifacesByVlan.add(vlanRange, i.getName()));
+      } else if (i.getSwitchportMode() == SwitchportMode.ACCESS && i.getAccessVlan() != null) {
+        ifacesByVlan.add(i.getAccessVlan(), i.getName());
+      } else if (i.getSwitchportMode() == SwitchportMode.NONE && i.getVlan() != null) {
+        ifacesByVlan.add(i.getVlan(), i.getName());
+      }
+    }
+    return ifacesByVlan;
+  }
+
   /**
    * Computes intra-node edges between non-switchport layer-2 entity (IRB or VNI) and switchport
    * interfaces associated with the entity's VLAN
    */
   private static @Nonnull Stream<Layer2Edge> computeSelfSwitchportNonSwitchportEdges(
-      Map<Integer, List<String>> switchportsByVlan,
+      InterfacesByVlanRange switchportsByVlan,
       String hostname,
       String nonSwitchportName,
       int vlanId) {
     Stream.Builder<Layer2Edge> edges = Stream.builder();
     switchportsByVlan
-        .getOrDefault(vlanId, ImmutableList.of())
+        .get(vlanId)
         .forEach(
-            switchportName -> {
-              edges.accept(
-                  new Layer2Edge(
-                      hostname, nonSwitchportName, null, hostname, switchportName, vlanId, null));
-            });
+            switchportName ->
+                edges.accept(
+                    new Layer2Edge(
+                        hostname, nonSwitchportName, null, hostname, switchportName, vlanId)));
     return edges.build();
   }
 
@@ -325,15 +366,7 @@ public final class TopologyUtil {
     // Compute mapping from parent interface -> child interfaces
     Map<Layer1Node, Set<Layer1Node>> parentChildrenMap = computeParentChildrenMap(configurations);
 
-    // First add layer2 edges for physical links.
-    layer1LogicalTopology
-        .getGraph()
-        .edges()
-        .forEach(
-            layer1Edge ->
-                computeLayer2EdgesForLayer1Edge(
-                    layer1Edge, configurations, l2TopologyBuilder::addEdge, parentChildrenMap));
-
+    // Pre-compute nodes that have L1 or VXLAN edges, and only compute L2 edges for those.
     Set<String> nodesWithL1Edge =
         layer1LogicalTopology.getGraph().edges().stream()
             .flatMap(edge -> Stream.of(edge.getNode1(), edge.getNode2()))
@@ -344,15 +377,40 @@ public final class TopologyUtil {
             .flatMap(edge -> Stream.of(edge.nodeU(), edge.nodeV()))
             .map(VxlanNode::getHostname)
             .collect(ImmutableSet.toImmutableSet());
-    Set<String> nodesWithUsefulL2SelfEdges =
-        ImmutableSet.<String>builder().addAll(nodesWithL1Edge).addAll(nodesWithVxlan).build();
+
+    // Break up each (useful) node into VLAN ranges based on interface configuration
+    Map<String, InterfacesByVlanRange> nodesWithUsefulL2SelfEdges =
+        Stream.concat(nodesWithL1Edge.stream(), nodesWithVxlan.stream())
+            .distinct()
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    Function.identity(),
+                    hostname -> computeInterfacesByVlan(configurations.get(hostname))));
 
     // Then add edges within each node to connect switchports and VNIs on the same VLAN(s).
     configurations.values().stream()
         // Optimization: skip nodes with neither L1 nor VXLAN edges, since their L2 self-edges will
         // not contribute to broadcast domains.
-        .filter(c -> nodesWithUsefulL2SelfEdges.contains(c.getHostname()))
-        .forEach(c -> computeLayer2SelfEdges(c, l2TopologyBuilder::addEdge));
+        .filter(c -> nodesWithUsefulL2SelfEdges.containsKey(c.getHostname()))
+        .forEach(
+            c ->
+                computeLayer2SelfEdges(
+                    c,
+                    nodesWithUsefulL2SelfEdges.get(c.getHostname()),
+                    l2TopologyBuilder::addEdge));
+
+    // Add layer2 edges for physical links.
+    layer1LogicalTopology
+        .getGraph()
+        .edges()
+        .forEach(
+            layer1Edge ->
+                computeLayer2EdgesForLayer1Edge(
+                    layer1Edge,
+                    configurations,
+                    l2TopologyBuilder::addEdge,
+                    parentChildrenMap,
+                    nodesWithUsefulL2SelfEdges));
 
     // Finally add edges between connected VNIs on different nodes
     computeVniInterNodeEdges(vxlanTopology).forEach(l2TopologyBuilder::addEdge);
@@ -383,8 +441,8 @@ public final class TopologyUtil {
     String vni1Name = computeVniName(vni1);
     String vni2Name = computeVniName(vni2);
     return Stream.of(
-        new Layer2Edge(h1, vni1Name, null, h2, vni2Name, null, null),
-        new Layer2Edge(h2, vni2Name, null, h1, vni1Name, null, null));
+        new Layer2Edge(h1, vni1Name, null, h2, vni2Name, null),
+        new Layer2Edge(h2, vni2Name, null, h1, vni1Name, null));
   }
 
   private static Map<Layer1Node, Set<Layer1Node>> computeParentChildrenMap(
@@ -411,7 +469,7 @@ public final class TopologyUtil {
                                             n -> ImmutableSet.builder())
                                         .add(new Layer1Node(hostname, iName)))));
     // finalize and freeze
-    return CollectionUtil.toImmutableMap(builderMap, Entry::getKey, e -> e.getValue().build());
+    return toImmutableMap(builderMap, Entry::getKey, e -> e.getValue().build());
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/InterfacesByVlanRangeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/InterfacesByVlanRangeTest.java
@@ -1,0 +1,151 @@
+package org.batfish.common.topology;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
+import org.batfish.datamodel.IntegerSpace;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test of {@link InterfacesByVlanRange} */
+public class InterfacesByVlanRangeTest {
+  private InterfacesByVlanRange _interfacesByVlanRange;
+
+  @Before
+  public void setUp() {
+    _interfacesByVlanRange = InterfacesByVlanRange.create();
+  }
+
+  @Test
+  public void testStartsEmpty() {
+    assertThat(_interfacesByVlanRange.asMap(), anEmptyMap());
+  }
+
+  @Test
+  public void testAddToEmpty() {
+    Range<Integer> range = Range.closed(1, 2);
+    ImmutableSet<String> interfaces = ImmutableSet.of("iface1", "iface2");
+    _interfacesByVlanRange.add(range, interfaces);
+    assertThat(_interfacesByVlanRange.asMap(), hasEntry(range, interfaces));
+  }
+
+  @Test
+  public void testAddWithIntersection() {
+    Range<Integer> range1 = Range.closed(1, 10);
+    Range<Integer> range2 = Range.closed(5, 20);
+    ImmutableSet<String> set1 = ImmutableSet.of("iface1");
+    ImmutableSet<String> set2 = ImmutableSet.of("iface2");
+    _interfacesByVlanRange.add(range1, set1);
+    _interfacesByVlanRange.add(range2, set2);
+    assertThat(
+        _interfacesByVlanRange.asMap(),
+        allOf(
+            hasEntry(Range.closedOpen(1, 5), set1),
+            hasEntry(Range.closed(5, 10), ImmutableSet.of("iface1", "iface2")),
+            hasEntry(Range.openClosed(10, 20), set2)));
+  }
+
+  @Test
+  public void testAddDoubleIntersection() {
+    Range<Integer> range1 = Range.closed(1, 10);
+    Range<Integer> range2 = Range.closed(20, 30);
+    Range<Integer> range3 = Range.closed(5, 25);
+    ImmutableSet<String> set1 = ImmutableSet.of("iface1");
+    ImmutableSet<String> set2 = ImmutableSet.of("iface2");
+    ImmutableSet<String> set3 = ImmutableSet.of("iface3");
+    _interfacesByVlanRange.add(range1, set1);
+    _interfacesByVlanRange.add(range2, set2);
+    _interfacesByVlanRange.add(range3, set3);
+    assertThat(
+        _interfacesByVlanRange.asMap(),
+        allOf(
+            hasEntry(Range.closedOpen(1, 5), set1),
+            hasEntry(Range.closed(5, 10), ImmutableSet.of("iface1", "iface3")),
+            hasEntry(Range.open(10, 20), set3),
+            hasEntry(Range.closed(20, 25), ImmutableSet.of("iface2", "iface3")),
+            hasEntry(Range.openClosed(25, 30), set2)));
+  }
+
+  @Test
+  public void testAddSubset() {
+    Range<Integer> range1 = Range.closed(1, 20);
+    Range<Integer> range2 = Range.closed(5, 10);
+    ImmutableSet<String> set1 = ImmutableSet.of("iface1");
+    ImmutableSet<String> set2 = ImmutableSet.of("iface2");
+    _interfacesByVlanRange.add(range1, set1);
+    _interfacesByVlanRange.add(range2, set2);
+    assertThat(
+        _interfacesByVlanRange.asMap(),
+        allOf(
+            hasEntry(Range.closedOpen(1, 5), set1),
+            hasEntry(Range.closed(5, 10), ImmutableSet.of("iface1", "iface2")),
+            hasEntry(Range.openClosed(10, 20), set1)));
+  }
+
+  @Test
+  public void testGet() {
+    Range<Integer> range = Range.closed(1, 10);
+    ImmutableSet<String> interfaces = ImmutableSet.of("iface1", "iface2");
+    _interfacesByVlanRange.add(range, interfaces);
+    for (int i = 1; i <= 10; i++) {
+      assertThat(_interfacesByVlanRange.get(i), equalTo(interfaces));
+    }
+    assertThat(_interfacesByVlanRange.get(11), empty());
+  }
+
+  @Test
+  public void testGetRange() {
+    Range<Integer> range = Range.closed(1, 10);
+    ImmutableSet<String> interfaces = ImmutableSet.of("iface1", "iface2");
+    _interfacesByVlanRange.add(range, interfaces);
+    for (int i = 1; i <= 10; i++) {
+      assertThat(_interfacesByVlanRange.getRange(i), equalTo(range));
+    }
+    assertThat(_interfacesByVlanRange.getRange(11), nullValue());
+  }
+
+  @Test
+  public void testIntersect() {
+    String localIface = "i1";
+    _interfacesByVlanRange.add(Range.closed(10, 20), localIface);
+    _interfacesByVlanRange.add(Range.closed(40, 50), localIface);
+    {
+      // simple intersection
+      Range<Integer> remoteIfaceRange = Range.closedOpen(12, 15);
+      assertThat(
+          _interfacesByVlanRange.intersect(localIface, IntegerSpace.of(remoteIfaceRange)),
+          contains(remoteIfaceRange));
+    }
+    {
+      // no intersection
+      assertThat(
+          _interfacesByVlanRange.intersect(localIface, IntegerSpace.of(Range.closed(21, 39))),
+          empty());
+    }
+    {
+      // local ranges are subset of remote range
+      assertThat(
+          _interfacesByVlanRange.intersect(localIface, IntegerSpace.of(Range.closed(1, 100))),
+          containsInAnyOrder(Range.closed(10, 20), Range.closed(40, 50)));
+    }
+    {
+      // complex intersection
+      assertThat(
+          _interfacesByVlanRange.intersect(
+              localIface,
+              IntegerSpace.unionOf(
+                  Range.closed(15, 25), Range.closed(39, 42), Range.singleton(49))),
+          containsInAnyOrder(
+              Range.closed(15, 20), Range.closedOpen(40, 43), Range.closedOpen(49, 50)));
+    }
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer2TopologyTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/Layer2TopologyTest.java
@@ -13,7 +13,7 @@ public final class Layer2TopologyTest {
   @Test
   public void testFromEdgesAsymmetric() {
     // should properly register nodes and initialize without error
-    fromEdges(ImmutableSet.of(new Layer2Edge("node1", "i", null, "node2", "i", null, null)));
+    fromEdges(ImmutableSet.of(new Layer2Edge("node1", "i", null, "node2", "i", null)));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/TopologyUtilTest.java
@@ -896,7 +896,7 @@ public final class TopologyUtilTest {
   /**
    * Even though two interfaces are mis-configured (native VLANs differ) we should still make an
    * edge to accurately model the mis-configuration that is present. Access ports will end up in the
-   * saem broadcast domain even though one is vlan 5 on n1 and another vlan 6 on n2
+   * same broadcast domain even though one is vlan 5 on n1 and another vlan 6 on n2
    */
   @Test
   public void testComputeLayer2TopologyMismatchedNativeVlans() {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BgpTopologyUtilsTest.java
@@ -238,7 +238,7 @@ public class BgpTopologyUtilsTest {
     assertThat(bgpTopology.edges(), empty());
 
     // Should see session if they're connected
-    Layer2Edge edge = new Layer2Edge(NODE1, iface1, null, NODE2, iface2, null, null);
+    Layer2Edge edge = new Layer2Edge(NODE1, iface1, null, NODE2, iface2, null);
     Layer2Topology connectedLayer2Topology = Layer2Topology.builder().addEdge(edge).build();
     bgpTopology =
         initBgpTopology(_configs, ImmutableMap.of(), true, false, null, connectedLayer2Topology)
@@ -252,8 +252,8 @@ public class BgpTopologyUtilsTest {
             EndpointPair.ordered(peer1Id, peer2To1Id), EndpointPair.ordered(peer2To1Id, peer1Id)));
 
     // Node 1 and 2 both have layer 2 edges but are not connected to any common node
-    Layer2Edge edge1To3 = new Layer2Edge(NODE2, iface2, null, "node3", "iface3", null, null);
-    Layer2Edge edge2To4 = new Layer2Edge(NODE2, iface2, null, "node4", "iface4", null, null);
+    Layer2Edge edge1To3 = new Layer2Edge(NODE2, iface2, null, "node3", "iface3", null);
+    Layer2Edge edge2To4 = new Layer2Edge(NODE2, iface2, null, "node4", "iface4", null);
     Layer2Topology disconnected =
         Layer2Topology.builder().addEdge(edge1To3).addEdge(edge2To4).build();
     bgpTopology =
@@ -292,7 +292,7 @@ public class BgpTopologyUtilsTest {
     _node1BgpProcess.setInterfaceNeighbors(ImmutableSortedMap.of(iface1, peer1));
     _node2BgpProcess.setInterfaceNeighbors(ImmutableSortedMap.of(iface2, peer2));
 
-    Layer2Edge edge = new Layer2Edge(NODE1, iface1, null, NODE2, iface2, null, null);
+    Layer2Edge edge = new Layer2Edge(NODE1, iface1, null, NODE2, iface2, null);
     Layer2Topology connectedLayer2Topology = Layer2Topology.builder().addEdge(edge).build();
     ValueGraph<BgpPeerConfigId, BgpSessionProperties> bgpTopology =
         initBgpTopology(_configs, ImmutableMap.of(), true, false, null, connectedLayer2Topology)
@@ -336,7 +336,7 @@ public class BgpTopologyUtilsTest {
     _node1BgpProcess.setInterfaceNeighbors(ImmutableSortedMap.of(iface1, peer1));
     _node2BgpProcess.setInterfaceNeighbors(ImmutableSortedMap.of(iface2, peer2));
 
-    Layer2Edge edge = new Layer2Edge(NODE1, iface1, null, NODE2, iface2, null, null);
+    Layer2Edge edge = new Layer2Edge(NODE1, iface1, null, NODE2, iface2, null);
     Layer2Topology connectedLayer2Topology = Layer2Topology.builder().addEdge(edge).build();
 
     // Shouldn't see session come up because of incompatible remote AS

--- a/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/edges/EdgesAnswerer.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
+import com.google.common.collect.Range;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.ValueGraph;
 import java.util.Collection;
@@ -32,6 +33,7 @@ import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpsecPeerConfig;
@@ -458,16 +460,19 @@ public class EdgesAnswerer extends Answerer {
   @VisibleForTesting
   static Row layer2EdgeToRow(Layer2Edge layer2Edge) {
     RowBuilder row = Row.builder();
+    Range<Integer> vlan1 = layer2Edge.getNode1().getSwitchportVlanRange();
+    Range<Integer> vlan2 = layer2Edge.getNode2().getSwitchportVlanRange();
     row.put(
             COL_INTERFACE,
             NodeInterfacePair.of(
                 layer2Edge.getNode1().getHostname(), layer2Edge.getNode1().getInterfaceName()))
-        .put(COL_VLAN, layer2Edge.getNode1().getSwitchportVlanId())
+        // Use integer space to pretty-stringify the range
+        .put(COL_VLAN, vlan1 == null ? null : IntegerSpace.of(vlan1).toString())
         .put(
             COL_REMOTE_INTERFACE,
             NodeInterfacePair.of(
                 layer2Edge.getNode2().getHostname(), layer2Edge.getNode2().getInterfaceName()))
-        .put(COL_REMOTE_VLAN, layer2Edge.getNode2().getSwitchportVlanId());
+        .put(COL_REMOTE_VLAN, vlan2 == null ? null : IntegerSpace.of(vlan2).toString());
 
     return row.build();
   }

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -695,7 +695,7 @@ public class EdgesAnswererTest {
 
   @Test
   public void testLayer2ToRow() {
-    Row row = layer2EdgeToRow(new Layer2Edge("host1", "int1", 1, "host2", "int2", 2, 12));
+    Row row = layer2EdgeToRow(new Layer2Edge("host1", "int1", 1, "host2", "int2", 2));
     assertThat(
         row,
         allOf(


### PR DESCRIPTION
Compute the topology vertices based on ranges of VLANs instead of
individual VLANs. This trims a pretty significant constant factor off of
the complexity and lets L2 computation scale to larger networks.

As an additional optimization, I also removed Comparable implementation
from L2 nodes and edges