### PR TITLE
IpsecPeerConfig: Require valid local address

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpsecPeerConfig.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.datamodel.Interface.UNSET_LOCAL_INTERFACE;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -41,10 +42,14 @@ public abstract class IpsecPeerConfig implements Serializable {
       @JsonProperty(PROP_POLICY_ACCESS_LIST) @Nullable IpAccessList policyAccessList,
       @JsonProperty(PROP_LOCAL_ADDRESS) @Nullable Ip localAddress,
       @JsonProperty(PROP_TUNNEL_INTERFACE) @Nullable String tunnelInterface) {
+    checkArgument(
+        localAddress != null && localAddress.valid(),
+        "Not a valid local address: %s",
+        localAddress);
     _ipsecPolicy = ipsecPolicy;
     _sourceInterface = firstNonNull(sourceInterface, UNSET_LOCAL_INTERFACE);
     _policyAccessList = policyAccessList;
-    _localAddress = firstNonNull(localAddress, Ip.AUTO);
+    _localAddress = localAddress;
     _tunnelInterface = tunnelInterface;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CompletionMetadataUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/CompletionMetadataUtilsTest.java
@@ -503,7 +503,8 @@ public final class CompletionMetadataUtilsTest {
     config.setIpsecPhase2Proposals(
         ImmutableSortedMap.of(ipsecPhase2ProposalName, new IpsecPhase2Proposal()));
     config.setIpsecPeerConfigs(
-        ImmutableSortedMap.of(ipsecPeerConfigName, IpsecStaticPeerConfig.builder().build()));
+        ImmutableSortedMap.of(
+            ipsecPeerConfigName, IpsecStaticPeerConfig.builder().setLocalAddress(Ip.ZERO).build()));
     config.setRouteFilterLists(
         ImmutableSortedMap.of(routeFilterListName, new RouteFilterList(routeFilterListName)));
     config.setRoute6FilterLists(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IpsecUtilHybridCloudTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IpsecUtilHybridCloudTest.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpsecPeerConfigId;
 import org.batfish.datamodel.IpsecPhase2Proposal;
 import org.batfish.datamodel.IpsecSession;
@@ -45,11 +46,13 @@ public class IpsecUtilHybridCloudTest {
         IpsecStaticPeerConfig.builder()
             .setSourceInterface("interface1")
             .setTunnelInterface("Tunnel1")
+            .setLocalAddress(Ip.parse("1.1.1.1"))
             .build();
     IpsecStaticPeerConfig ipsecPeerConfig2 =
         IpsecStaticPeerConfig.builder()
             .setSourceInterface("interface2")
             .setTunnelInterface("Tunnel2")
+            .setLocalAddress(Ip.parse("2.2.2.2"))
             .build();
 
     IpsecSession establishedSession =

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IpsecUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/IpsecUtilTest.java
@@ -26,6 +26,7 @@ import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.IkeKeyType;
 import org.batfish.datamodel.IkePhase1Key;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpsecPeerConfigId;
 import org.batfish.datamodel.IpsecPhase2Proposal;
 import org.batfish.datamodel.IpsecSession;
@@ -68,30 +69,41 @@ public class IpsecUtilTest {
         IpsecStaticPeerConfig.builder()
             .setSourceInterface("interface1")
             .setTunnelInterface("Tunnel1")
+            .setLocalAddress(Ip.parse("1.1.1.1"))
             .build();
     IpsecStaticPeerConfig ipsecPeerConfig2 =
         IpsecStaticPeerConfig.builder()
             .setSourceInterface("interface2")
             .setTunnelInterface("Tunnel2")
+            .setLocalAddress(Ip.parse("2.2.2.2"))
             .build();
     IpsecStaticPeerConfig ipsecPeerConfig3 =
         IpsecStaticPeerConfig.builder()
             .setSourceInterface("interface3")
             .setTunnelInterface("Tunnel3")
+            .setLocalAddress(Ip.parse("3.3.3.3"))
             .build();
     IpsecStaticPeerConfig ipsecPeerConfig4 =
         IpsecStaticPeerConfig.builder()
             .setSourceInterface("interface4")
             .setTunnelInterface("Tunnel4")
+            .setLocalAddress(Ip.parse("4.4.4.4"))
             .build();
     IpsecStaticPeerConfig ipsecPeerConfig5 =
-        IpsecStaticPeerConfig.builder().setSourceInterface("interface5").build();
+        IpsecStaticPeerConfig.builder()
+            .setSourceInterface("interface5")
+            .setLocalAddress(Ip.parse("5.5.5.5"))
+            .build();
     IpsecStaticPeerConfig ipsecPeerConfig6 =
-        IpsecStaticPeerConfig.builder().setSourceInterface("interface6").build();
+        IpsecStaticPeerConfig.builder()
+            .setSourceInterface("interface6")
+            .setLocalAddress(Ip.parse("6.6.6.6"))
+            .build();
     IpsecStaticPeerConfig ipsecPeerConfig7 =
         IpsecStaticPeerConfig.builder()
             .setSourceInterface("interface7")
             .setTunnelInterface("Tunnel7")
+            .setLocalAddress(Ip.parse("7.7.7.7"))
             .build();
 
     IpsecSession establishedSession =
@@ -194,24 +206,24 @@ public class IpsecUtilTest {
         getIpsecSession(
                 cb.setConfigurationFormat(AWS).build(),
                 cb.setConfigurationFormat(AWS).build(),
-                ipsecPeerConfigBuilder.build(),
-                ipsecPeerConfigBuilder.build())
+                ipsecPeerConfigBuilder.setLocalAddress(Ip.parse("1.1.1.1")).build(),
+                ipsecPeerConfigBuilder.setLocalAddress(Ip.parse("2.2.2.2")).build())
             .isCloud());
 
     assertTrue(
         getIpsecSession(
                 cb.setConfigurationFormat(CISCO_IOS).build(),
                 cb.setConfigurationFormat(AWS).build(),
-                ipsecPeerConfigBuilder.build(),
-                ipsecPeerConfigBuilder.build())
+                ipsecPeerConfigBuilder.setLocalAddress(Ip.parse("1.1.1.1")).build(),
+                ipsecPeerConfigBuilder.setLocalAddress(Ip.parse("2.2.2.2")).build())
             .isCloud());
 
     assertFalse(
         getIpsecSession(
                 cb.setConfigurationFormat(CISCO_IOS).build(),
                 cb.setConfigurationFormat(CISCO_IOS).build(),
-                ipsecPeerConfigBuilder.build(),
-                ipsecPeerConfigBuilder.build())
+                ipsecPeerConfigBuilder.setLocalAddress(Ip.parse("1.1.1.1")).build(),
+                ipsecPeerConfigBuilder.setLocalAddress(Ip.parse("2.2.2.2")).build())
             .isCloud());
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -2374,7 +2374,8 @@ public final class AristaConfiguration extends VendorConfiguration {
           continue;
         }
         // convert to IpsecPeerConfig
-        ipsecPeerConfigBuilder.put(name, toIpsecPeerConfig(tunnel, name, this, c));
+        toIpsecPeerConfig(tunnel, name, this, c, _w)
+            .ifPresent(config -> ipsecPeerConfigBuilder.put(name, config));
       }
     }
     c.setIpsecPeerConfigs(ipsecPeerConfigBuilder.build());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -3387,7 +3387,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
           continue;
         }
         // convert to IpsecPeerConfig
