### PR TITLE
OSPF: not-advertised summaries do not install a discard route

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/OspfAreaSummaryMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/OspfAreaSummaryMatchers.java
@@ -3,6 +3,7 @@ package org.batfish.datamodel.matchers;
 import static org.hamcrest.Matchers.equalTo;
 
 import org.batfish.datamodel.matchers.OspfAreaSummaryMatchersImpl.HasMetric;
+import org.batfish.datamodel.matchers.OspfAreaSummaryMatchersImpl.InstallsDiscard;
 import org.batfish.datamodel.matchers.OspfAreaSummaryMatchersImpl.IsAdvertised;
 import org.hamcrest.Matcher;
 
@@ -30,6 +31,19 @@ public final class OspfAreaSummaryMatchers {
    */
   public static IsAdvertised isAdvertised(Matcher<? super Boolean> subMatcher) {
     return new IsAdvertised(subMatcher);
+  }
+
+  /** Returns a matcher asserting that the OSPF summary route will be advertised. */
+  public static InstallsDiscard installsDiscard() {
+    return new InstallsDiscard(equalTo(true));
+  }
+
+  /**
+   * Provides a matcher that matches if the provided {@code subMatcher} matches the OSPF area
+   * summary's advertised flag.
+   */
+  public static InstallsDiscard installsDiscard(Matcher<? super Boolean> subMatcher) {
+    return new InstallsDiscard(subMatcher);
   }
 
   private OspfAreaSummaryMatchers() {}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/OspfAreaSummaryMatchersImpl.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/OspfAreaSummaryMatchersImpl.java
@@ -25,7 +25,18 @@ final class OspfAreaSummaryMatchersImpl {
 
     @Override
     protected Boolean featureValueOf(OspfAreaSummary arg0) {
-      return arg0.getAdvertised();
+      return arg0.isAdvertised();
+    }
+  }
+
+  static final class InstallsDiscard extends FeatureMatcher<OspfAreaSummary, Boolean> {
+    InstallsDiscard(Matcher<? super Boolean> subMatcher) {
+      super(subMatcher, "An OspfAreaSummary that installs discard:", "installs discard");
+    }
+
+    @Override
+    protected Boolean featureValueOf(OspfAreaSummary arg0) {
+      return arg0.installsDiscard();
     }
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfAreaSummaryTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfAreaSummaryTest.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.ospf;
 
+import static org.batfish.datamodel.ospf.OspfAreaSummary.SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD;
+import static org.batfish.datamodel.ospf.OspfAreaSummary.SummaryRouteBehavior.NOT_ADVERTISE_AND_NO_DISCARD;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -12,24 +14,24 @@ import org.junit.Test;
 public class OspfAreaSummaryTest {
   @Test
   public void testEquals() {
-    OspfAreaSummary summary = new OspfAreaSummary(true, 100L);
     new EqualsTester()
-        .addEqualityGroup(summary, summary, new OspfAreaSummary(true, 100L))
-        .addEqualityGroup(new OspfAreaSummary(false, 100L))
-        .addEqualityGroup(new OspfAreaSummary(true, 200L))
-        .addEqualityGroup(new Object())
+        .addEqualityGroup(
+            new OspfAreaSummary(ADVERTISE_AND_INSTALL_DISCARD, 100L),
+            new OspfAreaSummary(ADVERTISE_AND_INSTALL_DISCARD, 100L))
+        .addEqualityGroup(new OspfAreaSummary(NOT_ADVERTISE_AND_NO_DISCARD, 100L))
+        .addEqualityGroup(new OspfAreaSummary(NOT_ADVERTISE_AND_NO_DISCARD, 200L))
         .testEquals();
   }
 
   @Test
   public void testJavaSerialization() {
-    OspfAreaSummary summary = new OspfAreaSummary(true, 100L);
+    OspfAreaSummary summary = new OspfAreaSummary(ADVERTISE_AND_INSTALL_DISCARD, 100L);
     assertThat(SerializationUtils.clone(summary), equalTo(summary));
   }
 
   @Test
   public void testJsonSerialization() {
-    OspfAreaSummary summary = new OspfAreaSummary(true, 100L);
+    OspfAreaSummary summary = new OspfAreaSummary(ADVERTISE_AND_INSTALL_DISCARD, 100L);
     assertThat(BatfishObjectMapper.clone(summary, OspfAreaSummary.class), equalTo(summary));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
@@ -272,6 +272,7 @@ import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.isis.IsisInterfaceMode;
 import org.batfish.datamodel.isis.IsisLevel;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
+import org.batfish.datamodel.ospf.OspfAreaSummary.SummaryRouteBehavior;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.routing_policy.expr.AsExpr;
 import org.batfish.datamodel.routing_policy.expr.AutoAs;
@@ -6713,7 +6714,13 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
 
     Map<Prefix, OspfAreaSummary> area =
         _currentOspfProcess.getSummaries().computeIfAbsent(areaNum, k -> new TreeMap<>());
-    area.put(prefix, new OspfAreaSummary(advertise, cost));
+    area.put(
+        prefix,
+        new OspfAreaSummary(
+            advertise
+                ? SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD
+                : SummaryRouteBehavior.NOT_ADVERTISE_AND_NO_DISCARD,
+            cost));
   }
 
   @Override
@@ -7008,7 +7015,13 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
 
     Map<Prefix, OspfAreaSummary> area =
         _currentOspfProcess.getSummaries().computeIfAbsent(_currentOspfArea, k -> new TreeMap<>());
-    area.put(prefix, new OspfAreaSummary(advertise, cost));
+    area.put(
+        prefix,
+        new OspfAreaSummary(
+            advertise
+                ? SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD
+                : SummaryRouteBehavior.NOT_ADVERTISE_AND_NO_DISCARD,
+            cost));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -368,6 +368,7 @@ import org.batfish.datamodel.eigrp.WideMetric;
 import org.batfish.datamodel.isis.IsisInterfaceMode;
 import org.batfish.datamodel.isis.IsisLevel;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
+import org.batfish.datamodel.ospf.OspfAreaSummary.SummaryRouteBehavior;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.routing_policy.expr.AsExpr;
 import org.batfish.datamodel.routing_policy.expr.AutoAs;
@@ -7615,7 +7616,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
     Map<Prefix, OspfAreaSummary> area =
         _currentOspfProcess.getSummaries().computeIfAbsent(areaNum, k -> new TreeMap<>());
-    area.put(prefix, new OspfAreaSummary(advertise, cost));
+    area.put(
+        prefix,
+        new OspfAreaSummary(
+            advertise
+                ? SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD
+                : SummaryRouteBehavior.NOT_ADVERTISE_AND_NO_DISCARD,
+            cost));
   }
 
   @Override
@@ -8107,7 +8114,13 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
     Map<Prefix, OspfAreaSummary> area =
         _currentOspfProcess.getSummaries().computeIfAbsent(_currentOspfArea, k -> new TreeMap<>());
-    area.put(prefix, new OspfAreaSummary(advertise, cost));
+    area.put(
+        prefix,
+        new OspfAreaSummary(
+            advertise
+                ? SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD
+                : SummaryRouteBehavior.NOT_ADVERTISE_AND_NO_DISCARD,
+            cost));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/AsaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_asa/AsaControlPlaneExtractor.java
@@ -376,6 +376,7 @@ import org.batfish.datamodel.eigrp.WideMetric;
 import org.batfish.datamodel.isis.IsisInterfaceMode;
 import org.batfish.datamodel.isis.IsisLevel;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
+import org.batfish.datamodel.ospf.OspfAreaSummary.SummaryRouteBehavior;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.routing_policy.expr.AsExpr;
 import org.batfish.datamodel.routing_policy.expr.AutoAs;
@@ -7540,7 +7541,13 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
 
     Map<Prefix, OspfAreaSummary> area =
         _currentOspfProcess.getSummaries().computeIfAbsent(areaNum, k -> new TreeMap<>());
-    area.put(prefix, new OspfAreaSummary(advertise, cost));
+    area.put(
+        prefix,
+        new OspfAreaSummary(
+            advertise
+                ? SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD
+                : SummaryRouteBehavior.NOT_ADVERTISE_AND_NO_DISCARD,
+            cost));
   }
 
   @Override
@@ -8018,7 +8025,13 @@ public class AsaControlPlaneExtractor extends AsaParserBaseListener
 
     Map<Prefix, OspfAreaSummary> area =
         _currentOspfProcess.getSummaries().computeIfAbsent(_currentOspfArea, k -> new TreeMap<>());
-    area.put(prefix, new OspfAreaSummary(advertise, cost));
+    area.put(
+        prefix,
+        new OspfAreaSummary(
+            advertise
+                ? SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD
+                : SummaryRouteBehavior.NOT_ADVERTISE_AND_NO_DISCARD,
+            cost));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -269,6 +269,7 @@ import org.batfish.datamodel.isis.IsisInterfaceMode;
 import org.batfish.datamodel.isis.IsisLevel;
 import org.batfish.datamodel.isis.IsisMetricType;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
+import org.batfish.datamodel.ospf.OspfAreaSummary.SummaryRouteBehavior;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.routing_policy.expr.AsExpr;
 import org.batfish.datamodel.routing_policy.expr.AsPathSetElem;
@@ -6384,7 +6385,13 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
     Map<Prefix, OspfAreaSummary> area =
         _currentOspfProcess.getSummaries().computeIfAbsent(areaNum, k -> new TreeMap<>());
-    area.put(prefix, new OspfAreaSummary(advertise, cost));
+    area.put(
+        prefix,
+        new OspfAreaSummary(
+            advertise
+                ? SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD
+                : SummaryRouteBehavior.NOT_ADVERTISE_AND_NO_DISCARD,
+            cost));
   }
 
   @Override
