### PR TITLE
JunOS: parse and warn on no-prepend-global-as

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniperLexer.g4
@@ -1751,6 +1751,8 @@ NO_PING_RECORD_ROUTE: 'no-ping-record-route';
 
 NO_PING_TIME_STAMP: 'no-ping-time-stamp';
 
+NO_PREPEND_GLOBAL_AS: 'no-prepend-global-as';
+
 NO_READVERTISE: 'no-readvertise';
 
 NO_REDIRECTS: 'no-redirects';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_bgp.g4
@@ -449,12 +449,18 @@ bl_common
 :
    bl_alias
    | bl_loops
+   | bl_no_prepend_global_as
    | bl_private
 ;
 
 bl_loops
 :
    LOOPS dec
+;
+
+bl_no_prepend_global_as
+:
+   NO_PREPEND_GLOBAL_AS
 ;
 
 bl_number

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -3839,7 +3839,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
 
   @Override
   public void exitBl_no_prepend_global_as(Bl_no_prepend_global_asContext ctx) {
-    todo(ctx);
+    _currentBgpGroup.setNoPrependGlobalAs(true);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -214,7 +214,9 @@ import org.batfish.grammar.flatjuniper.FlatJuniperParser.BandwidthContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bfiu_loopsContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bfiu_rib_groupContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bgp_asnContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bl_aliasContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bl_loopsContext;
+import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bl_no_prepend_global_asContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bl_numberContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bl_privateContext;
 import org.batfish.grammar.flatjuniper.FlatJuniperParser.Bpa_asContext;
@@ -3824,10 +3826,20 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   }
 
   @Override
