### PR TITLE
JunOS: fix parsing range of from-color, then-tag, from-tag, then-color

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchColor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/MatchColor.java
@@ -2,7 +2,6 @@ package org.batfish.datamodel.routing_policy.expr;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Objects;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.batfish.datamodel.routing_policy.Result;
@@ -11,14 +10,14 @@ public final class MatchColor extends BooleanExpr {
 
   private static final String PROP_COLOR = "color";
 
-  private final int _color;
+  private final long _color;
 
   @JsonCreator
   private static MatchColor create(@JsonProperty(PROP_COLOR) int color) {
     return new MatchColor(color);
   }
 
-  public MatchColor(int color) {
+  public MatchColor(long color) {
     _color = color;
   }
 
@@ -33,7 +32,7 @@ public final class MatchColor extends BooleanExpr {
   }
 
   @JsonProperty(PROP_COLOR)
-  public int getColor() {
+  public long getColor() {
     return _color;
   }
 
@@ -41,8 +40,7 @@ public final class MatchColor extends BooleanExpr {
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (!(obj instanceof MatchColor)) {
+    } else if (!(obj instanceof MatchColor)) {
       return false;
     }
     MatchColor other = (MatchColor) obj;
@@ -51,6 +49,6 @@ public final class MatchColor extends BooleanExpr {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(_color);
+    return Long.hashCode(_color);
   }
 }

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_policy_options.g4
@@ -183,7 +183,7 @@ popsf_as_path_group
 
 popsf_color
 :
-   COLOR color = dec
+   COLOR color = uint32
 ;
 
 popsf_community
@@ -330,7 +330,7 @@ popsf_source_address_filter
 
 popsf_tag
 :
-   TAG dec
+   TAG uint32
 ;
 
 popsfpl_exact
@@ -427,8 +427,7 @@ popst_color
    COLOR
    (
       apply
-      | popstc_add_color
-      | popstc_color
+      | (ADD | SUBTRACT)? uint32
    )
 ;
 
@@ -437,8 +436,7 @@ popst_color2
    COLOR2
    (
       apply
-      | popstc2_add_color
-      | popstc2_color
+      | (ADD | SUBTRACT)? uint32
    )
 ;
 
@@ -626,27 +624,7 @@ popst_reject
 
 popst_tag
 :
-   TAG dec
-;
-
-popstc_add_color
-:
-   ADD color = dec
-;
-
-popstc_color
-:
-   color = dec
-;
-
-popstc2_add_color
-:
-   ADD color2 = dec
-;
-
-popstc2_color
-:
-   color2 = dec
+   TAG uint32
 ;
 
 popsto_level

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -400,6 +400,8 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_throughContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popsfrf_uptoContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_acceptContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_as_path_prependContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_color2Context;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_colorContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_community_addContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_community_deleteContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_community_setContext;
@@ -416,6 +418,7 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_next_termContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_originContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_preferenceContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_rejectContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Popst_tagContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.PortContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.ProposalContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Proposal_listContext;
@@ -761,6 +764,7 @@ import org.batfish.representation.juniper.PsThenNextPolicy;
 import org.batfish.representation.juniper.PsThenOrigin;
 import org.batfish.representation.juniper.PsThenPreference;
 import org.batfish.representation.juniper.PsThenReject;
+import org.batfish.representation.juniper.PsThenTag;
 import org.batfish.representation.juniper.QualifiedNextHop;
 import org.batfish.representation.juniper.RegexCommunityMember;
 import org.batfish.representation.juniper.RibGroup;
@@ -4813,7 +4817,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitPopsf_color(Popsf_colorContext ctx) {
-    int color = toInt(ctx.color);
+    long color = toLong(ctx.color);
     _currentPsTerm.getFroms().setFromColor(new PsFromColor(color));
   }
 
@@ -4957,7 +4961,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitPopsf_tag(Popsf_tagContext ctx) {
-    int tag = toInt(ctx.dec());
+    long tag = toLong(ctx.uint32());
     _currentPsTerm.getFroms().addFromTag(new PsFromTag(tag));
   }
 
@@ -4976,6 +4980,16 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     List<Long> asPaths =
         ctx.bgp_asn().stream().map(this::toAsNum).collect(ImmutableList.toImmutableList());
     _currentPsThens.add(new PsThenAsPathPrepend(asPaths));
+  }
+
+  @Override
+  public void exitPopst_color(Popst_colorContext ctx) {
+    todo(ctx);
+  }
+
+  @Override
+  public void exitPopst_color2(Popst_color2Context ctx) {
+    todo(ctx);
   }
 
   @Override
@@ -5108,6 +5122,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   @Override
   public void exitPopst_reject(Popst_rejectContext ctx) {
     _currentPsThens.add(PsThenReject.INSTANCE);
+  }
+
+  @Override
+  public void exitPopst_tag(Popst_tagContext ctx) {
+    _currentPsThens.add(new PsThenTag(toLong(ctx.uint32())));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromColor.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromColor.java
@@ -8,18 +8,34 @@ import org.batfish.datamodel.routing_policy.expr.MatchColor;
 /** Represents a "from color" line in a {@link PsTerm} */
 public final class PsFromColor extends PsFrom {
 
-  private final int _color;
+  private final long _color;
 
-  public PsFromColor(int color) {
+  public PsFromColor(long color) {
     _color = color;
   }
 
-  public int getColor() {
+  public long getColor() {
     return _color;
   }
 
   @Override
   public BooleanExpr toBooleanExpr(JuniperConfiguration jc, Configuration c, Warnings warnings) {
     return new MatchColor(_color);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsFromColor)) {
+      return false;
+    }
+    PsFromColor that = (PsFromColor) o;
+    return _color == that._color;
+  }
+
+  @Override
+  public int hashCode() {
+    return Long.hashCode(_color);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromTag.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFromTag.java
@@ -8,20 +8,36 @@ import org.batfish.datamodel.routing_policy.expr.LiteralLong;
 import org.batfish.datamodel.routing_policy.expr.MatchTag;
 
 /** Represents a "from tag" line in a {@link PsTerm} */
-public class PsFromTag extends PsFrom {
+public final class PsFromTag extends PsFrom {
 
-  private final int _tag;
+  private final long _tag;
 
-  public PsFromTag(int tag) {
+  public PsFromTag(long tag) {
     _tag = tag;
   }
 
-  public int getTag() {
+  public long getTag() {
     return _tag;
   }
 
   @Override
   public BooleanExpr toBooleanExpr(JuniperConfiguration jc, Configuration c, Warnings warnings) {
     return new MatchTag(IntComparator.EQ, new LiteralLong(_tag));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsFromTag)) {
+      return false;
+    }
+    PsFromTag psFromTag = (PsFromTag) o;
+    return _tag == psFromTag._tag;
+  }
+
+  @Override
+  public int hashCode() {
+    return Long.hashCode(_tag);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFroms.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsFroms.java
@@ -107,8 +107,8 @@ public final class PsFroms implements Serializable {
     return _fromAsPaths;
   }
 
-  @Nullable
-  PsFromColor getFromColor() {
+  @VisibleForTesting
+  public @Nullable PsFromColor getFromColor() {
     return _fromColor;
   }
 
@@ -176,8 +176,8 @@ public final class PsFroms implements Serializable {
     return _fromRouteFilters;
   }
 
-  @Nonnull
-  Set<PsFromTag> getFromTags() {
+  @VisibleForTesting
+  public @Nonnull Set<PsFromTag> getFromTags() {
     return _fromTags;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenTag.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/PsThenTag.java
@@ -1,0 +1,50 @@
+package org.batfish.representation.juniper;
+
+import java.util.List;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.routing_policy.expr.LiteralLong;
+import org.batfish.datamodel.routing_policy.statement.SetTag;
+import org.batfish.datamodel.routing_policy.statement.Statement;
+
+/**
+ * Represents the action in Juniper's routing policy (policy statement) which sets the tag for a
+ * matched route.
+ */
+public final class PsThenTag extends PsThen {
+
+  private final long _tag;
+
+  public PsThenTag(long tag) {
+    _tag = tag;
+  }
+
+  @Override
+  public void applyTo(
+      List<Statement> statements,
+      JuniperConfiguration juniperVendorConfiguration,
+      Configuration c,
+      Warnings warnings) {
+    statements.add(new SetTag(new LiteralLong(_tag)));
+  }
+
+  public long getTag() {
+    return _tag;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof PsThenTag)) {
+      return false;
+    }
+    PsThenTag psThenTag = (PsThenTag) o;
+    return _tag == psThenTag._tag;
+  }
+
+  @Override
+  public int hashCode() {
+    return Long.hashCode(_tag);
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsFromColorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsFromColorTest.java
@@ -1,0 +1,15 @@
+package org.batfish.representation.juniper;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+public class PsFromColorTest {
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(5)
+        .addEqualityGroup(new PsFromColor(5), new PsFromColor(5))
+        .addEqualityGroup(new PsFromColor(6))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsFromTagTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsFromTagTest.java
@@ -1,0 +1,16 @@
+package org.batfish.representation.juniper;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+public class PsFromTagTest {
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(5)
+        .addEqualityGroup(new PsFromTag(5), new PsFromTag(5))
+        .addEqualityGroup(new PsFromTag(6))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThenTagTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/PsThenTagTest.java
@@ -1,0 +1,16 @@
+package org.batfish.representation.juniper;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+public class PsThenTagTest {
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(5)
+        .addEqualityGroup(new PsThenTag(5), new PsThenTag(5))
+        .addEqualityGroup(new PsThenTag(6))
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-statement-from
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-statement-from
@@ -1,6 +1,12 @@
 #
 set system host-name juniper-policy-statement-from
 #
+set policy-options policy-statement COLOR_POLICY term TMIN from color 0
+set policy-options policy-statement COLOR_POLICY term TMAX from color 4294967295
+#
 set policy-options policy-statement LOCAL_PREFERENCE_POLICY term TMIN from local-preference 0
 set policy-options policy-statement LOCAL_PREFERENCE_POLICY term TMAX from local-preference 4294967295
+#
+set policy-options policy-statement TAG_POLICY term TMIN from tag 0
+set policy-options policy-statement TAG_POLICY term TMAX from tag 4294967295
 #

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-statement-then
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-policy-statement-then
@@ -1,7 +1,17 @@
 #
 set system host-name juniper-policy-statement-then
 #
+set policy-options policy-statement COLOR_POLICY term TSETMIN then color 0
+set policy-options policy-statement COLOR_POLICY term TADDMAX then color add 4294967295
+set policy-options policy-statement COLOR_POLICY term TSUB3 then color subtract 3
+set policy-options policy-statement COLOR_POLICY term T2SETMIN then color2 0
+set policy-options policy-statement COLOR_POLICY term T2ADDMAX then color2 add 4294967295
+set policy-options policy-statement COLOR_POLICY term T2SUB3 then color2 subtract 4294967295
+#
 set policy-options policy-statement LOCAL_PREFERENCE_POLICY term TSETMIN then local-preference 0
 set policy-options policy-statement LOCAL_PREFERENCE_POLICY term TADDMAX then local-preference add 4294967295
 set policy-options policy-statement LOCAL_PREFERENCE_POLICY term TSUB3 then local-preference subtract 3
+#
+set policy-options policy-statement TAG_POLICY term TMIN then tag 0
+set policy-options policy-statement TAG_POLICY term TMAX then tag 4294967295
 #

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -65908,7 +65908,7 @@
             "                    FROM:'from'",
             "                    (popsf_tag",
             "                      TAG:'tag'",
-            "                      (dec",
+            "                      (uint32",
             "                        UINT8:'11'))))))))))",
             "    NEWLINE:'\\n')",
             "  (set_line",


### PR DESCRIPTION
This is for #6335

Note that there does not appear to be a `from color2`. Add warnings where appropriate.