### PR TITLE
BDP: implement BGP route VRF leaking

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -477,11 +477,11 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     // newer redistribution model:
     if (_process.getRedistributionPolicy() != null) {
       // Place redistributed routes into our local RIB
-      String policyName = _process.getRedistributionPolicy();
-      assert policyName != null;
-      Optional<RoutingPolicy> policy = _policies.get(policyName);
+      Optional<RoutingPolicy> policy = _policies.get(_process.getRedistributionPolicy());
       if (!policy.isPresent()) {
-        LOGGER.debug("Undefined BGP redistribution policy {}. Skipping redistribution", policyName);
+        LOGGER.debug(
+            "Undefined BGP redistribution policy {}. Skipping redistribution",
+            _process.getRedistributionPolicy());
         return;
       }
       mainRibDelta

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -7,12 +7,12 @@ import static org.batfish.common.util.CollectionUtil.toImmutableSortedMap;
 import static org.batfish.common.util.CollectionUtil.toOrderedHashCode;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
 import static org.batfish.datamodel.routing_policy.Environment.Direction.IN;
+import static org.batfish.datamodel.routing_policy.Environment.Direction.OUT;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.transformBgpRouteOnImport;
 import static org.batfish.dataplane.rib.RibDelta.importDeltaToBuilder;
 import static org.batfish.dataplane.rib.RibDelta.importRibDelta;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -43,6 +43,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.AbstractRoute;
+import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.BgpAdvertisement;
 import org.batfish.datamodel.BgpAdvertisement.BgpAdvertisementType;
@@ -75,6 +76,7 @@ import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.dataplane.rib.RibGroup;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
+import org.batfish.datamodel.route.nh.NextHopVrf;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.vxlan.Layer2Vni;
@@ -125,24 +127,30 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
 
   // RIBs and RIB delta builders
   /** Helper RIB containing all paths obtained with external BGP, for IPv4 unicast */
-  @Nonnull Bgpv4Rib _ebgpv4Rib;
+  @Nonnull final Bgpv4Rib _ebgpv4Rib;
   /** RIB containing paths obtained with iBGP, for IPv4 unicast */
-  @Nonnull Bgpv4Rib _ibgpv4Rib;
+  @Nonnull final Bgpv4Rib _ibgpv4Rib;
+  /** RIB containing locally originated BGP routes */
+  @Nonnull final Bgpv4Rib _localBgpv4Rib;
 
   // outgoing RIB deltas for the current round (i.e., deltas generated in the previous round)
   @Nonnull private RibDelta<Bgpv4Route> _ebgpv4DeltaPrev = RibDelta.empty();
   @Nonnull private RibDelta<Bgpv4Route> _bgpv4DeltaPrev = RibDelta.empty();
+  // currently used for VRF-leaking only.
+  @Nonnull private RibDelta<Bgpv4Route> _localDeltaPrev = RibDelta.empty();
 
-  /**
-   * Helper RIB containing paths obtained with iBGP during current iteration. An Adj-RIB-in of sorts
-   * for IPv4 unicast
-   */
   /** Combined BGP (both iBGP and eBGP) RIB, for IPv4 unicast */
   @Nonnull Bgpv4Rib _bgpv4Rib;
   /** Builder for constructing {@link RibDelta} which represent changes to {@link #_bgpv4Rib} */
-  @Nonnull private Builder<Bgpv4Route> _bgpv4DeltaBuilder;
+  @Nonnull private Builder<Bgpv4Route> _bgpv4DeltaBuilder = RibDelta.builder();
   /** {@link RibDelta} representing changes to {@link #_ebgpv4Rib} in the current iteration */
-  @Nonnull private RibDelta<Bgpv4Route> _ebgpv4DeltaCurrent;
+  @Nonnull private Builder<Bgpv4Route> _ebgpv4DeltaBuilder = RibDelta.builder();
+  /**
+   * Keep track of redistributed routes that we have merged into our local RIB).
+   *
+   * <p>Currently used for VRF leaking only.
+   */
+  @Nonnull private RibDelta.Builder<Bgpv4Route> _localDeltaBuilder = RibDelta.builder();
 
   /** eBGP RIB for EVPN type 3 routes */
   @Nonnull private EvpnRib<EvpnType3Route> _ebgpType3EvpnRib;
@@ -248,7 +256,9 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
             multiPathMatchMode,
             true,
             clusterListAsIgpCost);
