### PR TITLE
CommunitySetMatchExprVarCollector: do not crash on collecting unsupported structures

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDD.java
@@ -97,6 +97,7 @@ public class CommunitySetMatchExprToBDD
 
   @Override
   public BDD visitCommunitySetMatchRegex(CommunitySetMatchRegex communitySetMatchRegex, Arg arg) {
+    // NOTE: when implementing, update CommunitySetMatchExprVarCollector#visitCommunitySetMatchRegex
     throw new UnsupportedOperationException("Currently not supporting community set regexes");
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunitySetMatchExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunitySetMatchExprVarCollector.java
@@ -1,11 +1,12 @@
 package org.batfish.minesweeper.communities;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import java.util.Set;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.common.BatfishException;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetAcl;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetAclLine;
@@ -50,16 +51,17 @@ public class CommunitySetMatchExprVarCollector
       CommunitySetMatchExprReference communitySetMatchExprReference, Configuration arg) {
     String name = communitySetMatchExprReference.getName();
     CommunitySetMatchExpr expr = arg.getCommunitySetMatchExprs().get(name);
-    if (expr == null) {
-      throw new BatfishException("Cannot find community set match expression: " + name);
-    }
+    // Expr should exist, enforced during conversion by CommunityStructuresVerifier.
+    checkState(expr != null, "Undefined reference in community exprs should not be possible");
     return expr.accept(this, arg);
   }
 
   @Override
   public Set<CommunityVar> visitCommunitySetMatchRegex(
       CommunitySetMatchRegex communitySetMatchRegex, Configuration arg) {
-    throw new UnsupportedOperationException("Community set regexes are not supported");
+    // This is not supported, but rather than throw we do nothing. If we end up needing to model
+    // this structure, the later code will crash instead.
+    return ImmutableSet.of();
   }
 
   @Override

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/CommunitySetMatchExprVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/CommunitySetMatchExprVarCollectorTest.java
@@ -1,6 +1,8 @@
 package org.batfish.minesweeper.communities;
 
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -20,8 +22,10 @@ import org.batfish.datamodel.routing_policy.communities.CommunitySetAclLine;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchAll;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchAny;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetNot;
 import org.batfish.datamodel.routing_policy.communities.HasCommunity;
+import org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated;
 import org.batfish.minesweeper.CommunityVar;
 import org.junit.Before;
 import org.junit.Test;
@@ -112,6 +116,18 @@ public class CommunitySetMatchExprVarCollectorTest {
     CommunityVar cvar = CommunityVar.from("^20:");
 
     assertEquals(ImmutableSet.of(cvar), result);
+  }
+
+  @Test
+  public void testVisitCommunitySetMatchRegex() {
+    CommunitySetMatchRegex cmsr =
+        new CommunitySetMatchRegex(
+            new TypesFirstAscendingSpaceSeparated(ColonSeparatedRendering.instance()),
+            "^65000:123 65011:12[3]$");
+
+    Set<CommunityVar> result = cmsr.accept(_varCollector, _baseConfig);
+    // TODO: this construct is not supported yet.
+    assertThat(result, empty());
   }
 
   @Test


### PR DESCRIPTION
Instead, defer that crashing to validation time. This enables SearchRoutePolicies to
run on devices where only some of the route policies can be successfully analyzed.