### PR TITLE
Cisco IOS: do not crash on malformed pool

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -6128,6 +6128,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     String name = _currentIosNatPoolName;
     Ip first = toIp(ctx.first);
     Ip last = toIp(ctx.last);
+    if (first.compareTo(last) > 0) {
+      warn(ctx, String.format("Skipping malformed NAT pool %s. First IP > End Ip", name));
+      return;
+    }
     if (ctx.mask != null) {
       Prefix subnet = IpWildcard.ipWithWildcardMask(first, toIp(ctx.mask).inverted()).toPrefix();
       createNatPool(name, first, last, subnet, ctx);
@@ -6145,6 +6149,10 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
     String name = _currentIosNatPoolName;
     Ip first = toIp(ctx.first);
     Ip last = toIp(ctx.last);
+    if (first.compareTo(last) > 0) {
+      warn(ctx, String.format("Skipping malformed NAT pool %s. First IP > End Ip", name));
+      return;
+    }
     if (ctx.prefix_length != null) {
       Prefix subnet = Prefix.create(first, Integer.parseInt(ctx.prefix_length.getText()));
       createNatPool(name, first, last, subnet, ctx);

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosDynamicNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosDynamicNat.java
@@ -1,6 +1,7 @@
 package org.batfish.representation.cisco;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
 import static org.batfish.datamodel.transformation.Transformation.when;
@@ -239,6 +240,9 @@ public final class CiscoIosDynamicNat extends CiscoIosNat {
       Map<String, Interface> interfaces) {
     if (_natPool != null) {
       NatPool pool = natPools.get(_natPool);
+      if (pool == null) {
+        return when(FALSE);
+      }
       return makeTransformation(shouldNat, pool.getFirst(), pool.getLast(), outgoing);
     } else {
       Ip ifaceAddress = interfaces.get(_interface).getAddress().getIp();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosDynamicNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosDynamicNat.java
@@ -1,7 +1,6 @@
 package org.batfish.representation.cisco;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.batfish.datamodel.acl.AclLineMatchExprs.FALSE;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
 import static org.batfish.datamodel.transformation.Transformation.when;
@@ -240,9 +239,6 @@ public final class CiscoIosDynamicNat extends CiscoIosNat {
       Map<String, Interface> interfaces) {
     if (_natPool != null) {
       NatPool pool = natPools.get(_natPool);
-      if (pool == null) {
-        return when(FALSE);
-      }
       return makeTransformation(shouldNat, pool.getFirst(), pool.getLast(), outgoing);
     } else {
       Ip ifaceAddress = interfaces.get(_interface).getAddress().getIp();

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -7291,4 +7291,11 @@ public final class CiscoGrammarTest {
                     hasNextHop(NextHopVrf.of("SRC_VRF"))))));
     assertThat(ribs.get("DST_IMPOSSIBLE").getRoutes(), empty());
   }
+
+  @Test
+  public void testNatMalformedNatPool() throws IOException {
+    String hostname = "ios-nat-malformed-pool";
+    // Do not crash
+    parseConfig(hostname);
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-nat-malformed-pool
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-nat-malformed-pool
@@ -7,5 +7,5 @@ interface Ethernet1
 ip access-list standard LIST
  permit 1.1.1.1 0.0.0.255
 ! Note the pool is not a valid range
-ip nat pool SNOOKER 10.161.151.222 10.161.151.30 netmask 255.255.255.0
+ip nat pool SNOOKER 10.1.1.10 10.1.1.5 netmask 255.255.255.0
 ip nat outside source list LIST pool SNOOKER

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-nat-malformed-pool
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-nat-malformed-pool
@@ -1,0 +1,11 @@
+hostname ios-nat-malformed-pool
+
+interface Ethernet1
+  ip nat outside
+  ip address 3.3.3.3 255.255.255.248
+
+ip access-list standard LIST
+ permit 1.1.1.1 0.0.0.255
+! Note the pool is not a valid range
+ip nat pool SNOOKER 10.161.151.222 10.161.151.30 netmask 255.255.255.0
+ip nat outside source list LIST pool SNOOKER


### PR DESCRIPTION
In some cases (like anonymized configs) we were crashing the whole node conversion on malformed NAT pools. This change simply skips pool creation, and warns that the pool is malformed. The transformation referencing the pool will not match.