-    _bgpv4DeltaBuilder = RibDelta.builder();
+    _localBgpv4Rib =
+        new Bgpv4Rib(
+            _mainRib, bestPathTieBreaker, 1, multiPathMatchMode, true, clusterListAsIgpCost);
 
     _toRedistribute = new HashMap<>(1);
 
@@ -460,8 +470,69 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   /** Redistribute routes from {@code srcVrfName} into our VRF. */
   public void redistribute(
       RibDelta<? extends AnnotatedRoute<AbstractRoute>> mainRibDelta, String srcVrfName) {
+    // Legacy redistribution model.
     assert _toRedistribute.values().stream().allMatch(RibDelta::isEmpty);
     _toRedistribute.put(srcVrfName, mainRibDelta);
+
+    // newer redistribution model:
+    if (_process.getRedistributionPolicy() != null) {
+      // Place redistributed routes into our local RIB
+      mainRibDelta
+          .getActions()
+          .map(this::redistributeRouteToLocalRib)
+          .forEach(_localDeltaBuilder::from);
+      LOGGER.debug(
+          "Redistributed into local BGP RIB node {}, VRF {}: {}",
+          _hostname,
+          _vrfName,
+          _localDeltaBuilder.build());
+    }
+  }
+
+  /**
+   * Convert a main RIB route to a BGP route and run it through the redistribution policy, if it
+   * exists
+   */
+  private RibDelta<Bgpv4Route> redistributeRouteToLocalRib(
+      RouteAdvertisement<? extends AnnotatedRoute<AbstractRoute>> route) {
+    String policyName = _process.getRedistributionPolicy();
+    assert policyName != null;
+    Optional<RoutingPolicy> policy = _policies.get(policyName);
+    if (!policy.isPresent()) {
+      LOGGER.debug("Undefined BGP redistribution policy {}. Skipping redistribution", policyName);
+      return RibDelta.empty();
+    }
+    return redistributeRouteToLocalRib(route, policy.get());
+  }
+
+  /** Convert a main RIB route to a BGP route and run them through the provided policy */
+  private RibDelta<Bgpv4Route> redistributeRouteToLocalRib(
+      RouteAdvertisement<? extends AnnotatedRoute<AbstractRoute>> routeAdv, RoutingPolicy policy) {
+    AbstractRouteDecorator route = routeAdv.getRoute();
+    if (route.getAbstractRoute() instanceof BgpRoute<?, ?>) {
+      // Do not place BGP routes back into BGP process.
+      return RibDelta.empty();
+    }
+    Bgpv4Route.Builder bgpBuilder =
+        BgpProtocolHelper.convertNonBgpRouteToBgpRoute(
+                route,
+                getRouterId(),
+                route.getAbstractRoute().getNextHopIp(),
+                _process.getAdminCost(RoutingProtocol.BGP),
+                RoutingProtocol.BGP)
+            // Prevent from funneling to main RIB
+            .setNonRouting(true);
+    // Hopefully, the direction should not matter here.
+    boolean accept = policy.process(route, bgpBuilder, OUT);
+    if (!accept) {
+      return RibDelta.empty();
+    }
+    Bgpv4Route builtBgpRoute = bgpBuilder.build();
+    if (routeAdv.isWithdrawn()) {
+      return _localBgpv4Rib.removeRouteGetDelta(builtBgpRoute);
+    } else {
+      return _localBgpv4Rib.mergeRouteGetDelta(builtBgpRoute);
+    }
   }
 
   @Override
