### PR TITLE
Support for OSPF summary discard routes

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfInternalSummaryRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfInternalSummaryRoute.java
@@ -1,0 +1,124 @@
+package org.batfish.datamodel;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.route.nh.NextHopDiscard;
+
+/** OSPF intra-area route. Must stay within a single OSPF area. */
+@ParametersAreNonnullByDefault
+public class OspfInternalSummaryRoute extends OspfInternalRoute {
+
+  private static final Interner<OspfInternalSummaryRoute> _cache = Interners.newWeakInterner();
+  private int _hashCode;
+
+  @JsonCreator
+  private static OspfInternalSummaryRoute jsonCreator(
+      @Nullable @JsonProperty(PROP_NETWORK) Prefix network,
+      @Nullable @JsonProperty(PROP_ADMINISTRATIVE_COST) Integer admin,
+      @Nullable @JsonProperty(PROP_METRIC) Long metric,
+      @Nullable @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
+      @Nullable @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface,
+      @Nullable @JsonProperty(PROP_AREA) Long area,
+      @JsonProperty(PROP_TAG) long tag) {
+    assert NextHop.legacyConverter(nextHopInterface, nextHopIp).equals(NextHopDiscard.instance());
+    checkArgument(network != null, "%s must be specified", PROP_NETWORK);
+    checkArgument(admin != null, "%s must be specified", PROP_ADMINISTRATIVE_COST);
+    checkArgument(metric != null, "%s must be specified", PROP_METRIC);
+    checkArgument(area != null, "%s must be specified", PROP_AREA);
+    return new OspfInternalSummaryRoute(network, admin, metric, area, tag);
+  }
+
+  public OspfInternalSummaryRoute(Prefix network, int admin, long metric, long area, long tag) {
+    super(network, NextHopDiscard.instance(), admin, metric, area, tag, false, false);
+  }
+
+  @Nonnull
+  @Override
+  public RoutingProtocol getProtocol() {
+    return RoutingProtocol.OSPF_IS;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder
+      extends AbstractRouteBuilder<Builder, OspfInternalSummaryRoute> {
+
+    private long _area;
+
+    @Nonnull
+    @Override
+    public OspfInternalSummaryRoute build() {
+      OspfInternalSummaryRoute r =
+          new OspfInternalSummaryRoute(getNetwork(), getAdmin(), getMetric(), _area, getTag());
+      return _cache.intern(r);
+    }
+
+    @Nonnull
+    @Override
+    protected Builder getThis() {
+      return this;
+    }
+
+    public Builder setArea(long area) {
+      _area = area;
+      return this;
+    }
+
+    private Builder() {}
+  }
+
+  /////// Keep #toBuilder, #equals, and #hashCode in sync ////////
+
+  @Override
+  public Builder toBuilder() {
+    return builder()
+        // AbstractRoute properties
+        .setNetwork(getNetwork())
+        .setNextHop(NextHopDiscard.instance())
+        .setAdmin(_admin)
+        .setMetric(_metric)
+        .setTag(_tag)
+        // OspfInternalSummaryRoute properties
+        .setArea(getArea());
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (o == this) {
+      return true;
+    } else if (!(o instanceof OspfInternalSummaryRoute)) {
+      return false;
+    }
+    OspfInternalSummaryRoute other = (OspfInternalSummaryRoute) o;
+    return _network.equals(other._network)
+        && _admin == other._admin
+        && _area == other._area
+        && _metric == other._metric
+        && _tag == other._tag;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = _hashCode;
+    if (h == 0) {
+      h = _network.hashCode();
+      h = 31 * h + _admin;
+      h = 31 * h + Long.hashCode(_area);
+      h = 31 * h + Long.hashCode(_metric);
+      h = 31 * h + Long.hashCode(_tag);
+
+      _hashCode = h;
+    }
+    return h;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RoutingProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RoutingProtocol.java
@@ -26,10 +26,16 @@ public enum RoutingProtocol {
   LISP("lisp"),
   LOCAL("local"),
   MSDP("msdp"),
+  /** OSPF Intra-area */
   OSPF("ospf"),
+  /** OSPF External type 1 */
   OSPF_E1("ospfE1"),
+  /** OSPF External type 2 */
   OSPF_E2("ospfE2"),
+  /** OSPF Inter-area */
   OSPF_IA("ospfIA"),
+  /** OSPF Internal summary */
+  OSPF_IS("ospfIS"),
   OSPF3("ospf3"),
   RIP("rip"),
   RSVP("rsvp"),
@@ -586,6 +592,48 @@ public enum RoutingProtocol {
           case CADANT:
             // TODO: verify. assumption based on incrementing IS-IS costs in manual.
             return 111;
+          case ARUBAOS: // TODO: verify https://github.com/batfish/batfish/issues/1548
+          case CISCO_ASA:
+          case CISCO_IOS:
+          case CISCO_IOS_XR:
+          case CISCO_NX:
+          case FORCE10:
+          case FOUNDRY:
+            return 110;
+          case FLAT_JUNIPER:
+          case JUNIPER:
+          case JUNIPER_SWITCH:
+            return 10;
+          case FLAT_VYOS:
+          case VYOS:
+            return 110;
+          case EMPTY:
+          case IGNORED:
+          case BLADENETWORK:
+          case F5:
+          case HOST:
+          case IPTABLES:
+          case MRV:
+          case MRV_COMMANDS:
+          case MSS:
+          case UNKNOWN:
+          case VXWORKS:
+            break;
+          default:
+            break;
+        }
+        break;
+
+      case OSPF_IS:
+        switch (vendor) {
+          case ALCATEL_AOS:
+            break;
+          case ARISTA:
+            return 110;
+          case AWS:
+            return 110;
+          case CADANT: // TODO: verify
+            return 110;
           case ARUBAOS: // TODO: verify https://github.com/batfish/batfish/issues/1548
           case CISCO_ASA:
           case CISCO_IOS:

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfInternalSummaryRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfInternalSummaryRouteTest.java
@@ -1,0 +1,53 @@
+package org.batfish.datamodel;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.junit.Test;
+
+/** Tests of {@link OspfInternalSummaryRoute} */
+public class OspfInternalSummaryRouteTest {
+
+  @Test
+  public void testEquals() {
+    OspfInternalSummaryRoute.Builder builder =
+        OspfInternalSummaryRoute.builder().setArea(0).setNetwork(Prefix.ZERO);
+    OspfInternalSummaryRoute r = builder.build();
+    new EqualsTester()
+        .addEqualityGroup(r, r, builder.build())
+        .addEqualityGroup(builder.setNetwork(Prefix.parse("1.1.1.1/32")).build())
+        .addEqualityGroup(builder.setAdmin(1000).build())
+        .addEqualityGroup(builder.setArea(2L).build())
+        .addEqualityGroup(builder.setMetric(20L).build())
+        .addEqualityGroup(new Object())
+        .testEquals();
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    OspfInternalSummaryRoute r =
+        OspfInternalSummaryRoute.builder().setArea(0).setNetwork(Prefix.ZERO).build();
+    assertThat(SerializationUtils.clone(r), equalTo(r));
+  }
+
+  @Test
+  public void testJsonSerialization() {
+    OspfInternalSummaryRoute r =
+        OspfInternalSummaryRoute.builder().setArea(0).setNetwork(Prefix.ZERO).build();
+    assertThat(BatfishObjectMapper.clone(r, OspfInternalSummaryRoute.class), equalTo(r));
+  }
+
+  @Test
+  public void testToBuilder() {
+    OspfInternalSummaryRoute r =
+        OspfInternalSummaryRoute.builder()
+            .setNetwork(Prefix.parse("1.1.1.0/24"))
+            .setMetric(1L)
+            .setArea(2L)
+            .build();
+    assertThat(r.toBuilder().build(), equalTo(r));
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/OspfRoutingProcess.java
@@ -38,6 +38,7 @@ import org.batfish.datamodel.OspfExternalRoute;
 import org.batfish.datamodel.OspfExternalType1Route;
 import org.batfish.datamodel.OspfExternalType2Route;
 import org.batfish.datamodel.OspfInterAreaRoute;
+import org.batfish.datamodel.OspfInternalSummaryRoute;
 import org.batfish.datamodel.OspfIntraAreaRoute;
 import org.batfish.datamodel.OspfRoute;
 import org.batfish.datamodel.Prefix;
@@ -175,7 +176,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
     }
 
     _changeset = RibDelta.builder();
-    _initializationDelta = new InternalDelta(RibDelta.empty(), RibDelta.empty());
+    _initializationDelta = new InternalDelta(RibDelta.empty(), RibDelta.empty(), RibDelta.empty());
     _queuedForRedistribution = new ExternalDelta();
     _activatedGeneratedRoutes = RibDelta.empty();
     _neighborsWhereDefaultIARouteWasInjected = new HashSet<>(0);
@@ -192,7 +193,8 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
       // If we haven't sent out the first round of updates after initialization, do so now. Then
       // clear the initialization delta
       sendOutInternalRoutes(_initializationDelta, allNodes, _topology);
-      _initializationDelta = new InternalDelta(RibDelta.empty(), RibDelta.empty());
+      _initializationDelta =
+          new InternalDelta(RibDelta.empty(), RibDelta.empty(), RibDelta.empty());
     }
 
     // Process internal routes
@@ -214,6 +216,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
     // Keep track of what what updates will go into the main RIB
     _changeset.from(RibDelta.importRibDelta(_ospfRib, internalDelta._intraArea));
     _changeset.from(RibDelta.importRibDelta(_ospfRib, internalDelta._interArea));
+    _changeset.from(RibDelta.importRibDelta(_ospfRib, internalDelta._internalSummary));
     _changeset.from(RibDelta.importRibDelta(_ospfRib, externalDelta._type1));
     _changeset.from(RibDelta.importRibDelta(_ospfRib, externalDelta._type2));
   }
@@ -346,7 +349,8 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
               r -> interAreaBuilder.add(OspfInterAreaRoute.builder(r).setNonRouting(true).build()));
     }
 
-    _initializationDelta = new InternalDelta(intraAreaDelta, interAreaBuilder.build());
+    _initializationDelta =
+        new InternalDelta(intraAreaDelta, interAreaBuilder.build(), RibDelta.empty());
     _changeset.from(RibDelta.importRibDelta(_ospfRib, intraAreaDelta));
   }
 
@@ -476,11 +480,18 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   private InternalDelta processInternalRoutes() {
     InternalDelta intraProcessingDelta = processIntraAreaRoutes();
     RibDelta.Builder<OspfInterAreaRoute> interAreaDelta = processInterAreaRoutes();
-    RibDelta<OspfInterAreaRoute> deltaOfSummaries = computeInterAreaSummaries();
+    // non-forwarding, for re-advertisement only
+    RibDelta<OspfInterAreaRoute> deltaOfInterAreaSummaries = computeInterAreaSummaries();
+    // discard summary routes for local use only
+    RibDelta<OspfInternalSummaryRoute> deltaOfInternalSummaries = computeInternalSummaries();
     // Merge inter-area deltas
     return new InternalDelta(
         intraProcessingDelta._intraArea,
-        interAreaDelta.from(intraProcessingDelta._interArea).from(deltaOfSummaries).build());
+        interAreaDelta
+            .from(intraProcessingDelta._interArea)
+            .from(deltaOfInterAreaSummaries)
+            .build(),
+        deltaOfInternalSummaries);
   }
 
   /**
@@ -591,7 +602,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
                 intraAreaDelta, interAreaDelta, ifaceName, incrementalCost, routeAdvertisement);
           }
         });
-    return new InternalDelta(intraAreaDelta.build(), interAreaDelta.build());
+    return new InternalDelta(intraAreaDelta.build(), interAreaDelta.build(), RibDelta.empty());
   }
 
   /**
@@ -671,6 +682,22 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
     return deltaBuilder.build();
   }
 
+  /**
+   * Compute internal summaries. Only applies to an ABR. Will return a {@link RibDelta} for all new
+   * internal summary discard routes to install, or empty delta if not an ABR.
+   */
+  @Nonnull
+  private RibDelta<OspfInternalSummaryRoute> computeInternalSummaries() {
+    if (!isABR()) {
+      return RibDelta.empty();
+    }
+    RibDelta.Builder<OspfInternalSummaryRoute> deltaBuilder = RibDelta.builder();
+    _process.getAreas().values().stream()
+        .map(this::computeInternalSummariesForArea)
+        .forEach(deltaBuilder::from);
+    return deltaBuilder.build();
+  }
+
   /** Compute inter-area summaries for a single area. */
   @Nonnull
   private RibDelta<OspfInterAreaRoute> computeInterAreaSummariesForArea(OspfArea area) {
@@ -678,13 +705,27 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
     area.getSummaries()
         .forEach(
             (prefix, summary) ->
-                computeSummaryRoute(prefix, summary, area.getAreaNumber())
+                computeInterAreaSummaryRoute(prefix, summary, area.getAreaNumber())
                     .ifPresent(r -> deltaBuilder.from(_interAreaRib.mergeRouteGetDelta(r))));
     return deltaBuilder.build();
   }
 
