### PR TITLE
BgpTopologyUtils: prevent crash on misconfigured IBGP peer

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BUILD
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/BUILD
@@ -1,0 +1,26 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "**/*Test.java",
+    ]),
+    resources = [
+        "//projects/batfish/src/test/resources",
+    ],
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
+        "@maven//:junit_junit",
+        "@maven//:org_apache_commons_commons_lang3",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)


### PR DESCRIPTION
A misconfigured IBGP peer could result in Batfish thinking that it could peer with
itself (local,remote AS the same, local,remote IP the same).

Fix this by skipping self-loops during topology computation.