### PR TITLE
Juniper: fix a last-line-lost bug

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperLexer.g4
@@ -44,7 +44,7 @@ CLOSE_PAREN
 START_FLAT_LINE
 :
   F_WhitespaceChar* ('activate'|'deactivate'|'delete'|'insert'|'set')
-  {lastTokenType() == -1 || lastTokenType() == NEWLINE}?
+  {lastTokenType() == -1 || lastTokenType() == NEWLINE}? -> pushMode(M_FLAT_LINE)
 ;
 
 INACTIVE
@@ -98,6 +98,27 @@ NEWLINE: F_NewlineChar+ -> channel(HIDDEN);
 WS
 :
    F_WhitespaceChar+ -> skip // so not counted as last token
+;
+
+mode M_FLAT_LINE;
+
+M_FLAT_LINE_WORD
+:
+   (
+      F_QuotedString
+      | F_ParenString
+      | F_WordChar+
+   ) -> type(WORD)
+;
+
+M_FLAT_LINE_NEWLINE
+:
+   F_NewlineChar -> type(NEWLINE), popMode
+;
+
+M_FLAT_LINE_WS
+:
+   F_WhitespaceChar+ -> skip
 ;
 
 fragment

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/juniper/JuniperParser.g4
@@ -28,7 +28,7 @@ statement
 
 flat_statement
 :
-  START_FLAT_LINE words += word+
+  START_FLAT_LINE words += word+ NEWLINE
 ;
 
 hierarchical_statement

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-after
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-after
@@ -8,3 +8,4 @@ set interfaces et-0/0/4 disable
 set policy-options policy-statement p1 term t3 then accept
 set policy-options policy-statement p1 term t4 then accept
 set policy-options policy-statement p1 term t2 then accept
+set policy-options policy-statement p1 term t5 then accept

--- a/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-before
+++ b/projects/batfish/src/test/resources/org/batfish/main/testconfigs/preprocess-flat-before
@@ -25,3 +25,6 @@ set policy-options policy-statement p1 term t4 then accept
 insert policy-options policy-statement p1 term t3 before term t1
 delete policy-options policy-statement p1 term t1
 insert policy-options policy-statement p1 term t4 after term t3
+set policy-options policy-statement p1 term t5 then accept
+
+{master:0}


### PR DESCRIPTION
Because flat lines were not newline-delimited, errors on a next line
could be considered as at the end of a flat line. This would in turn
lead to the flat line being truncated or dropped during preprocessing.

Fix this by adding newlines in the flat mode.