### PR TITLE
Reachability engine: explicitly filter rather than deadend

### DIFF
--- a/projects/allinone/BUILD
+++ b/projects/allinone/BUILD
@@ -128,6 +128,7 @@ junit_tests(
         "//projects/batfish:batfish_testlib",
         "//projects/batfish-common-protocol:common",
         "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
+        "//projects/batfish/src/test/java/org/batfish/bddreachability:testlib",
         "//projects/question",
         "@maven//:com_google_guava_guava",
         "@maven//:junit_junit",

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDOutgoingOriginalFlowFilterManager.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDOutgoingOriginalFlowFilterManager.java
@@ -224,7 +224,7 @@ public final class BDDOutgoingOriginalFlowFilterManager {
       return ret;
     }
     return _interfaceBdds.getOrDefault(
-        iface, _interfaceBdds.get(_activeButNoOriginalFlowFilterRepresentative));
+        iface, _finiteDomain.getConstraintForValue(_activeButNoOriginalFlowFilterRepresentative));
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDOutgoingOriginalFlowFilterManager.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDOutgoingOriginalFlowFilterManager.java
@@ -5,6 +5,7 @@ import static com.google.common.collect.Maps.immutableEntry;
 import static org.batfish.common.bdd.IpAccessListToBdd.toBdds;
 import static org.batfish.common.util.CollectionUtil.toImmutableMap;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -200,9 +201,30 @@ public final class BDDOutgoingOriginalFlowFilterManager {
    * Interface#getOutgoingOriginalFlowFilter() outgoingOriginalFlowFilters}. (Does not include entry
    * for {@code _activeButNoOriginalFlowFilterRepresentative} even if present in finite domain.)
    */
