### PR TITLE
IOS: Use regexes on individual communities where possible

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/IpAsPathAccessListLine.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/IpAsPathAccessListLine.java
@@ -19,7 +19,7 @@ public class IpAsPathAccessListLine implements Serializable {
   }
 
   public AsPathAccessListLine toAsPathAccessListLine() {
-    String regex = CiscoConfiguration.toJavaRegex(_regex);
+    String regex = CiscoConversions.toJavaRegex(_regex);
     return new AsPathAccessListLine(_action, regex);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cisco/CiscoConversionsTest.java
@@ -10,6 +10,9 @@ import static org.batfish.representation.cisco.CiscoConversions.createAclWithSym
 import static org.batfish.representation.cisco.CiscoConversions.getMatchingPsk;
 import static org.batfish.representation.cisco.CiscoConversions.sanityCheckDistributeList;
 import static org.batfish.representation.cisco.CiscoConversions.sanityCheckEigrpDistributeList;
+import static org.batfish.representation.cisco.CiscoConversions.toCommunitySetAclLine;
+import static org.batfish.representation.cisco.CiscoConversions.toCommunitySetAclLineOptimized;
+import static org.batfish.representation.cisco.CiscoConversions.toCommunitySetAclLineUnoptimized;
 import static org.batfish.representation.cisco.CiscoConversions.toOspfDeadInterval;
 import static org.batfish.representation.cisco.CiscoConversions.toOspfHelloInterval;
 import static org.hamcrest.Matchers.equalTo;
@@ -30,6 +33,7 @@ import org.batfish.datamodel.IkeKeyType;
 import org.batfish.datamodel.IkePhase1Key;
 import org.batfish.datamodel.IpAccessList;
 import org.batfish.datamodel.IpWildcard;
+import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.acl.MatchHeaderSpace;
 import org.batfish.datamodel.matchers.IkePhase1KeyMatchers;
@@ -265,6 +269,54 @@ public class CiscoConversionsTest {
         equalTo(
             "dist-list in OSPF process vrf:p1 uses a prefix-list which is not defined, this"
                 + " dist-list will allow everything"));
+  }
+
+  @Test
+  public void testToCommunitySetAclLine() {
+    ExpandedCommunityListLine l0 = new ExpandedCommunityListLine(LineAction.PERMIT, "34");
+    ExpandedCommunityListLine l1 = new ExpandedCommunityListLine(LineAction.PERMIT, "_34:567_");
+    ExpandedCommunityListLine l2 = new ExpandedCommunityListLine(LineAction.DENY, "_34:567");
+    ExpandedCommunityListLine l3 = new ExpandedCommunityListLine(LineAction.PERMIT, "_34:");
+    ExpandedCommunityListLine l4 = new ExpandedCommunityListLine(LineAction.DENY, "_34");
+    ExpandedCommunityListLine l5 = new ExpandedCommunityListLine(LineAction.PERMIT, "34:");
+    ExpandedCommunityListLine l6 = new ExpandedCommunityListLine(LineAction.DENY, "34:567_");
+    ExpandedCommunityListLine l7 = new ExpandedCommunityListLine(LineAction.PERMIT, ":567");
+    ExpandedCommunityListLine l8 = new ExpandedCommunityListLine(LineAction.DENY, ":567_");
+    ExpandedCommunityListLine l85 = new ExpandedCommunityListLine(LineAction.PERMIT, "567_");
+    ExpandedCommunityListLine l9 = new ExpandedCommunityListLine(LineAction.PERMIT, "34:567");
+    ExpandedCommunityListLine l10 = new ExpandedCommunityListLine(LineAction.DENY, ":");
+
+    ExpandedCommunityListLine l11 = new ExpandedCommunityListLine(LineAction.PERMIT, "^34:567_");
+    ExpandedCommunityListLine l12 = new ExpandedCommunityListLine(LineAction.DENY, "_34:567$");
+    ExpandedCommunityListLine l13 =
+        new ExpandedCommunityListLine(LineAction.PERMIT, "_34:56_78:9_");
+    ExpandedCommunityListLine l14 = new ExpandedCommunityListLine(LineAction.DENY, ":56_78:");
+    ExpandedCommunityListLine l15 = new ExpandedCommunityListLine(LineAction.PERMIT, "56_78");
+    ExpandedCommunityListLine l16 = new ExpandedCommunityListLine(LineAction.DENY, "^34:567$");
+    ExpandedCommunityListLine l17 = new ExpandedCommunityListLine(LineAction.DENY, "^34:");
+    ExpandedCommunityListLine l18 = new ExpandedCommunityListLine(LineAction.DENY, ":567$");
+
+    assertThat(toCommunitySetAclLine(l0), equalTo(toCommunitySetAclLineOptimized(l0)));
+    assertThat(toCommunitySetAclLine(l1), equalTo(toCommunitySetAclLineOptimized(l1)));
+    assertThat(toCommunitySetAclLine(l2), equalTo(toCommunitySetAclLineOptimized(l2)));
+    assertThat(toCommunitySetAclLine(l3), equalTo(toCommunitySetAclLineOptimized(l3)));
+    assertThat(toCommunitySetAclLine(l4), equalTo(toCommunitySetAclLineOptimized(l4)));
+    assertThat(toCommunitySetAclLine(l5), equalTo(toCommunitySetAclLineOptimized(l5)));
+    assertThat(toCommunitySetAclLine(l6), equalTo(toCommunitySetAclLineOptimized(l6)));
+    assertThat(toCommunitySetAclLine(l7), equalTo(toCommunitySetAclLineOptimized(l7)));
+    assertThat(toCommunitySetAclLine(l8), equalTo(toCommunitySetAclLineOptimized(l8)));
+    assertThat(toCommunitySetAclLine(l85), equalTo(toCommunitySetAclLineOptimized(l85)));
+    assertThat(toCommunitySetAclLine(l9), equalTo(toCommunitySetAclLineOptimized(l9)));
+    assertThat(toCommunitySetAclLine(l10), equalTo(toCommunitySetAclLineOptimized(l10)));
+
+    assertThat(toCommunitySetAclLine(l11), equalTo(toCommunitySetAclLineUnoptimized(l11)));
+    assertThat(toCommunitySetAclLine(l12), equalTo(toCommunitySetAclLineUnoptimized(l12)));
+    assertThat(toCommunitySetAclLine(l13), equalTo(toCommunitySetAclLineUnoptimized(l13)));
+    assertThat(toCommunitySetAclLine(l14), equalTo(toCommunitySetAclLineUnoptimized(l14)));
+    assertThat(toCommunitySetAclLine(l15), equalTo(toCommunitySetAclLineUnoptimized(l15)));
+    assertThat(toCommunitySetAclLine(l16), equalTo(toCommunitySetAclLineUnoptimized(l16)));
+    assertThat(toCommunitySetAclLine(l17), equalTo(toCommunitySetAclLineUnoptimized(l17)));
+    assertThat(toCommunitySetAclLine(l18), equalTo(toCommunitySetAclLineUnoptimized(l18)));
   }
 
   private static CiscoConfiguration basicCiscoConfig() {

--- a/tests/basic/outliers-verbose.ref
+++ b/tests/basic/outliers-verbose.ref
@@ -63,14 +63,14 @@
             {
               "action" : "PERMIT",
               "communitySetMatchExpr" : {
-                "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                "communityRendering" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                "expr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                   "communityRendering" : {
                     "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                  }
-                },
-                "regex" : "(,|\\{|\\}|^|$| )2:"
+                  },
+                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                }
               }
             }
           ]
