### PR TITLE
Implement recursive static routes and resolution policy

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FibImpl.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.Stack;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -86,12 +87,13 @@ public final class FibImpl implements Fib {
 
   private transient Supplier<Set<FibEntry>> _entries;
 
-  public FibImpl(@Nonnull GenericRib<? extends AbstractRouteDecorator> rib) {
+  public <R extends AbstractRouteDecorator> FibImpl(
+      @Nonnull GenericRib<R> rib, @Nullable Predicate<R> restriction) {
     _root = new PrefixTrieMultiMap<>(Prefix.ZERO);
     rib.getTypedRoutes()
         .forEach(
             r -> {
-              Set<FibEntry> s = resolveRoute(rib, r.getAbstractRoute());
+              Set<FibEntry> s = resolveRoute(rib, r.getAbstractRoute(), restriction);
               _root.putAll(r.getNetwork(), s);
             });
     initSuppliers();
@@ -116,13 +118,14 @@ public final class FibImpl implements Fib {
    *
    * @param rib {@link GenericRib} for which to do the resolution.
    * @param route {@link AbstractRoute} with a next hop IP to be resolved.
+   * @param restriction A restriction on which routes may be used to
    * @return A map (interface name -&gt; last hop IP -&gt; last taken route) for
    * @throws BatfishException if resolution depth is exceeded (high likelihood of a routing loop) OR
    *     an invalid route in the RIB has been encountered.
    */
   @VisibleForTesting
-  Set<FibEntry> resolveRoute(
-      GenericRib<? extends AbstractRouteDecorator> rib, AbstractRoute route) {
+  <R extends AbstractRouteDecorator> Set<FibEntry> resolveRoute(
+      GenericRib<R> rib, AbstractRoute route, @Nullable Predicate<R> restriction) {
     ResolutionTreeNode resolutionRoot = ResolutionTreeNode.root(route);
     buildResolutionTree(
         rib,
@@ -132,7 +135,8 @@ public final class FibImpl implements Fib {
         0,
         Prefix.MAX_PREFIX_LENGTH,
         null,
-        resolutionRoot);
+        resolutionRoot,
+        restriction);
     Builder<FibEntry> collector = ImmutableSet.builder();
     collectEntries(resolutionRoot, new Stack<>(), collector);
     return collector.build();
@@ -183,15 +187,16 @@ public final class FibImpl implements Fib {
    * number of leaf {@link ResolutionTreeNode}. Leaf nodes must contain non-null {@link
    * ResolutionTreeNode#_finalNextHopIp}
    */
-  private void buildResolutionTree(
-      GenericRib<? extends AbstractRouteDecorator> rib,
+  private <R extends AbstractRouteDecorator> void buildResolutionTree(
+      GenericRib<R> rib,
       AbstractRoute route,
       Ip mostRecentNextHopIp,
       Set<Prefix> seenNetworks,
       int depth,
       int maxPrefixLength,
       @Nullable AbstractRoute parentRoute,
-      ResolutionTreeNode treeNode) {
+      ResolutionTreeNode treeNode,
+      @Nullable Predicate<R> restriction) {
     Prefix network = route.getNetwork();
     if (seenNetworks.contains(network)) {
       // Don't enter a resolution loop
@@ -219,7 +224,8 @@ public final class FibImpl implements Fib {
             depth + 1,
             maxPrefixLength - 1,
             null,
-            treeNode);
+            treeNode,
+            restriction);
         return;
       }
     }
@@ -228,14 +234,30 @@ public final class FibImpl implements Fib {
 
       @Override
       public Void visitNextHopIp(NextHopIp nextHopIp) {
-        Set<? extends AbstractRouteDecorator> nextHopLongestPrefixMatchRoutes =
-            rib.longestPrefixMatch(nextHopIp.getIp(), maxPrefixLength);
-
-        /* Filter out any non-forwarding routes from the matches */
         Set<AbstractRoute> forwardingRoutes =
-            nextHopLongestPrefixMatchRoutes.stream()
+            rib
+                .longestPrefixMatch(
+                    nextHopIp.getIp(),
+                    maxPrefixLength,
+                    r -> {
+                      if (route.getProtocol() == RoutingProtocol.STATIC) {
+                        // TODO: factor out common code with
+                        // StaticRouteHelper.shouldActivateNextHopIpRoute
+                        if (r.getAbstractRoute().getProtocol() == RoutingProtocol.CONNECTED) {
+                          // All static routes can be activated by a connected route.
+                          return true;
+                        }
+                        if (!((StaticRoute) route).getRecursive()) {
+                          // Non-recursive static routes cannot be activated by non-connected
+                          // routes.
+                          return false;
+                        }
+                      }
+                      // Recursive routes must pass restriction if present.
+                      return restriction == null || restriction.test(r);
+                    })
+                .stream()
                 .map(AbstractRouteDecorator::getAbstractRoute)
-                .filter(r -> !r.getNonForwarding())
                 .collect(ImmutableSet.toImmutableSet());
 
         if (forwardingRoutes.isEmpty()) {
@@ -249,7 +271,8 @@ public final class FibImpl implements Fib {
               depth + 1,
               maxPrefixLength - 1,
               parentRoute,
-              treeNode);
+              treeNode,
+              restriction);
         } else {
           // We have at least one valid longest-prefix match
           for (AbstractRoute nextHopLongestPrefixMatchRoute : forwardingRoutes) {
@@ -261,7 +284,8 @@ public final class FibImpl implements Fib {
                 depth + 1,
                 Prefix.MAX_PREFIX_LENGTH,
                 route,
-                ResolutionTreeNode.withParent(nextHopLongestPrefixMatchRoute, treeNode, null));
+                ResolutionTreeNode.withParent(nextHopLongestPrefixMatchRoute, treeNode, null),
+                restriction);
           }
         }
         return null;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRibReadOnly.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRibReadOnly.java
@@ -2,8 +2,6 @@ package org.batfish.datamodel;
 
 import java.io.Serializable;
 import java.util.Set;
-import java.util.function.Predicate;
-import javax.annotation.Nullable;
 
 public interface GenericRibReadOnly<R extends AbstractRouteDecorator> extends Serializable {
 
@@ -27,7 +25,7 @@ public interface GenericRibReadOnly<R extends AbstractRouteDecorator> extends Se
    *     this may shorten the longest prefix.
    * @return a set of routes with the maximum allowable prefix length that match the {@code address}
    */
-  Set<R> longestPrefixMatch(Ip address, @Nullable Predicate<R> restriction);
+  Set<R> longestPrefixMatch(Ip address, ResolutionRestriction<R> restriction);
 
   /**
    * Execute a constrained longest prefix match for a given IP address.
@@ -35,8 +33,9 @@ public interface GenericRibReadOnly<R extends AbstractRouteDecorator> extends Se
    * <p><strong>Note</strong>: this function returns only forwarding routes, aka, routes where
    * {@link AbstractRoute#getNonForwarding()} returns false.
    *
-   * <p>Most callers should use {@link #longestPrefixMatch(Ip, Predicate)}; this function may be
-   * used when the longest prefix matches are unsatisfactory and less specific routes are required.
+   * <p>Most callers should use {@link #longestPrefixMatch(Ip, ResolutionRestriction)}; this
+   * function may be used when the longest prefix matches are unsatisfactory and less specific
+   * routes are required.
    *
    * @param address the IP address to match
    * @param maxPrefixLength the maximum prefix length allowed (i.e., do not match more specific
@@ -45,7 +44,7 @@ public interface GenericRibReadOnly<R extends AbstractRouteDecorator> extends Se
    *     this may shorten the longest prefix.
    * @return a set of routes that match the {@code address} given the constraint.
    */
-  Set<R> longestPrefixMatch(Ip address, int maxPrefixLength, @Nullable Predicate<R> restriction);
+  Set<R> longestPrefixMatch(Ip address, int maxPrefixLength, ResolutionRestriction<R> restriction);
 
   /**
    * Compare the preferability of one route with anther

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRibReadOnly.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GenericRibReadOnly.java
@@ -2,6 +2,8 @@ package org.batfish.datamodel;
 
 import java.io.Serializable;
 import java.util.Set;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
 
 public interface GenericRibReadOnly<R extends AbstractRouteDecorator> extends Serializable {
 
@@ -21,9 +23,11 @@ public interface GenericRibReadOnly<R extends AbstractRouteDecorator> extends Se
    * {@link AbstractRoute#getNonForwarding()} returns false.
    *
    * @param address the IP address to match
+   * @param restriction A predicate restricting which routes may be returned. Note that in general
+   *     this may shorten the longest prefix.
    * @return a set of routes with the maximum allowable prefix length that match the {@code address}
    */
-  Set<R> longestPrefixMatch(Ip address);
+  Set<R> longestPrefixMatch(Ip address, @Nullable Predicate<R> restriction);
 
   /**
    * Execute a constrained longest prefix match for a given IP address.
@@ -31,15 +35,17 @@ public interface GenericRibReadOnly<R extends AbstractRouteDecorator> extends Se
    * <p><strong>Note</strong>: this function returns only forwarding routes, aka, routes where
    * {@link AbstractRoute#getNonForwarding()} returns false.
    *
-   * <p>Most callers should use {@link #longestPrefixMatch(Ip)}; this function may be used when the
-   * longest prefix matches are unsatisfactory and less specific routes are required.
+   * <p>Most callers should use {@link #longestPrefixMatch(Ip, Predicate)}; this function may be
+   * used when the longest prefix matches are unsatisfactory and less specific routes are required.
    *
    * @param address the IP address to match
    * @param maxPrefixLength the maximum prefix length allowed (i.e., do not match more specific
    *     routes). This is a less than or equal constraint.
+   * @param restriction A predicate restricting which routes may be returned. Note that in general
+   *     this may shorten the longest prefix.
    * @return a set of routes that match the {@code address} given the constraint.
    */
-  Set<R> longestPrefixMatch(Ip address, int maxPrefixLength);
+  Set<R> longestPrefixMatch(Ip address, int maxPrefixLength, @Nullable Predicate<R> restriction);
 
   /**
    * Compare the preferability of one route with anther

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ResolutionRestriction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ResolutionRestriction.java
@@ -1,0 +1,19 @@
+package org.batfish.datamodel;
+
+import java.util.function.Predicate;
+import javax.annotation.Nonnull;
+
+/**
+ * A predicate on {@link org.batfish.datamodel.AbstractRouteDecorator} whose members may be used for
+ * next-hop-ip resolution.
+ */
+public interface ResolutionRestriction<R extends AbstractRouteDecorator> extends Predicate<R> {
+
+  ResolutionRestriction<AbstractRouteDecorator> ALWAYS_TRUE = r -> true;
+
+  @SuppressWarnings("unchecked")
+  @Nonnull
+  static <R extends AbstractRouteDecorator> ResolutionRestriction<R> alwaysTrue() {
+    return (ResolutionRestriction<R>) ALWAYS_TRUE;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
@@ -94,6 +94,7 @@ public class Vrf extends ComparableStructure<String> {
   private static final String PROP_KERNEL_ROUTES = "kernelRoutes";
   private static final String PROP_OSPF_PROCESS = "ospfProcess";
   private static final String PROP_OSPF_PROCESSES = "ospfProcesses";
+  private static final String PROP_RESOLUTION_POLICY = "resolutionPolicy";
   private static final String PROP_RIP_PROCESS = "ripProcess";
   private static final String PROP_STATIC_ROUTES = "staticRoutes";
   private static final String PROP_VRF_LEAKING_CONFIGS = "vrfLeakingConfigs";
@@ -116,6 +117,7 @@ public class Vrf extends ComparableStructure<String> {
   private IsisProcess _isisProcess;
   private SortedSet<KernelRoute> _kernelRoutes;
   @Nonnull private SortedMap<String, OspfProcess> _ospfProcesses;
+  @Nullable private String _resolutionPolicy;
   private RipProcess _ripProcess;
   private SnmpServer _snmpServer;
   private SortedSet<StaticRoute> _staticRoutes;
@@ -373,6 +375,17 @@ public class Vrf extends ComparableStructure<String> {
             .putAll(_ospfProcesses)
             .put(ospfProcess.getProcessId(), ospfProcess)
             .build();
+  }
+
+  @JsonProperty(PROP_RESOLUTION_POLICY)
+  @Nullable
+  public String getResolutionPolicy() {
+    return _resolutionPolicy;
+  }
+
+  @JsonProperty(PROP_RESOLUTION_POLICY)
+  public void setResolutionPolicy(@Nullable String resolutionPolicy) {
+    _resolutionPolicy = resolutionPolicy;
   }
 
   @JsonProperty(PROP_RIP_PROCESS)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/RoutingPolicy.java
@@ -25,6 +25,7 @@ import org.batfish.datamodel.AbstractRouteBuilder;
 import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpSessionProperties;
+import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.PrefixSpace;
 import org.batfish.datamodel.eigrp.EigrpProcess;
@@ -192,6 +193,15 @@ public class RoutingPolicy implements Serializable {
   @JsonProperty(PROP_STATEMENTS)
   public List<Statement> getStatements() {
     return _statements;
+  }
+
+  /**
+   * @return True if the policy accepts the route. Clients should only call this when state and
+   *     transformations are not needed.
+   */
+  public boolean processReadOnly(AbstractRouteDecorator inputRoute) {
+    // arbitrarily choose OUT direction, BGP route builder.
+    return process(inputRoute, Bgpv4Route.builder(), null, Direction.OUT, null);
   }
 
   /** @return True if the policy accepts the route. */

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 public class MockRib implements GenericRib<AnnotatedRoute<AbstractRoute>> {
 
@@ -94,12 +95,14 @@ public class MockRib implements GenericRib<AnnotatedRoute<AbstractRoute>> {
   }
 
   @Override
-  public Set<AnnotatedRoute<AbstractRoute>> longestPrefixMatch(Ip address) {
+  public Set<AnnotatedRoute<AbstractRoute>> longestPrefixMatch(
+      Ip address, Predicate<AnnotatedRoute<AbstractRoute>> restriction) {
     return _longestPrefixMatchResults.get(address);
   }
 
   @Override
-  public Set<AnnotatedRoute<AbstractRoute>> longestPrefixMatch(Ip address, int maxPrefixLength) {
+  public Set<AnnotatedRoute<AbstractRoute>> longestPrefixMatch(
+      Ip address, int maxPrefixLength, Predicate<AnnotatedRoute<AbstractRoute>> restriction) {
     throw new UnsupportedOperationException();
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/MockRib.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Predicate;
 
 public class MockRib implements GenericRib<AnnotatedRoute<AbstractRoute>> {
 
@@ -96,13 +95,15 @@ public class MockRib implements GenericRib<AnnotatedRoute<AbstractRoute>> {
 
   @Override
   public Set<AnnotatedRoute<AbstractRoute>> longestPrefixMatch(
-      Ip address, Predicate<AnnotatedRoute<AbstractRoute>> restriction) {
+      Ip address, ResolutionRestriction<AnnotatedRoute<AbstractRoute>> restriction) {
     return _longestPrefixMatchResults.get(address);
   }
 
   @Override
   public Set<AnnotatedRoute<AbstractRoute>> longestPrefixMatch(
-      Ip address, int maxPrefixLength, Predicate<AnnotatedRoute<AbstractRoute>> restriction) {
+      Ip address,
+      int maxPrefixLength,
+      ResolutionRestriction<AnnotatedRoute<AbstractRoute>> restriction) {
     throw new UnsupportedOperationException();
   }
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/flatjuniper/FlatJuniper_routing_instances.g4
@@ -230,6 +230,29 @@ ro_null
    ) null_filler
 ;
 
+ro_resolution
+:
+  RESOLUTION
+  (
+    apply
+    | rores_rib
+  )
+;
+
+rores_rib
+:
+  RIB name = variable
+  (
+    apply
+    | roresr_import
+  )
+;
+
+roresr_import
+:
+  IMPORT name = variable
+;
+
 ro_rib
 :
    RIB name = VARIABLE
@@ -733,6 +756,7 @@ s_routing_options
       | ro_interface_routes
       | ro_martians
       | ro_null
+      | ro_resolution
       | ro_rib
       | ro_rib_groups
       | ro_route_distinguisher_id

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/VirtualRouter.java
@@ -4,6 +4,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.batfish.common.util.CollectionUtil.toImmutableSortedMap;
 import static org.batfish.common.util.CollectionUtil.toOrderedHashCode;
+import static org.batfish.datamodel.ResolutionRestriction.alwaysTrue;
 import static org.batfish.datamodel.routing_policy.Environment.Direction.IN;
 import static org.batfish.dataplane.protocols.IsisProtocolHelper.convertRouteLevel1ToLevel2;
 import static org.batfish.dataplane.protocols.IsisProtocolHelper.exportNonIsisRouteToIsis;
@@ -31,7 +32,6 @@ import java.util.SortedSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -63,6 +63,7 @@ import org.batfish.datamodel.LocalRoute;
 import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.PrefixSpace;
+import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.RipInternalRoute;
 import org.batfish.datamodel.RipProcess;
 import org.batfish.datamodel.Route;
@@ -231,7 +232,8 @@ public final class VirtualRouter {
 
   @Nonnull private final RibExprEvaluator _ribExprEvaluator;
 
-  @Nullable private final Predicate<AnnotatedRoute<AbstractRoute>> _resolutionRestriction;
+  @Nonnull
+  private final ResolutionRestriction<AnnotatedRoute<AbstractRoute>> _resolutionRestriction;
 
   private static final Logger LOGGER = LogManager.getLogger(VirtualRouter.class);
 
@@ -243,7 +245,7 @@ public final class VirtualRouter {
     String resolutionPolicy = _vrf.getResolutionPolicy();
     _resolutionRestriction =
         resolutionPolicy == null
-            ? null
+            ? alwaysTrue()
             : _c.getRoutingPolicies().get(resolutionPolicy)::processReadOnly;
     // Main RIB + delta builder
     _mainRib = new Rib();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/StaticRouteHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/StaticRouteHelper.java
@@ -1,11 +1,10 @@
 package org.batfish.dataplane.protocols;
 
 import java.util.Set;
-import java.util.function.Predicate;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.AbstractRouteDecorator;
 import org.batfish.datamodel.GenericRib;
+import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
 
@@ -24,7 +23,7 @@ public class StaticRouteHelper {
    *     next-hops
    */
   public static <R extends AbstractRouteDecorator> boolean shouldActivateNextHopIpRoute(
-      StaticRoute route, GenericRib<R> rib, @Nullable Predicate<R> restriction) {
+      StaticRoute route, GenericRib<R> rib, ResolutionRestriction<R> restriction) {
     boolean recursive = route.getRecursive();
     Set<R> matchingRoutes =
         rib.longestPrefixMatch(
@@ -39,7 +38,7 @@ public class StaticRouteHelper {
                 return false;
               }
               // Recursive routes must pass restriction if present.
-              return restriction == null || restriction.test(r);
+              return restriction.test(r);
             });
 
     // If matchingRoutes is empty, cannot activate because next hop ip is unreachable
@@ -49,6 +48,7 @@ public class StaticRouteHelper {
             routeToNextHop ->
                 // Next hop has to be reachable through a route with a different prefix
                 !routeToNextHop.getNetwork().equals(route.getNetwork())
+                    // TODO: fix properly and stop allowing self-activation
                     || route.equals(routeToNextHop));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -15,6 +14,7 @@ import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.PrefixSpace;
+import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.dataplane.rib.RouteAdvertisement.Reason;
 
 /**
@@ -173,13 +173,13 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   public abstract int comparePreference(R lhs, R rhs);
 
   @Override
-  public @Nonnull Set<R> longestPrefixMatch(Ip address, @Nullable Predicate<R> restriction) {
+  public @Nonnull Set<R> longestPrefixMatch(Ip address, ResolutionRestriction<R> restriction) {
     return longestPrefixMatch(address, Prefix.MAX_PREFIX_LENGTH, restriction);
   }
 
   @Override
   public @Nonnull Set<R> longestPrefixMatch(
-      Ip address, int maxPrefixLength, @Nullable Predicate<R> restriction) {
+      Ip address, int maxPrefixLength, ResolutionRestriction<R> restriction) {
     return _tree.getLongestPrefixMatch(address, maxPrefixLength, restriction);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/AbstractRib.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -172,13 +173,14 @@ public abstract class AbstractRib<R extends AbstractRouteDecorator> implements G
   public abstract int comparePreference(R lhs, R rhs);
 
   @Override
-  public @Nonnull Set<R> longestPrefixMatch(Ip address) {
-    return longestPrefixMatch(address, Prefix.MAX_PREFIX_LENGTH);
+  public @Nonnull Set<R> longestPrefixMatch(Ip address, @Nullable Predicate<R> restriction) {
+    return longestPrefixMatch(address, Prefix.MAX_PREFIX_LENGTH, restriction);
   }
 
   @Override
-  public @Nonnull Set<R> longestPrefixMatch(Ip address, int maxPrefixLength) {
-    return _tree.getLongestPrefixMatch(address, maxPrefixLength);
+  public @Nonnull Set<R> longestPrefixMatch(
+      Ip address, int maxPrefixLength, @Nullable Predicate<R> restriction) {
+    return _tree.getLongestPrefixMatch(address, maxPrefixLength, restriction);
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -297,7 +297,7 @@ public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
     if (Ip.AUTO.equals(nextHopIp)) {
       return Long.MAX_VALUE;
     }
-    Set<AnnotatedRoute<AbstractRoute>> s = _mainRib.longestPrefixMatch(nextHopIp);
+    Set<AnnotatedRoute<AbstractRoute>> s = _mainRib.longestPrefixMatch(nextHopIp, null);
     return s.isEmpty() ? Long.MAX_VALUE : s.iterator().next().getAbstractRoute().getMetric();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/BgpRib.java
@@ -1,6 +1,7 @@
 package org.batfish.dataplane.rib;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.datamodel.ResolutionRestriction.alwaysTrue;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
@@ -297,7 +298,8 @@ public abstract class BgpRib<R extends BgpRoute<?, ?>> extends AbstractRib<R> {
     if (Ip.AUTO.equals(nextHopIp)) {
       return Long.MAX_VALUE;
     }
-    Set<AnnotatedRoute<AbstractRoute>> s = _mainRib.longestPrefixMatch(nextHopIp, null);
+    // TODO: implement resolution restriction
+    Set<AnnotatedRoute<AbstractRoute>> s = _mainRib.longestPrefixMatch(nextHopIp, alwaysTrue());
     return s.isEmpty() ? Long.MAX_VALUE : s.iterator().next().getAbstractRoute().getMetric();
   }
 

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
@@ -49,7 +49,8 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
       - routes that have a next vrf as the next hop
     */
     if (shouldCheckNextHopReachability(route)
-        .map(nextHopIp -> _mainRib != null && _mainRib.longestPrefixMatch(nextHopIp).isEmpty())
+        .map(
+            nextHopIp -> _mainRib != null && _mainRib.longestPrefixMatch(nextHopIp, null).isEmpty())
         .orElse(false)) {
       /*
       TODO: when backups are enabled again, we should probably put this in as a backup

--- a/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/rib/Bgpv4Rib.java
@@ -1,5 +1,7 @@
 package org.batfish.dataplane.rib;
 
+import static org.batfish.datamodel.ResolutionRestriction.alwaysTrue;
+
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -48,9 +50,11 @@ public final class Bgpv4Rib extends BgpRib<Bgpv4Route> {
       - routes with protocol AGGREGATE (for locally-generated routes/aggregates)
       - routes that have a next vrf as the next hop
     */
+    // TODO: implement resolution restriction
     if (shouldCheckNextHopReachability(route)
         .map(
-            nextHopIp -> _mainRib != null && _mainRib.longestPrefixMatch(nextHopIp, null).isEmpty())
+            nextHopIp ->
+                _mainRib != null && _mainRib.longestPrefixMatch(nextHopIp, alwaysTrue()).isEmpty())
         .orElse(false)) {
       /*
       TODO: when backups are enabled again, we should probably put this in as a backup

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -56,6 +56,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   POLICY_STATEMENT_THEN_ADD_COMMUNITY("policy-statement then add community"),
   POLICY_STATEMENT_THEN_DELETE_COMMUNITY("policy-statement then delete community"),
   POLICY_STATEMENT_THEN_SET_COMMUNITY("policy-statement then set community"),
+  RESOLUTION_RIB_IMPORT_POLICY("routing-instance resolution rib import"),
   ROUTING_INSTANCE_INTERFACE("routing-instance interface"),
   ROUTING_INSTANCE_VRF_EXPORT("routing-instance vrf-export"),
   ROUTING_INSTANCE_VRF_IMPORT("routing-instance vrf-import"),

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Resolution.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Resolution.java
@@ -1,0 +1,26 @@
+package org.batfish.representation.juniper;
+
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** Resolution settings for a routing instance. */
+@ParametersAreNonnullByDefault
+public final class Resolution implements Serializable {
+
+  @Nonnull
+  public ResolutionRib getOrReplaceRib(String name) {
+    if (_rib == null || !_rib.getName().equals(name)) {
+      _rib = new ResolutionRib(name);
+    }
+    return _rib;
+  }
+
+  @Nullable
+  public ResolutionRib getRib() {
+    return _rib;
+  }
+
+  @Nullable private ResolutionRib _rib;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/ResolutionRib.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/ResolutionRib.java
@@ -1,0 +1,35 @@
+package org.batfish.representation.juniper;
+
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/** Resolution RIB settings for a routing instance. */
+@ParametersAreNonnullByDefault
+public final class ResolutionRib implements Serializable {
+
+  public ResolutionRib(String name) {
+    _name = name;
+    _importPolicies = ImmutableList.of();
+  }
+
+  @Nonnull
+  public String getName() {
+    return _name;
+  }
+
+  public void addImportPolicy(String policy) {
+    _importPolicies = ImmutableList.<String>builder().addAll(_importPolicies).add(policy).build();
+  }
+
+  /** Returns the policy(ies) routes in this RIB must match to be usable for next-hop resolution. */
+  @Nonnull
+  public List<String> getImportPolicies() {
+    return _importPolicies;
+  }
+
+  @Nonnull private List<String> _importPolicies;
+  @Nonnull private final String _name;
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
@@ -55,6 +55,7 @@ public class RoutingInstance implements Serializable {
   private Ip _routerId;
   private SnmpServer _snmpServer;
   private final JuniperSystem _system;
+  @Nullable private Resolution _resolution;
 
   public RoutingInstance(String name) {
     _aggregateRouteDefaults = initAggregateRouteDefaults();
@@ -308,5 +309,16 @@ public class RoutingInstance implements Serializable {
     GeneratedRoute route = new GeneratedRoute(Prefix.ZERO);
     initAbstractAggregateRouteDefaults(route);
     return route;
+  }
+
+  public @Nullable Resolution getResolution() {
+    return _resolution;
+  }
+
+  public @Nonnull Resolution getOrCreateResolution() {
+    if (_resolution == null) {
+      _resolution = new Resolution();
+    }
+    return _resolution;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/StaticRoute.java
@@ -33,6 +33,8 @@ public class StaticRoute implements Serializable {
 
   private Prefix _prefix;
 
+  @Nullable private Boolean _resolve;
+
   /**
    * Each qualified next hop will produce a separate static route using properties of the static
    * route and overriding with properties of {@link QualifiedNextHop}
@@ -41,7 +43,7 @@ public class StaticRoute implements Serializable {
 
   private Long _tag;
 
-  private Boolean _noInstall;
+  @Nullable private Boolean _noInstall;
 
   public StaticRoute(Prefix prefix) {
     _communities = new TreeSet<>();
@@ -127,5 +129,14 @@ public class StaticRoute implements Serializable {
 
   public void setTag(long tag) {
     _tag = tag;
+  }
+
+  @Nullable
+  public Boolean getResolve() {
+    return _resolve;
+  }
+
+  public void setResolve(@Nullable Boolean resolve) {
+    _resolve = resolve;
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
@@ -1,5 +1,6 @@
 package org.batfish.dataplane;
 
+import static org.batfish.datamodel.ResolutionRestriction.alwaysTrue;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.FibActionMatchers.hasInterfaceName;
 import static org.batfish.datamodel.matchers.FibActionMatchers.isFibForwardActionThat;
@@ -259,7 +260,7 @@ public final class FibImplTest {
     rib.mergeRoute(annotateRoute(forwardingLessSpecificRoute));
     rib.mergeRoute(annotateRoute(testRoute));
 
-    Fib fib = new FibImpl(rib, null);
+    Fib fib = new FibImpl(rib, alwaysTrue());
     Set<AbstractRoute> fibRoutesEth1 = getTopLevelRoutesByInterface(fib, "Eth1");
 
     /* 2.2.2.0/24 should resolve to the "forwardingLessSpecificRoute" and thus eth1 */
@@ -397,7 +398,7 @@ public final class FibImplTest {
     rib.mergeRoute(annotateRoute(ecmpForwardingRoute1));
     rib.mergeRoute(annotateRoute(ecmpForwardingRoute2));
 
-    Fib fib = new FibImpl(rib, null);
+    Fib fib = new FibImpl(rib, alwaysTrue());
 
     /* 2.2.2.0/24 should resolve to eth3 and eth4*/
     assertThat(getTopLevelRoutesByInterface(fib, "Eth3"), hasItem(hasPrefix(TEST_PREFIX)));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/FibImplTest.java
@@ -22,6 +22,7 @@ import org.batfish.datamodel.AbstractRoute;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.Fib;
 import org.batfish.datamodel.FibEntry;
 import org.batfish.datamodel.FibForward;
@@ -45,7 +46,7 @@ import org.junit.runners.JUnit4;
 
 /** Tests of {@link FibImpl} */
 @RunWith(JUnit4.class)
-public class FibImplTest {
+public final class FibImplTest {
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
   private static final Ip DST_IP = Ip.parse("3.3.3.3");
@@ -198,7 +199,7 @@ public class FibImplTest {
     rib.mergeRoute(annotateRoute(nonForwardingRoute));
     rib.mergeRoute(annotateRoute(forwardingRoute));
 
-    Fib fib = new FibImpl(rib);
+    Fib fib = new FibImpl(rib, null);
     Set<AbstractRoute> fibRoutes = getTopLevelRoutesByInterface(fib, "Eth1");
 
     assertThat(fibRoutes, not(hasItem(hasPrefix(Prefix.parse("1.1.1.0/24")))));
@@ -219,7 +220,7 @@ public class FibImplTest {
 
     rib.mergeRoute(annotateRoute(nextVrfRoute));
 
-    Fib fib = new FibImpl(rib);
+    Fib fib = new FibImpl(rib, null);
 
     assertThat(
         fib.allEntries(),
@@ -258,7 +259,7 @@ public class FibImplTest {
     rib.mergeRoute(annotateRoute(forwardingLessSpecificRoute));
     rib.mergeRoute(annotateRoute(testRoute));
 
-    Fib fib = new FibImpl(rib);
+    Fib fib = new FibImpl(rib, null);
     Set<AbstractRoute> fibRoutesEth1 = getTopLevelRoutesByInterface(fib, "Eth1");
 
     /* 2.2.2.0/24 should resolve to the "forwardingLessSpecificRoute" and thus eth1 */
@@ -267,6 +268,83 @@ public class FibImplTest {
     /* Nothing can resolve to "eth2" */
     Set<AbstractRoute> fibRoutesEth2 = getTopLevelRoutesByInterface(fib, "Eth2");
     assertThat(fibRoutesEth2, empty());
+  }
+
+  @Test
+  public void testResolutionWhenNextHopMatchesRestrictionViolatingRoute() {
+    Rib rib = new Rib();
+
+    StaticRoute restrictionViolatingRoute =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("1.1.1.1/32"))
+            .setNextHopInterface("Eth2")
+            .setAdministrativeCost(1)
+            .build();
+
+    StaticRoute forwardingLessSpecificRoute =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("1.1.1.0/31"))
+            .setNextHopInterface("Eth1")
+            .setAdministrativeCost(1)
+            .build();
+
+    StaticRoute testRoute =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("2.2.2.0/24"))
+            .setNextHopIp(Ip.parse("1.1.1.1")) // matches both routes defined above
+            .setAdministrativeCost(1)
+            .build();
+
+    rib.mergeRoute(annotateRoute(restrictionViolatingRoute));
+    rib.mergeRoute(annotateRoute(forwardingLessSpecificRoute));
+    rib.mergeRoute(annotateRoute(testRoute));
+
+    Fib fib = new FibImpl(rib, r -> !r.getAbstractRoute().getNextHopInterface().equals("Eth2"));
+    Set<AbstractRoute> fibRoutesEth1 = getTopLevelRoutesByInterface(fib, "Eth1");
+
+    /* 2.2.2.0/24 should resolve to the "forwardingLessSpecificRoute" and thus eth1 */
+    assertThat(fibRoutesEth1, hasItem(hasPrefix(Prefix.parse("2.2.2.0/24"))));
+
+    // Only the route violating the restriction can resolve to eth2; nothing should recursively
+    // resolve to Eth2.
+    Set<AbstractRoute> fibRoutesEth2 = getTopLevelRoutesByInterface(fib, "Eth2");
+    assertThat(fibRoutesEth2, contains(restrictionViolatingRoute));
+  }
+
+  @Test
+  public void
+      testResolutionWhenRecursiveStaticRouteNextHopMatchesRestrictionViolatingConnectedRoute() {
+    Rib rib = new Rib();
+
+    ConnectedRoute restrictionViolatingRoute =
+        new ConnectedRoute(Prefix.strict("1.1.1.1/32"), "Eth2");
+
+    StaticRoute forwardingLessSpecificRoute =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("1.1.1.0/31"))
+            .setNextHopInterface("Eth1")
+            .setAdministrativeCost(1)
+            .build();
+
+    StaticRoute testRoute =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("2.2.2.0/24"))
+            .setNextHopIp(Ip.parse("1.1.1.1")) // matches both routes defined above
+            .setAdministrativeCost(1)
+            .setRecursive(true)
+            .build();
+
+    rib.mergeRoute(annotateRoute(restrictionViolatingRoute));
+    rib.mergeRoute(annotateRoute(forwardingLessSpecificRoute));
+    rib.mergeRoute(annotateRoute(testRoute));
+
+    Fib fib = new FibImpl(rib, r -> !r.getAbstractRoute().getNextHopInterface().equals("Eth2"));
+
+    // The route violating the restriction uses eth2; the recursive static route also resolves to
+    // eth2 despite the route for 1.1.1.1/32 violating restriction because the former route is a
+    // recursive static route and the latter route is a connected route.
+    Set<AbstractRoute> fibRoutesEth2 = getTopLevelRoutesByInterface(fib, "Eth2");
+    assertThat(fibRoutesEth2, containsInAnyOrder(testRoute, restrictionViolatingRoute));
   }
 
   @Test
@@ -319,7 +397,7 @@ public class FibImplTest {
     rib.mergeRoute(annotateRoute(ecmpForwardingRoute1));
     rib.mergeRoute(annotateRoute(ecmpForwardingRoute2));
 
-    Fib fib = new FibImpl(rib);
+    Fib fib = new FibImpl(rib, null);
 
     /* 2.2.2.0/24 should resolve to eth3 and eth4*/
     assertThat(getTopLevelRoutesByInterface(fib, "Eth3"), hasItem(hasPrefix(TEST_PREFIX)));
@@ -333,5 +411,67 @@ public class FibImplTest {
     /* Nothing can resolve to eth2 */
     Set<AbstractRoute> fibRoutesEth2 = getTopLevelRoutesByInterface(fib, "Eth2");
     assertThat(fibRoutesEth2, empty());
+  }
+
+  @Test
+  public void testResolutionWhenNextHopRouteDoesNotMatchRestrictionWithECMP() {
+    Rib rib = new Rib();
+
+    StaticRoute restrictionViolatingRoute =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("1.1.1.1/32"))
+            .setNextHopInterface("Eth2")
+            .setAdministrativeCost(1)
+            .build();
+
+    StaticRoute ecmpForwardingRoute1 =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("1.1.1.1/32"))
+            .setNextHopInterface("Eth3")
+            .setAdministrativeCost(1)
+            .build();
+    StaticRoute ecmpForwardingRoute2 =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("1.1.1.1/32"))
+            .setNextHopInterface("Eth4")
+            .setAdministrativeCost(1)
+            .build();
+
+    StaticRoute forwardingLessSpecificRoute =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("1.1.1.0/31"))
+            .setNextHopInterface("Eth1")
+            .setAdministrativeCost(1)
+            .build();
+
+    final Prefix TEST_PREFIX = Prefix.parse("2.2.2.0/24");
+    StaticRoute testRoute =
+        StaticRoute.testBuilder()
+            .setNetwork(TEST_PREFIX)
+            .setNextHopIp(Ip.parse("1.1.1.1")) // matches multiple routes defined above
+            .setAdministrativeCost(1)
+            .build();
+
+    rib.mergeRoute(annotateRoute(restrictionViolatingRoute));
+    rib.mergeRoute(annotateRoute(forwardingLessSpecificRoute));
+    rib.mergeRoute(annotateRoute(testRoute));
+    rib.mergeRoute(annotateRoute(ecmpForwardingRoute1));
+    rib.mergeRoute(annotateRoute(ecmpForwardingRoute2));
+
+    Fib fib = new FibImpl(rib, r -> !r.getAbstractRoute().getNextHopInterface().equals("Eth2"));
+
+    /* 2.2.2.0/24 should resolve to eth3 and eth4*/
+    assertThat(getTopLevelRoutesByInterface(fib, "Eth3"), hasItem(hasPrefix(TEST_PREFIX)));
+    assertThat(getTopLevelRoutesByInterface(fib, "Eth4"), hasItem(hasPrefix(TEST_PREFIX)));
+
+    /* 2.2.2.0/24 should NOT resolve to "forwardingLessSpecificRoute" (and thus Eth1)
+     * because more specific route exists to eth3/4
+     */
+    assertThat(getTopLevelRoutesByInterface(fib, "Eth1"), not(hasItem(hasPrefix(TEST_PREFIX))));
+
+    // Only the route violating the restriction can resolve to eth2; nothing should recursively
+    // resolve to Eth2.
+    Set<AbstractRoute> fibRoutesEth2 = getTopLevelRoutesByInterface(fib, "Eth2");
+    assertThat(fibRoutesEth2, contains(restrictionViolatingRoute));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/StaticRouteHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/StaticRouteHelperTest.java
@@ -1,5 +1,6 @@
 package org.batfish.dataplane.protocols;
 
+import static org.batfish.datamodel.ResolutionRestriction.alwaysTrue;
 import static org.batfish.dataplane.ibdp.TestUtils.annotateRoute;
 import static org.batfish.dataplane.protocols.StaticRouteHelper.shouldActivateNextHopIpRoute;
 import static org.hamcrest.Matchers.equalTo;
@@ -36,7 +37,7 @@ public final class StaticRouteHelperTest {
             .setNextHopIp(nextHop)
             .setAdministrativeCost(1)
             .build();
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(false));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(false));
   }
 
   /** Do not activate if no match for nextHop IP exists */
@@ -53,7 +54,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(false));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(false));
   }
 
   /** Activate if next hop IP matches a route */
@@ -76,7 +77,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(true));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(true));
   }
 
   /** Do not activate if the route to the next hop IP has same prefix as route in question. */
@@ -99,7 +100,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(false));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(false));
   }
 
   /** Activate the route with next hop IP within route's prefix, if it is already in the RIB */
@@ -114,7 +115,7 @@ public final class StaticRouteHelperTest {
     _rib.mergeRoute(annotateRoute(sr));
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(true));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(true));
   }
 
   /** Activate if route exists for the same prefix but next hop is different */
@@ -146,7 +147,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(true));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(true));
   }
 
   /** Allow activation in the RIB even if there would be a FIB resolution loop. */
@@ -180,7 +181,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(true));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(true));
   }
 
   /** Allow installation of a covered/more specific route */
@@ -197,7 +198,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(true));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()), equalTo(true));
   }
 
   /**
@@ -276,7 +277,7 @@ public final class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertFalse(shouldActivateNextHopIpRoute(sr, _rib, null));
+    assertFalse(shouldActivateNextHopIpRoute(sr, _rib, alwaysTrue()));
   }
 
   /**

--- a/projects/batfish/src/test/java/org/batfish/dataplane/protocols/StaticRouteHelperTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/protocols/StaticRouteHelperTest.java
@@ -3,7 +3,9 @@ package org.batfish.dataplane.protocols;
 import static org.batfish.dataplane.ibdp.TestUtils.annotateRoute;
 import static org.batfish.dataplane.protocols.StaticRouteHelper.shouldActivateNextHopIpRoute;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.Ip;
@@ -14,7 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /** Tests for {@link StaticRouteHelper} */
-public class StaticRouteHelperTest {
+public final class StaticRouteHelperTest {
 
   private Rib _rib;
 
@@ -34,7 +36,7 @@ public class StaticRouteHelperTest {
             .setNextHopIp(nextHop)
             .setAdministrativeCost(1)
             .build();
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib), equalTo(false));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(false));
   }
 
   /** Do not activate if no match for nextHop IP exists */
@@ -51,7 +53,7 @@ public class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib), equalTo(false));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(false));
   }
 
   /** Activate if next hop IP matches a route */
@@ -74,7 +76,7 @@ public class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib), equalTo(true));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(true));
   }
 
   /** Do not activate if the route to the next hop IP has same prefix as route in question. */