-        ipsecPeerConfigBuilder.put(name, toIpsecPeerConfig(tunnel, name, this, c));
+        toIpsecPeerConfig(tunnel, name, this, c, _w)
+            .ifPresent(config -> ipsecPeerConfigBuilder.put(name, config));
       }
     }
     c.setIpsecPeerConfigs(ipsecPeerConfigBuilder.build());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -827,18 +827,30 @@ public class CiscoConversions {
     return firstNonNull(AclIpSpace.union(networkObjectGroup.getLines()), EmptyIpSpace.INSTANCE);
   }
 
-  /** Converts a {@link Tunnel} to an {@link IpsecPeerConfig} */
-  static IpsecPeerConfig toIpsecPeerConfig(
+  /**
+   * Converts a {@link Tunnel} to an {@link IpsecPeerConfig}, or empty optional if it can't be
+   * converted
+   */
+  static Optional<IpsecPeerConfig> toIpsecPeerConfig(
       Tunnel tunnel,
       String tunnelIfaceName,
       CiscoConfiguration oldConfig,
-      Configuration newConfig) {
+      Configuration newConfig,
+      Warnings w) {
+    Ip localAddress = tunnel.getSourceAddress();
+    if (localAddress == null || !localAddress.valid()) {
+      w.redFlag(
+          String.format(
+              "Cannot create IPsec peer on tunnel %s: cannot determine tunnel source address",
+              tunnelIfaceName));
+      return Optional.empty();
+    }
 
     IpsecStaticPeerConfig.Builder ipsecStaticPeerConfigBuilder =
         IpsecStaticPeerConfig.builder()
             .setTunnelInterface(tunnelIfaceName)
             .setDestinationAddress(tunnel.getDestination())
-            .setLocalAddress(tunnel.getSourceAddress())
+            .setLocalAddress(localAddress)
             .setSourceInterface(tunnel.getSourceInterfaceName())
             .setIpsecPolicy(tunnel.getIpsecProfileName());
 
@@ -857,7 +869,7 @@ public class CiscoConversions {
               tunnel.getSourceInterfaceName()));
     }
 