@@ -93,14 +93,14 @@
             {
               "action" : "PERMIT",
               "communitySetMatchExpr" : {
-                "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                "communityRendering" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                "expr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                   "communityRendering" : {
                     "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                  }
-                },
-                "regex" : "(,|\\{|\\}|^|$| )1:"
+                  },
+                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                }
               }
             }
           ]
@@ -123,14 +123,14 @@
             {
               "action" : "PERMIT",
               "communitySetMatchExpr" : {
-                "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                "communityRendering" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                "expr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                   "communityRendering" : {
                     "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                  }
-                },
-                "regex" : "(,|\\{|\\}|^|$| )3:"
+                  },
+                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                }
               }
             }
           ]
@@ -376,14 +376,14 @@
             {
               "action" : "PERMIT",
               "communitySetMatchExpr" : {
-                "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                "communityRendering" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                "expr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                   "communityRendering" : {
                     "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                  }
-                },
-                "regex" : "(,|\\{|\\}|^|$| )65001:"
+                  },
+                  "regex" : "(,|\\{|\\}|^|$| )65001:"
+                }
               }
             }
           ]
@@ -960,14 +960,14 @@
             {
               "action" : "PERMIT",
               "communitySetMatchExpr" : {
-                "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                "communityRendering" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                "expr" : {
+                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                   "communityRendering" : {
                     "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                  }
-                },
-                "regex" : "(,|\\{|\\}|^|$| )4:"
+                  },
+                  "regex" : "(,|\\{|\\}|^|$| )4:"
+                }
               }
             }
           ]