+  @VisibleForTesting
   @Nonnull
   Map<String, BDD> getInterfaceBDDs() {
     return _interfaceBdds;
+  }
+
+  /**
+   * Returns the BDD representing the constraint indicating the set of flows to be evaluated against
+   * the outgoing filter on the given interface.
+   *
+   * <p>If there is no outging filter on the given interface, returns the constraint corresponding
+   * to the set of flows that were not evaluated against any interface's outgoing filter.
+   */
+  public @Nonnull BDD outgoingInterfaceBDD(String iface) {
+    if (isTrivial()) {
+      return _trueBdd;
+    }
+    if (_activeButNoOriginalFlowFilterRepresentative == null) {
+      BDD ret = _interfaceBdds.get(iface);
+      assert ret != null;
+      return ret;
+    }
+    return _interfaceBdds.getOrDefault(
+        iface, _interfaceBdds.get(_activeButNoOriginalFlowFilterRepresentative));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDFibGeneratorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDFibGeneratorTest.java
@@ -9,10 +9,12 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.sf.javabdd.BDD;
+import org.batfish.common.bdd.BDDFiniteDomain;
 import org.batfish.common.bdd.BDDPacket;
 import org.batfish.datamodel.Ip;
 import org.batfish.symbolic.state.EdgeStateExpr;
@@ -467,6 +469,8 @@ public final class BDDFibGeneratorTest {
 
   @Test
   public void testGenerateRules_PreOutVrf_PreOutEdge() {
+    BDDFiniteDomain<String> domain =
+        new BDDFiniteDomain<>(PKT, "outgoingOrigFilter", ImmutableSet.of(IFACE1, IFACE2));
     Map<String, Map<String, Map<org.batfish.datamodel.Edge, BDD>>> arpTrueEdgeBDDs =
         ImmutableMap.of(
             NODE1,
@@ -491,12 +495,12 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of(),
-            (node, iface) -> ONE);
+            (node, iface) -> domain.getConstraintForValue(iface));
     Edge expectedEdge =
         new Edge(
             new TestPreOutVrf(NODE1, VRF1),
             new TestPreOutEdge(NODE1, IFACE1, NODE2, IFACE2),
-            DSTIP1);
+            DSTIP1.and(domain.getConstraintForValue(IFACE1)));
 
     assertThat(
         generator
@@ -522,6 +526,8 @@ public final class BDDFibGeneratorTest {
 
   @Test
   public void testGenerateRules_PreOutVrf_PreOutInterfaceDisposition_all() {
+    BDDFiniteDomain<String> domain =
+        new BDDFiniteDomain<>(PKT, "outgoingOrigFilter", ImmutableSet.of(IFACE1, IFACE2));
     Map<String, Map<String, Map<String, BDD>>> neighborUnreachableBDDs =
         ImmutableMap.of(
             NODE1,
@@ -558,27 +564,27 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of(),
-            (node, iface) -> ONE);
+            (node, iface) -> domain.getConstraintForValue(iface));
     Edge expectedEdgeNeighborUnreachable =
         new Edge(
             new TestPreOutVrf(NODE1, VRF1),
             new TestPreOutInterfaceNeighborUnreachable(NODE1, IFACE1),
-            DSTIP1);
+            DSTIP1.and(domain.getConstraintForValue(IFACE1)));
     Edge expectedEdgeDeliveredToSubnet =
         new Edge(
             new TestPreOutVrf(NODE1, VRF1),
             new TestPreOutInterfaceDeliveredToSubnet(NODE1, IFACE1),
-            DSTIP2);
+            DSTIP2.and(domain.getConstraintForValue(IFACE1)));
     Edge expectedEdgeExitsNetwork =
         new Edge(
             new TestPreOutVrf(NODE1, VRF1),
             new TestPreOutInterfaceExitsNetwork(NODE1, IFACE2),
-            DSTIP1);
+            DSTIP1.and(domain.getConstraintForValue(IFACE2)));
     Edge expectedInsufficientInfo =
         new Edge(
             new TestPreOutVrf(NODE1, VRF1),
             new TestPreOutInterfaceInsufficientInfo(NODE1, IFACE2),
-            DSTIP2);
+            DSTIP2.and(domain.getConstraintForValue(IFACE2)));
 
     assertThat(
         generator

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDFibGeneratorTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDFibGeneratorTest.java
@@ -118,10 +118,14 @@ public final class BDDFibGeneratorTest {
   private static final BDDPacket PKT = new BDDPacket();
   private static final BDD DSTIP1;
   private static final BDD DSTIP2;
+  private static final BDD ONE;
+  private static final BDD ZERO;
 
   static {
     DSTIP1 = PKT.getDstIp().value(Ip.parse("10.0.0.1").asLong());
     DSTIP2 = PKT.getDstIp().value(Ip.parse("10.0.0.2").asLong());
+    ONE = PKT.getFactory().one();
+    ZERO = PKT.getFactory().zero();
   }
 
   @Test
@@ -135,6 +139,13 @@ public final class BDDFibGeneratorTest {
     // need corresponding entry in routableBDDs to prevent NPE in generateForwardingEdges
     Map<String, Map<String, BDD>> routableBDDs =
         ImmutableMap.of(NODE1, ImmutableMap.of(VRF1, DSTIP2), NODE2, ImmutableMap.of(VRF1, DSTIP2));
+    // need appropriate entries in nextVrfBDDs to prevent NPE in generateForwardingEdges
+    Map<String, Map<String, Map<String, BDD>>> nextVrfBDDs =
+        ImmutableMap.of(
+            NODE1,
+            ImmutableMap.of(VRF1, ImmutableMap.of()),
+            NODE2,
+            ImmutableMap.of(VRF1, ImmutableMap.of()));
     BDDFibGenerator generator =
         new BDDFibGenerator(
             ImmutableMap.of(),
@@ -145,8 +156,9 @@ public final class BDDFibGeneratorTest {
             ifaceAcceptBDDs,
             toVrfAcceptBdds(ifaceAcceptBDDs),
             routableBDDs,
+            nextVrfBDDs,
             ImmutableMap.of(),
-            ImmutableMap.of());
+            (node, iface) -> ONE);
     Edge expectedEdge =
         new Edge(
             new InterfaceAccept(NODE1, IFACE1), new VrfAccept(NODE1, VRF1), PKT.getFactory().one());
@@ -183,6 +195,13 @@ public final class BDDFibGeneratorTest {
     // need corresponding entry in routableBDDs to prevent NPE in generateForwardingEdges
     Map<String, Map<String, BDD>> routableBDDs =
         ImmutableMap.of(NODE1, ImmutableMap.of(VRF1, DSTIP2), NODE2, ImmutableMap.of(VRF1, DSTIP2));
+    // need appropriate entries in nextVrfBDDs to prevent NPE in generateForwardingEdges
+    Map<String, Map<String, Map<String, BDD>>> nextVrfBDDs =
+        ImmutableMap.of(
+            NODE1,
+            ImmutableMap.of(VRF1, ImmutableMap.of()),
+            NODE2,
+            ImmutableMap.of(VRF1, ImmutableMap.of()));
     BDDFibGenerator generator =
         new BDDFibGenerator(
             ImmutableMap.of(),
@@ -193,8 +212,9 @@ public final class BDDFibGeneratorTest {
             ifaceAcceptBDDs,
             toVrfAcceptBdds(ifaceAcceptBDDs),
             routableBDDs,
+            nextVrfBDDs,
             ImmutableMap.of(),
-            ImmutableMap.of());
+            (node, iface) -> ONE);
     Edge expectedEdge =
         new Edge(new TestPostInVrf(NODE1, VRF1), new InterfaceAccept(NODE1, IFACE1), DSTIP1);
 
@@ -229,6 +249,13 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(VRF1, ImmutableMap.of(IFACE2, DSTIP1)));
     Map<String, Map<String, BDD>> routableBDDs =
         ImmutableMap.of(NODE1, ImmutableMap.of(VRF1, DSTIP2), NODE2, ImmutableMap.of(VRF1, DSTIP2));
+    // need appropriate entries in nextVrfBDDs to prevent NPE in generateForwardingEdges
+    Map<String, Map<String, Map<String, BDD>>> nextVrfBDDs =
+        ImmutableMap.of(
+            NODE1,
+            ImmutableMap.of(VRF1, ImmutableMap.of()),
+            NODE2,
+            ImmutableMap.of(VRF1, ImmutableMap.of()));
     BDDFibGenerator generator =
         new BDDFibGenerator(
             ImmutableMap.of(),
@@ -239,8 +266,9 @@ public final class BDDFibGeneratorTest {
             ifaceAcceptBdds,
             toVrfAcceptBdds(ifaceAcceptBdds),
             routableBDDs,
+            nextVrfBDDs,
             ImmutableMap.of(),
-            ImmutableMap.of());
+            (node, iface) -> ONE);
     Edge expectedEdge =
         new Edge(new TestPostInVrf(NODE1, VRF1), new NodeDropNoRoute(NODE1), DSTIP1.nor(DSTIP2));
 
@@ -284,7 +312,8 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             nextVrfBDDs,
-            ImmutableMap.of());
+            ImmutableMap.of(),
+            (node, iface) -> ONE);
     Edge expectedEdge =
         new Edge(new TestPostInVrf(NODE1, VRF1), new TestPostInVrf(NODE1, VRF2), DSTIP1);
 
@@ -311,18 +340,29 @@ public final class BDDFibGeneratorTest {
 
   @Test
   public void testGenerateRules_PostInVrf_PreOutVrf() {
+    // Node1 has 1 vrf, routes dstip1 and 2, and only accepts dstip1. So dstip2 to PreOutVrf
+    // Node2 has 2 vrfs
+    //    vrf1 routes dstip1 and 2, sends dstip2 to vrf2 -> dstip1 to PreOutVrf
+    //    vrf2 routes dstip1, accepts nothing -> dstip1 to PreOutVrf
     Map<String, Map<String, Map<String, BDD>>> ifaceAcceptBdds =
         ImmutableMap.of(
             NODE1,
             ImmutableMap.of(VRF1, ImmutableMap.of(IFACE1, DSTIP1)),
             NODE2,
-            ImmutableMap.of(VRF1, ImmutableMap.of(IFACE2, DSTIP1)));
+            ImmutableMap.of(VRF1, ImmutableMap.of(IFACE2, ZERO), VRF2, ImmutableMap.of()));
     Map<String, Map<String, BDD>> routableBDDs =
         ImmutableMap.of(
             NODE1,
             ImmutableMap.of(VRF1, DSTIP1.or(DSTIP2)),
             NODE2,
-            ImmutableMap.of(VRF1, DSTIP1.or(DSTIP2)));
+            ImmutableMap.of(VRF1, DSTIP1.or(DSTIP2), VRF2, DSTIP1));
+    Map<String, Map<String, Map<String, BDD>>> nextVrfBDDs =
+        ImmutableMap.of(
+            NODE1,
+            ImmutableMap.of(VRF1, ImmutableMap.of()),
+            NODE2,
+            ImmutableMap.of(
+                VRF1, ImmutableMap.of(VRF2, DSTIP2), VRF2, ImmutableMap.of(VRF1, ZERO)));
     BDDFibGenerator generator =
         new BDDFibGenerator(
             ImmutableMap.of(),
@@ -333,17 +373,28 @@ public final class BDDFibGeneratorTest {
             ifaceAcceptBdds,
             toVrfAcceptBdds(ifaceAcceptBdds),
             routableBDDs,
+            nextVrfBDDs,
             ImmutableMap.of(),
-            ImmutableMap.of());
-    Edge expectedEdge =
+            (node, iface) -> ONE);
+    Edge expectedEdgeSimple =
         new Edge(new TestPostInVrf(NODE1, VRF1), new TestPreOutVrf(NODE1, VRF1), DSTIP2);
+    Edge expectedEdgeVrfLeakV1 =
+        new Edge(new TestPostInVrf(NODE2, VRF1), new TestPreOutVrf(NODE2, VRF1), DSTIP1);
+    Edge expectedEdgeVrfLeakV2 =
+        new Edge(new TestPostInVrf(NODE2, VRF2), new TestPreOutVrf(NODE2, VRF2), DSTIP1);
 
     assertThat(
         generator
             .generateRules_PostInVrf_PreOutVrf(
                 NODE1::equals, TestPostInVrf::new, TestPreOutVrf::new)
             .collect(ImmutableList.toImmutableList()),
-        contains(expectedEdge));
+        contains(expectedEdgeSimple));
+    assertThat(
+        generator
+            .generateRules_PostInVrf_PreOutVrf(
+                NODE2::equals, TestPostInVrf::new, TestPreOutVrf::new)
+            .collect(ImmutableList.toImmutableList()),
+        contains(expectedEdgeVrfLeakV1, expectedEdgeVrfLeakV2));
     // ensure edge is produced by top-level generation function
     assertThat(
         generator
@@ -357,7 +408,20 @@ public final class BDDFibGeneratorTest {
                 TestPreOutInterfaceInsufficientInfo::new,
                 TestPreOutInterfaceNeighborUnreachable::new)
             .collect(ImmutableList.toImmutableList()),
-        hasItem(expectedEdge));
+        hasItem(expectedEdgeSimple));
+    assertThat(
+        generator
+            .generateForwardingEdges(
+                NODE2::equals,
+                TestPostInVrf::new,
+                TestPreOutEdge::new,
+                TestPreOutVrf::new,
+                TestPreOutInterfaceDeliveredToSubnet::new,
+                TestPreOutInterfaceExitsNetwork::new,
+                TestPreOutInterfaceInsufficientInfo::new,
+                TestPreOutInterfaceNeighborUnreachable::new)
+            .collect(ImmutableList.toImmutableList()),
+        hasItems(expectedEdgeVrfLeakV1, expectedEdgeVrfLeakV2));
   }
 
   @Test
