### PR TITLE
granular allowRemoteAsOut behavior

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/AddressFamilyCapabilities.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/AddressFamilyCapabilities.java
@@ -1,12 +1,14 @@
 package org.batfish.datamodel.bgp;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.NEVER;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -35,7 +37,7 @@ public final class AddressFamilyCapabilities implements Serializable {
   private final boolean _advertiseExternal;
   private final boolean _advertiseInactive;
   private final boolean _allowLocalAsIn;
-  private final boolean _allowRemoteAsOut;
+  private final @Nonnull AllowRemoteAsOutMode _allowRemoteAsOut;
   private final boolean _sendCommunity;
   private final boolean _sendExtendedCommunity;
 
@@ -46,7 +48,7 @@ public final class AddressFamilyCapabilities implements Serializable {
       boolean advertiseExternal,
       boolean advertiseInactive,
       boolean allowLocalAsIn,
-      boolean allowRemoteAsOut,
+      AllowRemoteAsOutMode allowRemoteAsOut,
       boolean sendCommunity,
       boolean sendExtendedCommunity) {
     _additionalPathsReceive = additionalPathsReceive;
@@ -68,7 +70,7 @@ public final class AddressFamilyCapabilities implements Serializable {
       @Nullable @JsonProperty(PROP_ADVERTISE_EXTERNAL) Boolean advertiseExternal,
       @Nullable @JsonProperty(PROP_ADVERTISE_INACTIVE) Boolean advertiseInactive,
       @Nullable @JsonProperty(PROP_ALLOW_LOCAL_AS_IN) Boolean allowLocalAsIn,
-      @Nullable @JsonProperty(PROP_ALLOW_REMOTE_AS_OUT) Boolean allowRemoteAsOut,
+      @Nullable @JsonProperty(PROP_ALLOW_REMOTE_AS_OUT) AllowRemoteAsOutMode allowRemoteAsOut,
       @Nullable @JsonProperty(PROP_SEND_COMMUNITY) Boolean sendCommunity,
       @Nullable @JsonProperty(PROP_SEND_EXTENDED_COMMUNITY) Boolean sendExtendedCommunity) {
 
@@ -142,7 +144,7 @@ public final class AddressFamilyCapabilities implements Serializable {
 
   /** Whether to allow sending of advertisements containing the remote AS number in the AS-path */
   @JsonProperty(PROP_ALLOW_REMOTE_AS_OUT)
-  public boolean getAllowRemoteAsOut() {
+  public @Nonnull AllowRemoteAsOutMode getAllowRemoteAsOut() {
     return _allowRemoteAsOut;
   }
 
@@ -214,8 +216,9 @@ public final class AddressFamilyCapabilities implements Serializable {
   }
 
   /**
-   * Return a builder for {@link AddressFamilyCapabilities} By default all values are initialized to
-   * {@code false}.
+   * Return a builder for {@link AddressFamilyCapabilities} By default all boolean values are
+   * initialized to {@code false}, and {@code _allowRemoteAsOut} is initialized to {@link
+   * AllowRemoteAsOutMode#NEVER}.
    */
   public static Builder builder() {
     return new Builder();
@@ -228,11 +231,13 @@ public final class AddressFamilyCapabilities implements Serializable {
     private boolean _advertiseExternal;
     private boolean _advertiseInactive;
     private boolean _allowLocalAsIn;
-    private boolean _allowRemoteAsOut;
+    private @Nonnull AllowRemoteAsOutMode _allowRemoteAsOut;
     private boolean _sendCommunity;
     private boolean _sendExtendedCommunity;
 
-    private Builder() {}
+    private Builder() {
+      _allowRemoteAsOut = NEVER;
+    }
 
     public Builder setAdditionalPathsReceive(boolean additionalPathsReceive) {
       _additionalPathsReceive = additionalPathsReceive;
@@ -264,7 +269,7 @@ public final class AddressFamilyCapabilities implements Serializable {
       return this;
     }
 
-    public Builder setAllowRemoteAsOut(boolean allowRemoteAsOut) {
+    public Builder setAllowRemoteAsOut(AllowRemoteAsOutMode allowRemoteAsOut) {
       _allowRemoteAsOut = allowRemoteAsOut;
       return this;
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/AllowRemoteAsOutMode.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/AllowRemoteAsOutMode.java
@@ -1,0 +1,19 @@
+package org.batfish.datamodel.bgp;
+
+/**
+ * How a BGP speaker decides whether to export an outgoing advertisement to a peer whose AS appears
+ * in the AS-path of the advertisement.
+ */
+public enum AllowRemoteAsOutMode {
+  /**
+   * Always send, regardless of whether the peer's AS appears in the AS-path of the advertisement.
+   */
+  ALWAYS,
+  /** Never send if the the peer's AS appears in the AS-path of the advertisement. */
+  NEVER,
+  /**
+   * Send unless the first AS-set of the advertisement's AS-path (the next AS to be visited by
+   * traffic, and typically the latest added) contains the peer's AS.
+   */
+  EXCEPT_FIRST;
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/AddressFamilyCapabilitiesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/AddressFamilyCapabilitiesTest.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.bgp;
 
 import static org.batfish.datamodel.bgp.AddressFamilyCapabilities.builder;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -25,7 +26,7 @@ public class AddressFamilyCapabilitiesTest {
         .addEqualityGroup(builder.setAdvertiseExternal(true).build())
         .addEqualityGroup(builder.setAdvertiseInactive(true).build())
         .addEqualityGroup(builder.setAllowLocalAsIn(true).build())
-        .addEqualityGroup(builder.setAllowRemoteAsOut(true).build())
+        .addEqualityGroup(builder.setAllowRemoteAsOut(ALWAYS).build())
         .addEqualityGroup(builder.setSendCommunity(true).build())
         .addEqualityGroup(builder.setSendExtendedCommunity(true).build())
         .addEqualityGroup(new Object())
@@ -42,7 +43,7 @@ public class AddressFamilyCapabilitiesTest {
             .setAdvertiseExternal(true)
             .setAdvertiseInactive(true)
             .setAllowLocalAsIn(true)
-            .setAllowRemoteAsOut(true)
+            .setAllowRemoteAsOut(ALWAYS)
             .setSendCommunity(true)
             .setSendExtendedCommunity(true)
             .build();
@@ -59,7 +60,7 @@ public class AddressFamilyCapabilitiesTest {
             .setAdvertiseExternal(true)
             .setAdvertiseInactive(true)
             .setAllowLocalAsIn(true)
-            .setAllowRemoteAsOut(true)
+            .setAllowRemoteAsOut(ALWAYS)
             .setSendCommunity(true)
             .setSendExtendedCommunity(true)
             .build();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AddressFamilyCapabilitiesMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AddressFamilyCapabilitiesMatchers.java
@@ -3,7 +3,9 @@ package org.batfish.datamodel.matchers;
 import static org.hamcrest.Matchers.equalTo;
 
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
+import org.batfish.datamodel.bgp.AllowRemoteAsOutMode;
 import org.batfish.datamodel.matchers.AddressFamilyCapabilitiesMatchersImpl.HasAllowLocalAsIn;
 import org.batfish.datamodel.matchers.AddressFamilyCapabilitiesMatchersImpl.HasAllowRemoteAsOut;
 import org.batfish.datamodel.matchers.AddressFamilyCapabilitiesMatchersImpl.HasSendCommunity;
@@ -11,6 +13,7 @@ import org.batfish.datamodel.matchers.AddressFamilyCapabilitiesMatchersImpl.HasS
 import org.hamcrest.Matcher;
 
 /** Matchers for {@link AddressFamilyCapabilities} */
+@ParametersAreNonnullByDefault
 public final class AddressFamilyCapabilitiesMatchers {
 
   /**
@@ -27,7 +30,7 @@ public final class AddressFamilyCapabilitiesMatchers {
    * {@code value}.
    */
   @Nonnull
-  public static Matcher<AddressFamilyCapabilities> hasAllowRemoteAsOut(boolean value) {
+  public static Matcher<AddressFamilyCapabilities> hasAllowRemoteAsOut(AllowRemoteAsOutMode value) {
     return new HasAllowRemoteAsOut(equalTo(value));
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AddressFamilyCapabilitiesMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AddressFamilyCapabilitiesMatchersImpl.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel.matchers;
 
 import javax.annotation.Nonnull;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
+import org.batfish.datamodel.bgp.AllowRemoteAsOutMode;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
@@ -19,13 +20,13 @@ final class AddressFamilyCapabilitiesMatchersImpl {
   }
 
   static final class HasAllowRemoteAsOut
-      extends FeatureMatcher<AddressFamilyCapabilities, Boolean> {
-    HasAllowRemoteAsOut(@Nonnull Matcher<? super Boolean> subMatcher) {
+      extends FeatureMatcher<AddressFamilyCapabilities, AllowRemoteAsOutMode> {
+    HasAllowRemoteAsOut(@Nonnull Matcher<? super AllowRemoteAsOutMode> subMatcher) {
       super(subMatcher, "An AddressFamilyCapabilities with allowRemoteAsOut:", "allowRemoteAsOut");
     }
 
     @Override
-    protected Boolean featureValueOf(AddressFamilyCapabilities actual) {
+    protected AllowRemoteAsOutMode featureValueOf(AddressFamilyCapabilities actual) {
       return actual.getAllowRemoteAsOut();
     }
   }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.Route.UNSET_ROUTE_NEXT_HOP_IP;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -97,27 +98,12 @@ public final class BgpProtocolHelper {
     }
 
     // For eBGP, do not export if AS path contains the peer's AS in a disallowed position
-    if (sessionProperties.isEbgp() && !route.getAsPath().getAsSets().isEmpty()) {
-      AllowRemoteAsOutMode allowRemoteAsOutMode =
-          af.getAddressFamilyCapabilities().getAllowRemoteAsOut();
-      switch (allowRemoteAsOutMode) {
-        case ALWAYS:
-          break;
-        case NEVER:
-          if (route.getAsPath().getAsSets().stream()
-              .anyMatch(asSet -> asSet.containsAs(sessionProperties.getTailAs()))) {
-            return null;
-          }
-          break;
-        case EXCEPT_FIRST:
-          if (route.getAsPath().getAsSets().get(0).containsAs(sessionProperties.getTailAs())) {
-            return null;
-          }
-          break;
-        default:
-          throw new IllegalArgumentException(
-              String.format("Unsupported AllowsRemoteAsOutMode: %s", allowRemoteAsOutMode));
-      }
+    if (sessionProperties.isEbgp()
+        && !allowAsPathOut(
+            route.getAsPath(),
+            sessionProperties.getTailAs(),
+            af.getAddressFamilyCapabilities().getAllowRemoteAsOut())) {
+      return null;
     }
     // Also do not export if route has NO_EXPORT community and this is a true ebgp session
     if (route.getCommunities().getCommunities().contains(StandardCommunity.NO_EXPORT)
@@ -199,6 +185,29 @@ public final class BgpProtocolHelper {
             : BgpRoute.DEFAULT_LOCAL_PREFERENCE);
 
     return builder;
+  }
+
+  /**
+   * Return {@code true} if an outgoing eBGP advertisement with given {@code asPath} to {@code
+   * peerAs} should be allowed under the given {@code mode}.
+   */
+  @VisibleForTesting
+  static boolean allowAsPathOut(AsPath asPath, long peerAs, AllowRemoteAsOutMode mode) {
+    List<AsSet> asSets = asPath.getAsSets();
+    if (asPath.getAsSets().isEmpty()) {
+      return true;
+    }
+    switch (mode) {
+      case ALWAYS:
+        return true;
+      case NEVER:
+        return asSets.stream().noneMatch(asSet -> asSet.containsAs(peerAs));
+      case EXCEPT_FIRST:
+        return !asSets.get(0).containsAs(peerAs);
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unsupported AllowsRemoteAsOutMode: %s", mode));
+    }
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
@@ -5,6 +5,7 @@ import static org.batfish.datamodel.Names.generatedBgpCommonExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpPeerEvpnExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpPeerExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpPeerImportPolicyName;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.routing_policy.statement.Statements.RemovePrivateAs;
 import static org.batfish.representation.arista.AristaConfiguration.MAX_ADMINISTRATIVE_COST;
 
@@ -408,7 +409,7 @@ final class AristaConversions {
               .setAllowLocalAsIn(
                   firstNonNull(neighbor.getAllowAsIn(), firstNonNull(vrfConfig.getAllowAsIn(), 0))
                       > 0)
-              .setAllowRemoteAsOut(true) // this is always true on Arista
+              .setAllowRemoteAsOut(ALWAYS) // no outgoing remote-as check on Arista
               .setSendCommunity(firstNonNull(neighbor.getSendCommunity(), Boolean.FALSE))
               .setSendExtendedCommunity(
                   firstNonNull(neighbor.getSendExtendedCommunity(), Boolean.FALSE))
@@ -573,7 +574,7 @@ final class AristaConversions {
                       firstNonNull(
                               neighbor.getAllowAsIn(), firstNonNull(vrfConfig.getAllowAsIn(), 0))
                           > 0)
-                  .setAllowRemoteAsOut(true) // this is always true on Arista
+                  .setAllowRemoteAsOut(ALWAYS) // no outgoing remote-as check on Arista
                   .setSendCommunity(firstNonNull(neighbor.getSendCommunity(), Boolean.FALSE))
                   .setSendExtendedCommunity(
                       firstNonNull(neighbor.getSendCommunity(), Boolean.FALSE))

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1623,7 +1623,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               .setAdditionalPathsSelectAll(lpg.getAdditionalPathsSelectAll())
               .setAdditionalPathsSend(lpg.getAdditionalPathsSend())
               .setAllowLocalAsIn(lpg.getAllowAsIn())
-              .setAllowRemoteAsOut(ALWAYS) /* // no outgoing remote-as check on IOS */
+              .setAllowRemoteAsOut(ALWAYS) /* no outgoing remote-as check on IOS */
               /*
                * On Cisco IOS, advertise-inactive is true by default. This can be modified by
                * "bgp suppress-inactive" command,

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -11,6 +11,7 @@ import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PAT
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENGTH;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.routing_policy.Common.generateGenerationPolicy;
 import static org.batfish.datamodel.routing_policy.Common.suppressSummarizedPrefixes;
 import static org.batfish.representation.cisco.CiscoConversions.computeDistributeListPolicies;
@@ -1622,7 +1623,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
               .setAdditionalPathsSelectAll(lpg.getAdditionalPathsSelectAll())
               .setAdditionalPathsSend(lpg.getAdditionalPathsSend())
               .setAllowLocalAsIn(lpg.getAllowAsIn())
-              .setAllowRemoteAsOut(true) /* always true on IOS */
+              .setAllowRemoteAsOut(ALWAYS) /* // no outgoing remote-as check on IOS */
               /*
                * On Cisco IOS, advertise-inactive is true by default. This can be modified by
                * "bgp suppress-inactive" command,

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -45,6 +45,7 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
+import org.batfish.datamodel.bgp.AllowRemoteAsOutMode;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.Layer2VniConfig;
@@ -712,7 +713,10 @@ final class Conversions {
     return AddressFamilyCapabilities.builder()
         .setAdvertiseInactive(!firstNonNull(naf.getSuppressInactive(), inheritedSupressInactive))
         .setAllowLocalAsIn(firstNonNull(naf.getAllowAsIn(), 0) > 0)
-        .setAllowRemoteAsOut(firstNonNull(naf.getDisablePeerAsCheck(), Boolean.FALSE))
+        .setAllowRemoteAsOut(
+            firstNonNull(naf.getDisablePeerAsCheck(), Boolean.FALSE)
+                ? AllowRemoteAsOutMode.ALWAYS
+                : AllowRemoteAsOutMode.EXCEPT_FIRST)
         .setSendCommunity(firstNonNull(naf.getSendCommunityStandard(), Boolean.FALSE))
         .setSendExtendedCommunity(firstNonNull(naf.getSendCommunityExtended(), Boolean.FALSE))
         .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -714,7 +714,7 @@ final class Conversions {
         .setAdvertiseInactive(!firstNonNull(naf.getSuppressInactive(), inheritedSupressInactive))
         .setAllowLocalAsIn(firstNonNull(naf.getAllowAsIn(), 0) > 0)
         .setAllowRemoteAsOut(
-            Boolean.TRUE.equals(naf.getDisablePeerAsCheck())
+            firstNonNull(naf.getDisablePeerAsCheck(), Boolean.FALSE)
                 ? AllowRemoteAsOutMode.ALWAYS
                 : AllowRemoteAsOutMode.EXCEPT_FIRST)
         .setSendCommunity(firstNonNull(naf.getSendCommunityStandard(), Boolean.FALSE))

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -714,7 +714,7 @@ final class Conversions {
         .setAdvertiseInactive(!firstNonNull(naf.getSuppressInactive(), inheritedSupressInactive))
         .setAllowLocalAsIn(firstNonNull(naf.getAllowAsIn(), 0) > 0)
         .setAllowRemoteAsOut(
-            firstNonNull(naf.getDisablePeerAsCheck(), Boolean.FALSE)
+            Boolean.TRUE.equals(naf.getDisablePeerAsCheck())
                 ? AllowRemoteAsOutMode.ALWAYS
                 : AllowRemoteAsOutMode.EXCEPT_FIRST)
         .setSendCommunity(firstNonNull(naf.getSendCommunityStandard(), Boolean.FALSE))

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -8,6 +8,7 @@ import static org.batfish.datamodel.Interface.computeInterfaceType;
 import static org.batfish.datamodel.Interface.isRealInterfaceName;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENGTH;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.routing_policy.Common.generateGenerationPolicy;
 import static org.batfish.datamodel.routing_policy.Common.suppressSummarizedPrefixes;
 import static org.batfish.representation.cisco_xr.CiscoXrConversions.clearFalseStatementsAndAddMatchOwnAsn;
@@ -1272,7 +1273,7 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
               .setAdditionalPathsSelectAll(lpg.getAdditionalPathsSelectAll())
               .setAdditionalPathsSend(lpg.getAdditionalPathsSend())
               .setAllowLocalAsIn(lpg.getAllowAsIn())
-              .setAllowRemoteAsOut(true) // TODO: verify default on IOS-XR
+              .setAllowRemoteAsOut(ALWAYS) // TODO: support 'as-path-loopcheck out disable'
               /*
                * On Cisco IOS, advertise-inactive is true by default. This can be modified by
                * "bgp suppress-inactive" command,

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -8,6 +8,7 @@ import static org.batfish.common.util.CollectionUtil.toImmutableSortedMap;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENGTH;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.bgp.VniConfig.importRtPatternForAnyAs;
 import static org.batfish.representation.cumulus.BgpProcess.BGP_UNNUMBERED_IP;
 import static org.batfish.representation.cumulus.CumulusNcluConfiguration.CUMULUS_CLAG_DOMAIN_ID;
@@ -627,7 +628,7 @@ public final class CumulusConversions {
                 .setAllowLocalAsIn(
                     (ipv4UnicastAddressFamily != null
                         && (firstNonNull(ipv4UnicastAddressFamily.getAllowAsIn(), 0) > 0)))
-                .setAllowRemoteAsOut(true) // this is always true
+                .setAllowRemoteAsOut(ALWAYS) // no outgoing remote-as check on Cumulus
                 .build())
         .setExportPolicy(exportRoutingPolicy.getName())
         .setImportPolicy(importRoutingPolicy == null ? null : importRoutingPolicy.getName())
@@ -1165,7 +1166,7 @@ public final class CumulusConversions {
             AddressFamilyCapabilities.builder()
                 .setSendCommunity(true)
                 .setSendExtendedCommunity(true)
-                .setAllowRemoteAsOut(true) // this is always true
+                .setAllowRemoteAsOut(ALWAYS) // no outgoing remote-as check on Cumulus
                 .build())
         .setRouteReflectorClient(
             firstNonNull(

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -6,6 +6,8 @@ import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.NEVER;
 import static org.batfish.representation.juniper.JuniperStructureType.ADDRESS_BOOK;
 import static org.batfish.representation.juniper.NatPacketLocation.interfaceLocation;
 import static org.batfish.representation.juniper.NatPacketLocation.routingInstanceLocation;
@@ -525,7 +527,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       if (advertisePeerAs == null) {
         advertisePeerAs = false;
       }
-      ipv4AfSettingsBuilder.setAllowRemoteAsOut(advertisePeerAs);
+      ipv4AfSettingsBuilder.setAllowRemoteAsOut(advertisePeerAs ? ALWAYS : NEVER);
       Boolean advertiseExternal = ig.getAdvertiseExternal();
       if (advertiseExternal == null) {
         advertiseExternal = false;

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2116,7 +2116,9 @@ public class PaloAltoConfiguration extends VendorConfiguration {
              https://docs.paloaltonetworks.com/pan-os/8-1/pan-os-admin/networking/bgp/configure-a-bgp-peer-with-mp-bgp-for-ipv4-or-ipv6-unicast.html
             */
             .setAllowRemoteAsOut(
-                Boolean.TRUE.equals(peer.getEnableSenderSideLoopDetection()) ? NEVER : ALWAYS)
+                firstNonNull(peer.getEnableSenderSideLoopDetection(), Boolean.TRUE)
+                    ? NEVER
+                    : ALWAYS)
             // PAN always sends communities, but they can be updated (including remove all)
             .setSendCommunity(true)
             .setSendExtendedCommunity(true)

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -13,6 +13,7 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.deniedByAcl;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.NEVER;
 import static org.batfish.representation.palo_alto.Conversions.computeAndSetPerPeerExportPolicy;
 import static org.batfish.representation.palo_alto.Conversions.computeAndSetPerPeerImportPolicy;
 import static org.batfish.representation.palo_alto.Conversions.getBgpCommonExportPolicy;
@@ -2108,18 +2109,14 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     }
 
     Builder ipv4af = Ipv4UnicastAddressFamily.builder();
-    if (Boolean.TRUE.equals(peer.getEnableSenderSideLoopDetection())) {
-      /*
-       TODO: routes should be sent, but AS path should be modified to remove the peer's ASN
-       https://docs.paloaltonetworks.com/pan-os/8-1/pan-os-admin/networking/bgp/configure-a-bgp-peer-with-mp-bgp-for-ipv4-or-ipv6-unicast.html
-      */
-      getWarnings().redFlag("'enable-sender-side-loop-detection yes' is not supported");
-    }
     ipv4af.setAddressFamilyCapabilities(
         // TODO: need to support other setAddressFamilyCapabilities like sendCommunity, etc.
         AddressFamilyCapabilities.builder()
-            // TODO: support 'enable-sender-side-loop-detection=No'
-            .setAllowRemoteAsOut(ALWAYS)
+            /*
+             https://docs.paloaltonetworks.com/pan-os/8-1/pan-os-admin/networking/bgp/configure-a-bgp-peer-with-mp-bgp-for-ipv4-or-ipv6-unicast.html
+            */
+            .setAllowRemoteAsOut(
+                Boolean.TRUE.equals(peer.getEnableSenderSideLoopDetection()) ? NEVER : ALWAYS)
             // PAN always sends communities, but they can be updated (including remove all)
             .setSendCommunity(true)
             .setSendExtendedCommunity(true)

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -12,6 +12,7 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.deniedByAcl;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.representation.palo_alto.Conversions.computeAndSetPerPeerExportPolicy;
 import static org.batfish.representation.palo_alto.Conversions.computeAndSetPerPeerImportPolicy;
 import static org.batfish.representation.palo_alto.Conversions.getBgpCommonExportPolicy;
@@ -2117,8 +2118,8 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     ipv4af.setAddressFamilyCapabilities(
         // TODO: need to support other setAddressFamilyCapabilities like sendCommunity, etc.
         AddressFamilyCapabilities.builder()
-            // PAN always sends routes, but may change AS path (enable-sender-side-loop-detection)
-            .setAllowRemoteAsOut(true)
+            // TODO: support 'enable-sender-side-loop-detection=No'
+            .setAllowRemoteAsOut(ALWAYS)
             // PAN always sends communities, but they can be updated (including remove all)
             .setSendCommunity(true)
             .setSendExtendedCommunity(true)

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -8,6 +8,7 @@ import static org.batfish.datamodel.Names.generatedBgpPeerEvpnExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpPeerExportPolicyName;
 import static org.batfish.datamodel.Route.UNSET_ROUTE_NEXT_HOP_IP;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.AddressFamilyCapabilitiesMatchers.hasAllowRemoteAsOut;
 import static org.batfish.datamodel.matchers.AddressFamilyCapabilitiesMatchers.hasSendCommunity;
@@ -794,7 +795,7 @@ public class AristaGrammarTest {
                 hasActiveNeighbor(
                     neighborWithRemoteAs,
                     hasIpv4UnicastAddressFamily(
-                        hasAddressFamilyCapabilites(hasAllowRemoteAsOut(true)))))));
+                        hasAddressFamilyCapabilites(hasAllowRemoteAsOut(ALWAYS)))))));
   }
 
   @Test
@@ -1086,7 +1087,7 @@ public class AristaGrammarTest {
       assertThat(defaultOriginate.getAttributePolicy(), nullValue());
       Ipv4UnicastAddressFamily af = neighbor.getIpv4UnicastAddressFamily();
       assertThat(af.getAddressFamilyCapabilities().getAllowLocalAsIn(), equalTo(true));
-      assertThat(af.getAddressFamilyCapabilities().getAllowRemoteAsOut(), equalTo(true));
+      assertThat(af.getAddressFamilyCapabilities().getAllowRemoteAsOut(), equalTo(ALWAYS));
       assertThat(af.getRouteReflectorClient(), equalTo(false));
     }
     {
@@ -1491,8 +1492,9 @@ public class AristaGrammarTest {
       BgpActivePeerConfig neighbor =
           c.getDefaultVrf().getBgpProcess().getActiveNeighbors().get(ip.toPrefix());
       assertThat(neighbor.getEvpnAddressFamily(), notNullValue());
-      assertTrue(
-          neighbor.getEvpnAddressFamily().getAddressFamilyCapabilities().getAllowRemoteAsOut());
+      assertThat(
+          neighbor.getEvpnAddressFamily().getAddressFamilyCapabilities().getAllowRemoteAsOut(),
+          equalTo(ALWAYS));
       assertThat(
           neighbor.getEvpnAddressFamily().getL2VNIs(),
           equalTo(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/NxosBgpTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/NxosBgpTest.java
@@ -2,6 +2,8 @@ package org.batfish.grammar.cisco_nxos;
 
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENGTH;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.EXCEPT_FIRST;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.AddressFamilyCapabilitiesMatchers.hasAllowRemoteAsOut;
 import static org.batfish.datamodel.matchers.AddressFamilyMatchers.hasAddressFamilyCapabilites;
@@ -196,7 +198,7 @@ public class NxosBgpTest {
                         hasRemoteAs(2L),
                         hasLocalAs(1L),
                         hasIpv4UnicastAddressFamily(
-                            hasAddressFamilyCapabilites(hasAllowRemoteAsOut(true))))))));
+                            hasAddressFamilyCapabilites(hasAllowRemoteAsOut(ALWAYS))))))));
     assertThat(
         c,
         ConfigurationMatchers.hasVrf(
@@ -205,7 +207,7 @@ public class NxosBgpTest {
                 hasActiveNeighbor(
                     Prefix.parse("3.3.3.3/32"),
                     hasIpv4UnicastAddressFamily(
-                        hasAddressFamilyCapabilites(hasAllowRemoteAsOut(false)))))));
+                        hasAddressFamilyCapabilites(hasAllowRemoteAsOut(EXCEPT_FIRST)))))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -9,6 +9,7 @@ import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.batfish.datamodel.OriginType.EGP;
 import static org.batfish.datamodel.OriginType.IGP;
 import static org.batfish.datamodel.OriginType.INCOMPLETE;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasAdministrativeCost;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasMetric;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasNextHop;
@@ -909,8 +910,9 @@ public final class PaloAltoGrammarTest {
     assertThat(peer.getLocalIp(), equalTo(Ip.parse("1.2.3.6")));
     assertThat(peer.getLocalAs(), equalTo(65001L));
     assertThat(peer.getRemoteAsns(), equalTo(LongSpace.of(65001)));
-    assertTrue(
-        peer.getIpv4UnicastAddressFamily().getAddressFamilyCapabilities().getAllowRemoteAsOut());
+    assertThat(
+        peer.getIpv4UnicastAddressFamily().getAddressFamilyCapabilities().getAllowRemoteAsOut(),
+        equalTo(ALWAYS));
     assertTrue(
         peer.getIpv4UnicastAddressFamily().getAddressFamilyCapabilities().getSendCommunity());
     assertTrue(

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -7,6 +7,7 @@ import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.InterfaceType.PHYSICAL;
 import static org.batfish.datamodel.RoutingProtocol.BGP;
 import static org.batfish.datamodel.RoutingProtocol.IBGP;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.routing_policy.statement.Statements.ExitAccept;
 import static org.batfish.representation.cumulus.CumulusConversions.DEFAULT_MAX_MED;
 import static org.batfish.representation.cumulus.CumulusConversions.GENERATED_DEFAULT_ROUTE;
@@ -1004,8 +1005,8 @@ public final class CumulusConversionsTest {
       AddressFamilyCapabilities capabilities =
           convertIpv4UnicastAddressFamily(null, true, policy, null).getAddressFamilyCapabilities();
       assertFalse(capabilities.getAllowLocalAsIn());
-      // Counter-part to allow-as-in. Always true
-      assertTrue(capabilities.getAllowRemoteAsOut());
+      // Counter-part to allow-as-in. Always allowed.
+      assertThat(capabilities.getAllowRemoteAsOut(), equalTo(ALWAYS));
     }
 
     {
@@ -1014,8 +1015,8 @@ public final class CumulusConversionsTest {
       AddressFamilyCapabilities capabilities =
           convertIpv4UnicastAddressFamily(af, true, policy, null).getAddressFamilyCapabilities();
       assertFalse(capabilities.getAllowLocalAsIn());
-      // Counter-part to allow-as-in. Always true
-      assertTrue(capabilities.getAllowRemoteAsOut());
+      // Counter-part to allow-as-in. Always allowed.
+      assertThat(capabilities.getAllowRemoteAsOut(), equalTo(ALWAYS));
     }
 
     {
@@ -1025,8 +1026,8 @@ public final class CumulusConversionsTest {
       AddressFamilyCapabilities capabilities =
           convertIpv4UnicastAddressFamily(af, true, policy, null).getAddressFamilyCapabilities();
       assertTrue(capabilities.getAllowLocalAsIn());
-      // Counter-part to allow-as-in. Always true
-      assertTrue(capabilities.getAllowRemoteAsOut());
+      // Counter-part to allow-as-in. Always allowed.
+      assertThat(capabilities.getAllowRemoteAsOut(), equalTo(ALWAYS));
     }
   }
 

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -2418,7 +2418,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -18815,7 +18815,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -18995,7 +18995,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -19174,7 +19174,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -19324,7 +19324,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -22310,7 +22310,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -22335,7 +22335,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -22360,7 +22360,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -22385,7 +22385,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -22410,7 +22410,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -22435,7 +22435,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -45008,7 +45008,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -45039,7 +45039,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -45065,7 +45065,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -45095,7 +45095,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -45134,7 +45134,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -45177,7 +45177,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -48302,7 +48302,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -48328,7 +48328,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -48377,7 +48377,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -2753,7 +2753,7 @@
                     "advertiseExternal" : false,
                     "advertiseInactive" : true,
                     "allowLocalAsIn" : false,
-                    "allowRemoteAsOut" : true,
+                    "allowRemoteAsOut" : "ALWAYS",
                     "sendCommunity" : true,
                     "sendExtendedCommunity" : false
                   },
@@ -2780,7 +2780,7 @@
                     "advertiseExternal" : false,
                     "advertiseInactive" : true,
                     "allowLocalAsIn" : false,
-                    "allowRemoteAsOut" : true,
+                    "allowRemoteAsOut" : "ALWAYS",
                     "sendCommunity" : false,
                     "sendExtendedCommunity" : false
                   },
@@ -2806,7 +2806,7 @@
                     "advertiseExternal" : false,
                     "advertiseInactive" : true,
                     "allowLocalAsIn" : false,
-                    "allowRemoteAsOut" : true,
+                    "allowRemoteAsOut" : "ALWAYS",
                     "sendCommunity" : false,
                     "sendExtendedCommunity" : false
                   },
@@ -2832,7 +2832,7 @@
                     "advertiseExternal" : false,
                     "advertiseInactive" : true,
                     "allowLocalAsIn" : false,
-                    "allowRemoteAsOut" : true,
+                    "allowRemoteAsOut" : "ALWAYS",
                     "sendCommunity" : true,
                     "sendExtendedCommunity" : false
                   },

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -1323,7 +1323,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -1350,7 +1350,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -1376,7 +1376,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -1402,7 +1402,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -2793,7 +2793,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -2820,7 +2820,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -2854,7 +2854,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -3274,7 +3274,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -3301,7 +3301,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -4654,7 +4654,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -4681,7 +4681,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -4708,7 +4708,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -6002,7 +6002,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -6029,7 +6029,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -6056,7 +6056,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -6677,7 +6677,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -6704,7 +6704,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -6731,7 +6731,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -6758,7 +6758,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -7301,7 +7301,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -7328,7 +7328,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -7355,7 +7355,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -7382,7 +7382,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -8529,7 +8529,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -8563,7 +8563,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -9359,7 +9359,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -9386,7 +9386,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -9413,7 +9413,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -10209,7 +10209,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -10236,7 +10236,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -10263,7 +10263,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -11573,7 +11573,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -11600,7 +11600,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -12862,7 +12862,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -12889,7 +12889,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -13627,7 +13627,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -13654,7 +13654,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -1939,7 +1939,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -18401,7 +18401,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -22069,7 +22069,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -22382,7 +22382,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -22848,7 +22848,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -22874,7 +22874,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : false
                     },
@@ -23371,7 +23371,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -24128,7 +24128,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -27272,7 +27272,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -29297,7 +29297,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -35944,7 +35944,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -35973,7 +35973,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -36002,7 +36002,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -36031,7 +36031,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -36059,7 +36059,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -36089,7 +36089,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -36338,7 +36338,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -36378,7 +36378,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -37903,7 +37903,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -38339,7 +38339,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -38836,7 +38836,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -40882,7 +40882,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -42073,7 +42073,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : true
                     },
@@ -42100,7 +42100,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -42127,7 +42127,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -45775,7 +45775,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -45800,7 +45800,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -67830,7 +67830,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : true,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -68209,7 +68209,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -68240,7 +68240,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -75261,7 +75261,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -75287,7 +75287,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -75313,7 +75313,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -75785,7 +75785,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : true,
+                      "allowRemoteAsOut" : "ALWAYS",
                       "sendCommunity" : false,
                       "sendExtendedCommunity" : false
                     },
@@ -76233,7 +76233,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85669,7 +85669,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85703,7 +85703,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85737,7 +85737,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85771,7 +85771,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85802,7 +85802,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85833,7 +85833,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85864,7 +85864,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : false,
+                      "allowRemoteAsOut" : "NEVER",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },


### PR DESCRIPTION
Support 3 behaviors for allowRemoteAsOut via `AllowRemoteAsOutMode`:
Break `false` down into:
- `AllowRemoteAsOutMode.NEVER`: never send adverts whose as-path contains peer as
- `AllowRemoteAsOutMode.EXCEPT_FIRST` do not send adverts whose as-path's most recent as-set contains peer as
Change `true` to:
- `AllowRemoteAsOutMode.ALWAYS`: do not filter outgoing adverts based on presence of peer as in as-path