### PR TITLE
IOS-XE: bgp address-family import path

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -12579,6 +12579,11 @@ STREETADDRESS
    'streetaddress' -> pushMode ( M_Description )
 ;
 
+STRICT
+:
+   'strict'
+;
+
 STRICTHOSTKEYCHECK
 :
    'stricthostkeycheck'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_bgp.g4
@@ -53,6 +53,7 @@ address_family_rb_stanza
    (
       additional_paths_rb_stanza
       | aggregate_address_rb_stanza
+      | bgp_af_import
       | bgp_tail
       | neighbor_flat_rb_stanza
       | no_neighbor_activate_rb_stanza
@@ -141,6 +142,37 @@ as_path_multipath_relax_rb_stanza
 auto_summary_bgp_tail
 :
    NO? AUTO_SUMMARY NEWLINE
+;
+
+bgp_af_import
+:
+   IMPORT bgp_af_import_path
+;
+
+bgp_af_import_path
+:
+   PATH
+   (
+      bgp_afip_limit
+      | bgp_afip_selection
+   )
+;
+
+bgp_afip_limit
+:
+   // No effect on Batfish models, just BGP convergence time
+   LIMIT num = DEC NEWLINE
+;
+
+bgp_afip_selection
+:
+   // No effect on Batfish models, just BGP convergence time
+   SELECTION
+   (
+      ALL
+      | BESTPATH STRICT?
+      | MULTIPATH STRICT?
+   ) NEWLINE
 ;
 
 //confederations are not currently implemented

--- a/tests/parsing-tests/networks/unit-tests/configs/ios-xe/ios-xe-bgp-vrf
+++ b/tests/parsing-tests/networks/unit-tests/configs/ios-xe/ios-xe-bgp-vrf
@@ -1,0 +1,21 @@
+!RANCID-CONTENT-TYPE: cisco
+hostname ios-xe-bgp-vrf
+!
+! https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/iproute_bgp/configuration/xe-16-8/irg-xe-16-8-book/irg-event-vpn-import.html
+!
+vrf definition vrf-A
+ rd 45000:1
+ route-target both 45000:100
+ address-family ipv4 unicast
+ exit-address-family
+!
+interface FastEthernet 1/1
+ vrf forwarding vrf-A
+ ip address 10.4.8.149 255.255.255.0
+ no shutdown
+!
+router bgp 45000
+ address-family ipv4 vrf vrf-A
+ import path selection all
+ import path limit 3
+!

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -39889,6 +39889,132 @@
           }
         }
       },