@@ -375,7 +439,8 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of(),
-            nullRoutedBDDs);
+            nullRoutedBDDs,
+            (node, iface) -> ONE);
     Edge expectedEdge =
         new Edge(new TestPreOutVrf(NODE1, VRF1), new NodeDropNullRoute(NODE1), DSTIP1);
 
@@ -425,7 +490,8 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of(),
-            ImmutableMap.of());
+            ImmutableMap.of(),
+            (node, iface) -> ONE);
     Edge expectedEdge =
         new Edge(
             new TestPreOutVrf(NODE1, VRF1),
@@ -491,7 +557,8 @@ public final class BDDFibGeneratorTest {
             ImmutableMap.of(),
             ImmutableMap.of(),
             ImmutableMap.of(),
-            ImmutableMap.of());
+            ImmutableMap.of(),
+            (node, iface) -> ONE);
     Edge expectedEdgeNeighborUnreachable =
         new Edge(
             new TestPreOutVrf(NODE1, VRF1),
@@ -562,7 +629,8 @@ public final class BDDFibGeneratorTest {
                 NODE1::equals,
                 dispositionBddMap,
                 TestPreOutVrf::new,
-                TestPreOutInterfaceExitsNetwork::new)
+                TestPreOutInterfaceExitsNetwork::new,
+                (node, iface) -> ONE)
             .collect(ImmutableList.toImmutableList()),
         contains(
             new Edge(

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BUILD
@@ -1,0 +1,55 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+    )
+
+
+java_library(
+    name = "testlib",
+    srcs = glob(["**/*.java"], exclude=["**/*Test.java"]),
+    deps = [
+        "//projects/batfish",
+        "//projects/batfish:batfish_testlib",
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:common_testlib",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd:matchers",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
+        "//projects/bdd",
+        "//projects/symbolic",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
+        "@maven//:junit_junit",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob(
+        [
+            "**/*Test.java",
+        ],
+    ),
+    resources = [
+        "//projects/batfish/src/test/resources",
+    ],
+    deps = [
+        ":testlib",
+        "//projects/batfish",
+        "//projects/batfish:batfish_testlib",
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol:common_testlib",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd:matchers",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
+        "//projects/bdd",
+        "//projects/symbolic",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
+        "@maven//:junit_junit",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/transition/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/transition/BUILD
@@ -1,0 +1,24 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "**/*Test.java",
+    ]),
+    resources = [
+        "//projects/batfish/src/test/resources",
+    ],
+    deps = [
+        "//projects/batfish",
+        "//projects/batfish-common-protocol:common",
+        "//projects/bdd",
+        "@maven//:com_google_guava_guava",
+        "@maven//:junit_junit",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)


### PR DESCRIPTION
In some parts of the reachability graph, we are "leaking" flows that are
internal to a node too far, to a node where these flows have no outlet.

For example, flows that are only valid if sent out interface i1 were making it
to i2-related states, and flows that are only valid in vrf A were making it to
vrf B.

This is safe -- no wrong results are generated, the flows will just die, but
it is better to explicitly exclude such flows rather than having them "disappear"
in the middle of the reachability graph. This makes invariant checking easier.