### PR TITLE
fix hierarchical juniper multiline comments

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperLexer.g4
@@ -54,6 +54,11 @@ COMMENT_LINE
     -> skip // so not counted as last token
 ;
 
+MULTILINE_COMMENT
+:
+   '/*' .*? '*/' -> skip // so not counted as last token
+;
+
 OPEN_BRACE
 :
    '{'

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -2330,6 +2330,14 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testNestedConfigWithMultilineComment() throws IOException {
+    String hostname = "nested-config-with-multiline-comment";
+
+    // Confirm extraction works for nested configs even in the presence of multiline comments
+    assertThat(parseTextConfigs(hostname).keySet(), contains(hostname));
+  }
+
+  @Test
   public void testNestedConfigStructureDef() throws IOException {
     String hostname = "nested-config-structure-def";
     String filename = "configs/" + hostname;

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config-with-multiline-comment
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/nested-config-with-multiline-comment
@@ -1,0 +1,5 @@
+#RANCID-CONTENT-TYPE: juniper
+/* multi-line comment that should be discarded
+   */system {
+    host-name nested-config-with-multiline-comment;
+}


### PR DESCRIPTION
- hierarchical juniper can have multiline comments generated via the
`annotate` command
- fix regression caused by batfish/batfish#6598