### PR TITLE
Routes: do not populate Next_Hop (node) column if it  may be wrong

### DIFF
--- a/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
+++ b/projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
@@ -32,11 +32,11 @@ import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Table;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -121,10 +121,12 @@ public class RoutesAnswererUtil {
     if (nextHopIp == null || ipOwners == null) {
       return null;
     }
-    // TODO: https://github.com/batfish/batfish/issues/1862
-    return ipOwners.getOrDefault(nextHopIp, ImmutableSet.of()).stream()
-        .min(Comparator.naturalOrder())
-        .orElse(null);
+    Set<String> nextNodes = ipOwners.getOrDefault(nextHopIp, ImmutableSet.of());
+    if (nextNodes.size() == 1) {
+      return Iterables.getOnlyElement(nextNodes);
+    }
+    // TODO: https://github.com/batfish/batfish/issues/1862 can try harder for multiple outs
+    return null;
   }
 
   /**

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
@@ -365,6 +365,10 @@ public class RoutesAnswererUtilTest {
         computeNextHopNode(
             Ip.parse("1.1.1.1"), ImmutableMap.of(Ip.parse("1.1.1.2"), ImmutableSet.of("n1"))),
         nullValue());
+    assertThat(
+        computeNextHopNode(
+            Ip.parse("1.1.1.1"), ImmutableMap.of(Ip.parse("1.1.1.1"), ImmutableSet.of("n1", "n2"))),
+        nullValue());
   }
 
   @Test

--- a/tests/basic/routes.ref
+++ b/tests/basic/routes.ref
@@ -439,6 +439,21 @@
       },
       {
         "Node" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
+        "VRF" : "default",
+        "Network" : "2.128.0.0/16",
+        "Next_Hop_IP" : "2.1.1.2",
+        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop" : null,
+        "Protocol" : "ibgp",
+        "Tag" : null,
+        "Admin_Distance" : 200,
+        "Metric" : 0
+      },
+      {
+        "Node" : {
           "id" : "node-as2border1",
           "name" : "as2border1"
         },
@@ -466,6 +481,21 @@
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
+        "VRF" : "default",
+        "Network" : "2.128.0.0/16",
+        "Next_Hop_IP" : "2.1.1.2",
+        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop" : null,
+        "Protocol" : "ibgp",
+        "Tag" : null,
+        "Admin_Distance" : 200,
+        "Metric" : 0
       },
       {
         "Node" : {
@@ -4204,66 +4234,6 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.0.0/16",
-        "Next_Hop_IP" : "2.1.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.0.0/16",
-        "Next_Hop_IP" : "2.1.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.0.0/16",
-        "Next_Hop_IP" : "2.1.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.0.0/16",
-        "Next_Hop_IP" : "2.1.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 0
-      },
-      {
-        "Node" : {
           "id" : "node-as2dept1",
           "name" : "as2dept1"
         },
@@ -4804,6 +4774,36 @@
       },
       {
         "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "2.128.0.0/16",
+        "Next_Hop_IP" : "2.1.1.2",
+        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop" : null,
+        "Protocol" : "ibgp",
+        "Tag" : null,
+        "Admin_Distance" : 200,
+        "Metric" : 0
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "2.128.0.0/16",
+        "Next_Hop_IP" : "2.1.1.2",
+        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop" : null,
+        "Protocol" : "ibgp",
+        "Tag" : null,
+        "Admin_Distance" : 200,
+        "Metric" : 0
+      },
+      {
+        "Node" : {
           "id" : "node-as3border2",
           "name" : "as3border2"
         },
@@ -4894,21 +4894,6 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.0.0/16",
-        "Next_Hop_IP" : "2.1.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 0
-      },
-      {
-        "Node" : {
           "id" : "node-as2border2",
           "name" : "as2border2"
         },
@@ -4966,6 +4951,36 @@
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "2.128.0.0/16",
+        "Next_Hop_IP" : "2.1.1.2",
+        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop" : null,
+        "Protocol" : "ibgp",
+        "Tag" : null,
+        "Admin_Distance" : 200,
+        "Metric" : 0
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "2.128.0.0/16",
+        "Next_Hop_IP" : "2.1.1.2",
+        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop" : null,
+        "Protocol" : "ibgp",
+        "Tag" : null,
+        "Admin_Distance" : 200,
+        "Metric" : 0
       },
       {
         "Node" : {
@@ -5146,21 +5161,6 @@
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.0.0/16",
-        "Next_Hop_IP" : "2.1.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 0
       }
     ],
     "summary" : {


### PR DESCRIPTION
E.g., multiple owners of that next-hop IP.

This is for #1862.