### PR TITLE
Arista: delete RULE (mainly, voice stanzas)

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/AristaLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/AristaLexer.g4
@@ -3898,10 +3898,7 @@ RTR_ADV: 'rtr-adv';
 
 RTSP: 'rtsp';
 
-RULE
-:
-   'rule' {_enableRegex = true;}
-;
+RULE: 'rule';
 
 RULE_NAME: 'rule-name';
 
@@ -5254,7 +5251,6 @@ NEWLINE
   {
     _enableIpv6Address = true;
     _enableIpAddress = true;
-    _enableRegex = false;
   }
 ;
 
@@ -5281,16 +5277,6 @@ PERIOD
 PLUS
 :
    '+'
-;
-
-REGEX
-:
-   '/' {_enableRegex}?
-   (
-      ~('/' | '\\')
-      |
-      ( '\\' '/')
-   )* '/'
 ;
 
 SEMICOLON

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/AristaParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/AristaParser.g4
@@ -1954,15 +1954,6 @@ rmc_null
    ) null_rest_of_line
 ;
 
-role_null
-:
-   NO?
-   (
-      DESCRIPTION
-      | RULE
-   ) null_rest_of_line
-;
-
 route_tail
 :
    iface = variable destination = IP_ADDRESS mask = IP_ADDRESS gateway = IP_ADDRESS
@@ -2878,9 +2869,6 @@ s_rf
 s_role
 :
    NO? ROLE null_rest_of_line
-   (
-      role_null
-   )*
 ;
 
 s_route
@@ -3139,34 +3127,6 @@ s_vlan_internal_cisco
 s_vlan_name
 :
    VLAN_NAME name = variable_permissive NEWLINE
-;
-
-s_voice
-:
-   NO? VOICE
-   (
-      voice_class
-      | voice_null
-      | voice_service
-      | voice_translation_profile
-      | voice_translation_rule
-   )
-;
-
-s_voice_card
-:
-   NO? VOICE_CARD null_rest_of_line
-   (
-      vc_null
-   )*
-;
-
-s_voice_port
-:
-   NO? VOICE_PORT null_rest_of_line
-   (
-      vp_null
-   )*
 ;
 
 s_vpc
@@ -3630,9 +3590,6 @@ stanza
    | s_vlan_eos
    | s_vlan_internal_eos
    | s_vlan_name
-   | s_voice
-   | s_voice_card
-   | s_voice_port
    | s_vpc
    | s_vpdn_group
    | s_vpn
@@ -3998,18 +3955,6 @@ ur_null
    ) null_rest_of_line
 ;
 
-vc_null
-:
-   NO?
-   (
-      CODEC
-      | DSP
-      | DSPFARM
-      | VOICE_SERVICE
-      | WATCHDOG
-   ) null_rest_of_line
-;
-
 viaf_vrrp
 :
    NO? VRRP groupnum = DEC NEWLINE
@@ -4046,288 +3991,6 @@ viafv_preempt
 viafv_priority
 :
    PRIORITY priority = DEC NEWLINE
