### PR TITLE
Cisco/Arista: stop warning on unsupported ipv6 clauses

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
@@ -5078,7 +5078,7 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
                 .setUseUrg(true)
                 .build());
       } else {
-        warn(ctx, "Unsupported clause in IPv6 extended access list: " + feature.getText());
+        // warn(ctx, "Unsupported clause in IPv6 extended access list: " + feature.getText());
       }
     }
     String name = getFullText(ctx).trim();

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -5045,7 +5045,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
                 .setUseUrg(true)
                 .build());
       } else {
-        warn(ctx, "Unsupported clause in IPv6 extended access list: " + feature.getText());
+        // warn(ctx, "Unsupported clause in IPv6 extended access list: " + feature.getText());
       }
     }
     String name = getFullText(ctx).trim();

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -4388,7 +4388,7 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
                 .setUseUrg(true)
                 .build());
       } else {
-        warn(ctx, "Unsupported clause in IPv6 extended access list: " + feature.getText());
+        // warn(ctx, "Unsupported clause in IPv6 extended access list: " + feature.getText());
       }
     }
     String name = getFullText(ctx).trim();

--- a/tests/parsing-tests/unit-tests-warnings.ref
+++ b/tests/parsing-tests/unit-tests-warnings.ref
@@ -204,27 +204,6 @@
         "Comment" : "This feature is not currently supported"
       },
       {
-        "Filename" : "configs/cadant_acl",
-        "Line" : 22,
-        "Text" : "permit icmp any any 123",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: 123"
-      },
-      {
-        "Filename" : "configs/cadant_acl",
-        "Line" : 24,
-        "Text" : "permit nd any dead::/8 nd-type 133",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: nd-type"
-      },
-      {
-        "Filename" : "configs/cadant_acl",
-        "Line" : 24,
-        "Text" : "permit nd any dead::/8 nd-type 133",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: 133"
-      },
-      {
         "Filename" : "configs/cisco_acl",
         "Line" : 6,
         "Text" : "20 permit ip any any tracked",
@@ -391,90 +370,6 @@
         "Text" : "add-route",
         "Parser_Context" : "[ipnosm_add_route ipnos_static ipno_source ipn_outside s_ip_nat stanza cisco_configuration]",
         "Comment" : "This feature is not currently supported"
-      },
-      {
-        "Filename" : "configs/cisco_ipv6_access_list",
-        "Line" : 9,
-        "Text" : "deny icmpv6 any any router hoplimit",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: router"
-      },
-      {
-        "Filename" : "configs/cisco_ipv6_access_list",
-        "Line" : 9,
-        "Text" : "deny icmpv6 any any router hoplimit",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: hoplimit"
-      },
-      {
-        "Filename" : "configs/cisco_ipv6_access_list",
-        "Line" : 10,
-        "Text" : "deny icmpv6 any any router",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: router"
-      },
-      {
-        "Filename" : "configs/cisco_ipv6_access_list",
-        "Line" : 11,
-        "Text" : "deny icmpv6 any any nd",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: nd"
-      },
-      {
-        "Filename" : "configs/cisco_ipv6_access_list",
-        "Line" : 12,
-        "Text" : "deny icmpv6 any any nd",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: nd"
-      },
-      {
-        "Filename" : "configs/cisco_ipv6_access_list",
-        "Line" : 13,
-        "Text" : "deny icmpv6 any any 141",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: 141"
-      },
-      {
-        "Filename" : "configs/cisco_ipv6_access_list",
-        "Line" : 14,
-        "Text" : "deny icmpv6 any any 142",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: 142"
-      },
-      {
-        "Filename" : "configs/cisco_ipv6_access_list",
-        "Line" : 15,
-        "Text" : "deny icmpv6 any any neighbor",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: neighbor"
-      },
-      {
-        "Filename" : "configs/cisco_ipv6_access_list",
-        "Line" : 20,
-        "Text" : "10 permit icmp any any mld-query",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: mld-query"
-      },
-      {
-        "Filename" : "configs/cisco_ipv6_access_list",
-        "Line" : 21,
-        "Text" : "20 permit icmp any any mld-report",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: mld-report"
-      },
-      {
-        "Filename" : "configs/cisco_ipv6_access_list",
-        "Line" : 22,
-        "Text" : "30 permit icmp any any mld-reduction",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: mld-reduction"
-      },
-      {
-        "Filename" : "configs/cisco_ipv6_access_list",
-        "Line" : 23,
-        "Text" : "40 permit icmp any any mldv2",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: mldv2"
       },
       {
         "Filename" : "configs/cisco_misc",
@@ -1156,48 +1051,6 @@
         "Comment" : "This feature is not currently supported"
       },
       {
-        "Filename" : "configs/foundry_access_list",
-        "Line" : 11,
-        "Text" : "deny icmp any any 133 sequence 10",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: 133"
-      },
-      {
-        "Filename" : "configs/foundry_access_list",
-        "Line" : 12,
-        "Text" : "deny icmp any any 134 sequence 20",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: 134"
-      },
-      {
-        "Filename" : "configs/foundry_access_list",
-        "Line" : 13,
-        "Text" : "deny icmp any any 135 sequence 30",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: 135"
-      },
-      {
-        "Filename" : "configs/foundry_access_list",
-        "Line" : 14,
-        "Text" : "deny icmp any any 136 sequence 40",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: 136"
-      },
-      {
-        "Filename" : "configs/foundry_access_list",
-        "Line" : 15,
-        "Text" : "deny icmp any any 141 sequence 50",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: 141"
-      },
-      {
-        "Filename" : "configs/foundry_access_list",
-        "Line" : 16,
-        "Text" : "deny icmp any any 142 sequence 60",
-        "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-        "Comment" : "Unsupported clause in IPv6 extended access list: 142"
-      },
-      {
         "Filename" : "configs/ios_bgp",
         "Line" : 5,
         "Text" : "advertise-map ADVERTISE_MAP exist-map EXIST_MAP",
@@ -1486,10 +1339,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 206 results",
+      "notes" : "Found 185 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 206
+      "numResults" : 185
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -77083,28 +77083,6 @@
             }
           ]
         },
