### PR TITLE
dependency-check: lower CVSS for failure to 4

### DIFF
--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -437,7 +437,7 @@
           <version>${dependency-check-plugin.version}</version>
           <configuration>
             <skip>true</skip>
-            <failBuildOnCVSS>8</failBuildOnCVSS>
+            <failBuildOnCVSS>4</failBuildOnCVSS>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
I grabbed the value of 8 from some example, but since medium issues start
at 4, that's a better default.

https://nvd.nist.gov/vuln-metrics/cvss