### PR TITLE
Fib: minor memory allocation optimizations

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -91,10 +91,10 @@ public final class FibImpl implements Fib {
 
   public FibImpl(@Nonnull GenericRib<? extends AbstractRouteDecorator> rib) {
     _root = new PrefixTrieMultiMap<>(Prefix.ZERO);
-    rib.getRoutes()
+    rib.getTypedRoutes()
         .forEach(
             r -> {
-              Set<FibEntry> s = resolveRoute(rib, r);
+              Set<FibEntry> s = resolveRoute(rib, r.getAbstractRoute());
               _root.putAll(r.getNetwork(), s);
             });
     initSuppliers();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/PrefixTrieMultiMap.java
@@ -376,7 +376,15 @@ public final class PrefixTrieMultiMap<T> implements Serializable {
     if (node._elements.containsAll(elements)) {
       return false;
     }
-    node._elements = ImmutableSet.<T>builder().addAll(node._elements).addAll(elements).build();
+    if (node._elements.isEmpty()) {
+      node._elements = ImmutableSet.copyOf(elements);
+    } else {
+      node._elements =
+          ImmutableSet.<T>builderWithExpectedSize(node._elements.size() + elements.size())
+              .addAll(node._elements)
+              .addAll(elements)
+              .build();
+    }
     return true;
   }
 


### PR DESCRIPTION
* Avoid materializing an entire set just to throw it away. (`getRoutes` vs `getTypedRoutes`)
* Shortcut combining sets when one is empty.
* When combining, pre-allocate new set with guaranteed enough space.