### PR TITLE
EIGRP external routes: Maintain tag across nodes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -399,7 +399,8 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
             .setNextHopIp(nextHopIp)
             .setDestinationAsn(route.getDestinationAsn())
             .setEigrpMetric(newMetric)
-            .setNetwork(route.getNetwork());
+            .setNetwork(route.getNetwork())
+            .setTag(route.getTag());
     return filterRouteOnImport(route, routeBuilder, importPolicy);
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpRoutingProcessTest.java
@@ -80,14 +80,16 @@ public class EigrpRoutingProcessTest {
             .setProcessAsn(1L)
             .setNextHopIp(Ip.parse("1.1.1.1"))
             .setDestinationAsn(2L)
-            .setEigrpMetric(metric);
+            .setEigrpMetric(metric)
+            .setTag(3L);
     _internalRouteBuilder =
         EigrpInternalRoute.builder()
             .setNetwork(Prefix.parse("1.1.1.0/24"))
             .setAdmin(222)
             .setProcessAsn(1L)
             .setNextHopIp(Ip.parse("1.1.1.1"))
-            .setEigrpMetric(metric);
+            .setEigrpMetric(metric)
+            .setTag(3L);
   }
 
   @Test
@@ -134,10 +136,17 @@ public class EigrpRoutingProcessTest {
         _routingProcess.transformAndFilterExternalRouteFromNeighbor(routeIn, _ifaceMetric, ip, rp);
     assertTrue(maybeRoute.isPresent());
     EigrpExternalRoute route = maybeRoute.get();
-    assertThat(route.getNextHopIp(), equalTo(ip));
-    assertThat(route.getAdministrativeCost(), equalTo(_process.getExternalAdminCost()));
-    assertThat(route.getEigrpMetric(), equalTo(routeIn.getEigrpMetric().add(_ifaceMetric)));
-    assertThat(route.getProcessAsn(), equalTo(_process.getAsn()));
+    EigrpExternalRoute expected =
+        EigrpExternalRoute.builder()
+            .setNextHopIp(ip)
+            .setAdmin(_process.getExternalAdminCost())
+            .setEigrpMetric(routeIn.getEigrpMetric().add(_ifaceMetric))
+            .setProcessAsn(_process.getAsn())
+            .setTag(routeIn.getTag())
+            .setNetwork(routeIn.getNetwork())
+            .setDestinationAsn(routeIn.getDestinationAsn())
+            .build();
+    assertThat(route, equalTo(expected));
   }
 
   @Test


### PR DESCRIPTION
See sections 5.4.1.1 and 5.4.1.2 in RFC 7868:
https://tools.ietf.org/html/rfc7868#section-5.4.1.1

Tested on NXOS that these routes keep their tags after export (i.e. still have the same tag on the device to which they were exported):
- Tagged static route redistributed into EIGRP
- BGP route redistributed into EIGRP; its tag is its original BGP ASN
- BGP route that goes through a redistribution policy with `set tag`

Concluded that it is always correct to preserve external EIGRP routes' tags.