### PR TITLE
CommunityVarCollector: support LiteralCommunityConjunction

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/CommunityVarCollector.java
@@ -63,7 +63,9 @@ public class CommunityVarCollector implements VoidCommunitySetExprVisitor {
   @Override
   public void visitLiteralCommunityConjunction(
       LiteralCommunityConjunction literalCommunityConjunction) {
-    throw new UnsupportedOperationException("no implementation for generated method");
+    literalCommunityConjunction
+        .getRequiredCommunities()
+        .forEach(c -> _builder.add(toCommunityVar(c)));
   }
 
   @Override

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/CommunityVarCollectorTest.java
@@ -1,6 +1,8 @@
 package org.batfish.minesweeper;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -17,6 +19,7 @@ import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.routing_policy.expr.EmptyCommunitySetExpr;
 import org.batfish.datamodel.routing_policy.expr.LiteralCommunity;
+import org.batfish.datamodel.routing_policy.expr.LiteralCommunityConjunction;
 import org.batfish.datamodel.routing_policy.expr.LiteralCommunitySet;
 import org.batfish.datamodel.routing_policy.expr.NamedCommunitySet;
 import org.junit.Before;
@@ -80,6 +83,15 @@ public class CommunityVarCollectorTest {
     Set<CommunityVar> expected = ImmutableSet.of(CommunityVar.from(COMM1));
 
     assertEquals(expected, result);
+  }
+
+  @Test
+  public void testLiteralCommunityConjunction() {
+    LiteralCommunityConjunction lcc =
+        new LiteralCommunityConjunction(ImmutableSet.of(COMM1, COMM2));
+    Set<CommunityVar> result = CommunityVarCollector.collectCommunityVars(_baseConfig, lcc);
+
+    assertThat(result, containsInAnyOrder(CommunityVar.from(COMM1), CommunityVar.from(COMM2)));
   }
 
   @Test


### PR DESCRIPTION
It's easy to collect communities from a conjunction, it's just all the communities.