### PR TITLE
FortiOS: add interface outgoing filter test

### DIFF
--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/policy
@@ -1,0 +1,59 @@
+config system global
+    set hostname "policy"
+end
+config system interface
+    edit port1
+        set vdom "root"
+        set ip 10.0.1.1 255.255.255.0
+        set type physical
+    next
+    edit port2
+        set vdom "root"
+        set ip 10.0.2.1 255.255.255.0
+        set type physical
+    next
+    edit port3
+        set vdom "root"
+        set ip 10.0.3.1 255.255.255.0
+        set type physical
+    next
+    edit port4
+        set vdom "root"
+        set ip 10.0.4.1 255.255.255.0
+        set type physical
+    next
+end
+config firewall address
+    edit "all"
+        set type ipmask
+        set subnet 0.0.0.0  0.0.0.0
+    next
+end
+config firewall service custom
+    edit EXPLICIT_DENY
+        set protocol TCP/UDP/SCTP
+        set tcp-portrange 1234
+    next
+    edit ALL_TCP
+        set protocol TCP/UDP/SCTP
+        set tcp-portrange 1-65535
+    next
+end
+config firewall policy
+    edit 1
+        set action deny
+        set srcintf port1 port2
+        set dstintf port3 port4
+        set srcaddr all
+        set dstaddr all
+        set service EXPLICIT_DENY
+    next
+    edit 2
+        set action allow
+        set srcintf port1 port2
+        set dstintf port3 port4
+        set srcaddr all
+        set dstaddr all
+        set service ALL_TCP
+    next
+end


### PR DESCRIPTION
Add a test for converting policies as interface outgoing filters.

This test is currently ignored because of a bug in how we convert policies - deny rules that don't match still end up denying traffic.
