### PR TITLE
Traceroute pipeline: Pre-NAT routing

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
@@ -27,7 +27,7 @@ public final class FirewallSessionInterfaceInfo implements Serializable {
   /** Possible actions for traffic matching a session on this interface */
   public enum Action {
     /** Forward traffic directly out the interface where the original flow entered */
-    NO_FIB_LOOKUP,
+    FORWARD_OUT_IFACE,
     /** Do a FIB lookup on the untransformed return flow to determine egress interface */
     PRE_NAT_FIB_LOOKUP,
     /** Do a FIB lookup on the transformed return flow to determine egress interface */
@@ -42,7 +42,7 @@ public final class FirewallSessionInterfaceInfo implements Serializable {
     public SessionAction toSessionAction(
         String originalFlowIngressIface, @Nullable NodeInterfacePair nextHop) {
       switch (this) {
-        case NO_FIB_LOOKUP:
+        case FORWARD_OUT_IFACE:
           return new ForwardOutInterface(originalFlowIngressIface, nextHop);
         case PRE_NAT_FIB_LOOKUP:
           return PreNatFibLookup.INSTANCE;
@@ -90,7 +90,7 @@ public final class FirewallSessionInterfaceInfo implements Serializable {
       @JsonProperty(PROP_OUTGOING_ACL_NAME) @Nullable String outgoingAclName) {
     checkNotNull(sessionInterfaces, PROP_SESSION_INTERFACES + " cannot be null");
     Action backwardsCompatibleAction =
-        action != null ? action : fibLookup ? Action.POST_NAT_FIB_LOOKUP : Action.NO_FIB_LOOKUP;
+        action != null ? action : fibLookup ? Action.POST_NAT_FIB_LOOKUP : Action.FORWARD_OUT_IFACE;
     return new FirewallSessionInterfaceInfo(
         backwardsCompatibleAction, sessionInterfaces, incomingAclName, outgoingAclName);
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
@@ -12,6 +12,10 @@ import java.util.Set;
 import java.util.SortedSet;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.collections.NodeInterfacePair;
+import org.batfish.datamodel.flow.ForwardOutInterface;
+import org.batfish.datamodel.flow.PostNatFibLookup;
+import org.batfish.datamodel.flow.SessionAction;
 
 /**
  * Data that determines how to create sessions for flows that routed out interfaces. In particular,
@@ -19,19 +23,56 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 @ParametersAreNonnullByDefault
 public final class FirewallSessionInterfaceInfo implements Serializable {
+  /** Possible actions for traffic matching a session on this interface */
+  public enum Action {
+    /** Forward traffic directly out the interface where the original flow entered */
+    NO_FIB_LOOKUP,
+    /** Do a FIB lookup on the transformed return flow to determine egress interface */
+    POST_NAT_FIB_LOOKUP;
 
-  private static final String PROP_FIB_LOOKUP = "fibLookup";
+    /**
+     * Converts this {@link Action} to the corresponding {@link SessionAction}. Parameters are only
+     * necessary when creating a {@link ForwardOutInterface} action.
+     */
+    public SessionAction toSessionAction(
+        String originalFlowIngressIface, @Nullable NodeInterfacePair nextHop) {
+      switch (this) {
+        case NO_FIB_LOOKUP:
+          return new ForwardOutInterface(originalFlowIngressIface, nextHop);
+        case POST_NAT_FIB_LOOKUP:
+          return PostNatFibLookup.INSTANCE;
+        default:
+          throw new UnsupportedOperationException("Unknown session action " + this);
+      }
+    }
+  }
+
+  private static final String PROP_ACTION = "action";
+  private static final String PROP_FIB_LOOKUP = "fibLookup"; // for JSON backwards compatibility
   private static final String PROP_SESSION_INTERFACES = "sessionInterfaces";
   private static final String PROP_INCOMING_ACL_NAME = "incomingAclName";
   private static final String PROP_OUTGOING_ACL_NAME = "outgoingAclName";
 
-  private final boolean _fibLookup;
+  private final Action _action;
   private final SortedSet<String> _sessionInterfaces;
   private final @Nullable String _incomingAclName;
   private final @Nullable String _outgoingAclName;
 
+  // backwards compatible constructor
   public FirewallSessionInterfaceInfo(
       boolean fibLookup,
+      Iterable<String> sessionInterfaces,
+      @Nullable String incomingAclName,
+      @Nullable String outgoingAclName) {
+    this(
+        fibLookup ? Action.POST_NAT_FIB_LOOKUP : Action.NO_FIB_LOOKUP,
+        sessionInterfaces,
+        incomingAclName,
+        outgoingAclName);
+  }
+
+  public FirewallSessionInterfaceInfo(
+      Action action,
       Iterable<String> sessionInterfaces,
       @Nullable String incomingAclName,
       @Nullable String outgoingAclName) {
@@ -43,18 +84,23 @@ public final class FirewallSessionInterfaceInfo implements Serializable {
     _sessionInterfaces = ImmutableSortedSet.copyOf(sessionInterfaces);
     _incomingAclName = incomingAclName;
     _outgoingAclName = outgoingAclName;
-    _fibLookup = fibLookup;
+    _action = action;
   }
 
   @JsonCreator
   private static FirewallSessionInterfaceInfo jsonCreator(
+      @JsonProperty(PROP_ACTION) @Nullable Action action,
       @JsonProperty(PROP_FIB_LOOKUP) boolean fibLookup,
       @JsonProperty(PROP_SESSION_INTERFACES) @Nullable Set<String> sessionInterfaces,
       @JsonProperty(PROP_INCOMING_ACL_NAME) @Nullable String incomingAclName,
       @JsonProperty(PROP_OUTGOING_ACL_NAME) @Nullable String outgoingAclName) {
     checkNotNull(sessionInterfaces, PROP_SESSION_INTERFACES + " cannot be null");
+    if (action == null) {
+      // for backwards compatibility
+      action = fibLookup ? Action.POST_NAT_FIB_LOOKUP : Action.NO_FIB_LOOKUP;
+    }
     return new FirewallSessionInterfaceInfo(
-        fibLookup, sessionInterfaces, incomingAclName, outgoingAclName);
+        action, sessionInterfaces, incomingAclName, outgoingAclName);
   }
 
   @Override
@@ -66,7 +112,7 @@ public final class FirewallSessionInterfaceInfo implements Serializable {
       return false;
     }
     FirewallSessionInterfaceInfo that = (FirewallSessionInterfaceInfo) o;
-    return _fibLookup == that._fibLookup
+    return _action == that._action
         && Objects.equals(_sessionInterfaces, that._sessionInterfaces)
         && Objects.equals(_incomingAclName, that._incomingAclName)
         && Objects.equals(_outgoingAclName, that._outgoingAclName);
@@ -74,13 +120,13 @@ public final class FirewallSessionInterfaceInfo implements Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_fibLookup, _sessionInterfaces, _incomingAclName, _outgoingAclName);
+    return Objects.hash(_action.ordinal(), _sessionInterfaces, _incomingAclName, _outgoingAclName);
   }
 
-  /** Whether session return traffic should be forwarded via a FIB lookup */
+  /** What {@link Action} should be taken for return traffic that matches a session */
   @JsonProperty(PROP_FIB_LOOKUP)
-  public boolean getFibLookup() {
-    return _fibLookup;
+  public Action getAction() {
+    return _action;
   }
 
   /** The set of interfaces through which return flows can enter. */

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
@@ -15,6 +15,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.ForwardOutInterface;
 import org.batfish.datamodel.flow.PostNatFibLookup;
+import org.batfish.datamodel.flow.PreNatFibLookup;
 import org.batfish.datamodel.flow.SessionAction;
 
 /**
@@ -27,18 +28,24 @@ public final class FirewallSessionInterfaceInfo implements Serializable {
   public enum Action {
     /** Forward traffic directly out the interface where the original flow entered */
     NO_FIB_LOOKUP,
+    /** Do a FIB lookup on the untransformed return flow to determine egress interface */
+    PRE_NAT_FIB_LOOKUP,
     /** Do a FIB lookup on the transformed return flow to determine egress interface */
     POST_NAT_FIB_LOOKUP;
 
     /**
      * Converts this {@link Action} to the corresponding {@link SessionAction}. Parameters are only
-     * necessary when creating a {@link ForwardOutInterface} action.
+     * necessary when creating a {@link ForwardOutInterface} action. Never returns {@link
+     * org.batfish.datamodel.flow.Accept}; caller is expected to determine whether a return flow
+     * should be accepted.
      */
     public SessionAction toSessionAction(
         String originalFlowIngressIface, @Nullable NodeInterfacePair nextHop) {
       switch (this) {
         case NO_FIB_LOOKUP:
           return new ForwardOutInterface(originalFlowIngressIface, nextHop);
+        case PRE_NAT_FIB_LOOKUP:
+          return PreNatFibLookup.INSTANCE;
         case POST_NAT_FIB_LOOKUP:
           return PostNatFibLookup.INSTANCE;
         default:

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
@@ -118,7 +118,7 @@ public final class FirewallSessionInterfaceInfo implements Serializable {
   }
 
   /** What {@link Action} should be taken for return traffic that matches a session */
-  @JsonProperty(PROP_FIB_LOOKUP)
+  @JsonProperty(PROP_ACTION)
   public Action getAction() {
     return _action;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
@@ -58,19 +58,6 @@ public final class FirewallSessionInterfaceInfo implements Serializable {
   private final @Nullable String _incomingAclName;
   private final @Nullable String _outgoingAclName;
 
-  // backwards compatible constructor
-  public FirewallSessionInterfaceInfo(
-      boolean fibLookup,
-      Iterable<String> sessionInterfaces,
-      @Nullable String incomingAclName,
-      @Nullable String outgoingAclName) {
-    this(
-        fibLookup ? Action.POST_NAT_FIB_LOOKUP : Action.NO_FIB_LOOKUP,
-        sessionInterfaces,
-        incomingAclName,
-        outgoingAclName);
-  }
-
   public FirewallSessionInterfaceInfo(
       Action action,
       Iterable<String> sessionInterfaces,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FirewallSessionInterfaceInfo.java
@@ -89,12 +89,10 @@ public final class FirewallSessionInterfaceInfo implements Serializable {
       @JsonProperty(PROP_INCOMING_ACL_NAME) @Nullable String incomingAclName,
       @JsonProperty(PROP_OUTGOING_ACL_NAME) @Nullable String outgoingAclName) {
     checkNotNull(sessionInterfaces, PROP_SESSION_INTERFACES + " cannot be null");
-    if (action == null) {
-      // for backwards compatibility
-      action = fibLookup ? Action.POST_NAT_FIB_LOOKUP : Action.NO_FIB_LOOKUP;
-    }
+    Action backwardsCompatibleAction =
+        action != null ? action : fibLookup ? Action.POST_NAT_FIB_LOOKUP : Action.NO_FIB_LOOKUP;
     return new FirewallSessionInterfaceInfo(
-        action, sessionInterfaces, incomingAclName, outgoingAclName);
+        backwardsCompatibleAction, sessionInterfaces, incomingAclName, outgoingAclName);
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IpAccessList.java
@@ -141,7 +141,7 @@ public class IpAccessList implements Serializable {
 
   public FilterResult filter(
       Flow flow,
-      String srcInterface,
+      @Nullable String srcInterface,
       Map<String, IpAccessList> availableAcls,
       Map<String, IpSpace> namedIpSpaces) {
     AclLineEvaluator lineEvaluator =

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclLineEvaluator.java
@@ -21,7 +21,7 @@ public class AclLineEvaluator extends Evaluator implements GenericAclLineVisitor
 
   public AclLineEvaluator(
       Flow flow,
-      String srcInterface,
+      @Nullable String srcInterface,
       Map<String, IpAccessList> availableAcls,
       Map<String, IpSpace> namedIpSpaces) {
     super(flow, srcInterface, availableAcls, namedIpSpaces);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/Evaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/Evaluator.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel.acl;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpSpace;
@@ -23,11 +24,11 @@ public class Evaluator implements GenericAclLineMatchExprVisitor<Boolean> {
 
   protected final Map<String, IpSpace> _namedIpSpaces;
 
-  protected final String _srcInterface;
+  @Nullable protected final String _srcInterface;
 
   public Evaluator(
       Flow flow,
-      String srcInterface,
+      @Nullable String srcInterface,
       Map<String, IpAccessList> availableAcls,
       Map<String, IpSpace> namedIpSpaces) {
     _srcInterface = srcInterface;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/PostNatFibLookup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/PostNatFibLookup.java
@@ -9,17 +9,17 @@ import org.batfish.datamodel.visitors.SessionActionVisitor;
  * A {@link SessionAction} whereby return traffic is forwarded according to the result of a lookup
  * on the FIB of the interface on which the return traffic is received.
  */
-@JsonTypeName("FibLookup")
+@JsonTypeName("PostNatFibLookup")
 @ParametersAreNonnullByDefault
-public final class FibLookup implements SessionAction {
+public final class PostNatFibLookup implements SessionAction {
 
-  public static final FibLookup INSTANCE = new FibLookup();
+  public static final PostNatFibLookup INSTANCE = new PostNatFibLookup();
 
-  private FibLookup() {}
+  private PostNatFibLookup() {}
 
   @Override
   public <T> T accept(SessionActionVisitor<T> visitor) {
-    return visitor.visitFibLookup(this);
+    return visitor.visitPostNatFibLookup(this);
   }
 
   @Override
@@ -27,7 +27,7 @@ public final class FibLookup implements SessionAction {
     if (this == o) {
       return true;
     }
-    return o instanceof FibLookup;
+    return o instanceof PostNatFibLookup;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/PreNatFibLookup.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/PreNatFibLookup.java
@@ -7,27 +7,24 @@ import org.batfish.datamodel.visitors.SessionActionVisitor;
 
 /**
  * A {@link SessionAction} whereby return traffic is forwarded according to a FIB lookup using the
- * post-transformation packet.
+ * pre-transformation packet.
  */
-@JsonTypeName("PostNatFibLookup")
+@JsonTypeName("PreNatFibLookup")
 @ParametersAreNonnullByDefault
-public final class PostNatFibLookup implements SessionAction {
+public final class PreNatFibLookup implements SessionAction {
 
-  public static final PostNatFibLookup INSTANCE = new PostNatFibLookup();
+  public static final PreNatFibLookup INSTANCE = new PreNatFibLookup();
 
-  private PostNatFibLookup() {}
+  private PreNatFibLookup() {}
 
   @Override
   public <T> T accept(SessionActionVisitor<T> visitor) {
-    return visitor.visitPostNatFibLookup(this);
+    return visitor.visitPreNatFibLookup(this);
   }
 
   @Override
   public boolean equals(@Nullable Object o) {
-    if (this == o) {
-      return true;
-    }
-    return o instanceof PostNatFibLookup;
+    return o instanceof PreNatFibLookup;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionAction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionAction.java
@@ -8,6 +8,7 @@ import org.batfish.datamodel.visitors.SessionActionVisitor;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Accept.class, name = "Accept"),
+  @JsonSubTypes.Type(value = PreNatFibLookup.class, name = "PreNatFibLookup"),
   @JsonSubTypes.Type(value = PostNatFibLookup.class, name = "PostNatFibLookup"),
   @JsonSubTypes.Type(value = ForwardOutInterface.class, name = "ForwardOutInterface"),
 })

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionAction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/SessionAction.java
@@ -8,7 +8,7 @@ import org.batfish.datamodel.visitors.SessionActionVisitor;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Accept.class, name = "Accept"),
-  @JsonSubTypes.Type(value = FibLookup.class, name = "FibLookup"),
+  @JsonSubTypes.Type(value = PostNatFibLookup.class, name = "PostNatFibLookup"),
   @JsonSubTypes.Type(value = ForwardOutInterface.class, name = "ForwardOutInterface"),
 })
 public interface SessionAction {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationEvaluator.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDiff;
 import org.batfish.datamodel.Ip;
@@ -25,7 +26,7 @@ import org.batfish.datamodel.flow.TransformationStep.TransformationType;
 /** Evaluates a {@link Transformation} on an input {@link Flow}. */
 public class TransformationEvaluator {
   private final Flow.Builder _flowBuilder;
-  private final String _srcInterface;
+  @Nullable private final String _srcInterface;
   private final Map<String, IpAccessList> _namedAcls;
   private final Map<String, IpSpace> _namedIpSpaces;
   private final ImmutableList.Builder<Step<?>> _traceSteps;
@@ -193,7 +194,7 @@ public class TransformationEvaluator {
 
   private TransformationEvaluator(
       Flow flow,
-      String srcInterface,
+      @Nullable String srcInterface,
       Map<String, IpAccessList> namedAcls,
       Map<String, IpSpace> namedIpSpaces) {
     _currentFlow = flow;
@@ -227,7 +228,7 @@ public class TransformationEvaluator {
   public static TransformationResult eval(
       Transformation transformation,
       Flow flow,
-      String srcInterface,
+      @Nullable String srcInterface,
       Map<String, IpAccessList> namedAcls,
       Map<String, IpSpace> namedIpSpaces) {
     TransformationEvaluator evaluator =

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/SessionActionVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/SessionActionVisitor.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.visitors;
 import org.batfish.datamodel.flow.Accept;
 import org.batfish.datamodel.flow.ForwardOutInterface;
 import org.batfish.datamodel.flow.PostNatFibLookup;
+import org.batfish.datamodel.flow.PreNatFibLookup;
 
 /** A generic {@link org.batfish.datamodel.flow.SessionAction} visitor. */
 public interface SessionActionVisitor<T> {
@@ -10,6 +11,8 @@ public interface SessionActionVisitor<T> {
   T visitAcceptVrf(Accept acceptVrf);
 
   T visitPostNatFibLookup(PostNatFibLookup postNatFibLookup);
+
+  T visitPreNatFibLookup(PreNatFibLookup preNatFibLookup);
 
   T visitForwardOutInterface(ForwardOutInterface forwardOutInterface);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/SessionActionVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/visitors/SessionActionVisitor.java
@@ -1,15 +1,15 @@
 package org.batfish.datamodel.visitors;
 
 import org.batfish.datamodel.flow.Accept;
-import org.batfish.datamodel.flow.FibLookup;
 import org.batfish.datamodel.flow.ForwardOutInterface;
+import org.batfish.datamodel.flow.PostNatFibLookup;
 
 /** A generic {@link org.batfish.datamodel.flow.SessionAction} visitor. */
 public interface SessionActionVisitor<T> {
 
   T visitAcceptVrf(Accept acceptVrf);
 
-  T visitFibLookup(FibLookup fibLookup);
+  T visitPostNatFibLookup(PostNatFibLookup postNatFibLookup);
 
   T visitForwardOutInterface(ForwardOutInterface forwardOutInterface);
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
@@ -183,7 +183,7 @@ public class BDDSourceManagerTest {
     ib.setName(IFACE3)
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableList.of(IFACE3), null, null))
+                Action.FORWARD_OUT_IFACE, ImmutableList.of(IFACE3), null, null))
         .build();
 
     String hostname = config.getHostname();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BDDSourceManagerTest.java
@@ -24,6 +24,7 @@ import net.sf.javabdd.BDD;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.NetworkFactory;
@@ -181,7 +182,8 @@ public class BDDSourceManagerTest {
     ib.setName(IFACE2).build();
     ib.setName(IFACE3)
         .setFirewallSessionInterfaceInfo(
-            new FirewallSessionInterfaceInfo(false, ImmutableList.of(IFACE3), null, null))
+            new FirewallSessionInterfaceInfo(
+                Action.NO_FIB_LOOKUP, ImmutableList.of(IFACE3), null, null))
         .build();
 
     String hostname = config.getHostname();

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/traceroute/TraceDagImplTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/traceroute/TraceDagImplTest.java
@@ -15,10 +15,10 @@ import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpProtocol;
-import org.batfish.datamodel.flow.FibLookup;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
 import org.batfish.datamodel.flow.Hop;
 import org.batfish.datamodel.flow.OriginatingSessionScope;
+import org.batfish.datamodel.flow.PostNatFibLookup;
 import org.batfish.datamodel.flow.SessionMatchExpr;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
@@ -39,7 +39,7 @@ public class TraceDagImplTest {
     FirewallSessionTraceInfo session =
         new FirewallSessionTraceInfo(
             "B1",
-            FibLookup.INSTANCE,
+            PostNatFibLookup.INSTANCE,
             new OriginatingSessionScope("vrf"),
             new SessionMatchExpr(IpProtocol.TCP, Ip.ZERO, Ip.ZERO, 0, 0),
             null);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FirewallSessionInterfaceInfoTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FirewallSessionInterfaceInfoTest.java
@@ -2,6 +2,7 @@ package org.batfish.datamodel;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.junit.Test;
 
 /** Tests for {@link FirewallSessionInterfaceInfo}. */
@@ -12,12 +13,15 @@ public final class FirewallSessionInterfaceInfoTest {
     ImmutableSet<String> ifaces = ImmutableSet.of("A");
     new EqualsTester()
         .addEqualityGroup(
-            new FirewallSessionInterfaceInfo(false, ifaces, "IN_ACL", "OUT_ACL"),
-            new FirewallSessionInterfaceInfo(false, ifaces, "IN_ACL", "OUT_ACL"))
-        .addEqualityGroup(new FirewallSessionInterfaceInfo(false, ifaces, "IN_ACL", null))
-        .addEqualityGroup(new FirewallSessionInterfaceInfo(false, ifaces, null, "OUT_ACL"))
+            new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ifaces, "IN_ACL", "OUT_ACL"),
+            new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ifaces, "IN_ACL", "OUT_ACL"))
         .addEqualityGroup(
-            new FirewallSessionInterfaceInfo(false, ImmutableSet.of("B"), "IN_ACL", "OUT_ACL"))
+            new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ifaces, "IN_ACL", null))
+        .addEqualityGroup(
+            new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ifaces, null, "OUT_ACL"))
+        .addEqualityGroup(
+            new FirewallSessionInterfaceInfo(
+                Action.NO_FIB_LOOKUP, ImmutableSet.of("B"), "IN_ACL", "OUT_ACL"))
         .testEquals();
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FirewallSessionInterfaceInfoTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FirewallSessionInterfaceInfoTest.java
@@ -16,18 +16,18 @@ public final class FirewallSessionInterfaceInfoTest {
     ImmutableSet<String> ifaces = ImmutableSet.of("A");
     new EqualsTester()
         .addEqualityGroup(
-            new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ifaces, "IN_ACL", "OUT_ACL"),
-            new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ifaces, "IN_ACL", "OUT_ACL"))
+            new FirewallSessionInterfaceInfo(Action.FORWARD_OUT_IFACE, ifaces, "IN_ACL", "OUT_ACL"),
+            new FirewallSessionInterfaceInfo(Action.FORWARD_OUT_IFACE, ifaces, "IN_ACL", "OUT_ACL"))
         .addEqualityGroup(
             new FirewallSessionInterfaceInfo(
                 Action.POST_NAT_FIB_LOOKUP, ifaces, "IN_ACL", "OUT_ACL"))
         .addEqualityGroup(
-            new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ifaces, "IN_ACL", null))
+            new FirewallSessionInterfaceInfo(Action.FORWARD_OUT_IFACE, ifaces, "IN_ACL", null))
         .addEqualityGroup(
-            new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ifaces, null, "OUT_ACL"))
+            new FirewallSessionInterfaceInfo(Action.FORWARD_OUT_IFACE, ifaces, null, "OUT_ACL"))
         .addEqualityGroup(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableSet.of("B"), "IN_ACL", "OUT_ACL"))
+                Action.FORWARD_OUT_IFACE, ImmutableSet.of("B"), "IN_ACL", "OUT_ACL"))
         .testEquals();
   }
 
@@ -35,7 +35,7 @@ public final class FirewallSessionInterfaceInfoTest {
   public void testJsonSerialization() {
     FirewallSessionInterfaceInfo info =
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableSet.of("A"), "IN_ACL", "OUT_ACL");
+            Action.FORWARD_OUT_IFACE, ImmutableSet.of("A"), "IN_ACL", "OUT_ACL");
     FirewallSessionInterfaceInfo clone =
         BatfishObjectMapper.clone(info, FirewallSessionInterfaceInfo.class);
     assertEquals(info, clone);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FirewallSessionInterfaceInfoTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FirewallSessionInterfaceInfoTest.java
@@ -1,7 +1,10 @@
 package org.batfish.datamodel;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
+import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.junit.Test;
 
@@ -16,6 +19,9 @@ public final class FirewallSessionInterfaceInfoTest {
             new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ifaces, "IN_ACL", "OUT_ACL"),
             new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ifaces, "IN_ACL", "OUT_ACL"))
         .addEqualityGroup(
+            new FirewallSessionInterfaceInfo(
+                Action.POST_NAT_FIB_LOOKUP, ifaces, "IN_ACL", "OUT_ACL"))
+        .addEqualityGroup(
             new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ifaces, "IN_ACL", null))
         .addEqualityGroup(
             new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ifaces, null, "OUT_ACL"))
@@ -23,5 +29,15 @@ public final class FirewallSessionInterfaceInfoTest {
             new FirewallSessionInterfaceInfo(
                 Action.NO_FIB_LOOKUP, ImmutableSet.of("B"), "IN_ACL", "OUT_ACL"))
         .testEquals();
+  }
+
+  @Test
+  public void testJsonSerialization() {
+    FirewallSessionInterfaceInfo info =
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableSet.of("A"), "IN_ACL", "OUT_ACL");
+    FirewallSessionInterfaceInfo clone =
+        BatfishObjectMapper.clone(info, FirewallSessionInterfaceInfo.class);
+    assertEquals(info, clone);
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/MatchSessionStepTest.java
@@ -108,7 +108,7 @@ public final class MatchSessionStepTest {
             new MatchSessionStep(
                 MatchSessionStepDetail.builder()
                     .setSessionScope(sessionScope2)
-                    .setSessionAction(FibLookup.INSTANCE)
+                    .setSessionAction(PostNatFibLookup.INSTANCE)
                     .setMatchCriteria(matchCriteria)
                     .setTransformation(transformation)
                     .build()))
@@ -116,7 +116,7 @@ public final class MatchSessionStepTest {
             new MatchSessionStep(
                 MatchSessionStepDetail.builder()
                     .setSessionScope(sessionScope2)
-                    .setSessionAction(FibLookup.INSTANCE)
+                    .setSessionAction(PostNatFibLookup.INSTANCE)
                     .setMatchCriteria(matchCriteria2)
                     .setTransformation(transformation)
                     .build()))
@@ -124,7 +124,7 @@ public final class MatchSessionStepTest {
             new MatchSessionStep(
                 MatchSessionStepDetail.builder()
                     .setSessionScope(sessionScope2)
-                    .setSessionAction(FibLookup.INSTANCE)
+                    .setSessionAction(PostNatFibLookup.INSTANCE)
                     .setMatchCriteria(matchCriteria2)
                     .setTransformation(transformation2)
                     .build()))

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/PostNatFibLookupTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/PostNatFibLookupTest.java
@@ -1,6 +1,6 @@
 package org.batfish.datamodel.flow;
 
-import static org.batfish.datamodel.flow.FibLookup.INSTANCE;
+import static org.batfish.datamodel.flow.PostNatFibLookup.INSTANCE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -9,9 +9,9 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.junit.Test;
 
-/** Test of {@link FibLookup}. */
+/** Test of {@link PostNatFibLookup}. */
 @ParametersAreNonnullByDefault
-public final class FibLookupTest {
+public final class PostNatFibLookupTest {
 
   @Test
   public void testEquals() {
@@ -23,7 +23,7 @@ public final class FibLookupTest {
 
   @Test
   public void testSerialization() {
-    SessionAction clone = BatfishObjectMapper.clone(FibLookup.INSTANCE, SessionAction.class);
-    assertThat(clone, equalTo(FibLookup.INSTANCE));
+    SessionAction clone = BatfishObjectMapper.clone(PostNatFibLookup.INSTANCE, SessionAction.class);
+    assertThat(clone, equalTo(PostNatFibLookup.INSTANCE));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/PreNatFibLookupTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/PreNatFibLookupTest.java
@@ -1,0 +1,29 @@
+package org.batfish.datamodel.flow;
+
+import static org.batfish.datamodel.flow.PreNatFibLookup.INSTANCE;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Test of {@link PreNatFibLookup}. */
+@ParametersAreNonnullByDefault
+public final class PreNatFibLookupTest {
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(new Object())
+        .addEqualityGroup(INSTANCE, INSTANCE)
+        .testEquals();
+  }
+
+  @Test
+  public void testSerialization() {
+    SessionAction clone = BatfishObjectMapper.clone(PreNatFibLookup.INSTANCE, SessionAction.class);
+    assertThat(clone, equalTo(PreNatFibLookup.INSTANCE));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/TraceAndReverseFlowTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/TraceAndReverseFlowTest.java
@@ -31,7 +31,7 @@ public class TraceAndReverseFlowTest {
     return ImmutableList.of(
         new FirewallSessionTraceInfo(
             hostname,
-            FibLookup.INSTANCE,
+            PostNatFibLookup.INSTANCE,
             new OriginatingSessionScope("vrf"),
             new SessionMatchExpr(IpProtocol.TCP, Ip.ZERO, Ip.ZERO, 0, 0),
             null));

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactory.java
@@ -42,9 +42,9 @@ import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Accept;
-import org.batfish.datamodel.flow.FibLookup;
 import org.batfish.datamodel.flow.ForwardOutInterface;
 import org.batfish.datamodel.flow.OriginatingSessionScope;
+import org.batfish.datamodel.flow.PostNatFibLookup;
 import org.batfish.datamodel.flow.SessionAction;
 import org.batfish.symbolic.state.StateExpr;
 import org.batfish.symbolic.state.VrfAccept;
@@ -295,7 +295,7 @@ final class BDDReachabilityAnalysisSessionFactory {
                   assert !_lastHopManager.hasLastHopConstraint(srcToOutIfaceBdd);
 
                   SessionAction action =
-                      fibLookup ? FibLookup.INSTANCE : new ForwardOutInterface(src, null);
+                      fibLookup ? PostNatFibLookup.INSTANCE : new ForwardOutInterface(src, null);
 
                   BDD incomingTransformationRange =
                       _reverseTransformationRanges.reverseIncomingTransformationRange(
@@ -334,7 +334,9 @@ final class BDDReachabilityAnalysisSessionFactory {
                       NodeInterfacePair lastHop =
                           lastHopOutIface == NO_LAST_HOP ? null : lastHopOutIface;
                       SessionAction action =
-                          fibLookup ? FibLookup.INSTANCE : new ForwardOutInterface(src, lastHop);
+                          fibLookup
+                              ? PostNatFibLookup.INSTANCE
+                              : new ForwardOutInterface(src, lastHop);
 
                       BDD incomingTransformationRange =
                           _reverseTransformationRanges.reverseIncomingTransformationRange(
@@ -417,7 +419,7 @@ final class BDDReachabilityAnalysisSessionFactory {
                         hostname,
                         new OriginatingSessionScope(vrfName),
                         // Batfish does not support VRF-originating sessions with other actions
-                        FibLookup.INSTANCE,
+                        PostNatFibLookup.INSTANCE,
                         getSessionFlowMatchBdd(srcToAcceptBdd),
                         compose(incomingTransformation, constraint(incomingTransformationRange))));
                 return;
@@ -447,7 +449,7 @@ final class BDDReachabilityAnalysisSessionFactory {
                             hostname,
                             new OriginatingSessionScope(vrfName),
                             // Batfish does not support VRF-originating sessions with other actions
-                            FibLookup.INSTANCE,
+                            PostNatFibLookup.INSTANCE,
                             sessionBdd,
                             compose(
                                 incomingTransformation, constraint(incomingTransformationRange))));

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactory.java
@@ -36,13 +36,13 @@ import org.batfish.common.bdd.BDDOps;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.FirewallSessionVrfInfo;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Accept;
-import org.batfish.datamodel.flow.ForwardOutInterface;
 import org.batfish.datamodel.flow.OriginatingSessionScope;
 import org.batfish.datamodel.flow.PostNatFibLookup;
 import org.batfish.datamodel.flow.SessionAction;
@@ -256,7 +256,7 @@ final class BDDReachabilityAnalysisSessionFactory {
         _reverseFlowTransformationFactory.reverseFlowOutgoingTransformation(
             hostname, outIface.getName());
 
-    boolean fibLookup = outIface.getFirewallSessionInterfaceInfo().getFibLookup();
+    Action matchAction = outIface.getFirewallSessionInterfaceInfo().getAction();
     ImmutableList.Builder<BDDFirewallSessionTraceInfo> builder = ImmutableList.builder();
     srcMgr
         .getSourceBDDs()
@@ -294,8 +294,7 @@ final class BDDReachabilityAnalysisSessionFactory {
                   // The src interface has no neighbors
                   assert !_lastHopManager.hasLastHopConstraint(srcToOutIfaceBdd);
 
-                  SessionAction action =
-                      fibLookup ? PostNatFibLookup.INSTANCE : new ForwardOutInterface(src, null);
+                  SessionAction action = matchAction.toSessionAction(src, null);
 
                   BDD incomingTransformationRange =
                       _reverseTransformationRanges.reverseIncomingTransformationRange(
@@ -333,10 +332,7 @@ final class BDDReachabilityAnalysisSessionFactory {
                       // Next hop for session flows
                       NodeInterfacePair lastHop =
                           lastHopOutIface == NO_LAST_HOP ? null : lastHopOutIface;
-                      SessionAction action =
-                          fibLookup
-                              ? PostNatFibLookup.INSTANCE
-                              : new ForwardOutInterface(src, lastHop);
+                      SessionAction action = matchAction.toSessionAction(src, lastHop);
 
                       BDD incomingTransformationRange =
                           _reverseTransformationRanges.reverseIncomingTransformationRange(

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/SessionInstrumentation.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/SessionInstrumentation.java
@@ -38,6 +38,7 @@ import org.batfish.datamodel.flow.ForwardOutInterface;
 import org.batfish.datamodel.flow.IncomingSessionScope;
 import org.batfish.datamodel.flow.OriginatingSessionScope;
 import org.batfish.datamodel.flow.PostNatFibLookup;
+import org.batfish.datamodel.flow.PreNatFibLookup;
 import org.batfish.datamodel.flow.SessionAction;
 import org.batfish.datamodel.flow.SessionScopeVisitor;
 import org.batfish.datamodel.visitors.SessionActionVisitor;
@@ -147,6 +148,7 @@ public class SessionInstrumentation {
             initializedSessionsEntry ->
                 initializedSessionsEntry.getValue().stream()
                     .map(BDDFirewallSessionTraceInfo::getAction)
+                    // TODO Update when reachability supports PreNatFibLookup
                     .anyMatch(PostNatFibLookup.class::isInstance))
         .map(Entry::getKey)
         .collect(ImmutableSet.toImmutableSet());
@@ -233,6 +235,13 @@ public class SessionInstrumentation {
               }
 
               @Override
+              public Stream<Edge> visitPreNatFibLookup(PreNatFibLookup preNatFibLookup) {
+                // TODO
+                throw new UnsupportedOperationException(
+                    "Reachability does not yet support PreNatFibLookup");
+              }
+
+              @Override
               public Stream<Edge> visitForwardOutInterface(
                   ForwardOutInterface forwardOutInterface) {
                 if (forwardOutInterface.getNextHop() == null) {
@@ -257,6 +266,7 @@ public class SessionInstrumentation {
    */
   private Stream<Edge> computeFibLookupSessionEdges(BDDFirewallSessionTraceInfo sessionInfo) {
     SessionAction action = sessionInfo.getAction();
+    // TODO Update when reachability supports PreNatFibLookup
     checkArgument(
         action instanceof PostNatFibLookup,
         "Unsupported session action for FibLookup session: %s",
@@ -288,6 +298,13 @@ public class SessionInstrumentation {
               @Override
               public Stream<Edge> visitPostNatFibLookup(PostNatFibLookup postNatFibLookup) {
                 return computeFibLookupSessionEdges(sessionInfo);
+              }
+
+              @Override
+              public Stream<Edge> visitPreNatFibLookup(PreNatFibLookup preNatFibLookup) {
+                // TODO
+                throw new UnsupportedOperationException(
+                    "Reachability does not yet support PreNatFibLookup");
               }
 
               @Override
@@ -387,6 +404,13 @@ public class SessionInstrumentation {
               @Override
               public Stream<Edge> visitPostNatFibLookup(PostNatFibLookup postNatFibLookup) {
                 return Stream.of();
+              }
+
+              @Override
+              public Stream<Edge> visitPreNatFibLookup(PreNatFibLookup preNatFibLookup) {
+                // TODO
+                throw new UnsupportedOperationException(
+                    "Reachability does not yet support PreNatFibLookup");
               }
 
               @Override

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/SessionInstrumentation.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/SessionInstrumentation.java
@@ -34,10 +34,10 @@ import org.batfish.datamodel.FirewallSessionInterfaceInfo;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Accept;
-import org.batfish.datamodel.flow.FibLookup;
 import org.batfish.datamodel.flow.ForwardOutInterface;
 import org.batfish.datamodel.flow.IncomingSessionScope;
 import org.batfish.datamodel.flow.OriginatingSessionScope;
+import org.batfish.datamodel.flow.PostNatFibLookup;
 import org.batfish.datamodel.flow.SessionAction;
 import org.batfish.datamodel.flow.SessionScopeVisitor;
 import org.batfish.datamodel.visitors.SessionActionVisitor;
@@ -147,7 +147,7 @@ public class SessionInstrumentation {
             initializedSessionsEntry ->
                 initializedSessionsEntry.getValue().stream()
                     .map(BDDFirewallSessionTraceInfo::getAction)
-                    .anyMatch(FibLookup.class::isInstance))
+                    .anyMatch(PostNatFibLookup.class::isInstance))
         .map(Entry::getKey)
         .collect(ImmutableSet.toImmutableSet());
   }
@@ -227,7 +227,7 @@ public class SessionInstrumentation {
               }
 
               @Override
-              public Stream<Edge> visitFibLookup(FibLookup fibLookup) {
+              public Stream<Edge> visitPostNatFibLookup(PostNatFibLookup postNatFibLookup) {
                 // Does not necessarily lead to success; handled separately in fibLookupSessionEdges
                 return Stream.of();
               }
@@ -251,14 +251,14 @@ public class SessionInstrumentation {
   }
 
   /**
-   * Produce edges representing matching the given {@link FibLookup} session. These edges are
+   * Produce edges representing matching the given {@link PostNatFibLookup} session. These edges are
    * conditioned on the {@code sessionFlows} BDD and include PreInInterface->PostInVrfSession,
    * OriginateVrf->PostInVrfSession, and OriginateInterface->PostInVrfSession transitions.
    */
   private Stream<Edge> computeFibLookupSessionEdges(BDDFirewallSessionTraceInfo sessionInfo) {
     SessionAction action = sessionInfo.getAction();
     checkArgument(
-        action instanceof FibLookup,
+        action instanceof PostNatFibLookup,
         "Unsupported session action for FibLookup session: %s",
         action);
 
@@ -286,7 +286,7 @@ public class SessionInstrumentation {
               }
 
               @Override
-              public Stream<Edge> visitFibLookup(FibLookup fibLookup) {
+              public Stream<Edge> visitPostNatFibLookup(PostNatFibLookup postNatFibLookup) {
                 return computeFibLookupSessionEdges(sessionInfo);
               }
 
@@ -385,7 +385,7 @@ public class SessionInstrumentation {
               }
 
               @Override
-              public Stream<Edge> visitFibLookup(FibLookup fibLookup) {
+              public Stream<Edge> visitPostNatFibLookup(PostNatFibLookup postNatFibLookup) {
                 return Stream.of();
               }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/SessionScopeFibLookupSessionEdges.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/SessionScopeFibLookupSessionEdges.java
@@ -13,9 +13,9 @@ import net.sf.javabdd.BDD;
 import org.batfish.bddreachability.transition.Transition;
 import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.datamodel.Interface;
-import org.batfish.datamodel.flow.FibLookup;
 import org.batfish.datamodel.flow.IncomingSessionScope;
 import org.batfish.datamodel.flow.OriginatingSessionScope;
+import org.batfish.datamodel.flow.PostNatFibLookup;
 import org.batfish.datamodel.flow.SessionScope;
 import org.batfish.datamodel.flow.SessionScopeVisitor;
 import org.batfish.symbolic.state.OriginateInterface;
@@ -26,9 +26,10 @@ import org.batfish.symbolic.state.StateExpr;
 
 /**
  * Visitor for a {@link SessionScope} that returns the {@link Edge edges} that flows can traverse
- * when they match a session with action {@link FibLookup}. These edges all terminate in {@link
- * PostInVrfSession}, and may start with {@link PreInInterface} (for {@link IncomingSessionScope})
- * or {@link OriginateInterface} or {@link OriginateVrf} (for {@link OriginatingSessionScope}).
+ * when they match a session with action {@link PostNatFibLookup}. These edges all terminate in
+ * {@link PostInVrfSession}, and may start with {@link PreInInterface} (for {@link
+ * IncomingSessionScope}) or {@link OriginateInterface} or {@link OriginateVrf} (for {@link
+ * OriginatingSessionScope}).
  */
 @ParametersAreNonnullByDefault
 public class SessionScopeFibLookupSessionEdges implements SessionScopeVisitor<Stream<Edge>> {

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -1072,6 +1072,7 @@ class FlowTracer {
 
               @Override
               public Void visitForwardOutInterface(ForwardOutInterface forwardOutInterface) {
+                _steps.addAll(transformationSteps);
                 // cycle detection
                 Breadcrumb breadcrumb =
                     new Breadcrumb(currentNodeName, _vrfName, _ingressInterface, originalFlow);

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -96,6 +96,7 @@ import org.batfish.datamodel.flow.OriginateStep.OriginateStepDetail;
 import org.batfish.datamodel.flow.OriginatingSessionScope;
 import org.batfish.datamodel.flow.PolicyStep;
 import org.batfish.datamodel.flow.PolicyStep.PolicyStepDetail;
+import org.batfish.datamodel.flow.PostNatFibLookup;
 import org.batfish.datamodel.flow.RoutingStep;
 import org.batfish.datamodel.flow.RoutingStep.Builder;
 import org.batfish.datamodel.flow.RoutingStep.RoutingStepDetail;
@@ -921,7 +922,7 @@ class FlowTracer {
               }
 
               @Override
-              public Void visitFibLookup(org.batfish.datamodel.flow.FibLookup fibLookup) {
+              public Void visitPostNatFibLookup(PostNatFibLookup postNatFibLookup) {
                 Ip dstIp = _currentFlow.getDstIp();
 
                 // Accept if the flow is destined for this vrf on this host.
@@ -1203,7 +1204,7 @@ class FlowTracer {
       @Nullable String ingressInterface,
       @Nullable NodeInterfacePair lastHopNodeAndOutgoingInterface) {
     return fibLookup
-        ? org.batfish.datamodel.flow.FibLookup.INSTANCE
+        ? PostNatFibLookup.INSTANCE
         : ingressInterface != null
             ? new ForwardOutInterface(ingressInterface, lastHopNodeAndOutgoingInterface)
             : Accept.INSTANCE;

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -98,6 +98,7 @@ import org.batfish.datamodel.flow.OriginatingSessionScope;
 import org.batfish.datamodel.flow.PolicyStep;
 import org.batfish.datamodel.flow.PolicyStep.PolicyStepDetail;
 import org.batfish.datamodel.flow.PostNatFibLookup;
+import org.batfish.datamodel.flow.PreNatFibLookup;
 import org.batfish.datamodel.flow.RoutingStep;
 import org.batfish.datamodel.flow.RoutingStep.Builder;
 import org.batfish.datamodel.flow.RoutingStep.RoutingStepDetail;
@@ -961,6 +962,12 @@ class FlowTracer {
               }
 
               @Override
+              public Void visitPreNatFibLookup(PreNatFibLookup preNatFibLookup) {
+                // TODO
+                return null;
+              }
+
+              @Override
               public Void visitForwardOutInterface(ForwardOutInterface forwardOutInterface) {
                 // cycle detection
                 Breadcrumb breadcrumb =
@@ -1211,6 +1218,8 @@ class FlowTracer {
             : Accept.INSTANCE;
       case POST_NAT_FIB_LOOKUP:
         return PostNatFibLookup.INSTANCE;
+      case PRE_NAT_FIB_LOOKUP:
+        return PreNatFibLookup.INSTANCE;
       default:
         throw new UnsupportedOperationException("Unrecognized action " + action);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -37,6 +37,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpSpace;
@@ -373,11 +374,14 @@ public class AwsConfiguration extends VendorConfiguration {
         .get(BACKBONE_FACING_INTERFACE_NAME)
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                false, ImmutableList.of(BACKBONE_FACING_INTERFACE_NAME), null, null));
+                Action.NO_FIB_LOOKUP,
+                ImmutableList.of(BACKBONE_FACING_INTERFACE_NAME),
+                null,
+                null));
 
     outInterface.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            false, ImmutableList.of(outInterface.getName()), null, null));
+            Action.NO_FIB_LOOKUP, ImmutableList.of(outInterface.getName()), null, null));
 
     // configure location info
     IpSpace servicesIpSpace =

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/AwsConfiguration.java
@@ -374,14 +374,14 @@ public class AwsConfiguration extends VendorConfiguration {
         .get(BACKBONE_FACING_INTERFACE_NAME)
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP,
+                Action.FORWARD_OUT_IFACE,
                 ImmutableList.of(BACKBONE_FACING_INTERFACE_NAME),
                 null,
                 null));
 
     outInterface.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(outInterface.getName()), null, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(outInterface.getName()), null, null));
 
     // configure location info
     IpSpace servicesIpSpace =

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
@@ -42,6 +42,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
@@ -369,7 +370,8 @@ public final class LoadBalancer implements AwsVpcEntity, Serializable {
       viIface.setIncomingTransformation(chainListenerTransformations(listenerTransformations));
     }
     viIface.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(viIface.getName()), null, null));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(viIface.getName()), null, null));
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/LoadBalancer.java
@@ -371,7 +371,7 @@ public final class LoadBalancer implements AwsVpcEntity, Serializable {
     }
     viIface.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(viIface.getName()), null, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(viIface.getName()), null, null));
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/NatGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/NatGateway.java
@@ -37,6 +37,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
@@ -193,7 +194,7 @@ final class NatGateway implements AwsVpcEntity, Serializable {
         addNodeToSubnet(cfgNode, networkInterface, subnet, awsConfiguration, warnings);
     ifaceToSubnet.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            false, ImmutableList.of(ifaceToSubnet.getName()), null, null));
+            Action.NO_FIB_LOOKUP, ImmutableList.of(ifaceToSubnet.getName()), null, null));
 
     // post transformation filter on the interface to the subnet
     IpAccessList postTransformationFilter =
@@ -223,7 +224,7 @@ final class NatGateway implements AwsVpcEntity, Serializable {
       ifaceToVpc.setIncomingTransformation(computeOutgoingNatTransformation(getPrivateIp()));
       ifaceToVpc.setFirewallSessionInterfaceInfo(
           new FirewallSessionInterfaceInfo(
-              false,
+              Action.NO_FIB_LOOKUP,
               ImmutableList.of(ifaceToVpc.getName()),
               null,
               egressAcl == null ? null : egressAcl.getName()));

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/NatGateway.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/NatGateway.java
@@ -194,7 +194,7 @@ final class NatGateway implements AwsVpcEntity, Serializable {
         addNodeToSubnet(cfgNode, networkInterface, subnet, awsConfiguration, warnings);
     ifaceToSubnet.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(ifaceToSubnet.getName()), null, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(ifaceToSubnet.getName()), null, null));
 
     // post transformation filter on the interface to the subnet
     IpAccessList postTransformationFilter =
@@ -224,7 +224,7 @@ final class NatGateway implements AwsVpcEntity, Serializable {
       ifaceToVpc.setIncomingTransformation(computeOutgoingNatTransformation(getPrivateIp()));
       ifaceToVpc.setFirewallSessionInterfaceInfo(
           new FirewallSessionInterfaceInfo(
-              Action.NO_FIB_LOOKUP,
+              Action.FORWARD_OUT_IFACE,
               ImmutableList.of(ifaceToVpc.getName()),
               null,
               egressAcl == null ? null : egressAcl.getName()));

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -919,7 +919,7 @@ public final class Region implements Serializable {
     // Set up reverse sessions for outbound traffic.
     i.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(i.getName()), null, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(i.getName()), null, null));
     i.getVrf().setFirewallSessionVrfInfo(new FirewallSessionVrfInfo(false));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Region.java
@@ -41,6 +41,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DeviceType;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.FirewallSessionVrfInfo;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
@@ -917,7 +918,8 @@ public final class Region implements Serializable {
     applyEgressAcl(stableGroups, c, i);
     // Set up reverse sessions for outbound traffic.
     i.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(i.getName()), null, null));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(i.getName()), null, null));
     i.getVrf().setFirewallSessionVrfInfo(new FirewallSessionVrfInfo(false));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
@@ -42,6 +42,7 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpAccessList;
@@ -406,7 +407,10 @@ public class Subnet implements AwsVpcEntity, Serializable {
     // To make life easier, just use both network ACLs in subnets' VPC ifaces session info.
     subnetToVpcIface.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            false, ImmutableList.of(subnetToVpcIfaceName), incomingAclName, outgoingAclName));
+            Action.NO_FIB_LOOKUP,
+            ImmutableList.of(subnetToVpcIfaceName),
+            incomingAclName,
+            outgoingAclName));
 
     // For each NLB in the subnet: new interface connecting to NLB, no filters
     for (LoadBalancer nlb : nlbs) {
@@ -424,7 +428,8 @@ public class Subnet implements AwsVpcEntity, Serializable {
       String nlbIfaceName = interfaceNameToRemote(subnetCfg, NLB_INSTANCE_TARGETS_IFACE_SUFFIX);
       Interface nlbIface = nlbConfig.getAllInterfaces().get(nlbIfaceName);
       nlbIface.setFirewallSessionInterfaceInfo(
-          new FirewallSessionInterfaceInfo(false, ImmutableList.of(nlbIfaceName), null, null));
+          new FirewallSessionInterfaceInfo(
+              Action.NO_FIB_LOOKUP, ImmutableList.of(nlbIfaceName), null, null));
     }
 
     // Add static routes in subnet's new VRF and connect subnet to its instance targets
@@ -469,7 +474,7 @@ public class Subnet implements AwsVpcEntity, Serializable {
         // Subnet needs to set up a session for return traffic from the instance
         subnetToInstanceIface.setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                false, ImmutableList.of(subnetToInstanceIfaceName), null, null));
+                Action.NO_FIB_LOOKUP, ImmutableList.of(subnetToInstanceIfaceName), null, null));
 
         staticRouteNextHopIface = subnetToInstanceIfaceName;
 
@@ -480,7 +485,7 @@ public class Subnet implements AwsVpcEntity, Serializable {
             toStaticRoute(instancePrefix, vpcToSubnetIfaceName, AwsConfiguration.LINK_LOCAL_IP));
         vpcToSubnetIface.setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                false, ImmutableList.of(vpcToSubnetIfaceName), null, null));
+                Action.NO_FIB_LOOKUP, ImmutableList.of(vpcToSubnetIfaceName), null, null));
       }
 
       /*

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/Subnet.java
@@ -407,7 +407,7 @@ public class Subnet implements AwsVpcEntity, Serializable {
     // To make life easier, just use both network ACLs in subnets' VPC ifaces session info.
     subnetToVpcIface.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP,
+            Action.FORWARD_OUT_IFACE,
             ImmutableList.of(subnetToVpcIfaceName),
             incomingAclName,
             outgoingAclName));
@@ -429,7 +429,7 @@ public class Subnet implements AwsVpcEntity, Serializable {
       Interface nlbIface = nlbConfig.getAllInterfaces().get(nlbIfaceName);
       nlbIface.setFirewallSessionInterfaceInfo(
           new FirewallSessionInterfaceInfo(
-              Action.NO_FIB_LOOKUP, ImmutableList.of(nlbIfaceName), null, null));
+              Action.FORWARD_OUT_IFACE, ImmutableList.of(nlbIfaceName), null, null));
     }
 
     // Add static routes in subnet's new VRF and connect subnet to its instance targets
@@ -474,7 +474,7 @@ public class Subnet implements AwsVpcEntity, Serializable {
         // Subnet needs to set up a session for return traffic from the instance
         subnetToInstanceIface.setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableList.of(subnetToInstanceIfaceName), null, null));
+                Action.FORWARD_OUT_IFACE, ImmutableList.of(subnetToInstanceIfaceName), null, null));
 
         staticRouteNextHopIface = subnetToInstanceIfaceName;
 
@@ -485,7 +485,7 @@ public class Subnet implements AwsVpcEntity, Serializable {
             toStaticRoute(instancePrefix, vpcToSubnetIfaceName, AwsConfiguration.LINK_LOCAL_IP));
         vpcToSubnetIface.setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableList.of(vpcToSubnetIfaceName), null, null));
+                Action.FORWARD_OUT_IFACE, ImmutableList.of(vpcToSubnetIfaceName), null, null));
       }
 
       /*

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -91,6 +91,7 @@ import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.GeneratedRoute6;
 import org.batfish.datamodel.IkePhase1Key;
@@ -1937,7 +1938,8 @@ public final class CiscoConfiguration extends VendorConfiguration {
       // That is, return flows can only enter the interface the forward flow exited in order to
       // match the session setup by the forward flow.
       newIface.setFirewallSessionInterfaceInfo(
-          new FirewallSessionInterfaceInfo(true, ImmutableSet.of(newIface.getName()), null, null));
+          new FirewallSessionInterfaceInfo(
+              Action.POST_NAT_FIB_LOOKUP, ImmutableSet.of(newIface.getName()), null, null));
     }
     return newIface;
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
@@ -50,6 +50,7 @@ import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IcmpType;
@@ -1491,7 +1492,8 @@ public class F5BigipConfiguration extends VendorConfiguration {
     // packet filter for established connections. However, packet filters are not fully supported at
     // this point
     newIface.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(newIface.getName()), null, null));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(newIface.getName()), null, null));
     return newIface;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/f5_bigip/F5BigipConfiguration.java
@@ -1493,7 +1493,7 @@ public class F5BigipConfiguration extends VendorConfiguration {
     // this point
     newIface.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(newIface.getName()), null, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(newIface.getName()), null, null));
     return newIface;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1754,7 +1754,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       // create session info
       newIface.setFirewallSessionInterfaceInfo(
           new FirewallSessionInterfaceInfo(
-              Action.NO_FIB_LOOKUP,
+              Action.FORWARD_OUT_IFACE,
               zone.getInterfaces(),
               iface.getIncomingFilter(),
               iface.getOutgoingFilter()));

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -67,6 +67,7 @@ import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.IkeKeyType;
 import org.batfish.datamodel.IkePhase1Key;
 import org.batfish.datamodel.IkePhase1Policy;
@@ -1753,7 +1754,10 @@ public final class JuniperConfiguration extends VendorConfiguration {
       // create session info
       newIface.setFirewallSessionInterfaceInfo(
           new FirewallSessionInterfaceInfo(
-              false, zone.getInterfaces(), iface.getIncomingFilter(), iface.getOutgoingFilter()));
+              Action.NO_FIB_LOOKUP,
+              zone.getInterfaces(),
+              iface.getIncomingFilter(),
+              iface.getOutgoingFilter()));
     }
 
     String incomingFilterName = iface.getIncomingFilter();

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -98,6 +98,7 @@ import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Interface.Dependency;
@@ -1761,7 +1762,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
               outgoingFilterName));
       newIface.setFirewallSessionInterfaceInfo(
           new FirewallSessionInterfaceInfo(
-              true, sharedGateway.getImportedInterfaces(), null, null));
+              Action.POST_NAT_FIB_LOOKUP, sharedGateway.getImportedInterfaces(), null, null));
     } else if (zone != null) {
       newIface.setZoneName(zone.getName());
       if (zone.getType() == Type.LAYER3) {
@@ -1776,7 +1777,8 @@ public class PaloAltoConfiguration extends VendorConfiguration {
                 ifaceOutgoingTraceElement(
                     iface.getName(), zone.getName(), zone.getVsys().getName())));
         newIface.setFirewallSessionInterfaceInfo(
-            new FirewallSessionInterfaceInfo(true, zone.getInterfaceNames(), null, null));
+            new FirewallSessionInterfaceInfo(
+                Action.POST_NAT_FIB_LOOKUP, zone.getInterfaceNames(), null, null));
       }
     } else {
       // Do not allow any traffic to exit an unzoned interface

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
@@ -45,9 +45,9 @@ import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Accept;
-import org.batfish.datamodel.flow.FibLookup;
 import org.batfish.datamodel.flow.ForwardOutInterface;
 import org.batfish.datamodel.flow.OriginatingSessionScope;
+import org.batfish.datamodel.flow.PostNatFibLookup;
 import org.batfish.symbolic.state.OriginateVrf;
 import org.batfish.symbolic.state.PreInInterface;
 import org.batfish.symbolic.state.PreOutEdgePostNat;
@@ -608,7 +608,7 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
             allOf(
                 hasHostname(FW),
                 hasSessionScope(new OriginatingSessionScope(FW_VRF)),
-                hasAction(FibLookup.INSTANCE),
+                hasAction(PostNatFibLookup.INSTANCE),
                 hasSessionFlows(srcBdd(routePrefix)),
                 hasTransformation(FWI1_REVERSE_TRANSFORMATION))));
   }
@@ -671,7 +671,7 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
                 // R1:I1 -> FW:I1
                 hasHostname(FW),
                 hasSessionScope(new OriginatingSessionScope(FW_VRF)),
-                hasAction(FibLookup.INSTANCE),
+                hasAction(PostNatFibLookup.INSTANCE),
                 hasSessionFlows(r1I1SessionFlows),
                 hasTransformation(
                     compose(
@@ -680,7 +680,7 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
                 // R2:I1 -> FW:I1
                 hasHostname(FW),
                 hasSessionScope(new OriginatingSessionScope(FW_VRF)),
-                hasAction(FibLookup.INSTANCE),
+                hasAction(PostNatFibLookup.INSTANCE),
                 hasSessionFlows(r2I1SessionFlows),
                 hasTransformation(
                     compose(
@@ -739,14 +739,14 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
                 // R1:I1 -> FW:I1
                 hasHostname(FW),
                 hasSessionScope(new OriginatingSessionScope(FW_VRF)),
-                hasAction(FibLookup.INSTANCE),
+                hasAction(PostNatFibLookup.INSTANCE),
                 hasSessionFlows(r1I1SessionFlows),
                 hasTransformation(FWI1_REVERSE_TRANSFORMATION)),
             allOf(
                 // R3:I1 -> FW:I2
                 hasHostname(FW),
                 hasSessionScope(new OriginatingSessionScope(FW_VRF)),
-                hasAction(FibLookup.INSTANCE),
+                hasAction(PostNatFibLookup.INSTANCE),
                 hasSessionFlows(r3I1SessionFlows),
                 hasTransformation(FWI2_REVERSE_TRANSFORMATION))));
   }
@@ -776,7 +776,7 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
             allOf(
                 hasHostname(FW),
                 hasSessionScope(new OriginatingSessionScope(FW_VRF)),
-                hasAction(FibLookup.INSTANCE),
+                hasAction(PostNatFibLookup.INSTANCE),
                 hasSessionFlows(srcBdd(routePrefix)),
                 hasTransformation(FWI1_REVERSE_TRANSFORMATION))));
   }

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
@@ -37,6 +37,7 @@ import org.batfish.common.bdd.HeaderSpaceToBDD;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.FirewallSessionVrfInfo;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpProtocol;
@@ -188,7 +189,8 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
 
       // Create sessions for flows exiting FW:I3
       fwi3.setFirewallSessionInterfaceInfo(
-          new FirewallSessionInterfaceInfo(false, ImmutableSet.of(FWI3), null, null));
+          new FirewallSessionInterfaceInfo(
+              Action.NO_FIB_LOOKUP, ImmutableSet.of(FWI3), null, null));
     }
 
     _configs = ImmutableMap.of(FW, fw, R1, r1, R2, r2, R3, r3);
@@ -196,7 +198,7 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
 
     // temporarily add a FirewallSessionInterfaceInfo to FW to force its last hops to be tracked
     fwi1.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(FWI2), null, null));
+        new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ImmutableList.of(FWI2), null, null));
     Set<org.batfish.datamodel.Edge> edges =
         ImmutableSet.of(
             // R1:I1 -- FW:I1

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisSessionFactoryTest.java
@@ -190,7 +190,7 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
       // Create sessions for flows exiting FW:I3
       fwi3.setFirewallSessionInterfaceInfo(
           new FirewallSessionInterfaceInfo(
-              Action.NO_FIB_LOOKUP, ImmutableSet.of(FWI3), null, null));
+              Action.FORWARD_OUT_IFACE, ImmutableSet.of(FWI3), null, null));
     }
 
     _configs = ImmutableMap.of(FW, fw, R1, r1, R2, r2, R3, r3);
@@ -198,7 +198,8 @@ public class BDDReachabilityAnalysisSessionFactoryTest {
 
     // temporarily add a FirewallSessionInterfaceInfo to FW to force its last hops to be tracked
     fwi1.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(Action.NO_FIB_LOOKUP, ImmutableList.of(FWI2), null, null));
+        new FirewallSessionInterfaceInfo(
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(FWI2), null, null));
     Set<org.batfish.datamodel.Edge> edges =
         ImmutableSet.of(
             // R1:I1 -- FW:I1

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
@@ -202,7 +202,7 @@ public class BDDReverseTransformationRangesImplTest {
     // make the node a session node.
     iface.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(iName), null, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(iName), null, null));
 
     _lastHopManager =
         new LastHopOutgoingInterfaceManager(

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReverseTransformationRangesImplTest.java
@@ -20,6 +20,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
@@ -200,7 +201,8 @@ public class BDDReverseTransformationRangesImplTest {
 
     // make the node a session node.
     iface.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(iName), null, null));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(iName), null, null));
 
     _lastHopManager =
         new LastHopOutgoingInterfaceManager(

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BidirectionalReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BidirectionalReachabilityAnalysisTest.java
@@ -307,7 +307,7 @@ public final class BidirectionalReachabilityAnalysisTest {
 
     fwI2.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(fwI2.getName()), null, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(fwI2.getName()), null, null));
 
     SortedMap<String, Configuration> configurations =
         ImmutableSortedMap.of(
@@ -569,7 +569,7 @@ public final class BidirectionalReachabilityAnalysisTest {
 
     fwI2.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(fwI2.getName()), null, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(fwI2.getName()), null, null));
 
     SortedMap<String, Configuration> configurations =
         ImmutableSortedMap.of(
@@ -745,7 +745,10 @@ public final class BidirectionalReachabilityAnalysisTest {
         nf.aclBuilder().setOwner(fw).setLines(ImmutableList.of(permitUdpLine)).build();
     fwI2.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(fwI2.getName()), null, permitUdpAcl.getName()));
+            Action.FORWARD_OUT_IFACE,
+            ImmutableList.of(fwI2.getName()),
+            null,
+            permitUdpAcl.getName()));
 
     // transform source IP before setting up session on fwI3
     Ip poolIp = Ip.parse("5.5.5.5");
@@ -756,7 +759,7 @@ public final class BidirectionalReachabilityAnalysisTest {
 
     fwI3.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(fwI3.getName()), null, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(fwI3.getName()), null, null));
 
     SortedMap<String, Configuration> configurations =
         ImmutableSortedMap.of(

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BidirectionalReachabilityAnalysisTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BidirectionalReachabilityAnalysisTest.java
@@ -65,6 +65,7 @@ import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.FirewallSessionVrfInfo;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.Flow.Builder;
@@ -305,7 +306,8 @@ public final class BidirectionalReachabilityAnalysisTest {
     Interface fwI2 = ib.setAddress(ConcreteInterfaceAddress.parse("255.255.255.0/24")).build();
 
     fwI2.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(fwI2.getName()), null, null));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(fwI2.getName()), null, null));
 
     SortedMap<String, Configuration> configurations =
         ImmutableSortedMap.of(
@@ -566,7 +568,8 @@ public final class BidirectionalReachabilityAnalysisTest {
         nf.aclBuilder().setOwner(fw).setLines(ImmutableList.of(ExprAclLine.REJECT_ALL)).build());
 
     fwI2.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(fwI2.getName()), null, null));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(fwI2.getName()), null, null));
 
     SortedMap<String, Configuration> configurations =
         ImmutableSortedMap.of(
@@ -742,7 +745,7 @@ public final class BidirectionalReachabilityAnalysisTest {
         nf.aclBuilder().setOwner(fw).setLines(ImmutableList.of(permitUdpLine)).build();
     fwI2.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            false, ImmutableList.of(fwI2.getName()), null, permitUdpAcl.getName()));
+            Action.NO_FIB_LOOKUP, ImmutableList.of(fwI2.getName()), null, permitUdpAcl.getName()));
 
     // transform source IP before setting up session on fwI3
     Ip poolIp = Ip.parse("5.5.5.5");
@@ -752,7 +755,8 @@ public final class BidirectionalReachabilityAnalysisTest {
         nf.aclBuilder().setOwner(fw).setLines(ImmutableList.of(ExprAclLine.REJECT_ALL)).build());
 
     fwI3.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(fwI3.getName()), null, null));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(fwI3.getName()), null, null));
 
     SortedMap<String, Configuration> configurations =
         ImmutableSortedMap.of(
@@ -942,7 +946,8 @@ public final class BidirectionalReachabilityAnalysisTest {
         .setVrf(separateEgressVrf ? egressVrf : ingressVrf)
         .setAddress(SFL_EGRESS_IFACE_ADDRESS)
         .setFirewallSessionInterfaceInfo(
-            new FirewallSessionInterfaceInfo(true, ImmutableSet.of(SFL_EGRESS_IFACE), null, null))
+            new FirewallSessionInterfaceInfo(
+                Action.POST_NAT_FIB_LOOKUP, ImmutableSet.of(SFL_EGRESS_IFACE), null, null))
         .setIncomingFilter(
             blockNonSessionReverse
                 ? IpAccessList.builder()
@@ -1035,7 +1040,8 @@ public final class BidirectionalReachabilityAnalysisTest {
                 .setLines(ExprAclLine.rejecting(AclLineMatchExprs.TRUE))
                 .build())
         .setFirewallSessionInterfaceInfo(
-            new FirewallSessionInterfaceInfo(true, ImmutableSet.of(SFL_INGRESS_IFACE), null, null))
+            new FirewallSessionInterfaceInfo(
+                Action.POST_NAT_FIB_LOOKUP, ImmutableSet.of(SFL_INGRESS_IFACE), null, null))
         .build();
 
     // Sanity check: VRF currently does NOT originate sessions. All return flows should be blocked

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/LastHopOutgoingInterfaceManagerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/LastHopOutgoingInterfaceManagerTest.java
@@ -22,6 +22,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Vrf;
@@ -63,7 +64,8 @@ public final class LastHopOutgoingInterfaceManagerTest {
     Configuration c = _cb.build();
     Vrf vrf = _vb.setOwner(c).build();
     FirewallSessionInterfaceInfo firewallSessionInterfaceInfo =
-        new FirewallSessionInterfaceInfo(false, ImmutableSet.of("iface"), null, null);
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableSet.of("iface"), null, null);
     _ib.setActive(true)
         .setName("iface")
         .setOwner(c)

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/LastHopOutgoingInterfaceManagerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/LastHopOutgoingInterfaceManagerTest.java
@@ -65,7 +65,7 @@ public final class LastHopOutgoingInterfaceManagerTest {
     Vrf vrf = _vb.setOwner(c).build();
     FirewallSessionInterfaceInfo firewallSessionInterfaceInfo =
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableSet.of("iface"), null, null);
+            Action.FORWARD_OUT_IFACE, ImmutableSet.of("iface"), null, null);
     _ib.setActive(true)
         .setName("iface")
         .setOwner(c)

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
@@ -34,9 +34,9 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Accept;
-import org.batfish.datamodel.flow.FibLookup;
 import org.batfish.datamodel.flow.ForwardOutInterface;
 import org.batfish.datamodel.flow.OriginatingSessionScope;
+import org.batfish.datamodel.flow.PostNatFibLookup;
 import org.batfish.symbolic.state.NodeAccept;
 import org.batfish.symbolic.state.NodeDropAclIn;
 import org.batfish.symbolic.state.NodeDropAclOut;
@@ -282,7 +282,7 @@ public final class SessionInstrumentationTest {
     BDD sessionHeaders = PKT.getDstIp().value(10L);
     BDDFirewallSessionTraceInfo sessionInfo =
         new BDDFirewallSessionTraceInfo(
-            FW, ImmutableSet.of(FW_I1), FibLookup.INSTANCE, sessionHeaders, IDENTITY);
+            FW, ImmutableSet.of(FW_I1), PostNatFibLookup.INSTANCE, sessionHeaders, IDENTITY);
 
     assertThat(
         fibLookupSessionEdges(sessionInfo),
@@ -302,7 +302,7 @@ public final class SessionInstrumentationTest {
     Transition nat = Transitions.eraseAndSet(PKT.getSrcIp(), poolBdd);
     BDDFirewallSessionTraceInfo sessionInfo =
         new BDDFirewallSessionTraceInfo(
-            FW, ImmutableSet.of(FW_I1), FibLookup.INSTANCE, sessionHeaders, nat);
+            FW, ImmutableSet.of(FW_I1), PostNatFibLookup.INSTANCE, sessionHeaders, nat);
 
     assertThat(
         fibLookupSessionEdges(sessionInfo),
@@ -322,7 +322,11 @@ public final class SessionInstrumentationTest {
     BDD sessionHeaders = PKT.getDstIp().value(10L);
     BDDFirewallSessionTraceInfo sessionInfo =
         new BDDFirewallSessionTraceInfo(
-            FW, new OriginatingSessionScope(FW_VRF), FibLookup.INSTANCE, sessionHeaders, IDENTITY);
+            FW,
+            new OriginatingSessionScope(FW_VRF),
+            PostNatFibLookup.INSTANCE,
+            sessionHeaders,
+            IDENTITY);
 
     BDD originating = _fwSrcMgr.getOriginatingFromDeviceBDD();
     Matcher<Transition> expectedTransition =
@@ -347,7 +351,11 @@ public final class SessionInstrumentationTest {
     Transition nat = Transitions.eraseAndSet(PKT.getSrcIp(), poolBdd);
     BDDFirewallSessionTraceInfo natSessionInfo =
         new BDDFirewallSessionTraceInfo(
-            FW, new OriginatingSessionScope(FW_VRF), FibLookup.INSTANCE, sessionHeaders, nat);
+            FW,
+            new OriginatingSessionScope(FW_VRF),
+            PostNatFibLookup.INSTANCE,
+            sessionHeaders,
+            nat);
 
     BDD originating = _fwSrcMgr.getOriginatingFromDeviceBDD();
     Matcher<Transition> expectedTransition =

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
@@ -243,7 +243,7 @@ public final class SessionInstrumentationTest {
     // FW_I1 has an incoming session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), PERMIT_TCP, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(FW_I1), PERMIT_TCP, null));
     assertThat(
         nodeAcceptEdges(sessionInfo),
         contains(
@@ -413,7 +413,7 @@ public final class SessionInstrumentationTest {
     // FW_I1 has an incoming session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), PERMIT_TCP, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(FW_I1), PERMIT_TCP, null));
     assertThat(
         preInInterfaceEdges(sessionInfo),
         contains(
@@ -434,7 +434,7 @@ public final class SessionInstrumentationTest {
     // FW_I1 has an outgoing session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), null, PERMIT_TCP));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(FW_I1), null, PERMIT_TCP));
     assertThat(
         preInInterfaceEdges(sessionInfo),
         contains(
@@ -513,7 +513,7 @@ public final class SessionInstrumentationTest {
     // FW_I1 has an incoming session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), PERMIT_TCP, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(FW_I1), PERMIT_TCP, null));
     assertThat(
         deliveredToSubnetEdges(sessionInfo),
         contains(
@@ -528,7 +528,7 @@ public final class SessionInstrumentationTest {
     // FW_I1 has an outgoing session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), null, PERMIT_TCP));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(FW_I1), null, PERMIT_TCP));
     assertThat(
         deliveredToSubnetEdges(sessionInfo),
         contains(
@@ -581,7 +581,7 @@ public final class SessionInstrumentationTest {
     // FW_I1 has an incoming session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), PERMIT_TCP, null));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(FW_I1), PERMIT_TCP, null));
     assertThat(
         nodeDropAclInEdges(sessionInfo),
         contains(
@@ -614,7 +614,7 @@ public final class SessionInstrumentationTest {
     // FW_I1 has an outgoing session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
         new FirewallSessionInterfaceInfo(
-            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), null, PERMIT_TCP));
+            Action.FORWARD_OUT_IFACE, ImmutableList.of(FW_I1), null, PERMIT_TCP));
     assertThat(
         nodeDropAclOutEdges(sessionInfo),
         contains(

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/SessionInstrumentationTest.java
@@ -28,6 +28,7 @@ import org.batfish.common.bdd.BDDSourceManager;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.NetworkFactory;
@@ -241,7 +242,8 @@ public final class SessionInstrumentationTest {
 
     // FW_I1 has an incoming session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(FW_I1), PERMIT_TCP, null));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), PERMIT_TCP, null));
     assertThat(
         nodeAcceptEdges(sessionInfo),
         contains(
@@ -410,7 +412,8 @@ public final class SessionInstrumentationTest {
 
     // FW_I1 has an incoming session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(FW_I1), PERMIT_TCP, null));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), PERMIT_TCP, null));
     assertThat(
         preInInterfaceEdges(sessionInfo),
         contains(
@@ -430,7 +433,8 @@ public final class SessionInstrumentationTest {
 
     // FW_I1 has an outgoing session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(FW_I1), null, PERMIT_TCP));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), null, PERMIT_TCP));
     assertThat(
         preInInterfaceEdges(sessionInfo),
         contains(
@@ -508,7 +512,8 @@ public final class SessionInstrumentationTest {
 
     // FW_I1 has an incoming session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(FW_I1), PERMIT_TCP, null));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), PERMIT_TCP, null));
     assertThat(
         deliveredToSubnetEdges(sessionInfo),
         contains(
@@ -522,7 +527,8 @@ public final class SessionInstrumentationTest {
 
     // FW_I1 has an outgoing session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(FW_I1), null, PERMIT_TCP));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), null, PERMIT_TCP));
     assertThat(
         deliveredToSubnetEdges(sessionInfo),
         contains(
@@ -574,7 +580,8 @@ public final class SessionInstrumentationTest {
 
     // FW_I1 has an incoming session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(FW_I1), PERMIT_TCP, null));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), PERMIT_TCP, null));
     assertThat(
         nodeDropAclInEdges(sessionInfo),
         contains(
@@ -606,7 +613,8 @@ public final class SessionInstrumentationTest {
 
     // FW_I1 has an outgoing session ACL
     _fwI1.setFirewallSessionInterfaceInfo(
-        new FirewallSessionInterfaceInfo(false, ImmutableList.of(FW_I1), null, PERMIT_TCP));
+        new FirewallSessionInterfaceInfo(
+            Action.NO_FIB_LOOKUP, ImmutableList.of(FW_I1), null, PERMIT_TCP));
     assertThat(
         nodeDropAclOutEdges(sessionInfo),
         contains(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -66,6 +66,7 @@ import org.batfish.datamodel.FibForward;
 import org.batfish.datamodel.FibNextVrf;
 import org.batfish.datamodel.FibNullRoute;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.FirewallSessionVrfInfo;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDiff;
@@ -1255,22 +1256,23 @@ public final class FlowTracerTest {
     NodeInterfacePair lastHopNodeAndOutgoingInterface = NodeInterfacePair.of("node", "iface");
     String ingressIface = "ingressIface";
 
-    // Fib lookup true: action should always be fib lookup
+    // Post-NAT FIB lookup: action should always be post-NAT FIB lookup
     assertThat(
-        getSessionAction(true, null, lastHopNodeAndOutgoingInterface),
+        getSessionAction(Action.POST_NAT_FIB_LOOKUP, null, lastHopNodeAndOutgoingInterface),
         equalTo(PostNatFibLookup.INSTANCE));
     assertThat(
-        getSessionAction(true, ingressIface, lastHopNodeAndOutgoingInterface),
+        getSessionAction(Action.POST_NAT_FIB_LOOKUP, ingressIface, lastHopNodeAndOutgoingInterface),
         equalTo(PostNatFibLookup.INSTANCE));
 
     // Ingress interface defined: action should be forward to last hop node and interface
     assertThat(
-        getSessionAction(false, ingressIface, lastHopNodeAndOutgoingInterface),
+        getSessionAction(Action.NO_FIB_LOOKUP, ingressIface, lastHopNodeAndOutgoingInterface),
         equalTo(new ForwardOutInterface(ingressIface, lastHopNodeAndOutgoingInterface)));
 
     // Ingress interface null: action should be accept (flow that set up session originated here)
     assertThat(
-        getSessionAction(false, null, lastHopNodeAndOutgoingInterface), equalTo(Accept.INSTANCE));
+        getSessionAction(Action.NO_FIB_LOOKUP, null, lastHopNodeAndOutgoingInterface),
+        equalTo(Accept.INSTANCE));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -451,7 +451,8 @@ public final class FlowTracerTest {
         .setVrf(vrf)
         .setName(ifaceName)
         .setFirewallSessionInterfaceInfo(
-            new FirewallSessionInterfaceInfo(false, ImmutableSet.of(ifaceName), null, null))
+            new FirewallSessionInterfaceInfo(
+                Action.NO_FIB_LOOKUP, ImmutableSet.of(ifaceName), null, null))
         .build();
 
     // To match session, return flow must have same protocol and port and swapped src/dst IPs
@@ -577,7 +578,8 @@ public final class FlowTracerTest {
         .setVrf(vrf)
         .setName(ifaceName)
         .setFirewallSessionInterfaceInfo(
-            new FirewallSessionInterfaceInfo(true, ImmutableSet.of(ifaceName), null, null))
+            new FirewallSessionInterfaceInfo(
+                Action.POST_NAT_FIB_LOOKUP, ImmutableSet.of(ifaceName), null, null))
         .setAddress(address)
         .build();
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -96,7 +96,6 @@ import org.batfish.datamodel.flow.Accept;
 import org.batfish.datamodel.flow.ArpErrorStep;
 import org.batfish.datamodel.flow.DeliveredStep;
 import org.batfish.datamodel.flow.EnterInputIfaceStep;
-import org.batfish.datamodel.flow.FibLookup;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
 import org.batfish.datamodel.flow.ForwardOutInterface;
 import org.batfish.datamodel.flow.Hop;
@@ -105,6 +104,7 @@ import org.batfish.datamodel.flow.IncomingSessionScope;
 import org.batfish.datamodel.flow.LoopStep;
 import org.batfish.datamodel.flow.MatchSessionStep;
 import org.batfish.datamodel.flow.OriginatingSessionScope;
+import org.batfish.datamodel.flow.PostNatFibLookup;
 import org.batfish.datamodel.flow.RouteInfo;
 import org.batfish.datamodel.flow.RoutingStep;
 import org.batfish.datamodel.flow.RoutingStep.RoutingStepDetail;
@@ -340,7 +340,7 @@ public final class FlowTracerTest {
       FirewallSessionTraceInfo expectedNewSession =
           new FirewallSessionTraceInfo(
               hostname,
-              FibLookup.INSTANCE,
+              PostNatFibLookup.INSTANCE,
               new OriginatingSessionScope(vrfName),
               flowMatchingNewSession,
               null);
@@ -600,7 +600,7 @@ public final class FlowTracerTest {
     FirewallSessionTraceInfo incomingSession =
         new FirewallSessionTraceInfo(
             c.getHostname(),
-            FibLookup.INSTANCE,
+            PostNatFibLookup.INSTANCE,
             new IncomingSessionScope(ImmutableSet.of(ifaceName)),
             flowMatchingNewSession,
             null);
@@ -1257,10 +1257,11 @@ public final class FlowTracerTest {
 
     // Fib lookup true: action should always be fib lookup
     assertThat(
-        getSessionAction(true, null, lastHopNodeAndOutgoingInterface), equalTo(FibLookup.INSTANCE));
+        getSessionAction(true, null, lastHopNodeAndOutgoingInterface),
+        equalTo(PostNatFibLookup.INSTANCE));
     assertThat(
         getSessionAction(true, ingressIface, lastHopNodeAndOutgoingInterface),
-        equalTo(FibLookup.INSTANCE));
+        equalTo(PostNatFibLookup.INSTANCE));
 
     // Ingress interface defined: action should be forward to last hop node and interface
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -106,6 +106,7 @@ import org.batfish.datamodel.flow.LoopStep;
 import org.batfish.datamodel.flow.MatchSessionStep;
 import org.batfish.datamodel.flow.OriginatingSessionScope;
 import org.batfish.datamodel.flow.PostNatFibLookup;
+import org.batfish.datamodel.flow.PreNatFibLookup;
 import org.batfish.datamodel.flow.RouteInfo;
 import org.batfish.datamodel.flow.RoutingStep;
 import org.batfish.datamodel.flow.RoutingStep.RoutingStepDetail;
@@ -1258,10 +1259,16 @@ public final class FlowTracerTest {
     NodeInterfacePair lastHopNodeAndOutgoingInterface = NodeInterfacePair.of("node", "iface");
     String ingressIface = "ingressIface";
 
-    // Post-NAT FIB lookup: action should always be post-NAT FIB lookup
+    // Pre- or post- NAT FIB lookup: action should always be the corresponding FIB lookup
+    assertThat(
+        getSessionAction(Action.PRE_NAT_FIB_LOOKUP, null, lastHopNodeAndOutgoingInterface),
+        equalTo(PreNatFibLookup.INSTANCE));
     assertThat(
         getSessionAction(Action.POST_NAT_FIB_LOOKUP, null, lastHopNodeAndOutgoingInterface),
         equalTo(PostNatFibLookup.INSTANCE));
+    assertThat(
+        getSessionAction(Action.PRE_NAT_FIB_LOOKUP, ingressIface, lastHopNodeAndOutgoingInterface),
+        equalTo(PreNatFibLookup.INSTANCE));
     assertThat(
         getSessionAction(Action.POST_NAT_FIB_LOOKUP, ingressIface, lastHopNodeAndOutgoingInterface),
         equalTo(PostNatFibLookup.INSTANCE));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -84,6 +84,7 @@ import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.HeaderSpace;
@@ -1345,7 +1346,8 @@ public class TracerouteEngineImplTest {
     ib.setName("i2")
         .setAddresses(ConcreteInterfaceAddress.parse("10.0.2.1/24"))
         .setFirewallSessionInterfaceInfo(
-            new FirewallSessionInterfaceInfo(true, ImmutableSet.of(i2Name), null, null))
+            new FirewallSessionInterfaceInfo(
+                Action.POST_NAT_FIB_LOOKUP, ImmutableSet.of(i2Name), null, null))
         .build();
     SortedMap<String, Configuration> configs = ImmutableSortedMap.of(hostname, c);
     Batfish batfish = BatfishTestUtils.getBatfish(configs, _tempFolder);
@@ -1408,7 +1410,8 @@ public class TracerouteEngineImplTest {
         .setVrf(vrf2)
         .setAddresses(ConcreteInterfaceAddress.parse("10.0.2.1/24"))
         .setFirewallSessionInterfaceInfo(
-            new FirewallSessionInterfaceInfo(true, ImmutableSet.of(i2Name), null, null))
+            new FirewallSessionInterfaceInfo(
+                Action.POST_NAT_FIB_LOOKUP, ImmutableSet.of(i2Name), null, null))
         .build();
     vrf1.getStaticRoutes()
         .add(
@@ -1600,7 +1603,7 @@ public class TracerouteEngineImplTest {
         .setAddress(ConcreteInterfaceAddress.parse("1.1.2.1/24"))
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                false, ImmutableSet.of(i2Name), incomingAclName, outgoingAclName))
+                Action.NO_FIB_LOOKUP, ImmutableSet.of(i2Name), incomingAclName, outgoingAclName))
         .build();
 
     String i3Name = "iface3";
@@ -1617,7 +1620,7 @@ public class TracerouteEngineImplTest {
             always().apply(assignSourceIp(poolIp, poolIp), assignSourcePort(2000, 2000)).build())
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                false, ImmutableSet.of(i4Name), incomingAclName, outgoingAclName))
+                Action.NO_FIB_LOOKUP, ImmutableSet.of(i4Name), incomingAclName, outgoingAclName))
         .build();
 
     // Compute data plane
@@ -1828,7 +1831,8 @@ public class TracerouteEngineImplTest {
     ib.setName(c2i2Name)
         .setAddress(ConcreteInterfaceAddress.parse("1.1.2.1/24"))
         .setFirewallSessionInterfaceInfo(
-            new FirewallSessionInterfaceInfo(false, ImmutableSet.of(c2i2Name), null, null))
+            new FirewallSessionInterfaceInfo(
+                Action.NO_FIB_LOOKUP, ImmutableSet.of(c2i2Name), null, null))
         .build();
 
     // Compute data plane
@@ -1931,7 +1935,10 @@ public class TracerouteEngineImplTest {
         .setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24"))
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                false, ImmutableSet.of(c1i1Name), sessionIngressFilter.getName(), null))
+                Action.NO_FIB_LOOKUP,
+                ImmutableSet.of(c1i1Name),
+                sessionIngressFilter.getName(),
+                null))
         .build();
 
     String c1i2Name = "c1i2";
@@ -1942,7 +1949,10 @@ public class TracerouteEngineImplTest {
         .setAddress(ConcreteInterfaceAddress.parse("1.1.2.1/24"))
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                false, ImmutableSet.of(c1i2Name), null, sessionEgressFilter.getName()))
+                Action.NO_FIB_LOOKUP,
+                ImmutableSet.of(c1i2Name),
+                null,
+                sessionEgressFilter.getName()))
         .build();
 
     Configuration c2 = cb.build();
@@ -2536,7 +2546,8 @@ public class TracerouteEngineImplTest {
         .setVrf(fwVrf)
         .setAddress(ConcreteInterfaceAddress.parse("20.0.0.1/24"))
         .setFirewallSessionInterfaceInfo(
-            new FirewallSessionInterfaceInfo(true, ImmutableSet.of(fwOutName), null, null))
+            new FirewallSessionInterfaceInfo(
+                Action.POST_NAT_FIB_LOOKUP, ImmutableSet.of(fwOutName), null, null))
         .build();
 
     // set up a static route for the reverse flow
@@ -2657,7 +2668,8 @@ public class TracerouteEngineImplTest {
         .setVrf(fwVrf)
         .setAddress(ConcreteInterfaceAddress.parse("20.0.0.1/24"))
         .setFirewallSessionInterfaceInfo(
-            new FirewallSessionInterfaceInfo(true, ImmutableSet.of(fwOutName), null, null))
+            new FirewallSessionInterfaceInfo(
+                Action.POST_NAT_FIB_LOOKUP, ImmutableSet.of(fwOutName), null, null))
         .build();
 
     // set up a dummy interface to cause arp failure for return flow

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -1603,7 +1603,10 @@ public class TracerouteEngineImplTest {
         .setAddress(ConcreteInterfaceAddress.parse("1.1.2.1/24"))
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableSet.of(i2Name), incomingAclName, outgoingAclName))
+                Action.FORWARD_OUT_IFACE,
+                ImmutableSet.of(i2Name),
+                incomingAclName,
+                outgoingAclName))
         .build();
 
     String i3Name = "iface3";
@@ -1620,7 +1623,10 @@ public class TracerouteEngineImplTest {
             always().apply(assignSourceIp(poolIp, poolIp), assignSourcePort(2000, 2000)).build())
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableSet.of(i4Name), incomingAclName, outgoingAclName))
+                Action.FORWARD_OUT_IFACE,
+                ImmutableSet.of(i4Name),
+                incomingAclName,
+                outgoingAclName))
         .build();
 
     // Compute data plane
@@ -1832,7 +1838,7 @@ public class TracerouteEngineImplTest {
         .setAddress(ConcreteInterfaceAddress.parse("1.1.2.1/24"))
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableSet.of(c2i2Name), null, null))
+                Action.FORWARD_OUT_IFACE, ImmutableSet.of(c2i2Name), null, null))
         .build();
 
     // Compute data plane
@@ -1935,7 +1941,7 @@ public class TracerouteEngineImplTest {
         .setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24"))
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP,
+                Action.FORWARD_OUT_IFACE,
                 ImmutableSet.of(c1i1Name),
                 sessionIngressFilter.getName(),
                 null))
@@ -1949,7 +1955,7 @@ public class TracerouteEngineImplTest {
         .setAddress(ConcreteInterfaceAddress.parse("1.1.2.1/24"))
         .setFirewallSessionInterfaceInfo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP,
+                Action.FORWARD_OUT_IFACE,
                 ImmutableSet.of(c1i2Name),
                 null,
                 sessionEgressFilter.getName()))

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -312,6 +312,7 @@ import org.batfish.datamodel.EigrpRoute;
 import org.batfish.datamodel.EncryptionAlgorithm;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.GenericRib;
@@ -7381,10 +7382,14 @@ public final class CiscoGrammarTest {
     // attached to it
     assertThat(
         inside,
-        equalTo(new FirewallSessionInterfaceInfo(true, ImmutableSet.of("inside"), null, null)));
+        equalTo(
+            new FirewallSessionInterfaceInfo(
+                Action.POST_NAT_FIB_LOOKUP, ImmutableSet.of("inside"), null, null)));
     assertThat(
         outside,
-        equalTo(new FirewallSessionInterfaceInfo(true, ImmutableSet.of("outside"), null, null)));
+        equalTo(
+            new FirewallSessionInterfaceInfo(
+                Action.POST_NAT_FIB_LOOKUP, ImmutableSet.of("outside"), null, null)));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -226,6 +226,7 @@ import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.EncryptionAlgorithm;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.GeneratedRoute6;
@@ -5484,16 +5485,19 @@ public final class FlatJuniperGrammarTest {
         c.getAllInterfaces().get(i0Name).getFirewallSessionInterfaceInfo(),
         equalTo(
             new FirewallSessionInterfaceInfo(
-                false, ImmutableList.of(i0Name, i1Name), "FILTER1", "FILTER2")));
+                Action.NO_FIB_LOOKUP, ImmutableList.of(i0Name, i1Name), "FILTER1", "FILTER2")));
 
     assertThat(
         c.getAllInterfaces().get(i1Name).getFirewallSessionInterfaceInfo(),
         equalTo(
-            new FirewallSessionInterfaceInfo(false, ImmutableList.of(i0Name, i1Name), null, null)));
+            new FirewallSessionInterfaceInfo(
+                Action.NO_FIB_LOOKUP, ImmutableList.of(i0Name, i1Name), null, null)));
 
     assertThat(
         c.getAllInterfaces().get(i2Name).getFirewallSessionInterfaceInfo(),
-        equalTo(new FirewallSessionInterfaceInfo(false, ImmutableList.of(i2Name), null, null)));
+        equalTo(
+            new FirewallSessionInterfaceInfo(
+                Action.NO_FIB_LOOKUP, ImmutableList.of(i2Name), null, null)));
 
     // ge-0/0/0.3 is not part of any zoone, so no firewall session interface info.
     assertThat(c.getAllInterfaces().get(i3Name).getFirewallSessionInterfaceInfo(), nullValue());

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -5485,19 +5485,19 @@ public final class FlatJuniperGrammarTest {
         c.getAllInterfaces().get(i0Name).getFirewallSessionInterfaceInfo(),
         equalTo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableList.of(i0Name, i1Name), "FILTER1", "FILTER2")));
+                Action.FORWARD_OUT_IFACE, ImmutableList.of(i0Name, i1Name), "FILTER1", "FILTER2")));
 
     assertThat(
         c.getAllInterfaces().get(i1Name).getFirewallSessionInterfaceInfo(),
         equalTo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableList.of(i0Name, i1Name), null, null)));
+                Action.FORWARD_OUT_IFACE, ImmutableList.of(i0Name, i1Name), null, null)));
 
     assertThat(
         c.getAllInterfaces().get(i2Name).getFirewallSessionInterfaceInfo(),
         equalTo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableList.of(i2Name), null, null)));
+                Action.FORWARD_OUT_IFACE, ImmutableList.of(i2Name), null, null)));
 
     // ge-0/0/0.3 is not part of any zoone, so no firewall session interface info.
     assertThat(c.getAllInterfaces().get(i3Name).getFirewallSessionInterfaceInfo(), nullValue());

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -50,6 +50,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
@@ -286,7 +287,7 @@ public class ElasticsearchDomainTest {
           iface.getFirewallSessionInterfaceInfo(),
           equalTo(
               new FirewallSessionInterfaceInfo(
-                  false, ImmutableList.of(iface.getName()), null, null)));
+                  Action.NO_FIB_LOOKUP, ImmutableList.of(iface.getName()), null, null)));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/ElasticsearchDomainTest.java
@@ -287,7 +287,7 @@ public class ElasticsearchDomainTest {
           iface.getFirewallSessionInterfaceInfo(),
           equalTo(
               new FirewallSessionInterfaceInfo(
-                  Action.NO_FIB_LOOKUP, ImmutableList.of(iface.getName()), null, null)));
+                  Action.FORWARD_OUT_IFACE, ImmutableList.of(iface.getName()), null, null)));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerTest.java
@@ -62,6 +62,7 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DeviceModel;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
@@ -411,7 +412,7 @@ public class LoadBalancerTest {
         viIface.getFirewallSessionInterfaceInfo(),
         equalTo(
             new FirewallSessionInterfaceInfo(
-                false, ImmutableList.of(viIface.getName()), null, null)));
+                Action.NO_FIB_LOOKUP, ImmutableList.of(viIface.getName()), null, null)));
   }
 
   @Test
@@ -425,7 +426,7 @@ public class LoadBalancerTest {
         viIface.getFirewallSessionInterfaceInfo(),
         equalTo(
             new FirewallSessionInterfaceInfo(
-                false, ImmutableList.of(viIface.getName()), null, null)));
+                Action.NO_FIB_LOOKUP, ImmutableList.of(viIface.getName()), null, null)));
   }
 
   /** Test that we skip over bad actions and create the right transformation for the good one */

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/LoadBalancerTest.java
@@ -412,7 +412,7 @@ public class LoadBalancerTest {
         viIface.getFirewallSessionInterfaceInfo(),
         equalTo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableList.of(viIface.getName()), null, null)));
