### PR TITLE
batfish-common-protocol/pom.xml: add java9+ deps

### DIFF
--- a/projects/batfish-common-protocol/pom.xml
+++ b/projects/batfish-common-protocol/pom.xml
@@ -38,6 +38,10 @@
                   </ignoredUnusedDeclaredDependency>
                   <ignoredUnusedDeclaredDependency>commons-beanutils:commons-beanutils
                   </ignoredUnusedDeclaredDependency>
+                  <ignoredUnusedDeclaredDependency>javax.activation:activation
+                  </ignoredUnusedDeclaredDependency>
+                  <ignoredUnusedDeclaredDependency>javax.xml.bind:jaxb-api
+                  </ignoredUnusedDeclaredDependency>
                   <ignoredUnusedDeclaredDependency>org.apache.logging:log4j-core
                   </ignoredUnusedDeclaredDependency>
                   <ignoredUnusedDeclaredDependency>org.glassfish.jersey.inject:jersey-hk2
@@ -291,13 +295,26 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Test dependencies. -->
+    <!-- Runtime dependencies for Jersey. -->
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
 
+    <!-- Test dependencies. -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>

--- a/projects/coordinator/pom.xml
+++ b/projects/coordinator/pom.xml
@@ -206,6 +206,7 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Remove tons of warnings about missing native libs.