### PR TITLE
FortiOS: addr type warning

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -451,7 +451,10 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
   @Override
   public void exitCfa_set_type(Cfa_set_typeContext ctx) {
     Address.Type newType = toAddressType(ctx.type);
-    if (_currentAddress.getType() != null && !Addrgrp.validExcludeMemberType(newType)) {
+    Address prevAddress = _c.getAddresses().get(_currentAddress.getName());
+    if (prevAddress != null
+        && prevAddress.getType() != null
+        && !Addrgrp.validExcludeMemberType(newType)) {
       // Note: this can warn even when the type-change is okay / isn't used as addrgrp exclude
       warn(ctx, "If this address is used as an addrgrp exclude, it's type cannot be changed");
     }

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -456,7 +456,9 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
         && validExcludeMemberType(prevAddress.getTypeEffective())
         && !validExcludeMemberType(newType)) {
       // Note: this can warn even when the type-change is okay / isn't used as addrgrp exclude
-      warn(ctx, "If this address is used as an addrgrp exclude, its type cannot be changed");
+      warn(
+          ctx,
+          "If this address is used as an addrgrp exclude, the FortiOS CLI will reject this line");
     }
     _currentAddress.setType(newType);
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -453,7 +453,7 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
     Address.Type newType = toAddressType(ctx.type);
     Address prevAddress = _c.getAddresses().get(_currentAddress.getName());
     if (prevAddress != null
-        && prevAddress.getType() != null
+        && Addrgrp.validExcludeMemberType(prevAddress.getTypeEffective())
         && !Addrgrp.validExcludeMemberType(newType)) {
       // Note: this can warn even when the type-change is okay / isn't used as addrgrp exclude
       warn(ctx, "If this address is used as an addrgrp exclude, it's type cannot be changed");

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -453,8 +453,8 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
     Address.Type newType = toAddressType(ctx.type);
     Address prevAddress = _c.getAddresses().get(_currentAddress.getName());
     if (prevAddress != null
-        && Addrgrp.validExcludeMemberType(prevAddress.getTypeEffective())
-        && !Addrgrp.validExcludeMemberType(newType)) {
+        && validExcludeMemberType(prevAddress.getTypeEffective())
+        && !validExcludeMemberType(newType)) {
       // Note: this can warn even when the type-change is okay / isn't used as addrgrp exclude
       warn(ctx, "If this address is used as an addrgrp exclude, it's type cannot be changed");
     }
@@ -2282,6 +2282,14 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
       return "device must be set";
     }
     return null;
+  }
+
+  /**
+   * Returns a boolean indicating if the specified address type is valid to use for an exclude
+   * member for an addrgrp.
+   */
+  private static boolean validExcludeMemberType(Address.Type type) {
+    return type == Address.Type.IPRANGE || type == Address.Type.IPMASK;
   }
 
   /**

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -450,7 +450,12 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
 
   @Override
   public void exitCfa_set_type(Cfa_set_typeContext ctx) {
-    _currentAddress.setType(toAddressType(ctx.type));
+    Address.Type newType = toAddressType(ctx.type);
+    if (_currentAddress.getType() != null && !Addrgrp.validExcludeMemberType(newType)) {
+      // Note: this can warn even when the type-change is okay / isn't used as addrgrp exclude
+      warn(ctx, "If this address is used as an addrgrp exclude, it's type cannot be changed");
+    }
+    _currentAddress.setType(newType);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -456,7 +456,7 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
         && validExcludeMemberType(prevAddress.getTypeEffective())
         && !validExcludeMemberType(newType)) {
       // Note: this can warn even when the type-change is okay / isn't used as addrgrp exclude
-      warn(ctx, "If this address is used as an addrgrp exclude, it's type cannot be changed");
+      warn(ctx, "If this address is used as an addrgrp exclude, its type cannot be changed");
     }
     _currentAddress.setType(newType);
   }

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Addrgrp.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Addrgrp.java
@@ -19,14 +19,6 @@ public class Addrgrp extends AddrgrpMember implements Serializable {
   public static final Type DEFAULT_TYPE = Type.DEFAULT;
   public static final boolean DEFAULT_EXCLUDE = false;
 
-  /**
-   * Returns a boolean indicating if the specified address type is valid to use for an exclude
-   * member.
-   */
-  public static boolean validExcludeMemberType(Address.Type type) {
-    return type == Address.Type.IPRANGE || type == Address.Type.IPMASK;
-  }
-
   @Override
   public @Nonnull String getName() {
     return _name;

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Addrgrp.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Addrgrp.java
@@ -19,6 +19,14 @@ public class Addrgrp extends AddrgrpMember implements Serializable {
   public static final Type DEFAULT_TYPE = Type.DEFAULT;
   public static final boolean DEFAULT_EXCLUDE = false;
 
+  /**
+   * Returns a boolean indicating if the specified address type is valid to use for an exclude
+   * member.
+   */
+  public static boolean validExcludeMemberType(Address.Type type) {
+    return type == Address.Type.IPRANGE || type == Address.Type.IPMASK;
+  }
+
   @Override
   public @Nonnull String getName() {
     return _name;

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -351,6 +351,9 @@ public final class FortiosGrammarTest {
     warningMatchers.add(hasComment("No interface or zone named undefined_iface"));
     warningMatchers.add(hasComment("No interface named undefined_iface"));
 
+    warningMatchers.add(
+        hasComment("If this address is used as an addrgrp exclude, it's type cannot be changed"));
+
     // Warn on all type-specific fields set for inappropriate types
     for (String f : ImmutableList.of("start-ip", "end-ip", "interface", "wildcard")) {
       warningMatchers.add(

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -352,7 +352,7 @@ public final class FortiosGrammarTest {
     warningMatchers.add(hasComment("No interface named undefined_iface"));
 
     warningMatchers.add(
-        hasComment("If this address is used as an addrgrp exclude, it's type cannot be changed"));
+        hasComment("If this address is used as an addrgrp exclude, its type cannot be changed"));
 
     // Warn on all type-specific fields set for inappropriate types
     for (String f : ImmutableList.of("start-ip", "end-ip", "interface", "wildcard")) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -352,7 +352,9 @@ public final class FortiosGrammarTest {
     warningMatchers.add(hasComment("No interface named undefined_iface"));
 
     warningMatchers.add(
-        hasComment("If this address is used as an addrgrp exclude, its type cannot be changed"));
+        hasComment(
+            "If this address is used as an addrgrp exclude, the FortiOS CLI will reject this"
+                + " line"));
 
     // Warn on all type-specific fields set for inappropriate types
     for (String f : ImmutableList.of("start-ip", "end-ip", "interface", "wildcard")) {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/address_warnings
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/address_warnings
@@ -79,4 +79,14 @@ config firewall address
         set interface "undefined_iface"
         set subnet 1.1.1.0 255.255.255.0
     next
+    edit type_change
+        set type iprange
+        set start-ip 1.1.1.0
+        set end-ip 1.1.1.255
+    next
+    edit type_change
+        # Should generate a warning, since it's changing from a valid to potentially invalid type
+        set type wildcard
+        set wildcard 1.1.0.1 255.255.0.255
+    next
 end


### PR DESCRIPTION
In some situations, address types cannot be changed.

This is likely an uncommon occurrence, but add a warning if it is possible this has occurred.