-;
-
-voice_class
-:
-   CLASS
-   (
-      voice_class_codec
-      | voice_class_dpg
-      | voice_class_e164
-      | voice_class_h323
-      | voice_class_server_group
-      | voice_class_sip_profiles
-      | voice_class_uri
-   )
-;
-
-voice_class_codec
-:
-   CODEC null_rest_of_line
-   (
-      voice_class_codec_null
-   )*
-;
-
-voice_class_codec_null
-:
-   NO?
-   (
-      CODEC
-   ) null_rest_of_line
-;
-
-voice_class_dpg
-:
-   DPG null_rest_of_line
-   (
-      voice_class_dpg_null
-   )*
-;
-
-voice_class_dpg_null
-:
-    NO?
-    (
-       DESCRIPTION
-       | DIAL_PEER
-    ) null_rest_of_line
-;
-
-voice_class_e164
-:
-   E164_PATTERN_MAP null_rest_of_line
-   (
-      voice_class_e164_null
-   )*
-;
-
-voice_class_e164_null
-:
-   NO?
-   (
-      DESCRIPTION
-      | E164
-      | URL
-   ) null_rest_of_line
-;
-
-voice_class_h323
-:
-   H323 null_rest_of_line
-   (
-      voice_class_h323_null
-   )*
-;
-
-voice_class_h323_null
-:
-   NO?
-   (
-      CALL
-      | H225
-      | TELEPHONY_SERVICE
-   ) null_rest_of_line
-;
-
-voice_class_server_group
-:
-   SERVER_GROUP null_rest_of_line
-   (
-      voice_class_server_group_null
-   )*
-;
-
-voice_class_server_group_null
-:
-   NO?
-      (  DESCRIPTION
-         | IPV4
-      ) null_rest_of_line
-;
-
-voice_class_sip_profiles
-:
-   SIP_PROFILES null_rest_of_line
-   (
-      voice_class_sip_profiles_null
-   )*
-;
-
-voice_class_sip_profiles_null
-:
-   NO?
-   (
-      REQUEST
-   ) null_rest_of_line
-;
-
-voice_class_uri
-:
-    URI null_rest_of_line
-    (
-        HOST null_rest_of_line
-    )
-;
-
-voice_null
-:
-   (
-      ALG_BASED_CAC
-      | CALL
-      | DIALPLAN_PROFILE
-      | HUNT
-      | IEC
-      | LOGGING
-      | REAL_TIME_CONFIG
-      | RTCP_INACTIVITY
-      | RTP
-      | SIP
-      | SIP_MIDCALL_REQ_TIMEOUT
-   ) null_rest_of_line
-;
-
-voice_service
-:
-   SERVICE
-   (
-      voice_service_voip
-   )
-;
-
-voice_service_voip
-:
-   VOIP NEWLINE
-   (
-      voice_service_voip_h323
-      | voice_service_voip_ip_address_trusted_list
-      | voice_service_voip_null
-      | voice_service_voip_sip
-   )*
-;
-
-voice_service_voip_h323
-:
-   H323 NEWLINE
-   (
-      voice_service_voip_h323_null
-   )*
-;
-
-voice_service_voip_h323_null
-:
-   NO?
-   (
-      CALL
-      | H225
-   ) null_rest_of_line
-;
-
-voice_service_voip_ip_address_trusted_list
-:
-   IP ADDRESS TRUSTED LIST NEWLINE
-   (
-      voice_service_voip_ip_address_trusted_list_null
-   )*
-;
-
-voice_service_voip_ip_address_trusted_list_null
-:
-   NO?
-   (
-      IPV4
-   ) null_rest_of_line
-;
-
-voice_service_voip_null
-:
-   NO?
-   (
-      ADDRESS_HIDING
-      | ALLOW_CONNECTIONS
-      | FAX
-      | H225
-      | MEDIA
-      | MODE
-      | MODEM
-      | REDUNDANCY_GROUP
-      | RTP_PORT
-      | SHUTDOWN
-      | SUPPLEMENTARY_SERVICE
-   ) null_rest_of_line
-;
-
-voice_service_voip_sip
-:
-   SIP NEWLINE
-   (
-      voice_service_voip_sip_null
-   )*
-;
-
-voice_service_voip_sip_null
-:
-   NO?
-   (
-      BIND
-      | EARLY_OFFER
-      | ERROR_PASSTHRU
-      | G729
-      | HEADER_PASSING
-      | LISTEN_PORT
-      | MIDCALL_SIGNALING
-      | SIP_PROFILES
-      | TRANSPORT
-   ) null_rest_of_line
-;
-
-voice_translation_profile
-:
-   TRANSLATION_PROFILE null_rest_of_line
-   (
-      voice_translation_profile_null
-   )*
-;
-
-voice_translation_profile_null
-:
-   NO?
-   (
-      TRANSLATE
-   ) null_rest_of_line
-;
-
-voice_translation_rule
-:
-   TRANSLATION_RULE null_rest_of_line
-   (
-      voice_translation_rule_null
-   )*
-;
-
-voice_translation_rule_null
-:
-   NO?
-   (
-      RULE
-   ) null_rest_of_line
-;
-
-vp_null
-:
-   NO?
-   (
-      CALLER_ID
-      | CONNECTION
-      | CPTONE
-      | DESCRIPTION
-      | ECHO_CANCEL
-      | SHUTDOWN
-      | SIGNAL
-      | TIMEOUTS
-      | TIMING
-   ) null_rest_of_line
 ;
 
 vpc_null

--- a/projects/batfish/src/main/java/org/batfish/grammar/arista/parsing/AristaBaseLexer.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/arista/parsing/AristaBaseLexer.java
@@ -46,7 +46,6 @@ public abstract class AristaBaseLexer extends BatfishLexer {
 
   protected boolean _enableIpv6Address = true;
   protected boolean _enableIpAddress = true;
-  protected boolean _enableRegex = false;
 
   private int _lastTokenType = -1;
   private int _secondToLastTokenType = -1;
@@ -56,7 +55,6 @@ public abstract class AristaBaseLexer extends BatfishLexer {
     StringBuilder sb = new StringBuilder();
     sb.append("_enableIpAddress: " + _enableIpAddress + "\n");
     sb.append("_enableIpv6Address: " + _enableIpv6Address + "\n");
-    sb.append("_enableRegex: " + _enableRegex + "\n");
     return sb.toString();
   }
 }


### PR DESCRIPTION
None of the places that RULE were used are valid in EOS. Delete the `_enableRegex` predicate.