+      "ios-xe-bgp-vrf" : {
+        "configurationFormat" : "CISCO_IOS",
+        "name" : "ios-xe-bgp-vrf",
+        "defaultCrossZoneAction" : "PERMIT",
+        "defaultInboundAction" : "PERMIT",
+        "deviceModel" : "CISCO_UNSPECIFIED",
+        "deviceType" : "ROUTER",
+        "interfaces" : {
+          "FastEthernet1/1" : {
+            "name" : "FastEthernet1/1",
+            "active" : true,
+            "additionalArpIps" : {
+              "class" : "org.batfish.datamodel.EmptyIpSpace"
+            },
+            "allPrefixes" : [
+              "10.4.8.149/24"
+            ],
+            "allowedVlans" : "",
+            "autostate" : true,
+            "bandwidth" : 1.0E8,
+            "declaredNames" : [
+              "FastEthernet1/1"
+            ],
+            "mtu" : 1500,
+            "prefix" : "10.4.8.149/24",
+            "proxyArp" : true,
+            "ripEnabled" : false,
+            "ripPassive" : false,
+            "spanningTreePortfast" : false,
+            "speed" : 1.0E8,
+            "switchport" : false,
+            "switchportMode" : "NONE",
+            "switchportTrunkEncapsulation" : "DOT1Q",
+            "type" : "PHYSICAL",
+            "vrf" : "vrf-A"
+          }
+        },
+        "routingPolicies" : {
+          "~BGP_COMMON_EXPORT_POLICY:default~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:default~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                  "protocols" : [
+                    "bgp",
+                    "ibgp"
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          },
+          "~BGP_COMMON_EXPORT_POLICY:vrf-A~" : {
+            "name" : "~BGP_COMMON_EXPORT_POLICY:vrf-A~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchProtocol",
+                  "protocols" : [
+                    "bgp",
+                    "ibgp"
+                  ]
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ]
+              },
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                "type" : "ReturnFalse"
+              }
+            ]
+          }
+        },
+        "vendorFamily" : {
+          "cisco" : {
+            "hostname" : "ios-xe-bgp-vrf",
+            "logging" : {
+              "on" : true
+            }
+          }
+        },
+        "vrfs" : {
+          "default" : {
+            "name" : "default",
+            "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
+              "routerId" : "0.0.0.0",
+              "clusterListAsIgpCost" : false,
+              "multipathEbgp" : false,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : false,
+              "tieBreaker" : "ARRIVAL_ORDER"
+            }
+          },
+          "vrf-A" : {
+            "name" : "vrf-A",
+            "bgpProcess" : {
+              "ebgpAdminCost" : 20,
+              "ibgpAdminCost" : 200,
+              "routerId" : "10.4.8.149",
+              "clusterListAsIgpCost" : false,
+              "multipathEbgp" : false,
+              "multipathEquivalentAsPathMatchMode" : "EXACT_PATH",
+              "multipathIbgp" : false,
+              "tieBreaker" : "ARRIVAL_ORDER"
+            }
+          }
+        }
+      },
       "ios_banner" : {
         "configurationFormat" : "CISCO_IOS",
         "name" : "ios_banner",

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -565,6 +565,9 @@
         "interfacemtu" : [
           "configs/juniper-interfaces"
         ],
+        "ios-xe-bgp-vrf" : [
+          "configs/ios-xe/ios-xe-bgp-vrf"
+        ],
         "ios_banner" : [
           "configs/ios_banner"
         ],
@@ -1104,6 +1107,7 @@
         "configs/interface_exit" : "PASSED",
         "configs/interface_name" : "PASSED",
         "configs/interface_sdr" : "PASSED",
+        "configs/ios-xe/ios-xe-bgp-vrf" : "PASSED",
         "configs/ios_banner" : "PASSED",
         "configs/ios_banner_dos" : "PASSED",
         "configs/ios_bfd" : "PASSED",
@@ -52365,6 +52369,112 @@
             "  EOF:<EOF>)"
           ]
         },
