### PR TITLE
JunOS: support for then local-preference (add|substract)

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -526,7 +526,7 @@ popst_local_preference
 :
    LOCAL_PREFERENCE
    (
-      localpref = DEC
+      (ADD | SUBTRACT)? localpref = DEC
       | apply_groups
    )
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -5027,7 +5027,13 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitPopst_local_preference(Popst_local_preferenceContext ctx) {
     int localPreference = toInt(ctx.localpref);
-    PsThenLocalPreference then = new PsThenLocalPreference(localPreference);
+    PsThenLocalPreference.Operator op =
+        ctx.ADD() != null
+            ? PsThenLocalPreference.Operator.ADD
+            : (ctx.SUBTRACT() != null
+                ? PsThenLocalPreference.Operator.SUBTRACT
+                : PsThenLocalPreference.Operator.SET);
+    PsThenLocalPreference then = new PsThenLocalPreference(localPreference, op);
     _currentPsThens.add(then);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenLocalPreference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenLocalPreference.java
@@ -1,20 +1,36 @@
 package org.batfish.representation.juniper;
 
 import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.expr.DecrementLocalPreference;
+import org.batfish.datamodel.routing_policy.expr.IncrementLocalPreference;
 import org.batfish.datamodel.routing_policy.expr.LiteralLong;
+import org.batfish.datamodel.routing_policy.expr.LongExpr;
 import org.batfish.datamodel.routing_policy.statement.SetLocalPreference;
 import org.batfish.datamodel.routing_policy.statement.Statement;
 
 @ParametersAreNonnullByDefault
 public final class PsThenLocalPreference extends PsThen {
 
-  private final long _localPreference;
+  public enum Operator {
+    /** Increment the local-preference, clipping at 4,294,967,295. */
+    ADD,
+    /** Decrement the local-preference, clipping at 0. */
+    SUBTRACT,
+    /** Set the local-preference to the given value. */
+    SET,
+  }
 
-  public PsThenLocalPreference(long localPreference) {
+  private final long _localPreference;
+  private final @Nonnull Operator _op;
+
+  public PsThenLocalPreference(long localPreference, Operator op) {
     _localPreference = localPreference;
+    _op = op;
   }
 
   @Override
@@ -23,10 +39,39 @@ public final class PsThenLocalPreference extends PsThen {
       JuniperConfiguration juniperVendorConfiguration,
       Configuration c,
       Warnings warnings) {
-    statements.add(new SetLocalPreference(new LiteralLong(_localPreference)));
+    LongExpr expr;
+    if (_op == Operator.ADD) {
+      expr = new IncrementLocalPreference(_localPreference);
+    } else if (_op == Operator.SUBTRACT) {
+      expr = new DecrementLocalPreference(_localPreference);
+    } else {
+      assert _op == Operator.SET;
+      expr = new LiteralLong(_localPreference);
+    }
+    statements.add(new SetLocalPreference(expr));
   }
 
   public long getLocalPreference() {
     return _localPreference;
+  }
+
+  public @Nonnull Operator getOp() {
+    return _op;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenLocalPreference)) {
+      return false;
+    }
+    PsThenLocalPreference that = (PsThenLocalPreference) o;
+    return _localPreference == that._localPreference && _op == that._op;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_localPreference, _op);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenLocalPreference.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenLocalPreference.java
@@ -72,6 +72,6 @@ public final class PsThenLocalPreference extends PsThen {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_localPreference, _op);
+    return Objects.hash(_localPreference, _op.ordinal());
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -351,6 +351,9 @@ import org.batfish.representation.juniper.NatRuleThenPrefix;
 import org.batfish.representation.juniper.NatRuleThenPrefixName;
 import org.batfish.representation.juniper.NoPortTranslation;
 import org.batfish.representation.juniper.PatPool;
+import org.batfish.representation.juniper.PolicyStatement;
+import org.batfish.representation.juniper.PsThenLocalPreference;
+import org.batfish.representation.juniper.PsThenLocalPreference.Operator;
 import org.batfish.representation.juniper.RoutingInstance;
 import org.batfish.representation.juniper.Screen;
 import org.batfish.representation.juniper.ScreenAction;
@@ -3524,6 +3527,25 @@ public final class FlatJuniperGrammarTest {
                     .setOriginalRoute(new ConnectedRoute(Prefix.parse("3.3.3.0/24"), "nextHop"))
                     .build());
     assertThat(result.getBooleanValue(), equalTo(false));
+  }
+
+  @Test
+  public void testJuniperPolicyStatementTermThenExtraction() {
+    JuniperConfiguration c = parseJuniperConfig("juniper-policy-statement-then");
+    {
+      PolicyStatement policy =
+          c.getMasterLogicalSystem().getPolicyStatements().get("LOCAL_PREFERENCE_POLICY");
+      assertThat(policy.getTerms(), hasKeys("T1", "T2", "T3"));
+      assertThat(
+          policy.getTerms().get("T1").getThens(),
+          contains(new PsThenLocalPreference(1, Operator.SET)));
+      assertThat(
+          policy.getTerms().get("T2").getThens(),
+          contains(new PsThenLocalPreference(2, Operator.ADD)));
+      assertThat(
+          policy.getTerms().get("T3").getThens(),
+          contains(new PsThenLocalPreference(3, Operator.SUBTRACT)));
+    }
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThenLocalPreferenceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThenLocalPreferenceTest.java
@@ -1,0 +1,58 @@
+package org.batfish.representation.juniper;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.LinkedList;
+import java.util.List;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.routing_policy.expr.DecrementLocalPreference;
+import org.batfish.datamodel.routing_policy.expr.IncrementLocalPreference;
+import org.batfish.datamodel.routing_policy.expr.LiteralLong;
+import org.batfish.datamodel.routing_policy.statement.SetLocalPreference;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.batfish.representation.juniper.PsThenLocalPreference.Operator;
+import org.junit.Test;
+
+public class PsThenLocalPreferenceTest {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(5L)
+        .addEqualityGroup(
+            new PsThenLocalPreference(1, Operator.SET), new PsThenLocalPreference(1, Operator.SET))
+        .addEqualityGroup(new PsThenLocalPreference(2, Operator.SET))
+        .addEqualityGroup(new PsThenLocalPreference(1, Operator.ADD))
+        .addEqualityGroup(new PsThenLocalPreference(1, Operator.SUBTRACT))
+        .testEquals();
+  }
+
+  List<Statement> getStatements(PsThenLocalPreference p) {
+    List<Statement> statements = new LinkedList<>();
+    JuniperConfiguration fakeVsConfig = new JuniperConfiguration();
+    fakeVsConfig.setHostname("c");
+    Configuration fakeConfig =
+        Configuration.builder()
+            .setHostname("c")
+            .setConfigurationFormat(ConfigurationFormat.JUNIPER)
+            .build();
+    p.applyTo(statements, fakeVsConfig, fakeConfig, new Warnings());
+    return statements;
+  }
+
+  @Test
+  public void testConversion() {
+    assertThat(
+        getStatements(new PsThenLocalPreference(1, Operator.SET)),
+        contains(new SetLocalPreference(new LiteralLong(1))));
+    assertThat(
+        getStatements(new PsThenLocalPreference(2, Operator.SUBTRACT)),
+        contains(new SetLocalPreference(new DecrementLocalPreference(2))));
+    assertThat(
+        getStatements(new PsThenLocalPreference(3, Operator.ADD)),
+        contains(new SetLocalPreference(new IncrementLocalPreference(3))));
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-statement-then
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-statement-then
@@ -1,0 +1,7 @@
+#
+set system host-name juniper-policy-statement-then
+#
+set policy-options policy-statement LOCAL_PREFERENCE_POLICY term T1 then local-preference 1
+set policy-options policy-statement LOCAL_PREFERENCE_POLICY term T2 then local-preference add 2
+set policy-options policy-statement LOCAL_PREFERENCE_POLICY term T3 then local-preference subtract 3
+#


### PR DESCRIPTION
This is for batfish/batfish#6637.