### PR TITLE
IOS: support VRF leaking for vrfs not defined under router bgp

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3446,6 +3446,17 @@ public final class CiscoConfiguration extends VendorConfiguration {
           if (bgpProcess != null) {
             org.batfish.datamodel.BgpProcess newBgpProcess = toBgpProcess(c, bgpProcess, vrfName);
             newVrf.setBgpProcess(newBgpProcess);
+          } else if (vrf.getIpv4UnicastAddressFamily() != null
+              && !vrf.getIpv4UnicastAddressFamily().getRouteTargetImport().isEmpty()) {
+            /*
+             * Despite no BGP config this vrf is leaked into. Make a dummy BGP process.
+             */
+            assert newVrf.getBgpProcess() == null;
+            newVrf.setBgpProcess(
+                org.batfish.datamodel.BgpProcess.builder()
+                    .setRouterId(Ip.ZERO)
+                    .setAdminCostsToVendorDefaults(c.getConfigurationFormat())
+                    .build());
           }
         });
     /*

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-vrf-leaking
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/ios-vrf-leaking
@@ -23,10 +23,16 @@ vrf definition DST_VRF
  exit-address-family
 !
  vrf definition DST_IMPOSSIBLE
-  rd 65003:2
+  rd 65003:3
   !
   address-family ipv4
    import map UNDEFINED
+   route-target import 65003:11
+  exit-address-family
+!
+ vrf definition NOT_UNDER_ROUTER_BGP
+  rd 65003:4
+  address-family ipv4
    route-target import 65003:11
   exit-address-family
 !


### PR DESCRIPTION
Make dummy processes to ensure we can leak BGP routes even if the VRF is missing a definition under router bgp