### PR TITLE
FlowTracer: packets matching a session may be accepted

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -922,8 +922,15 @@ class FlowTracer {
 
               @Override
               public Void visitFibLookup(org.batfish.datamodel.flow.FibLookup fibLookup) {
+                Ip dstIp = _currentFlow.getDstIp();
+
+                // Accept if the flow is destined for this vrf on this host.
+                if (isAcceptedAtCurrentVrf(dstIp)) {
+                  return null;
+                }
+
                 fibLookup(
-                    _currentFlow.getDstIp(),
+                    dstIp,
                     currentNodeName,
                     _tracerouteContext.getFib(currentNodeName, _vrfName).get(),
                     (flowTracer, fibForward) -> {

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -650,7 +650,7 @@ public final class FlowTracerTest {
               0);
       flowTracer.processHop();
 
-      // Reverse trace should match session and get forwarded out original ingress interface
+      // Reverse trace should match session and get accepted.
       TraceAndReverseFlow traceAndReverseFlow = Iterables.getOnlyElement(traces);
       Trace trace = traceAndReverseFlow.getTrace();
       assertThat(trace, hasDisposition(ACCEPTED));


### PR DESCRIPTION
Decvices like PAN will setup sessions with FibLookup action, but they may also be
accepted.