### PR TITLE
Vendor Configuration: support structure renaming

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -225,8 +225,7 @@ public abstract class VendorConfiguration implements Serializable {
     SortedMap<String, SortedMap<StructureUsage, SortedMultiset<Integer>>> refsByName =
         _structureReferences.get(type);
     if (refsByName != null && refsByName.containsKey(orgName)) {
-      SortedMap<StructureUsage, SortedMultiset<Integer>> refs = refsByName.get(orgName);
-      refsByName.remove(orgName);
+      SortedMap<StructureUsage, SortedMultiset<Integer>> refs = refsByName.remove(orgName);
       refsByName.put(newName, refs);
     }
   }
@@ -247,7 +246,9 @@ public abstract class VendorConfiguration implements Serializable {
       StructureType type,
       Collection<StructureType> sameNamespaceTypes) {
     boolean succeeded = renameStructureDefinition(origName, newName, type, sameNamespaceTypes);
-    renameStructureReferences(origName, newName, type);
+    if (succeeded) {
+      renameStructureReferences(origName, newName, type);
+    }
     return succeeded;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -236,15 +236,16 @@ public abstract class VendorConfiguration implements Serializable {
    * conflict), otherwise returns {@code true}.
    *
    * <p>The specified {@link Collection} of {@link StructureType} should contain all structure types
-   * that share the same namespace; i.e. a rename will only succeed if a defined structure exists
-   * for one of the specified types and the new name is not already in use by any structures of the
-   * specified types.
+   * that share the same namespace (including the specified structure {@code type}); i.e. a rename
+   * will only succeed if a defined structure exists for one of the specified types and the new name
+   * is not already in use by any structures of the specified types.
    */
   public boolean renameStructure(
       String origName,
       String newName,
       StructureType type,
       Collection<StructureType> sameNamespaceTypes) {
+    assert sameNamespaceTypes.contains(type);
     boolean succeeded = renameStructureDefinition(origName, newName, type, sameNamespaceTypes);
     if (succeeded) {
       renameStructureReferences(origName, newName, type);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/vendor/VendorConfiguration.java
@@ -237,8 +237,8 @@ public abstract class VendorConfiguration implements Serializable {
    *
    * <p>The specified {@link Collection} of {@link StructureType} should contain all structure types
    * that share the same namespace (including the specified structure {@code type}); i.e. a rename
-   * will only succeed if a defined structure exists for one of the specified types and the new name
-   * is not already in use by any structures of the specified types.
+   * will only succeed if the new name is not already in use by any structures of the specified
+   * types.
    */
   public boolean renameStructure(
       String origName,

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/vendor/VendorConfigurationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/vendor/VendorConfigurationTest.java
@@ -53,15 +53,13 @@ public final class VendorConfigurationTest {
     }
   }
 
-  private final TestStructureType TEST_STRUCTURE_TYPE = TestStructureType.TEST_STRUCTURE_TYPE1;
-  private final TestStructureUsage TEST_STRUCTURE_USAGE = TestStructureUsage.TEST_STRUCTURE_USAGE1;
+  private final TestStructureType _testStructureType = TestStructureType.TEST_STRUCTURE_TYPE1;
+  private final TestStructureUsage _testStructureUsage = TestStructureUsage.TEST_STRUCTURE_USAGE1;
 
   private static final class TestVendorConfiguration extends VendorConfiguration {
-    private final String HOSTNAME = "hostname";
-
     @Override
     public String getHostname() {
-      return HOSTNAME;
+      return "hostname";
     }
 
     @Override
@@ -98,7 +96,7 @@ public final class VendorConfigurationTest {
     {
       VendorConfiguration c = buildVendorConfiguration();
 
-      c.renameStructure(TEST_STRUCTURE_TYPE, orgName, newName);
+      c.renameStructure(_testStructureType, orgName, newName);
       // Produce an appropriate warning
       assertThat(
           c.getWarnings(), hasRedFlag(hasText("Cannot rename undefined structure orgName.")));
@@ -108,10 +106,10 @@ public final class VendorConfigurationTest {
     {
       VendorConfiguration c = buildVendorConfiguration();
 
-      c.defineSingleLineStructure(TEST_STRUCTURE_TYPE, orgName, orgLine);
-      c.defineSingleLineStructure(TEST_STRUCTURE_TYPE, newName, otherLine);
+      c.defineSingleLineStructure(_testStructureType, orgName, orgLine);
+      c.defineSingleLineStructure(_testStructureType, newName, otherLine);
 
-      c.renameStructure(TEST_STRUCTURE_TYPE, orgName, newName);
+      c.renameStructure(_testStructureType, orgName, newName);
       // Produces appropriate warning
       assertThat(c.getWarnings(), hasRedFlag(hasText("New name newName is already in use.")));
 
@@ -119,22 +117,22 @@ public final class VendorConfigurationTest {
       assertThat(
           c.getAnswerElement(),
           hasDefinedStructureWithDefinitionLines(
-              FILENAME, TEST_STRUCTURE_TYPE, orgName, contains(orgLine)));
+              FILENAME, _testStructureType, orgName, contains(orgLine)));
       assertThat(
           c.getAnswerElement(),
           hasDefinedStructureWithDefinitionLines(
-              FILENAME, TEST_STRUCTURE_TYPE, newName, contains(otherLine)));
+              FILENAME, _testStructureType, newName, contains(otherLine)));
     }
 
     // Valid structure renaming
     {
       VendorConfiguration c = buildVendorConfiguration();
 
-      c.defineSingleLineStructure(TEST_STRUCTURE_TYPE, orgName, orgLine);
-      c.defineSingleLineStructure(TEST_STRUCTURE_TYPE, unaffectedName, otherLine);
-      c.referenceStructure(TEST_STRUCTURE_TYPE, unaffectedName, TEST_STRUCTURE_USAGE, 11);
-      c.referenceStructure(TEST_STRUCTURE_TYPE, orgName, TEST_STRUCTURE_USAGE, 22);
-      c.renameStructure(TEST_STRUCTURE_TYPE, orgName, newName);
+      c.defineSingleLineStructure(_testStructureType, orgName, orgLine);
+      c.defineSingleLineStructure(_testStructureType, unaffectedName, otherLine);
+      c.referenceStructure(_testStructureType, unaffectedName, _testStructureUsage, 11);
+      c.referenceStructure(_testStructureType, orgName, _testStructureUsage, 22);
+      c.renameStructure(_testStructureType, orgName, newName);
       // Need to call setAnswerElement to trigger population of CCAE / answerElement (for refs)
       c.setAnswerElement(new ConvertConfigurationAnswerElement());
 
@@ -144,15 +142,15 @@ public final class VendorConfigurationTest {
       assertThat(
           c.getAnswerElement(),
           hasDefinedStructureWithDefinitionLines(
-              FILENAME, TEST_STRUCTURE_TYPE, newName, contains(orgLine)));
+              FILENAME, _testStructureType, newName, contains(orgLine)));
       assertThat(
           c.getAnswerElement(),
-          hasReferencedStructure(FILENAME, TEST_STRUCTURE_TYPE, newName, TEST_STRUCTURE_USAGE));
+          hasReferencedStructure(FILENAME, _testStructureType, newName, _testStructureUsage));
       // Unaffected reference should persist
       assertThat(
           c.getAnswerElement(),
           hasReferencedStructure(
-              FILENAME, TEST_STRUCTURE_TYPE, unaffectedName, TEST_STRUCTURE_USAGE));
+              FILENAME, _testStructureType, unaffectedName, _testStructureUsage));
     }
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/vendor/VendorConfigurationTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/vendor/VendorConfigurationTest.java
@@ -1,0 +1,158 @@
+package org.batfish.vendor;
+
+import static org.batfish.common.matchers.WarningMatchers.hasText;
+import static org.batfish.common.matchers.WarningsMatchers.hasRedFlag;
+import static org.batfish.common.matchers.WarningsMatchers.hasRedFlags;
+import static org.batfish.datamodel.matchers.DataModelMatchers.hasDefinedStructureWithDefinitionLines;
+import static org.batfish.datamodel.matchers.DataModelMatchers.hasReferencedStructure;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterable;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.batfish.common.VendorConversionException;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
+import org.junit.Test;
+
+/** Test for {@link VendorConfiguration}. */
+public final class VendorConfigurationTest {
+
+  private static final String FILENAME = "filename";
+
+  private enum TestStructureType implements StructureType {
+    TEST_STRUCTURE_TYPE1("structure type1");
+
+    private final String _description;
+
+    TestStructureType(String description) {
+      _description = description;
+    }
+
+    @Override
+    public String getDescription() {
+      return _description;
+    }
+  }
+
+  private enum TestStructureUsage implements StructureUsage {
+    TEST_STRUCTURE_USAGE1("structure usage1");
+
+    private final String _description;
+
+    TestStructureUsage(String description) {
+      _description = description;
+    }
+
+    @Override
+    public String getDescription() {
+      return _description;
+    }
+  }
+
+  private final TestStructureType TEST_STRUCTURE_TYPE = TestStructureType.TEST_STRUCTURE_TYPE1;
+  private final TestStructureUsage TEST_STRUCTURE_USAGE = TestStructureUsage.TEST_STRUCTURE_USAGE1;
+
+  private static final class TestVendorConfiguration extends VendorConfiguration {
+    private final String HOSTNAME = "hostname";
+
+    @Override
+    public String getHostname() {
+      return HOSTNAME;
+    }
+
+    @Override
+    public void setHostname(String hostname) {}
+
+    @Override
+    public void setVendor(ConfigurationFormat format) {}
+
+    @Override
+    public List<Configuration> toVendorIndependentConfigurations()
+        throws VendorConversionException {
+      return ImmutableList.of();
+    }
+  }
+
+  private static VendorConfiguration buildVendorConfiguration() {
+    VendorConfiguration c = new TestVendorConfiguration();
+    c.setFilename(FILENAME);
+    c.setAnswerElement(new ConvertConfigurationAnswerElement());
+    c.setWarnings(new Warnings(true, true, true));
+    return c;
+  }
+
+  @Test
+  public void testRenameStructure() {
+    String orgName = "orgName";
+    int orgLine = 1;
+    String newName = "newName";
+
+    int otherLine = 2;
+    String unaffectedName = "unaffectedName";
+
+    // Renaming an undefined structure
+    {
+      VendorConfiguration c = buildVendorConfiguration();
+
+      c.renameStructure(TEST_STRUCTURE_TYPE, orgName, newName);
+      // Produce an appropriate warning
+      assertThat(
+          c.getWarnings(), hasRedFlag(hasText("Cannot rename undefined structure orgName.")));
+    }
+
+    // Renaming is invalid if it would clash with another structure
+    {
+      VendorConfiguration c = buildVendorConfiguration();
+
+      c.defineSingleLineStructure(TEST_STRUCTURE_TYPE, orgName, orgLine);
+      c.defineSingleLineStructure(TEST_STRUCTURE_TYPE, newName, otherLine);
+
+      c.renameStructure(TEST_STRUCTURE_TYPE, orgName, newName);
+      // Produces appropriate warning
+      assertThat(c.getWarnings(), hasRedFlag(hasText("New name newName is already in use.")));
+
+      // Both org and new structure defs persist
+      assertThat(
+          c.getAnswerElement(),
+          hasDefinedStructureWithDefinitionLines(
+              FILENAME, TEST_STRUCTURE_TYPE, orgName, contains(orgLine)));
+      assertThat(
+          c.getAnswerElement(),
+          hasDefinedStructureWithDefinitionLines(
+              FILENAME, TEST_STRUCTURE_TYPE, newName, contains(otherLine)));
+    }
+
+    // Valid structure renaming
+    {
+      VendorConfiguration c = buildVendorConfiguration();
+
+      c.defineSingleLineStructure(TEST_STRUCTURE_TYPE, orgName, orgLine);
+      c.defineSingleLineStructure(TEST_STRUCTURE_TYPE, unaffectedName, otherLine);
+      c.referenceStructure(TEST_STRUCTURE_TYPE, unaffectedName, TEST_STRUCTURE_USAGE, 11);
+      c.referenceStructure(TEST_STRUCTURE_TYPE, orgName, TEST_STRUCTURE_USAGE, 22);
+      c.renameStructure(TEST_STRUCTURE_TYPE, orgName, newName);
+      // Need to call setAnswerElement to trigger population of CCAE / answerElement (for refs)
+      c.setAnswerElement(new ConvertConfigurationAnswerElement());
+
+      // No warnings
+      assertThat(c.getWarnings(), hasRedFlags(emptyIterable()));
+      // Has a definition and reference for the new structure name
+      assertThat(
+          c.getAnswerElement(),
+          hasDefinedStructureWithDefinitionLines(
+              FILENAME, TEST_STRUCTURE_TYPE, newName, contains(orgLine)));
+      assertThat(
+          c.getAnswerElement(),
+          hasReferencedStructure(FILENAME, TEST_STRUCTURE_TYPE, newName, TEST_STRUCTURE_USAGE));
+      // Unaffected reference should persist
+      assertThat(
+          c.getAnswerElement(),
+          hasReferencedStructure(
+              FILENAME, TEST_STRUCTURE_TYPE, unaffectedName, TEST_STRUCTURE_USAGE));
+    }
+  }
+}


### PR DESCRIPTION
Add support for renaming structures (definitions and references) in `VendorConfiguration`.