+  /** Compute internal summaries for a single area. */
+  @Nonnull
+  private RibDelta<OspfInternalSummaryRoute> computeInternalSummariesForArea(OspfArea area) {
+    RibDelta.Builder<OspfInternalSummaryRoute> deltaBuilder = RibDelta.builder();
+    area.getSummaries()
+        .keySet()
+        .forEach(
+            prefix ->
+                computeInternalSummaryRoute(prefix, area.getAreaNumber())
+                    // TODO: support withdrawals
+                    .ifPresent(r -> deltaBuilder.add(r)));
+    return deltaBuilder.build();
+  }
+
   /**
-   * Compute a summary route for a given area and prefix.
+   * Compute an inter-area summary route for a given area and prefix.
    *
    * <p><emph>Note:</emph> The resulting route will be marked non-routing
    *
@@ -696,12 +737,11 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
    *     no contributing routes, otherwise an optional containing a new inter-area route
    */
   @Nonnull
-  private Optional<OspfInterAreaRoute> computeSummaryRoute(
+  private Optional<OspfInterAreaRoute> computeInterAreaSummaryRoute(
       Prefix prefix, OspfAreaSummary summary, long areaNumber) {
     if (!summary.getAdvertised()) {
       return Optional.empty();
     }
-
     /*
     TODO:
       1. make summary computation delta-driven (No need to scan over all RIB routes)
@@ -711,8 +751,7 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
      Both are only applicable to fully incremental computation
      */
     Stream<Long> contributingMetrics =
-        Stream.concat(
-                _intraAreaRib.getTypedRoutes().stream(), _interAreaRib.getTypedRoutes().stream())
+        _intraAreaRib.getTypedRoutes().stream()
             .filter(
                 /*
                  * Only routes in the same area and within the summary prefix can
@@ -742,6 +781,50 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
             .setArea(areaNumber)
             // Note the non-routing bit: must not go into our own main RIB
             .setNonRouting(true)
+            .build();
+    return Optional.of(summaryRoute);
+  }
+
+  /**
+   * Compute an internal summary discard route for a given area and prefix.
+   *
+   * <p><emph>Note:</emph> The resulting route will be used as a local discard route only. The
+   * summary that gets advertised is an {@link OspfInterAreaRoute}, computed separately.
+   *
+   * @param prefix The prefix for which to create a summary route
+   * @param areaNumber area number for which to generate the route
+   * @return {@link Optional#empty()} if there are no contributing routes, otherwise an optional
+   *     containing a new internal summary route
+   */
+  @Nonnull
+  private Optional<OspfInternalSummaryRoute> computeInternalSummaryRoute(
+      Prefix prefix, long areaNumber) {
+    /*
+    TODO:
+      1. make summary computation delta-driven (No need to scan over all RIB routes)
+      2. add dependency tracking so a withdrawn route may trigger summary withdrawal
+         (if remaining number of contributing routes is 0).
+
+     Both are only applicable to fully incremental computation
+     */
+    if (!_intraAreaRib.getTypedRoutes().stream()
+        .anyMatch(
+            /*
+             * Only routes in the same area and within the summary prefix can
+             * contribute to creation of summary route
+             */
+            candidateContributor ->
+                candidateContributor.getArea() == areaNumber
+                    && prefix.containsPrefix(candidateContributor.getNetwork()))) {
+      return Optional.empty();
+    }
+
+    OspfInternalSummaryRoute summaryRoute =
+        OspfInternalSummaryRoute.builder()
+            .setNetwork(prefix)
+            .setAdmin(_process.getAdminCosts().get(RoutingProtocol.OSPF_IS))
+            .setMetric(_process.getSummaryDiscardMetric())
+            .setArea(areaNumber)
             .build();
     return Optional.of(summaryRoute);
   }
@@ -1544,14 +1627,19 @@ final class OspfRoutingProcess implements RoutingProcess<OspfTopology, OspfRoute
   private static final class InternalDelta {
     @Nonnull private final RibDelta<OspfIntraAreaRoute> _intraArea;
     @Nonnull private final RibDelta<OspfInterAreaRoute> _interArea;
+    @Nonnull private final RibDelta<OspfInternalSummaryRoute> _internalSummary;
 
-    InternalDelta(RibDelta<OspfIntraAreaRoute> intraArea, RibDelta<OspfInterAreaRoute> interArea) {
+    InternalDelta(
+        RibDelta<OspfIntraAreaRoute> intraArea,
+        RibDelta<OspfInterAreaRoute> interArea,
+        RibDelta<OspfInternalSummaryRoute> internalSummary) {
       _intraArea = intraArea;
       _interArea = interArea;
+      _internalSummary = internalSummary;
     }
 
     private boolean isEmpty() {
-      return _intraArea.isEmpty() && _interArea.isEmpty();
+      return _intraArea.isEmpty() && _interArea.isEmpty() && _internalSummary.isEmpty();
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/OspfRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/OspfRib.java
@@ -24,11 +24,14 @@ public class OspfRib extends AbstractRib<OspfRoute> {
       case OSPF:
         return 0;
       case OSPF_E1:
-        return 2;
-      case OSPF_E2:
         return 3;
+      case OSPF_E2:
+        return 4;
       case OSPF_IA:
+        return 2;
+      case OSPF_IS:
         return 1;
+
         // $CASES-OMITTED$
       default:
         throw new BatfishException("Invalid OSPF protocol: '" + protocol + "'");

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -15,6 +15,7 @@ import static org.batfish.representation.juniper.NatPacketLocation.interfaceLoca
 import static org.batfish.representation.juniper.NatPacketLocation.routingInstanceLocation;
 import static org.batfish.representation.juniper.NatPacketLocation.zoneLocation;
 import static org.batfish.representation.juniper.RoutingInformationBase.RIB_IPV4_UNICAST;
+import static org.batfish.representation.juniper.RoutingInstance.OSPF_INTERNAL_SUMMARY_DISCARD_METRIC;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
@@ -1101,6 +1102,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
             .setSummaryAdminCost(
                 RoutingProtocol.OSPF_IA.getSummaryAdministrativeCost(_c.getConfigurationFormat()))
             .setRouterId(ospfRouterId)
+            .setSummaryDiscardMetric(OSPF_INTERNAL_SUMMARY_DISCARD_METRIC)
             .build();
     String vrfName = routingInstance.getName();
     // export policies
@@ -3437,15 +3439,6 @@ public final class JuniperConfiguration extends VendorConfiguration {
         OspfProcess oproc = createOspfProcess(ri);
         if (oproc != null) {
           vrf.setOspfProcesses(ImmutableSortedMap.of(oproc.getProcessId(), oproc));
-          // add discard routes for OSPF summaries
-          oproc.getAreas().values().stream()
-              .flatMap(a -> a.getSummaries().entrySet().stream())
-              .forEach(
-                  summaryEntry ->
-                      vrf.getGeneratedRoutes()
-                          .add(
-                              ospfSummaryToAggregateRoute(
-                                  summaryEntry.getKey(), summaryEntry.getValue())));
         }
       }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
@@ -20,6 +20,7 @@ import org.batfish.datamodel.SnmpServer;
 
 public class RoutingInstance implements Serializable {
 
+  public static final long OSPF_INTERNAL_SUMMARY_DISCARD_METRIC = 0x00FFFFFFL;
   private static final double DEFAULT_OSPF_REFERENCE_BANDWIDTH = 1E9;
   private static final String MASTER_INTERFACE_NAME = "MASTER_INTERFACE";
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -122,6 +122,8 @@ public class OspfRoutingProcessTest {
       ImmutableMap.of(
           RoutingProtocol.OSPF,
           100,
+          RoutingProtocol.OSPF_IS,
+          150,
           RoutingProtocol.OSPF_IA,
           200,
           RoutingProtocol.OSPF_E1,

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -63,7 +63,6 @@ import static org.batfish.datamodel.matchers.DataModelMatchers.hasRouteFilterLis
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasRouteFilterLists;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasUndefinedReference;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasUndefinedReferenceWithReferenceLines;
-import static org.batfish.datamodel.matchers.GeneratedRouteMatchers.isDiscard;
 import static org.batfish.datamodel.matchers.IkePhase1PolicyMatchers.hasIkePhase1Key;
 import static org.batfish.datamodel.matchers.IkePhase1PolicyMatchers.hasIkePhase1Proposals;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAccessVlan;
@@ -122,7 +121,6 @@ import static org.batfish.datamodel.matchers.RouteFilterListMatchers.permits;
 import static org.batfish.datamodel.matchers.SetAdministrativeCostMatchers.hasAdmin;
 import static org.batfish.datamodel.matchers.SetAdministrativeCostMatchers.isSetAdministrativeCostThat;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasBgpProcess;
-import static org.batfish.datamodel.matchers.VrfMatchers.hasGeneratedRoutes;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasOspfProcess;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasStaticRoutes;
 import static org.batfish.datamodel.transformation.IpField.DESTINATION;
@@ -159,6 +157,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.INTERFACE
 import static org.batfish.representation.juniper.JuniperStructureUsage.OSPF_AREA_INTERFACE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.POLICY_STATEMENT_FROM_COMMUNITY;
 import static org.batfish.representation.juniper.JuniperStructureUsage.SECURITY_POLICY_MATCH_APPLICATION;
+import static org.batfish.representation.juniper.RoutingInstance.OSPF_INTERNAL_SUMMARY_DISCARD_METRIC;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.anything;
@@ -2527,6 +2526,15 @@ public final class FlatJuniperGrammarTest {
   }
 
   @Test
+  public void testOspfSummaryDiscardMetric() {
+    String hostname = "ospf-reference-bandwidth";
+    Configuration c = parseConfig(hostname);
+    assertThat(
+        c.getDefaultVrf().getOspfProcesses().get(DEFAULT_VRF_NAME).getSummaryDiscardMetric(),
+        equalTo(OSPF_INTERNAL_SUMMARY_DISCARD_METRIC));
+  }
+
+  @Test
   public void testOspfReferenceBandwidth() {
     String hostname = "ospf-reference-bandwidth";
     Configuration c = parseConfig(hostname);
@@ -4647,11 +4655,6 @@ public final class FlatJuniperGrammarTest {
   public void testOspfSummaries() {
     Configuration c = parseConfig(("ospf-abr-with-summaries"));
 
-    assertThat(
-        c,
-        hasDefaultVrf(
-            hasGeneratedRoutes(
-                hasItem(allOf(hasPrefix(Prefix.parse("10.0.1.0/24")), isDiscard())))));
     assertThat(
         c,
         hasDefaultVrf(

--- a/tests/aws/vimodel-example-aws.ref
+++ b/tests/aws/vimodel-example-aws.ref
@@ -44961,7 +44961,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "0" : {
@@ -44980,7 +44981,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "10.10.255.8",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "bgpProcess" : {

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -2707,7 +2707,8 @@
                 "ospf" : 110,
                 "ospfE1" : 110,
                 "ospfE2" : 110,
-                "ospfIA" : 110
+                "ospfIA" : 110,
+                "ospfIS" : 110
               },
               "areas" : {
                 "1" : {
@@ -2725,7 +2726,8 @@
               "processId" : "1",
               "referenceBandwidth" : 1.0E8,
               "routerId" : "1.1.1.1",
-              "summaryAdminCost" : 254
+              "summaryAdminCost" : 254,
+              "summaryDiscardMetric" : 0
             }
           },
           "bgpProcess" : {

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -1277,7 +1277,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -1295,7 +1296,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "1.1.1.1",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "bgpProcess" : {
@@ -2747,7 +2749,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -2765,7 +2768,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "1.2.2.2",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "bgpProcess" : {
@@ -3227,7 +3231,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -3246,7 +3251,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "1.10.1.1",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "bgpProcess" : {
@@ -4593,7 +4599,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -4612,7 +4619,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.1.1.1",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "aggregateRoutes" : [
@@ -5941,7 +5949,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -5960,7 +5969,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.1.1.2",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "aggregateRoutes" : [
@@ -6628,7 +6638,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -6649,7 +6660,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.1.2.1",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "bgpProcess" : {
@@ -7252,7 +7264,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -7273,7 +7286,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.1.2.2",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "bgpProcess" : {
@@ -9312,7 +9326,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -9331,7 +9346,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.1.3.1",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "bgpProcess" : {
@@ -10162,7 +10178,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -10181,7 +10198,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.1.3.2",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "bgpProcess" : {
@@ -11527,7 +11545,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -11545,7 +11564,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "3.1.1.1",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "bgpProcess" : {
@@ -12816,7 +12836,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -12834,7 +12855,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "3.2.2.2",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "bgpProcess" : {
@@ -13580,7 +13602,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -13599,7 +13622,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "3.10.1.1",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "bgpProcess" : {

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -21767,7 +21767,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "0" : {
@@ -21784,7 +21785,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "192.168.1.0",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             }
           }
@@ -31200,7 +31202,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "0" : {
@@ -31241,7 +31244,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 4.0E10,
                 "routerId" : "1.2.3.4",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             }
           }
@@ -31489,7 +31493,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "0" : {
@@ -31530,27 +31535,31 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "1.1.1.1",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               },
               "abcdefg" : {
                 "adminCosts" : {
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "exportPolicy" : "~OSPF_EXPORT_POLICY:default~",
                 "processId" : "abcdefg",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "1.1.1.1",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               },
               "ignored" : {
                 "adminCosts" : {
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "0" : {
@@ -31579,7 +31588,8 @@
                 "processId" : "ignored",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "1.1.1.1",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             }
           }
@@ -38799,7 +38809,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "0" : {
@@ -38812,7 +38823,8 @@
                 "processId" : "65001",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "10.0.1.1",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "bgpProcess" : {
@@ -39802,7 +39814,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "0" : {
@@ -39820,7 +39833,8 @@
                 "processId" : "1",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "2.130.0.1",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             }
           }
@@ -40749,7 +40763,8 @@
                   "ospf" : 10,
                   "ospfE1" : 150,
                   "ospfE2" : 150,
-                  "ospfIA" : 10
+                  "ospfIA" : 10,
+                  "ospfIS" : 10
                 },
                 "areas" : {
                   "0" : {
@@ -40767,7 +40782,8 @@
                 "processId" : "default",
                 "referenceBandwidth" : 1.0E9,
                 "routerId" : "10.1.2.3",
-                "summaryAdminCost" : 10
+                "summaryAdminCost" : 10,
+                "summaryDiscardMetric" : 0
               }
             }
           }
@@ -42698,7 +42714,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "0" : {
@@ -42751,7 +42768,8 @@
                 "processId" : "2",
                 "referenceBandwidth" : 1.0E8,
                 "routerId" : "169.232.1.4",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             }
           }
@@ -66992,16 +67010,6 @@
               }
             ],
             "name" : "~OSPF_SUMMARY_FILTER:default:66051~"
-          },
-          "~SUMMARY1_2_0_0_16_RF~" : {
-            "lines" : [
-              {
-                "action" : "PERMIT",
-                "ipWildcard" : "1.2.0.0/16",
-                "lengthRange" : "17-32"
-              }
-            ],
-            "name" : "~SUMMARY1_2_0_0_16_RF~"
           }
         },
         "routingPolicies" : {
@@ -67030,36 +67038,6 @@
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
                 "type" : "ExitReject"
-              }
-            ]
-          },
-          "~SUMMARY1_2_0_0_16~" : {
-            "name" : "~SUMMARY1_2_0_0_16~",
-            "statements" : [
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "falseStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitReject"
-                  }
-                ],
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
-                  "prefix" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
-                  },
-                  "prefixSet" : {
-                    "class" : "org.batfish.datamodel.routing_policy.expr.NamedPrefixSet",
-                    "name" : "~SUMMARY1_2_0_0_16_RF~"
-                  }
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitAccept"
-                  }
-                ]
               }
             ]
           }
@@ -67106,7 +67084,8 @@
                   "ospf" : 10,
                   "ospfE1" : 150,
                   "ospfE2" : 150,
-                  "ospfIA" : 10
+                  "ospfIA" : 10,
+                  "ospfIS" : 10
                 },
                 "areas" : {
                   "66051" : {
@@ -67132,23 +67111,10 @@
                 "processId" : "default",
                 "referenceBandwidth" : 1.0E9,
                 "routerId" : "1.1.1.1",
-                "summaryAdminCost" : 10
+                "summaryAdminCost" : 10,
+                "summaryDiscardMetric" : 0
               }
-            },
-            "aggregateRoutes" : [
-              {
-                "class" : "org.batfish.datamodel.GeneratedRoute",
-                "administrativeCost" : 10,
-                "asPath" : [ ],
-                "discard" : true,
-                "generationPolicy" : "~SUMMARY1_2_0_0_16~",
-                "metric" : 100,
-                "network" : "1.2.0.0/16",
-                "nextHopInterface" : "null_interface",
-                "nextHopIp" : "AUTO/NONE(-1l)",
-                "tag" : -1
-              }
-            ]
+            }
           }
         }
       },
@@ -71106,7 +71072,8 @@
                   "ospf" : 10,
                   "ospfE1" : 150,
                   "ospfE2" : 150,
-                  "ospfIA" : 10
+                  "ospfIA" : 10,
+                  "ospfIS" : 10
                 },
                 "areas" : {
                   "7" : {
@@ -71134,7 +71101,8 @@
                 "processId" : "default",
                 "referenceBandwidth" : 1.0E9,
                 "routerId" : "1.1.1.1",
-                "summaryAdminCost" : 10
+                "summaryAdminCost" : 10,
+                "summaryDiscardMetric" : 0
               }
             }
           }
@@ -76520,7 +76488,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "areas" : {
                   "1" : {
@@ -76541,21 +76510,24 @@
                 "processId" : "1",
                 "referenceBandwidth" : 4.0E10,
                 "routerId" : "1.2.3.4",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               },
               "ignored" : {
                 "adminCosts" : {
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "maxMetricExternalNetworks" : 65535,
                 "maxMetricTransitLinks" : 65535,
                 "processId" : "ignored",
                 "referenceBandwidth" : 4.0E10,
                 "routerId" : "5.6.7.8",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             }
           },
@@ -76567,36 +76539,42 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "processId" : "1",
                 "referenceBandwidth" : 4.0E10,
                 "routerId" : "1.2.3.4",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               },
               "100" : {
                 "adminCosts" : {
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "processId" : "100",
                 "referenceBandwidth" : 4.0E10,
                 "routerId" : "0.0.0.0",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               },
               "ignored" : {
                 "adminCosts" : {
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "processId" : "ignored",
                 "referenceBandwidth" : 4.0E10,
                 "routerId" : "5.6.7.8",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             },
             "snmpServer" : { }
@@ -76609,7 +76587,8 @@
                   "ospf" : 110,
                   "ospfE1" : 110,
                   "ospfE2" : 110,
-                  "ospfIA" : 110
+                  "ospfIA" : 110,
+                  "ospfIS" : 110
                 },
                 "maxMetricExternalNetworks" : 65535,
                 "maxMetricSummaryNetworks" : 65535,
@@ -76617,7 +76596,8 @@
                 "processId" : "100",
                 "referenceBandwidth" : 4.0E10,
                 "routerId" : "0.0.0.0",
-                "summaryAdminCost" : 254
+                "summaryAdminCost" : 254,
+                "summaryDiscardMetric" : 0
               }
             }
           },


### PR DESCRIPTION
- install a 0-cost discard route for active OSPF inter-area summaries
  - new route type called OspfInternalSummaryRoute
  - install even if summaries are not advertised
- remove Juniper creation of generated route for this purpose
  - behavior now handled in OspfRoutingProcess
- TODO: proper redistribution handling for internal summary routes