### PR TITLE
IOS: BGP aggregates have origin type IGP

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -293,7 +293,7 @@ public final class BgpProtocolHelper {
          * but are needed initially
          */
         .setOriginatorIp(routerId)
-        .setOriginType(OriginType.INCOMPLETE)
+        .setOriginType(generatedRoute.getOriginType())
         .setReceivedFromIp(/* Originated locally. */ Ip.ZERO)
         .setNonRouting(nonRouting);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1059,6 +1059,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
           GeneratedRoute.builder()
               .setNetwork(prefix)
               .setAdmin(CISCO_AGGREGATE_ROUTE_ADMIN_COST)
+              .setOriginType(OriginType.IGP)
               .setGenerationPolicy(genPolicy.getName())
               .setDiscard(true);
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/BgpProtocolHelperTransformBgpRouteOnExportTest.java
@@ -2,6 +2,7 @@ package org.batfish.dataplane.protocols;
 
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasNextHopIp;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasCommunities;
+import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasOriginType;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.convertGeneratedRouteToBgp;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.convertNonBgpRouteToBgpRoute;
 import static org.batfish.dataplane.protocols.BgpProtocolHelper.transformBgpRoutePostExport;
@@ -197,6 +198,27 @@ public final class BgpProtocolHelperTransformBgpRouteOnExportTest {
     assertThat(
         convertGeneratedRouteToBgp(_baseAggRouteBuilder.build(), Ip.ZERO, nextHopIp, false).build(),
         hasNextHopIp(nextHopIp));
+  }
+
+  @Test
+  public void testConvertGeneratedToBgpPreservesOriginType() {
+    Ip nextHopIp = Ip.parse("1.1.1.1");
+    assertThat(
+        convertGeneratedRouteToBgp(
+                _baseAggRouteBuilder.setOriginType(OriginType.IGP).build(),
+                Ip.ZERO,
+                nextHopIp,
+                false)
+            .build(),
+        hasOriginType(OriginType.IGP));
+    assertThat(
+        convertGeneratedRouteToBgp(
+                _baseAggRouteBuilder.setOriginType(OriginType.INCOMPLETE).build(),
+                Ip.ZERO,
+                nextHopIp,
+                false)
+            .build(),
+        hasOriginType(OriginType.INCOMPLETE));
   }
 
   /**

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -4981,7 +4981,7 @@
                 "network" : "2.128.0.0/16",
                 "nextHopInterface" : "null_interface",
                 "nextHopIp" : "AUTO/NONE(-1l)",
-                "originType" : "incomplete",
+                "originType" : "igp",
                 "tag" : -1,
                 "weight" : 0
               }
@@ -6448,7 +6448,7 @@
                 "network" : "2.128.0.0/16",
                 "nextHopInterface" : "null_interface",
                 "nextHopIp" : "AUTO/NONE(-1l)",
-                "originType" : "incomplete",
+                "originType" : "igp",
                 "tag" : -1,
                 "weight" : 0
               }

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -18886,7 +18886,7 @@
                 "network" : "192.154.2.0/24",
                 "nextHopInterface" : "null_interface",
                 "nextHopIp" : "AUTO/NONE(-1l)",
-                "originType" : "incomplete",
+                "originType" : "igp",
                 "tag" : -1,
                 "weight" : 0
               }
@@ -27340,7 +27340,7 @@
                 "network" : "192.168.0.0/16",
                 "nextHopInterface" : "null_interface",
                 "nextHopIp" : "AUTO/NONE(-1l)",
-                "originType" : "incomplete",
+                "originType" : "igp",
                 "tag" : -1,
                 "weight" : 0,
                 "attributePolicySources" : [


### PR DESCRIPTION
Also modify the BgpProtocolHelper to preserve this routing type.