### PR TITLE
Fix IOS NAT compareTo bug

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosDynamicNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosDynamicNat.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.cisco;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
 import static org.batfish.datamodel.transformation.Transformation.when;
@@ -109,16 +110,16 @@ public final class CiscoIosDynamicNat extends CiscoIosNat {
 
   @Override
   protected int natCompare(CiscoIosNat o) {
-    if (!(o instanceof CiscoIosDynamicNat)) {
-      return 0;
-    }
+    checkArgument(
+        o instanceof CiscoIosDynamicNat,
+        "CiscoIosNat.natCompare should only be used for NATs of the same type.");
     // Based on GNS3 testing, dynamic NAT rules are applied in order of ACL name.
     // Deprioritize NATs with null ACLs, as they can't be converted at all.
     CiscoIosDynamicNat other = (CiscoIosDynamicNat) o;
     if (_aclName == null) {
-      return other._aclName == null ? 0 : -1;
+      return other._aclName == null ? 0 : 1;
     } else if (other._aclName == null) {
-      return 1;
+      return -1;
     }
     // ACLs with numeric names come first in numerical order, followed by others in lexicographical
     // order. It is not possible to configure two rules with the same ACL.
@@ -135,11 +136,11 @@ public final class CiscoIosDynamicNat extends CiscoIosNat {
       // expected
     }
     if (thisAcl != 0 && otherAcl != 0) {
-      return Integer.compare(otherAcl, thisAcl);
+      return Integer.compare(thisAcl, otherAcl);
     }
     // Don't need to special-case exactly one ACL being numeric, because numbers come first
     // lexicographically anyway. Non-numeric ACL names must begin with a letter.
-    return other._aclName.compareTo(_aclName);
+    return _aclName.compareTo(other._aclName);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosStaticNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosStaticNat.java
@@ -1,7 +1,9 @@
 package org.batfish.representation.cisco;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.representation.cisco.CiscoConfiguration.DEFAULT_STATIC_ROUTE_DISTANCE;
 
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -25,11 +27,14 @@ public class CiscoIosStaticNat extends CiscoIosNat {
 
   @Override
   protected int natCompare(CiscoIosNat o) {
-    if (!(o instanceof CiscoIosStaticNat)) {
-      return 0;
-    }
+    checkArgument(
+        o instanceof CiscoIosStaticNat,
+        "CiscoIosNat.natCompare should only be used for NATs of the same type.");
     CiscoIosStaticNat other = (CiscoIosStaticNat) o;
-    return Integer.compare(_localNetwork.getPrefixLength(), other._localNetwork.getPrefixLength());
+    // Rules with longer prefixes should come first
+    return Comparator.comparing(Prefix::getPrefixLength)
+        .reversed()
+        .compare(_localNetwork, other._localNetwork);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoIosNatTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoIosNatTest.java
@@ -1,0 +1,18 @@
+package org.batfish.representation.cisco;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
+import org.junit.Test;
+
+public class CiscoIosNatTest {
+  @Test
+  public void testCompareStaticVsDynamic() {
+    // Static rules should always come before dynamic
+    CiscoIosNat staticNat = new CiscoIosStaticNat();
+    CiscoIosNat dynamicNat = new CiscoIosDynamicNat();
+    assertThat(staticNat.compareTo(dynamicNat), lessThan(0));
+    assertThat(dynamicNat.compareTo(staticNat), greaterThan(0));
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoIosStaticNatTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoIosStaticNatTest.java
@@ -1,0 +1,42 @@
+package org.batfish.representation.cisco;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.batfish.datamodel.Prefix;
+import org.junit.Test;
+
+public class CiscoIosStaticNatTest {
+
+  @Test
+  public void testNatCompare() {
+    CiscoIosStaticNat nat16 = natWithLocalNetwork("1.2.0.0/16");
+    CiscoIosStaticNat nat24_1 = natWithLocalNetwork("1.2.3.0/24");
+    CiscoIosStaticNat nat24_2 = natWithLocalNetwork("4.5.6.0/24");
+    CiscoIosStaticNat nat32 = natWithLocalNetwork("1.2.3.4/32");
+
+    // Rules with the same prefix length are considered the same priority (they match mutually
+    // exclusive traffic)
+    assertThat(nat24_1.compareTo(nat24_2), equalTo(0));
+    assertThat(nat24_2.compareTo(nat24_1), equalTo(0));
+
+    // Rules whose local networks are longer prefixes should come first
+    List<CiscoIosStaticNat> ordered = ImmutableList.of(nat32, nat24_1, nat16);
+    for (int i = 0; i < ordered.size() - 1; i++) {
+      for (int j = i + 1; j < ordered.size(); j++) {
+        assertThat(ordered.get(i).compareTo(ordered.get(j)), lessThan(0));
+        assertThat(ordered.get(j).compareTo(ordered.get(i)), greaterThan(0));
+      }
+    }
+  }
+
+  private static CiscoIosStaticNat natWithLocalNetwork(String prefix) {
+    CiscoIosStaticNat nat = new CiscoIosStaticNat();
+    nat.setLocalNetwork(Prefix.parse(prefix));
+    return nat;
+  }
+}


### PR DESCRIPTION
`Comparator.thenComparing` takes a key function or a comparator, not a comparator function.