### PR TITLE
IOS: Convert route-map-based NAT rules

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2027,9 +2027,9 @@ public final class CiscoConfiguration extends VendorConfiguration {
       if (!firstNonNull(nat.getVrf(), Configuration.DEFAULT_VRF_NAME).equals(vrfName)) {
         continue;
       }
-      nat.toIncomingTransformation(c.getIpAccessLists(), _natPools, _interfaces)
+      nat.toIncomingTransformation(c.getIpAccessLists(), _routeMaps, _natPools, _interfaces)
           .ifPresent(incoming -> convertedIncomingNats.put(nat, incoming));
-      nat.toOutgoingTransformation(_natPools, getNatInside(), _interfaces, c)
+      nat.toOutgoingTransformation(_routeMaps, _natPools, getNatInside(), _interfaces, c)
           .ifPresent(outgoing -> convertedOutgoingNats.put(nat, outgoing));
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2027,9 +2027,9 @@ public final class CiscoConfiguration extends VendorConfiguration {
       if (!firstNonNull(nat.getVrf(), Configuration.DEFAULT_VRF_NAME).equals(vrfName)) {
         continue;
       }
-      nat.toIncomingTransformation(c.getIpAccessLists(), _routeMaps, _natPools, _interfaces)
+      nat.toIncomingTransformation(c.getIpAccessLists(), _routeMaps, _natPools, _interfaces, _w)
           .ifPresent(incoming -> convertedIncomingNats.put(nat, incoming));
-      nat.toOutgoingTransformation(_routeMaps, _natPools, getNatInside(), _interfaces, c)
+      nat.toOutgoingTransformation(_routeMaps, _natPools, getNatInside(), _interfaces, c, _w)
           .ifPresent(outgoing -> convertedOutgoingNats.put(nat, outgoing));
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNat.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.BatfishException;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.transformation.IpField;
@@ -72,7 +73,8 @@ public abstract class CiscoIosNat implements Comparable<CiscoIosNat>, Serializab
       Map<String, NatPool> natPools,
       Set<String> insideInterfaces,
       Map<String, Interface> interfaces,
-      Configuration c);
+      Configuration c,
+      Warnings w);
 
   /**
    * Converts a single NAT from the configuration into a {@link Transformation}.
@@ -86,7 +88,8 @@ public abstract class CiscoIosNat implements Comparable<CiscoIosNat>, Serializab
       Map<String, IpAccessList> ipAccessLists,
       Map<String, RouteMap> routeMaps,
       Map<String, NatPool> natPools,
-      Map<String, Interface> interfaces);
+      Map<String, Interface> interfaces,
+      Warnings w);
 
   /**
    * Creates the {@link StaticRoute} that will be added due to this NAT, if any (only possible if

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNat.java
@@ -68,6 +68,7 @@ public abstract class CiscoIosNat implements Comparable<CiscoIosNat>, Serializab
    *     Transformation} could not be built
    */
   public abstract Optional<Transformation.Builder> toOutgoingTransformation(
+      Map<String, RouteMap> routeMaps,
       Map<String, NatPool> natPools,
       Set<String> insideInterfaces,
       Map<String, Interface> interfaces,
@@ -83,6 +84,7 @@ public abstract class CiscoIosNat implements Comparable<CiscoIosNat>, Serializab
    */
   public abstract Optional<Transformation.Builder> toIncomingTransformation(
       Map<String, IpAccessList> ipAccessLists,
+      Map<String, RouteMap> routeMaps,
       Map<String, NatPool> natPools,
       Map<String, Interface> interfaces);
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNatUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNatUtil.java
@@ -57,16 +57,21 @@ final class CiscoIosNatUtil {
    *   <li>set lines
    *   <li>match lines other than matching v4 ACLs
    *   <li>references to undefined ACLs
+   *   <li>empty clauses or no clauses
    * </ul>
    */
   static Optional<AclLineMatchExpr> toMatchExpr(RouteMap routeMap, Set<String> validAclNames) {
     ImmutableList.Builder<AclLineMatchExpr> clauseExprs = ImmutableList.builder();
+    if (routeMap.getClauses().isEmpty()) {
+      return Optional.empty();
+    }
     for (RouteMapClause clause : routeMap.getClauses().values()) {
-      if (clause.getAction() != LineAction.PERMIT) {
+      if (clause.getAction() != LineAction.PERMIT
+          || !clause.getSetList().isEmpty()
+          || clause.getMatchList().isEmpty()) {
         // TODO Support NAT rules referencing route-maps with deny clauses
-        return Optional.empty();
-      } else if (!clause.getSetList().isEmpty()) {
         // TODO Check if set lines take effect in context of NAT rule-matching
+        // TODO Check behavior of empty clauses (deny all or permit all?)
         return Optional.empty();
       }
       for (RouteMapMatchLine matchLine : clause.getMatchList()) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNatUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNatUtil.java
@@ -99,7 +99,7 @@ final class CiscoIosNatUtil {
               String.format(
                   "Ignoring NAT rule with route-map %s: lines of type %s not supported in this"
                       + " context",
-                  routeMap.getName(), matchLine.getClass()));
+                  routeMap.getName(), matchLine.getClass().getCanonicalName()));
           return Optional.empty();
         }
         Set<String> listNames = ((RouteMapMatchIpAccessListLine) matchLine).getListNames();
@@ -109,7 +109,7 @@ final class CiscoIosNatUtil {
               String.format(
                   "Ignoring NAT rule with route-map %s: route-map references at least one"
                       + " undefined ACL",
-                  routeMap.getName(), matchLine.getClass().getCanonicalName()));
+                  routeMap.getName()));
           return Optional.empty();
         }
         // Never need to reverse these ACLs because route-maps can't be used for destination inside.

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNatUtil.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosNatUtil.java
@@ -1,18 +1,25 @@
 package org.batfish.representation.cisco;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.BatfishException;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.transformation.IpField;
 import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.transformation.Transformation.Builder;
