### PR TITLE
FortiOS: handle zone-interface name conflicts

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -428,11 +428,13 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
   @Override
   public void enterCsi_edit(Csi_editContext ctx) {
     Optional<String> name = toString(ctx, ctx.interface_name());
-    if (!name.isPresent()) {
-      _currentInterface = new Interface(toString(ctx.interface_name().str())); // dummy
+    Interface existing = name.map(_c.getInterfaces()::get).orElse(null);
+    if (existing == null) {
+      // TODO edit block validation / committing
+      _currentInterface = new Interface(toString(ctx.interface_name().str()));
       return;
     }
-    _currentInterface = _c.getInterfaces().computeIfAbsent(name.get(), Interface::new);
+    _currentInterface = existing;
   }
 
   @Override
@@ -448,6 +450,7 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
           name,
           FortiosStructureUsage.INTERFACE_SELF_REF,
           ctx.start.getLine());
+      _c.getInterfaces().put(name, _currentInterface);
     }
     _currentInterface = null;
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -439,7 +439,9 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
   public void exitCsi_edit(Csi_editContext ctx) {
     // TODO better validation
     String name = _currentInterface.getName();
-    if (INTERFACE_NAME_PATTERN.matcher(name).matches()) {
+    if (_c.getZones().containsKey(name)) {
+      warn(ctx, "Interface edit block ignored: name conflicts with a zone name");
+    } else if (INTERFACE_NAME_PATTERN.matcher(name).matches()) {
       _c.defineStructure(FortiosStructureType.INTERFACE, name, ctx);
       _c.referenceStructure(
           FortiosStructureType.INTERFACE,

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -841,9 +841,12 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
   }
 
   /** Returns message indicating why this zone can't be committed in the CLI, or null if it can */
-  private static @Nullable String getZoneInvalidReason(Zone zone, boolean nameValid) {
+  private static @Nullable String getZoneInvalidReason(
+      Zone zone, boolean nameValid, Set<String> interfaceNames) {
     if (!nameValid) {
       return "name is invalid";
+    } else if (interfaceNames.contains(zone.getName())) {
+      return "name conflicts with a system interface name";
     } else if (zone.getInterface().isEmpty()) {
       return "interface must be set";
     }
@@ -853,7 +856,8 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
   @Override
   public void exitCsz_edit(Csz_editContext ctx) {
     // If edited item is valid, add/update the entry in VS map
-    String invalidReason = getZoneInvalidReason(_currentZone, _currentZoneNameValid);
+    String invalidReason =
+        getZoneInvalidReason(_currentZone, _currentZoneNameValid, _c.getInterfaces().keySet());
     if (invalidReason == null) { // is valid
       String name = _currentZone.getName();
       _c.defineStructure(FortiosStructureType.ZONE, name, ctx);

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -664,6 +664,29 @@ public final class FortiosGrammarTest {
   }
 
   @Test
+  public void testInterfaceWarnings() throws IOException {
+    String hostname = "iface_warn";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    Warnings parseWarnings =
+        getOnlyElement(
+            batfish
+                .loadParseVendorConfigurationAnswerElement(batfish.getSnapshot())
+                .getWarnings()
+                .values());
+    assertThat(
+        parseWarnings,
+        hasParseWarnings(
+            containsInAnyOrder(
+                allOf(
+                    hasComment("Illegal value for interface name"),
+                    hasText(containsString("name is too long for iface"))),
+                allOf(
+                    hasComment("Illegal value for interface alias"),
+                    hasText(containsString("alias string is too long to associate with iface"))),
+                hasComment("Interface edit block ignored: name conflicts with a zone name"))));
+  }
+
+  @Test
   public void testZoneExtraction() {
     String hostname = "zone";
     FortiosConfiguration vc = parseVendorConfig(hostname);

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -1235,6 +1235,9 @@ public final class FortiosGrammarTest {
                 hasComment("Cannot rename non-existent address undefined"),
                 hasComment("Cannot rename non-existent service custom undefined"),
                 hasComment("Cannot rename non-existent zone undefined"),
+                hasComment(
+                    "Renaming zone new_zone1 conflicts with an existing object port1, ignoring"
+                        + " this rename operation"),
                 allOf(
                     hasComment("Illegal value for zone name"),
                     hasText(containsString("a name that is too long to use for this object type"))),

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -666,6 +666,7 @@ public final class FortiosGrammarTest {
   @Test
   public void testInterfaceWarnings() throws IOException {
     String hostname = "iface_warn";
+    FortiosConfiguration vc = parseVendorConfig(hostname);
     Batfish batfish = getBatfishForConfigurationNames(hostname);
     Warnings parseWarnings =
         getOnlyElement(
@@ -684,6 +685,10 @@ public final class FortiosGrammarTest {
                     hasComment("Illegal value for interface alias"),
                     hasText(containsString("alias string is too long to associate with iface"))),
                 hasComment("Interface edit block ignored: name conflicts with a zone name"))));
+
+    // Also check extraction to make sure the conflicting-name lines are discarded, i.e. no VS
+    // object is created when the name conflicts
+    assertThat(vc.getInterfaces(), hasKeys("port1"));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -718,7 +718,9 @@ public final class FortiosGrammarTest {
                 hasComment("Interface UNDEFINED is undefined and cannot be added to zone zone3"),
                 hasComment(
                     "Interface port1 is already in another zone and cannot be added to zone"
-                        + " zone4"))));
+                        + " zone4"),
+                hasComment(
+                    "Zone edit block ignored: name conflicts with a system interface name"))));
 
     // Also check extraction to make sure the right lines/blocks are discarded
     Map<String, Zone> zones = vc.getZones();

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/iface_warn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/iface_warn
@@ -1,0 +1,27 @@
+config system global
+    set hostname "iface_warn"
+end
+config system interface
+    edit "port1"
+        set vdom "root"
+        # mask format
+        set ip 192.168.122.2 255.255.255.0
+        set type physical
+        set alias "alias string is too long to associate with iface"
+    next
+    edit "name is too long for iface"
+        set vdom "root"
+        set type vlan
+    next
+end
+config system zone
+    edit conflict
+        set interface port1
+    next
+end
+
+config system interface
+    # Cannot use the same name for an interface and zone
+    edit conflict
+    next
+end

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/rename
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/rename
@@ -88,7 +88,10 @@ config system zone
     rename undefined to other
 end
 
-# Renaming a valid object with an unused but invalid name should fail w/ warning
 config system zone
+    # Renaming a valid object with an unused but invalid name should fail w/ warning
     rename new_zone2 to "a name that is too long to use for this object type"
+
+    # Trying to rename to a named already used by interface should fail w/ warning
+    rename new_zone1 to port1
 end

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/zone_warn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/zone_warn
@@ -37,4 +37,7 @@ config system zone
         set interface port1
         append interface port2
     next
+    # Can't use a name already taken by an interface
+    edit port3
+    next
 end


### PR DESCRIPTION
Handle (prevent) conflicting names between interfaces and zones.
