### PR TITLE
FortiOS: fix str rule

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_common.g4
@@ -49,7 +49,7 @@ uint32
 word: str;
 
 // can include whitespace, newlines, html tags, etc.
-str: (double_quoted_string | single_quoted_string | UNQUOTED_WORD_CHARS)*;
+str: (double_quoted_string | single_quoted_string | UNQUOTED_WORD_CHARS)+;
 
 enable_or_disable: ENABLE | DISABLE;
 


### PR DESCRIPTION
Currently the `str` rule will accept empty strings.

This PR requires it to match at least one token. No functional change yet, but this means we will be able to use it in list rules going forward, e.g. `string_list_rule: str+;`
