### PR TITLE
Hotfix disable-peer-as-check for nxos

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -93,9 +93,9 @@ public final class BgpProtocolHelper {
     // Do not export route if it has NO_ADVERTISE community, or if its AS path contains the remote
     // peer's AS and local peer has not set getAllowRemoteOut
     if (route.getCommunities().getCommunities().contains(StandardCommunity.NO_ADVERTISE)
-        || (sessionProperties.isEbgp()
-            && route.getAsPath().containsAs(sessionProperties.getTailAs())
-            && !af.getAddressFamilyCapabilities().getAllowRemoteAsOut())) {
+        || (sessionProperties.isEbgp() && !af.getAddressFamilyCapabilities().getAllowRemoteAsOut())
+            && !route.getAsPath().getAsSets().isEmpty()
+            && route.getAsPath().getAsSets().get(0).containsAs(sessionProperties.getTailAs())) {
       return null;
     }
     // Also do not export if route has NO_EXPORT community and this is a true ebgp session


### PR DESCRIPTION
This implements the more correct behavior for nxos as a stop-gap. 
https://www.cisco.com/c/en/us/support/docs/ios-nx-os-software/nx-os-software/214619-configure-disable-peer-as-check-in-bgp-o.html

Looks at last AS in the AS path, instead of the entire AS path.
We need to do more vendor tests, and likely we will need to expand our VI model to support more variations on eBGP loop prevention