### PR TITLE
PAN: fix up default BGP AF capabilities

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAltoLexer.g4
@@ -468,6 +468,11 @@ ENABLE
     'enable'
 ;
 
+ENABLE_SENDER_SIDE_LOOP_DETECTION
+:
+    'enable-sender-side-loop-detection'
+;
+
 ENCRYPTION
 :
     'encryption'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_bgp.g4
@@ -99,6 +99,7 @@ bgppg_peer
         bgppgp_bfd
         | bgppgp_connection_options
         | bgppgp_enable
+        | bgppgp_enable_sender_side_loop_detection
         | bgppgp_local_address
         | bgppgp_max_prefixes
         | bgppgp_peer_address
@@ -182,6 +183,11 @@ bgppgp_coo_local_port
 bgppgp_enable
 :
     ENABLE yn = yes_or_no
+;
+
+bgppgp_enable_sender_side_loop_detection
+:
+    ENABLE_SENDER_SIDE_LOOP_DETECTION yn = yes_or_no
 ;
 
 bgppgp_local_address

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -122,6 +122,7 @@ import org.batfish.grammar.palo_alto.PaloAltoParser.Bgppgp_coi_remote_portContex
 import org.batfish.grammar.palo_alto.PaloAltoParser.Bgppgp_coo_allowContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Bgppgp_coo_local_portContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Bgppgp_enableContext;
+import org.batfish.grammar.palo_alto.PaloAltoParser.Bgppgp_enable_sender_side_loop_detectionContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Bgppgp_la_interfaceContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Bgppgp_la_ipContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Bgppgp_max_prefixesContext;
@@ -946,6 +947,12 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
   @Override
   public void exitBgppgp_enable(Bgppgp_enableContext ctx) {
     _currentBgpPeer.setEnable(toBoolean(ctx.yn));
+  }
+
+  @Override
+  public void exitBgppgp_enable_sender_side_loop_detection(
+      Bgppgp_enable_sender_side_loop_detectionContext ctx) {
+    _currentBgpPeer.setEnableSenderSideLoopDetection(toBoolean(ctx.yn));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/BgpPeer.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/BgpPeer.java
@@ -36,6 +36,15 @@ public class BgpPeer implements Serializable {
     _enable = enable;
   }
 
+  @Nullable
+  public Boolean getEnableSenderSideLoopDetection() {
+    return _enableSenderSideLoopDetection;
+  }
+
+  public void setEnableSenderSideLoopDetection(boolean enableSenderSideLoopDetection) {
+    _enableSenderSideLoopDetection = enableSenderSideLoopDetection;
+  }
+
   public @Nullable Ip getLocalAddress() {
     return _localAddress;
   }
@@ -93,6 +102,7 @@ public class BgpPeer implements Serializable {
 
   private BgpConnectionOptions _connectionOptions = new BgpConnectionOptions();
   private boolean _enable;
+  private @Nullable Boolean _enableSenderSideLoopDetection;
   private @Nullable Ip _localAddress;
   private @Nullable String _localInterface;
   private final @Nonnull String _name;

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -879,6 +879,7 @@ public final class PaloAltoGrammarTest {
     assertThat(pg.getPeers().keySet(), contains("PEER"));
     BgpPeer peer = pg.getOrCreatePeerGroup("PEER");
     assertThat(peer.getEnable(), equalTo(true));
+    assertThat(peer.getEnableSenderSideLoopDetection(), equalTo(false));
     assertThat(peer.getLocalInterface(), equalTo("ethernet1/1"));
     assertThat(peer.getLocalAddress(), equalTo(Ip.parse("1.2.3.6")));
     assertThat(peer.getPeerAddress(), equalTo(Ip.parse("5.4.3.2")));
@@ -905,6 +906,8 @@ public final class PaloAltoGrammarTest {
     assertThat(peer.getLocalIp(), equalTo(Ip.parse("1.2.3.6")));
     assertThat(peer.getLocalAs(), equalTo(65001L));
     assertThat(peer.getRemoteAsns(), equalTo(LongSpace.of(65001)));
+    assertTrue(
+        peer.getIpv4UnicastAddressFamily().getAddressFamilyCapabilities().getAllowRemoteAsOut());
     // BgpRoutingProcess requires an export policy be present
     String exportPolicyName = peer.getIpv4UnicastAddressFamily().getExportPolicy();
     assertThat(exportPolicyName, not(nullValue()));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/bgp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/bgp
@@ -41,6 +41,7 @@ network {
                  }
                }
                enable yes;
+               enable-sender-side-loop-detection no;
                local-address {
                  interface ethernet1/1;
                  ip 1.2.3.6/24;


### PR DESCRIPTION
AllowRemoteAsOut is true; Warn in the case where we do not support correct enable-sender-side-loop-detection semantics.