### PR TITLE
JunOS: fix reference tacking for as-path-group as-path

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3439,6 +3439,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
         JuniperStructureType.ADDRESS_BOOK, JuniperStructureUsage.ADDRESS_BOOK_ATTACH_ZONE);
     markConcreteStructure(
         JuniperStructureType.AS_PATH, JuniperStructureUsage.POLICY_STATEMENT_FROM_AS_PATH);
+    markConcreteStructure(JuniperStructureType.AS_PATH_GROUP_AS_PATH);
     markConcreteStructure(
         JuniperStructureType.AUTHENTICATION_KEY_CHAIN,
         JuniperStructureUsage.AUTHENTICATION_KEY_CHAINS_POLICY);

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -2696,26 +2696,6 @@
         }
       },
       {
-        "Structure_Type" : "as-path-group as-path",
-        "Structure_Name" : "AS_PATH_REGEX_NAME1",
-        "Source_Lines" : {
-          "filename" : "configs/juniper_as_path_group",
-          "lines" : [
-            5
-          ]
-        }
-      },
-      {
-        "Structure_Type" : "as-path-group as-path",
-        "Structure_Name" : "AS_PATH_REGEX_NAME2",
-        "Source_Lines" : {
-          "filename" : "configs/juniper_as_path_group",
-          "lines" : [
-            6
-          ]
-        }
-      },
-      {
         "Structure_Type" : "bgp group",
         "Structure_Name" : "GROUP",
         "Source_Lines" : {
@@ -3928,10 +3908,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 265 results",
+      "notes" : "Found 263 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 265
+      "numResults" : 263
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -81580,11 +81580,11 @@
           "as-path-group as-path" : {
             "AS_PATH_REGEX_NAME1" : {
               "definitionLines" : "5",
-              "numReferrers" : 0
+              "numReferrers" : 1
             },
             "AS_PATH_REGEX_NAME2" : {
               "definitionLines" : "6",
-              "numReferrers" : 0
+              "numReferrers" : 1
             }
           }
         },


### PR DESCRIPTION
The right self-reference was there, we just didn't actually ever count them.

This is for #6637