@@ -97,7 +99,7 @@ public class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib), equalTo(false));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(false));
   }
 
   /** Activate the route with next hop IP within route's prefix, if it is already in the RIB */
@@ -112,7 +114,7 @@ public class StaticRouteHelperTest {
     _rib.mergeRoute(annotateRoute(sr));
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib), equalTo(true));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(true));
   }
 
   /** Activate if route exists for the same prefix but next hop is different */
@@ -144,7 +146,7 @@ public class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib), equalTo(true));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(true));
   }
 
   /** Allow activation in the RIB even if there would be a FIB resolution loop. */
@@ -178,7 +180,7 @@ public class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib), equalTo(true));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(true));
   }
 
   /** Allow installation of a covered/more specific route */
@@ -195,6 +197,106 @@ public class StaticRouteHelperTest {
             .build();
 
     // Test & Assert
-    assertThat(shouldActivateNextHopIpRoute(sr, _rib), equalTo(true));
+    assertThat(shouldActivateNextHopIpRoute(sr, _rib, null), equalTo(true));
+  }
+
+  /**
+   * Activate if route is recursive and next hop IP matches a route that is permitted by restriction
+   */
+  @Test
+  public void testShouldActivateRecursiveRestrictionPermits() {
+    _rib.mergeRoute(
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.parse("1.0.0.0/8"))
+                .setNextHopInterface("Eth0")
+                .setAdministrativeCost(1)
+                .build()));
+
+    // Route in question
+    StaticRoute sr =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("9.9.9.0/24"))
+            .setNextHopIp(Ip.parse("1.1.1.1"))
+            .setAdministrativeCost(1)
+            .build();
+
+    // Test & Assert
+    assertTrue(shouldActivateNextHopIpRoute(sr, _rib, r -> r.getNetwork().getPrefixLength() == 8));
+  }
+
+  /**
+   * Do not activate if route is recursive but next hop IP matches no route that is permitted by
+   * restriction
+   */
+  @Test
+  public void testShouldActivateRecursiveRestrictionDenies() {
+    _rib.mergeRoute(
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.parse("1.0.0.0/8"))
+                .setNextHopInterface("Eth0")
+                .setAdministrativeCost(1)
+                .build()));
+
+    // Route in question
+    StaticRoute sr =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("9.9.9.0/24"))
+            .setNextHopIp(Ip.parse("1.1.1.1"))
+            .setAdministrativeCost(1)
+            .build();
+
+    // Test & Assert
+    assertFalse(
+        shouldActivateNextHopIpRoute(sr, _rib, r -> r.getNetwork().getPrefixLength() == 16));
+  }
+
+  /**
+   * Do not activate if route is non-recursive and the only routes matching next hop IP are
+   * non-connected
+   */
+  @Test
+  public void testShouldActivateNonRecursiveNoConnected() {
+    _rib.mergeRoute(
+        annotateRoute(
+            StaticRoute.testBuilder()
+                .setNetwork(Prefix.parse("1.0.0.0/8"))
+                .setNextHopInterface("Eth0")
+                .setAdministrativeCost(1)
+                .build()));
+
+    // Route in question
+    StaticRoute sr =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("9.9.9.0/24"))
+            .setNextHopIp(Ip.parse("1.1.1.1"))
+            .setAdministrativeCost(1)
+            .setRecursive(false)
+            .build();
+
+    // Test & Assert
+    assertFalse(shouldActivateNextHopIpRoute(sr, _rib, null));
+  }
+
+  /**
+   * Activate if route is non-recursive and the next hop IP matches a connected route, even if the
+   * connected route does not match the restriction.
+   */
+  @Test
+  public void testShouldActivateNonRecursiveConnected() {
+    _rib.mergeRoute(annotateRoute(new ConnectedRoute(Prefix.parse("1.0.0.0/8"), "Eth0")));
+
+    // Route in question
+    StaticRoute sr =
+        StaticRoute.testBuilder()
+            .setNetwork(Prefix.parse("9.9.9.0/24"))
+            .setNextHopIp(Ip.parse("1.1.1.1"))
+            .setAdministrativeCost(1)
+            .setRecursive(false)
+            .build();
+
+    // Test & Assert
+    assertTrue(shouldActivateNextHopIpRoute(sr, _rib, r -> false));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -1,5 +1,6 @@
 package org.batfish.dataplane.rib;
 
+import static org.batfish.datamodel.ResolutionRestriction.alwaysTrue;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -24,6 +25,7 @@ import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.OspfIntraAreaRoute;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.RipInternalRoute;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
@@ -128,8 +130,8 @@ public class AbstractRibTest {
   /** Ensure that empty RIB doesn't have any prefix matches */
   @Test
   public void testLongestPrefixMatchWhenEmpty() {
-    assertThat(_rib.longestPrefixMatch(Ip.parse("1.1.1.1"), null), empty());
-    assertThat(_rib.longestPrefixMatch(Ip.parse("0.0.0.0"), null), empty());
+    assertThat(_rib.longestPrefixMatch(Ip.parse("1.1.1.1"), alwaysTrue()), empty());
+    assertThat(_rib.longestPrefixMatch(Ip.parse("0.0.0.0"), alwaysTrue()), empty());
   }
 
   /** Ensure that longestPrefixMatch finds route in root (guarantee no off-by-one length error) */
@@ -141,37 +143,58 @@ public class AbstractRibTest {
             .setAdministrativeCost(1)
             .build();
     _rib.mergeRouteGetDelta(r);
-    assertThat(_rib.longestPrefixMatch(Ip.parse("1.1.1.1"), 32, null), contains(r));
+    assertThat(_rib.longestPrefixMatch(Ip.parse("1.1.1.1"), 32, alwaysTrue()), contains(r));
   }
 
   /**
-   * Ensure that {@link GenericRibReadOnly#longestPrefixMatch(Ip, java.util.function.Predicate)}
-   * returns correct routes when the RIB is non-empty
+   * Ensure that {@link GenericRibReadOnly#longestPrefixMatch(Ip,
+   * org.batfish.datamodel.ResolutionRestriction)} returns correct routes when the RIB is non-empty
    */
   @Test
   public void testLongestPrefixMatch() {
     List<StaticRoute> routes = setupOverlappingRoutes();
 
-    Set<StaticRoute> match = _rib.longestPrefixMatch(Ip.parse("10.1.1.1"), null);
+    Set<StaticRoute> match = _rib.longestPrefixMatch(Ip.parse("10.1.1.1"), alwaysTrue());
     assertThat(match, contains(routes.get(3)));
 
-    match = _rib.longestPrefixMatch(Ip.parse("10.1.1.2"), null);
+    match = _rib.longestPrefixMatch(Ip.parse("10.1.1.2"), alwaysTrue());
     assertThat(match, contains(routes.get(1)));
 
-    match = _rib.longestPrefixMatch(Ip.parse("11.1.1.1"), null);
+    match = _rib.longestPrefixMatch(Ip.parse("11.1.1.1"), alwaysTrue());
+    assertThat(match, empty());
+  }
+
+  /**
+   * Ensure that {@link GenericRibReadOnly#longestPrefixMatch(Ip,
+   * org.batfish.datamodel.ResolutionRestriction)} returns correct routes when the RIB is non-empty
+   * and restriction is applied.
+   */
+  @Test
+  public void testLongestPrefixMatchRestriction() {
+    ResolutionRestriction<StaticRoute> restriction = r -> r.getNetwork().getPrefixLength() < 32;
+
+    List<StaticRoute> routes = setupOverlappingRoutes();
+
+    Set<StaticRoute> match = _rib.longestPrefixMatch(Ip.parse("10.1.1.1"), restriction);
+    assertThat(match, contains(routes.get(1)));
+
+    match = _rib.longestPrefixMatch(Ip.parse("10.1.1.2"), restriction);
+    assertThat(match, contains(routes.get(1)));
+
+    match = _rib.longestPrefixMatch(Ip.parse("11.1.1.1"), restriction);
     assertThat(match, empty());
   }
 
   /**
    * Ensure that {@link GenericRibReadOnly#longestPrefixMatch(Ip, int,
-   * java.util.function.Predicate)} returns correct routes when the RIB is non-empty
+   * org.batfish.datamodel.ResolutionRestriction)} returns correct routes when the RIB is non-empty
    */
   @Test
   public void testLongestPrefixMatchConstrained() {
     List<StaticRoute> routes = setupOverlappingRoutes();
 
     // Only the first route matches with prefix len of <= 8
-    Set<StaticRoute> match = _rib.longestPrefixMatch(Ip.parse("10.1.1.1"), 8, null);
+    Set<StaticRoute> match = _rib.longestPrefixMatch(Ip.parse("10.1.1.1"), 8, alwaysTrue());
     assertThat(match, contains(routes.get(0)));
   }
 
@@ -389,11 +412,11 @@ public class AbstractRibTest {
     _rib.mergeRoute(r32);
     _rib.mergeRoute(r18);
 
-    assertThat(_rib.longestPrefixMatch(ip, 32, null), contains(r32));
-    assertThat(_rib.longestPrefixMatch(ip, 31, null), contains(r18));
-    assertThat(_rib.longestPrefixMatch(ip, 19, null), contains(r18));
-    assertThat(_rib.longestPrefixMatch(ip, 18, null), contains(r18));
-    assertThat(_rib.longestPrefixMatch(ip, 17, null), empty());
+    assertThat(_rib.longestPrefixMatch(ip, 32, alwaysTrue()), contains(r32));
+    assertThat(_rib.longestPrefixMatch(ip, 31, alwaysTrue()), contains(r18));
+    assertThat(_rib.longestPrefixMatch(ip, 19, alwaysTrue()), contains(r18));
+    assertThat(_rib.longestPrefixMatch(ip, 18, alwaysTrue()), contains(r18));
+    assertThat(_rib.longestPrefixMatch(ip, 17, alwaysTrue()), empty());
   }
 
   @Test
@@ -414,7 +437,7 @@ public class AbstractRibTest {
         b.setNetwork(Prefix.parse("1.2.3.4/8")).setNonForwarding(false).build());
 
     // Looking for 1.2.3.4, should skip the /32 and /31, and then find the single forwarding /30
-    Set<StaticRoute> routes = _rib.longestPrefixMatch(Ip.parse("1.2.3.4"), null);
+    Set<StaticRoute> routes = _rib.longestPrefixMatch(Ip.parse("1.2.3.4"), alwaysTrue());
     assertThat(routes, contains(hasPrefix(Prefix.parse("1.2.3.4/30"))));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -19,7 +19,6 @@ import java.util.stream.Collectors;
 import org.batfish.datamodel.BgpTieBreaker;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.ConfigurationFormat;
-import org.batfish.datamodel.GenericRibReadOnly;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.OriginType;
@@ -147,7 +146,7 @@ public class AbstractRibTest {
   }
 
   /**
-   * Ensure that {@link GenericRibReadOnly#longestPrefixMatch(Ip,
+   * Ensure that {@link org.batfish.datamodel.GenericRibReadOnly#longestPrefixMatch(Ip,
    * org.batfish.datamodel.ResolutionRestriction)} returns correct routes when the RIB is non-empty
    */
   @Test
@@ -165,7 +164,7 @@ public class AbstractRibTest {
   }
 
   /**
-   * Ensure that {@link GenericRibReadOnly#longestPrefixMatch(Ip,
+   * Ensure that {@link org.batfish.datamodel.GenericRibReadOnly#longestPrefixMatch(Ip,
    * org.batfish.datamodel.ResolutionRestriction)} returns correct routes when the RIB is non-empty
    * and restriction is applied.
    */

--- a/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/rib/AbstractRibTest.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import org.batfish.datamodel.BgpTieBreaker;
 import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.GenericRibReadOnly;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.OriginType;
@@ -127,8 +128,8 @@ public class AbstractRibTest {
   /** Ensure that empty RIB doesn't have any prefix matches */
   @Test
   public void testLongestPrefixMatchWhenEmpty() {
-    assertThat(_rib.longestPrefixMatch(Ip.parse("1.1.1.1")), empty());
-    assertThat(_rib.longestPrefixMatch(Ip.parse("0.0.0.0")), empty());
+    assertThat(_rib.longestPrefixMatch(Ip.parse("1.1.1.1"), null), empty());
+    assertThat(_rib.longestPrefixMatch(Ip.parse("0.0.0.0"), null), empty());
   }
 
   /** Ensure that longestPrefixMatch finds route in root (guarantee no off-by-one length error) */
@@ -140,37 +141,37 @@ public class AbstractRibTest {
             .setAdministrativeCost(1)
             .build();
     _rib.mergeRouteGetDelta(r);
-    assertThat(_rib.longestPrefixMatch(Ip.parse("1.1.1.1"), 32), contains(r));
+    assertThat(_rib.longestPrefixMatch(Ip.parse("1.1.1.1"), 32, null), contains(r));
   }
 
   /**
-   * Ensure that {@link AbstractRib#longestPrefixMatch(Ip)} returns correct routes when the RIB is
-   * non-empty
+   * Ensure that {@link GenericRibReadOnly#longestPrefixMatch(Ip, java.util.function.Predicate)}
+   * returns correct routes when the RIB is non-empty
    */
   @Test
   public void testLongestPrefixMatch() {
     List<StaticRoute> routes = setupOverlappingRoutes();
 
-    Set<StaticRoute> match = _rib.longestPrefixMatch(Ip.parse("10.1.1.1"));
+    Set<StaticRoute> match = _rib.longestPrefixMatch(Ip.parse("10.1.1.1"), null);
     assertThat(match, contains(routes.get(3)));
 
-    match = _rib.longestPrefixMatch(Ip.parse("10.1.1.2"));
+    match = _rib.longestPrefixMatch(Ip.parse("10.1.1.2"), null);
     assertThat(match, contains(routes.get(1)));
 
-    match = _rib.longestPrefixMatch(Ip.parse("11.1.1.1"));
+    match = _rib.longestPrefixMatch(Ip.parse("11.1.1.1"), null);
     assertThat(match, empty());
   }
 
   /**
-   * Ensure that {@link AbstractRib#longestPrefixMatch(Ip, int)} returns correct routes when the RIB
-   * is non-empty
+   * Ensure that {@link GenericRibReadOnly#longestPrefixMatch(Ip, int,
+   * java.util.function.Predicate)} returns correct routes when the RIB is non-empty
    */
   @Test
   public void testLongestPrefixMatchConstrained() {
     List<StaticRoute> routes = setupOverlappingRoutes();
 
     // Only the first route matches with prefix len of <= 8
-    Set<StaticRoute> match = _rib.longestPrefixMatch(Ip.parse("10.1.1.1"), 8);
+    Set<StaticRoute> match = _rib.longestPrefixMatch(Ip.parse("10.1.1.1"), 8, null);
     assertThat(match, contains(routes.get(0)));
   }
 
@@ -388,11 +389,11 @@ public class AbstractRibTest {
     _rib.mergeRoute(r32);
     _rib.mergeRoute(r18);
 
-    assertThat(_rib.longestPrefixMatch(ip, 32), contains(r32));
-    assertThat(_rib.longestPrefixMatch(ip, 31), contains(r18));
-    assertThat(_rib.longestPrefixMatch(ip, 19), contains(r18));
-    assertThat(_rib.longestPrefixMatch(ip, 18), contains(r18));
-    assertThat(_rib.longestPrefixMatch(ip, 17), empty());
+    assertThat(_rib.longestPrefixMatch(ip, 32, null), contains(r32));
+    assertThat(_rib.longestPrefixMatch(ip, 31, null), contains(r18));
+    assertThat(_rib.longestPrefixMatch(ip, 19, null), contains(r18));
+    assertThat(_rib.longestPrefixMatch(ip, 18, null), contains(r18));
+    assertThat(_rib.longestPrefixMatch(ip, 17, null), empty());
   }
 
   @Test
@@ -413,7 +414,7 @@ public class AbstractRibTest {
         b.setNetwork(Prefix.parse("1.2.3.4/8")).setNonForwarding(false).build());
 
     // Looking for 1.2.3.4, should skip the /32 and /31, and then find the single forwarding /30
-    Set<StaticRoute> routes = _rib.longestPrefixMatch(Ip.parse("1.2.3.4"));
+    Set<StaticRoute> routes = _rib.longestPrefixMatch(Ip.parse("1.2.3.4"), null);
     assertThat(routes, contains(hasPrefix(Prefix.parse("1.2.3.4/30"))));
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-resolution
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/juniper-resolution
@@ -1,0 +1,7 @@
+#
+set system host-name juniper-resolution
+#
+set routing-options resolution rib inet.0 import respol
+#
+set policy-options policy-statement respol term t1 from route-filter 0.0.0.0/0 prefix-length-range /24-/24
+set policy-options policy-statement respol term t1 then accept

--- a/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-routes
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/juniper/testconfigs/static-routes
@@ -5,6 +5,8 @@ set routing-options static route 1.0.0.0/8 next-hop 10.0.0.1
 set routing-instances ri2 routing-options static route 2.0.0.0/8 next-hop 10.0.0.2
 set routing-options static route 3.0.0.0/8 no-install
 set routing-options static route 4.0.0.0/8 next-hop ge-0/0/0.0
+set routing-options static route 6.0.0.0/8 next-hop 10.0.0.1
+set routing-options static route 6.0.0.0/8 resolve
 #
 set routing-instances ri3 routing-options static route 5.5.5.0/24 preference 150
 set routing-instances ri3 routing-options static route 5.5.5.0/24 next-hop 2.3.4.5

--- a/projects/question/src/main/java/org/batfish/question/lpmroutes/LpmRoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/lpmroutes/LpmRoutesAnswerer.java
@@ -78,7 +78,7 @@ public class LpmRoutesAnswerer extends Answerer {
         }
 
         toRow(
-                vrfEntry.getValue().longestPrefixMatch(ip),
+                vrfEntry.getValue().longestPrefixMatch(ip, null),
                 nodeEntry.getKey(),
                 vrfEntry.getKey(),
                 ip,

--- a/projects/question/src/main/java/org/batfish/question/lpmroutes/LpmRoutesAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/lpmroutes/LpmRoutesAnswerer.java
@@ -1,5 +1,7 @@
 package org.batfish.question.lpmroutes;
 
+import static org.batfish.datamodel.ResolutionRestriction.alwaysTrue;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -77,8 +79,9 @@ public class LpmRoutesAnswerer extends Answerer {
           continue;
         }
 
+        // TODO: implement resolution restriction
         toRow(
-                vrfEntry.getValue().longestPrefixMatch(ip, null),
+                vrfEntry.getValue().longestPrefixMatch(ip, alwaysTrue()),
                 nodeEntry.getKey(),
                 vrfEntry.getKey(),
                 ip,

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.function.Predicate;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.AbstractRoute;
@@ -549,12 +550,12 @@ public class RoutesAnswererTest {
     }
 
     @Override
-    public Set<R> longestPrefixMatch(Ip address) {
+    public Set<R> longestPrefixMatch(Ip address, Predicate<R> restriction) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public Set<R> longestPrefixMatch(Ip address, int maxPrefixLength) {
+    public Set<R> longestPrefixMatch(Ip address, int maxPrefixLength, Predicate<R> restriction) {
       throw new UnsupportedOperationException();
     }
 

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererTest.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.function.Predicate;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.plugin.IBatfishTestAdapter;
 import org.batfish.datamodel.AbstractRoute;
@@ -62,6 +61,7 @@ import org.batfish.datamodel.NetworkConfigurations;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.PrefixSpace;
+import org.batfish.datamodel.ResolutionRestriction;
 import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.AnswerElement;
@@ -550,12 +550,13 @@ public class RoutesAnswererTest {
     }
 
     @Override
-    public Set<R> longestPrefixMatch(Ip address, Predicate<R> restriction) {
+    public Set<R> longestPrefixMatch(Ip address, ResolutionRestriction<R> restriction) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public Set<R> longestPrefixMatch(Ip address, int maxPrefixLength, Predicate<R> restriction) {
+    public Set<R> longestPrefixMatch(
+        Ip address, int maxPrefixLength, ResolutionRestriction<R> restriction) {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
- iBDP implement resolution policy
  - distinguish between recursive and non-recursive static routes
  - use resolution policy to filter which routes can be used to resolve
    next hops, activate static routes
- Juniper implement `static route resolve` and `resolution rib import`