### PR TITLE
BDP: do not chain leak bgp routes

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -23,6 +23,7 @@ import com.google.common.graph.ValueGraph;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -146,6 +147,11 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
   @Nonnull private Builder<Bgpv4Route> _bgpv4DeltaBuilder = RibDelta.builder();
   /** {@link RibDelta} representing changes to {@link #_ebgpv4Rib} in the current iteration */
   @Nonnull private Builder<Bgpv4Route> _ebgpv4DeltaBuilder = RibDelta.builder();
+  /**
+   * Keep track of routes we had imported from other VRF during leaking, to avoid exporting them
+   * again (chain leaking).
+   */
+  @Nonnull private final Set<Bgpv4Route> _importedFromOtherVrfs = new HashSet<>(0);
   /**
    * Keep track of redistributed routes that we have merged into our local RIB.
    *
@@ -1701,12 +1707,15 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
                 getRib(
                     Bgpv4Route.class,
                     route.getProtocol() == RoutingProtocol.IBGP ? RibType.IBGP : RibType.EBGP);
+            Bgpv4Route transformedRoute = builder.build();
             if (ra.isWithdrawn()) {
-              ribDeltaBuilders.get(targetRib).remove(builder.build(), Reason.WITHDRAW);
+              ribDeltaBuilders.get(targetRib).remove(transformedRoute, Reason.WITHDRAW);
+              _importedFromOtherVrfs.remove(transformedRoute);
             } else {
-              RibDelta<Bgpv4Route> d = targetRib.mergeRouteGetDelta(builder.build());
+              RibDelta<Bgpv4Route> d = targetRib.mergeRouteGetDelta(transformedRoute);
               LOGGER.debug("Node {}, VRF {}, route {} leaked", _hostname, _vrfName, d);
               ribDeltaBuilders.get(targetRib).from(d);
+              _importedFromOtherVrfs.add(transformedRoute);
             }
           } else {
             LOGGER.trace(
@@ -1804,8 +1813,9 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
    * locally-generated and received routes.
    */
   Stream<RouteAdvertisement<Bgpv4Route>> getRoutesToLeak() {
-    // TODO: in the fullness of time this is what getV4Routes should return.
-    return Stream.concat(_localDeltaPrev.getActions(), _bgpv4DeltaPrev.getActions());
+    return Stream.concat(
+        _localDeltaPrev.getActions(),
+        _bgpv4DeltaPrev.getActions().filter(r -> !_importedFromOtherVrfs.contains(r.getRoute())));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/BgpRoutingProcessTest.java
@@ -672,5 +672,10 @@ public class BgpRoutingProcessTest {
                     hasNextHop(NextHopVrf.of(otherVrf)),
                     isNonRouting(false),
                     hasCommunities(contains(routeTarget))))));
+
+    // Finally check that routes imported from other vrfs won't be exported for leaking.
+    // Fake up end of round
+    _routingProcess.endOfRound();
+    assertThat(_routingProcess.getRoutesToLeak().collect(Collectors.toList()), empty());
   }
 }


### PR DESCRIPTION
Keep local state such that BGP routes imported from other vrfs are not considered for later export to leak to other VRFs