### PR TITLE
FortiOS: fix stale references / track UUIDs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -148,6 +148,11 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
     _c = configuration;
   }
 
+  /** Get a new, unique BatfishUUID. */
+  public @Nonnull BatfishUUID getUUID() {
+    return new BatfishUUID(_uuidSequenceNumber++);
+  }
+
   @Override
   public String getInputText() {
     return _text;
@@ -230,7 +235,7 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
       // Make a clone to edit
       _currentAddress = SerializationUtils.clone(existingAddress);
     } else {
-      _currentAddress = new Address(toString(ctx.address_name().str()));
+      _currentAddress = new Address(toString(ctx.address_name().str()), getUUID());
     }
   }
 
@@ -559,10 +564,10 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
   public void enterCfsc_edit(Cfsc_editContext ctx) {
     Optional<String> name = toString(ctx, ctx.service_name());
     if (!name.isPresent()) {
-      _currentService = new Service(toString(ctx.service_name().str())); // dummy
+      _currentService = new Service(toString(ctx.service_name().str()), getUUID()); // dummy
       return;
     }
-    _currentService = _c.getServices().computeIfAbsent(name.get(), Service::new);
+    _currentService = _c.getServices().computeIfAbsent(name.get(), s -> new Service(s, getUUID()));
   }
 
   @Override
@@ -1150,5 +1155,7 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
   private final @Nonnull FortiosConfiguration _c;
   private final @Nonnull FortiosCombinedParser _parser;
   private final @Nonnull String _text;
+  // Internal sequence number to generate unique UUIDs for structure that may be renamed or cloned
+  private int _uuidSequenceNumber = 0;
   private final @Nonnull Warnings _w;
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -119,6 +119,7 @@ import org.batfish.grammar.fortios.FortiosParser.Up_or_downContext;
 import org.batfish.grammar.fortios.FortiosParser.VrfContext;
 import org.batfish.grammar.fortios.FortiosParser.WordContext;
 import org.batfish.representation.fortios.Address;
+import org.batfish.representation.fortios.BatfishUUID;
 import org.batfish.representation.fortios.FortiosConfiguration;
 import org.batfish.representation.fortios.Interface;
 import org.batfish.representation.fortios.Interface.Type;
@@ -169,19 +170,19 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
       policy
           .getSrcAddr()
           .addAll(
-              policy.getSrcAddrUuids().stream()
+              policy.getSrcAddrUUIDs().stream()
                   .map(u -> _c.getRenameableObjects().get(u).getName())
                   .collect(ImmutableSet.toImmutableSet()));
       policy
           .getDstAddr()
           .addAll(
-              policy.getDstAddrUuids().stream()
+              policy.getDstAddrUUIDs().stream()
                   .map(u -> _c.getRenameableObjects().get(u).getName())
                   .collect(ImmutableSet.toImmutableSet()));
       policy
           .getService()
           .addAll(
-              policy.getServiceUuids().stream()
+              policy.getServiceUUIDs().stream()
                   .map(u -> _c.getRenameableObjects().get(u).getName())
                   .collect(ImmutableSet.toImmutableSet()));
     }
