### PR TITLE
IOS NAT rules with interface instead of pool

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_nat.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_nat.g4
@@ -89,8 +89,11 @@ ipnosm_add_route
 
 ipnis_list
 :
-   // Delegate to common ACL NAT specification
-   acl_pool = ipnc_list
+   LIST acl = variable
+   (
+     POOL pool = variable
+     | INTERFACE iname = interface_name
+   )
    // order matters
    ipnios_vrf?
    OVERLOAD?
@@ -100,7 +103,10 @@ ipnis_list
 ipnis_route_map
 :
    ROUTE_MAP mapname = variable
-   INTERFACE iname = interface_name
+   (
+     POOL pool = variable
+     | INTERFACE iname = interface_name
+   )
    ( VRF variable )?
    OVERLOAD?
    NEWLINE

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1997,9 +1997,9 @@ public final class CiscoConfiguration extends VendorConfiguration {
       if (!firstNonNull(nat.getVrf(), Configuration.DEFAULT_VRF_NAME).equals(vrfName)) {
         continue;
       }
-      nat.toIncomingTransformation(ipAccessLists, _natPools)
+      nat.toIncomingTransformation(ipAccessLists, _natPools, _interfaces)
           .ifPresent(incoming -> convertedIncomingNats.put(nat, incoming));
-      nat.toOutgoingTransformation(ipAccessLists, _natPools, getNatInside(), c)
+      nat.toOutgoingTransformation(ipAccessLists, _natPools, getNatInside(), _interfaces, c)
           .ifPresent(outgoing -> convertedOutgoingNats.put(nat, outgoing));
     }
 
@@ -3689,7 +3689,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
         CiscoStructureUsage.ZONE_PAIR_DESTINATION_ZONE,
         CiscoStructureUsage.ZONE_PAIR_SOURCE_ZONE);
 
-    markConcreteStructure(CiscoStructureType.NAT_POOL, CiscoStructureUsage.IP_NAT_SOURCE_POOL);
+    markConcreteStructure(CiscoStructureType.NAT_POOL);
     markConcreteStructure(
         CiscoStructureType.AS_PATH_ACCESS_LIST,
         CiscoStructureUsage.BGP_NEIGHBOR_FILTER_AS_PATH_ACCESS_LIST,

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNat.java
@@ -59,6 +59,7 @@ public abstract class CiscoIosNat implements Comparable<CiscoIosNat>, Serializab
       Map<String, IpAccessList> ipAccessLists,
       Map<String, NatPool> natPools,
       Set<String> insideInterfaces,
+      Map<String, Interface> interfaces,
       Configuration c);
 
   /**
@@ -70,10 +71,12 @@ public abstract class CiscoIosNat implements Comparable<CiscoIosNat>, Serializab
    *     Transformation} could not be built
    */
   public abstract Optional<Transformation.Builder> toIncomingTransformation(
-      Map<String, IpAccessList> ipAccessLists, Map<String, NatPool> natPools);
+      Map<String, IpAccessList> ipAccessLists,
+      Map<String, NatPool> natPools,
+      Map<String, Interface> interfaces);
 
   @Override
-  public abstract boolean equals(Object o);
+  public abstract boolean equals(@Nullable Object o);
 
   @Override
   public abstract int hashCode();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosStaticNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosStaticNat.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.Prefix;
@@ -14,6 +15,7 @@ import org.batfish.datamodel.acl.MatchSrcInterface;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.TransformationStep;
 
