### PR TITLE
Reachability: always apply outgoing original-flow filter

### DIFF
--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -35,7 +35,17 @@ import static org.batfish.datamodel.transformation.TransformationStep.assignDest
 import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationPort;
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourcePort;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -1822,8 +1832,8 @@ public final class BDDReachabilityAnalysisFactoryTest {
   }
 
   /**
-   * For {@link BDDReachabilityAnalysisFactory::generateRules_PreOutEdgePostNat_NodeDropAclOut},
-   * test that the outgoing original flow filter is still applied if outgoing filter is null.
+   * For {@link BDDReachabilityAnalysisFactory#generateRules_PreOutEdgePostNat_NodeDropAclOut}, test
+   * that the outgoing original flow filter is still applied if outgoing filter is null.
    */
   @Test
   public void testOutgoingOriginalFlowFilterWithoutOutgoingFilter_arpSuccess() throws IOException {
@@ -1853,13 +1863,12 @@ public final class BDDReachabilityAnalysisFactoryTest {
     // c2
     Configuration c2 = cb.setHostname("c2").build();
     Vrf v2 = nf.vrfBuilder().setOwner(c2).build();
-    Interface i2 =
-        nf.interfaceBuilder()
-            .setName("i2")
-            .setOwner(c2)
-            .setVrf(v2)
-            .setAddress(ConcreteInterfaceAddress.parse("1.1.1.2/24"))
-            .build();
+    nf.interfaceBuilder()
+        .setName("i2")
+        .setOwner(c2)
+        .setVrf(v2)
+        .setAddress(ConcreteInterfaceAddress.parse("1.1.1.2/24"))
+        .build();
 
     BDDReachabilityAnalysisFactory factory =
         makeBddReachabilityAnalysisFactory(
@@ -1898,7 +1907,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
 
   /**
    * For {@link
-   * BDDReachabilityAnalysisFactory::generateRules_PreOutInterfaceDisposition_NodeDropAclOut}, test
+   * BDDReachabilityAnalysisFactory#generateRules_PreOutInterfaceDisposition_NodeDropAclOut}, test
    * that the outgoing original flow filter is still applied if outgoing filter is null.
    */
   @Test

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -1,6 +1,7 @@
 package org.batfish.bddreachability;
 
 import static org.batfish.bddreachability.EdgeMatchers.edge;
+import static org.batfish.bddreachability.EdgeMatchers.hasTransition;
 import static org.batfish.bddreachability.TransitionMatchers.mapsBackward;
 import static org.batfish.bddreachability.TransitionMatchers.mapsForward;
 import static org.batfish.bddreachability.transition.Transitions.IDENTITY;
@@ -34,16 +35,7 @@ import static org.batfish.datamodel.transformation.TransformationStep.assignDest
 import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationPort;
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourcePort;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -76,6 +68,7 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.ExprAclLine;
 import org.batfish.datamodel.Flow;
 import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.HeaderSpace;
@@ -90,6 +83,7 @@ import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.UniverseIpSpace;
 import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.answers.AnswerElement;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceWrapperAsAnswerElement;
@@ -1825,6 +1819,142 @@ public final class BDDReachabilityAnalysisFactoryTest {
         .build();
 
     return ImmutableSortedMap.of(c1.getHostname(), c1, c2.getHostname(), c2);
+  }
+
+  /**
+   * For {@link BDDReachabilityAnalysisFactory::generateRules_PreOutEdgePostNat_NodeDropAclOut},
+   * test that the outgoing original flow filter is still applied if outgoing filter is null.
+   */
+  @Test
+  public void testOutgoingOriginalFlowFilterWithoutOutgoingFilter_arpSuccess() throws IOException {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    // c1
+    Configuration c1 = cb.setHostname("c1").build();
+    Vrf v1 = nf.vrfBuilder().setOwner(c1).build();
+
+    Ip permittedDstIp = Ip.parse("1.1.1.1");
+
+    IpAccessList originalFlowFilter =
+        nf.aclBuilder()
+            .setLines(ExprAclLine.accepting(AclLineMatchExprs.matchDst(permittedDstIp)))
+            .build();
+
+    Interface i1 =
+        nf.interfaceBuilder()
+            .setName("i1")
+            .setOwner(c1)
+            .setVrf(v1)
+            .setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24"))
+            .setOutgoingOriginalFlowFilter(originalFlowFilter)
+            .build();
+
+    // c2
+    Configuration c2 = cb.setHostname("c2").build();
+    Vrf v2 = nf.vrfBuilder().setOwner(c2).build();
+    Interface i2 =
+        nf.interfaceBuilder()
+            .setName("i2")
+            .setOwner(c2)
+            .setVrf(v2)
+            .setAddress(ConcreteInterfaceAddress.parse("1.1.1.2/24"))
+            .build();
+
+    BDDReachabilityAnalysisFactory factory =
+        makeBddReachabilityAnalysisFactory(
+            ImmutableSortedMap.of(c1.getHostname(), c1, c2.getHostname(), c2));
+
+    BDD permittedBdd =
+        factory
+            .getBddOutgoingOriginalFlowFilterManagers()
+            .get(c1.getHostname())
+            .permittedByOriginalFlowEgressFilter(i1.getName());
+    BDD deniedBdd =
+        factory
+            .getBddOutgoingOriginalFlowFilterManagers()
+            .get(c1.getHostname())
+            .deniedByOriginalFlowEgressFilter(i1.getName());
+    BDD oneBdd = PKT.getFactory().one();
+    BDD zeroBdd = PKT.getFactory().zero();
+
+    List<Edge> edges =
+        factory
+            .generateRules_PreOutEdgePostNat_NodeDropAclOut()
+            .filter(
+                edge ->
+                    ((NodeDropAclOut) edge.getPostState()).getHostname().equals(c1.getHostname()))
+            .collect(Collectors.toList());
+    assertFalse("edges must not be empty", edges.isEmpty());
+    assertThat(
+        edges,
+        everyItem(
+            allOf(
+                // every flow marked as denied can traverse this edge (and the marking is removed)
+                hasTransition(mapsForward(deniedBdd, oneBdd)),
+                // no flow marked as permitted can traverse this edge
+                hasTransition(mapsForward(permittedBdd, zeroBdd)))));
+  }
+
+  /**
+   * For {@link
+   * BDDReachabilityAnalysisFactory::generateRules_PreOutInterfaceDisposition_NodeDropAclOut}, test
+   * that the outgoing original flow filter is still applied if outgoing filter is null.
+   */
+  @Test
+  public void testOutgoingOriginalFlowFilterWithoutOutgoingFilter_arpFailure() throws IOException {
+    NetworkFactory nf = new NetworkFactory();
+    Configuration.Builder cb =
+        nf.configurationBuilder().setConfigurationFormat(ConfigurationFormat.CISCO_IOS);
+    Configuration c1 = cb.setHostname("c1").build();
+    // Create i1 on c1 with the appropriate filters
+    Vrf vrf = nf.vrfBuilder().setOwner(c1).build();
+
+    Ip permittedDstIp = Ip.parse("1.1.1.1");
+
+    IpAccessList originalFlowFilter =
+        nf.aclBuilder()
+            .setLines(ExprAclLine.accepting(AclLineMatchExprs.matchDst(permittedDstIp)))
+            .build();
+
+    Interface i1 =
+        nf.interfaceBuilder()
+            .setName("i1")
+            .setOwner(c1)
+            .setVrf(vrf)
+            .setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24"))
+            .setOutgoingOriginalFlowFilter(originalFlowFilter)
+            .build();
+
+    BDDReachabilityAnalysisFactory factory =
+        makeBddReachabilityAnalysisFactory(ImmutableSortedMap.of(c1.getHostname(), c1));
+
+    BDD permittedBdd =
+        factory
+            .getBddOutgoingOriginalFlowFilterManagers()
+            .get(c1.getHostname())
+            .permittedByOriginalFlowEgressFilter(i1.getName());
+    BDD deniedBdd =
+        factory
+            .getBddOutgoingOriginalFlowFilterManagers()
+            .get(c1.getHostname())
+            .deniedByOriginalFlowEgressFilter(i1.getName());
+    BDD oneBdd = PKT.getFactory().one();
+    BDD zeroBdd = PKT.getFactory().zero();
+
+    List<Edge> edges =
+        factory
+            .generateRules_PreOutInterfaceDisposition_NodeDropAclOut()
+            .collect(Collectors.toList());
+    assertFalse("edges must not be empty", edges.isEmpty());
+    assertThat(
+        edges,
+        everyItem(
+            allOf(
+                // every flow marked as denied can traverse this edge (and the marking is removed)
+                hasTransition(mapsForward(deniedBdd, oneBdd)),
+                // no flow marked as permitted can traverse this edge
+                hasTransition(mapsForward(permittedBdd, zeroBdd)))));
   }
 
   /** Test that PBR takes precedence over incoming filter when both are present on an interface. */

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -1845,11 +1845,9 @@ public final class BDDReachabilityAnalysisFactoryTest {
     Configuration c1 = cb.setHostname("c1").build();
     Vrf v1 = nf.vrfBuilder().setOwner(c1).build();
 
-    Ip permittedDstIp = Ip.parse("1.1.1.1");
-
     IpAccessList originalFlowFilter =
         nf.aclBuilder()
-            .setLines(ExprAclLine.accepting(AclLineMatchExprs.matchDst(permittedDstIp)))
+            .setLines(ExprAclLine.accepting(AclLineMatchExprs.matchDst(Ip.parse("1.1.1.1"))))
             .build();
 
     Interface i1 =
@@ -1917,11 +1915,9 @@ public final class BDDReachabilityAnalysisFactoryTest {
     // Create i1 on c1 with the appropriate filters
     Vrf vrf = nf.vrfBuilder().setOwner(c1).build();
 
-    Ip permittedDstIp = Ip.parse("1.1.1.1");
-
     IpAccessList originalFlowFilter =
         nf.aclBuilder()
-            .setLines(ExprAclLine.accepting(AclLineMatchExprs.matchDst(permittedDstIp)))
+            .setLines(ExprAclLine.accepting(AclLineMatchExprs.matchDst(Ip.parse("1.1.1.1"))))
             .build();
 
     Interface i1 =

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/EdgeMatchers.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/EdgeMatchers.java
@@ -22,4 +22,9 @@ public final class EdgeMatchers {
         new HasPostState(equalTo(postState)),
         new HasTransition(transitionMatcher));
   }
+
+  /** Matches {@link Edge#getTransition()}. */
+  public static Matcher<Edge> hasTransition(Matcher<Transition> transitionMatcher) {
+    return new HasTransition(transitionMatcher);
+  }
 }


### PR DESCRIPTION
Previously we incorrectly skipped creating edges to NodeDropAclOut if there was no outgoing filter, even if there was an outgoing original-flow filter.