### PR TITLE
FRR: introduce ospf area intermediate representation

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -202,6 +202,7 @@ import org.batfish.representation.cumulus.IpCommunityListStandard;
 import org.batfish.representation.cumulus.IpCommunityListStandardLine;
 import org.batfish.representation.cumulus.IpPrefixList;
 import org.batfish.representation.cumulus.IpPrefixListLine;
+import org.batfish.representation.cumulus.OspfArea;
 import org.batfish.representation.cumulus.OspfAreaRange;
 import org.batfish.representation.cumulus.OspfNetworkArea;
 import org.batfish.representation.cumulus.OspfNetworkType;
@@ -251,7 +252,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   private @Nullable BgpNeighborIpv4UnicastAddressFamily _currentBgpNeighborIpv4UnicastAddressFamily;
   private @Nullable BgpNeighborL2vpnEvpnAddressFamily _currentBgpNeighborL2vpnEvpnAddressFamily;
   private @Nullable FrrInterface _currentInterface;
-  private Long _currentOspfArea;
+  private OspfArea _currentOspfArea;
   private OspfVrf _currentOspfVrf;
 
   public CumulusFrrConfigurationBuilder(
@@ -854,7 +855,8 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
 
   @Override
   public void enterRo_area(Ro_areaContext ctx) {
-    _currentOspfArea = toLong(ctx.area);
+    long area = toLong(ctx.area);
+    _currentOspfArea = _currentOspfVrf.getOrCreateArea(area);
   }
 
   @Override
@@ -935,9 +937,8 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
 
   @Override
   public void exitRoa_range(Roa_rangeContext ctx) {
-    assert _currentOspfArea != null;
     Prefix pfx = toPrefix(ctx.pfx);
-    OspfAreaRange range = _currentOspfVrf.getOrCreateAreaRange(_currentOspfArea, pfx);
+    OspfAreaRange range = _currentOspfArea.getOrCreateRange(pfx);
     if (ctx.cost != null) {
       toInteger(ctx.getParent(), ctx.cost).ifPresent(range::setCost);
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/OspfArea.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/OspfArea.java
@@ -1,0 +1,37 @@
+package org.batfish.representation.cumulus;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.Prefix;
+
+/** OSPF configuration for an area in a vrf. */
+public class OspfArea implements Serializable {
+
+  private final long _area;
+  private final @Nonnull Map<Prefix, OspfAreaRange> _ranges;
+
+  public OspfArea(long area) {
+    _area = area;
+    _ranges = new HashMap<>();
+  }
+
+  public long getArea() {
+    return _area;
+  }
+
+  public @Nonnull OspfAreaRange getOrCreateRange(@Nonnull Prefix range) {
+    return _ranges.computeIfAbsent(range, OspfAreaRange::new);
+  }
+
+  public @Nullable OspfAreaRange getRange(@Nonnull Prefix range) {
+    return _ranges.get(range);
+  }
+
+  public @Nonnull Map<Prefix, OspfAreaRange> getRanges() {
+    return Collections.unmodifiableMap(_ranges);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/OspfAreaRange.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/OspfAreaRange.java
@@ -8,17 +8,11 @@ import org.batfish.datamodel.Prefix;
 /** OSPF configuration for {@code area A range A.B.C.D/M [cost C]}. */
 public class OspfAreaRange implements Serializable {
 
-  private final long _area;
   private final @Nonnull Prefix _range;
   private @Nullable Integer _cost;
 
-  public OspfAreaRange(long area, @Nonnull Prefix range) {
-    _area = area;
+  public OspfAreaRange(@Nonnull Prefix range) {
     _range = range;
-  }
-
-  public long getArea() {
-    return _area;
   }
 
   public @Nonnull Prefix getRange() {

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/OspfVrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/OspfVrf.java
@@ -1,36 +1,30 @@
 package org.batfish.representation.cumulus;
 
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Table;
 import java.io.Serializable;
-import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Ip;
-import org.batfish.datamodel.Prefix;
 
 /** OSPF configuration for a particular VRF. */
 public class OspfVrf implements Serializable {
 
   private final @Nonnull String _vrfName;
   private @Nullable Ip _routerId;
-  private final @Nonnull Table<Long, Prefix, OspfAreaRange> _ospfAreaRange;
+  private final @Nonnull Map<Long, OspfArea> _areas;
 
   public OspfVrf(String name) {
     _vrfName = name;
-    _ospfAreaRange = HashBasedTable.create();
+    _areas = new HashMap<>();
   }
 
-  public @Nonnull OspfAreaRange getOrCreateAreaRange(long area, @Nonnull Prefix prefix) {
-    return _ospfAreaRange.row(area).computeIfAbsent(prefix, p -> new OspfAreaRange(area, p));
+  public @Nonnull OspfArea getOrCreateArea(long area) {
+    return _areas.computeIfAbsent(area, OspfArea::new);
   }
 
-  public @Nullable OspfAreaRange getAreaRange(long area, @Nonnull Prefix prefix) {
-    return _ospfAreaRange.get(area, prefix);
-  }
-
-  public @Nonnull Collection<OspfAreaRange> getAreaRanges() {
-    return _ospfAreaRange.values();
+  public @Nullable OspfArea getArea(long area) {
+    return _areas.get(area);
   }
 
   @Nullable

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -110,6 +110,7 @@ import org.batfish.representation.cumulus.IpCommunityListExpanded;
 import org.batfish.representation.cumulus.IpCommunityListExpandedLine;
 import org.batfish.representation.cumulus.IpPrefixList;
 import org.batfish.representation.cumulus.IpPrefixListLine;
+import org.batfish.representation.cumulus.OspfArea;
 import org.batfish.representation.cumulus.OspfNetworkArea;
 import org.batfish.representation.cumulus.OspfNetworkType;
 import org.batfish.representation.cumulus.OspfVrf;
@@ -1841,11 +1842,14 @@ public class CumulusFrrGrammarTest {
             + " area 5 range 1.255.0.0/17\n");
     Prefix prefix = Prefix.parse("1.255.0.0/17");
     OspfVrf vrf = _frr.getOspfProcess().getDefaultVrf();
-    assertThat(vrf.getAreaRanges(), hasSize(2));
-    assertThat(vrf.getAreaRange(Ip.parse("1.1.1.0").asLong(), prefix), notNullValue());
-    assertThat(vrf.getAreaRange(Ip.parse("1.1.1.0").asLong(), prefix).getCost(), equalTo(10));
-    assertThat(vrf.getAreaRange(5L, prefix), notNullValue());
-    assertThat(vrf.getAreaRange(5L, prefix).getCost(), nullValue());
+    OspfArea area1110 = vrf.getArea(Ip.parse("1.1.1.0").asLong());
+    assertThat(area1110, notNullValue());
+    assertThat(area1110.getRanges(), hasKeys(prefix));
+    assertThat(area1110.getRange(prefix).getCost(), equalTo(10));
+    OspfArea area5 = vrf.getArea(5L);
+    assertThat(area5, notNullValue());
+    assertThat(area5.getRanges(), hasKeys(prefix));
+    assertThat(area5.getRange(prefix).getCost(), nullValue());
   }
 
   @Test


### PR DESCRIPTION
Better than sticking per-area configs in the Vrf itself.