@@ -451,10 +452,10 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
   // List items
   @Override
   public void exitCfp_set_dstaddr(Cfp_set_dstaddrContext ctx) {
-    toAddresses(ctx.addresses)
+    toAddressUUIDs(ctx.addresses)
         .ifPresent(
             addresses -> {
-              Set<String> addrs = _currentPolicy.getDstAddrUuids();
+              Set<BatfishUUID> addrs = _currentPolicy.getDstAddrUUIDs();
               addrs.clear();
               addrs.addAll(addresses);
             });
@@ -462,10 +463,10 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
 
   @Override
   public void exitCfp_set_srcaddr(Cfp_set_srcaddrContext ctx) {
-    toAddresses(ctx.addresses)
+    toAddressUUIDs(ctx.addresses)
         .ifPresent(
             addresses -> {
-              Set<String> addrs = _currentPolicy.getSrcAddrUuids();
+              Set<BatfishUUID> addrs = _currentPolicy.getSrcAddrUUIDs();
               addrs.clear();
               addrs.addAll(addresses);
             });
@@ -495,10 +496,10 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
 
   @Override
   public void exitCfp_set_service(Cfp_set_serviceContext ctx) {
-    toServices(ctx.services)
+    toServiceUUIDs(ctx.services)
         .ifPresent(
             s -> {
-              Set<String> service = _currentPolicy.getServiceUuids();
+              Set<BatfishUUID> service = _currentPolicy.getServiceUUIDs();
               service.clear();
               service.addAll(s);
             });
@@ -506,20 +507,20 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
 
   @Override
   public void exitCfp_append_dstaddr(Cfp_append_dstaddrContext ctx) {
-    toAddresses(ctx.addresses)
+    toAddressUUIDs(ctx.addresses)
         .ifPresent(
             a -> {
-              Set<String> addrs = _currentPolicy.getDstAddrUuids();
+              Set<BatfishUUID> addrs = _currentPolicy.getDstAddrUUIDs();
               addrs.addAll(a);
             });
   }
 
   @Override
   public void exitCfp_append_srcaddr(Cfp_append_srcaddrContext ctx) {
-    toAddresses(ctx.addresses)
+    toAddressUUIDs(ctx.addresses)
         .ifPresent(
             a -> {
-              Set<String> addrs = _currentPolicy.getSrcAddrUuids();
+              Set<BatfishUUID> addrs = _currentPolicy.getSrcAddrUUIDs();
               addrs.addAll(a);
             });
   }
@@ -546,10 +547,10 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
 
   @Override
   public void exitCfp_append_service(Cfp_append_serviceContext ctx) {
-    toServices(ctx.services)
+    toServiceUUIDs(ctx.services)
         .ifPresent(
             s -> {
-              Set<String> service = _currentPolicy.getServiceUuids();
+              Set<BatfishUUID> service = _currentPolicy.getServiceUUIDs();
               service.addAll(s);
             });
   }
@@ -670,9 +671,9 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
    * Generate a list of service UUIDs for the supplied Service_names context. Returns {@link
    * Optional#empty()} if invalid.
    */
-  private Optional<Set<String>> toServices(Service_namesContext ctx) {
+  private Optional<Set<BatfishUUID>> toServiceUUIDs(Service_namesContext ctx) {
     Map<String, Service> servicesMap = _c.getServices();
-    ImmutableSet.Builder<String> serviceUuidsBuilder = ImmutableSet.builder();
+    ImmutableSet.Builder<BatfishUUID> serviceUuidsBuilder = ImmutableSet.builder();
     Set<String> services =
         ctx.service_name().stream()
             .map(n -> toString(n.str()))
@@ -700,9 +701,9 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
    * Generate a list of address UUIDs for the supplied Address_names context. Returns {@link
    * Optional#empty()} if invalid.
    */
-  private Optional<Set<String>> toAddresses(Address_namesContext ctx) {
+  private Optional<Set<BatfishUUID>> toAddressUUIDs(Address_namesContext ctx) {
     Map<String, Address> addressesMap = _c.getAddresses();
-    ImmutableSet.Builder<String> addressUuidsBuilder = ImmutableSet.builder();
+    ImmutableSet.Builder<BatfishUUID> addressUuidsBuilder = ImmutableSet.builder();
     Set<String> addresses =
         ctx.address_name().stream()
             .map(n -> toString(n.str()))

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -122,8 +122,6 @@ import org.batfish.representation.fortios.Address;
 import org.batfish.representation.fortios.FortiosConfiguration;
 import org.batfish.representation.fortios.Interface;
 import org.batfish.representation.fortios.Interface.Type;
-import org.batfish.representation.fortios.InterfaceAny;
-import org.batfish.representation.fortios.InterfaceOrZone;
 import org.batfish.representation.fortios.Policy;
 import org.batfish.representation.fortios.Policy.Action;
 import org.batfish.representation.fortios.Policy.Status;
@@ -478,7 +476,7 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
     toInterfaces(ctx.interfaces, false)
         .ifPresent(
             i -> {
-              Set<InterfaceOrZone> ifaces = _currentPolicy.getDstIntf();
+              Set<String> ifaces = _currentPolicy.getDstIntf();
               ifaces.clear();
               ifaces.addAll(i);
             });
@@ -489,7 +487,7 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
     toInterfaces(ctx.interfaces, true)
         .ifPresent(
             i -> {
-              Set<InterfaceOrZone> ifaces = _currentPolicy.getSrcIntf();
+              Set<String> ifaces = _currentPolicy.getSrcIntf();
               ifaces.clear();
               ifaces.addAll(i);
             });
@@ -531,7 +529,7 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
     toInterfaces(ctx.interfaces, false)
         .ifPresent(
             i -> {
-              Set<InterfaceOrZone> ifaces = _currentPolicy.getDstIntf();
+              Set<String> ifaces = _currentPolicy.getDstIntf();
               ifaces.addAll(i);
             });
   }
@@ -541,7 +539,7 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
     toInterfaces(ctx.interfaces, true)
         .ifPresent(
             i -> {
-              Set<InterfaceOrZone> ifaces = _currentPolicy.getSrcIntf();
+              Set<String> ifaces = _currentPolicy.getSrcIntf();
               ifaces.addAll(i);
             });
   }
@@ -729,13 +727,12 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
   }
 
   /**
-   * Convert specified interface or zone names context into a set of interfaces. If {@code pruneAny}
-   * is true, then the special 'any' interface will be removed if specified with other interfaces.
+   * Convert specified interface or zone names context into a set of names. If {@code pruneAny} is
+   * true, then the special 'any' interface will be removed if specified with other interfaces.
    */
-  private Optional<Set<InterfaceOrZone>> toInterfaces(
-      Interface_or_zone_namesContext ctx, boolean pruneAny) {
+  private Optional<Set<String>> toInterfaces(Interface_or_zone_namesContext ctx, boolean pruneAny) {
     Map<String, Interface> ifacesMap = _c.getInterfaces();
-    ImmutableSet.Builder<InterfaceOrZone> ifaceBuilder = ImmutableSet.builder();
+    ImmutableSet.Builder<String> ifaceNameBuilder = ImmutableSet.builder();
     Set<String> ifaces =
         ctx.interface_or_zone_name().stream()
             .map(n -> toString(n.str()))
@@ -746,9 +743,9 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
           warn(ctx, "When 'any' is set together with other interfaces, it is removed");
           continue;
         }
-        ifaceBuilder.add(InterfaceAny.INSTANCE);
+        ifaceNameBuilder.add(Policy.ANY_INTERFACE);
       } else if (ifacesMap.containsKey(name)) {
-        ifaceBuilder.add(ifacesMap.get(name));
+        ifaceNameBuilder.add(name);
       } else {
         warn(
             ctx,
@@ -758,7 +755,7 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
         return Optional.empty();
       }
     }
-    return Optional.of(ifaceBuilder.build());
+    return Optional.of(ifaceNameBuilder.build());
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
@@ -3,6 +3,7 @@ package org.batfish.representation.fortios;
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 import java.io.Serializable;
+import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
@@ -14,7 +15,7 @@ import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.Prefix;
 
 /** FortiOS datamodel component containing address configuration */
-public class Address implements Serializable {
+public class Address implements FortiosRenameableObject, Serializable {
   public enum Type {
     INTERFACE_SUBNET,
     IPMASK,
@@ -97,7 +98,8 @@ public class Address implements Serializable {
   @Nullable private String _associatedInterface;
   @Nullable private String _comment;
   @Nullable private Boolean _fabricObject;
-  @Nonnull private final String _name;
+  @Nonnull private String _name;
+  @Nonnull private String _uuid;
   @Nullable private Type _type;
   @Nonnull private final TypeSpecificFields _typeSpecificFields;
 
@@ -108,6 +110,7 @@ public class Address implements Serializable {
   public Address(String name) {
     _name = name;
     _typeSpecificFields = new TypeSpecificFields();
+    _uuid = UUID.randomUUID().toString();
   }
 
   public IpSpace toIpSpace(Warnings w) {
@@ -168,8 +171,24 @@ public class Address implements Serializable {
     return firstNonNull(_fabricObject, DEFAULT_FABRIC_OBJECT);
   }
 
+  @Override
   public @Nonnull String getName() {
     return _name;
+  }
+
+  @Override
+  public String getUUID() {
+    return _uuid;
+  }
+
+  @Override
+  public void setName(String name) {
+    _name = name;
+  }
+
+  @Override
+  public void setUUID(String uuid) {
+    _uuid = uuid;
   }
 
   public @Nullable Type getType() {

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
@@ -106,10 +106,10 @@ public class Address implements FortiosRenameableObject, Serializable {
   public static final boolean DEFAULT_FABRIC_OBJECT = false;
   public static final Type DEFAULT_TYPE = Type.IPMASK;
 
-  public Address(String name) {
+  public Address(String name, BatfishUUID uuid) {
     _name = name;
     _typeSpecificFields = new TypeSpecificFields();
-    _uuid = new BatfishUUID();
+    _uuid = uuid;
   }
 
   public IpSpace toIpSpace(Warnings w) {

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
@@ -98,7 +98,7 @@ public class Address implements FortiosRenameableObject, Serializable {
   @Nullable private String _comment;
   @Nullable private Boolean _fabricObject;
   @Nonnull private String _name;
-  @Nonnull private BatfishUUID _uuid;
+  @Nonnull private final BatfishUUID _uuid;
   @Nullable private Type _type;
   @Nonnull private final TypeSpecificFields _typeSpecificFields;
 
@@ -183,11 +183,6 @@ public class Address implements FortiosRenameableObject, Serializable {
   @Override
   public void setName(String name) {
     _name = name;
-  }
-
-  @Override
-  public void setBatfishUUID(BatfishUUID uuid) {
-    _uuid = uuid;
   }
 
   public @Nullable Type getType() {

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
@@ -3,7 +3,6 @@ package org.batfish.representation.fortios;
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 import java.io.Serializable;
-import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
@@ -99,7 +98,7 @@ public class Address implements FortiosRenameableObject, Serializable {
   @Nullable private String _comment;
   @Nullable private Boolean _fabricObject;
   @Nonnull private String _name;
-  @Nonnull private String _uuid;
+  @Nonnull private BatfishUUID _uuid;
   @Nullable private Type _type;
   @Nonnull private final TypeSpecificFields _typeSpecificFields;
 
@@ -110,7 +109,7 @@ public class Address implements FortiosRenameableObject, Serializable {
   public Address(String name) {
     _name = name;
     _typeSpecificFields = new TypeSpecificFields();
-    _uuid = UUID.randomUUID().toString();
+    _uuid = new BatfishUUID();
   }
 
   public IpSpace toIpSpace(Warnings w) {
@@ -177,7 +176,7 @@ public class Address implements FortiosRenameableObject, Serializable {
   }
 
   @Override
-  public String getBatfishUUID() {
+  public BatfishUUID getBatfishUUID() {
     return _uuid;
   }
 
@@ -187,7 +186,7 @@ public class Address implements FortiosRenameableObject, Serializable {
   }
 
   @Override
-  public void setBatfishUUID(String uuid) {
+  public void setBatfishUUID(BatfishUUID uuid) {
     _uuid = uuid;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
@@ -177,7 +177,7 @@ public class Address implements FortiosRenameableObject, Serializable {
   }
 
   @Override
-  public String getUUID() {
+  public String getBatfishUUID() {
     return _uuid;
   }
 
@@ -187,7 +187,7 @@ public class Address implements FortiosRenameableObject, Serializable {
   }
 
   @Override
-  public void setUUID(String uuid) {
+  public void setBatfishUUID(String uuid) {
     _uuid = uuid;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/BatfishUUID.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/BatfishUUID.java
@@ -1,8 +1,6 @@
 package org.batfish.representation.fortios;
 
 import java.io.Serializable;
-import java.util.UUID;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -20,17 +18,17 @@ public class BatfishUUID implements Serializable {
       return false;
     }
     BatfishUUID that = (BatfishUUID) o;
-    return _uuid.equals(that._uuid);
+    return _uuid == that._uuid;
   }
 
   @Override
   public int hashCode() {
-    return _uuid.hashCode();
+    return _uuid;
   }
 
-  public BatfishUUID() {
-    _uuid = UUID.randomUUID();
+  public BatfishUUID(int uuid) {
+    _uuid = uuid;
   }
 
-  @Nonnull private final UUID _uuid;
+  private final int _uuid;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/BatfishUUID.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/BatfishUUID.java
@@ -1,0 +1,36 @@
+package org.batfish.representation.fortios;
+
+import java.io.Serializable;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Internal UUID for tracking FortiOS structures that may be renamed or changed. The UUID persists
+ * across renames and structure edits and can be used to track structure references when the
+ * structure might change.
+ */
+public class BatfishUUID implements Serializable {
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BatfishUUID)) {
+      return false;
+    }
+    BatfishUUID that = (BatfishUUID) o;
+    return _uuid.equals(that._uuid);
+  }
+
+  @Override
+  public int hashCode() {
+    return _uuid.hashCode();
+  }
+
+  public BatfishUUID() {
+    _uuid = UUID.randomUUID();
+  }
+
+  @Nonnull private final UUID _uuid;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosConfiguration.java
@@ -19,6 +19,7 @@ public class FortiosConfiguration extends VendorConfiguration {
     _addresses = new HashMap<>();
     _interfaces = new HashMap<>();
     _policies = new LinkedHashMap<>();
+    _renameableObjects = new HashMap<>();
     _replacemsgs = new HashMap<>();
     _services = new HashMap<>();
   }
@@ -59,6 +60,11 @@ public class FortiosConfiguration extends VendorConfiguration {
     return _replacemsgs;
   }
 
+  /** UUID -> renameable object */
+  public @Nonnull Map<String, FortiosRenameableObject> getRenameableObjects() {
+    return _renameableObjects;
+  }
+
   /** name -> service */
   public @Nonnull Map<String, Service> getServices() {
     return _services;
@@ -69,6 +75,7 @@ public class FortiosConfiguration extends VendorConfiguration {
   private final @Nonnull Map<String, Interface> _interfaces;
   // Note: this is a LinkedHashMap to preserve insertion order
   private final @Nonnull Map<String, Policy> _policies;
+  private final @Nonnull Map<String, FortiosRenameableObject> _renameableObjects;
   private final @Nonnull Map<String, Map<String, Replacemsg>> _replacemsgs;
   private final @Nonnull Map<String, Service> _services;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosConfiguration.java
@@ -61,7 +61,7 @@ public class FortiosConfiguration extends VendorConfiguration {
   }
 
   /** UUID -> renameable object */
-  public @Nonnull Map<String, FortiosRenameableObject> getRenameableObjects() {
+  public @Nonnull Map<BatfishUUID, FortiosRenameableObject> getRenameableObjects() {
     return _renameableObjects;
   }
 
@@ -75,7 +75,7 @@ public class FortiosConfiguration extends VendorConfiguration {
   private final @Nonnull Map<String, Interface> _interfaces;
   // Note: this is a LinkedHashMap to preserve insertion order
   private final @Nonnull Map<String, Policy> _policies;
-  private final @Nonnull Map<String, FortiosRenameableObject> _renameableObjects;
+  private final @Nonnull Map<BatfishUUID, FortiosRenameableObject> _renameableObjects;
   private final @Nonnull Map<String, Map<String, Replacemsg>> _replacemsgs;
   private final @Nonnull Map<String, Service> _services;
 

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosRenameableObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosRenameableObject.java
@@ -3,9 +3,10 @@ package org.batfish.representation.fortios;
 public interface FortiosRenameableObject {
   String getName();
 
-  String getUUID();
+  /** Batfish-internal UUID. Persists across object rename. */
+  String getBatfishUUID();
 
   void setName(String name);
 
-  void setUUID(String uuid);
+  void setBatfishUUID(String uuid);
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosRenameableObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosRenameableObject.java
@@ -1,12 +1,16 @@
 package org.batfish.representation.fortios;
 
+/**
+ * Interface for FortiOS objects that may be renamed. Contains both a mutable name and an internal
+ * UUID which persists across renames and structure edits.
+ */
 public interface FortiosRenameableObject {
   String getName();
 
   /** Batfish-internal UUID. Persists across object rename. */
-  String getBatfishUUID();
+  BatfishUUID getBatfishUUID();
 
   void setName(String name);
 
-  void setBatfishUUID(String uuid);
+  void setBatfishUUID(BatfishUUID uuid);
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosRenameableObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosRenameableObject.java
@@ -11,6 +11,4 @@ public interface FortiosRenameableObject {
   BatfishUUID getBatfishUUID();
 
   void setName(String name);
-
-  void setBatfishUUID(BatfishUUID uuid);
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosRenameableObject.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosRenameableObject.java
@@ -1,0 +1,11 @@
+package org.batfish.representation.fortios;
+
+public interface FortiosRenameableObject {
+  String getName();
+
+  String getUUID();
+
+  void setName(String name);
+
+  void setUUID(String uuid);
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Policy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Policy.java
@@ -75,18 +75,36 @@ public final class Policy implements Serializable {
   }
 
   @Nonnull
-  public Set<Address> getSrcAddr() {
+  public Set<String> getSrcAddr() {
     return _srcAddr;
   }
 
+  /** Set of Batfish-internal UUIDs associated with srcaddr references. */
   @Nonnull
-  public Set<Address> getDstAddr() {
-    return _dstAddr;
+  public Set<String> getSrcAddrUuids() {
+    return _srcAddrUuids;
   }
 
   @Nonnull
-  public Set<Service> getService() {
+  public Set<String> getDstAddr() {
+    return _dstAddr;
+  }
+
+  /** Set of Batfish-internal UUIDs associated with dstaddr references. */
+  @Nonnull
+  public Set<String> getDstAddrUuids() {
+    return _dstAddrUuids;
+  }
+
+  @Nonnull
+  public Set<String> getService() {
     return _service;
+  }
+
+  /** Set of Batfish-internal UUIDs associated with service references. */
+  @Nonnull
+  public Set<String> getServiceUuids() {
+    return _serviceUuids;
   }
 
   public void setAction(Action action) {
@@ -112,15 +130,22 @@ public final class Policy implements Serializable {
     _srcAddr = new HashSet<>();
     _dstAddr = new HashSet<>();
     _service = new HashSet<>();
+
+    _srcAddrUuids = new HashSet<>();
+    _dstAddrUuids = new HashSet<>();
+    _serviceUuids = new HashSet<>();
   }
 
   @Nonnull private String _number;
   @Nullable private String _name;
   @Nonnull private final Set<InterfaceOrZone> _srcIntf;
   @Nonnull private final Set<InterfaceOrZone> _dstIntf;
-  @Nonnull private final Set<Address> _srcAddr;
-  @Nonnull private final Set<Address> _dstAddr;
-  @Nonnull private final Set<Service> _service;
+  @Nonnull private final Set<String> _srcAddr;
+  @Nonnull private final Set<String> _srcAddrUuids;
+  @Nonnull private final Set<String> _dstAddr;
+  @Nonnull private final Set<String> _dstAddrUuids;
+  @Nonnull private final Set<String> _service;
+  @Nonnull private final Set<String> _serviceUuids;
   @Nullable private Status _status;
   @Nullable private String _comments;
   @Nullable private Action _action;

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Policy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Policy.java
@@ -81,7 +81,7 @@ public final class Policy implements Serializable {
 
   /** Set of Batfish-internal UUIDs associated with srcaddr references. */
   @Nonnull
-  public Set<String> getSrcAddrUuids() {
+  public Set<BatfishUUID> getSrcAddrUUIDs() {
     return _srcAddrUuids;
   }
 
@@ -92,7 +92,7 @@ public final class Policy implements Serializable {
 
   /** Set of Batfish-internal UUIDs associated with dstaddr references. */
   @Nonnull
-  public Set<String> getDstAddrUuids() {
+  public Set<BatfishUUID> getDstAddrUUIDs() {
     return _dstAddrUuids;
   }
 
@@ -103,7 +103,7 @@ public final class Policy implements Serializable {
 
   /** Set of Batfish-internal UUIDs associated with service references. */
   @Nonnull
-  public Set<String> getServiceUuids() {
+  public Set<BatfishUUID> getServiceUUIDs() {
     return _serviceUuids;
   }
 
@@ -141,11 +141,11 @@ public final class Policy implements Serializable {
   @Nonnull private final Set<String> _srcIntf;
   @Nonnull private final Set<String> _dstIntf;
   @Nonnull private final Set<String> _srcAddr;
-  @Nonnull private final Set<String> _srcAddrUuids;
+  @Nonnull private final Set<BatfishUUID> _srcAddrUuids;
   @Nonnull private final Set<String> _dstAddr;
-  @Nonnull private final Set<String> _dstAddrUuids;
+  @Nonnull private final Set<BatfishUUID> _dstAddrUuids;
   @Nonnull private final Set<String> _service;
-  @Nonnull private final Set<String> _serviceUuids;
+  @Nonnull private final Set<BatfishUUID> _serviceUuids;
   @Nullable private Status _status;
   @Nullable private String _comments;
   @Nullable private Action _action;

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Policy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Policy.java
@@ -65,12 +65,12 @@ public final class Policy implements Serializable {
   }
 
   @Nonnull
-  public Set<InterfaceOrZone> getSrcIntf() {
+  public Set<String> getSrcIntf() {
     return _srcIntf;
   }
 
   @Nonnull
-  public Set<InterfaceOrZone> getDstIntf() {
+  public Set<String> getDstIntf() {
     return _dstIntf;
   }
 
@@ -138,8 +138,8 @@ public final class Policy implements Serializable {
 
   @Nonnull private String _number;
   @Nullable private String _name;
-  @Nonnull private final Set<InterfaceOrZone> _srcIntf;
-  @Nonnull private final Set<InterfaceOrZone> _dstIntf;
+  @Nonnull private final Set<String> _srcIntf;
+  @Nonnull private final Set<String> _dstIntf;
   @Nonnull private final Set<String> _srcAddr;
   @Nonnull private final Set<String> _srcAddrUuids;
   @Nonnull private final Set<String> _dstAddr;

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Service.java
@@ -51,11 +51,6 @@ public final class Service implements FortiosRenameableObject, Serializable {
     _name = name;
   }
 
-  @Override
-  public void setBatfishUUID(BatfishUUID uuid) {
-    _uuid = uuid;
-  }
-
   @VisibleForTesting
   @Nullable
   public Protocol getProtocol() {
@@ -214,7 +209,7 @@ public final class Service implements FortiosRenameableObject, Serializable {
   }
 
   @Nonnull private String _name;
-  @Nonnull private BatfishUUID _uuid;
+  @Nonnull private final BatfishUUID _uuid;
   @Nullable private Protocol _protocol;
   @Nullable private Integer _protocolNumber;
   @Nullable private String _comment;

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Service.java
@@ -7,7 +7,6 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -43,7 +42,7 @@ public final class Service implements FortiosRenameableObject, Serializable {
   }
 
   @Override
-  public String getBatfishUUID() {
+  public BatfishUUID getBatfishUUID() {
     return _uuid;
   }
 
@@ -53,7 +52,7 @@ public final class Service implements FortiosRenameableObject, Serializable {
   }
 
   @Override
-  public void setBatfishUUID(String uuid) {
+  public void setBatfishUUID(BatfishUUID uuid) {
     _uuid = uuid;
   }
 
@@ -211,11 +210,11 @@ public final class Service implements FortiosRenameableObject, Serializable {
 
   public Service(String name) {
     _name = name;
-    _uuid = UUID.randomUUID().toString();
+    _uuid = new BatfishUUID();
   }
 
   @Nonnull private String _name;
-  @Nonnull private String _uuid;
+  @Nonnull private BatfishUUID _uuid;
   @Nullable private Protocol _protocol;
   @Nullable private Integer _protocolNumber;
   @Nullable private String _comment;

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Service.java
@@ -208,9 +208,9 @@ public final class Service implements FortiosRenameableObject, Serializable {
     _sctpPortRangeSrc = sctpPortRange;
   }
 
-  public Service(String name) {
+  public Service(String name, BatfishUUID uuid) {
     _name = name;
-    _uuid = new BatfishUUID();
+    _uuid = uuid;
   }
 
   @Nonnull private String _name;

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Service.java
@@ -43,7 +43,7 @@ public final class Service implements FortiosRenameableObject, Serializable {
   }
 
   @Override
-  public String getUUID() {
+  public String getBatfishUUID() {
     return _uuid;
   }
 
@@ -53,7 +53,7 @@ public final class Service implements FortiosRenameableObject, Serializable {
   }
 
   @Override
-  public void setUUID(String uuid) {
+  public void setBatfishUUID(String uuid) {
     _uuid = uuid;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Service.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Service.java
@@ -7,6 +7,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -21,7 +22,7 @@ import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.acl.OrMatchExpr;
 
 /** FortiOS datamodel component containing firewall service configuration */
-public final class Service implements Serializable {
+public final class Service implements FortiosRenameableObject, Serializable {
 
   public static final Protocol DEFAULT_PROTOCOL = Protocol.TCP_UDP_SCTP;
   public static final int DEFAULT_PROTOCOL_NUMBER = 0;
@@ -35,9 +36,25 @@ public final class Service implements Serializable {
     IP,
   }
 
+  @Override
   @Nonnull
   public String getName() {
     return _name;
+  }
+
+  @Override
+  public String getUUID() {
+    return _uuid;
+  }
+
+  @Override
+  public void setName(String name) {
+    _name = name;
+  }
+
+  @Override
+  public void setUUID(String uuid) {
+    _uuid = uuid;
   }
 
   @VisibleForTesting
@@ -194,9 +211,11 @@ public final class Service implements Serializable {
 
   public Service(String name) {
     _name = name;
+    _uuid = UUID.randomUUID().toString();
   }
 
-  @Nonnull private final String _name;
+  @Nonnull private String _name;
+  @Nonnull private String _uuid;
   @Nullable private Protocol _protocol;
   @Nullable private Integer _protocolNumber;
   @Nullable private String _comment;

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -554,17 +554,16 @@ public final class FortiosGrammarTest {
     Policy policyAny = policies.get("2");
 
     Map<String, Service> services = vc.getServices();
-    assertThat(
-        services, hasKeys(containsInAnyOrder("custom_tcp_11", "custom_tcp_11_from_12", "ALL")));
-    Service service11 = services.get("custom_tcp_11");
-    Service service11From12 = services.get("custom_tcp_11_from_12");
-    Service serviceAll = services.get("ALL");
+    String service11 = "custom_tcp_11";
+    String service11From12 = "custom_tcp_11_from_12";
+    String serviceAll = "ALL";
+    assertThat(services, hasKeys(containsInAnyOrder(service11, service11From12, serviceAll)));
 
     Map<String, Address> addresses = vc.getAddresses();
-    assertThat(addresses, hasKeys(containsInAnyOrder("addr1", "addr2", "all")));
-    Address addr1 = addresses.get("addr1");
-    Address addr2 = addresses.get("addr2");
-    Address addrAll = addresses.get("all");
+    String addr1 = "addr1";
+    String addr2 = "addr2";
+    String addrAll = "all";
+    assertThat(addresses, hasKeys(containsInAnyOrder(addr1, addr2, addrAll)));
 
     Map<String, Interface> interfaces = vc.getInterfaces();
     assertThat(interfaces, hasKeys(containsInAnyOrder("port1", "port2")));
@@ -621,13 +620,14 @@ public final class FortiosGrammarTest {
     Policy policy = policies.get("1");
 
     Map<String, Service> services = vc.getServices();
-    assertThat(services, hasKeys(containsInAnyOrder("service10", "service20")));
-    Service service20 = services.get("service20");
+    String service10 = "service10";
+    String service20 = "service20";
+    assertThat(services, hasKeys(containsInAnyOrder(service10, service20)));
 
     Map<String, Address> addresses = vc.getAddresses();
-    assertThat(addresses, hasKeys(containsInAnyOrder("addr10", "addr20")));
-    Address addr10 = addresses.get("addr10");
-    Address addr20 = addresses.get("addr20");
+    String addr10 = "addr10";
+    String addr20 = "addr20";
+    assertThat(addresses, hasKeys(containsInAnyOrder(addr10, addr20)));
 
     Map<String, Interface> interfaces = vc.getInterfaces();
     assertThat(interfaces, hasKeys(containsInAnyOrder("port10", "port20")));

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -57,7 +57,6 @@ import org.batfish.representation.fortios.FortiosConfiguration;
 import org.batfish.representation.fortios.Interface;
 import org.batfish.representation.fortios.Interface.Status;
 import org.batfish.representation.fortios.Interface.Type;
-import org.batfish.representation.fortios.InterfaceAny;
 import org.batfish.representation.fortios.Policy;
 import org.batfish.representation.fortios.Policy.Action;
 import org.batfish.representation.fortios.Service;
@@ -566,9 +565,9 @@ public final class FortiosGrammarTest {
     assertThat(addresses, hasKeys(containsInAnyOrder(addr1, addr2, addrAll)));
 
     Map<String, Interface> interfaces = vc.getInterfaces();
-    assertThat(interfaces, hasKeys(containsInAnyOrder("port1", "port2")));
-    Interface port1 = interfaces.get("port1");
-    Interface port2 = interfaces.get("port2");
+    String port1 = "port1";
+    String port2 = "port2";
+    assertThat(interfaces, hasKeys(containsInAnyOrder(port1, port2)));
 
     assertThat(policyDisable.getAction(), equalTo(Action.DENY));
     assertThat(policyDisable.getStatus(), equalTo(Policy.Status.DISABLE));
@@ -603,8 +602,8 @@ public final class FortiosGrammarTest {
     assertThat(policyAny.getService(), contains(serviceAll));
     assertThat(policyAny.getSrcAddr(), contains(addrAll));
     assertThat(policyAny.getDstAddr(), contains(addrAll));
-    assertThat(policyAny.getSrcIntf(), contains(InterfaceAny.INSTANCE));
-    assertThat(policyAny.getDstIntf(), contains(InterfaceAny.INSTANCE));
+    assertThat(policyAny.getSrcIntf(), contains(Policy.ANY_INTERFACE));
+    assertThat(policyAny.getDstIntf(), contains(Policy.ANY_INTERFACE));
   }
 
   /**
@@ -630,9 +629,9 @@ public final class FortiosGrammarTest {
     assertThat(addresses, hasKeys(containsInAnyOrder(addr10, addr20)));
 
     Map<String, Interface> interfaces = vc.getInterfaces();
-    assertThat(interfaces, hasKeys(containsInAnyOrder("port10", "port20")));
-    Interface port10 = interfaces.get("port10");
-    Interface port20 = interfaces.get("port20");
+    String port10 = "port10";
+    String port20 = "port20";
+    assertThat(interfaces, hasKeys(containsInAnyOrder(port10, port20)));
 
     // Confirm invalid any/all specifiers are dropped when appropriate
     assertThat(policy.getSrcIntf(), contains(port10));
@@ -641,7 +640,7 @@ public final class FortiosGrammarTest {
     // Confirm a line with invalid ALL service is ignored; i.e. previous value isn't overwritten
     assertThat(policy.getService(), contains(service20));
     // Confirm a line with dstintf combining any and another interface is accepted
-    assertThat(policy.getDstIntf(), containsInAnyOrder(InterfaceAny.INSTANCE, port20));
+    assertThat(policy.getDstIntf(), containsInAnyOrder(Policy.ANY_INTERFACE, port20));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/fortios/AddressTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/fortios/AddressTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 public class AddressTest {
   @Test
   public void testToIpSpace_ipmask() {
-    Address address = new Address("name");
+    Address address = new Address("name", new BatfishUUID(1));
     Prefix prefix = Prefix.parse("1.1.1.0/24");
     address.getTypeSpecificFields().setSubnet(prefix);
     assertConvertsWithoutWarnings(address, prefix.toIpSpace());
@@ -27,7 +27,7 @@ public class AddressTest {
 
   @Test
   public void testToIpSpace_iprange() {
-    Address address = new Address("name");
+    Address address = new Address("name", new BatfishUUID(1));
     address.setType(Address.Type.IPRANGE);
     Ip startIp = Ip.parse("1.1.1.0");
     Ip endIp = Ip.parse("1.1.1.255");
@@ -38,7 +38,7 @@ public class AddressTest {
 
   @Test
   public void testToIpSpace_wildcard() {
-    Address address = new Address("name");
+    Address address = new Address("name", new BatfishUUID(1));
     address.setType(Address.Type.WILDCARD);
     IpWildcard wildcard =
         IpWildcard.ipWithWildcardMask(Ip.parse("1.1.1.1"), Ip.parse("255.0.255.128"));
@@ -56,7 +56,7 @@ public class AddressTest {
             Address.Type.MAC)
         .forEach(
             unsupportedType -> {
-              Address address = new Address("name");
+              Address address = new Address("name", new BatfishUUID(1));
               address.setType(unsupportedType);
               Warnings w = new Warnings(true, true, true);
               assertThat(address.toIpSpace(w), equalTo(EmptyIpSpace.INSTANCE));

--- a/projects/batfish/src/test/java/org/batfish/representation/fortios/BUILD
+++ b/projects/batfish/src/test/java/org/batfish/representation/fortios/BUILD
@@ -17,7 +17,9 @@ junit_tests(
         "//projects/batfish/src/main/java/org/batfish/representation/fortios",
         "//projects/bdd",
         "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
         "@maven//:junit_junit",
+        "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",
     ],
 )

--- a/projects/batfish/src/test/java/org/batfish/representation/fortios/BatfishUUIDTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/fortios/BatfishUUIDTest.java
@@ -10,17 +10,15 @@ import org.junit.Test;
 public class BatfishUUIDTest {
   @Test
   public void testJavaSerialization() {
-    BatfishUUID uuid = new BatfishUUID();
+    BatfishUUID uuid = new BatfishUUID(1);
     assertThat(SerializationUtils.clone(uuid), equalTo(uuid));
   }
 
   @Test
   public void testEquals() {
-    BatfishUUID uuid1 = new BatfishUUID();
-    BatfishUUID uuid2 = new BatfishUUID();
     new EqualsTester()
-        .addEqualityGroup(uuid1)
-        .addEqualityGroup(uuid2)
+        .addEqualityGroup(new BatfishUUID(1), new BatfishUUID(1))
+        .addEqualityGroup(new BatfishUUID(2))
         .addEqualityGroup(new Object())
         .testEquals();
   }

--- a/projects/batfish/src/test/java/org/batfish/representation/fortios/BatfishUUIDTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/fortios/BatfishUUIDTest.java
@@ -1,0 +1,27 @@
+package org.batfish.representation.fortios;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Test;
+
+public class BatfishUUIDTest {
+  @Test
+  public void testJavaSerialization() {
+    BatfishUUID uuid = new BatfishUUID();
+    assertThat(SerializationUtils.clone(uuid), equalTo(uuid));
+  }
+
+  @Test
+  public void testEquals() {
+    BatfishUUID uuid1 = new BatfishUUID();
+    BatfishUUID uuid2 = new BatfishUUID();
+    new EqualsTester()
+        .addEqualityGroup(uuid1)
+        .addEqualityGroup(uuid2)
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+}

--- a/projects/batfish/src/test/java/org/batfish/representation/fortios/ServiceTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/fortios/ServiceTest.java
@@ -38,7 +38,7 @@ public class ServiceTest {
   public void testToMatchExpr_tcpUdpSctp_defaults() {
     // Default service with no dst ports specified matches nothing and files warning
     String svcName = "name";
-    Service service = new Service(svcName);
+    Service service = new Service(svcName, new BatfishUUID(1));
     Warnings w = new Warnings(true, true, true);
     assertThat(ACL_TO_BDD.toBdd(service.toMatchExpr(w)), equalTo(ZERO));
     assertThat(
@@ -53,7 +53,7 @@ public class ServiceTest {
   @Test
   public void testToMatchExpr_tcpUdpSctp_oneCustom() {
     IntegerSpace tcpDstPorts = IntegerSpace.of(1);
-    Service service = new Service("name");
+    Service service = new Service("name", new BatfishUUID(1));
     service.setTcpPortRangeDst(tcpDstPorts);
     BDD tcp =
         HS_TO_BDD.toBDD(
@@ -76,7 +76,7 @@ public class ServiceTest {
     IntegerSpace udpDstPorts = IntegerSpace.of(4);
     IntegerSpace sctpSrcPorts = IntegerSpace.of(5);
     IntegerSpace sctpDstPorts = IntegerSpace.of(6);
-    Service service = new Service("name");
+    Service service = new Service("name", new BatfishUUID(1));
     service.setTcpPortRangeSrc(tcpSrcPorts);
     service.setTcpPortRangeDst(tcpDstPorts);
     service.setUdpPortRangeSrc(udpSrcPorts);
@@ -110,7 +110,7 @@ public class ServiceTest {
 
   @Test
   public void testToMatchExpr_icmp_defaults() {
-    Service service = new Service("name");
+    Service service = new Service("name", new BatfishUUID(1));
     service.setProtocol(Service.Protocol.ICMP);
     HeaderSpace expected = HeaderSpace.builder().setIpProtocols(IpProtocol.ICMP).build();
     assertConvertsWithoutWarnings(service, HS_TO_BDD.toBDD(expected));
@@ -118,7 +118,7 @@ public class ServiceTest {
 
   @Test
   public void testToMatchExpr_icmp6_defaults() {
-    Service service = new Service("name");
+    Service service = new Service("name", new BatfishUUID(1));
     service.setProtocol(Service.Protocol.ICMP6);
     HeaderSpace expected = HeaderSpace.builder().setIpProtocols(IpProtocol.IPV6_ICMP).build();
     assertConvertsWithoutWarnings(service, HS_TO_BDD.toBDD(expected));
@@ -128,7 +128,7 @@ public class ServiceTest {
   public void testToMatchExpr_icmp_custom() {
     int icmpCode = 1;
     int icmpType = 2;
-    Service service = new Service("name");
+    Service service = new Service("name", new BatfishUUID(1));
     service.setProtocol(Service.Protocol.ICMP);
     service.setIcmpCode(icmpCode);
     service.setIcmpType(icmpType);
@@ -145,7 +145,7 @@ public class ServiceTest {
   public void testToMatchExpr_icmp6_custom() {
     int icmpCode = 1;
     int icmpType = 2;
-    Service service = new Service("name");
+    Service service = new Service("name", new BatfishUUID(1));
     service.setProtocol(Service.Protocol.ICMP6);
     service.setIcmpCode(icmpCode);
     service.setIcmpType(icmpType);
@@ -160,7 +160,7 @@ public class ServiceTest {
 
   @Test
   public void testToMatchExpr_ip_default() {
-    Service service = new Service("name");
+    Service service = new Service("name", new BatfishUUID(1));
     service.setProtocol(Service.Protocol.IP);
     HeaderSpace expected =
         HeaderSpace.builder()
@@ -172,7 +172,7 @@ public class ServiceTest {
   @Test
   public void testToMatchExpr_ip_custom() {
     int protocolNumber = 88;
-    Service service = new Service("name");
+    Service service = new Service("name", new BatfishUUID(1));
     service.setProtocol(Service.Protocol.IP);
     service.setProtocolNumber(protocolNumber);
     HeaderSpace expected =
@@ -183,7 +183,7 @@ public class ServiceTest {
   @Test
   public void testToMatchExpr_traceElement() {
     String svcName = "name";
-    Service service = new Service(svcName);
+    Service service = new Service(svcName, new BatfishUUID(1));
     service.setProtocol(Service.Protocol.ICMP);
     assertThat(
         service.toMatchExpr(new Warnings()).getTraceElement(),


### PR DESCRIPTION
This PR changes how we track renamable structure references. Instead of keeping track of object references, we now track a Batfish-specific UUID for each object, which is converted to a name at the end of extraction (when rename operations are complete).

This allows us to still rename structures without affecting references, correctly clone and replace objects (i.e. speculatively build a modified object before we know if a config block is value), avoid serializing graphs, etc.