-    return ipsecStaticPeerConfigBuilder.build();
+    return Optional.of(ipsecStaticPeerConfigBuilder.build());
   }
 
   /**
@@ -890,19 +902,30 @@ public class CiscoConversions {
         continue;
       }
       // add one IPSec peer config per interface for the crypto map entry
-      ipsecPeerConfigsBuilder.put(
-          String.format("~IPSEC_PEER_CONFIG:%s_%s~", cryptoMapNameSeqNumber, iface.getName()),
-          toIpsecPeerConfig(c, cryptoMapEntry, iface, ipsecPhase2Policy, w));
+      String peerName =
+          String.format("~IPSEC_PEER_CONFIG:%s_%s~", cryptoMapNameSeqNumber, iface.getName());
+      toIpsecPeerConfig(c, cryptoMapEntry, iface, ipsecPhase2Policy, w)
+          .ifPresent(config -> ipsecPeerConfigsBuilder.put(peerName, config));
     }
     return ipsecPeerConfigsBuilder.build();
   }
 
-  private static IpsecPeerConfig toIpsecPeerConfig(
+  private static Optional<IpsecPeerConfig> toIpsecPeerConfig(
       Configuration c,
       CryptoMapEntry cryptoMapEntry,
       org.batfish.datamodel.Interface iface,
       String ipsecPhase2Policy,
       Warnings w) {
+    Ip localAddress =
+        Optional.ofNullable(iface.getConcreteAddress())
+            .map(ConcreteInterfaceAddress::getIp)
+            .orElse(null);
+    if (localAddress == null || !localAddress.valid()) {
+      w.redFlag(
+          String.format(
+              "Cannot create IPsec peer on interface %s: no valid interface IP", iface.getName()));
+      return Optional.empty();
+    }
 
     IpsecPeerConfig.Builder<?, ?> newIpsecPeerConfigBuilder;
 
@@ -934,11 +957,11 @@ public class CiscoConversions {
     newIpsecPeerConfigBuilder
         .setSourceInterface(iface.getName())
         .setIpsecPolicy(ipsecPhase2Policy)
-        .setLocalAddress(iface.getConcreteAddress().getIp());
+        .setLocalAddress(localAddress);
 
     setIpsecPeerConfigPolicyAccessList(c, cryptoMapEntry, newIpsecPeerConfigBuilder, w);
 
-    return newIpsecPeerConfigBuilder.build();
+    return Optional.of(newIpsecPeerConfigBuilder.build());
   }
 
   private static void setIpsecPeerConfigPolicyAccessList(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -2384,7 +2384,8 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
           continue;
         }
         // convert to IpsecPeerConfig
-        ipsecPeerConfigBuilder.put(name, toIpsecPeerConfig(tunnel, name, this, c));
+        toIpsecPeerConfig(tunnel, name, this, c, _w)
+            .ifPresent(config -> ipsecPeerConfigBuilder.put(name, config));
       }
     }
     c.setIpsecPeerConfigs(ipsecPeerConfigBuilder.build());

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -2487,17 +2487,20 @@ public final class JuniperConfiguration extends VendorConfiguration {
 
     ipsecStaticConfigBuilder.setSourceInterface(externalIfaceName);
 
+    Ip localAddress = null;
     if (ikeGateway.getLocalAddress() != null) {
-      ipsecStaticConfigBuilder.setLocalAddress(ikeGateway.getLocalAddress());
+      localAddress = ikeGateway.getLocalAddress();
     } else if (externalIface != null && externalIface.getPrimaryAddress() != null) {
-      ipsecStaticConfigBuilder.setLocalAddress(externalIface.getPrimaryAddress().getIp());
-    } else {
+      localAddress = externalIface.getPrimaryAddress().getIp();
+    }
+    if (localAddress == null || !localAddress.valid()) {
       _w.redFlag(
           String.format(
               "External interface %s configured on IKE Gateway %s does not have any IP",
               externalIfaceName, ikeGateway.getName()));
       return null;
     }
+    ipsecStaticConfigBuilder.setLocalAddress(localAddress);
 
     ipsecStaticConfigBuilder.setIpsecPolicy(ipsecVpn.getIpsecPolicy());
     ipsecStaticConfigBuilder.setIkePhase1Policy(ikeGateway.getIkePolicy());

--- a/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/vyos/VyosConfiguration.java
@@ -126,6 +126,10 @@ public class VyosConfiguration extends VendorConfiguration {
       IpsecStaticPeerConfig.Builder ipsecPeerConfigBuilder = IpsecStaticPeerConfig.builder();
       ipsecPeerConfigBuilder.setDestinationAddress(peerAddress);
       Ip localAddress = ipsecPeer.getLocalAddress();
+      if (localAddress == null || !localAddress.valid()) {
+        _w.redFlag("No local address configured for VPN " + newIpsecVpnName);
+        continue;
+      }
       org.batfish.datamodel.Interface externalInterface = _ipToInterfaceMap.get(localAddress);
       if (externalInterface == null) {
         _w.redFlag(

--- a/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/edges/EdgesAnswererTest.java
@@ -204,21 +204,25 @@ public class EdgesAnswererTest {
         IpsecStaticPeerConfig.builder()
             .setSourceInterface("int11")
             .setTunnelInterface("tunnel11")
+            .setLocalAddress(Ip.parse("11.11.11.11"))
             .build();
     IpsecStaticPeerConfig peer2 =
         IpsecStaticPeerConfig.builder()
             .setSourceInterface("int12")
             .setTunnelInterface("tunnel12")
+            .setLocalAddress(Ip.parse("12.12.12.12"))
             .build();
     IpsecStaticPeerConfig peer3 =
         IpsecStaticPeerConfig.builder()
             .setSourceInterface("int21")
             .setTunnelInterface("tunnel21")
+            .setLocalAddress(Ip.parse("21.21.21.21"))
             .build();
     IpsecStaticPeerConfig peer4 =
         IpsecStaticPeerConfig.builder()
             .setSourceInterface("int22")
             .setTunnelInterface("tunnel22")
+            .setLocalAddress(Ip.parse("22.22.22.22"))
             .build();
 
     _host1.setIpsecPeerConfigs(ImmutableSortedMap.of("peer1", peer1, "peer2", peer2));


### PR DESCRIPTION
Building the IPsec topology can fail if we create peer configs with invalid (`Ip.AUTO`) local addresses.