### PR TITLE
EIGRP: add metric version and plumb throughout

### DIFF
--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -2238,7 +2238,8 @@ public class Client extends AbstractClient implements IClient {
         }
       } catch (JsonProcessingException e) {
         _logger.errorf(
-            "Error deserializing answer %s: %s\n", testOutput, Throwables.getStackTraceAsString(e));
+            "Error deserializing answer %s: %s\n",
+            testOutput.substring(0, 2048), Throwables.getStackTraceAsString(e));
       } catch (Exception e) {
         _logger.errorf(
             "Exception in comparing test results: %s\n", Throwables.getStackTraceAsString(e));

--- a/projects/batfish-client/src/main/java/org/batfish/client/Client.java
+++ b/projects/batfish-client/src/main/java/org/batfish/client/Client.java
@@ -2238,8 +2238,7 @@ public class Client extends AbstractClient implements IClient {
         }
       } catch (JsonProcessingException e) {
         _logger.errorf(
-            "Error deserializing answer %s: %s\n",
-            testOutput.substring(0, 2048), Throwables.getStackTraceAsString(e));
+            "Error deserializing answer %s: %s\n", testOutput, Throwables.getStackTraceAsString(e));
       } catch (Exception e) {
         _logger.errorf(
             "Exception in comparing test results: %s\n", Throwables.getStackTraceAsString(e));

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpExternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpExternalRoute.java
@@ -2,7 +2,6 @@ package org.batfish.datamodel;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.hash;
-import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -11,6 +10,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.eigrp.EigrpMetric;
+import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 
 /** Represents an external EIGRP route */
 public class EigrpExternalRoute extends EigrpRoute {
@@ -28,11 +28,21 @@ public class EigrpExternalRoute extends EigrpRoute {
       long destinationAsn,
       @Nullable Ip nextHopIp,
       @Nonnull EigrpMetric metric,
+      @Nonnull EigrpMetricVersion metricVersion,
       long processAsn,
       long tag,
       boolean nonForwarding,
       boolean nonRouting) {
-    super(admin, network, nextHopIp, metric, processAsn, tag, nonForwarding, nonRouting);
+    super(
+        admin,
+        network,
+        nextHopIp,
+        metric,
+        metricVersion,
+        processAsn,
+        tag,
+        nonForwarding,
+        nonRouting);
     _destinationAsn = destinationAsn;
   }
 
@@ -43,15 +53,26 @@ public class EigrpExternalRoute extends EigrpRoute {
       @Nullable @JsonProperty(PROP_NETWORK) Prefix network,
       @Nullable @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @Nullable @JsonProperty(PROP_EIGRP_METRIC) EigrpMetric metric,
+      @Nullable @JsonProperty(PROP_EIGRP_METRIC_VERSION) EigrpMetricVersion metricVersion,
       @Nullable @JsonProperty(PROP_PROCESS_ASN) Long processAsn,
       @Nullable @JsonProperty(PROP_TAG) Long tag) {
     checkArgument(admin != null, "EIGRP route: missing %s", PROP_ADMINISTRATIVE_COST);
     checkArgument(destinationAsn != null, "EIGRP route: missing %s", PROP_DESTINATION_ASN);
     checkArgument(metric != null, "EIGRP route: missing %s", PROP_EIGRP_METRIC);
+    checkArgument(metricVersion != null, "EIGRP route: missing %s", PROP_EIGRP_METRIC_VERSION);
     checkArgument(processAsn != null, "EIGRP route: missing %s", PROP_PROCESS_ASN);
     checkArgument(tag != null, "EIGRP route: missing %s", PROP_TAG);
     return new EigrpExternalRoute(
-        network, admin, destinationAsn, nextHopIp, metric, processAsn, tag, false, false);
+        network,
+        admin,
+        destinationAsn,
+        nextHopIp,
+        metric,
+        metricVersion,
+        processAsn,
+        tag,
+        false,
+        false);
   }
 
   @JsonProperty(PROP_DESTINATION_ASN)
@@ -79,13 +100,16 @@ public class EigrpExternalRoute extends EigrpRoute {
       checkArgument(getNetwork() != null, "EIGRP route: missing %s", PROP_NETWORK);
       checkArgument(_destinationAsn != null, "EIGRP route: missing %s", PROP_DESTINATION_ASN);
       checkArgument(_eigrpMetric != null, "EIGRP route: missing %s", PROP_EIGRP_METRIC);
+      checkArgument(
+          _eigrpMetricVersion != null, "EIGRP route: missing %s", PROP_EIGRP_METRIC_VERSION);
       checkArgument(_processAsn != null, "EIGRP route: missing %s", PROP_PROCESS_ASN);
       return new EigrpExternalRoute(
           getNetwork(),
           getAdmin(),
           _destinationAsn,
           getNextHopIp(),
-          requireNonNull(_eigrpMetric),
+          _eigrpMetric,
+          _eigrpMetricVersion,
           _processAsn,
           getTag(),
           getNonForwarding(),
@@ -115,6 +139,7 @@ public class EigrpExternalRoute extends EigrpRoute {
         // EigrpExternalRoute properties
         .setDestinationAsn(getDestinationAsn())
         .setEigrpMetric(getEigrpMetric())
+        .setEigrpMetricVersion(getEigrpMetricVersion())
         .setProcessAsn(getProcessAsn());
   }
 
@@ -130,6 +155,7 @@ public class EigrpExternalRoute extends EigrpRoute {
     return _admin == rhs._admin
         && Objects.equals(_destinationAsn, rhs._destinationAsn)
         && _metric.equals(rhs._metric)
+        && _metricVersion == rhs._metricVersion
         && _network.equals(rhs._network)
         && _nextHopIp.equals(rhs._nextHopIp)
         && _processAsn == rhs._processAsn
@@ -149,6 +175,7 @@ public class EigrpExternalRoute extends EigrpRoute {
         getNonRouting(),
         _destinationAsn,
         _metric,
+        _metricVersion,
         _processAsn);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpInternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpInternalRoute.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.eigrp.EigrpMetric;
+import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 
 /** Represents an internal EIGRP route */
 public class EigrpInternalRoute extends EigrpRoute {
@@ -19,10 +20,20 @@ public class EigrpInternalRoute extends EigrpRoute {
       @Nullable Prefix network,
       @Nullable Ip nextHopIp,
       @Nonnull EigrpMetric metric,
+      @Nonnull EigrpMetricVersion metricVersion,
       long tag,
       boolean nonForwarding,
       boolean nonRouting) {
-    super(admin, network, nextHopIp, metric, processAsn, tag, nonForwarding, nonRouting);
+    super(
+        admin,
+        network,
+        nextHopIp,
+        metric,
+        metricVersion,
+        processAsn,
+        tag,
+        nonForwarding,
+        nonRouting);
   }
 
   @JsonCreator
@@ -32,12 +43,15 @@ public class EigrpInternalRoute extends EigrpRoute {
       @Nullable @JsonProperty(PROP_NETWORK) Prefix network,
       @Nullable @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @Nullable @JsonProperty(PROP_EIGRP_METRIC) EigrpMetric metric,
+      @Nullable @JsonProperty(PROP_EIGRP_METRIC_VERSION) EigrpMetricVersion metricVersion,
       @Nullable @JsonProperty(PROP_TAG) Long tag) {
-    checkArgument(admin != null, "EIGRP rooute: missing %s", PROP_ADMINISTRATIVE_COST);
+    checkArgument(admin != null, "EIGRP route: missing %s", PROP_ADMINISTRATIVE_COST);
     checkArgument(metric != null, "EIGRP route: missing %s", PROP_EIGRP_METRIC);
+    checkArgument(metricVersion != null, "EIGRP route: missing %s", PROP_EIGRP_METRIC_VERSION);
     checkArgument(processAsn != null, "EIGRP route: missing %s", PROP_PROCESS_ASN);
     checkArgument(tag != null, "EIGRP route: missing %s", PROP_TAG);
-    return new EigrpInternalRoute(admin, processAsn, network, nextHopIp, metric, tag, false, false);
+    return new EigrpInternalRoute(
+        admin, processAsn, network, nextHopIp, metric, metricVersion, tag, false, false);
   }
 
   public static Builder builder() {
@@ -58,6 +72,8 @@ public class EigrpInternalRoute extends EigrpRoute {
     public EigrpInternalRoute build() {
       checkArgument(getNetwork() != null, "EIGRP route: missing %s", PROP_NETWORK);
       checkArgument(_eigrpMetric != null, "EIGRP route: missing %s", PROP_EIGRP_METRIC);
+      checkArgument(
+          _eigrpMetricVersion != null, "EIGRP route: missing %s", PROP_EIGRP_METRIC_VERSION);
       checkArgument(_processAsn != null, "EIGRP route: missing %s", PROP_PROCESS_ASN);
       checkArgument(
           getMetric() == 0, "EIGRP route: cannot set metric directly, use setEigrpMetric instead");
@@ -67,6 +83,7 @@ public class EigrpInternalRoute extends EigrpRoute {
           getNetwork(),
           getNextHopIp(),
           _eigrpMetric,
+          _eigrpMetricVersion,
           getTag(),
           getNonForwarding(),
           getNonRouting());
@@ -94,6 +111,7 @@ public class EigrpInternalRoute extends EigrpRoute {
         .setNonRouting(getNonRouting())
         // EigrpInternalRoute properties
         .setEigrpMetric(getEigrpMetric())
+        .setEigrpMetricVersion(getEigrpMetricVersion())
         .setProcessAsn(getProcessAsn());
   }
 
@@ -113,6 +131,7 @@ public class EigrpInternalRoute extends EigrpRoute {
         && _tag == rhs._tag
         && _processAsn == rhs._processAsn
         && _metric.equals(rhs._metric)
+        && _metricVersion == rhs._metricVersion
         && getNonForwarding() == rhs.getNonForwarding()
         && getNonRouting() == rhs.getNonRouting();
   }
@@ -126,6 +145,7 @@ public class EigrpInternalRoute extends EigrpRoute {
         _tag,
         _processAsn,
         _metric,
+        _metricVersion,
         getNonForwarding(),
         getNonRouting());
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpMetric.java
@@ -13,14 +13,14 @@ import java.io.Serializable;
 })
 public interface EigrpMetric extends Serializable {
 
-  /** Return metric as a single value, used for route preference tie breaking. */
-  UnsignedLong cost();
+  /** Return the metric as a single value, used for route preference tie breaking. */
+  UnsignedLong cost(EigrpMetricVersion version);
 
   /**
-   * Return metric as a single value, scaled as needed to fit into a 4-byte value. Used for route
-   * preference tie breaking.
+   * Return metric as a single value, scaled as needed to fit into a 4-byte value. Used as a metric
+   * expected to be seen in the main RIB.
    */
-  long ribMetric();
+  long ribMetric(EigrpMetricVersion version);
 
   /**
    * Check if this metric and {@code other} are compatible, i.e., have the same type and k values

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpMetricVersion.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpMetricVersion.java
@@ -1,0 +1,13 @@
+package org.batfish.datamodel.eigrp;
+
+/**
+ * Identifies how to summarize an {@link EigrpMetric} as a single value.
+ *
+ * <p>Is implementation-dependent. E.g., IOS-XE uses V1 and NX-OS uses V2.
+ */
+public enum EigrpMetricVersion {
+  /** IOS-XE -like. */
+  V1,
+  /** NX-OS -like. Higher precision than IOS-XE. */
+  V2,
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpProcess.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/EigrpProcess.java
@@ -23,6 +23,7 @@ import org.batfish.datamodel.Ip;
 public final class EigrpProcess implements Serializable {
   private static final String PROP_ASN = "asn";
   private static final String PROP_EXPORT_POLICY = "exportPolicy";
+  private static final String PROP_METRIC_VERSION = "metricVersion";
   private static final String PROP_MODE = "eigrpMode";
   private static final String PROP_NEIGHBORS = "neighbors";
   private static final String PROP_ROUTER_ID = "routerId";
@@ -31,6 +32,7 @@ public final class EigrpProcess implements Serializable {
 
   private final long _asn;
   @Nullable private final String _redistributionPolicy;
+  @Nonnull private final EigrpMetricVersion _metricVersion;
   @Nonnull private final EigrpProcessMode _mode;
   @Nonnull private SortedMap<String, EigrpNeighborConfig> _neighbors;
   @Nonnull private final Ip _routerId;
@@ -41,6 +43,7 @@ public final class EigrpProcess implements Serializable {
       long asn,
       @Nullable String exportPolicy,
       EigrpProcessMode mode,
+      EigrpMetricVersion metricVersion,
       Ip routerId,
       Map<String, EigrpNeighborConfig> neighbors,
       int internalAdminCost,
@@ -48,6 +51,7 @@ public final class EigrpProcess implements Serializable {
     _asn = asn;
     _redistributionPolicy = exportPolicy;
     _mode = mode;
+    _metricVersion = metricVersion;
     _neighbors = ImmutableSortedMap.copyOf(neighbors);
     _routerId = routerId;
     _internalAdminCost = internalAdminCost;
@@ -58,12 +62,14 @@ public final class EigrpProcess implements Serializable {
   private static EigrpProcess jsonCreator(
       @Nullable @JsonProperty(PROP_ASN) Long asn,
       @Nullable @JsonProperty(PROP_EXPORT_POLICY) String exportPolicy,
+      @Nullable @JsonProperty(PROP_METRIC_VERSION) EigrpMetricVersion metricVersion,
       @Nullable @JsonProperty(PROP_MODE) EigrpProcessMode mode,
       @Nullable @JsonProperty(PROP_NEIGHBORS) Map<String, EigrpNeighborConfig> neighbors,
       @Nullable @JsonProperty(PROP_ROUTER_ID) Ip routerId,
       @Nullable @JsonProperty(PROP_INTERNAL_ADMIN_COST) Integer internalAdminCost,
       @Nullable @JsonProperty(PROP_EXTERNAL_ADMIN_COST) Integer externalAdminCost) {
     checkArgument(asn != null, "Missing %s", PROP_ASN);
+    checkArgument(metricVersion != null, "Missing %s", PROP_METRIC_VERSION);
     checkArgument(mode != null, "Missing %s", PROP_MODE);
     checkArgument(routerId != null, "Missing %s", PROP_ROUTER_ID);
     checkArgument(internalAdminCost != null, "Missing %s", PROP_INTERNAL_ADMIN_COST);
@@ -72,6 +78,7 @@ public final class EigrpProcess implements Serializable {
         asn,
         exportPolicy,
         mode,
+        metricVersion,
         routerId,
         firstNonNull(neighbors, ImmutableMap.of()),
         internalAdminCost,
@@ -110,6 +117,13 @@ public final class EigrpProcess implements Serializable {
   @JsonProperty(PROP_ROUTER_ID)
   public Ip getRouterId() {
     return _routerId;
+  }
+
+  /** @return The {@link EigrpMetricVersion} used by this process */
+  @Nonnull
+  @JsonProperty(PROP_METRIC_VERSION)
+  public EigrpMetricVersion getMetricVersion() {
+    return _metricVersion;
   }
 
   /** @return The EIGRP mode for this process */
@@ -182,6 +196,7 @@ public final class EigrpProcess implements Serializable {
   public static class Builder {
     @Nullable private Long _asn;
     @Nullable private String _exportPolicy;
+    @Nullable private EigrpMetricVersion _metricVersion;
     @Nullable private EigrpProcessMode _mode;
     @Nullable private Map<String, EigrpNeighborConfig> _neighbors;
     @Nullable private Ip _routerId;
@@ -194,12 +209,14 @@ public final class EigrpProcess implements Serializable {
     @Nonnull
     public EigrpProcess build() {
       checkArgument(_asn != null, "Missing %s", PROP_ASN);
+      checkArgument(_metricVersion != null, "Missing %s", PROP_METRIC_VERSION);
       checkArgument(_mode != null, "Missing %s", PROP_MODE);
       checkArgument(_routerId != null, "Missing %s", PROP_ROUTER_ID);
       return new EigrpProcess(
           _asn,
           _exportPolicy,
           _mode,
+          _metricVersion,
           _routerId,
           firstNonNull(_neighbors, ImmutableMap.of()),
           _internalAdminCost,
@@ -226,6 +243,12 @@ public final class EigrpProcess implements Serializable {
     @Nonnull
     public Builder setRouterId(Ip routerId) {
       _routerId = routerId;
+      return this;
+    }
+
+    @Nonnull
+    public Builder setMetricVersion(EigrpMetricVersion version) {
+      _metricVersion = version;
       return this;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/WideMetric.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/eigrp/WideMetric.java
@@ -100,7 +100,19 @@ public final class WideMetric implements EigrpMetric {
   }
 
   @Override
-  public UnsignedLong cost() {
+  public UnsignedLong cost(EigrpMetricVersion version) {
+    switch (version) {
+      case V1:
+        return costV1();
+      case V2:
+        /* TODO */
+        return costV1();
+      default:
+        throw new IllegalArgumentException("Unsupported version " + version);
+    }
+  }
+
+  private UnsignedLong costV1() {
     checkState(_values.getBandwidth() != null, "Cannot calculate cost before bandwidth is set");
     UnsignedLong scaledBw =
         UnsignedLong.valueOf(BANDWIDTH_FACTOR)
@@ -137,8 +149,8 @@ public final class WideMetric implements EigrpMetric {
   }
 
   @Override
-  public long ribMetric() {
-    return cost().dividedBy(UnsignedLong.valueOf(_ribScale)).longValue();
+  public long ribMetric(EigrpMetricVersion version) {
+    return cost(version).dividedBy(UnsignedLong.valueOf(_ribScale)).longValue();
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EigrpExternalRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EigrpExternalRouteTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertThat;
 
 import org.batfish.datamodel.eigrp.ClassicMetric;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
+import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -15,6 +16,7 @@ public class EigrpExternalRouteTest {
         EigrpExternalRoute.builder()
             .setNetwork(Prefix.parse("1.1.1.0/24"))
             .setMetric(1L)
+            .setEigrpMetricVersion(EigrpMetricVersion.V1)
             .setDestinationAsn(1L)
             .setEigrpMetric(
                 ClassicMetric.builder()

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EigrpInternalRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EigrpInternalRouteTest.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel;
 import static org.junit.Assert.assertThat;
 
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
+import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.batfish.datamodel.eigrp.WideMetric;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -14,6 +15,7 @@ public class EigrpInternalRouteTest {
     EigrpInternalRoute r =
         EigrpInternalRoute.builder()
             .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setEigrpMetricVersion(EigrpMetricVersion.V1)
             .setEigrpMetric(
                 WideMetric.builder()
                     .setValues(EigrpMetricValues.builder().setBandwidth(1E8).setDelay(1D).build())

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EigrpRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/EigrpRouteTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
+import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.batfish.datamodel.eigrp.WideMetric;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,6 +24,7 @@ public class EigrpRouteTest {
                 WideMetric.builder()
                     .setValues(EigrpMetricValues.builder().setBandwidth(1000).setDelay(2).build())
                     .build())
+            .setEigrpMetricVersion(EigrpMetricVersion.V1)
             .setProcessAsn(1L)
             .build();
 
@@ -38,6 +40,7 @@ public class EigrpRouteTest {
                 WideMetric.builder()
                     .setValues(EigrpMetricValues.builder().setBandwidth(1000).setDelay(2).build())
                     .build())
+            .setEigrpMetricVersion(EigrpMetricVersion.V1)
             .setProcessAsn(1L)
             .setDestinationAsn(2L)
             .build();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/BUILD
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/BUILD
@@ -1,0 +1,23 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:private"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob(
+        ["*.java"],
+        exclude = ["Test*.java"],
+    ),
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
+        "@maven//:org_hamcrest_hamcrest",
+        "@maven//:junit_junit",
+        "@maven//:org_apache_commons_commons_lang3",
+    ],
+)

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/EigrpTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/eigrp/EigrpTopologyUtilsTest.java
@@ -68,6 +68,7 @@ public class EigrpTopologyUtilsTest {
             .setAsNumber(1L)
             .setRedistributionPolicy("ep")
             .setMode(EigrpProcessMode.NAMED)
+            .setMetricVersion(EigrpMetricVersion.V1)
             .setRouterId(Ip.parse("1.1.1.1"))
             .setRedistributionPolicy("policy")
             .build());
@@ -130,6 +131,7 @@ public class EigrpTopologyUtilsTest {
     vrf.addEigrpProcess(
         EigrpProcess.builder()
             .setAsNumber(1L)
+            .setMetricVersion(EigrpMetricVersion.V1)
             .setMode(EigrpProcessMode.NAMED)
             .setRouterId(Ip.parse("1.1.1.1"))
             .build());
@@ -158,6 +160,7 @@ public class EigrpTopologyUtilsTest {
         EigrpProcess.builder()
             .setAsNumber(1L)
             .setMode(EigrpProcessMode.NAMED)
+            .setMetricVersion(EigrpMetricVersion.V1)
             .setRouterId(Ip.parse("1.1.1.4"))
             .build());
     return ImmutableMap.of(conf1.getHostname(), conf1, conf2.getHostname(), conf2);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/EigrpMetricMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/EigrpMetricMatchers.java
@@ -5,23 +5,10 @@ import static org.hamcrest.Matchers.equalTo;
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.matchers.EigrpMetricMatchersImpl.HasBandwidth;
-import org.batfish.datamodel.matchers.EigrpMetricMatchersImpl.HasCost;
 import org.batfish.datamodel.matchers.EigrpMetricMatchersImpl.HasDelay;
 import org.hamcrest.Matcher;
 
 public class EigrpMetricMatchers {
-  /** Provides a matcher that matches if the {@link EigrpMetric}'s cost is {@code expectedCost}. */
-  public static @Nonnull Matcher<EigrpMetric> hasCost(long expectedCost) {
-    return new HasCost(equalTo(expectedCost));
-  }
-
-  /**
-   * Provides a matcher that matches if the provided {@code subMatcher} matches the {@link
-   * EigrpMetric}'s cost.
-   */
-  public static @Nonnull Matcher<EigrpMetric> hasCost(@Nonnull Matcher<? super Long> subMatcher) {
-    return new HasCost(subMatcher);
-  }
 
   /**
    * Provides a matcher that matches if the {@link EigrpMetric}'s delay is {@code expectedDelay}.

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/EigrpMetricMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/EigrpMetricMatchersImpl.java
@@ -20,18 +20,6 @@ class EigrpMetricMatchersImpl {
     }
   }
 
-  static final class HasCost extends FeatureMatcher<EigrpMetric, Long> {
-    HasCost(@Nonnull Matcher<? super Long> subMatcher) {
-      super(subMatcher, "An EigrpMetric with composite cost:", "composite cost");
-    }
-
-    @Override
-    @Nonnull
-    protected Long featureValueOf(EigrpMetric actual) {
-      return actual.cost().longValue();
-    }
-  }
-
   static final class HasDelay extends FeatureMatcher<EigrpMetric, Long> {
     HasDelay(@Nonnull Matcher<? super Long> subMatcher) {
       super(subMatcher, "An EigrpMetric with delay:", "delay");

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -536,7 +536,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
   private Optional<EigrpExternalRoute> filterAndTransformExternalRoute(
       EigrpNeighborConfigId neighborConfigId, EigrpExternalRoute route) {
     RoutingPolicy exportPolicy = getOwnExportPolicy(neighborConfigId);
-    EigrpExternalRoute.Builder builder = (EigrpExternalRoute.Builder) route.toBuilder();
+    EigrpExternalRoute.Builder builder = route.toBuilder();
     boolean allowed = exportPolicy.process(route, builder, Direction.OUT);
     return allowed ? Optional.of(builder.build()) : Optional.empty();
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -537,7 +537,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
       EigrpNeighborConfigId neighborConfigId, EigrpExternalRoute route) {
     RoutingPolicy exportPolicy = getOwnExportPolicy(neighborConfigId);
     EigrpExternalRoute.Builder builder = route.toBuilder();
-    boolean allowed = exportPolicy.process(route, builder, Direction.OUT);
+    boolean allowed = exportPolicy.process(route, builder, _process, Direction.OUT);
     return allowed ? Optional.of(builder.build()) : Optional.empty();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -260,6 +260,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
                 .setAdmin(
                     RoutingProtocol.EIGRP.getDefaultAdministrativeCost(c.getConfigurationFormat()))
                 .setEigrpMetric(iface.getEigrp().getMetric())
+                .setEigrpMetricVersion(_process.getMetricVersion())
                 .setNetwork(prefix)
                 .setProcessAsn(_asn)
                 .build();
@@ -322,6 +323,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
         EigrpInternalRoute.builder()
             .setAdmin(_process.getInternalAdminCost())
             .setEigrpMetric(newMetric)
+            .setEigrpMetricVersion(_process.getMetricVersion())
             .setNetwork(route.getNetwork())
             .setNextHopIp(nextHopIp)
             .setProcessAsn(_asn);
@@ -399,6 +401,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
             .setNextHopIp(nextHopIp)
             .setDestinationAsn(route.getDestinationAsn())
             .setEigrpMetric(newMetric)
+            .setEigrpMetricVersion(_process.getMetricVersion())
             .setNetwork(route.getNetwork())
             .setTag(route.getTag());
     return filterRouteOnImport(route, routeBuilder, importPolicy);
@@ -519,7 +522,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
     }
   }
 
-  /** Checks if a given {@link EigrpRoute} is allowed to be sent out from a given neighbor */
+  /** Checks if a given {@link EigrpRoute} is allowed to be sent to from a given neighbor */
   private boolean allowedByExportPolicy(
       EigrpNeighborConfigId neighborConfigId, EigrpRoute eigrpRoute) {
     RoutingPolicy exportPolicy = getOwnExportPolicy(neighborConfigId);
@@ -531,7 +534,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
    * Optional#empty()} if the route should not be sent to the remote neighbor.
    */
   private Optional<EigrpExternalRoute> filterAndTransformExternalRoute(
-      EigrpNeighborConfigId neighborConfigId, EigrpRoute route) {
+      EigrpNeighborConfigId neighborConfigId, EigrpExternalRoute route) {
     RoutingPolicy exportPolicy = getOwnExportPolicy(neighborConfigId);
     EigrpExternalRoute.Builder builder = (EigrpExternalRoute.Builder) route.toBuilder();
     boolean allowed = exportPolicy.process(route, builder, Direction.OUT);
@@ -559,7 +562,8 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
   private EigrpExternalRoute computeEigrpExportRoute(
       RoutingPolicy exportPolicy, AnnotatedRoute<AbstractRoute> potentialExportRoute) {
     AbstractRoute unannotatedPotentialRoute = potentialExportRoute.getRoute();
-    EigrpExternalRoute.Builder outputRouteBuilder = EigrpExternalRoute.builder();
+    EigrpExternalRoute.Builder outputRouteBuilder =
+        EigrpExternalRoute.builder().setEigrpMetricVersion(_process.getMetricVersion());
     // Set the metric to match the route metric by default for EIGRP into EIGRP
     if (unannotatedPotentialRoute instanceof EigrpRoute) {
       outputRouteBuilder.setEigrpMetric(((EigrpRoute) unannotatedPotentialRoute).getEigrpMetric());

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/EigrpRoutingProcess.java
@@ -522,7 +522,7 @@ final class EigrpRoutingProcess implements RoutingProcess<EigrpTopology, EigrpRo
     }
   }
 
-  /** Checks if a given {@link EigrpRoute} is allowed to be sent to from a given neighbor */
+  /** Checks if a given {@link EigrpRoute} is allowed to be sent out to a given neighbor */
   private boolean allowedByExportPolicy(
       EigrpNeighborConfigId neighborConfigId, EigrpRoute eigrpRoute) {
     RoutingPolicy exportPolicy = getOwnExportPolicy(neighborConfigId);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -89,6 +89,7 @@ import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
+import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.batfish.datamodel.isis.IsisLevelSettings;
 import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.routing_policy.Common;
@@ -1101,7 +1102,7 @@ public class CiscoConversions {
         return null;
       }
     }
-    newProcess.setRouterId(routerId);
+    newProcess.setRouterId(routerId).setMetricVersion(EigrpMetricVersion.V1);
 
     /*
      * Route redistribution modifies the configuration structure, so do this last to avoid having to

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -118,6 +118,7 @@ import org.batfish.datamodel.eigrp.ClassicMetric;
 import org.batfish.datamodel.eigrp.EigrpInterfaceSettings;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
+import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.batfish.datamodel.eigrp.EigrpProcess;
 import org.batfish.datamodel.eigrp.EigrpProcessMode;
 import org.batfish.datamodel.isis.IsisMetricType;
@@ -892,7 +893,8 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
                 firstNonNull(
                     vrfConfig.getDistanceExternal(),
                     EigrpProcessConfiguration.DEFAULT_DISTANCE_EXTERNAL))
-            .setRouterId(routerId);
+            .setRouterId(routerId)
+            .setMetricVersion(EigrpMetricVersion.V2);
     proc.setMode(EigrpProcessMode.CLASSIC);
     String redistPolicyName = eigrpRedistributionPolicyName(vrfName, asn);
     if (createEigrpRedistributionPolicy(vrfConfig, redistPolicyName)) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConversions.java
@@ -84,6 +84,7 @@ import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
+import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.batfish.datamodel.isis.IsisLevelSettings;
 import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.routing_policy.Common;
@@ -1413,7 +1414,8 @@ public class CiscoXrConversions {
   static org.batfish.datamodel.eigrp.EigrpProcess toEigrpProcess(
       EigrpProcess proc, String vrfName, Configuration c, CiscoXrConfiguration oldConfig) {
     org.batfish.datamodel.eigrp.EigrpProcess.Builder newProcess =
-        org.batfish.datamodel.eigrp.EigrpProcess.builder();
+        org.batfish.datamodel.eigrp.EigrpProcess.builder()
+            .setMetricVersion(/* TODO: investigate XR metric. */ EigrpMetricVersion.V1);
 
     if (proc.getAsn() == null) {
       oldConfig.getWarnings().redFlag("Invalid EIGRP process");

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/EigrpRoutingProcessTest.java
@@ -17,6 +17,7 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.eigrp.ClassicMetric;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
+import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.batfish.datamodel.eigrp.EigrpProcess;
 import org.batfish.datamodel.eigrp.EigrpProcessMode;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
@@ -46,6 +47,7 @@ public class EigrpRoutingProcessTest {
         EigrpProcess.builder()
             .setAsNumber(1)
             .setMode(EigrpProcessMode.CLASSIC)
+            .setMetricVersion(EigrpMetricVersion.V1)
             .setRouterId(Ip.ZERO)
             .build();
     _routingProcess = new EigrpRoutingProcess(_process, "vrf", RoutingPolicies.from(_c));
@@ -79,6 +81,7 @@ public class EigrpRoutingProcessTest {
             .setNextHopIp(Ip.parse("1.1.1.1"))
             .setDestinationAsn(2L)
             .setEigrpMetric(metric)
+            .setEigrpMetricVersion(EigrpMetricVersion.V1)
             .setTag(3L);
     _internalRouteBuilder =
         EigrpInternalRoute.builder()
@@ -87,6 +90,7 @@ public class EigrpRoutingProcessTest {
             .setProcessAsn(1L)
             .setNextHopIp(Ip.parse("1.1.1.1"))
             .setEigrpMetric(metric)
+            .setEigrpMetricVersion(EigrpMetricVersion.V1)
             .setTag(3L);
   }
 
@@ -139,6 +143,7 @@ public class EigrpRoutingProcessTest {
             .setNextHopIp(ip)
             .setAdmin(_process.getExternalAdminCost())
             .setEigrpMetric(routeIn.getEigrpMetric().add(_ifaceMetric))
+            .setEigrpMetricVersion(EigrpMetricVersion.V1)
             .setProcessAsn(_process.getAsn())
             .setTag(routeIn.getTag())
             .setNetwork(routeIn.getNetwork())

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/VirtualRouterTest.java
@@ -69,6 +69,7 @@ import org.batfish.datamodel.VrfLeakingConfig;
 import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.eigrp.ClassicMetric;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
+import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.batfish.datamodel.eigrp.EigrpTopology;
 import org.batfish.datamodel.eigrp.WideMetric;
 import org.batfish.datamodel.isis.IsisEdge;
@@ -138,6 +139,7 @@ public class VirtualRouterTest {
                 WideMetric.builder()
                     .setValues(EigrpMetricValues.builder().setBandwidth(1E8).setDelay(1D).build())
                     .build())
+            .setEigrpMetricVersion(EigrpMetricVersion.V1)
             .setProcessAsn(2L)
             .build(),
         EigrpInternalRoute.builder()
@@ -146,6 +148,7 @@ public class VirtualRouterTest {
                 ClassicMetric.builder()
                     .setValues(EigrpMetricValues.builder().setBandwidth(1E8).setDelay(1D).build())
                     .build())
+            .setEigrpMetricVersion(EigrpMetricVersion.V1)
             .setProcessAsn(2L)
             .build(),
         GeneratedRoute.builder().setNetwork(Prefix.parse("1.0.4.0/24")).setAdmin(1).build(),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -366,6 +366,7 @@ import org.batfish.datamodel.eigrp.ClassicMetric;
 import org.batfish.datamodel.eigrp.EigrpInterfaceSettings;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
+import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.batfish.datamodel.eigrp.EigrpNeighborConfig;
 import org.batfish.datamodel.eigrp.EigrpProcessMode;
 import org.batfish.datamodel.eigrp.WideMetric;
@@ -1825,7 +1826,8 @@ public final class CiscoGrammarTest {
     RoutingPolicy routingPolicy = c.getRoutingPolicies().get(exportPolicyName);
     assertThat(routingPolicy, notNullValue());
 
-    EigrpExternalRoute.Builder outputRouteBuilder = EigrpExternalRoute.builder();
+    EigrpExternalRoute.Builder outputRouteBuilder =
+        EigrpExternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V1);
     outputRouteBuilder
         .setDestinationAsn(1L)
         .setNetwork(Prefix.parse("1.0.0.0/32"))
@@ -1843,6 +1845,7 @@ public final class CiscoGrammarTest {
         EigrpInternalRoute.builder()
             .setAdmin(90)
             .setEigrpMetric(originalMetric)
+            .setEigrpMetricVersion(EigrpMetricVersion.V1)
             .setNetwork(outputRouteBuilder.getNetwork())
             .setProcessAsn(1L)
             .build();
@@ -1870,7 +1873,8 @@ public final class CiscoGrammarTest {
     RoutingPolicy routingPolicy = c.getRoutingPolicies().get(exportPolicyName);
     assertThat(routingPolicy, notNullValue());
 
-    EigrpExternalRoute.Builder outputRouteBuilder = EigrpExternalRoute.builder();
+    EigrpExternalRoute.Builder outputRouteBuilder =
+        EigrpExternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V1);
     outputRouteBuilder
         .setDestinationAsn(asn)
         .setNetwork(Prefix.parse("1.0.0.0/32"))
@@ -2812,6 +2816,7 @@ public final class CiscoGrammarTest {
             EigrpExternalRoute.builder()
                 .setNetwork(Prefix.parse("172.21.30.0/24"))
                 .setEigrpMetric(metric)
+                .setEigrpMetricVersion(EigrpMetricVersion.V1)
                 .setProcessAsn(2L)
                 .setDestinationAsn(5L)
                 .build(),
@@ -2827,6 +2832,7 @@ public final class CiscoGrammarTest {
             EigrpExternalRoute.builder()
                 .setNetwork(Prefix.parse("172.21.30.0/24"))
                 .setEigrpMetric(metric)
+                .setEigrpMetricVersion(EigrpMetricVersion.V1)
                 .setProcessAsn(1L)
                 .setDestinationAsn(5L)
                 .build(),
@@ -2838,6 +2844,7 @@ public final class CiscoGrammarTest {
             EigrpExternalRoute.builder()
                 .setNetwork(Prefix.parse("172.21.31.0/24"))
                 .setEigrpMetric(metric)
+                .setEigrpMetricVersion(EigrpMetricVersion.V1)
                 .setProcessAsn(1L)
                 .setDestinationAsn(5L)
                 .build(),
@@ -2849,6 +2856,7 @@ public final class CiscoGrammarTest {
             EigrpInternalRoute.builder()
                 .setNetwork(Prefix.parse("172.21.30.0/24"))
                 .setEigrpMetric(metric)
+                .setEigrpMetricVersion(EigrpMetricVersion.V1)
                 .setProcessAsn(1L)
                 .build(),
             EigrpExternalRoute.builder(),
@@ -2860,6 +2868,7 @@ public final class CiscoGrammarTest {
             EigrpExternalRoute.builder()
                 .setNetwork(Prefix.parse("172.21.30.0/24"))
                 .setEigrpMetric(metric)
+                .setEigrpMetricVersion(EigrpMetricVersion.V1)
                 .setProcessAsn(3L)
                 .setDestinationAsn(5L)
                 .build(),
@@ -2943,6 +2952,7 @@ public final class CiscoGrammarTest {
                 ClassicMetric.builder()
                     .setValues(EigrpMetricValues.builder().setBandwidth(2e9).setDelay(4e5).build())
                     .build())
+            .setEigrpMetricVersion(EigrpMetricVersion.V1)
             .setProcessAsn(1L);
     {
       String ifaceName = "GigabitEthernet0/0";
@@ -3063,6 +3073,7 @@ public final class CiscoGrammarTest {
                 ClassicMetric.builder()
                     .setValues(EigrpMetricValues.builder().setBandwidth(2e9).setDelay(4e5).build())
                     .build())
+            .setEigrpMetricVersion(EigrpMetricVersion.V1)
             .setProcessAsn(1L);
     {
       String ifaceName = "GigabitEthernet0/0";
@@ -4062,7 +4073,8 @@ public final class CiscoGrammarTest {
             .setEigrpMetric(
                 ClassicMetric.builder()
                     .setValues(EigrpMetricValues.builder().setDelay(1).setBandwidth(1).build())
-                    .build());
+                    .build())
+            .setEigrpMetricVersion(EigrpMetricVersion.V1);
     EigrpRoute matchEigrp = internalRb.setNetwork(matchRm).build();
     EigrpRoute noMatchEigrp = internalRb.setNetwork(noMatchRm).build();
 
@@ -4136,6 +4148,7 @@ public final class CiscoGrammarTest {
                   ClassicMetric.builder()
                       .setValues(EigrpMetricValues.builder().setDelay(1).setBandwidth(1).build())
                       .build())
+              .setEigrpMetricVersion(EigrpMetricVersion.V1)
               .setNetwork(matchRm)
               .build();
       Bgpv4Route.Builder rb =
@@ -6947,6 +6960,7 @@ public final class CiscoGrammarTest {
                 org.batfish.datamodel.eigrp.EigrpProcess.builder()
                     .setAsNumber(1)
                     .setMode(EigrpProcessMode.CLASSIC)
+                    .setMetricVersion(EigrpMetricVersion.V1)
                     .setRouterId(Ip.ZERO)
                     .build(),
                 Direction.OUT));

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -219,6 +219,7 @@ import org.batfish.datamodel.eigrp.ClassicMetric;
 import org.batfish.datamodel.eigrp.EigrpInterfaceSettings;
 import org.batfish.datamodel.eigrp.EigrpMetric;
 import org.batfish.datamodel.eigrp.EigrpMetricValues;
+import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.batfish.datamodel.eigrp.EigrpProcess;
 import org.batfish.datamodel.eigrp.EigrpProcessMode;
 import org.batfish.datamodel.matchers.HsrpGroupMatchers;
@@ -785,6 +786,7 @@ public final class CiscoNxosGrammarTest {
     EigrpInternalRoute.Builder internalRb =
         EigrpInternalRoute.builder()
             .setProcessAsn(1L)
+            .setEigrpMetricVersion(EigrpMetricVersion.V2)
             .setEigrpMetric(
                 ClassicMetric.builder()
                     .setValues(EigrpMetricValues.builder().setDelay(1).setBandwidth(1).build())
@@ -858,6 +860,7 @@ public final class CiscoNxosGrammarTest {
           EigrpExternalRoute.builder()
               .setProcessAsn(1L)
               .setDestinationAsn(2L)
+              .setEigrpMetricVersion(EigrpMetricVersion.V2)
               .setEigrpMetric(
                   ClassicMetric.builder()
                       .setValues(EigrpMetricValues.builder().setDelay(1).setBandwidth(1).build())
@@ -1481,6 +1484,7 @@ public final class CiscoNxosGrammarTest {
       assertThat(
           p123.getExternalAdminCost(),
           equalTo(EigrpProcessConfiguration.DEFAULT_DISTANCE_EXTERNAL));
+      assertThat(p123.getMetricVersion(), equalTo(EigrpMetricVersion.V2));
     }
     {
       org.batfish.datamodel.Vrf v = c.getVrfs().get(MANAGEMENT_VRF_NAME);
@@ -1493,6 +1497,7 @@ public final class CiscoNxosGrammarTest {
       assertThat(p12345.getRouterId(), equalTo(Ip.parse("98.98.98.98")));
       assertThat(p12345.getInternalAdminCost(), equalTo(20));
       assertThat(p12345.getExternalAdminCost(), equalTo(22));
+      assertThat(p12345.getMetricVersion(), equalTo(EigrpMetricVersion.V2));
     }
   }
 
@@ -1543,12 +1548,14 @@ public final class CiscoNxosGrammarTest {
             .build();
     {
       // Redistribution policy denies static route that doesn't match static_redist route-map
-      EigrpExternalRoute.Builder rb = EigrpExternalRoute.builder();
+      EigrpExternalRoute.Builder rb =
+          EigrpExternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2);
       assertFalse(redistPolicy.process(staticDenied, rb, eigrpProc, Direction.OUT));
     }
     {
       // Redistribution policy permits static route that matches static_redist route-map
-      EigrpExternalRoute.Builder rb = EigrpExternalRoute.builder();
+      EigrpExternalRoute.Builder rb =
+          EigrpExternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2);
       assertTrue(redistPolicy.process(staticPermitted, rb, eigrpProc, Direction.OUT));
       // Policy should set default EIGRP metric. To check route's EIGRP metric, it needs to be
       // built, so first set other required fields.
@@ -1557,12 +1564,14 @@ public final class CiscoNxosGrammarTest {
     }
     {
       // Redistribution policy denies BGP route that doesn't match bgp_redist route-map
-      EigrpExternalRoute.Builder rb = EigrpExternalRoute.builder();
+      EigrpExternalRoute.Builder rb =
+          EigrpExternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2);
       assertFalse(redistPolicy.process(bgpDenied, rb, eigrpProc, Direction.OUT));
     }
     {
       // Redistribution policy permits BGP route that matches bgp_redist route-map
-      EigrpExternalRoute.Builder rb = EigrpExternalRoute.builder();
+      EigrpExternalRoute.Builder rb =
+          EigrpExternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2);
       assertTrue(redistPolicy.process(bgpPermitted, rb, eigrpProc, Direction.OUT));
       // Policy should set default EIGRP metric. To check route's EIGRP metric, it needs to be
       // built, so first set other required fields.
@@ -1573,14 +1582,21 @@ public final class CiscoNxosGrammarTest {
       // Redistribution policy correctly denies/permits connected routes
       assertFalse(
           redistPolicy.process(
-              connectedDenied, EigrpExternalRoute.builder(), eigrpProc, Direction.OUT));
+              connectedDenied,
+              EigrpExternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2),
+              eigrpProc,
+              Direction.OUT));
       assertTrue(
           redistPolicy.process(
-              connectedPermitted, EigrpExternalRoute.builder(), eigrpProc, Direction.OUT));
+              connectedPermitted,
+              EigrpExternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2),
+              eigrpProc,
+              Direction.OUT));
     }
     {
       // Make sure VRF redistribution policy correctly applies default-metric 1 2 3 4 5
-      EigrpExternalRoute.Builder rb = EigrpExternalRoute.builder();
+      EigrpExternalRoute.Builder rb =
+          EigrpExternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2);
       assertTrue(vrfRedistPolicy.process(staticPermitted, rb, vrfEigrpProc, Direction.OUT));
       // Policy should set default EIGRP metric. To check route's EIGRP metric, it needs to be
       // built, so first set other required fields.
@@ -6516,12 +6532,14 @@ public final class CiscoNxosGrammarTest {
               .setAdmin(90)
               .setNetwork(Prefix.ZERO)
               .setEigrpMetric(originalMetric)
+              .setEigrpMetricVersion(EigrpMetricVersion.V2)
               .setProcessAsn(1L)
               .build();
       EigrpExternalRoute.Builder builder =
           EigrpExternalRoute.builder()
               .setAdmin(90)
               .setNetwork(Prefix.ZERO)
+              .setEigrpMetricVersion(EigrpMetricVersion.V2)
               .setDestinationAsn(1L)
               .setProcessAsn(1L)
               .setNetwork(Prefix.ZERO);
@@ -6532,6 +6550,7 @@ public final class CiscoNxosGrammarTest {
               EigrpProcess.builder()
                   .setAsNumber(1L)
                   .setMode(EigrpProcessMode.CLASSIC)
+                  .setMetricVersion(EigrpMetricVersion.V2)
                   .setRouterId(Ip.ZERO)
                   .build(),
               Direction.IN));
@@ -8213,6 +8232,7 @@ public final class CiscoNxosGrammarTest {
     EigrpInternalRoute.Builder builder =
         EigrpInternalRoute.builder()
             .setAdmin(90)
+            .setEigrpMetricVersion(EigrpMetricVersion.V2)
             .setEigrpMetric(
                 ClassicMetric.builder()
                     .setValues(EigrpMetricValues.builder().setBandwidth(2e9).setDelay(4e5).build())
@@ -8231,12 +8251,12 @@ public final class CiscoNxosGrammarTest {
       assertTrue(
           importPolicy.process(
               builder.setNetwork(Prefix.parse("1.1.1.1/26")).build(),
-              EigrpInternalRoute.builder(),
+              EigrpInternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2),
               Direction.IN));
       assertFalse(
           importPolicy.process(
               builder.setNetwork(Prefix.parse("5.5.5.5/31")).build(),
-              EigrpInternalRoute.builder(),
+              EigrpInternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2),
               Direction.IN));
 
       RoutingPolicy exportPolicy = policies.get(exportPolicyName);
@@ -8244,12 +8264,12 @@ public final class CiscoNxosGrammarTest {
       assertTrue(
           exportPolicy.process(
               builder.setNetwork(Prefix.parse("2.2.2.2/26")).build(),
-              EigrpInternalRoute.builder(),
+              EigrpInternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2),
               Direction.OUT));
       assertFalse(
           exportPolicy.process(
               builder.setNetwork(Prefix.parse("5.5.5.5/30")).build(),
-              EigrpInternalRoute.builder(),
+              EigrpInternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2),
               Direction.OUT));
     }
     {
@@ -8265,14 +8285,14 @@ public final class CiscoNxosGrammarTest {
       assertTrue(
           importPolicy.process(
               builder.setNetwork(Prefix.parse("5.5.5.5/31")).build(),
-              EigrpInternalRoute.builder(),
+              EigrpInternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2),
               Direction.IN));
 
       RoutingPolicy exportPolicy = policies.get(exportPolicyName);
       assertTrue(
           exportPolicy.process(
               builder.setNetwork(Prefix.parse("5.5.5.5/30")).build(),
-              EigrpInternalRoute.builder(),
+              EigrpInternalRoute.builder().setEigrpMetricVersion(EigrpMetricVersion.V2),
               Direction.OUT));
     }
   }

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -27358,6 +27358,7 @@
                 "exportPolicy" : "~EIGRP_EXPORT_POLICY:default:5~",
                 "externalAdminCost" : 170,
                 "internalAdminCost" : 90,
+                "metricVersion" : "V1",
                 "routerId" : "100.1.1.1"
               }
             }


### PR DESCRIPTION
Different implementations of EIGRP compute the cost with greater and lesser
degrees of precision. Add a setting to each EIGRP process to indicate which
cost implementation it uses, and add the classic metric computations for NX-OS.