### PR TITLE
cisco: remove disable-peer-as-check from non-NX-OS parsers

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -3319,11 +3319,6 @@ DISABLE_CONNECTED_CHECK
    'disable-connected-check'
 ;
 
-DISABLE_PEER_AS_CHECK
-:
-   'disable-peer-as-check'
-;
-
 DISCRIMINATOR
 :
    'discriminator'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco/Cisco_bgp.g4
@@ -242,7 +242,6 @@ bgp_tail
    | default_originate_bgp_tail
    | default_shutdown_bgp_tail
    | description_bgp_tail
-   | disable_peer_as_check_bgp_tail
    | distribute_list_bgp_tail
    | ebgp_multihop_bgp_tail
    | local_as_bgp_tail
@@ -317,11 +316,6 @@ default_shutdown_bgp_tail
 description_bgp_tail
 :
    description_line
-;
-
-disable_peer_as_check_bgp_tail
-:
-   DISABLE_PEER_AS_CHECK NEWLINE
 ;
 
 distribute_list_bgp_tail

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
@@ -3056,11 +3056,6 @@ DISABLE_CONNECTED_CHECK
    'disable-connected-check'
 ;
 
-DISABLE_PEER_AS_CHECK
-:
-   'disable-peer-as-check'
-;
-
 DISCRIMINATOR
 :
    'discriminator'

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_bgp.g4
@@ -204,7 +204,6 @@ bgp_tail
    | default_originate_bgp_tail
    | default_shutdown_bgp_tail
    | description_bgp_tail
-   | disable_peer_as_check_bgp_tail
    | distribute_list_bgp_tail
    | ebgp_multihop_bgp_tail
    | local_as_bgp_tail
@@ -278,11 +277,6 @@ default_shutdown_bgp_tail
 description_bgp_tail
 :
    description_line
-;
-
-disable_peer_as_check_bgp_tail
-:
-   DISABLE_PEER_AS_CHECK NEWLINE
 ;
 
 distribute_list_bgp_tail

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -547,7 +547,6 @@ import org.batfish.grammar.cisco.CiscoParser.Default_shutdown_bgp_tailContext;
 import org.batfish.grammar.cisco.CiscoParser.Description_bgp_tailContext;
 import org.batfish.grammar.cisco.CiscoParser.Description_lineContext;
 import org.batfish.grammar.cisco.CiscoParser.Dh_groupContext;
-import org.batfish.grammar.cisco.CiscoParser.Disable_peer_as_check_bgp_tailContext;
 import org.batfish.grammar.cisco.CiscoParser.Distribute_list_bgp_tailContext;
 import org.batfish.grammar.cisco.CiscoParser.Distribute_list_is_stanzaContext;
 import org.batfish.grammar.cisco.CiscoParser.Domain_lookupContext;