-        "configs/cadant_acl" : {
-          "Parse warnings" : [
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: 123",
-              "Line" : 22,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "permit icmp any any 123"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: nd-type",
-              "Line" : 24,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "permit nd any dead::/8 nd-type 133"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: 133",
-              "Line" : 24,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "permit nd any dead::/8 nd-type 133"
-            }
-          ]
-        },
         "configs/cisco_acl" : {
           "Parse warnings" : [
             {
@@ -77270,82 +77248,6 @@
               "Line" : 13,
               "Parser_Context" : "[ipnosm_add_route ipnos_static ipno_source ipn_outside s_ip_nat stanza cisco_configuration]",
               "Text" : "add-route"
-            }
-          ]
-        },
-        "configs/cisco_ipv6_access_list" : {
-          "Parse warnings" : [
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: router",
-              "Line" : 9,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmpv6 any any router hoplimit"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: hoplimit",
-              "Line" : 9,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmpv6 any any router hoplimit"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: router",
-              "Line" : 10,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmpv6 any any router"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: nd",
-              "Line" : 11,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmpv6 any any nd"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: nd",
-              "Line" : 12,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmpv6 any any nd"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: 141",
-              "Line" : 13,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmpv6 any any 141"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: 142",
-              "Line" : 14,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmpv6 any any 142"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: neighbor",
-              "Line" : 15,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmpv6 any any neighbor"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: mld-query",
-              "Line" : 20,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "10 permit icmp any any mld-query"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: mld-report",
-              "Line" : 21,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "20 permit icmp any any mld-report"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: mld-reduction",
-              "Line" : 22,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "30 permit icmp any any mld-reduction"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: mldv2",
-              "Line" : 23,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "40 permit icmp any any mldv2"
             }
           ]
         },
@@ -78236,46 +78138,6 @@
               "Line" : 55,
               "Parser_Context" : "[sys_snmp s_sys statement f5_bigip_structured_configuration]",
               "Text" : "snmp {"
-            }
-          ]
-        },
-        "configs/foundry_access_list" : {
-          "Parse warnings" : [
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: 133",
-              "Line" : 11,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmp any any 133 sequence 10"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: 134",
-              "Line" : 12,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmp any any 134 sequence 20"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: 135",
-              "Line" : 13,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmp any any 135 sequence 30"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: 136",
-              "Line" : 14,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmp any any 136 sequence 40"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: 141",
-              "Line" : 15,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmp any any 141 sequence 50"
-            },
-            {
-              "Comment" : "Unsupported clause in IPv6 extended access list: 142",
-              "Line" : 16,
-              "Parser_Context" : "[extended_ipv6_access_list_tail extended_ipv6_access_list_stanza stanza cisco_configuration]",
-              "Text" : "deny icmp any any 142 sequence 60"
             }
           ]
         },


### PR DESCRIPTION
Redundant with other warnings