### PR TITLE
IOS VRF leaking: keep track of route targets

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrfLeakingConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/VrfLeakingConfig.java
@@ -172,7 +172,7 @@ public final class VrfLeakingConfig implements Serializable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
       if (this == o) {
         return true;
       }
@@ -200,7 +200,8 @@ public final class VrfLeakingConfig implements Serializable {
 
     @JsonCreator
     private static BgpLeakConfig jsonCreate(
-        @JsonProperty(PROP_ATTACH_ROUTE_TARGET) ExtendedCommunity attachRouteTarget) {
+        @Nullable @JsonProperty(PROP_ATTACH_ROUTE_TARGET) ExtendedCommunity attachRouteTarget) {
+      checkArgument(attachRouteTarget != null, "Missing %s", PROP_ATTACH_ROUTE_TARGET);
       return new BgpLeakConfig(attachRouteTarget);
     }
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfLeakingConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfLeakingConfigTest.java
@@ -6,7 +6,9 @@ import static org.hamcrest.Matchers.equalTo;
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.VrfLeakingConfig.BgpLeakConfig;
 import org.batfish.datamodel.VrfLeakingConfig.Builder;
+import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.junit.Test;
 
 /** Tests of {@link VrfLeakingConfig} */
@@ -18,7 +20,7 @@ public class VrfLeakingConfigTest {
         VrfLeakingConfig.builder()
             .setImportFromVrf("vrf1")
             .setImportPolicy("policy")
-            .setLeakAsBgp(false)
+            .setBgpLeakConfig(new BgpLeakConfig(ExtendedCommunity.target(1, 2)))
             .build();
     assertThat(SerializationUtils.clone(val), equalTo(val));
   }
@@ -29,24 +31,21 @@ public class VrfLeakingConfigTest {
         VrfLeakingConfig.builder()
             .setImportFromVrf("vrf1")
             .setImportPolicy("policy")
-            .setLeakAsBgp(false)
+            .setBgpLeakConfig(new BgpLeakConfig(ExtendedCommunity.target(1, 2)))
             .build();
     assertThat(BatfishObjectMapper.clone(val, VrfLeakingConfig.class), equalTo(val));
   }
 
   @Test
   public void testEquals() {
-    Builder b =
-        VrfLeakingConfig.builder()
-            .setImportFromVrf("vrf1")
-            .setImportPolicy("policy")
-            .setLeakAsBgp(false);
+    Builder b = VrfLeakingConfig.builder().setImportFromVrf("vrf1").setImportPolicy("policy");
     VrfLeakingConfig val = b.build();
     new EqualsTester()
         .addEqualityGroup(val, val, b.build())
         .addEqualityGroup(b.setImportFromVrf("vrf2").build())
         .addEqualityGroup(b.setImportPolicy("policy2").build())
-        .addEqualityGroup(b.setLeakAsBgp(true).build())
+        .addEqualityGroup(
+            b.setBgpLeakConfig(new BgpLeakConfig(ExtendedCommunity.target(1, 2))).build())
         .addEqualityGroup(new Object())
         .testEquals();
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -1372,10 +1372,12 @@ public final class VirtualRouter {
               .getVirtualRouter(vrfLeakConfig.getImportFromVrf())
               .map(VirtualRouter::getBgpRoutingProcess);
       if (exportingBgpProc.isPresent()) {
+        assert vrfLeakConfig.getBgpConfig() != null; // invariant of leakAsBgp()
         _bgpRoutingProcess.importCrossVrfV4Routes(
             exportingBgpProc.get().getRoutesToLeak(),
             vrfLeakConfig.getImportPolicy(),
-            vrfLeakConfig.getImportFromVrf());
+            vrfLeakConfig.getImportFromVrf(),
+            vrfLeakConfig.getBgpConfig());
       } else {
         LOGGER.error(
             "Leaking BGP routes from VRF {} to VRF {} on node {} failed. Exporting VRF has no BGP"

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -86,6 +86,7 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.TcpFlagsMatchConditions;
 import org.batfish.datamodel.VrfLeakingConfig;
+import org.batfish.datamodel.VrfLeakingConfig.BgpLeakConfig;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AndMatchExpr;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
@@ -1748,7 +1749,7 @@ public class CiscoConversions {
           }
           viVrf.addVrfLeakingConfig(
               VrfLeakingConfig.builder()
-                  .setLeakAsBgp(true)
+                  .setBgpLeakConfig(new BgpLeakConfig(importRt))
                   .setImportFromVrf(exportingVrf)
                   .setImportPolicy(routeMapOrRejectAll(ipv4uaf.getImportMap(), c))
                   .build());

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3338,7 +3338,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
         for (String referencedVrf : referencedVrfs) {
           vrf.addVrfLeakingConfig(
               VrfLeakingConfig.builder()
-                  .setLeakAsBgp(false)
                   .setImportFromVrf(referencedVrf)
                   .setImportPolicy(instanceImportPolicy.getName())
                   .build());

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -6,6 +6,7 @@ import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasN
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasProtocol;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.isNonRouting;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasCommunities;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.isBgpv4RouteThat;
 import static org.batfish.datamodel.vxlan.Layer2Vni.testBuilder;
 import static org.batfish.dataplane.ibdp.BgpRoutingProcess.initEvpnType3Route;
@@ -50,6 +51,7 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.VrfLeakingConfig.BgpLeakConfig;
 import org.batfish.datamodel.bgp.AddressFamily.Type;
 import org.batfish.datamodel.bgp.BgpTopology;
 import org.batfish.datamodel.bgp.BgpTopology.EdgeId;
@@ -614,11 +616,13 @@ public class BgpRoutingProcessTest {
     String otherVrf = "otherVrf";
     // Process denied prefix, specify policy
     Prefix deniedPrefix = Prefix.parse("2.2.2.0/24");
+    ExtendedCommunity routeTarget = ExtendedCommunity.target(1, 1);
     _routingProcess.importCrossVrfV4Routes(
         Stream.of(
             RouteAdvertisement.adding(Bgpv4Route.testBuilder().setNetwork(deniedPrefix).build())),
         policy.getName(),
-        otherVrf);
+        otherVrf,
+        new BgpLeakConfig(routeTarget));
     assertThat(
         _routingProcess
             .getBgpv4DeltaBuilder()
@@ -632,7 +636,8 @@ public class BgpRoutingProcessTest {
         Stream.of(
             RouteAdvertisement.adding(Bgpv4Route.testBuilder().setNetwork(allowedPrefix).build())),
         policy.getName(),
-        otherVrf);
+        otherVrf,
+        new BgpLeakConfig(routeTarget));
     assertThat(
         _routingProcess
             .getBgpv4DeltaBuilder()
@@ -644,14 +649,16 @@ public class BgpRoutingProcessTest {
                 allOf(
                     hasPrefix(allowedPrefix),
                     hasNextHop(NextHopVrf.of(otherVrf)),
-                    isNonRouting(false)))));
+                    isNonRouting(false),
+                    hasCommunities(contains(routeTarget))))));
 
     // Process denied prefix, but because no policy is specified, allow it
     _routingProcess.importCrossVrfV4Routes(
         Stream.of(
             RouteAdvertisement.adding(Bgpv4Route.testBuilder().setNetwork(deniedPrefix).build())),
         null, // no policy
-        otherVrf);
+        otherVrf,
+        new BgpLeakConfig(routeTarget));
     assertThat(
         _routingProcess
             .getBgpv4DeltaBuilder()
@@ -663,6 +670,7 @@ public class BgpRoutingProcessTest {
                 allOf(
                     hasPrefix(deniedPrefix),
                     hasNextHop(NextHopVrf.of(otherVrf)),
-                    isNonRouting(false)))));
+                    isNonRouting(false),
+                    hasCommunities(contains(routeTarget))))));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -353,6 +353,7 @@ import org.batfish.datamodel.TunnelConfiguration;
 import org.batfish.datamodel.TunnelConfiguration.Builder;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.VrfLeakingConfig;