@@ -4507,11 +4506,6 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitDescription_bgp_tail(Description_bgp_tailContext ctx) {
     _currentPeerGroup.setDescription(getDescription(ctx.description_line()));
-  }
-
-  @Override
-  public void exitDisable_peer_as_check_bgp_tail(Disable_peer_as_check_bgp_tailContext ctx) {
-    _currentPeerGroup.setDisablePeerAsCheck(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -445,7 +445,6 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Delete_community_rp_stanzaCont
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Description_bgp_tailContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Description_lineContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Dh_groupContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.Disable_peer_as_check_bgp_tailContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Disposition_rp_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Distribute_list_bgp_tailContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Distribute_list_is_stanzaContext;
@@ -3854,11 +3853,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   @Override
   public void exitDescription_bgp_tail(Description_bgp_tailContext ctx) {
     _currentPeerGroup.setDescription(getDescription(ctx.description_line()));
-  }
-
-  @Override
-  public void exitDisable_peer_as_check_bgp_tail(Disable_peer_as_check_bgp_tailContext ctx) {
-    _currentPeerGroup.setDisablePeerAsCheck(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpPeerGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/BgpPeerGroup.java
@@ -21,7 +21,6 @@ public abstract class BgpPeerGroup implements Serializable {
   protected Boolean _defaultOriginate;
   protected String _defaultOriginateMap;
   protected String _description;
-  protected Boolean _disablePeerAsCheck;
   protected Boolean _ebgpMultihop;
   private String _groupName;
   /** Name of IPv4 access list used to filter inbound BGP routes to this peer */
@@ -96,10 +95,6 @@ public abstract class BgpPeerGroup implements Serializable {
 
   public String getDescription() {
     return _description;
-  }
-
-  public Boolean getDisablePeerAsCheck() {
-    return _disablePeerAsCheck;
   }
 
   public Boolean getEbgpMultihop() {
@@ -264,9 +259,6 @@ public abstract class BgpPeerGroup implements Serializable {
     if (_description == null) {
       _description = pg.getDescription();
     }
-    if (_disablePeerAsCheck == null) {
-      _disablePeerAsCheck = pg.getDisablePeerAsCheck();
-    }
     if (_ebgpMultihop == null) {
       _ebgpMultihop = pg.getEbgpMultihop();
     }
@@ -391,10 +383,6 @@ public abstract class BgpPeerGroup implements Serializable {
 
   public void setDescription(String description) {
     _description = description;
-  }
-
-  public void setDisablePeerAsCheck(boolean disablePeerAsCheck) {
-    _disablePeerAsCheck = disablePeerAsCheck;
   }
 
   public void setEbgpMultihop(boolean ebgpMultihop) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1622,7 +1622,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               .setAdditionalPathsSelectAll(lpg.getAdditionalPathsSelectAll())
               .setAdditionalPathsSend(lpg.getAdditionalPathsSend())
               .setAllowLocalAsIn(lpg.getAllowAsIn())
-              .setAllowRemoteAsOut(firstNonNull(lpg.getDisablePeerAsCheck(), Boolean.TRUE))
+              .setAllowRemoteAsOut(true) /* always true on IOS */
               /*
                * On Cisco IOS, advertise-inactive is true by default. This can be modified by
                * "bgp suppress-inactive" command,

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/MasterBgpPeerGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/MasterBgpPeerGroup.java
@@ -15,7 +15,6 @@ public class MasterBgpPeerGroup extends BgpPeerGroup {
     _additionalPathsSend = false;
     _allowAsIn = false;
     _defaultOriginate = false;
-    _disablePeerAsCheck = true;
     _ebgpMultihop = false;
     _routeReflectorClient = false;
     _sendCommunity = false;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/BgpPeerGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/BgpPeerGroup.java
@@ -22,7 +22,6 @@ public abstract class BgpPeerGroup implements Serializable {
   protected Boolean _defaultOriginate;
   protected String _defaultOriginateMap;
   protected String _description;
-  protected Boolean _disablePeerAsCheck;
   protected Boolean _ebgpMultihop;
   private String _groupName;
   /** Name of IPv4 access list used to filter inbound BGP routes to this peer */
@@ -101,10 +100,6 @@ public abstract class BgpPeerGroup implements Serializable {
 
   public String getDescription() {
     return _description;
-  }
-
-  public Boolean getDisablePeerAsCheck() {
-    return _disablePeerAsCheck;
   }
 
   public Boolean getEbgpMultihop() {
@@ -272,9 +267,6 @@ public abstract class BgpPeerGroup implements Serializable {
     if (_description == null) {
       _description = pg.getDescription();
     }
-    if (_disablePeerAsCheck == null) {
-      _disablePeerAsCheck = pg.getDisablePeerAsCheck();
-    }
     if (_ebgpMultihop == null) {
       _ebgpMultihop = pg.getEbgpMultihop();
     }
@@ -403,10 +395,6 @@ public abstract class BgpPeerGroup implements Serializable {
 
   public void setDescription(String description) {
     _description = description;
-  }
-
-  public void setDisablePeerAsCheck(boolean disablePeerAsCheck) {
-    _disablePeerAsCheck = disablePeerAsCheck;
   }
 
   public void setEbgpMultihop(boolean ebgpMultihop) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -1272,7 +1272,7 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
               .setAdditionalPathsSelectAll(lpg.getAdditionalPathsSelectAll())
               .setAdditionalPathsSend(lpg.getAdditionalPathsSend())
               .setAllowLocalAsIn(lpg.getAllowAsIn())
-              .setAllowRemoteAsOut(firstNonNull(lpg.getDisablePeerAsCheck(), Boolean.TRUE))
+              .setAllowRemoteAsOut(true) // TODO: verify default on IOS-XR
               /*
                * On Cisco IOS, advertise-inactive is true by default. This can be modified by
                * "bgp suppress-inactive" command,

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/MasterBgpPeerGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/MasterBgpPeerGroup.java
@@ -16,7 +16,6 @@ public class MasterBgpPeerGroup extends BgpPeerGroup {
     _advertiseInactive = false;
     _allowAsIn = false;
     _defaultOriginate = false;
-    _disablePeerAsCheck = true;
     _ebgpMultihop = false;
     _routeReflectorClient = false;
     _sendCommunity = false;

--- a/tests/parsing-errors-tests/networks/all-fail/configs/as2r1.cfg
+++ b/tests/parsing-errors-tests/networks/all-fail/configs/as2r1.cfg
@@ -13,10 +13,8 @@ interface Loopback0
 router bgp 2
  neighbor 10.12.11.1 remote-as 1
   address-family ipv4 unicast
-   disable-peer-as-check
  neighbor 10.12.21.1 remote-as 1
   address-family ipv4 unicast
-   disable-peer-as-check
  network 2.0.0.1 mask 255.255.255.255
 !
 

--- a/tests/parsing-errors-tests/networks/single-fail/configs/as2r1.cfg
+++ b/tests/parsing-errors-tests/networks/single-fail/configs/as2r1.cfg
@@ -13,10 +13,8 @@ interface Loopback0
 router bgp 2
  neighbor 10.12.11.1 remote-as 1
   address-family ipv4 unicast
-   disable-peer-as-check
  neighbor 10.12.21.1 remote-as 1
   address-family ipv4 unicast
-   disable-peer-as-check
  network 2.0.0.1 mask 255.255.255.255
 !
 


### PR DESCRIPTION
This is leftover from before we split out NX-OS.