### PR TITLE
BDDPacket: enhance and expose sane flow constraint

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/BDDPacket.java
@@ -174,6 +174,11 @@ public class BDDPacket {
     _saneFlow = saneIpFlow();
   }
 
+  public @Nonnull BDD getSaneFlowConstraint() {
+    // Make a copy, just in case the caller does something silly like try to free it.
+    return _saneFlow.id();
+  }
+
   /*
    * Helper function that builds a map from BDD variable index
    * to some more meaningful name. Helpful for debugging.
@@ -475,8 +480,14 @@ public class BDDPacket {
   private BDD saneIpFlow() {
     BDD ipPacketsAreAtLeast20Long = _packetLength.geq(20);
     BDD validIcmp = _ipProtocol.value(IpProtocol.ICMP).impWith(_packetLength.geq(64));
-    BDD validUdp = _ipProtocol.value(IpProtocol.UDP).impWith(_packetLength.geq(28));
-    BDD validTcp = _ipProtocol.value(IpProtocol.TCP).impWith(_packetLength.geq(40));
+    BDD validUdp =
+        _ipProtocol
+            .value(IpProtocol.UDP)
+            .impWith(_packetLength.geq(28).and(_srcPort.geq(1)).and(_dstPort.geq(1)));
+    BDD validTcp =
+        _ipProtocol
+            .value(IpProtocol.TCP)
+            .impWith(_packetLength.geq(40).and(_srcPort.geq(1)).and(_dstPort.geq(1)));
     return BDDOps.andNull(ipPacketsAreAtLeast20Long, validIcmp, validTcp, validUdp);
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDPacketTest.java
@@ -63,6 +63,8 @@ public class BDDPacketTest {
     BDDPacket pkt = new BDDPacket();
     BDDPacketLength length = pkt.getPacketLength();
     BDDIpProtocol protocol = pkt.getIpProtocol();
+    BDDInteger srcPort = pkt.getSrcPort();
+    BDDInteger dstPort = pkt.getDstPort();
     assertThat(pkt.getFlow(length.value(19)), equalTo(Optional.empty()));
     assertThat(
         pkt.getFlow(length.value(27).and(protocol.value(IpProtocol.UDP))),
@@ -72,6 +74,18 @@ public class BDDPacketTest {
         equalTo(Optional.empty()));
     assertThat(
         pkt.getFlow(length.value(63).and(protocol.value(IpProtocol.ICMP))),
+        equalTo(Optional.empty()));
+    assertThat(
+        pkt.getFlow(srcPort.value(0).and(protocol.value(IpProtocol.TCP))),
+        equalTo(Optional.empty()));
+    assertThat(
+        pkt.getFlow(dstPort.value(0).and(protocol.value(IpProtocol.TCP))),
+        equalTo(Optional.empty()));
+    assertThat(
+        pkt.getFlow(srcPort.value(0).and(protocol.value(IpProtocol.UDP))),
+        equalTo(Optional.empty()));
+    assertThat(
+        pkt.getFlow(dstPort.value(0).and(protocol.value(IpProtocol.UDP))),
         equalTo(Optional.empty()));
   }
 


### PR DESCRIPTION
* TCP/UDP port 0 are actually invalid, should not be used for picking representative flows
* Expose the constraint so it can be used in other places than just picking flows