@@ -38,6 +45,49 @@ final class CiscoIosNatUtil {
       throw new BatfishException("Unsupported NAT type");
     }
     return typePrecedence.get(name);
+  }
+
+  /**
+   * Converts the given {@link RouteMap} to an {@link AclLineMatchExpr} for use as a guard in a
+   * {@link Transformation}. Currently only offers limited support (pending behavior tests); returns
+   * empty if the route-map has any of the following:
+   *
+   * <ul>
+   *   <li>deny clauses
+   *   <li>set lines
+   *   <li>match lines other than matching v4 ACLs
+   *   <li>references to undefined ACLs
+   * </ul>
+   */
+  static Optional<AclLineMatchExpr> toMatchExpr(RouteMap routeMap, Set<String> validAclNames) {
+    ImmutableList.Builder<AclLineMatchExpr> clauseExprs = ImmutableList.builder();
+    for (RouteMapClause clause : routeMap.getClauses().values()) {
+      if (clause.getAction() != LineAction.PERMIT) {
+        // TODO Support NAT rules referencing route-maps with deny clauses
+        return Optional.empty();
+      } else if (!clause.getSetList().isEmpty()) {
+        // TODO Check if set lines take effect in context of NAT rule-matching
+        return Optional.empty();
+      }
+      for (RouteMapMatchLine matchLine : clause.getMatchList()) {
+        if (!(matchLine instanceof RouteMapMatchIpAccessListLine)) {
+          // TODO Check what other types of lines NAT rule route-maps can have and support them
+          return Optional.empty();
+        }
+        Set<String> listNames = ((RouteMapMatchIpAccessListLine) matchLine).getListNames();
+        if (!validAclNames.containsAll(listNames)) {
+          // TODO Check behavior of match ACL line when some or all ACLs are undefined
+          return Optional.empty();
+        }
+        // Never need to reverse these ACLs because route-maps can't be used for destination inside.
+        List<AclLineMatchExpr> permittedByAcls =
+            listNames.stream()
+                .map(AclLineMatchExprs::permittedByAcl)
+                .collect(ImmutableList.toImmutableList());
+        clauseExprs.add(or(permittedByAcls));
+      }
+    }
+    return Optional.of(or(clauseExprs.build()));
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosStaticNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosStaticNat.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.Prefix;
@@ -77,7 +78,8 @@ public class CiscoIosStaticNat extends CiscoIosNat {
       Map<String, NatPool> natPools,
       Set<String> insideInterfaces,
       Map<String, Interface> interfaces,
-      Configuration c) {
+      Configuration c,
+      Warnings w) {
 
     /*
      * No named ACL in rule, but need to match src/dest to global/local according
@@ -107,7 +109,8 @@ public class CiscoIosStaticNat extends CiscoIosNat {
       Map<String, IpAccessList> ipAccessLists,
       Map<String, RouteMap> routeMaps,
       Map<String, NatPool> natPools,
-      Map<String, Interface> interfaces) {
+      Map<String, Interface> interfaces,
+      Warnings w) {
     /*
      * No named ACL in rule, but need to match src/dest to global/local according
      * to direction and rule type

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosStaticNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoIosStaticNat.java
@@ -73,6 +73,7 @@ public class CiscoIosStaticNat extends CiscoIosNat {
 
   @Override
   public Optional<Transformation.Builder> toOutgoingTransformation(
+      Map<String, RouteMap> routeMaps,
       Map<String, NatPool> natPools,
       Set<String> insideInterfaces,
       Map<String, Interface> interfaces,
@@ -104,6 +105,7 @@ public class CiscoIosStaticNat extends CiscoIosNat {
   @Override
   public Optional<Transformation.Builder> toIncomingTransformation(
       Map<String, IpAccessList> ipAccessLists,
+      Map<String, RouteMap> routeMaps,
       Map<String, NatPool> natPools,
       Map<String, Interface> interfaces) {
     /*

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -5620,7 +5620,7 @@ public final class CiscoGrammarTest {
   public void testIosDynamicNatRouteMapsExtraction() throws IOException {
     CiscoConfiguration c =
         parseCiscoConfig("ios-nat-dynamic-route-maps", ConfigurationFormat.CISCO_IOS);
-    assertThat(c.getCiscoIosNats(), hasSize(5));
+    assertThat(c.getCiscoIosNats(), hasSize(6));
     List<CiscoIosNat> nats = c.getCiscoIosNats();
     {
       assertThat(nats.get(0), instanceOf(CiscoIosDynamicNat.class));
@@ -5644,9 +5644,11 @@ public final class CiscoGrammarTest {
       assertFalse(nat.getOverload());
       assertThat(nat.getVrf(), nullValue());
     }
+    // note, the indices skip 2 because there's an inside dest rule that's only present to test how
+    // it gets incorporated in the converted transformations
     {
-      assertThat(nats.get(2), instanceOf(CiscoIosDynamicNat.class));
-      CiscoIosDynamicNat nat = (CiscoIosDynamicNat) nats.get(2);
+      assertThat(nats.get(3), instanceOf(CiscoIosDynamicNat.class));
+      CiscoIosDynamicNat nat = (CiscoIosDynamicNat) nats.get(3);
       assertNull(nat.getAclName());
       assertThat(nat.getRouteMap(), equalTo("22"));
       assertThat(nat.getAction(), equalTo(RuleAction.SOURCE_OUTSIDE));
@@ -5656,8 +5658,8 @@ public final class CiscoGrammarTest {
       assertThat(nat.getVrf(), nullValue());
     }
     {
-      assertThat(nats.get(3), instanceOf(CiscoIosDynamicNat.class));
-      CiscoIosDynamicNat nat = (CiscoIosDynamicNat) nats.get(3);
+      assertThat(nats.get(4), instanceOf(CiscoIosDynamicNat.class));
+      CiscoIosDynamicNat nat = (CiscoIosDynamicNat) nats.get(4);
       assertNull(nat.getAclName());
       assertThat(nat.getRouteMap(), equalTo("12"));
       assertThat(nat.getAction(), equalTo(RuleAction.SOURCE_INSIDE));
@@ -5667,8 +5669,8 @@ public final class CiscoGrammarTest {
       assertThat(nat.getVrf(), equalTo("vrf1"));
     }
     {
-      assertThat(nats.get(4), instanceOf(CiscoIosDynamicNat.class));
-      CiscoIosDynamicNat nat = (CiscoIosDynamicNat) nats.get(4);
+      assertThat(nats.get(5), instanceOf(CiscoIosDynamicNat.class));
+      CiscoIosDynamicNat nat = (CiscoIosDynamicNat) nats.get(5);
       assertNull(nat.getAclName());
       assertThat(nat.getRouteMap(), equalTo("23"));
       assertThat(nat.getAction(), equalTo(RuleAction.SOURCE_OUTSIDE));
@@ -5681,8 +5683,6 @@ public final class CiscoGrammarTest {
 
   @Test
   public void testIosDynamicNatRouteMapsConversion() throws IOException {
-    // TODO: Add an inside destination rule and test that it is NOT included in the transformations
-    //  where route-maps are matched. (Route-map-based rules create extended NAT table entries.)
     Configuration c = parseConfig("ios-nat-dynamic-route-maps");
     String insideIntf = "Ethernet1";
     String outsideIntf = "Ethernet2";
@@ -5698,11 +5698,14 @@ public final class CiscoGrammarTest {
       // NAT in default VRF
       Ip insideSrcPoolFirst = Ip.parse("3.3.3.1");
       Ip insideSrcPoolLast = Ip.parse("3.3.3.254");
+      Ip insideDstPoolFirst = Ip.parse("3.3.4.1");
+      Ip insideDstPoolLast = Ip.parse("3.3.4.254");
       Ip outsideSrcPoolFirst = Ip.parse("4.4.4.1");
       Ip outsideSrcPoolLast = Ip.parse("4.4.4.254");
       Ip insideSrcIfaceAddr = Ip.parse("1.1.1.1");
       String insideSrcPoolAcl = "10";
       String insideSrcIfaceAcl = "13";
+      String insideDstPoolAcl = computeDynamicDestinationNatAclName("11");
       String outsideSrcPoolAcl = "22";
 
       Interface inside = c.getAllInterfaces().get(insideIntf);
@@ -5718,19 +5721,27 @@ public final class CiscoGrammarTest {
 
       assertThat(outside.getIncomingTransformation(), equalTo(inTransformation));
 
+      Transformation destTransformation =
+          when(and(permittedByAcl(insideDstPoolAcl), matchSrcInside))
+              .apply(assignDestinationIp(insideDstPoolFirst, insideDstPoolLast))
+              .build();
+
       Transformation outTransformation =
           when(and(permittedByAcl(insideSrcPoolAcl), matchSrcInside))
               .apply(assignSourceIp(insideSrcPoolFirst, insideSrcPoolLast))
+              .setAndThen(destTransformation)
               .setOrElse(
                   when(and(permittedByAcl(insideSrcIfaceAcl), matchSrcInside))
                       .apply(assignSourceIp(insideSrcIfaceAddr, insideSrcIfaceAddr))
+                      .setAndThen(destTransformation)
+                      .setOrElse(destTransformation)
                       .build())
               .build();
 
       assertThat(outside.getOutgoingTransformation(), equalTo(outTransformation));
     }
     {
-      // NAT in default VRF
+      // NAT in vrf1
       Ip insidePoolFirst = Ip.parse("5.5.5.1");
       Ip insidePoolLast = Ip.parse("5.5.5.254");
       Ip outsidePoolFirst = Ip.parse("6.6.6.1");

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoIosNatUtilTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoIosNatUtilTest.java
@@ -4,13 +4,16 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
 import static org.batfish.representation.cisco.CiscoIosNatUtil.toMatchExpr;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import java.util.Set;
+import org.batfish.common.Warnings;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.acl.OrMatchExpr;
 import org.junit.Test;
@@ -20,7 +23,13 @@ public class CiscoIosNatUtilTest {
   @Test
   public void testToMatchExpr_inconvertibleRouteMaps() {
     // Empty route-map should not convert
-    assertFalse(toMatchExpr(new RouteMap("rm"), ImmutableSet.of()).isPresent());
+    {
+      Warnings w = new Warnings(true, true, true);
+      assertFalse(toMatchExpr(new RouteMap("rm"), ImmutableSet.of(), w).isPresent());
+      assertThat(
+          Iterables.getOnlyElement(w.getRedFlagWarnings()).getText(),
+          containsString("empty route-map"));
+    }
 
     // We will assume there is one ACL defined, called acl1
     Set<String> definedAcls = ImmutableSet.of("acl1");
@@ -29,9 +38,9 @@ public class CiscoIosNatUtilTest {
     acl1Clause.addMatchLine(acl1MatchLine);
 
     // Sanity check: make sure a route-map with only acl1Clause does convert successfully
-    RouteMap convertible = new RouteMap("rm");
-    convertible.getClauses().put(10, acl1Clause);
-    assertTrue(toMatchExpr(convertible, definedAcls).isPresent());
+    assertTrue(
+        toMatchExpr(rmWithClauses(acl1Clause), definedAcls, new Warnings(true, true, true))
+            .isPresent());
 
     // In these tests, acl1Clause is included in all route maps to confirm that conversion will fail
     // if *any* clauses are unsupported rather than *all*.
@@ -39,37 +48,61 @@ public class CiscoIosNatUtilTest {
     // also contain a supported match line.
     {
       // Clause is empty
-      assertRouteMapCannotConvertWithClauses(definedAcls, acl1Clause, rmcWithMatchLines());
+      Warnings w = new Warnings(true, true, true);
+      assertFalse(
+          toMatchExpr(rmWithClauses(acl1Clause, rmcWithMatchLines()), definedAcls, w).isPresent());
+      assertThat(
+          Iterables.getOnlyElement(w.getRedFlagWarnings()).getText(),
+          containsString("clauses without match lines"));
     }
     {
       // Clause denies
       RouteMapClause rmc = new RouteMapClause(LineAction.DENY, "rmc", 10);
       rmc.addMatchLine(acl1MatchLine); // inconvertible bc it denies, not bc no match lines
-      assertRouteMapCannotConvertWithClauses(definedAcls, acl1Clause, rmc);
+      Warnings w = new Warnings(true, true, true);
+      assertFalse(toMatchExpr(rmWithClauses(acl1Clause, rmc), definedAcls, w).isPresent());
+      assertThat(
+          Iterables.getOnlyElement(w.getRedFlagWarnings()).getText(),
+          containsString("deny clause"));
     }
     {
       // Clause includes a set line
       RouteMapClause rmc = rmcWithMatchLines(acl1MatchLine);
       rmc.addSetLine(new RouteMapSetCommunityLine(ImmutableList.of(1L)));
-      assertRouteMapCannotConvertWithClauses(definedAcls, acl1Clause, rmc);
+      Warnings w = new Warnings(true, true, true);
+      assertFalse(toMatchExpr(rmWithClauses(acl1Clause, rmc), definedAcls, w).isPresent());
+      assertThat(
+          Iterables.getOnlyElement(w.getRedFlagWarnings()).getText(), containsString("set line"));
     }
     {
       // Clause references undefined ACL acl2
       RouteMapClause rmc = rmcWithMatchLines(acl1MatchLine);
       rmc.addMatchLine(new RouteMapMatchIpAccessListLine(ImmutableSet.of("acl2")));
-      assertRouteMapCannotConvertWithClauses(definedAcls, acl1Clause, rmc);
+      Warnings w = new Warnings(true, true, true);
+      assertFalse(toMatchExpr(rmWithClauses(acl1Clause, rmc), definedAcls, w).isPresent());
+      assertThat(
+          Iterables.getOnlyElement(w.getRedFlagWarnings()).getText(),
+          containsString("undefined ACL"));
     }
     {
       // Clause references defined ACL acl1 but also undefined ACL acl2
       RouteMapClause rmc = rmcWithMatchLines(acl1MatchLine);
       rmc.addMatchLine(new RouteMapMatchIpAccessListLine(ImmutableSet.of("acl1", "acl2")));
-      assertRouteMapCannotConvertWithClauses(definedAcls, acl1Clause, rmc);
+      Warnings w = new Warnings(true, true, true);
+      assertFalse(toMatchExpr(rmWithClauses(acl1Clause, rmc), definedAcls, w).isPresent());
+      assertThat(
+          Iterables.getOnlyElement(w.getRedFlagWarnings()).getText(),
+          containsString("undefined ACL"));
     }
     {
       // Clause uses an unsupported type of match line
       RouteMapClause rmc = rmcWithMatchLines(acl1MatchLine);
       rmc.addMatchLine(new RouteMapMatchIpPrefixListLine(ImmutableSet.of("pl")));
-      assertRouteMapCannotConvertWithClauses(definedAcls, acl1Clause, rmc);
+      Warnings w = new Warnings(true, true, true);
+      assertFalse(toMatchExpr(rmWithClauses(acl1Clause, rmc), definedAcls, w).isPresent());
+      assertThat(
+          Iterables.getOnlyElement(w.getRedFlagWarnings()).getText(),
+          containsString(RouteMapMatchIpPrefixListLine.class.getCanonicalName()));
     }
   }
 
@@ -83,21 +116,25 @@ public class CiscoIosNatUtilTest {
 
     {
       RouteMap rm = rmWithClauses(rmcWithMatchLines(acl1MatchLine));
-      assertThat(toMatchExpr(rm, definedAcls).get(), equalTo(permittedByAcl("acl1")));
+      assertThat(
+          toMatchExpr(rm, definedAcls, new Warnings(true, true, true)).get(),
+          equalTo(permittedByAcl("acl1")));
     }
     {
       // need to create second clause manually so it has a different sequence number
       RouteMapClause matchAcl2 = new RouteMapClause(LineAction.PERMIT, "rmc2", 20);
       matchAcl2.addMatchLine(acl2MatchLine);
       RouteMap rm = rmWithClauses(rmcWithMatchLines(acl1MatchLine), matchAcl2);
-      OrMatchExpr matchExpr = (OrMatchExpr) toMatchExpr(rm, definedAcls).get();
+      OrMatchExpr matchExpr =
+          (OrMatchExpr) toMatchExpr(rm, definedAcls, new Warnings(true, true, true)).get();
       assertThat(
           matchExpr.getDisjuncts(),
           containsInAnyOrder(permittedByAcl("acl1"), permittedByAcl("acl2")));
     }
     {
       RouteMap rm = rmWithClauses(rmcWithMatchLines(acl1And2MatchLine));
-      OrMatchExpr matchExpr = (OrMatchExpr) toMatchExpr(rm, definedAcls).get();
+      OrMatchExpr matchExpr =
+          (OrMatchExpr) toMatchExpr(rm, definedAcls, new Warnings(true, true, true)).get();
       assertThat(
           matchExpr.getDisjuncts(),
           containsInAnyOrder(permittedByAcl("acl1"), permittedByAcl("acl2")));
@@ -121,15 +158,5 @@ public class CiscoIosNatUtilTest {
       rm.getClauses().put(clause.getSeqNum(), clause);
     }
     return rm;
-  }
-
-  private static void assertRouteMapCannotConvertWithClauses(
-      Set<String> definedAcls, RouteMapClause... clauses) {
-    RouteMap rm = new RouteMap("rm");
-    for (RouteMapClause clause : clauses) {
-      assert !rm.getClauses().containsKey(clause.getSeqNum()); // clauses must have unique seq nums
-      rm.getClauses().put(clause.getSeqNum(), clause);
-    }
-    assertFalse(toMatchExpr(rm, definedAcls).isPresent());
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoIosNatUtilTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoIosNatUtilTest.java
@@ -1,0 +1,135 @@
+package org.batfish.representation.cisco;
+
+import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
+import static org.batfish.representation.cisco.CiscoIosNatUtil.toMatchExpr;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.acl.OrMatchExpr;
+import org.junit.Test;
+
+public class CiscoIosNatUtilTest {
+
+  @Test
+  public void testToMatchExpr_inconvertibleRouteMaps() {
+    // Empty route-map should not convert
+    assertFalse(toMatchExpr(new RouteMap("rm"), ImmutableSet.of()).isPresent());
+
+    // We will assume there is one ACL defined, called acl1
+    Set<String> definedAcls = ImmutableSet.of("acl1");
+    RouteMapMatchLine acl1MatchLine = new RouteMapMatchIpAccessListLine(ImmutableSet.of("acl1"));
+    RouteMapClause acl1Clause = new RouteMapClause(LineAction.PERMIT, "acl1", 5);
+    acl1Clause.addMatchLine(acl1MatchLine);
+
+    // Sanity check: make sure a route-map with only acl1Clause does convert successfully
+    RouteMap convertible = new RouteMap("rm");
+    convertible.getClauses().put(10, acl1Clause);
+    assertTrue(toMatchExpr(convertible, definedAcls).isPresent());
+
+    // In these tests, acl1Clause is included in all route maps to confirm that conversion will fail
+    // if *any* clauses are unsupported rather than *all*.
+    // Similarly, clauses that aren't supported because they contain an unsupported match line will
+    // also contain a supported match line.
+    {
+      // Clause is empty
+      assertRouteMapCannotConvertWithClauses(definedAcls, acl1Clause, rmcWithMatchLines());
+    }
+    {
+      // Clause denies
+      RouteMapClause rmc = new RouteMapClause(LineAction.DENY, "rmc", 10);
+      rmc.addMatchLine(acl1MatchLine); // inconvertible bc it denies, not bc no match lines
+      assertRouteMapCannotConvertWithClauses(definedAcls, acl1Clause, rmc);
+    }
+    {
+      // Clause includes a set line
+      RouteMapClause rmc = rmcWithMatchLines(acl1MatchLine);
+      rmc.addSetLine(new RouteMapSetCommunityLine(ImmutableList.of(1L)));
+      assertRouteMapCannotConvertWithClauses(definedAcls, acl1Clause, rmc);
+    }
+    {
+      // Clause references undefined ACL acl2
+      RouteMapClause rmc = rmcWithMatchLines(acl1MatchLine);
+      rmc.addMatchLine(new RouteMapMatchIpAccessListLine(ImmutableSet.of("acl2")));
+      assertRouteMapCannotConvertWithClauses(definedAcls, acl1Clause, rmc);
+    }
+    {
+      // Clause references defined ACL acl1 but also undefined ACL acl2
+      RouteMapClause rmc = rmcWithMatchLines(acl1MatchLine);
+      rmc.addMatchLine(new RouteMapMatchIpAccessListLine(ImmutableSet.of("acl1", "acl2")));
+      assertRouteMapCannotConvertWithClauses(definedAcls, acl1Clause, rmc);
+    }
+    {
+      // Clause uses an unsupported type of match line
+      RouteMapClause rmc = rmcWithMatchLines(acl1MatchLine);
+      rmc.addMatchLine(new RouteMapMatchIpPrefixListLine(ImmutableSet.of("pl")));
+      assertRouteMapCannotConvertWithClauses(definedAcls, acl1Clause, rmc);
+    }
+  }
+
+  @Test
+  public void testToMatchExpr() {
+    Set<String> definedAcls = ImmutableSet.of("acl1", "acl2");
+    RouteMapMatchLine acl1MatchLine = new RouteMapMatchIpAccessListLine(ImmutableSet.of("acl1"));
+    RouteMapMatchLine acl2MatchLine = new RouteMapMatchIpAccessListLine(ImmutableSet.of("acl2"));
+    RouteMapMatchLine acl1And2MatchLine =
+        new RouteMapMatchIpAccessListLine(ImmutableSet.of("acl1", "acl2"));
+
+    {
+      RouteMap rm = rmWithClauses(rmcWithMatchLines(acl1MatchLine));
+      assertThat(toMatchExpr(rm, definedAcls).get(), equalTo(permittedByAcl("acl1")));
+    }
+    {
+      // need to create second clause manually so it has a different sequence number
+      RouteMapClause matchAcl2 = new RouteMapClause(LineAction.PERMIT, "rmc2", 20);
+      matchAcl2.addMatchLine(acl2MatchLine);
+      RouteMap rm = rmWithClauses(rmcWithMatchLines(acl1MatchLine), matchAcl2);
+      OrMatchExpr matchExpr = (OrMatchExpr) toMatchExpr(rm, definedAcls).get();
+      assertThat(
+          matchExpr.getDisjuncts(),
+          containsInAnyOrder(permittedByAcl("acl1"), permittedByAcl("acl2")));
+    }
+    {
+      RouteMap rm = rmWithClauses(rmcWithMatchLines(acl1And2MatchLine));
+      OrMatchExpr matchExpr = (OrMatchExpr) toMatchExpr(rm, definedAcls).get();
+      assertThat(
+          matchExpr.getDisjuncts(),
+          containsInAnyOrder(permittedByAcl("acl1"), permittedByAcl("acl2")));
+    }
+  }
+
+  /** Creates a permitting {@link RouteMapClause} with the given match lines and seq number 10. */
+  private static RouteMapClause rmcWithMatchLines(RouteMapMatchLine... lines) {
+    RouteMapClause rmc = new RouteMapClause(LineAction.PERMIT, "rmc", 10);
+    for (RouteMapMatchLine line : lines) {
+      rmc.addMatchLine(line);
+    }
+    return rmc;
+  }
+
+  /** Creates a {@link RouteMap} with the given clauses. */
+  private static RouteMap rmWithClauses(RouteMapClause... clauses) {
+    RouteMap rm = new RouteMap("rm");
+    for (RouteMapClause clause : clauses) {
+      assert !rm.getClauses().containsKey(clause.getSeqNum()); // clauses must have unique seq nums
+      rm.getClauses().put(clause.getSeqNum(), clause);
+    }
+    return rm;
+  }
+
+  private static void assertRouteMapCannotConvertWithClauses(
+      Set<String> definedAcls, RouteMapClause... clauses) {
+    RouteMap rm = new RouteMap("rm");
+    for (RouteMapClause clause : clauses) {
+      assert !rm.getClauses().containsKey(clause.getSeqNum()); // clauses must have unique seq nums
+      rm.getClauses().put(clause.getSeqNum(), clause);
+    }
+    assertFalse(toMatchExpr(rm, definedAcls).isPresent());
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-nat-dynamic-route-maps
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-nat-dynamic-route-maps
@@ -50,6 +50,7 @@ ip nat pool vrf-out-src-nat-pool 6.6.6.1 6.6.6.254 prefix-length 24
 
 ip nat inside source route-map 10 pool in-src-nat-pool overload
 ip nat inside source route-map 13 interface Ethernet10
+ip nat inside destination list 11 pool in-dst-nat-pool
 ip nat outside source route-map 22 pool out-src-nat-pool
 
 ip nat inside source route-map 12 pool vrf-in-src-nat-pool vrf vrf1


### PR DESCRIPTION
Same basic idea as ACL-based NAT rules. So far, only limited support for content of route-maps that are used in NAT rules. The rule will be ignored if the route-map has:
- deny clauses
- set lines
- match lines other than matching IPv4 ACLs
- references to undefined ACLs