### PR TITLE
FortiOS: better name handling

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/FortiosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/FortiosLexer.g4
@@ -22,14 +22,14 @@ ADMIN:
 
 AGGREGATE: 'aggregate';
 ALERTMAIL: 'alertmail';
-ALIAS: 'alias';
+ALIAS: 'alias' -> pushMode(M_Str);
 AUTH: 'auth';
 BUFFER: 'buffer' -> pushMode(M_Str);
 CONFIG: 'config';
-DESCRIPTION: 'description';
+DESCRIPTION: 'description' -> pushMode(M_Str);
 DISABLE: 'disable';
 DOWN: 'down';
-EDIT: 'edit';
+EDIT: 'edit' -> pushMode(M_Str);
 EMAC_VLAN: 'emac-vlan';
 ENABLE: 'enable';
 END: 'end';
@@ -62,7 +62,7 @@ TYPE: 'type';
 UNSET: 'unset';
 UP: 'up';
 UTM: 'utm';
-VDOM: 'vdom';
+VDOM: 'vdom' -> pushMode(M_Str);
 VLAN: 'vlan';
 VRF: 'vrf';
 WEBPROXY: 'webproxy';

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -157,6 +157,9 @@ public final class FortiosGrammarTest {
     assertThat(port1.getVrf(), nullValue());
     assertThat(port1.getVrfEffective(), equalTo(0));
 
+    assertThat(port2.getVdom(), equalTo("root"));
+    assertThat(port2.getAlias(), equalTo("no_spaces"));
+    assertThat(port2.getDescription(), equalTo("no_spaces_descr"));
     // Check overriding defaults
     assertThat(port2.getMtuOverride(), equalTo(true));
     assertThat(port2.getMtu(), equalTo(1234));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/iface
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/iface
@@ -11,8 +11,10 @@ config system interface
         set description "quoted description w/ spaces and more"
         set snmp-index 1
     next
-    edit "port2"
-        set vdom "root"
+    edit port2
+        set vdom root
+        set alias no_spaces
+        set description no_spaces_descr
         set mtu-override enable
         set mtu 1234
     next


### PR DESCRIPTION
Use `M_Str` in more places to better capture structure names.
