### PR TITLE
FortiOS: fix policy action

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/FortiosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/FortiosLexer.g4
@@ -21,6 +21,7 @@ ADMIN:
   }
 ;
 
+ACCEPT: 'accept';
 ACTION: 'action';
 ADDRESS: 'address';
 AGGREGATE: 'aggregate';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_policy.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_policy.g4
@@ -79,7 +79,7 @@ policy_status: enable_or_disable;
 // 0-4294967294
 policy_number: str;
 
-policy_action: ALLOW | DENY | IPSEC;
+policy_action: ACCEPT | DENY | IPSEC;
 
 address_names: address_name+;
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -1151,8 +1151,8 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
   }
 
   private @Nonnull Policy.Action toAction(Policy_actionContext ctx) {
-    if (ctx.ALLOW() != null) {
-      return Action.ALLOW;
+    if (ctx.ACCEPT() != null) {
+      return Action.ACCEPT;
     } else if (ctx.DENY() != null) {
       return Action.DENY;
     } else {

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosPolicyConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosPolicyConversions.java
@@ -283,7 +283,7 @@ public final class FortiosPolicyConversions {
 
     ExprAclLine.Builder line;
     switch (policy.getActionEffective()) {
-      case ALLOW:
+      case ACCEPT:
         line = ExprAclLine.accepting();
         break;
       case DENY:

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Policy.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Policy.java
@@ -23,7 +23,7 @@ public final class Policy implements Serializable {
   }
 
   public enum Action {
-    ALLOW,
+    ACCEPT,
     DENY,
     IPSEC,
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -986,7 +986,7 @@ public final class FortiosGrammarTest {
     assertThat(policyDeny.getSrcAddr(), contains(addr1));
     assertThat(policyDeny.getDstAddr(), contains(addr2));
 
-    assertThat(policyAllow.getAction(), equalTo(Action.ALLOW));
+    assertThat(policyAllow.getAction(), equalTo(Action.ACCEPT));
     assertThat(policyAllow.getStatus(), equalTo(Policy.Status.ENABLE));
     assertThat(policyAllow.getStatusEffective(), equalTo(Policy.Status.ENABLE));
     assertThat(policyAllow.getService(), containsInAnyOrder(service11, service12From11));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/firewall_policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/firewall_policy
@@ -78,7 +78,7 @@ config firewall policy
     # Number doesn't indicate order, just a unique identifier
     edit 1
         set name "Permit Custom TCP Traffic"
-        set action allow
+        set action accept
         set srcintf port1
         set dstintf port2
         set srcaddr addr1
@@ -92,7 +92,7 @@ config firewall policy
         append service custom_tcp_12_from_11
     next
     edit 2
-        set action allow
+        set action accept
         set srcintf any
         set dstintf any
         set srcaddr all
@@ -100,7 +100,7 @@ config firewall policy
         set service ALL
     next
     edit 3
-        set action allow
+        set action accept
         set srcintf zone1 port2 zone3
         append srcintf zone2
         set dstintf zone1 zone2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/firewall_policy_warn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/firewall_policy_warn
@@ -29,7 +29,7 @@ config firewall address
 end
 config firewall policy
     edit 4294967295
-        set action allow
+        set action accept
         set name "this name is too long to use as a firewall policy name"
         set srcintf port1
         set dstintf port2

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/firewall_vi_policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/firewall_vi_policy
@@ -45,7 +45,7 @@ config firewall policy
         set service ALL
     next
     edit 2
-        set action allow
+        set action accept
         set srcintf any
         set dstintf zone1
         set srcaddr all

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/policy
@@ -49,7 +49,7 @@ config firewall policy
         set service EXPLICIT_DENY
     next
     edit 2
-        set action allow
+        set action accept
         set srcintf port1 port2
         set dstintf port3 port4
         set srcaddr all

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/policy_defs_refs
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/policy_defs_refs
@@ -39,7 +39,7 @@ config firewall address
 end
 config firewall policy
     edit 1
-        set action allow
+        set action accept
         set status enable
 
         # Undefined references


### PR DESCRIPTION
Policy action uses `accept` not `allow` (unlike intrazone action, which does use `allow`)