+                Action.FORWARD_OUT_IFACE, ImmutableList.of(viIface.getName()), null, null)));
   }
 
   @Test
@@ -426,7 +426,7 @@ public class LoadBalancerTest {
         viIface.getFirewallSessionInterfaceInfo(),
         equalTo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableList.of(viIface.getName()), null, null)));
+                Action.FORWARD_OUT_IFACE, ImmutableList.of(viIface.getName()), null, null)));
   }
 
   /** Test that we skip over bad actions and create the right transformation for the good one */

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/NatGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/NatGatewayTest.java
@@ -151,7 +151,7 @@ public class NatGatewayTest {
         ifaceToSubnet.getFirewallSessionInterfaceInfo(),
         equalTo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP, ImmutableList.of(ifaceToSubnet.getName()), null, null)));
+                Action.FORWARD_OUT_IFACE, ImmutableList.of(ifaceToSubnet.getName()), null, null)));
     assertThat(
         ifaceToSubnet.getPostTransformationIncomingFilter().getName(),
         equalTo(ILLEGAL_PACKET_FILTER_NAME));
@@ -170,7 +170,7 @@ public class NatGatewayTest {
         ifaceToVpc.getFirewallSessionInterfaceInfo(),
         equalTo(
             new FirewallSessionInterfaceInfo(
-                Action.NO_FIB_LOOKUP,
+                Action.FORWARD_OUT_IFACE,
                 ImmutableList.of(ifaceToVpc.getName()),
                 null,
                 nacl.getEgressAcl().getName())));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/NatGatewayTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/NatGatewayTest.java
