### PR TITLE
BDP: factor out wrapper around routing policies for each node

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -61,8 +61,8 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
 
   /** Parent process containing configuration */
   @Nonnull private final EigrpProcess _process;
-  /** Configuration containing the process */
-  @Nonnull private final Configuration _configuration;
+  /** All routing policies present at our parent node */
+  @Nonnull private final RoutingPolicies _routingPolicies;
   /** Name of the VRF in which this process resides */
   @Nonnull private final String _vrfName;
   /** Our AS number */
@@ -103,14 +103,14 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
   /** Set of edges in the topology that are new in the current iteration */
   private Collection<EigrpEdge> _edgesWentUp = ImmutableSet.of();
 
-  EigrpRoutingProcess(final EigrpProcess process, final String vrfName, final Configuration c) {
+  EigrpRoutingProcess(EigrpProcess process, String vrfName, RoutingPolicies policies) {
     _process = process;
     _asn = process.getAsn();
     _externalRib = new EigrpExternalRib();
     _internalRib = new EigrpInternalRib();
     _rib = new EigrpRib();
     _vrfName = vrfName;
-    _configuration = c;
+    _routingPolicies = policies;
     _topology = EigrpTopology.EMPTY;
     _initializationDelta = RibDelta.empty();
     _queuedForRedistribution = RibDelta.empty();
@@ -219,7 +219,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
       return;
     }
     RoutingPolicy exportPolicy =
-        _configuration.getRoutingPolicies().get(_process.getRedistributionPolicy());
+        _routingPolicies.get(_process.getRedistributionPolicy()).orElse(null);
     if (exportPolicy == null) {
       return;
     }
@@ -291,7 +291,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
     @Nullable
     RoutingPolicy importPolicy =
         Optional.ofNullable(localEigrpIface.getImportPolicy())
-            .map(_configuration.getRoutingPolicies()::get)
+            .flatMap(_routingPolicies::get)
             .orElse(null);
     while (!queue.isEmpty()) {
       RouteAdvertisement<EigrpInternalRoute> ra = queue.remove();
@@ -364,7 +364,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
       @Nullable
       RoutingPolicy importPolicy =
           Optional.ofNullable(localIface.getEigrp().getImportPolicy())
-              .map(_configuration.getRoutingPolicies()::get)
+              .flatMap(_routingPolicies::get)
               .orElse(null);
       Optional<EigrpExternalRoute> transformedRoute =
           transformAndFilterExternalRouteFromNeighbor(
@@ -545,10 +545,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
     EigrpNeighborConfig neighborConfig =
         _process.getNeighbors().get(neighborConfigId.getInterfaceName());
     assert neighborConfig != null;
-    RoutingPolicy exportPolicy =
-        _configuration.getRoutingPolicies().get(neighborConfig.getExportPolicy());
-    assert exportPolicy != null;
-    return exportPolicy;
+    return _routingPolicies.getOrThrow(neighborConfig.getExportPolicy());
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/Node.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/Node.java
@@ -16,6 +16,7 @@ public final class Node {
 
   private final Configuration _c;
   private final SortedMap<String, VirtualRouter> _virtualRouters;
+  @Nonnull private final RoutingPolicies _routingPolicies;
 
   /**
    * Create a new node based on the configuration. Initializes virtual routers based on {@link
@@ -23,7 +24,7 @@ public final class Node {
    *
    * @param configuration the {@link Configuration} backing this node
    */
-  public Node(@Nonnull Configuration configuration) {
+  public Node(Configuration configuration) {
     _c = configuration;
     ImmutableSortedMap.Builder<String, VirtualRouter> b = ImmutableSortedMap.naturalOrder();
     for (String vrfName : _c.getVrfs().keySet()) {
@@ -31,12 +32,19 @@ public final class Node {
       b.put(vrfName, vr);
     }
     _virtualRouters = b.build();
+    _routingPolicies = RoutingPolicies.from(configuration);
   }
 
   /** @return The {@link Configuration} backing this Node */
   @Nonnull
   public Configuration getConfiguration() {
     return _c;
+  }
+
+  /** Returns all routing policies present in the configuration of this node. */
+  @Nonnull
+  public RoutingPolicies getRoutingPolicies() {
+    return _routingPolicies;
   }
 
   /** Return the list of virtual routers at this node */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/RoutingPolicies.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/RoutingPolicies.java
@@ -1,0 +1,48 @@
+package org.batfish.dataplane.ibdp;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.RoutingPolicy;
+
+/** Internal iBDP implementation. A collection of all routing polices on a single device. */
+@ParametersAreNonnullByDefault
+final class RoutingPolicies {
+
+  RoutingPolicies(Map<String, RoutingPolicy> policies, String hostname) {
+    _policies = ImmutableMap.copyOf(policies);
+    _hostname = hostname;
+  }
+
+  /** Return a routing policy of a given name */
+  @Nonnull
+  public Optional<RoutingPolicy> get(String name) {
+    return Optional.ofNullable(_policies.get(name));
+  }
+
+  /**
+   * Return a routing policy of a given name.
+   *
+   * @throws IllegalStateException if the routing policy does not exist
+   */
+  @Nonnull
+  public RoutingPolicy getOrThrow(String name) {
+    return get(name)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    String.format("Routing policy %s does not exist on node %s", name, _hostname)));
+  }
+
+  @Nonnull
+  static RoutingPolicies from(Configuration c) {
+    return new RoutingPolicies(c.getRoutingPolicies(), c.getHostname());
+  }
+
+  @Nonnull private final Map<String, RoutingPolicy> _policies;
+  // For internal informational purposes only
+  @Nonnull private final String _hostname;
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -312,7 +312,9 @@ public final class VirtualRouter {
   private void initEigrp() {
     _eigrpProcesses =
         _vrf.getEigrpProcesses().values().stream()
-            .map(eigrpProcess -> new EigrpRoutingProcess(eigrpProcess, _name, _c))
+            .map(
+                eigrpProcess ->
+                    new EigrpRoutingProcess(eigrpProcess, _name, RoutingPolicies.from(_c)))
             .collect(ImmutableMap.toImmutableMap(EigrpRoutingProcess::getAsn, Function.identity()));
     _eigrpProcesses.values().forEach(p -> p.initialize(_node));
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpRoutingProcessTest.java
@@ -48,9 +48,7 @@ public class EigrpRoutingProcessTest {
             .setMode(EigrpProcessMode.CLASSIC)
             .setRouterId(Ip.ZERO)
             .build();
-    _routingProcess =
-        new EigrpRoutingProcess(
-            _process, "vrf", new Configuration("host", ConfigurationFormat.CISCO_IOS));
+    _routingProcess = new EigrpRoutingProcess(_process, "vrf", RoutingPolicies.from(_c));
     _ifaceMetric =
         ClassicMetric.builder()
             .setValues(


### PR DESCRIPTION
Gets us a slightly cleaner APIs over just maps.
Helps us migrate towards better patterns: individual routing processes should not have direct access to configuration (in the long term)