### PR TITLE
PAN: fix default BGP export policy

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/Conversions.java
@@ -251,7 +251,10 @@ final class Conversions {
     RoutingPolicy.builder()
         .setOwner(c)
         .setName(policyRulesRpNameForPeer)
-        .setStatements(statementsForExportPolicyRules)
+        .setStatements(
+            !statementsForExportPolicyRules.isEmpty()
+                ? statementsForExportPolicyRules
+                : ImmutableList.of(Statements.ExitAccept.toStaticStatement()))
         .build();
 
     // for a route to be exported by this peer, it has to match the common BGP export policy AND

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1030,6 +1030,18 @@ public final class PaloAltoGrammarTest {
             srb.setNetwork(Prefix.parse("1.1.1.0/24")).build(),
             Bgpv4Route.testBuilder(),
             Direction.IN));
+
+    {
+      // testing export policy generated for peer 2, any BGP route is allowed
+      String exportPolicyName = "~BGP_PEER_EXPORT_POLICY:vr1:peer2~";
+      RoutingPolicy exportRoutingPolicy = c.getRoutingPolicies().get(exportPolicyName);
+
+      assertTrue(
+          exportRoutingPolicy.process(
+              srb.setNetwork(Prefix.parse("1.1.1.0/24")).build(),
+              Bgpv4Route.testBuilder(),
+              Direction.OUT));
+    }
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/bgp-export-import-policies
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/bgp-export-import-policies
@@ -4,6 +4,10 @@ set deviceconfig system hostname bgp-export-import-policies
 set network interface ethernet ethernet1/3 layer3 units ethernet1/3.5 comment "unit 5"
 set network interface ethernet ethernet1/3 layer3 units ethernet1/3.5 ip 1.1.1.3/24
 set network virtual-router vr1 interface ethernet1/3.5
+set network interface ethernet ethernet1/3 layer3 units ethernet1/3.6 comment "unit 6"
+set network interface ethernet ethernet1/3 layer3 units ethernet1/3.6 ip 1.1.6.3/24
+set network virtual-router vr1 interface ethernet1/3.6
+
 
 set network virtual-router vr1 protocol redist-profile rdp1 filter type static
 set network virtual-router vr1 protocol redist-profile rdp1 filter destination [ 1.1.1.0/24 2.2.2.0/24 3.3.3.0/24 ]
@@ -42,3 +46,10 @@ set network virtual-router vr1 protocol bgp peer-group pg1 peer peer1 local-addr
 set network virtual-router vr1 protocol bgp peer-group pg1 peer peer1 peer-address ip 120.120.120.120
 set network virtual-router vr1 protocol bgp peer-group pg1 peer peer1 peer-as 2345
 set network virtual-router vr1 protocol bgp peer-group pg1 peer peer1 enable yes
+
+# PG2 (and peer2) do not use any export/import rules. Any bgp routes will be allowed
+set network virtual-router vr1 protocol bgp peer-group pg2 enable yes
+set network virtual-router vr1 protocol bgp peer-group pg2 peer peer2 local-address interface ethernet1/3.6
+set network virtual-router vr1 protocol bgp peer-group pg2 peer peer2 peer-address ip 6.6.6.6
+set network virtual-router vr1 protocol bgp peer-group pg2 peer peer2 peer-as 2345
+set network virtual-router vr1 protocol bgp peer-group pg2 peer peer2 enable yes


### PR DESCRIPTION
If no export policy rules are defined, default is allow-BGP, not
deny-BGP (which is what previous list of empty statements was doing)