+  public void exitBl_alias(Bl_aliasContext ctx) {
+    todo(ctx);
+  }
+
+  @Override
   public void exitBl_loops(Bl_loopsContext ctx) {
     todo(ctx);
     int loops = toInt(ctx.dec());
     _currentBgpGroup.setLoops(loops);
+  }
+
+  @Override
+  public void exitBl_no_prepend_global_as(Bl_no_prepend_global_asContext ctx) {
+    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/BgpGroup.java
@@ -36,6 +36,7 @@ public class BgpGroup implements Serializable {
   private Integer _loops;
   private Boolean _multipath;
   private Boolean _multipathMultipleAs;
+  private Boolean _noPrependGlobalAs;
   private BgpGroup _parent;
   private Long _peerAs;
   private @Nullable Integer _preference;
@@ -109,6 +110,9 @@ public class BgpGroup implements Serializable {
       }
       if (_multipathMultipleAs == null) {
         _multipathMultipleAs = _parent._multipathMultipleAs;
+      }
+      if (_noPrependGlobalAs == null) {
+        _noPrependGlobalAs = _parent._noPrependGlobalAs;
       }
       if (_peerAs == null) {
         _peerAs = _parent._peerAs;
@@ -309,6 +313,14 @@ public class BgpGroup implements Serializable {
 
   public void setMultipathMultipleAs(Boolean multipathMultipleAs) {
     _multipathMultipleAs = multipathMultipleAs;
+  }
+
+  public @Nullable Boolean getNoPrependGlobalAs() {
+    return _noPrependGlobalAs;
+  }
+
+  public void setNoPrependGlobalAs(@Nullable Boolean noPrependGlobalAs) {
+    _noPrependGlobalAs = noPrependGlobalAs;
   }
 
   public final void setParent(BgpGroup parent) {

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -475,7 +475,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       if (!ibgp) {
         // Do not include iBGP peer [groups] in this computation: multiple-as only matters for
         // eBGP multipath (in iBGP, the next AS is always the same, and iBGP routes are always
-        // worse than eBGP routes).org.batfish.grammar.flatjuniper.FlatJuniperGrammarTest
+        // worse than eBGP routes).
         //
         // As the iBGP setting does not matter, don't look for conflicts with it. We have seen
         // it set 'inconsistently' in real configs.
@@ -630,6 +630,14 @@ public final class JuniperConfiguration extends VendorConfiguration {
       if (ig.getLocalAs() == null) {
         _w.redFlag("Missing local-as for neighbor: " + ig.getRemoteAddress());
         continue;
+      }
+
+      // Warn if configured to prepend global-as, plus global-as and local-as both exist
+      boolean prependGlobalAs = !ibgp && !firstNonNull(ig.getNoPrependGlobalAs(), Boolean.FALSE);
+      if (prependGlobalAs
+          && mg.getLocalAs() != null
+          && mg.getLocalAs().longValue() != ig.getLocalAs().longValue()) {
+        _w.redFlag("Unimplemented: prepending both local-as and global-as for BGP routes");
       }
 
       /* Inherit multipath */

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -963,6 +963,22 @@ public final class FlatJuniperGrammarTest {
     assertThat(def.getBgpProcess().getAdminCost(RoutingProtocol.IBGP), equalTo(140));
   }
 
+  /** For https://github.com/batfish/batfish/issues/6710 */
+  @Test
+  public void testBgpRoutingOptionsAutonomousSystemGH6710() {
+    Configuration c = parseConfig("bgp-routing-options-as-gh-6710");
+    Vrf def = c.getDefaultVrf();
+    assertThat(def.getBgpProcess(), notNullValue());
+    // Peer in group_a should pick up local-as
+    assertThat(
+        def.getBgpProcess().getActiveNeighbors(),
+        hasEntry(equalTo(Prefix.parse("10.255.16.23/32")), hasLocalAs(64611L)));
+    // Peer in group_b should pick up routing-options autonomous-system
+    assertThat(
+        def.getBgpProcess().getActiveNeighbors(),
+        hasEntry(equalTo(Prefix.parse("10.255.42.23/32")), hasLocalAs(1111L)));
+  }
+
   @Test
   public void testBgpMultipathMultipleAs() throws IOException {
     String testrigName = "multipath-multiple-as";

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-routing-options-as-gh-6710
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/bgp-routing-options-as-gh-6710
@@ -1,0 +1,34 @@
+#RANCID-CONTENT-TYPE: juniper
+system {
+  host-name bgp-routing-options-as-gh-6710;
+}
+#
+routing-options {
+    router-id 111.0.0.1;
+    autonomous-system 1111 loops 3;
+}
+groups {
+  replace:
+  mesh_bgp{
+    protocols {
+      bgp {
+        group group_a {
+          type external;
+          local-as 64611 private no-prepend-global-as;
+          neighbor 10.255.16.23 {
+            description group_a-to_1;
+            peer-as 64616;
+          }
+        }
+        group group_b {
+          type external;
+          neighbor 10.255.42.23 {
+            description group_b-to_1;
+            peer-as 64642;
+          }
+        }
+      }
+    }
+  }
+}
+apply-groups mesh_bgp;

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -80254,7 +80254,7 @@
         "variables" : "PASSED",
         "variables_dos" : "PASSED",
         "vlan_access_map4" : "PASSED",
-        "vmx4" : "WARNINGS"
+        "vmx4" : "PASSED"
       },
       "definedStructures" : {
         "aws_configs" : { },
@@ -93916,14 +93916,6 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "NAT rule MISSING_TO ignored because it has no to zone configured"
-            }
-          ]
-        },
-        "vmx4" : {
-          "Red flags" : [
-            {
-              "tag" : "MISCELLANEOUS",
-              "text" : "Unimplemented: prepending both local-as and global-as for BGP routes"
             }
           ]
         }

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -80254,7 +80254,7 @@
         "variables" : "PASSED",
         "variables_dos" : "PASSED",
         "vlan_access_map4" : "PASSED",
-        "vmx4" : "PASSED"
+        "vmx4" : "WARNINGS"
       },
       "definedStructures" : {
         "aws_configs" : { },
@@ -93916,6 +93916,14 @@
             {
               "tag" : "MISCELLANEOUS",
               "text" : "NAT rule MISSING_TO ignored because it has no to zone configured"
+            }
+          ]
+        },
+        "vmx4" : {
+          "Red flags" : [
+            {
+              "tag" : "MISCELLANEOUS",
+              "text" : "Unimplemented: prepending both local-as and global-as for BGP routes"
             }
           ]
         }


### PR DESCRIPTION
Add missing warnings for related constructs.

This is for batfish/batfish#6710.