+import org.batfish.datamodel.VrfLeakingConfig.BgpLeakConfig;
 import org.batfish.datamodel.acl.AclLineMatchExpr;
 import org.batfish.datamodel.acl.AclTracer;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
@@ -373,6 +374,7 @@ import org.batfish.datamodel.eigrp.EigrpMetricVersion;
 import org.batfish.datamodel.eigrp.EigrpNeighborConfig;
 import org.batfish.datamodel.eigrp.EigrpProcessMode;
 import org.batfish.datamodel.eigrp.WideMetric;
+import org.batfish.datamodel.matchers.BgpRouteMatchers;
 import org.batfish.datamodel.matchers.ConfigurationMatchers;
 import org.batfish.datamodel.matchers.EigrpInterfaceSettingsMatchers;
 import org.batfish.datamodel.matchers.EigrpMetricMatchers;
@@ -7329,7 +7331,9 @@ public final class CiscoGrammarTest {
   public void testIosVrfLeakingConversion() throws IOException {
     String hostname = "ios-vrf-leaking";
     Configuration c = parseConfig(hostname);
-    VrfLeakingConfig.Builder builder = VrfLeakingConfig.builder().setLeakAsBgp(true);
+    VrfLeakingConfig.Builder builder =
+        VrfLeakingConfig.builder()
+            .setBgpLeakConfig(new BgpLeakConfig(ExtendedCommunity.target(65003, 11)));
     assertThat(
         c.getVrfs().get("DST_VRF").getVrfLeakConfigs(),
         contains(builder.setImportFromVrf("SRC_VRF").setImportPolicy("IMPORT_MAP").build()));
@@ -7358,7 +7362,9 @@ public final class CiscoGrammarTest {
                 allOf(
                     hasPrefix(Prefix.parse("2.2.2.0/24")),
                     hasProtocol(RoutingProtocol.BGP),
-                    hasNextHop(NextHopVrf.of("SRC_VRF"))))));
+                    hasNextHop(NextHopVrf.of("SRC_VRF")),
+                    BgpRouteMatchers.hasCommunities(
+                        contains(ExtendedCommunity.target(65003, 11)))))));
     assertThat(ribs.get("DST_IMPOSSIBLE").getRoutes(), empty());
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5247,7 +5247,6 @@ public final class FlatJuniperGrammarTest {
     Vrf defaultVrf = c.getVrfs().get(DEFAULT_VRF_NAME);
     VrfLeakingConfig.Builder leakConfigBuilder =
         VrfLeakingConfig.builder()
-            .setLeakAsBgp(false)
             .setImportPolicy(generateInstanceImportPolicyName(DEFAULT_VRF_NAME));
     assertThat(
         defaultVrf.getVrfLeakConfigs(),


### PR DESCRIPTION
Show data indicates that route target communities persist on the route after leaking