### PR TITLE
CiscoIosNat: simplify comparator

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNat.java
@@ -112,12 +112,9 @@ public abstract class CiscoIosNat implements Comparable<CiscoIosNat>, Serializab
 
   @Override
   public final int compareTo(CiscoIosNat other) {
-    int typeCompare =
-        Comparator.comparingInt(CiscoIosNatUtil::getTypePrecedence).compare(this, other);
-    if (typeCompare != 0) {
-      return typeCompare;
-    }
-    return this.natCompare(other);
+    return Comparator.comparingInt(CiscoIosNatUtil::getTypePrecedence)
+        .thenComparing(CiscoIosNat::natCompare)
+        .compare(this, other);
   }
 
   public enum RuleAction {


### PR DESCRIPTION
Passing a 1-arg member function as a class function makes it a 2-arg static function,
which is correctly interpreted as a Comparator