### PR TITLE
SearchRoutePolicies: Support a special case of matching on community-set regexes

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDD.java
@@ -98,17 +98,17 @@ public class CommunitySetMatchExprToBDD
 
   @Override
   public BDD visitCommunitySetMatchRegex(CommunitySetMatchRegex communitySetMatchRegex, Arg arg) {
-    // NOTE: when implementing, update CommunitySetMatchExprVarCollector#visitCommunitySetMatchRegex
-    BDD bdd =
-        communityVarsToBDD(
-            communitySetMatchRegex.accept(
-                new CommunitySetMatchExprVarCollector(), arg.getTransferBDD().getConfiguration()),
-            arg);
-    if (bdd.isZero()) {
+    // Only handles the special case when the regex applies to a single community within the set.
+    // If that is not the case, the collected set of community variables will be empty (see
+    // CommunitySetMatchExprVarCollector#visitCommunitySetMatchRegex) and we throw an exception.
+    Set<CommunityVar> cvars =
+        communitySetMatchRegex.accept(
+            new CommunitySetMatchExprVarCollector(), arg.getTransferBDD().getConfiguration());
+    if (cvars.isEmpty()) {
       throw new UnsupportedOperationException(
           "Currently not supporting arbitrary community set regexes");
     } else {
-      return bdd;
+      return communityVarsToBDD(cvars, arg);
     }
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDD.java
@@ -24,6 +24,7 @@ import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetNot;
 import org.batfish.datamodel.routing_policy.communities.HasCommunity;
 import org.batfish.minesweeper.CommunityVar;
+import org.batfish.minesweeper.communities.CommunitySetMatchExprVarCollector;
 
 /**
  * Create a BDD from a {@link
@@ -98,7 +99,17 @@ public class CommunitySetMatchExprToBDD
   @Override
   public BDD visitCommunitySetMatchRegex(CommunitySetMatchRegex communitySetMatchRegex, Arg arg) {
     // NOTE: when implementing, update CommunitySetMatchExprVarCollector#visitCommunitySetMatchRegex
-    throw new UnsupportedOperationException("Currently not supporting community set regexes");
+    BDD bdd =
+        communityVarsToBDD(
+            communitySetMatchRegex.accept(
+                new CommunitySetMatchExprVarCollector(), arg.getTransferBDD().getConfiguration()),
+            arg);
+    if (bdd.isZero()) {
+      throw new UnsupportedOperationException(
+          "Currently not supporting arbitrary community set regexes");
+    } else {
+      return bdd;
+    }
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunitySetMatchExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunitySetMatchExprVarCollector.java
@@ -67,7 +67,7 @@ public class CommunitySetMatchExprVarCollector
     if (cvar.toAutomaton().isEmpty()) {
       return ImmutableSet.of();
     } else {
-      return ImmutableSet.of(CommunityVar.from(regex));
+      return ImmutableSet.of(cvar);
     }
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunitySetMatchExprVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/communities/CommunitySetMatchExprVarCollector.java
@@ -59,9 +59,16 @@ public class CommunitySetMatchExprVarCollector
   @Override
   public Set<CommunityVar> visitCommunitySetMatchRegex(
       CommunitySetMatchRegex communitySetMatchRegex, Configuration arg) {
-    // This is not supported, but rather than throw we do nothing. If we end up needing to model
-    // this structure, the later code will crash instead.
-    return ImmutableSet.of();
+    // See if this regex can be treated as one that applies to a single community.  If so,
+    // we collect it and treat it as such.  If not, we ignore this regex; later if the symbolic
+    // analysis ever needs to consider this regex then it will fail with an exception.
+    String regex = communitySetMatchRegex.getRegex();
+    CommunityVar cvar = CommunityVar.from(regex);
+    if (cvar.toAutomaton().isEmpty()) {
+      return ImmutableSet.of();
+    } else {
+      return ImmutableSet.of(CommunityVar.from(regex));
+    }
   }
 
   @Override

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/CommunitySetMatchExprToBDDTest.java
@@ -26,8 +26,10 @@ import org.batfish.datamodel.routing_policy.communities.CommunitySetAclLine;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchAll;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchAny;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprReference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetNot;
 import org.batfish.datamodel.routing_policy.communities.HasCommunity;
+import org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated;
 import org.batfish.datamodel.routing_policy.expr.LiteralCommunity;
 import org.batfish.minesweeper.CommunityVar;
 import org.batfish.minesweeper.Graph;
@@ -141,6 +143,19 @@ public class CommunitySetMatchExprToBDDTest {
     CommunitySetMatchExprReference csmer = new CommunitySetMatchExprReference(name);
 
     BDD result = _communitySetMatchExprToBDD.visitCommunitySetMatchExprReference(csmer, _arg);
+
+    CommunityVar cvar = CommunityVar.from("^20:");
+
+    assertEquals(cvarToBDD(cvar), result);
+  }
+
+  @Test
+  public void testVisitCommunitySetMatchRegex() {
+    CommunitySetMatchRegex csmr =
+        new CommunitySetMatchRegex(
+            new TypesFirstAscendingSpaceSeparated(ColonSeparatedRendering.instance()), "^20:");
+
+    BDD result = _communitySetMatchExprToBDD.visitCommunitySetMatchRegex(csmr, _arg);
 
     CommunityVar cvar = CommunityVar.from("^20:");
 

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/CommunitySetMatchExprVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/communities/CommunitySetMatchExprVarCollectorTest.java
@@ -131,6 +131,19 @@ public class CommunitySetMatchExprVarCollectorTest {
   }
 
   @Test
+  public void testVisitCommunitySetMatchRegexSpecialCase() {
+    // We support the special case of community-set regexes that are just requiring a single
+    // community to be in the set.
+    CommunitySetMatchRegex cmsr =
+        new CommunitySetMatchRegex(
+            new TypesFirstAscendingSpaceSeparated(ColonSeparatedRendering.instance()), "^65000:");
+
+    Set<CommunityVar> result = cmsr.accept(_varCollector, _baseConfig);
+    // TODO: this construct is not supported yet.
+    assertEquals(result, ImmutableSet.of(CommunityVar.from("^65000:")));
+  }
+
+  @Test
   public void testVisitCommunitySetNot() {
     CommunitySetNot csn = new CommunitySetNot(new HasCommunity(new CommunityIs(COMM1)));
 


### PR DESCRIPTION
Adds support to SearchRoutePolicies for a special case of regex matching on community sets.  When the regex only applies to a single community within the set, then we can treat it as a regex on an individual community and use the existing machinery for community regexes to handle it properly.  There is still no support for more general community-set regexes.