@@ -475,8 +546,10 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
         || !_ebgpv4DeltaPrev.isEmpty()
         || !_bgpv4DeltaPrev.isEmpty()
         || _toRedistribute.values().stream().anyMatch(d -> !d.isEmpty())
+        || !_localDeltaPrev.isEmpty()
         // Delta builders
         || !_bgpv4DeltaBuilder.isEmpty()
+        || !_localDeltaBuilder.isEmpty()
         || !_evpnDeltaBuilder.isEmpty()
         // Initialization state
         || !_evpnInitializationDelta.isEmpty();
@@ -610,15 +683,16 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
 
   /** Merge ribs, in a specific order, into real ribs */
   private void unstage(Map<Bgpv4Rib, Builder<Bgpv4Route>> ribDeltaBuilders) {
-    _ebgpv4DeltaCurrent = ribDeltaBuilders.get(_ebgpv4Rib).build();
+    RibDelta<Bgpv4Route> ebgpDeltaCurrent = ribDeltaBuilders.get(_ebgpv4Rib).build();
+    _ebgpv4DeltaBuilder.from(ebgpDeltaCurrent);
     RibDelta<Bgpv4Route> ibgpDelta = ribDeltaBuilders.get(_ibgpv4Rib).build();
 
     // Note: keep ebgp before ibgp, as ebgp routes are often preferred, so less thrash
-    _bgpv4DeltaBuilder.from(importRibDelta(_bgpv4Rib, _ebgpv4DeltaCurrent));
+    _bgpv4DeltaBuilder.from(importRibDelta(_bgpv4Rib, ebgpDeltaCurrent));
     _bgpv4DeltaBuilder.from(importRibDelta(_bgpv4Rib, ibgpDelta));
     // Finally, prepare the delta we will feed into the main RIB
     RibDelta<Bgpv4Route> bgpv4RibDelta = _bgpv4DeltaBuilder.build();
-    LOGGER.debug("Got v4 routes: {}", bgpv4RibDelta);
+    LOGGER.trace("Unstaged BGP routes, current bgpv4Delta: {}", bgpv4RibDelta);
     _toMainRib.from(bgpv4RibDelta);
   }
 
@@ -659,7 +733,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
       RouteAdvertisement<Bgpv4Route> remoteRouteAdvert = exportedRoutes.next();
       Bgpv4Route remoteRoute = remoteRouteAdvert.getRoute();
 
-      LOGGER.debug("{} Processing bgpv4 route {}", _hostname, remoteRoute);
+      //      LOGGER.debug("{} Processing bgpv4 route {}", _hostname, remoteRoute);
 
       Bgpv4Route.Builder transformedIncomingRouteBuilder =
           transformBgpRouteOnImport(
@@ -888,14 +962,6 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
 
     RibDelta<AnnotatedRoute<Bgpv4Route>> bgpRoutesToExport = bgpRibExports.build();
 
-    LOGGER.debug("{} exporting routes BEFORE export policy: {}", _hostname, bgpRoutesToExport);
-    if (LOGGER.isDebugEnabled()) {
-      ImmutableList<RouteAdvertisement<Bgpv4Route>> routeAdvertisements =
-          neighborGeneratedRoutes.collect(ImmutableList.toImmutableList());
-      LOGGER.debug("{} exporting routes AFTER routing policy: {}", _hostname, routeAdvertisements);
-      neighborGeneratedRoutes = routeAdvertisements.stream();
-    }
-
     // Compute a set of advertisements that can be queued on remote VR
     Stream<RouteAdvertisement<Bgpv4Route>> advertisementStream =
         Stream.concat(
@@ -929,13 +995,6 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
                 .filter(Objects::nonNull)
                 .distinct(),
             mainRibExports);
-
-    if (LOGGER.isDebugEnabled()) {
-      ImmutableList<RouteAdvertisement<Bgpv4Route>> routeAdvertisements =
-          advertisementStream.collect(ImmutableList.toImmutableList());
-      LOGGER.debug("{} exporting routes AFTER routing policy: {}", _hostname, routeAdvertisements);
-      advertisementStream = routeAdvertisements.stream();
-    }
 
     return Stream.concat(advertisementStream, neighborGeneratedRoutes);
   }
