### PR TITLE
 Generalize VRF leaking datamodel

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
@@ -96,6 +96,7 @@ public class Vrf extends ComparableStructure<String> {
   private static final String PROP_OSPF_PROCESSES = "ospfProcesses";
   private static final String PROP_RIP_PROCESS = "ripProcess";
   private static final String PROP_STATIC_ROUTES = "staticRoutes";
+  private static final String PROP_VRF_LEAKING_CONFIGS = "vrfLeakingConfigs";
 
   public static @Nonnull Builder builder() {
     return new Builder(null);
@@ -272,7 +273,8 @@ public class Vrf extends ComparableStructure<String> {
             .build();
   }
 
-  public Collection<VrfLeakingConfig> getVrfLeakConfigs() {
+  @JsonProperty(PROP_VRF_LEAKING_CONFIGS)
+  public List<VrfLeakingConfig> getVrfLeakConfigs() {
     return _vrfLeakConfigs;
   }
 
@@ -281,9 +283,10 @@ public class Vrf extends ComparableStructure<String> {
         ImmutableList.<VrfLeakingConfig>builder().addAll(_vrfLeakConfigs).add(c).build();
   }
 
-  /** For Builder use only */
-  private void setVrfLeakConfigs(List<VrfLeakingConfig> vrfLeakConfigs) {
-    _vrfLeakConfigs = vrfLeakConfigs;
+  /** For Builder (or Jackson) use only */
+  @JsonProperty(PROP_VRF_LEAKING_CONFIGS)
+  private void setVrfLeakConfigs(@Nullable List<VrfLeakingConfig> vrfLeakConfigs) {
+    _vrfLeakConfigs = ImmutableList.copyOf(firstNonNull(vrfLeakConfigs, ImmutableList.of()));
   }
 
   public void setAppliedRibGroups(Map<RoutingProtocol, RibGroup> appliedRibGroups) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
@@ -8,15 +8,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -45,7 +45,7 @@ public class Vrf extends ComparableStructure<String> {
     @Nonnull private Map<Long, EigrpProcess> _eigrpProcesses = ImmutableMap.of();
 
     @Nonnull
-    private ImmutableSet.Builder<VrfLeakingConfig> _vrfLeakingConfigs = ImmutableSet.builder();
+    private ImmutableList.Builder<VrfLeakingConfig> _vrfLeakingConfigs = ImmutableList.builder();
 
     private Builder(Supplier<String> nameGenerator) {
       _nameGenerator = nameGenerator;
@@ -120,7 +120,7 @@ public class Vrf extends ComparableStructure<String> {
   private SortedSet<StaticRoute> _staticRoutes;
   private Map<Integer, Layer2Vni> _layer2Vnis;
   private Map<Integer, Layer3Vni> _layer3Vnis;
-  private Set<VrfLeakingConfig> _vrfLeakConfigs;
+  private List<VrfLeakingConfig> _vrfLeakConfigs;
 
   public Vrf(@Nonnull String name) {
     super(name);
@@ -133,7 +133,7 @@ public class Vrf extends ComparableStructure<String> {
     _staticRoutes = new TreeSet<>();
     _layer2Vnis = ImmutableMap.of();
     _layer3Vnis = ImmutableMap.of();
-    _vrfLeakConfigs = ImmutableSet.of();
+    _vrfLeakConfigs = ImmutableList.of();
   }
 
   @JsonCreator
@@ -278,11 +278,11 @@ public class Vrf extends ComparableStructure<String> {
 
   public void addVrfLeakingConfig(@Nonnull VrfLeakingConfig c) {
     _vrfLeakConfigs =
-        ImmutableSet.<VrfLeakingConfig>builder().addAll(_vrfLeakConfigs).add(c).build();
+        ImmutableList.<VrfLeakingConfig>builder().addAll(_vrfLeakConfigs).add(c).build();
   }
 
   /** For Builder use only */
-  private void setVrfLeakConfigs(Set<VrfLeakingConfig> vrfLeakConfigs) {
+  private void setVrfLeakConfigs(List<VrfLeakingConfig> vrfLeakConfigs) {
     _vrfLeakConfigs = vrfLeakConfigs;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrfLeakingConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrfLeakingConfig.java
@@ -1,0 +1,132 @@
+package org.batfish.datamodel;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.base.MoreObjects;
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * Configuration responsible for VRF leaking. To successfully leak routes from one VRF to another,
+ * the destination VRF should contain one or more {@link VrfLeakingConfig} objects.
+ *
+ * <p>This object describes <em>how</em> to leak the routes, in particular:
+ *
+ * <ul>
+ *   <li>from which source VRF to pull routes
+ *   <li>what import policy to apply, if any
+ *   <li>whether to leak routes as BGP or not
+ * </ul>
+ *
+ * <p><b>Note on BGP leaking: please see {@link #leakAsBgp()} for full explanation of semantics</b>
+ */
+@ParametersAreNonnullByDefault
+public class VrfLeakingConfig implements Serializable {
+
+  /**
+   * Name of the import policy to apply to imported routes when leaking. If {@code null} no policy
+   * is applied, all routes are allowed.
+   */
+  @Nullable
+  public String getImportPolicy() {
+    return _importPolicy;
+  }
+
+  /**
+   * Name of the source VRF from which to copy routes.
+   *
+   * <p>If {@link #leakAsBgp()} is set, the source VRF <b>must</b> have a BGP process/RIBs.
+   */
+  @Nonnull
+  public String getImportFromVrf() {
+    return _importFromVrf;
+  }
+
+  /**
+   * Whether or not to leak routes between BGP RIBs or main RIBs.
+   *
+   * <p>For those familiar with vendor semantics: if set to {@code true}, leaking routes as BGP is
+   * equivalent to IOS vrf leaking which is done between BGP RIBs of different VRFs (on a real
+   * device, via VPNv4 address family). If set to {@code false}, the leaking process more closely
+   * follows the Juniper model, where routes are simply copied from the main RIB of one routing
+   * instance (read: VRF) into another, with appropriate src-VRF annotation.
+   */
+  public boolean leakAsBgp() {
+    return _leakAsBgp;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof VrfLeakingConfig)) {
+      return false;
+    }
+    VrfLeakingConfig that = (VrfLeakingConfig) o;
+    return _importFromVrf.equals(that._importFromVrf)
+        && Objects.equals(_importPolicy, that._importPolicy)
+        && _leakAsBgp == that._leakAsBgp;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_importPolicy, _importFromVrf, _leakAsBgp);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(VrfLeakingConfig.class)
+        .add("importPolicy", _importPolicy)
+        .add("importFromVrf", _importFromVrf)
+        .add("leakAsBgp", _leakAsBgp)
+        .toString();
+  }
+
+  @Nullable private final String _importPolicy;
+  @Nonnull private final String _importFromVrf;
+  private final boolean _leakAsBgp;
+
+  private VrfLeakingConfig(Builder builder) {
+    checkArgument(builder._importFromVrf != null, "VRF leaking config is missing import VRF");
+    _importPolicy = builder._importPolicy;
+    _importFromVrf = builder._importFromVrf;
+    _leakAsBgp = builder._leakAsBgp;
+  }
+
+  @ParametersAreNonnullByDefault
+  public static class Builder {
+
+    public Builder setImportPolicy(@Nullable String importPolicy) {
+      _importPolicy = importPolicy;
+      return this;
+    }
+
+    public Builder setImportFromVrf(String importFromVrf) {
+      _importFromVrf = importFromVrf;
+      return this;
+    }
+
+    public Builder setLeakAsBgp(boolean leakAsBgp) {
+      _leakAsBgp = leakAsBgp;
+      return this;
+    }
+
+    public VrfLeakingConfig build() {
+      return new VrfLeakingConfig(this);
+    }
+
+    @Nullable private String _importPolicy;
+    @Nullable private String _importFromVrf;
+    private boolean _leakAsBgp;
+
+    private Builder() {}
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfLeakingConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfLeakingConfigTest.java
@@ -1,0 +1,41 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.datamodel.VrfLeakingConfig.Builder;
+import org.junit.Test;
+
+/** Tests of {@link VrfLeakingConfig} */
+public class VrfLeakingConfigTest {
+
+  @Test
+  public void testJavaSerialization() {
+    VrfLeakingConfig val =
+        VrfLeakingConfig.builder()
+            .setImportFromVrf("vrf1")
+            .setImportPolicy("policy")
+            .setLeakAsBgp(false)
+            .build();
+    assertThat(SerializationUtils.clone(val), equalTo(val));
+  }
+
+  @Test
+  public void testEquals() {
+    Builder b =
+        VrfLeakingConfig.builder()
+            .setImportFromVrf("vrf1")
+            .setImportPolicy("policy")
+            .setLeakAsBgp(false);
+    VrfLeakingConfig val = b.build();
+    new EqualsTester()
+        .addEqualityGroup(val, val, b.build())
+        .addEqualityGroup(b.setImportFromVrf("vrf2").build())
+        .addEqualityGroup(b.setImportPolicy("policy2").build())
+        .addEqualityGroup(b.setLeakAsBgp(true).build())
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfLeakingConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfLeakingConfigTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.VrfLeakingConfig.Builder;
 import org.junit.Test;
 
@@ -20,6 +21,17 @@ public class VrfLeakingConfigTest {
             .setLeakAsBgp(false)
             .build();
     assertThat(SerializationUtils.clone(val), equalTo(val));
+  }
+
+  @Test
+  public void testJsonSerialization() {
+    VrfLeakingConfig val =
+        VrfLeakingConfig.builder()
+            .setImportFromVrf("vrf1")
+            .setImportPolicy("policy")
+            .setLeakAsBgp(false)
+            .build();
+    assertThat(BatfishObjectMapper.clone(val, VrfLeakingConfig.class), equalTo(val));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -65,6 +65,7 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Topology;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.VrfLeakingConfig;
 import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.eigrp.ClassicMetric;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
@@ -750,9 +751,15 @@ public class VirtualRouterTest {
 
     // Create VRFs in configuration and set up cross-VRF import VRF and policy for empty one
     nf.vrfBuilder().setOwner(c).setName(vrfWithRoutesName).build();
-    Vrf emptyVrf = nf.vrfBuilder().setOwner(c).setName(emptyVrfName).build();
-    emptyVrf.setCrossVrfImportVrfs(ImmutableList.of(vrfWithRoutesName));
-    emptyVrf.setCrossVrfImportPolicy(importPolicyName);
+    nf.vrfBuilder()
+        .setOwner(c)
+        .setName(emptyVrfName)
+        .addVrfLeakingConfig(
+            VrfLeakingConfig.builder()
+                .setImportFromVrf(vrfWithRoutesName)
+                .setImportPolicy(importPolicyName)
+                .build())
+        .build();
 
     // Create a Node based on the configuration and get its VirtualRouters
     Node n = new Node(c);

--- a/tests/parsing-tests/networks/unit-tests/configs/juniper_routing_options
+++ b/tests/parsing-tests/networks/unit-tests/configs/juniper_routing_options
@@ -14,8 +14,3 @@ set routing-options generate route 10.0.1.0/24 active
 set routing-options generate route 10.0.1.0/24 community 2:6
 set routing-options generate route 10.0.1.0/24 discard
 #
-set routing-options instance-import POLICY
-#
-# Avoid undefined reference warning; test structures generated for instance-import
-set policy-options policy-statement POLICY then accept
-#

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -70988,43 +70988,6 @@
           }
         },
         "routingPolicies" : {
-          "POLICY" : {
-            "name" : "POLICY",
-            "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "falseStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitAccept"
-                  }
-                ],
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
-                  "type" : "CallExprContext"
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnTrue"
-                  }
-                ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "falseStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "Return"
-                  }
-                ],
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
-                  "type" : "CallExprContext"
-                }
-              }
-            ]
-          },
           "~AGGREGATE_ROUTE_POLICY:10.0.0.0/8~" : {
             "name" : "~AGGREGATE_ROUTE_POLICY:10.0.0.0/8~",
             "statements" : [
@@ -71169,30 +71132,6 @@
               }
             ]
           },
-          "~DEFAULT_REJECT_POLICY~" : {
-            "name" : "~DEFAULT_REJECT_POLICY~",
-            "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "falseStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitReject"
-                  }
-                ],
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
-                  "type" : "CallExprContext"
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnFalse"
-                  }
-                ]
-              }
-            ]
-          },
           "~GENERATED_ROUTE_POLICY:10.0.1.0/24~" : {
             "name" : "~GENERATED_ROUTE_POLICY:10.0.1.0/24~",
             "statements" : [
@@ -71218,39 +71157,6 @@
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
                 "type" : "SetDefaultActionAccept"
-              }
-            ]
-          },
-          "~INSTANCE_IMPORT_POLICY_default~" : {
-            "name" : "~INSTANCE_IMPORT_POLICY_default~",
-            "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.SetDefaultPolicy",
-                "defaultPolicy" : "~DEFAULT_REJECT_POLICY~"
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "falseStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnFalse"
-                  }
-                ],
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.FirstMatchChain",
-                  "subroutines" : [
-                    {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.CallExpr",
-                      "calledPolicyName" : "POLICY"
-                    }
-                  ]
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ReturnTrue"
-                  }
-                ]
               }
             ]
           }

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -71376,8 +71376,7 @@
                 "nextHopIp" : "AUTO/NONE(-1l)",
                 "tag" : -1
               }
