### PR TITLE
Reachability: add Blackhole state

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDOutgoingOriginalFlowFilterManager.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDOutgoingOriginalFlowFilterManager.java
@@ -5,6 +5,7 @@ import static com.google.common.collect.Maps.immutableEntry;
 import static org.batfish.common.bdd.IpAccessListToBdd.toBdds;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -200,9 +201,25 @@ public final class BDDOutgoingOriginalFlowFilterManager {
    * Interface#getOutgoingOriginalFlowFilter() outgoingOriginalFlowFilters}. (Does not include entry
    * for {@code _activeButNoOriginalFlowFilterRepresentative} even if present in finite domain.)
    */
+  @VisibleForTesting
   @Nonnull
   Map<String, BDD> getInterfaceBDDs() {
     return _interfaceBdds;
+  }
+
+  /**
+   * Returns the BDD representing the constraint indicating the set of flows to be evaluated against
+   * the outgoing filter on the given interface.
+   *
+   * <p>If there is no outging filter on the given interface, returns the constraint corresponding
+   * to the set of flows that were not evaluated against any interface's outgoing filter.
+   */
+  public @Nonnull BDD outgoingInterfaceBDD(String iface) {
+    if (isTrivial()) {
+      return _trueBdd;
+    }
+    return _interfaceBdds.getOrDefault(
+        iface, _interfaceBdds.get(_activeButNoOriginalFlowFilterRepresentative));
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateExprToLocation.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateExprToLocation.java
@@ -54,6 +54,11 @@ public final class OriginationStateExprToLocation implements StateExprVisitor<Op
   }
 
   @Override
+  public Optional<Location> visitBlackHole() {
+    return Optional.empty();
+  }
+
+  @Override
   public Optional<Location> visitDeliveredToSubnet() {
     return Optional.empty();
   }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateToTerminationState.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/OriginationStateToTerminationState.java
@@ -54,6 +54,11 @@ public class OriginationStateToTerminationState implements StateExprVisitor<List
   }
 
   @Override
+  public List<StateExpr> visitBlackHole() {
+    return null;
+  }
+
+  @Override
   public List<StateExpr> visitDropAclIn() {
     return null;
   }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/PreOutgoingTransformationNodeVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/PreOutgoingTransformationNodeVisitor.java
@@ -47,6 +47,11 @@ public class PreOutgoingTransformationNodeVisitor implements StateExprVisitor<No
   }
 
   @Override
+  public NodeInterfacePair visitBlackHole() {
+    return null;
+  }
+
+  @Override
   public NodeInterfacePair visitDropAclIn() {
     return null;
   }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/ReversePassOriginationState.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/ReversePassOriginationState.java
@@ -63,6 +63,11 @@ public class ReversePassOriginationState implements StateExprVisitor<StateExpr> 
   }
 
   @Override
+  public StateExpr visitBlackHole() {
+    return null;
+  }
+
+  @Override
   public StateExpr visitDropAclIn() {
     return null;
   }

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/SessionCreationNodeVisitor.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/SessionCreationNodeVisitor.java
@@ -53,6 +53,11 @@ final class SessionCreationNodeVisitor implements StateExprVisitor<NodeInterface
   }
 
   @Override
+  public NodeInterfacePair visitBlackHole() {
+    return null;
+  }
+
+  @Override
   public NodeInterfacePair visitDropAclIn() {
     return null;
   }

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/BlackHole.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/BlackHole.java
@@ -1,0 +1,22 @@
+package org.batfish.symbolic.state;
+
+/**
+ * Represents a sink for "impossible" flows. For example, flows leaving an interface that are only
+ * valid if routed to a different interface.
+ *
+ * <p>This can happen because of out-of-order computations in the reachability graph.
+ */
+public final class BlackHole implements StateExpr {
+
+  public static final BlackHole INSTANCE = new BlackHole();
+
+  @Override
+  public <R> R accept(StateExprVisitor<R> visitor) {
+    return visitor.visitAccept();
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+}

--- a/projects/symbolic/src/main/java/org/batfish/symbolic/state/StateExprVisitor.java
+++ b/projects/symbolic/src/main/java/org/batfish/symbolic/state/StateExprVisitor.java
@@ -4,6 +4,8 @@ public interface StateExprVisitor<R> {
 
   R visitAccept();
 
+  R visitBlackHole();
+
   R visitDeliveredToSubnet();
 
   R visitDropAclIn();


### PR DESCRIPTION
There are some impossible flows generated in the BDD Reachability engine, e.g.,
flows that are only valid if they exit a specific interface. This is safe (no
wrong results are generated), but it is better to specifically blackhole such
flows rather than having them "disappear "in the middle of the reachability
graph. This makes invariant checking easier.

We can also take minor advantage of this to hopefully speed up some ACL
computations: remove irrelevant flows before feeding them through transitions,
applying ACLs, etc.