### PR TITLE
FRR: use interface runtime data if provides

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/runtime/InterfaceRuntimeData.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/runtime/InterfaceRuntimeData.java
@@ -10,7 +10,7 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 
 /** Represents runtime data for an interface */
 public final class InterfaceRuntimeData {
-  static final class Builder {
+  public static final class Builder {
     @Nullable private ConcreteInterfaceAddress _address;
     @Nullable private Double _bandwidth;
     @Nullable private Boolean _lineUp;
@@ -18,36 +18,36 @@ public final class InterfaceRuntimeData {
 
     private Builder() {}
 
-    InterfaceRuntimeData build() {
+    public InterfaceRuntimeData build() {
       return new InterfaceRuntimeData(_address, _bandwidth, _lineUp, _speed);
     }
 
-    Builder setAddress(@Nullable ConcreteInterfaceAddress address) {
+    public Builder setAddress(@Nullable ConcreteInterfaceAddress address) {
       _address = address;
       return this;
     }
 
-    Builder setBandwidth(@Nullable Double bandwidth) {
+    public Builder setBandwidth(@Nullable Double bandwidth) {
       _bandwidth = bandwidth;
       return this;
     }
 
-    Builder setLineUp(@Nullable Boolean lineUp) {
+    public Builder setLineUp(@Nullable Boolean lineUp) {
       _lineUp = lineUp;
       return this;
     }
 
-    Builder setSpeed(@Nullable Double speed) {
+    public Builder setSpeed(@Nullable Double speed) {
       _speed = speed;
       return this;
     }
   }
 
-  static Builder builder() {
+  public static Builder builder() {
     return new Builder();
   }
 
-  static final InterfaceRuntimeData EMPTY_INTERFACE_RUNTIME_DATA = builder().build();
+  public static final InterfaceRuntimeData EMPTY_INTERFACE_RUNTIME_DATA = builder().build();
 
   private static final String PROP_ADDRESS = "address";
   private static final String PROP_BANDWIDTH = "bandwidth";
@@ -91,7 +91,7 @@ public final class InterfaceRuntimeData {
     return _lineUp;
   }
 
-  Builder toBuilder() {
+  public Builder toBuilder() {
     return builder()
         .setAddress(_address)
         .setBandwidth(_bandwidth)

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -209,9 +209,11 @@ public class CumulusFrrGrammarTest {
     CumulusFrrConfigurationBuilder cb =
         new CumulusFrrConfigurationBuilder(_config, parser, _warnings, src);
     walker.walk(cb, tree);
+
+    // SerializationUtils.clone will clear transient state, which we save and restore.
+    // Or populate with default values for things that supplied by Batfish pre-conversion.
     Warnings w = _config.getWarnings();
     _config = SerializationUtils.clone(_config);
-    // Gets cleared during parsing, only needed during conversion.
     _config.setRuntimeData(SnapshotRuntimeData.EMPTY_SNAPSHOT_RUNTIME_DATA);
     _config.setWarnings(w);
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -60,6 +60,7 @@ import org.batfish.common.BatfishLogger;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.Warning;
 import org.batfish.common.Warnings;
+import org.batfish.common.runtime.SnapshotRuntimeData;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.AsPath;
 import org.batfish.datamodel.BgpPeerConfigId;
@@ -210,6 +211,8 @@ public class CumulusFrrGrammarTest {
     walker.walk(cb, tree);
     Warnings w = _config.getWarnings();
     _config = SerializationUtils.clone(_config);
+    // Gets cleared during parsing, only needed during conversion.
+    _config.setRuntimeData(SnapshotRuntimeData.EMPTY_SNAPSHOT_RUNTIME_DATA);
     _config.setWarnings(w);
   }
 


### PR DESCRIPTION
Generally, FRR boxes do not have bandwidth configured in the config, so it will need
to be provided via runtime data.