@@ -31,6 +31,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
@@ -150,7 +151,7 @@ public class NatGatewayTest {
         ifaceToSubnet.getFirewallSessionInterfaceInfo(),
         equalTo(
             new FirewallSessionInterfaceInfo(
-                false, ImmutableList.of(ifaceToSubnet.getName()), null, null)));
+                Action.NO_FIB_LOOKUP, ImmutableList.of(ifaceToSubnet.getName()), null, null)));
     assertThat(
         ifaceToSubnet.getPostTransformationIncomingFilter().getName(),
         equalTo(ILLEGAL_PACKET_FILTER_NAME));
@@ -169,7 +170,7 @@ public class NatGatewayTest {
         ifaceToVpc.getFirewallSessionInterfaceInfo(),
         equalTo(
             new FirewallSessionInterfaceInfo(
-                false,
+                Action.NO_FIB_LOOKUP,
                 ImmutableList.of(ifaceToVpc.getName()),
                 null,
                 nacl.getEgressAcl().getName())));

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -46,6 +46,7 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Edge;
 import org.batfish.datamodel.FirewallSessionInterfaceInfo;
+import org.batfish.datamodel.FirewallSessionInterfaceInfo.Action;
 import org.batfish.datamodel.HeaderSpace;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
@@ -223,7 +224,7 @@ public class RdsInstanceTest {
           iface.getFirewallSessionInterfaceInfo(),
           equalTo(
               new FirewallSessionInterfaceInfo(
-                  false, ImmutableList.of(iface.getName()), null, null)));
+                  Action.NO_FIB_LOOKUP, ImmutableList.of(iface.getName()), null, null)));
     }
   }
 