@@ -1615,10 +1674,63 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
         .collect(toOrderedHashCode());
   }
 
+  public void importCrossVrfV4Routes(
+      Stream<RouteAdvertisement<Bgpv4Route>> routesToLeak,
+      @Nullable String importPolicyName,
+      String importFromVrf) {
+    // Keep track of changes to the RIBs using delta builders, keyed by RIB type
+    Map<Bgpv4Rib, RibDelta.Builder<Bgpv4Route>> ribDeltaBuilders = new IdentityHashMap<>();
+    ribDeltaBuilders.put(_ebgpv4Rib, RibDelta.builder());
+    ribDeltaBuilders.put(_ibgpv4Rib, RibDelta.builder());
+    routesToLeak.forEach(
+        ra -> {
+          Bgpv4Route route = ra.getRoute();
+          LOGGER.trace("Node {}, VRF {}, Leaking bgpv4 route {}", _hostname, _vrfName, route);
+
+          /*
+           Once the route is leaked to a new VRF it can become routing again (it could have been
+           non-routing after redistribution). Also, update the next hop to be next-vrf
+          */
+          Bgpv4Route.Builder builder =
+              route.toBuilder().setNonRouting(false).setNextHop(NextHopVrf.of(importFromVrf));
+
+          // Process route through import policy, if one exists
+          boolean accept = true;
+          if (importPolicyName != null) {
+            accept =
+                _policies.getOrThrow(importPolicyName).processBgpRoute(route, builder, null, IN);
+          }
+          if (accept) {
+            Bgpv4Rib targetRib =
+                getRib(
+                    Bgpv4Route.class,
+                    route.getProtocol() == RoutingProtocol.IBGP ? RibType.IBGP : RibType.EBGP);
+            if (ra.isWithdrawn()) {
+              ribDeltaBuilders.get(targetRib).remove(builder.build(), Reason.WITHDRAW);
+            } else {
+              RibDelta<Bgpv4Route> d = targetRib.mergeRouteGetDelta(builder.build());
+              LOGGER.debug("Node {}, VRF {}, route {} leaked", _hostname, _vrfName, d);
+              ribDeltaBuilders.get(targetRib).from(d);
+            }
+          } else {
+            LOGGER.trace(
+                "Node {}, VRF {}, route {} not leaked because policy denied",
+                _hostname,
+                _vrfName,
+                route);
+          }
+        });
+    unstage(ribDeltaBuilders);
+  }
+
   public void endOfRound() {
     _bgpv4DeltaPrev = _bgpv4DeltaBuilder.build();
     _bgpv4DeltaBuilder = RibDelta.builder();
-    _ebgpv4DeltaPrev = _ebgpv4DeltaCurrent;
+    _ebgpv4DeltaPrev = _ebgpv4DeltaBuilder.build();
+    _ebgpv4DeltaBuilder = RibDelta.builder();
+    _localDeltaPrev = _localDeltaBuilder.build();
+    _localDeltaBuilder = RibDelta.builder();
+    // Legacy redistribution map
     _toRedistribute = new HashMap<>();
   }
 
@@ -1691,7 +1803,18 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     _bgpv4DeltaBuilder.from(_bgpAggDeps.deleteRoute(route, _bgpv4Rib));
   }
 
