### PR TITLE
IOS: Extract route-map-based dynamic NAT rules

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_nat.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_nat.g4
@@ -107,7 +107,7 @@ ipnis_route_map
      POOL pool = variable
      | INTERFACE iname = interface_name
    )
-   ( VRF variable )?
+   ipnios_vrf?
    OVERLOAD?
    NEWLINE
 ;
@@ -140,7 +140,7 @@ ipnos_route_map
 :
    ROUTE_MAP mapname = variable
    POOL pname = variable
-   ( VRF vrfname = variable )?
+   ipnios_vrf?
    ipnosm_add_route?
    NEWLINE
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -6294,10 +6294,8 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitIpnosm_add_route(Ipnosm_add_routeContext ctx) {
-    // TODO Once ipnos_route_map is supported, we should assert _currentIosSourceNat != null
-    if (_currentIosSourceNat != null) {
-      _currentIosSourceNat.setAddRoute(true);
-    }
+    assert _currentIosSourceNat != null;
+    _currentIosSourceNat.setAddRoute(true);
     if (_currentIosSourceNat instanceof CiscoIosDynamicNat) {
       todo(ctx);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosDynamicNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosDynamicNat.java
@@ -36,7 +36,10 @@ import org.batfish.datamodel.transformation.TransformationStep;
 @ParametersAreNonnullByDefault
 public final class CiscoIosDynamicNat extends CiscoIosNat {
 
+  /* NAT must use either an ACL or a route-map to specify traffic to match. */
   private @Nullable String _aclName;
+  private @Nullable String _routeMap;
+
   /* Interface whose address to use as pool (this and _natPool are mutually exclusive) */
   private @Nullable String _interface;
   private @Nullable String _natPool;
@@ -55,6 +58,7 @@ public final class CiscoIosDynamicNat extends CiscoIosNat {
     return String.format("~DYNAMIC_DESTINATION_NAT_INSIDE_ACL~%s~", natAclName);
   }
 
+  /** ACL specifying matching traffic (mutually exclusive with {@link #getRouteMap() route-map}) */
   @Nullable
   public String getAclName() {
     return _aclName;
@@ -88,6 +92,16 @@ public final class CiscoIosDynamicNat extends CiscoIosNat {
     _natPool = natPool;
   }
 
+  /** Route-map specifying matching traffic (mutually exclusive with {@link #getAclName() ACL}) */
+  @Nullable
+  public String getRouteMap() {
+    return _routeMap;
+  }
+
+  public void setRouteMap(@Nullable String routeMap) {
+    _routeMap = routeMap;
+  }
+
   @Override
   public boolean equals(@Nullable Object o) {
     if (!(o instanceof CiscoIosDynamicNat)) {
@@ -100,13 +114,14 @@ public final class CiscoIosDynamicNat extends CiscoIosNat {
         && Objects.equals(_aclName, other._aclName)
         && Objects.equals(_interface, other._interface)
         && Objects.equals(_natPool, other._natPool)
-        && Objects.equals(_overload, other._overload);
+        && Objects.equals(_overload, other._overload)
+        && Objects.equals(_routeMap, other._routeMap);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        _aclName, getAction(), getAddRoute(), _interface, _natPool, _overload, getVrf());
+        _aclName, getAction(), getAddRoute(), _interface, _natPool, _overload, _routeMap, getVrf());
   }
 
   @Override
@@ -116,15 +131,22 @@ public final class CiscoIosDynamicNat extends CiscoIosNat {
         "CiscoIosNat.natCompare should only be used for NATs of the same type.");
     CiscoIosDynamicNat other = (CiscoIosDynamicNat) o;
     /* Based on GNS3 testing:
-     - Dynamic NAT rules are applied in order of ACL name
+     - Dynamic NAT rules configured with ACLs come before those configured with route-maps
      - ACLs with numeric names come first in numerical order, then others in lexicographical order
-     - It is not possible to configure two rules with the same ACL
+     - Route-maps are ordered lexicographically
+     - It is not possible to configure two rules with the same structure
     */
-    return Comparator.comparing(
-            CiscoIosDynamicNat::toIntOrNull, Comparator.nullsLast(Integer::compareTo))
-        // Deprioritize NATs with null ACL, as they can't be converted at all
-        .thenComparing(Comparator.nullsLast(String::compareTo))
-        .compare(_aclName, other._aclName);
+    int aclsCompare =
+        Comparator.comparing(
+                CiscoIosDynamicNat::toIntOrNull, Comparator.nullsLast(Integer::compareTo))
+            .thenComparing(Comparator.nullsLast(String::compareTo))
+            .compare(_aclName, other._aclName);
+    if (aclsCompare != 0) {
+      return aclsCompare;
+    }
+    // Neither NAT has an ACL defined. That should mean both have route-maps defined, but if either
+    // has a null route-map, deprioritize that one as it can't be converted at all.
+    return Comparator.nullsLast(String::compareTo).compare(_routeMap, other.getRouteMap());
   }
 
   /** Converts given ACL name to an int if possible, otherwise returns null. */

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosDynamicNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosDynamicNat.java
@@ -180,7 +180,6 @@ public final class CiscoIosDynamicNat extends CiscoIosNat {
 
   @Override
   public Optional<Transformation.Builder> toOutgoingTransformation(
-      Map<String, IpAccessList> ipAccessLists,
       Map<String, NatPool> natPools,
       Set<String> insideInterfaces,
       Map<String, Interface> interfaces,
@@ -196,12 +195,12 @@ public final class CiscoIosDynamicNat extends CiscoIosNat {
       return Optional.empty();
     }
 
-    if (isMalformed(natPools, ipAccessLists, interfaces)) {
+    if (isMalformed(natPools, c.getIpAccessLists(), interfaces)) {
       return Optional.empty();
     }
     assert _aclName != null; // invariant of isMalformed being false, to help compiler.
 
-    IpAccessList natAcl = ipAccessLists.get(_aclName);
+    IpAccessList natAcl = c.getIpAccessLists().get(_aclName);
 
     if (getAction() == RuleAction.DESTINATION_INSIDE) {
       // Expect all lines to be header space matches for NAT ACL

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNat.java
@@ -61,7 +61,6 @@ public abstract class CiscoIosNat implements Comparable<CiscoIosNat>, Serializab
   /**
    * Converts a single NAT from the configuration into a {@link Transformation}.
    *
-   * @param ipAccessLists Named access lists which may be referenced by dynamic NATs
    * @param natPools NAT pools from the configuration
    * @param insideInterfaces Names of interfaces which are defined as 'inside'
    * @param c Configuration
@@ -69,7 +68,6 @@ public abstract class CiscoIosNat implements Comparable<CiscoIosNat>, Serializab
    *     Transformation} could not be built
    */
   public abstract Optional<Transformation.Builder> toOutgoingTransformation(
-      Map<String, IpAccessList> ipAccessLists,
       Map<String, NatPool> natPools,
       Set<String> insideInterfaces,
       Map<String, Interface> interfaces,

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosStaticNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosStaticNat.java
@@ -73,7 +73,6 @@ public class CiscoIosStaticNat extends CiscoIosNat {
 
   @Override
   public Optional<Transformation.Builder> toOutgoingTransformation(
-      Map<String, IpAccessList> ipAccessLists,
       Map<String, NatPool> natPools,
       Set<String> insideInterfaces,
       Map<String, Interface> interfaces,

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -249,6 +249,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -5613,6 +5614,75 @@ public final class CiscoGrammarTest {
 
       assertThat(outside.getOutgoingTransformation(), equalTo(outTransformation));
     }
+  }
+
+  @Test
+  public void testIosDynamicNatRouteMapsExtraction() throws IOException {
+    CiscoConfiguration c =
+        parseCiscoConfig("ios-nat-dynamic-route-maps", ConfigurationFormat.CISCO_IOS);
+    assertThat(c.getCiscoIosNats(), hasSize(5));
+    List<CiscoIosNat> nats = c.getCiscoIosNats();
+    {
+      assertThat(nats.get(0), instanceOf(CiscoIosDynamicNat.class));
+      CiscoIosDynamicNat nat = (CiscoIosDynamicNat) nats.get(0);
+      assertNull(nat.getAclName());
+      assertThat(nat.getRouteMap(), equalTo("10"));
+      assertThat(nat.getAction(), equalTo(RuleAction.SOURCE_INSIDE));
+      assertThat(nat.getInterface(), nullValue());
+      assertThat(nat.getNatPool(), equalTo("in-src-nat-pool"));
+      assertThat(nat.getOverload(), equalTo(true));
+      assertThat(nat.getVrf(), nullValue());
+    }
+    {
+      assertThat(nats.get(1), instanceOf(CiscoIosDynamicNat.class));
+      CiscoIosDynamicNat nat = (CiscoIosDynamicNat) nats.get(1);
+      assertNull(nat.getAclName());
+      assertThat(nat.getRouteMap(), equalTo("13"));
+      assertThat(nat.getAction(), equalTo(RuleAction.SOURCE_INSIDE));
+      assertThat(nat.getInterface(), equalTo("Ethernet10"));
+      assertThat(nat.getNatPool(), nullValue());
+      assertFalse(nat.getOverload());
+      assertThat(nat.getVrf(), nullValue());
+    }
+    {
+      assertThat(nats.get(2), instanceOf(CiscoIosDynamicNat.class));
+      CiscoIosDynamicNat nat = (CiscoIosDynamicNat) nats.get(2);
+      assertNull(nat.getAclName());
+      assertThat(nat.getRouteMap(), equalTo("22"));
+      assertThat(nat.getAction(), equalTo(RuleAction.SOURCE_OUTSIDE));
+      assertThat(nat.getInterface(), nullValue());
+      assertThat(nat.getNatPool(), equalTo("out-src-nat-pool"));
+      assertFalse(nat.getOverload());
+      assertThat(nat.getVrf(), nullValue());
+    }
+    {
+      assertThat(nats.get(3), instanceOf(CiscoIosDynamicNat.class));
+      CiscoIosDynamicNat nat = (CiscoIosDynamicNat) nats.get(3);
+      assertNull(nat.getAclName());
+      assertThat(nat.getRouteMap(), equalTo("12"));
+      assertThat(nat.getAction(), equalTo(RuleAction.SOURCE_INSIDE));
+      assertThat(nat.getInterface(), nullValue());
+      assertThat(nat.getNatPool(), equalTo("vrf-in-src-nat-pool"));
+      assertFalse(nat.getOverload());
+      assertThat(nat.getVrf(), equalTo("vrf1"));
+    }
+    {
+      assertThat(nats.get(4), instanceOf(CiscoIosDynamicNat.class));
+      CiscoIosDynamicNat nat = (CiscoIosDynamicNat) nats.get(4);
+      assertNull(nat.getAclName());
+      assertThat(nat.getRouteMap(), equalTo("23"));
+      assertThat(nat.getAction(), equalTo(RuleAction.SOURCE_OUTSIDE));
+      assertThat(nat.getInterface(), nullValue());
+      assertThat(nat.getNatPool(), equalTo("vrf-out-src-nat-pool"));
+      assertFalse(nat.getOverload());
+      assertThat(nat.getVrf(), equalTo("vrf1"));
+    }
+  }
+
+  @Test
+  public void testIosDynamicNatRouteMapsConversion() throws IOException {
+    // don't crash
+    parseConfig("ios-nat-dynamic-route-maps");
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoIosDynamicNatTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoIosDynamicNatTest.java
@@ -58,12 +58,17 @@ public class CiscoIosDynamicNatTest {
       overload.setOverload(true);
       et.addEqualityGroup(overload);
     }
+    {
+      CiscoIosDynamicNat routeMap = baseNat();
+      routeMap.setRouteMap("diffRouteMap");
+      et.addEqualityGroup(routeMap);
+    }
     et.testEquals();
   }
 
   @Test
   public void testNatCompare() {
-    // If both NATs have null ACLs, compare should give 0
+    // If both NATs have null ACLs and route-maps, compare should give 0
     assertThat(new CiscoIosDynamicNat().compareTo(new CiscoIosDynamicNat()), equalTo(0));
 
     List<CiscoIosDynamicNat> ordered =
@@ -76,6 +81,12 @@ public class CiscoIosDynamicNatTest {
             natWithAcl("Z"),
             natWithAcl("a"),
             natWithAcl("b"),
+            // NAT rules with route-maps come after ACL-based rules, sorted lexicographically
+            natWithRouteMap("0a"),
+            natWithRouteMap("10"),
+            natWithRouteMap("2"),
+            natWithRouteMap("Z"),
+            natWithRouteMap("a"),
             new CiscoIosDynamicNat());
     for (int i = 0; i < ordered.size() - 1; i++) {
       for (int j = i + 1; j < ordered.size(); j++) {
@@ -88,6 +99,12 @@ public class CiscoIosDynamicNatTest {
   private static CiscoIosDynamicNat natWithAcl(String aclName) {
     CiscoIosDynamicNat nat = new CiscoIosDynamicNat();
     nat.setAclName(aclName);
+    return nat;
+  }
+
+  private static CiscoIosDynamicNat natWithRouteMap(String mapName) {
+    CiscoIosDynamicNat nat = new CiscoIosDynamicNat();
+    nat.setRouteMap(mapName);
     return nat;
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-nat-dynamic-route-maps
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-nat-dynamic-route-maps
@@ -1,0 +1,56 @@
+!
+hostname ios-nat-dynamic-route-maps
+!
+!
+access-list 10 permit host 10.10.10.10
+access-list 11 permit host 11.11.11.11
+access-list 12 permit host 12.12.12.12
+access-list 13 permit host 13.13.13.13
+access-list 22 permit host 22.22.22.22
+access-list 23 permit host 23.23.23.23
+!
+route-map 10 permit 10
+ match ip address 10
+route-map 11 permit 10
+ match ip address 11
+route-map 12 permit 10
+ match ip address 12
+route-map 13 permit 10
+ match ip address 13
+route-map 22 permit 10
+ match ip address 22
+route-map 23 permit 10
+ match ip address 23
+!
+ip vrf vrf1
+!
+interface Ethernet1
+ ip nat inside
+!
+interface Ethernet2
+ ip nat outside
+!
+interface Ethernet3
+ ip vrf forwarding vrf1
+ ip nat inside
+!
+interface Ethernet4
+ ip vrf forwarding vrf1
+ ip nat outside
+!
+! For use in "ip nat inside source route-map 13 interface" rule
+interface Ethernet10
+ ip address 1.1.1.1 255.255.255.0
+
+ip nat pool in-src-nat-pool 3.3.3.1 3.3.3.254 prefix-length 24
+ip nat pool in-dst-nat-pool 3.3.4.1 3.3.4.254 prefix-length 24
+ip nat pool out-src-nat-pool 4.4.4.1 4.4.4.254 prefix-length 24
+ip nat pool vrf-in-src-nat-pool 5.5.5.1 5.5.5.254 prefix-length 24
+ip nat pool vrf-out-src-nat-pool 6.6.6.1 6.6.6.254 prefix-length 24
+
+ip nat inside source route-map 10 pool in-src-nat-pool overload
+ip nat inside source route-map 13 interface Ethernet10
+ip nat outside source route-map 22 pool out-src-nat-pool
+
+ip nat inside source route-map 12 pool vrf-in-src-nat-pool vrf vrf1
+ip nat outside source route-map 23 pool vrf-out-src-nat-pool vrf vrf1


### PR DESCRIPTION
Not yet converted; route-map-based rules will be considered malformed and skipped for now