--- a/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/aws/RdsInstanceTest.java
@@ -224,7 +224,7 @@ public class RdsInstanceTest {
           iface.getFirewallSessionInterfaceInfo(),
           equalTo(
               new FirewallSessionInterfaceInfo(
-                  Action.NO_FIB_LOOKUP, ImmutableList.of(iface.getName()), null, null)));
+                  Action.FORWARD_OUT_IFACE, ImmutableList.of(iface.getName()), null, null)));
     }
   }
 

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -26,7 +26,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet subnet-1641fa70",
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
+              "action" : "NO_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "subnet-1641fa70"
               ]
@@ -256,7 +256,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet subnet-7044ff16",
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
+              "action" : "NO_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "subnet-7044ff16"
               ]
@@ -501,7 +501,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To AWS services",
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
+              "action" : "NO_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "aws-services"
               ]
@@ -529,7 +529,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To AWS backbone",
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
+              "action" : "NO_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "backbone"
               ]
@@ -47374,7 +47374,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet subnet-1641fa70",
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
+              "action" : "NO_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "test-rds-subnet-1641fa70"
               ]

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -26,7 +26,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet subnet-1641fa70",
             "firewallSessionInterfaceInfo" : {
-              "action" : "NO_FIB_LOOKUP",
+              "action" : "FORWARD_OUT_IFACE",
               "sessionInterfaces" : [
                 "subnet-1641fa70"
               ]
@@ -256,7 +256,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet subnet-7044ff16",
             "firewallSessionInterfaceInfo" : {
-              "action" : "NO_FIB_LOOKUP",
+              "action" : "FORWARD_OUT_IFACE",
               "sessionInterfaces" : [
                 "subnet-7044ff16"
               ]
@@ -501,7 +501,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To AWS services",
             "firewallSessionInterfaceInfo" : {
-              "action" : "NO_FIB_LOOKUP",
+              "action" : "FORWARD_OUT_IFACE",
               "sessionInterfaces" : [
                 "aws-services"
               ]
@@ -529,7 +529,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To AWS backbone",
             "firewallSessionInterfaceInfo" : {
-              "action" : "NO_FIB_LOOKUP",
+              "action" : "FORWARD_OUT_IFACE",
               "sessionInterfaces" : [
                 "backbone"
               ]
@@ -47374,7 +47374,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To subnet subnet-1641fa70",
             "firewallSessionInterfaceInfo" : {
-              "action" : "NO_FIB_LOOKUP",
+              "action" : "FORWARD_OUT_IFACE",
               "sessionInterfaces" : [
                 "test-rds-subnet-1641fa70"
               ]

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -22,7 +22,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To AWS services",
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
+              "action" : "NO_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "aws-services"
               ]
@@ -50,7 +50,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To AWS backbone",
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
+              "action" : "NO_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "backbone"
               ]
@@ -20197,7 +20197,7 @@
               "GigabitEthernet0/1"
             ],
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : true,
+              "action" : "POST_NAT_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "GigabitEthernet0/1"
               ]
@@ -20227,7 +20227,7 @@
               "GigabitEthernet0/2"
             ],
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : true,
+              "action" : "POST_NAT_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "GigabitEthernet0/2"
               ]