+        "configs/ios-xe/ios-xe-bgp-vrf" : {
+          "sentences" : [
+            "(cisco_configuration",
+            "  (stanza",
+            "    (s_hostname",
+            "      HOSTNAME:'hostname'",
+            "      VARIABLE:'ios-xe-bgp-vrf'",
+            "      NEWLINE:'\\n'))",
+            "  (stanza",
+            "    (s_vrf_definition",
+            "      VRF:'vrf'",
+            "      DEFINITION:'definition'",
+            "      name = (variable",
+            "        VARIABLE:'vrf-A')",
+            "      NEWLINE:'\\n'",
+            "      (vrfd_rd",
+            "        RD:'rd'",
+            "        rd = (route_distinguisher",
+            "          (bgp_asn",
+            "            asn = DEC:'45000')",
+            "          COLON:':'",
+            "          DEC:'1')",
+            "        NEWLINE:'\\n')",
+            "      (vrfd_route_target",
+            "        ROUTE_TARGET:'route-target'",
+            "        type = (both_export_import",
+            "          BOTH:'both')",
+            "        rt = (route_target",
+            "          (bgp_asn",
+            "            asn = DEC:'45000')",
+            "          COLON:':'",
+            "          DEC:'100')",
+            "        NEWLINE:'\\n')",
+            "      (vrfd_address_family",
+            "        ADDRESS_FAMILY:'address-family'",
+            "        IPV4:'ipv4'",
+            "        UNICAST:'unicast'",
+            "        NEWLINE:'\\n'",
+            "        EXIT_ADDRESS_FAMILY:'exit-address-family'",
+            "        NEWLINE:'\\n')))",
+            "  (stanza",
+            "    (s_interface",
+            "      INTERFACE:'interface'",
+            "      iname = (interface_name",
+            "        name_prefix_alpha = M_Interface_PREFIX:'FastEthernet'  <== mode:M_Interface",
+            "        DEC:'1'  <== mode:M_Interface",
+            "        FORWARD_SLASH:'/'  <== mode:M_Interface",
+            "        (range",
+            "          (subrange",
+            "            low = DEC:'1'  <== mode:M_Interface)))",
+            "      NEWLINE:'\\n'  <== mode:M_Interface",
+            "      (if_inner",
+            "        (if_ip_vrf_forwarding",
+            "          VRF:'vrf'",
+            "          FORWARDING:'forwarding'",
+            "          vrf = (variable",
+            "            VARIABLE:'vrf-A')",
+            "          NEWLINE:'\\n'))",
+            "      (if_inner",
+            "        (if_ip_address",
+            "          IP:'ip'",
+            "          ADDRESS:'address'",
+            "          ip = IP_ADDRESS:'10.4.8.149'",
+            "          subnet = IP_ADDRESS:'255.255.255.0'",
+            "          NEWLINE:'\\n'))",
+            "      (if_inner",
+            "        (if_shutdown",
+            "          NO:'no'",
+            "          SHUTDOWN:'shutdown'",
+            "          NEWLINE:'\\n'))))",
+            "  (stanza",
+            "    (router_bgp_stanza",
+            "      ROUTER:'router'",
+            "      BGP:'bgp'",
+            "      procnum = (bgp_asn",
+            "        asn = DEC:'45000')",
+            "      NEWLINE:'\\n'",
+            "      (router_bgp_stanza_tail",
+            "        (address_family_rb_stanza",
+            "          (address_family_header",
+            "            ADDRESS_FAMILY:'address-family'",
+            "            af = (bgp_address_family",
+            "              IPV4:'ipv4'",
+            "              VRF:'vrf'",
+            "              vrf_name = VARIABLE:'vrf-A')",
+            "            NEWLINE:'\\n')",
+            "          (bgp_af_import",
+            "            IMPORT:'import'",
+            "            (bgp_af_import_path",
+            "              PATH:'path'",
+            "              (bgp_afip_selection",
+            "                SELECTION:'selection'",
+            "                ALL:'all'",
+            "                NEWLINE:'\\n')))",
+            "          (bgp_af_import",
+            "            IMPORT:'import'",
+            "            (bgp_af_import_path",
+            "              PATH:'path'",
+            "              (bgp_afip_limit",
+            "                LIMIT:'limit'",
+            "                num = DEC:'3'",
+            "                NEWLINE:'\\n')))",
+            "          (address_family_footer)))))",
+            "  EOF:<EOF>)"
+          ]
+        },
         "configs/ios_banner" : {
           "sentences" : [
             "(cisco_configuration",
@@ -78681,6 +78791,7 @@
         "interface_name" : "PASSED",
         "interface_sdr" : "PASSED",
         "interfacemtu" : "PASSED",
+        "ios-xe-bgp-vrf" : "PASSED",
         "ios_banner" : "PASSED",
         "ios_banner_dos" : "PASSED",
         "ios_bfd" : "PASSED",
@@ -80938,6 +81049,14 @@
           "interface" : {
             "Loopback0" : {
               "definitionLines" : "4-10",
+              "numReferrers" : 1
+            }
+          }
+        },
+        "configs/ios-xe/ios-xe-bgp-vrf" : {
+          "interface" : {
+            "FastEthernet1/1" : {
+              "definitionLines" : "12-15",
               "numReferrers" : 1
             }
           }
@@ -83399,6 +83518,9 @@
         ],
         "configs/interface_sdr" : [
           "interface_sdr"
+        ],
+        "configs/ios-xe/ios-xe-bgp-vrf" : [
+          "ios-xe-bgp-vrf"
         ],
         "configs/ios_banner" : [
           "ios_banner"
@@ -86987,6 +87109,15 @@
             "Loopback0" : {
               "interface" : [
                 4
+              ]
+            }
+          }
+        },
+        "configs/ios-xe/ios-xe-bgp-vrf" : {
+          "interface" : {
+            "FastEthernet1/1" : {
+              "interface" : [
+                12
               ]
             }
           }
@@ -92661,6 +92792,7 @@
         "configs/interface_exit" : "PASSED",
         "configs/interface_name" : "PASSED",
         "configs/interface_sdr" : "PASSED",
+        "configs/ios-xe/ios-xe-bgp-vrf" : "PASSED",
         "configs/ios_banner" : "PASSED",
         "configs/ios_banner_dos" : "PASSED",
         "configs/ios_bfd" : "PASSED",


### PR DESCRIPTION
This is for BGP Event-based VPN Import, which affects convergence but not our
modeling.

https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/iproute_bgp/configuration/xe-16-8/irg-xe-16-8-book/irg-event-vpn-import.html

Keeps parser properly in context.