@@ -6682,7 +6689,13 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
     Map<Prefix, OspfAreaSummary> area =
         _currentOspfProcess.getSummaries().computeIfAbsent(_currentOspfArea, k -> new TreeMap<>());
-    area.put(prefix, new OspfAreaSummary(advertise, cost));
+    area.put(
+        prefix,
+        new OspfAreaSummary(
+            advertise
+                ? SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD
+                : SummaryRouteBehavior.NOT_ADVERTISE_AND_NO_DISCARD,
+            cost));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -171,6 +171,7 @@ import org.batfish.datamodel.isis.IsisAuthenticationAlgorithm;
 import org.batfish.datamodel.isis.IsisHelloAuthenticationType;
 import org.batfish.datamodel.isis.IsisOption;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
+import org.batfish.datamodel.ospf.OspfAreaSummary.SummaryRouteBehavior;
 import org.batfish.datamodel.ospf.OspfDefaultOriginateType;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.ospf.StubType;
@@ -4676,7 +4677,11 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void exitOa_area_range(FlatJuniperParser.Oa_area_rangeContext ctx) {
     if (_currentAreaRangePrefix != null) {
       OspfAreaSummary summary =
-          new OspfAreaSummary(!_currentAreaRangeRestrict, _currentAreaRangeMetric);
+          new OspfAreaSummary(
+              _currentAreaRangeRestrict
+                  ? SummaryRouteBehavior.NOT_ADVERTISE_AND_INSTALL_DISCARD
+                  : SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD,
+              _currentAreaRangeMetric);
       _currentArea.getSummaries().put(_currentAreaRangePrefix, summary);
     } else {
       todo(ctx);

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -1456,7 +1456,7 @@ public final class AristaConfiguration extends VendorConfiguration {
         OspfAreaSummary summary = e2.getValue();
         int prefixLength = prefix.getPrefixLength();
         int filterMinPrefixLength =
-            summary.getAdvertised()
+            summary.isAdvertised()
                 ? Math.min(Prefix.MAX_PREFIX_LENGTH, prefixLength + 1)
                 : prefixLength;
         summaryFilter.addLine(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2001,7 +2001,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
         OspfAreaSummary summary = e2.getValue();
         int prefixLength = prefix.getPrefixLength();
         int filterMinPrefixLength =
-            summary.getAdvertised()
+            summary.isAdvertised()
                 ? Math.min(Prefix.MAX_PREFIX_LENGTH, prefixLength + 1)
                 : prefixLength;
         summaryFilter.addLine(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -2313,7 +2313,7 @@ public final class AsaConfiguration extends VendorConfiguration {
         OspfAreaSummary summary = e2.getValue();
         int prefixLength = prefix.getPrefixLength();
         int filterMinPrefixLength =
-            summary.getAdvertised()
+            summary.isAdvertised()
                 ? Math.min(Prefix.MAX_PREFIX_LENGTH, prefixLength + 1)
                 : prefixLength;
         summaryFilter.addLine(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -121,6 +121,7 @@ import org.batfish.datamodel.eigrp.EigrpProcessMode;
 import org.batfish.datamodel.isis.IsisMetricType;
 import org.batfish.datamodel.ospf.NssaSettings;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
+import org.batfish.datamodel.ospf.OspfAreaSummary.SummaryRouteBehavior;
 import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.ospf.StubSettings;
@@ -2624,7 +2625,11 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   }
 
   private @Nonnull OspfAreaSummary toOspfAreaSummary(OspfSummaryAddress ospfSummaryAddress) {
-    return new OspfAreaSummary(!ospfSummaryAddress.getNotAdvertise(), null);
+    return new OspfAreaSummary(
+        ospfSummaryAddress.getNotAdvertise()
+            ? SummaryRouteBehavior.NOT_ADVERTISE_AND_NO_DISCARD
+            : SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD,
+        null);
   }
 
   private void createOspfExportPolicy(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -1734,7 +1734,7 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
         OspfAreaSummary summary = e2.getValue();
         int prefixLength = prefix.getPrefixLength();
         int filterMinPrefixLength =
-            summary.getAdvertised()
+            summary.isAdvertised()
                 ? Math.min(Prefix.MAX_PREFIX_LENGTH, prefixLength + 1)
                 : prefixLength;
         summaryFilter.addLine(

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -83,6 +83,7 @@ import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.ospf.OspfArea;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
+import org.batfish.datamodel.ospf.OspfAreaSummary.SummaryRouteBehavior;
 import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.routing_policy.Common;
@@ -1486,7 +1487,8 @@ public final class CumulusConversions {
         // that. Upconvert if not null.
         Prefix prefix = range.getRange();
         Long cost = range.getCost() == null ? null : range.getCost().longValue();
-        OspfAreaSummary summary = new OspfAreaSummary(true, cost);
+        OspfAreaSummary summary =
+            new OspfAreaSummary(SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD, cost);
         ret.addSummary(prefix, summary);
         lines.add(new RouteFilterLine(LineAction.DENY, PrefixRange.moreSpecificThan(prefix)));
       }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1277,7 +1277,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
       OspfAreaSummary summary = e2.getValue();
       int prefixLength = prefix.getPrefixLength();
       int filterMinPrefixLength =
-          summary.getAdvertised()
+          summary.isAdvertised()
               ? Math.min(Prefix.MAX_PREFIX_LENGTH, prefixLength + 1)
               : prefixLength;
       summaryFilter.addLine(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -139,6 +139,7 @@ import static org.batfish.datamodel.matchers.OspfAreaMatchers.hasStub;
 import static org.batfish.datamodel.matchers.OspfAreaMatchers.hasStubType;
 import static org.batfish.datamodel.matchers.OspfAreaMatchers.hasSummary;
 import static org.batfish.datamodel.matchers.OspfAreaSummaryMatchers.hasMetric;
+import static org.batfish.datamodel.matchers.OspfAreaSummaryMatchers.installsDiscard;
 import static org.batfish.datamodel.matchers.OspfAreaSummaryMatchers.isAdvertised;
 import static org.batfish.datamodel.matchers.OspfProcessMatchers.hasArea;
 import static org.batfish.datamodel.matchers.SnmpServerMatchers.hasCommunities;
@@ -3262,12 +3263,10 @@ public final class CiscoGrammarTest {
             hasOspfProcess(
                 "1",
                 hasArea(
-                    1L, hasSummary(Prefix.parse("10.0.0.0/16"), isAdvertised(equalTo(false)))))));
-    assertThat(
-        manual,
-        hasDefaultVrf(
-            hasOspfProcess(
-                "1", hasArea(1L, hasSummary(Prefix.parse("10.0.0.0/16"), hasMetric(100L))))));
+                    1L,
+                    hasSummary(
+                        Prefix.parse("10.0.0.0/16"),
+                        allOf(not(isAdvertised()), not(installsDiscard()), hasMetric(100L)))))));
 
     Configuration defaults = parseConfig("iosOspfCostDefaults");
 
@@ -3275,13 +3274,12 @@ public final class CiscoGrammarTest {
         defaults,
         hasDefaultVrf(
             hasOspfProcess(
-                "1", hasArea(1L, hasSummary(Prefix.parse("10.0.0.0/16"), isAdvertised())))));
-    assertThat(
-        defaults,
-        hasDefaultVrf(
-            hasOspfProcess(
                 "1",
-                hasArea(1L, hasSummary(Prefix.parse("10.0.0.0/16"), hasMetric(nullValue()))))));
+                hasArea(
+                    1L,
+                    hasSummary(
+                        Prefix.parse("10.0.0.0/16"),
+                        allOf(isAdvertised(), installsDiscard(), hasMetric(nullValue())))))));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -120,6 +120,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -233,6 +234,7 @@ import org.batfish.datamodel.matchers.RouteFilterListMatchers;
 import org.batfish.datamodel.matchers.StubSettingsMatchers;
 import org.batfish.datamodel.matchers.VniSettingsMatchers;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
+import org.batfish.datamodel.ospf.OspfAreaSummary.SummaryRouteBehavior;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.ospf.OspfNetworkType;
 import org.batfish.datamodel.packet_policy.FibLookup;
@@ -5246,9 +5248,12 @@ public final class CiscoNxosGrammarTest {
       Map<Prefix, OspfAreaSummary> summaries = proc.getAreas().get(0L).getSummaries();
 
       assertThat(summaries, hasKeys(p0, p1, p2));
-      assertTrue(summaries.get(p0).getAdvertised());
-      assertFalse(summaries.get(p1).getAdvertised());
-      assertTrue(summaries.get(p2).getAdvertised());
+      assertThat(
+          summaries.get(p0).getBehavior(), is(SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD));
+      assertThat(
+          summaries.get(p1).getBehavior(), is(SummaryRouteBehavior.NOT_ADVERTISE_AND_NO_DISCARD));
+      assertThat(
+          summaries.get(p2).getBehavior(), is(SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD));
       // TODO: convert and test tags
     }
     // TODO: convert and test OSPF timers

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -86,6 +86,7 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
+import org.batfish.datamodel.ospf.OspfAreaSummary.SummaryRouteBehavior;
 import org.batfish.datamodel.ospf.OspfProcess;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.expr.LiteralLong;
@@ -1920,7 +1921,8 @@ public class CumulusFrrGrammarTest {
       org.batfish.datamodel.ospf.OspfArea area = proc.getAreas().get(area1110);
       assertThat(area.getSummaries(), hasKeys(Prefix.parse("1.255.0.0/17")));
       OspfAreaSummary summary = Iterables.getOnlyElement(area.getSummaries().values());
-      assertThat(summary.getAdvertised(), equalTo(true));
+      assertThat(
+          summary.getBehavior(), equalTo(SummaryRouteBehavior.ADVERTISE_AND_INSTALL_DISCARD));
       assertThat(summary.getMetric(), equalTo(10L));
       String name = computeOspfAreaRangeFilterName(c.getDefaultVrf().getName(), area1110);
       assertThat(area.getSummaryFilter(), equalTo(name));

--- a/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/flatjuniper/FlatJuniperGrammarTest.java
@@ -114,6 +114,7 @@ import static org.batfish.datamodel.matchers.OspfAreaMatchers.hasStub;
 import static org.batfish.datamodel.matchers.OspfAreaMatchers.hasStubType;
 import static org.batfish.datamodel.matchers.OspfAreaMatchers.hasSummary;
 import static org.batfish.datamodel.matchers.OspfAreaSummaryMatchers.hasMetric;
+import static org.batfish.datamodel.matchers.OspfAreaSummaryMatchers.installsDiscard;
 import static org.batfish.datamodel.matchers.OspfAreaSummaryMatchers.isAdvertised;
 import static org.batfish.datamodel.matchers.OspfProcessMatchers.hasArea;
 import static org.batfish.datamodel.matchers.OspfProcessMatchers.hasRouterId;
@@ -2499,8 +2500,7 @@ public final class FlatJuniperGrammarTest {
             .get(1L)
             .getSummaries()
             .get(Prefix.parse("10.0.0.0/16"));
-    assertThat(summary, not(isAdvertised()));
-    assertThat(summary, hasMetric(123L));
+    assertThat(summary, allOf(not(isAdvertised()), installsDiscard(), hasMetric(123L)));
 
     // Defaults
     summary =
@@ -2512,8 +2512,7 @@ public final class FlatJuniperGrammarTest {
             .get(2L)
             .getSummaries()
             .get(Prefix.parse("10.0.0.0/16"));
-    assertThat(summary, isAdvertised());
-    assertThat(summary, hasMetric(nullValue()));
+    assertThat(summary, allOf(isAdvertised(), installsDiscard(), hasMetric(nullValue())));
 
     // Interface override
     assertThat(config, hasInterface("fe-1/0/1.0", hasOspfCost(equalTo(17))));

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -31097,7 +31097,7 @@
                     "stubType" : "NSSA",
                     "summaries" : {
                       "1.2.3.0/24" : {
-                        "advertise" : true,
+                        "behavior" : "ADVERTISE_AND_INSTALL_DISCARD",
                         "metric" : 17
                       }
                     },
@@ -31110,7 +31110,7 @@
                     "stubType" : "NONE",
                     "summaries" : {
                       "1.2.3.0/24" : {
-                        "advertise" : false
+                        "behavior" : "NOT_ADVERTISE_AND_NO_DISCARD"
                       }
                     },
                     "summaryFilter" : "~OSPF_SUMMARY_FILTER:default:16909056~"
@@ -31388,7 +31388,7 @@
                     "stubType" : "NSSA",
                     "summaries" : {
                       "1.2.3.0/24" : {
-                        "advertise" : true,
+                        "behavior" : "ADVERTISE_AND_INSTALL_DISCARD",
                         "metric" : 17
                       }
                     },
@@ -31401,7 +31401,7 @@
                     "stubType" : "NONE",
                     "summaries" : {
                       "1.2.3.0/24" : {
-                        "advertise" : false
+                        "behavior" : "NOT_ADVERTISE_AND_NO_DISCARD"
                       }
                     },
                     "summaryFilter" : "~OSPF_SUMMARY_FILTER:default:16909056~"
@@ -31454,7 +31454,7 @@
                     "stubType" : "NONE",
                     "summaries" : {
                       "3.3.3.0/24" : {
-                        "advertise" : true
+                        "behavior" : "ADVERTISE_AND_INSTALL_DISCARD"
                       }
                     },
                     "summaryFilter" : "~OSPF_SUMMARY_FILTER:default:1~"
@@ -42611,7 +42611,7 @@
                     "stubType" : "NONE",
                     "summaries" : {
                       "10.0.0.0/15" : {
-                        "advertise" : true
+                        "behavior" : "ADVERTISE_AND_INSTALL_DISCARD"
                       }
                     },
                     "summaryFilter" : "~OSPF_SUMMARY_FILTER:default:0~"
@@ -66976,7 +66976,7 @@
                     "stubType" : "NSSA",
                     "summaries" : {
                       "1.2.0.0/16" : {
-                        "advertise" : true,
+                        "behavior" : "ADVERTISE_AND_INSTALL_DISCARD",
                         "metric" : 100
                       }
                     },


### PR DESCRIPTION
Since the summary isn't advertised, there's no need to install this discard route to
prevent a loop that can't happen.