### PR TITLE
Trace: add missing equals test

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Trace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Trace.java
@@ -76,7 +76,6 @@ public final class Trace {
    *   <li>All hops but the last must end with {@link ExitOutputIfaceStep}. (The last may).
    * </ul>
    */
-  @Nonnull
   @VisibleForTesting
   static boolean validateHops(@Nonnull List<Hop> hops) {
     for (int i = 0; i < hops.size(); ++i) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/TraceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/TraceTest.java
@@ -1,9 +1,12 @@
 package org.batfish.datamodel.flow;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.EnterInputIfaceStep.EnterInputIfaceStepDetail;
 import org.batfish.datamodel.flow.ExitOutputIfaceStep.ExitOutputIfaceStepDetail;
+import org.batfish.datamodel.flow.InboundStep.InboundStepDetail;
 import org.batfish.datamodel.pojo.Node;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,6 +40,18 @@ public class TraceTest {
                           .setOutputInterface(NodeInterfacePair.of("Exit", "out"))
                           .build())
                   .build()));
+  private Hop _acceptedHop =
+      new Hop(
+          new Node("Enter"),
+          ImmutableList.of(
+              EnterInputIfaceStep.builder()
+                  .setAction(StepAction.RECEIVED)
+                  .setDetail(
+                      EnterInputIfaceStepDetail.builder()
+                          .setInputInterface(NodeInterfacePair.of("Enter", "in"))
+                          .build())
+                  .build(),
+              InboundStep.builder().setDetail(new InboundStepDetail("Loopback0")).build()));
 
   @Test
   public void validateHopBeginsWithEnterInputInterface() {
@@ -57,5 +72,19 @@ public class TraceTest {
     Trace.validateHops(ImmutableList.of(_hopWithOnlyEnter));
     Trace.validateHops(ImmutableList.of(_hopWithOnlyExit));
     Trace.validateHops(ImmutableList.of(_hopWithOnlyExit, _hopWithOnlyEnter));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(5L)
+        .addEqualityGroup(new Trace(FlowDisposition.ACCEPTED, ImmutableList.of(_acceptedHop)))
+        .addEqualityGroup(
+            new Trace(FlowDisposition.ACCEPTED, ImmutableList.of(_hopWithOnlyExit, _acceptedHop)))
+        .addEqualityGroup(
+            new Trace(FlowDisposition.DELIVERED_TO_SUBNET, ImmutableList.of(_hopWithOnlyExit)))
+        .addEqualityGroup(
+            new Trace(FlowDisposition.EXITS_NETWORK, ImmutableList.of(_hopWithOnlyExit)))
+        .testEquals();
   }
 }


### PR DESCRIPTION
Coverage on master is flaky since this is not covered by unit tests.