@@ -20257,7 +20257,7 @@
               "Redundant1"
             ],
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : true,
+              "action" : "POST_NAT_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "Redundant1"
               ]
@@ -20286,7 +20286,7 @@
               "Redundant2"
             ],
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : true,
+              "action" : "POST_NAT_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "Redundant2"
               ]
@@ -20320,7 +20320,7 @@
             ],
             "encapsulationVlan" : 2,
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : true,
+              "action" : "POST_NAT_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "redundant1sub"
               ]
@@ -20356,7 +20356,7 @@
             ],
             "encapsulationVlan" : 2,
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : true,
+              "action" : "POST_NAT_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "redundant2sub"
               ]
@@ -21400,7 +21400,7 @@
               "ifname"
             ],
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : true,
+              "action" : "POST_NAT_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "ifname"
               ]
@@ -21631,7 +21631,7 @@
               "blah"
             ],
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : true,
+              "action" : "POST_NAT_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "blah"
               ]
@@ -38054,7 +38054,7 @@
             "autostate" : true,
             "bandwidth" : 1.0E12,
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
+              "action" : "NO_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "/Common/MYVLAN"
               ]
@@ -70710,7 +70710,7 @@
               "ge-0/0/0.0"
             ],
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
+              "action" : "NO_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "ge-0/0/0.0"
               ]
