### PR TITLE
Specialize bgp and evpn rib questions

### DIFF
--- a/questions/stable/bgpRib.json
+++ b/questions/stable/bgpRib.json
@@ -1,0 +1,42 @@
+{
+    "class": "org.batfish.question.routes.RoutesQuestion",
+    "differential": false,
+    "instance": {
+        "description": "Returns routes in the BGP RIB.",
+        "instanceName": "bgpRib",
+        "longDescription": "Shows BGP routes for specified VRF and node(s).",
+        "orderedVariableNames": [
+            "nodes",
+            "network",
+            "vrfs"
+        ],
+        "tags": [
+            "dataplane",
+            "routing"
+        ],
+        "variables": {
+            "nodes": {
+                "description": "Examine routes on nodes matching this specifier",
+                "type": "nodeSpec",
+                "optional": true,
+                "displayName": "Nodes"
+            },
+            "vrfs": {
+                "description": "Examine routes on VRFs matching this name or regex",
+                "type": "vrf",
+                "optional": true,
+                "displayName": "VRFs"
+            },
+            "network": {
+                "description": "Examine routes for networks matching this prefix",
+                "type": "prefix",
+                "optional": true,
+                "displayName": "Network"
+            },
+        }
+    },
+    "network": "${network}",
+    "nodes": "${nodes}",
+    "vrfs": "${vrfs}",
+    "rib": "bgp"
+}

--- a/questions/stable/bgpRib.json
+++ b/questions/stable/bgpRib.json
@@ -32,7 +32,7 @@
                 "type": "prefix",
                 "optional": true,
                 "displayName": "Network"
-            },
+            }
         }
     },
     "network": "${network}",

--- a/questions/stable/evpnRib.json
+++ b/questions/stable/evpnRib.json
@@ -1,0 +1,42 @@
+{
+    "class": "org.batfish.question.routes.RoutesQuestion",
+    "differential": false,
+    "instance": {
+        "description": "Returns routes in the EVPN RIB.",
+        "instanceName": "evpnRib",
+        "longDescription": "Shows EVPN routes for specified VRF and node(s).",
+        "orderedVariableNames": [
+            "nodes",
+            "network",
+            "vrfs"
+        ],
+        "tags": [
+            "dataplane",
+            "routing"
+        ],
+        "variables": {
+            "nodes": {
+                "description": "Examine routes on nodes matching this specifier",
+                "type": "nodeSpec",
+                "optional": true,
+                "displayName": "Nodes"
+            },
+            "vrfs": {
+                "description": "Examine routes on VRFs matching this name or regex",
+                "type": "vrf",
+                "optional": true,
+                "displayName": "VRFs"
+            },
+            "network": {
+                "description": "Examine routes for networks matching this prefix",
+                "type": "prefix",
+                "optional": true,
+                "displayName": "Network"
+            },
+        }
+    },
+    "network": "${network}",
+    "nodes": "${nodes}",
+    "vrfs": "${vrfs}",
+    "rib": "evpn"
+}

--- a/questions/stable/evpnRib.json
+++ b/questions/stable/evpnRib.json
@@ -32,7 +32,7 @@
                 "type": "prefix",
                 "optional": true,
                 "displayName": "Network"
-            },
+            }
         }
     },
     "network": "${network}",

--- a/tests/questions/stable/bgpRib.ref
+++ b/tests/questions/stable/bgpRib.ref
@@ -1,0 +1,47 @@
+{
+  "class" : "org.batfish.question.routes.RoutesQuestion",
+  "network" : "1.1.1.0/24",
+  "nodes" : "n1",
+  "protocols" : "all",
+  "rib" : "BGP",
+  "vrfs" : "default",
+  "differential" : false,
+  "includeOneTableKeys" : true,
+  "instance" : {
+    "description" : "Returns routes in the BGP RIB.",
+    "instanceName" : "qname",
+    "longDescription" : "Shows BGP routes for specified VRF and node(s).",
+    "orderedVariableNames" : [
+      "nodes",
+      "network",
+      "vrfs"
+    ],
+    "tags" : [
+      "dataplane",
+      "routing"
+    ],
+    "variables" : {
+      "network" : {
+        "description" : "Examine routes for networks matching this prefix",
+        "displayName" : "Network",
+        "optional" : true,
+        "type" : "prefix",
+        "value" : "1.1.1.1/24"
+      },
+      "nodes" : {
+        "description" : "Examine routes on nodes matching this specifier",
+        "displayName" : "Nodes",
+        "optional" : true,
+        "type" : "nodeSpec",
+        "value" : "n1"
+      },
+      "vrfs" : {
+        "description" : "Examine routes on VRFs matching this name or regex",
+        "displayName" : "VRFs",
+        "optional" : true,
+        "type" : "vrf",
+        "value" : "default"
+      }
+    }
+  }
+}

--- a/tests/questions/stable/commands
+++ b/tests/questions/stable/commands
@@ -21,8 +21,14 @@ test -raw tests/questions/stable/edges.ref validate-template edges edgeType="bgp
 # validate bgpEdges
 test -raw tests/questions/stable/bgpEdges.ref validate-template bgpEdges nodes=".*", remoteNodes=".*"
 
+# validate bgpRib
+test -raw tests/questions/stable/bgpRib.ref validate-template bgpRib network="1.1.1.1/24", nodes="n1", vrfs="default"
+
 # validate eigrpEdges
 test -raw tests/questions/stable/eigrpEdges.ref validate-template eigrpEdges nodes=".*", remoteNodes=".*"
+
+# validate evpnRib
+test -raw tests/questions/stable/evpnRib.ref validate-template evpnRib network="1.1.1.1/24", nodes="n1", vrfs="default"
 
 # validate ipsecEdges
 test -raw tests/questions/stable/ipsecEdges.ref validate-template ipsecEdges nodes=".*", remoteNodes=".*"

--- a/tests/questions/stable/evpnRib.ref
+++ b/tests/questions/stable/evpnRib.ref
@@ -1,0 +1,47 @@
+{
+  "class" : "org.batfish.question.routes.RoutesQuestion",
+  "network" : "1.1.1.0/24",
+  "nodes" : "n1",
+  "protocols" : "all",
+  "rib" : "EVPN",
+  "vrfs" : "default",
+  "differential" : false,
+  "includeOneTableKeys" : true,
+  "instance" : {
+    "description" : "Returns routes in the EVPN RIB.",
+    "instanceName" : "qname",
+    "longDescription" : "Shows EVPN routes for specified VRF and node(s).",
+    "orderedVariableNames" : [
+      "nodes",
+      "network",
+      "vrfs"
+    ],
+    "tags" : [
+      "dataplane",
+      "routing"
+    ],
+    "variables" : {
+      "network" : {
+        "description" : "Examine routes for networks matching this prefix",
+        "displayName" : "Network",
+        "optional" : true,
+        "type" : "prefix",
+        "value" : "1.1.1.1/24"
+      },
+      "nodes" : {
+        "description" : "Examine routes on nodes matching this specifier",
+        "displayName" : "Nodes",
+        "optional" : true,
+        "type" : "nodeSpec",
+        "value" : "n1"
+      },
+      "vrfs" : {
+        "description" : "Examine routes on VRFs matching this name or regex",
+        "displayName" : "VRFs",
+        "optional" : true,
+        "type" : "vrf",
+        "value" : "default"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Specialize the routes question for BGP and EVPN ribs. The questions have different columns in the answer tables, which are otherwise not visible in the documentation and left users wondering how they get BGP-specific fields. 