+@ParametersAreNonnullByDefault
 public class CiscoIosStaticNat extends CiscoIosNat {
 
   private Prefix _localNetwork;
@@ -29,7 +31,7 @@ public class CiscoIosStaticNat extends CiscoIosNat {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (!(o instanceof CiscoIosStaticNat)) {
       return false;
     }
@@ -65,7 +67,8 @@ public class CiscoIosStaticNat extends CiscoIosNat {
   public Optional<Transformation.Builder> toOutgoingTransformation(
       Map<String, IpAccessList> ipAccessLists,
       Map<String, NatPool> natPools,
-      @Nullable Set<String> insideInterfaces,
+      Set<String> insideInterfaces,
+      Map<String, Interface> interfaces,
       Configuration c) {
 
     /*
@@ -87,16 +90,15 @@ public class CiscoIosStaticNat extends CiscoIosNat {
         return Optional.empty();
     }
 
-    if (insideInterfaces != null) {
-      matchExpr = AclLineMatchExprs.and(matchExpr, new MatchSrcInterface(insideInterfaces));
-    }
-
+    matchExpr = AclLineMatchExprs.and(matchExpr, new MatchSrcInterface(insideInterfaces));
     return Optional.of(Transformation.when(matchExpr).apply(step));
   }
 
   @Override
   public Optional<Transformation.Builder> toIncomingTransformation(
-      Map<String, IpAccessList> ipAccessLists, Map<String, NatPool> natPools) {
+      Map<String, IpAccessList> ipAccessLists,
+      Map<String, NatPool> natPools,
+      Map<String, Interface> interfaces) {
     /*
      * No named ACL in rule, but need to match src/dest to global/local according
      * to direction and rule type

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -5375,15 +5375,17 @@ public final class CiscoGrammarTest {
 
     {
       // NAT in default VRF
-      Ip nat1PoolFirst = Ip.parse("3.3.3.1");
-      Ip nat1PoolLast = Ip.parse("3.3.3.254");
-      Ip nat2PoolFirst = Ip.parse("3.3.4.1");
-      Ip nat2PoolLast = Ip.parse("3.3.4.254");
-      Ip nat3PoolFirst = Ip.parse("4.4.4.1");
-      Ip nat3PoolLast = Ip.parse("4.4.4.254");
-      String nat1AclName = "10";
-      String nat2AclName = computeDynamicDestinationNatAclName("11");
-      String nat3AclName = "22";
+      Ip insideSrcPoolFirst = Ip.parse("3.3.3.1");
+      Ip insideSrcPoolLast = Ip.parse("3.3.3.254");
+      Ip insideDstPoolFirst = Ip.parse("3.3.4.1");
+      Ip insideDstPoolLast = Ip.parse("3.3.4.254");
+      Ip outsideSrcPoolFirst = Ip.parse("4.4.4.1");
+      Ip outsideSrcPoolLast = Ip.parse("4.4.4.254");
+      Ip insideSrcIfaceAddr = Ip.parse("1.1.1.1");
+      String insideSrcPoolAcl = "10";
+      String insideSrcIfaceAcl = "13";
+      String insideDstPoolAcl = computeDynamicDestinationNatAclName("11");
+      String outsideSrcPoolAcl = "22";
 
       Interface inside = c.getAllInterfaces().get(insideIntf);
       assertThat(inside.getIncomingTransformation(), nullValue());
@@ -5392,22 +5394,27 @@ public final class CiscoGrammarTest {
       Interface outside = c.getAllInterfaces().get(outsideIntf);
 
       Transformation inTransformation =
-          when(permittedByAcl(nat3AclName))
-              .apply(assignSourceIp(nat3PoolFirst, nat3PoolLast))
+          when(permittedByAcl(outsideSrcPoolAcl))
+              .apply(assignSourceIp(outsideSrcPoolFirst, outsideSrcPoolLast))
               .build();
 
       assertThat(outside.getIncomingTransformation(), equalTo(inTransformation));
 
       Transformation destTransformation =
-          when(and(permittedByAcl(nat2AclName), matchSrcInside))
-              .apply(assignDestinationIp(nat2PoolFirst, nat2PoolLast))
+          when(and(permittedByAcl(insideDstPoolAcl), matchSrcInside))
+              .apply(assignDestinationIp(insideDstPoolFirst, insideDstPoolLast))
               .build();
 
       Transformation outTransformation =
-          when(and(permittedByAcl(nat1AclName), matchSrcInside))
-              .apply(assignSourceIp(nat1PoolFirst, nat1PoolLast))
+          when(and(permittedByAcl(insideSrcPoolAcl), matchSrcInside))
+              .apply(assignSourceIp(insideSrcPoolFirst, insideSrcPoolLast))
               .setAndThen(destTransformation)
-              .setOrElse(destTransformation)
+              .setOrElse(
+                  when(and(permittedByAcl(insideSrcIfaceAcl), matchSrcInside))
+                      .apply(assignSourceIp(insideSrcIfaceAddr, insideSrcIfaceAddr))
+                      .setAndThen(destTransformation)
+                      .setOrElse(destTransformation)
+                      .build())
               .build();
 
       assertThat(outside.getOutgoingTransformation(), equalTo(outTransformation));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -5599,10 +5599,11 @@ public final class CiscoGrammarTest {
         batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot());
 
     assertThat(ccae, hasNumReferrers(filename, ROUTE_MAP, "ipniss", 4));
-    assertThat(ccae, hasNumReferrers(filename, ROUTE_MAP, "ipnisr", 4));
-    assertThat(ccae, hasNumReferrers(filename, INTERFACE, "GigabitEthernet0/0", 5));
+    assertThat(ccae, hasNumReferrers(filename, ROUTE_MAP, "ipnisr", 8));
+    assertThat(ccae, hasNumReferrers(filename, INTERFACE, "GigabitEthernet0/0", 7));
     assertThat(ccae, hasNumReferrers(filename, ROUTE_MAP, "ipnosr", 4));
-    assertThat(ccae, hasNumReferrers(filename, NAT_POOL, "p1", 4));
+    assertThat(ccae, hasNumReferrers(filename, NAT_POOL, "p1", 12));
+    assertThat(ccae, hasNumReferrers(filename, IPV4_ACCESS_LIST_STANDARD, "10", 6));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoIosDynamicNatTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoIosDynamicNatTest.java
@@ -41,6 +41,18 @@ public class CiscoIosDynamicNatTest {
       diffPool.setNatPool("diffpool");
       et.addEqualityGroup(diffPool);
     }
+    {
+      CiscoIosDynamicNat ifaceNat = baseNat();
+      ifaceNat.setNatPool(null);
+      ifaceNat.setInterface("iface");
+      et.addEqualityGroup(ifaceNat);
+    }
+    {
+      CiscoIosDynamicNat diffIface = baseNat();
+      diffIface.setNatPool(null);
+      diffIface.setInterface("diffIface");
+      et.addEqualityGroup(diffIface);
+    }
     et.testEquals();
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-nat-dynamic
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-nat-dynamic
@@ -5,6 +5,7 @@ hostname ios-nat-dynamic
 access-list 10 permit host 10.10.10.10
 access-list 11 permit host 11.11.11.11
 access-list 12 permit host 12.12.12.12
+access-list 13 permit host 13.13.13.13
 access-list 22 permit host 22.22.22.22
 access-list 23 permit host 23.23.23.23
 !
@@ -24,6 +25,9 @@ interface Ethernet4
  ip vrf forwarding vrf1
  ip nat outside
 !
+! For use in "ip nat inside source list 13 interface" rule
+interface Ethernet10
+ ip address 1.1.1.1 255.255.255.0
 
 ip nat pool in-src-nat-pool 3.3.3.1 3.3.3.254 prefix-length 24
 ip nat pool in-dst-nat-pool 3.3.4.1 3.3.4.254 prefix-length 24
@@ -32,6 +36,7 @@ ip nat pool vrf-in-src-nat-pool 5.5.5.1 5.5.5.254 prefix-length 24
 ip nat pool vrf-out-src-nat-pool 6.6.6.1 6.6.6.254 prefix-length 24
 
 ip nat inside source list 10 pool in-src-nat-pool
+ip nat inside source list 13 interface Ethernet10
 ip nat inside destination list 11 pool in-dst-nat-pool
 ip nat outside source list 22 pool out-src-nat-pool
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-nat-parsed-variants
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-nat-parsed-variants
@@ -53,6 +53,11 @@ ip nat inside source route-map ipnisr interface GigabitEthernet0/0 vrf v1
 ip nat inside source route-map ipnisr interface GigabitEthernet0/0 vrf v1 overload
 ip nat inside source route-map ipnisr interface GigabitEthernet0/0 overload
 !
+ip nat inside source route-map ipnisr pool p1
+ip nat inside source route-map ipnisr pool p1 vrf v1
+ip nat inside source route-map ipnisr pool p1 vrf v1 overload
+ip nat inside source route-map ipnisr pool p1 overload
+!
 ! outside source route-map
 !
 route-map ipnosr permit 10
@@ -67,10 +72,15 @@ ip nat outside source route-map ipnosr pool p1 add-route
 !
 ! inside list
 !
-ip nat inside source list acl1 pool p1
-ip nat inside source list acl1 pool p1 overload
+access-list 10 permit any
+!
+ip nat inside source list 10 pool p1
+ip nat inside source list 10 pool p1 overload
+!
+ip nat inside source list 10 interface GigabitEthernet0/0
+ip nat inside source list 10 interface GigabitEthernet0/0 overload
 !
 ! outside list
 !
-ip nat outside source list acl1 pool p1
-ip nat outside source list acl1 pool p1 add-route
+ip nat outside source list 10 pool p1
+ip nat outside source list 10 pool p1 add-route


### PR DESCRIPTION
We support dynamic NAT rules of this form:
`ip nat inside source list 1 pool pool1`

But it is possible to use an interface in place of a pool. This causes the interface's address to be the sole member of the pool (IOS console automatically adds `overload` to this line to allow for more than one NAT entry):
`ip nat inside source list 1 interface Ethernet1/1`

Still to do: This PR does not support NAT rules of the above form where the interface is inactive or has no address; such rules will be ignored. However, on real IOS devices, these rules still match traffic, and matched traffic is dropped.

After #6524 and #6527 (which impacts test).