-            ],
-            "crossVrfImportPolicy" : "~INSTANCE_IMPORT_POLICY_default~"
+            ]
           }
         }
       },

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -67363,36 +67363,6 @@
             "                  (rog_discard",
             "                    DISCARD:'discard'))))))))",
             "    NEWLINE:'\\n')",
-            "  (set_line",
-            "    SET:'set'",
-            "    (set_line_tail",
-            "      (statement",
-            "        (s_common",
-            "          (s_routing_options",
-            "            ROUTING_OPTIONS:'routing-options'",
-            "            (ro_instance_import",
-            "              INSTANCE_IMPORT:'instance-import'",
-            "              name = (variable",
-            "                text = VARIABLE:'POLICY'))))))",
-            "    NEWLINE:'\\n')",
-            "  (set_line",
-            "    SET:'set'",
-            "    (set_line_tail",
-            "      (statement",
-            "        (s_common",
-            "          (s_policy_options",
-            "            POLICY_OPTIONS:'policy-options'",
-            "            (po_policy_statement",
-            "              POLICY_STATEMENT:'policy-statement'",
-            "              name = (variable",
-            "                text = VARIABLE:'POLICY')",
-            "              (pops_common",
-            "                (pops_then",
-            "                  THEN:'then'",
-            "                  (popst_common",
-            "                    (popst_accept",
-            "                      ACCEPT:'accept')))))))))",
-            "    NEWLINE:'\\n')",
             "  EOF:<EOF>)"
           ]
         },
@@ -81795,14 +81765,7 @@
             }
           }
         },
-        "configs/juniper_routing_options" : {
-          "policy-statement" : {
-            "POLICY" : {
-              "definitionLines" : "20",
-              "numReferrers" : 1
-            }
-          }
-        },
+        "configs/juniper_routing_options" : { },
         "configs/juniper_routing_policy" : {
           "interface" : {
             "ge-0/0/0" : {
@@ -88144,11 +88107,6 @@
             "AGGREGATE_ROUTE_POLICY" : {
               "aggregate route policy" : [
                 9
-              ]
-            },
-            "POLICY" : {
-              "routing-options instance-import" : [
-                17
               ]
             }
           }


### PR DESCRIPTION
Encapsulate in a separate object, allow leaking as BGP.
No new functionality in this PR, just prepping for future work. 