### PR TITLE
IOS: fix interpretation of standard access-list when matching routes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -1635,12 +1635,10 @@ public class CiscoConversions {
      */
     IpWildcard srcIpWildcard =
         ((WildcardAddressSpecifier) fromLine.getSrcAddressSpecifier()).getIpWildcard();
-    Prefix prefix = srcIpWildcard.toPrefix();
 
-    return new RouteFilterLine(
-        action,
-        IpWildcard.create(prefix),
-        new SubRange(prefix.getPrefixLength(), Prefix.MAX_PREFIX_LENGTH));
+    // A standard ACL is simply a wildcard on the network address, and does not filter on the
+    // prefix length at all (beyond the prefix length implied by the unmasked bits in wildcard).
+    return new RouteFilterLine(action, srcIpWildcard, new SubRange(0, Prefix.MAX_PREFIX_LENGTH));
   }
 
   /**

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/eigrp-distribute-list-wildcard/configs/receiver
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/eigrp-distribute-list-wildcard/configs/receiver
@@ -1,0 +1,8 @@
+hostname receiver
+!
+interface GigabitEthernet2
+ ip address 3.3.3.4 255.255.255.0
+!
+router eigrp 1
+ network 3.3.3.0 0.0.0.255
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/eigrp-distribute-list-wildcard/configs/sender
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testrigs/eigrp-distribute-list-wildcard/configs/sender
@@ -1,0 +1,35 @@
+hostname sender
+!
+interface GigabitEthernet2
+ ip address 3.3.3.3 255.255.255.0
+!
+router eigrp 1
+ default-metric 200 20 0 0 1500
+ distribute-list DL_OUT out
+ network 3.3.3.0 0.0.0.255
+ redistribute static
+!
+ip access-list standard DL_OUT
+ permit 128.0.64.0 0.255.0.255
+!
+ip route 128.0.0.0 255.255.128.0 Null0
+ip route 128.0.64.0 255.255.192.0 Null0
+ip route 128.0.64.0 255.255.224.0 Null0
+ip route 128.0.64.0 255.255.240.0 Null0
+ip route 128.0.64.0 255.255.248.0 Null0
+ip route 128.0.64.0 255.255.252.0 Null0
+ip route 128.0.64.0 255.255.254.0 Null0
+ip route 128.0.64.0 255.255.255.0 Null0
+ip route 128.0.64.1 255.255.255.255 Null0
+ip route 128.0.64.2 255.255.255.254 Null0
+ip route 128.0.64.4 255.255.255.252 Null0
+ip route 128.0.64.8 255.255.255.248 Null0
+ip route 128.0.64.16 255.255.255.240 Null0
+ip route 128.0.64.32 255.255.255.224 Null0
+ip route 128.0.64.64 255.255.255.192 Null0
+ip route 128.0.64.128 255.255.255.128 Null0
+ip route 128.0.96.0 255.255.224.0 Null0
+ip route 128.0.127.0 255.255.255.0 Null0
+ip route 128.0.128.0 255.255.128.0 Null0
+ip route 128.1.64.0 255.255.255.255 Null0
+!


### PR DESCRIPTION
Rather than being interpreted as a prefix, the ACL wildcard is used as a pure
wildcard against the network address. This means, for example:

    permit 10.0.0.0 0.255.255.255

permits 10.0.0.0/7, since its network address is 10.0.0.0, and permits
10.1.0.0/16, since its network address is 10.1.0.0 and masked to 10.0.0.0, in
addition to simply 10.0.0.0/8.

It also means that non-prefix wildcards are allowed.

Fix #5997 and fix #4683.