### PR TITLE
PaloAlto: BGP peers send communities unconditionally

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_policy_rule.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_policy_rule.g4
@@ -88,12 +88,12 @@ praau_as_path
 
 praau_community
 :
-    COMMUNITY name = variable
+    COMMUNITY NONE
 ;
 
 praau_extended_community
 :
-    EXTENDED_COMMUNITY name = variable
+    EXTENDED_COMMUNITY NONE
 ;
 
 praau_med

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2117,8 +2117,11 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     ipv4af.setAddressFamilyCapabilities(
         // TODO: need to support other setAddressFamilyCapabilities like sendCommunity, etc.
         AddressFamilyCapabilities.builder()
-            .setAllowRemoteAsOut(
-                true) // PAN always sends routes, but may change AS path (see above)
+            // PAN always sends routes, but may change AS path (enable-sender-side-loop-detection)
+            .setAllowRemoteAsOut(true)
+            // PAN always sends communities, but they can be updated (including remove all)
+            .setSendCommunity(true)
+            .setSendExtendedCommunity(true)
             .build());
 
     ipv4af.setExportPolicy(

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -911,6 +911,12 @@ public final class PaloAltoGrammarTest {
     assertThat(peer.getRemoteAsns(), equalTo(LongSpace.of(65001)));
     assertTrue(
         peer.getIpv4UnicastAddressFamily().getAddressFamilyCapabilities().getAllowRemoteAsOut());
+    assertTrue(
+        peer.getIpv4UnicastAddressFamily().getAddressFamilyCapabilities().getSendCommunity());
+    assertTrue(
+        peer.getIpv4UnicastAddressFamily()
+            .getAddressFamilyCapabilities()
+            .getSendExtendedCommunity());
     // BgpRoutingProcess requires an export policy be present
     String exportPolicyName = peer.getIpv4UnicastAddressFamily().getExportPolicy();
     assertThat(exportPolicyName, not(nullValue()));


### PR DESCRIPTION
We still need to implement `update community` and `update extended-community`
variants that aren't `none`, but this gets us going.