@@ -72871,7 +72871,7 @@
               "xe-0/0/0.0"
             ],
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
+              "action" : "NO_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "xe-0/0/0.0"
               ]
@@ -72929,7 +72929,7 @@
               "xe-1/0/0.0"
             ],
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : false,
+              "action" : "NO_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "xe-1/0/0.0"
               ]
@@ -79354,7 +79354,7 @@
             "autostate" : true,
             "bandwidth" : 1.0E9,
             "firewallSessionInterfaceInfo" : {
-              "fibLookup" : true,
+              "action" : "POST_NAT_FIB_LOOKUP",
               "sessionInterfaces" : [
                 "ethernet1/2"
               ]

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -22,7 +22,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To AWS services",
             "firewallSessionInterfaceInfo" : {
-              "action" : "NO_FIB_LOOKUP",
+              "action" : "FORWARD_OUT_IFACE",
               "sessionInterfaces" : [
                 "aws-services"
               ]
@@ -50,7 +50,7 @@
             "bandwidth" : 1.0E12,
             "description" : "To AWS backbone",
             "firewallSessionInterfaceInfo" : {
-              "action" : "NO_FIB_LOOKUP",
+              "action" : "FORWARD_OUT_IFACE",
               "sessionInterfaces" : [
                 "backbone"
               ]
@@ -38054,7 +38054,7 @@
             "autostate" : true,
             "bandwidth" : 1.0E12,
             "firewallSessionInterfaceInfo" : {
-              "action" : "NO_FIB_LOOKUP",
+              "action" : "FORWARD_OUT_IFACE",
               "sessionInterfaces" : [
                 "/Common/MYVLAN"
               ]
@@ -70710,7 +70710,7 @@
               "ge-0/0/0.0"
             ],
             "firewallSessionInterfaceInfo" : {
-              "action" : "NO_FIB_LOOKUP",
+              "action" : "FORWARD_OUT_IFACE",
               "sessionInterfaces" : [
                 "ge-0/0/0.0"
               ]
@@ -72871,7 +72871,7 @@
               "xe-0/0/0.0"
             ],
             "firewallSessionInterfaceInfo" : {
-              "action" : "NO_FIB_LOOKUP",
+              "action" : "FORWARD_OUT_IFACE",
               "sessionInterfaces" : [
                 "xe-0/0/0.0"
               ]
@@ -72929,7 +72929,7 @@
               "xe-1/0/0.0"
             ],
             "firewallSessionInterfaceInfo" : {
-              "action" : "NO_FIB_LOOKUP",
+              "action" : "FORWARD_OUT_IFACE",
               "sessionInterfaces" : [
                 "xe-1/0/0.0"
               ]


### PR DESCRIPTION
This will be needed to support bidirectional traceroute for IOS devices with NAT, because IOS applies NAT _after_ routing for session-matching flows going from inside to outside.