### PR TITLE
CumulusInterfaces: cleanup and add automatic /32, /128 for addresses

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesLexer.g4
@@ -339,6 +339,11 @@ IP_ADDRESS
   F_IpAddress
 ;
 
+IPV6_ADDRESS
+:
+  F_Ipv6Address
+;
+
 IP_PREFIX
 :
   F_IpPrefix

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesParser.g4
@@ -96,14 +96,18 @@ i_address
 :
   IP? ADDRESS
   (
-    prefix
-    | prefix6
+    v4 = interface_address
+    | v6 = interface_address6
   ) NEWLINE
 ;
 
 i_address_virtual
 :
-  ADDRESS_VIRTUAL MAC_ADDRESS IP_PREFIX NEWLINE
+  ADDRESS_VIRTUAL MAC_ADDRESS
+  (
+    v4 = interface_address
+    | v6 = interface_address6
+  ) NEWLINE
 ;
 
 i_alias
@@ -193,12 +197,12 @@ i_clag_id
 
 i_clagd_backup_ip
 :
-  CLAGD_BACKUP_IP IP_ADDRESS (VRF vrf_name)? NEWLINE
+  CLAGD_BACKUP_IP address (VRF vrf_name)? NEWLINE
 ;
 
 i_clagd_peer_ip
 :
-  CLAGD_PEER_IP (IP_ADDRESS | LINK_LOCAL) NEWLINE
+  CLAGD_PEER_IP (address | LINK_LOCAL) NEWLINE
 ;
 
 i_clagd_priority
@@ -213,12 +217,12 @@ i_clagd_sys_mac
 
 i_clagd_vxlan_anycast_ip
 :
-  CLAGD_VXLAN_ANYCAST_IP IP_ADDRESS NEWLINE
+  CLAGD_VXLAN_ANYCAST_IP address NEWLINE
 ;
 
 i_gateway
 :
-  GATEWAY IP_ADDRESS NEWLINE
+  GATEWAY address NEWLINE
 ;
 
 i_hwaddress
@@ -296,11 +300,11 @@ ipui_route
 
 ipuir_add
 :
-   ADD IP_PREFIX
+   ADD prefix
    // this rule is more permissive than reality; it allows for multiple occurrences of dev/via
    // we check for conformance in the extractor
    (
-     VIA IP_ADDRESS
+     VIA address
      | DEV interface_name
    )+
    NEWLINE
@@ -333,5 +337,5 @@ i_vxlan_id
 
 i_vxlan_local_tunnel_ip
 :
-  VXLAN_LOCAL_TUNNEL_IP IP_ADDRESS NEWLINE
+  VXLAN_LOCAL_TUNNEL_IP address NEWLINE
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/CumulusInterfaces_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_interfaces/CumulusInterfaces_common.g4
@@ -19,14 +19,36 @@ number_or_range
   lo = number (DASH hi = number)?
 ;
 
+address
+:
+  IP_ADDRESS
+;
+
 prefix
 :
   IP_PREFIX
 ;
 
+interface_address
+:
+  addr_32 = address
+  | addr_mask = prefix
+;
+
+address6
+:
+  IPV6_ADDRESS
+;
+
 prefix6
 :
   IPV6_PREFIX
+;
+
+interface_address6
+:
+  addr_128 = address6
+  | addr_mask = prefix6
 ;
 
 vlan_id

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
@@ -218,8 +218,21 @@ public class CumulusInterfacesGrammarTest {
   }
 
   @Test
+  public void testIfaceAddress32() {
+    String input = "iface swp1\n address 10.12.13.14\n";
+    InterfacesInterface iface = parse(input).getInterfaces().get("swp1");
+    assertThat(iface.getAddresses(), contains(ConcreteInterfaceAddress.parse("10.12.13.14/32")));
+  }
+
+  @Test
   public void testIfaceAddressV6() {
     parse("iface swp1\n address ::1/128\n");
+    assertThat(_warnings.getParseWarnings().size(), equalTo(0));
+  }
+
+  @Test
+  public void testIfaceAddressV6_128() {
+    parse("iface swp1\n address ::1\n");
     assertThat(_warnings.getParseWarnings().size(), equalTo(0));
   }
 
@@ -233,6 +246,18 @@ public class CumulusInterfacesGrammarTest {
             ImmutableMap.of(
                 MacAddress.parse("00:00:00:00:00:00"),
                 ImmutableSet.of(ConcreteInterfaceAddress.parse("1.2.3.4/24")))));
+  }
+
+  @Test
+  public void testIfaceAddressVirtual_32() {
+    String input = "iface vlan1\n address-virtual 00:00:00:00:00:00 1.2.3.4\n";
+    InterfacesInterface iface = parse(input).getInterfaces().get("vlan1");
+    assertThat(
+        iface.getAddressVirtuals(),
+        equalTo(
+            ImmutableMap.of(
+                MacAddress.parse("00:00:00:00:00:00"),
+                ImmutableSet.of(ConcreteInterfaceAddress.parse("1.2.3.4/32")))));
   }
 
   @Test


### PR DESCRIPTION
1. add toIp, toPrefix, and use throughout. Standard stuff so we don't reinvent the wheel.
2. interface address commands all default to /32 (v4) or /128 (v6) if the prefix is not given.