-  /** Return a set of all bgpv4 routes */
+  /**
+   * Return a stream of route advertisements we can leak to other VRFs. This includes
+   * locally-generated and received routes.
+   */
+  Stream<RouteAdvertisement<Bgpv4Route>> getRoutesToLeak() {
+    // TODO: in the fullness of time this is what getV4Routes should return.
+    return Stream.concat(_localDeltaPrev.getActions(), _bgpv4DeltaPrev.getActions());
+  }
+
+  /**
+   * Return a set of all bgpv4 routes. Excludes locally-generated (redistributed) routes for now.
+   */
   public Set<Bgpv4Route> getV4Routes() {
     return _bgpv4Rib.getTypedRoutes();
   }
@@ -1699,6 +1822,17 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   /** Return a set of all bgpv4 bestpath routes */
   public Set<Bgpv4Route> getBestPathRoutes() {
     return _bgpv4Rib.getBestPathRoutes();
+  }
+
+  @VisibleForTesting
+  Set<Bgpv4Route> getV4LocalRoutes() {
+    return _localBgpv4Rib.getTypedRoutes();
+  }
+
+  @Nonnull
+  @VisibleForTesting
+  Builder<Bgpv4Route> getBgpv4DeltaBuilder() {
+    return _bgpv4DeltaBuilder;
   }
 
   /** Container for eBGP+iBGP RIB deltas */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1284,13 +1284,13 @@ public final class VirtualRouter {
    */
   void queueCrossVrfImports() {
     for (VrfLeakingConfig leakConfig : _vrf.getVrfLeakConfigs()) {
-      String importFromVrf = leakConfig.getImportFromVrf();
-      VirtualRouter exportingVR = _node.getVirtualRouterOrThrow(importFromVrf);
-      CrossVrfEdgeId otherVrfToOurRib = new CrossVrfEdgeId(importFromVrf, RibId.DEFAULT_RIB_NAME);
       if (leakConfig.leakAsBgp()) {
         /* handled in bgpIteration() */
         continue;
       }
+      String importFromVrf = leakConfig.getImportFromVrf();
+      VirtualRouter exportingVR = _node.getVirtualRouterOrThrow(importFromVrf);
+      CrossVrfEdgeId otherVrfToOurRib = new CrossVrfEdgeId(importFromVrf, RibId.DEFAULT_RIB_NAME);
       enqueueCrossVrfRoutes(
           otherVrfToOurRib,
           // TODO Will need to update once support is added for cross-VRF export policies

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
@@ -1,5 +1,6 @@
 package org.batfish.dataplane.rib;
 
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -10,8 +11,12 @@ import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.GenericRibReadOnly;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
-import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RoutingProtocol;
+import org.batfish.datamodel.route.nh.NextHopDiscard;
+import org.batfish.datamodel.route.nh.NextHopInterface;
+import org.batfish.datamodel.route.nh.NextHopIp;
+import org.batfish.datamodel.route.nh.NextHopVisitor;
+import org.batfish.datamodel.route.nh.NextHopVrf;
 
 /** BGPv4-specific RIB implementation */
 @ParametersAreNonnullByDefault
@@ -36,18 +41,16 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
   @Nonnull
   @Override
   public RibDelta<Bgpv4Route> mergeRouteGetDelta(Bgpv4Route route) {
-    Ip nextHopIp = route.getNextHopIp();
     /*
       Do not merge routes for which next hop is not reachable.
       However, due to some complications with how we create routes, we must skip this check for:
       - routes with link-local address as next hop (i.e., next-hop interface is set to something)
-      - routes with Ip.AUTO as next hop or protocol AGGREGATE (for locally-generated routes/aggregates)
+      - routes with protocol AGGREGATE (for locally-generated routes/aggregates)
+      - routes that have a next vrf as the next hop
     */
-    if (Route.UNSET_NEXT_HOP_INTERFACE.equals(route.getNextHopInterface())
-        && !nextHopIp.equals(Ip.AUTO)
-        && route.getProtocol() != RoutingProtocol.AGGREGATE
-        && _mainRib != null
-        && _mainRib.longestPrefixMatch(nextHopIp).isEmpty()) {
+    if (shouldCheckNextHopReachability(route)
+        .map(nextHopIp -> _mainRib != null && _mainRib.longestPrefixMatch(nextHopIp).isEmpty())
+        .orElse(false)) {
       /*
       TODO: when backups are enabled again, we should probably put this in as a backup
          and then return empty delta
@@ -56,4 +59,43 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
     }
     return super.mergeRouteGetDelta(route);
   }
+
+  /**
+   * Returns the next hop IP for which to check reachability (i.e., look for route in main RIB), if
+   * applicable. If reachability should not be checked returns {@link Optional#empty}
+   */
+  private static Optional<Ip> shouldCheckNextHopReachability(Bgpv4Route route) {
+    if (route.getProtocol() == RoutingProtocol.AGGREGATE) {
+      return Optional.empty();
+    }
+    return NEXT_HOP_REACHABILITY_VISITOR.visit(route.getNextHop());
+  }
+
+  private static final NextHopVisitor<Optional<Ip>> NEXT_HOP_REACHABILITY_VISITOR =
+      new NextHopVisitor<Optional<Ip>>() {
+
+        @Override
+        public Optional<Ip> visitNextHopIp(NextHopIp nextHopIp) {
+          // Real IP, we should make sure we can reach it.
+          return Optional.of(nextHopIp.getIp());
+        }
+
+        @Override
+        public Optional<Ip> visitNextHopInterface(NextHopInterface nextHopInterface) {
+          // Next hop-interface. Likely BGP unnumbered, nothing to check
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<Ip> visitNextHopDiscard(NextHopDiscard nextHopDiscard) {
+          // Discard route, nothing to check
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<Ip> visitNextHopVrf(NextHopVrf nextHopVrf) {
+          // The next hop is in a different VRF, so nothing to check in current main RIB
+          return Optional.empty();
+        }
+      };
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/RibDelta.java
@@ -236,6 +236,11 @@ public final class RibDelta<R extends AbstractRouteDecorator> {
       }
       return this;
     }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this).add("actions", _actions).toString();
+    }
   }
 
   @Nonnull

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -2,14 +2,21 @@ package org.batfish.dataplane.ibdp;
 
 import static org.batfish.datamodel.BumTransportMethod.UNICAST_FLOOD_GROUP;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasNextHop;
+import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
+import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasProtocol;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpv4RouteThat;
 import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
 import static org.batfish.dataplane.ibdp.BgpRoutingProcess.initEvpnType3Route;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -19,6 +26,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.batfish.datamodel.AnnotatedRoute;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
@@ -29,12 +37,17 @@ import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.EvpnType3Route;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.PrefixRange;
+import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.RoutingProtocol;
+import org.batfish.datamodel.StaticRoute;
+import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.AddressFamily.Type;
 import org.batfish.datamodel.bgp.BgpTopology;
@@ -48,10 +61,19 @@ import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.VniConfig;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
+import org.batfish.datamodel.route.nh.NextHopInterface;
+import org.batfish.datamodel.route.nh.NextHopVrf;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.expr.DestinationNetwork;
+import org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.MatchPrefixSet;
+import org.batfish.datamodel.routing_policy.expr.MatchProtocol;
+import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.dataplane.rib.Rib;
+import org.batfish.dataplane.rib.RibDelta;
+import org.batfish.dataplane.rib.RouteAdvertisement;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -495,5 +517,143 @@ public class BgpRoutingProcessTest {
     assertThat(
         routingProcNode2._evpnType3IncomingRoutes.get(new BgpTopology.EdgeId(peer1Id, peer2Id)),
         not(empty()));
+  }
+
+  /**
+   * Check that redistribution does not affect local RIB if the redistribution policy is not
+   * defined.
+   */
+  @Test
+  public void testRedistributionNoPolicy() {
+    _routingProcess.redistribute(
+        RibDelta.adding(
+            new AnnotatedRoute<>(
+                StaticRoute.testBuilder().setNetwork(Prefix.ZERO).build(), _vrf.getName())));
+    assertThat(_routingProcess.getV4LocalRoutes(), empty());
+  }
+
+  /**
+   * Check that redistribution affects the local RIB if the redistribution policy is defined and
+   * allows the route.
+   */
+  @Test
+  public void testRedistributionWithPolicy() {
+    // Make up a policy
+    RoutingPolicy policy =
+        RoutingPolicy.builder()
+            .setOwner(_c)
+            .setName("redistribute_policy")
+            .addStatement(
+                new If(
+                    new MatchProtocol(RoutingProtocol.CONNECTED),
+                    ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
+                    ImmutableList.of(Statements.ExitReject.toStaticStatement())))
+            .build();
+    _bgpProcess.setRedistributionPolicy(policy.getName());
+    // re-init routing process after modifying configuration.
+    _routingProcess =
+        new BgpRoutingProcess(
+            _bgpProcess, _c, DEFAULT_VRF_NAME, new Rib(), BgpTopology.EMPTY, new PrefixTracer());
+
+    Prefix prefix = Prefix.parse("1.1.1.0/24");
+
+    // Process denied route
+    _routingProcess.redistribute(
+        RibDelta.adding(
+            new AnnotatedRoute<>(
+                StaticRoute.testBuilder().setNetwork(prefix).build(), _vrf.getName())));
+    assertThat(_routingProcess.getV4LocalRoutes(), empty());
+
+    // Fake up end of round before other test
+    _routingProcess.endOfRound();
+
+    // Process allowed route
+    _routingProcess.redistribute(
+        RibDelta.adding(
+            new AnnotatedRoute<>(
+                ConnectedRoute.builder()
+                    .setNetwork(prefix)
+                    .setNextHop(NextHopInterface.of("foo"))
+                    .build(),
+                _vrf.getName())));
+    assertThat(
+        _routingProcess.getV4LocalRoutes(),
+        contains(
+            isBgpv4RouteThat(
+                allOf(
+                    hasNextHop(NextHopDiscard.instance()),
+                    hasPrefix(prefix),
+                    hasProtocol(RoutingProtocol.BGP)))));
+  }
+
+  @Test
+  public void testCrossVrfImport() {
+    // Make up a policy
+    Prefix allowedPrefix = Prefix.parse("1.1.1.0/24");
+    RoutingPolicy policy =
+        RoutingPolicy.builder()
+            .setOwner(_c)
+            .setName("redistribute_policy")
+            .addStatement(
+                new If(
+                    new MatchPrefixSet(
+                        DestinationNetwork.instance(),
+                        new ExplicitPrefixSet(
+                            new PrefixSpace(new PrefixRange(allowedPrefix, new SubRange(24, 32))))),
+                    ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
+                    ImmutableList.of(Statements.ExitReject.toStaticStatement())))
+            .build();
+    _bgpProcess.setRedistributionPolicy(policy.getName());
+    // re-init routing process after modifying configuration.
+    _routingProcess =
+        new BgpRoutingProcess(
+            _bgpProcess, _c, DEFAULT_VRF_NAME, new Rib(), BgpTopology.EMPTY, new PrefixTracer());
+
+    String otherVrf = "otherVrf";
+    // Process denied prefix, specify policy
+    Prefix deniedPrefix = Prefix.parse("2.2.2.0/24");
+    _routingProcess.importCrossVrfV4Routes(
+        Stream.of(
+            RouteAdvertisement.adding(Bgpv4Route.testBuilder().setNetwork(deniedPrefix).build())),
+        policy.getName(),
+        otherVrf);
+    assertThat(
+        _routingProcess
+            .getBgpv4DeltaBuilder()
+            .build()
+            .getRoutesStream()
+            .collect(Collectors.toList()),
+        empty());
+
+    // Process allowed prefix with policy
+    _routingProcess.importCrossVrfV4Routes(
+        Stream.of(
+            RouteAdvertisement.adding(Bgpv4Route.testBuilder().setNetwork(allowedPrefix).build())),
+        policy.getName(),
+        otherVrf);
+    assertThat(
+        _routingProcess
+            .getBgpv4DeltaBuilder()
+            .build()
+            .getRoutesStream()
+            .collect(Collectors.toList()),
+        contains(
+            isBgpv4RouteThat(
+                allOf(hasPrefix(allowedPrefix), hasNextHop(NextHopVrf.of(otherVrf))))));
+
+    // Process denied prefix, but because no policy is specified, allow it
+    _routingProcess.importCrossVrfV4Routes(
+        Stream.of(
+            RouteAdvertisement.adding(Bgpv4Route.testBuilder().setNetwork(deniedPrefix).build())),
+        null, // no policy
+        otherVrf);
+    assertThat(
+        _routingProcess
+            .getBgpv4DeltaBuilder()
+            .build()
+            .getRoutesStream()
+            .collect(Collectors.toList()),
+        hasItem(
+            isBgpv4RouteThat(allOf(hasPrefix(deniedPrefix), hasNextHop(NextHopVrf.of(otherVrf))))));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasNextHop;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasProtocol;
+import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.isNonRouting;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpv4RouteThat;
 import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
 import static org.batfish.dataplane.ibdp.BgpRoutingProcess.initEvpnType3Route;
@@ -583,7 +584,8 @@ public class BgpRoutingProcessTest {
                 allOf(
                     hasNextHop(NextHopDiscard.instance()),
                     hasPrefix(prefix),
-                    hasProtocol(RoutingProtocol.BGP)))));
+                    hasProtocol(RoutingProtocol.BGP),
+                    isNonRouting(true)))));
   }
 
   @Test