--- a/tests/basic/viModel.ref
+++ b/tests/basic/viModel.ref
@@ -59,14 +59,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )1:"
+                  }
                 }
               }
             ]
@@ -77,14 +77,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )2:"
+                  }
                 }
               }
             ]
@@ -95,14 +95,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )3:"
+                  }
                 }
               }
             ]
@@ -1606,14 +1606,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )1:"
+                  }
                 }
               }
             ]
@@ -1624,14 +1624,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )2:"
+                  }
                 }
               }
             ]
@@ -1642,14 +1642,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )3:"
+                  }
                 }
               }
             ]
@@ -1660,14 +1660,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )4:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )4:"
+                  }
                 }
               }
             ]
@@ -3614,14 +3614,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )1:"
+                  }
                 }
               }
             ]
@@ -3632,14 +3632,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )2:"
+                  }
                 }
               }
             ]
@@ -3650,14 +3650,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )3:"
+                  }
                 }
               }
             ]
@@ -5147,14 +5147,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )1:"
+                  }
                 }
               }
             ]
@@ -5165,14 +5165,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )2:"
+                  }
                 }
               }
             ]
@@ -5183,14 +5183,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )3:"
+                  }
                 }
               }
             ]
@@ -7907,14 +7907,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )2:"
+                  }
                 }
               }
             ]
@@ -9127,14 +9127,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )65001:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )65001:"
+                  }
                 }
               }
             ]
@@ -10011,14 +10011,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )65001:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )65001:"
+                  }
                 }
               }
             ]
@@ -10925,14 +10925,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )1:"
+                  }
                 }
               }
             ]
@@ -10943,14 +10943,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )2:"
+                  }
                 }
               }
             ]
@@ -10961,14 +10961,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )3:"
+                  }
                 }
               }
             ]
@@ -12369,14 +12369,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )1:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )1:"
+                  }
                 }
               }
             ]
@@ -12387,14 +12387,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )2:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )2:"
+                  }
                 }
               }
             ]
@@ -12405,14 +12405,14 @@
               {
                 "action" : "PERMIT",
                 "communitySetMatchExpr" : {
-                  "class" : "org.batfish.datamodel.routing_policy.communities.CommunitySetMatchRegex",
-                  "communityRendering" : {
-                    "class" : "org.batfish.datamodel.routing_policy.communities.TypesFirstAscendingSpaceSeparated",
+                  "class" : "org.batfish.datamodel.routing_policy.communities.HasCommunity",
+                  "expr" : {
+                    "class" : "org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex",
                     "communityRendering" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering"
-                    }
-                  },
-                  "regex" : "(,|\\{|\\}|^|$| )3:"
+                    },
+                    "regex" : "(,|\\{|\\}|^|$| )3:"
+                  }
                 }
               }
             ]


### PR DESCRIPTION
When converting IOS community-set regexes to the VI model, if a regex only requires that some community matching a particular format exists, then we represent it as a community regex rather than a community-set regex.  Community regexes have a simpler semantics, and some questions (e.g., SearchRoutePolicies) don't handle community-set regexes.