### PR TITLE
PAN: support multiple ports in application-override rules

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_application_override.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/palo_alto/PaloAlto_application_override.g4
@@ -62,7 +62,7 @@ srao_negate_source
 
 srao_port
 :
-    PORT port = port_number
+    PORT variable_port_list
 ;
 
 srao_protocol

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -2481,7 +2481,14 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
 
   @Override
   public void exitSrao_port(Srao_portContext ctx) {
-    _currentApplicationOverrideRule.setPort(toInteger(ctx.port));
+    for (Port_or_rangeContext item : ctx.variable_port_list().port_or_range()) {
+      if (item.port != null) {
+        _currentApplicationOverrideRule.addPort(toInteger(item.port));
+      } else {
+        assert item.range != null;
+        _currentApplicationOverrideRule.addPorts(new SubRange(getText(item.range)));
+      }
+    }
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ApplicationOverrideRule.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/ApplicationOverrideRule.java
@@ -10,6 +10,8 @@ import java.util.TreeSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNullableByDefault;
+import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.SubRange;
 
 /** PAN datamodel component containing application-override rule configuration */
 @ParametersAreNullableByDefault
@@ -44,7 +46,7 @@ public final class ApplicationOverrideRule implements Serializable {
 
   // Traffic characteristics to match
   @Nullable private Protocol _protocol;
-  @Nullable private Integer _port;
+  @Nonnull private IntegerSpace _port;
 
   @Nonnull private final Set<String> _tags;
 
@@ -58,6 +60,7 @@ public final class ApplicationOverrideRule implements Serializable {
     _to = new TreeSet<>();
     _tags = new HashSet<>(1);
     _name = name;
+    _port = IntegerSpace.EMPTY;
   }
 
   @Nonnull
@@ -113,7 +116,7 @@ public final class ApplicationOverrideRule implements Serializable {
   }
 
   @Nullable
-  public Integer getPort() {
+  public IntegerSpace getPort() {
     return _port;
   }
 
@@ -146,7 +149,11 @@ public final class ApplicationOverrideRule implements Serializable {
     _protocol = protocol;
   }
 
-  public void setPort(Integer port) {
-    _port = port;
+  public void addPort(int port) {
+    _port = IntegerSpace.builder().including(_port).including(port).build();
+  }
+
+  public void addPorts(@Nonnull SubRange ports) {
+    _port = IntegerSpace.builder().including(_port).including(ports).build();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoGrammarTest.java
@@ -128,6 +128,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Range;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -167,6 +168,7 @@ import org.batfish.datamodel.FilterResult;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.IcmpType;
 import org.batfish.datamodel.IkeHashingAlgorithm;
+import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.InterfaceType;
@@ -3923,7 +3925,9 @@ public final class PaloAltoGrammarTest {
         contains(
             new RuleEndpoint(IP_ADDRESS, "10.10.10.10"), new RuleEndpoint(REFERENCE, "ADDR2")));
     assertTrue(rule.getNegateDestination());
-    assertThat(rule.getPort(), equalTo(8642));
+    assertThat(
+        rule.getPort(),
+        equalTo(IntegerSpace.unionOf(Range.closed(8642, 8643), Range.closed(8765, 8888))));
     assertThat(rule.getProtocol(), equalTo(ApplicationOverrideRule.Protocol.UDP));
     assertThat(rule.getApplication(), equalTo("APP_UNDEF"));
     assertThat(rule.getDescription(), equalTo("longish description"));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/application-override-rule
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/palo_alto/testconfigs/application-override-rule
@@ -24,7 +24,7 @@ set rulebase application-override rules OVERRIDE_APP_RULE2 source [ 10.10.10.10 
 set rulebase application-override rules OVERRIDE_APP_RULE2 negate-source yes
 set rulebase application-override rules OVERRIDE_APP_RULE2 destination [ 10.10.10.10 ADDR2 ]
 set rulebase application-override rules OVERRIDE_APP_RULE2 negate-destination yes
-set rulebase application-override rules OVERRIDE_APP_RULE2 port 8642
+set rulebase application-override rules OVERRIDE_APP_RULE2 port 8642,8643,8765-8888
 set rulebase application-override rules OVERRIDE_APP_RULE2 protocol udp
 set rulebase application-override rules OVERRIDE_APP_RULE2 application APP_UNDEF
 set rulebase application-override rules OVERRIDE_APP_RULE2 description "longish description"


### PR DESCRIPTION
`application-override rules` allow you to specify more than one port for the `port` parameter,  this PR adds support for that