@@ -639,7 +641,10 @@ public class BgpRoutingProcessTest {
             .collect(Collectors.toList()),
         contains(
             isBgpv4RouteThat(
-                allOf(hasPrefix(allowedPrefix), hasNextHop(NextHopVrf.of(otherVrf))))));
+                allOf(
+                    hasPrefix(allowedPrefix),
+                    hasNextHop(NextHopVrf.of(otherVrf)),
+                    isNonRouting(false)))));
 
     // Process denied prefix, but because no policy is specified, allow it
     _routingProcess.importCrossVrfV4Routes(
@@ -654,6 +659,10 @@ public class BgpRoutingProcessTest {
             .getRoutesStream()
             .collect(Collectors.toList()),
         hasItem(
-            isBgpv4RouteThat(allOf(hasPrefix(deniedPrefix), hasNextHop(NextHopVrf.of(otherVrf))))));
+            isBgpv4RouteThat(
+                allOf(
+                    hasPrefix(deniedPrefix),
+                    hasNextHop(NextHopVrf.of(otherVrf)),
+                    isNonRouting(false)))));
   }
 }


### PR DESCRIPTION
Implements cisco-style VRF leaking using BGP routes in our dataplane. 
To do so, we
1. Create local BGP ribs and allow BDP to redistribute BGP routes into a local RIB even when BGP neighbors are not defined. (long time coming, this is the "classic" mode of operation for BGP across many vendors w/ exception being juniper). Currently this will only be used for VRF leaking.
2. Use these local RIBs (or more precisely, updates to these ribs from the previous round) as well as regular BGP rib deltas to leak BGP routes into neighboring `BgpRoutingProcess`es (if configured, of course)
3. The leaking process updates next hops of leaked routes to the special `NextHopVrf` next hop to ensure that FIBs are built correctly and packets hop VRFs during forwarding.