### PR TITLE
PAN: loopback interfaces can have units

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_interface.g4
@@ -237,6 +237,7 @@ snil_unit
     name = variable
     (
         if_common
+        | snil_ip
     )?
 ;
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -1404,6 +1404,7 @@ public final class PaloAltoGrammarTest {
     String eth1_8 = "ethernet1/8";
     String eth1_21 = "ethernet1/21";
     String loopback = "loopback";
+    String loopback_123 = "loopback.123";
     Configuration c = parseConfig(hostname);
     Configuration cLoopbackRef = parseConfig(hostnameLoopbackRef);
     Configuration cLoopbackRefInvalid = parseConfig(hostnameLoopbackRefInvalid);
@@ -1412,8 +1413,18 @@ public final class PaloAltoGrammarTest {
     assertThat(
         c.getAllInterfaces().keySet(),
         containsInAnyOrder(
-            eth1_1, eth1_2, eth1_3, eth1_3_11, eth1_4, eth1_5, eth1_6, eth1_7, eth1_8, eth1_21,
-            loopback));
+            eth1_1,
+            eth1_2,
+            eth1_3,
+            eth1_3_11,
+            eth1_4,
+            eth1_5,
+            eth1_6,
+            eth1_7,
+            eth1_8,
+            eth1_21,
+            loopback,
+            loopback_123));
     assertThat(cLoopbackRef.getAllInterfaces().keySet(), contains(loopback));
     assertThat(cLoopbackRefInvalid.getAllInterfaces().keySet(), contains(loopback));
     assertThat(cLoopbackRefInvalidRange.getAllInterfaces().keySet(), contains(loopback));
@@ -1458,6 +1469,10 @@ public final class PaloAltoGrammarTest {
         cLoopbackRef,
         hasInterface(
             loopback, hasAllAddresses(contains(ConcreteInterfaceAddress.parse("10.10.10.10/32")))));
+    assertThat(
+        c,
+        hasInterface(
+            loopback_123, hasAllAddresses(contains(ConcreteInterfaceAddress.parse("1.2.3.4/32")))));
     // Bad address object references
     assertThat(cLoopbackRefInvalid, hasInterface(loopback, hasAllAddresses(emptyIterable())));
     assertThat(cLoopbackRefInvalidRange, hasInterface(loopback, hasAllAddresses(emptyIterable())));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/interface
@@ -26,5 +26,6 @@ set network interface ethernet ethernet1/8 layer3 ip GRP1
 set network interface ethernet ethernet1/21 link-state down
 set network interface loopback ip 7.7.7.7/32
 set network interface loopback ip 7.7.7.8
+set network interface loopback units loopback.123 ip 1.2.3.4
 # Interfaces are not functionally active unless they are in a virtual-router
-set network virtual-router default interface [ ethernet1/1 ethernet1/2 ethernet1/3 ethernet1/5 ethernet1/6 ethernet1/7 loopback ]
+set network virtual-router default interface [ ethernet1/1 ethernet1/2 ethernet1/3 ethernet1/5 ethernet1/6 ethernet1/7 loopback loopback.123 ]


### PR DESCRIPTION
And those units can have IP addresses.

I did confirm that the same interface can have both main loopback and
loopback.123, and both can be active and with L3 config.