### PR TITLE
JunOS: fix default BGP loop AS Path check

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -7,7 +7,7 @@ import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
-import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.NEVER;
+import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.EXCEPT_FIRST;
 import static org.batfish.representation.juniper.JuniperStructureType.ADDRESS_BOOK;
 import static org.batfish.representation.juniper.NatPacketLocation.interfaceLocation;
 import static org.batfish.representation.juniper.NatPacketLocation.routingInstanceLocation;
@@ -527,7 +527,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       if (advertisePeerAs == null) {
         advertisePeerAs = false;
       }
-      ipv4AfSettingsBuilder.setAllowRemoteAsOut(advertisePeerAs ? ALWAYS : NEVER);
+      ipv4AfSettingsBuilder.setAllowRemoteAsOut(advertisePeerAs ? ALWAYS : EXCEPT_FIRST);
       Boolean advertiseExternal = ig.getAdvertiseExternal();
       if (advertiseExternal == null) {
         advertiseExternal = false;

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -22069,7 +22069,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : "NEVER",
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -22382,7 +22382,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : "NEVER",
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -67830,7 +67830,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : true,
                       "allowLocalAsIn" : true,
-                      "allowRemoteAsOut" : "NEVER",
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -68209,7 +68209,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : "NEVER",
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -68240,7 +68240,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : "NEVER",
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85669,7 +85669,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : "NEVER",
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85703,7 +85703,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : "NEVER",
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85737,7 +85737,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : "NEVER",
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85771,7 +85771,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : "NEVER",
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85802,7 +85802,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : "NEVER",
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85833,7 +85833,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : "NEVER",
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },
@@ -85864,7 +85864,7 @@
                       "advertiseExternal" : false,
                       "advertiseInactive" : false,
                       "allowLocalAsIn" : false,
-                      "allowRemoteAsOut" : "NEVER",
+                      "allowRemoteAsOut" : "EXCEPT_FIRST",
                       "sendCommunity" : true,
                       "sendExtendedCommunity" : true
                     },


### PR DESCRIPTION
It actually only checks the most recent ASN, not the entire AS Path.

Fixup batfish/batfish#6613