### PR TITLE
NX-OS: stop defining OSPF area

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -34,7 +34,6 @@ import static org.batfish.representation.cisco_nxos.CiscoNxosStructureType.MAC_A
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureType.NVE;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureType.OBJECT_GROUP_IP_ADDRESS;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureType.OBJECT_GROUP_IP_PORT;
-import static org.batfish.representation.cisco_nxos.CiscoNxosStructureType.OSPF_AREA;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureType.POLICY_MAP_CONTROL_PLANE;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureType.POLICY_MAP_NETWORK_QOS;
 import static org.batfish.representation.cisco_nxos.CiscoNxosStructureType.POLICY_MAP_QOS;
@@ -2659,7 +2658,6 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   public void enterRo_area(Ro_areaContext ctx) {
     long areaId = toLong(ctx.id);
     _currentOspfArea = _currentOspfProcess.getAreas().computeIfAbsent(areaId, OspfArea::new);
-    _c.defineStructure(OSPF_AREA, Long.toString(areaId), ctx);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosStructureType.java
@@ -29,7 +29,6 @@ public enum CiscoNxosStructureType implements StructureType {
   NVE("nve"),
   OBJECT_GROUP_IP_ADDRESS("object-group ip address"),
   OBJECT_GROUP_IP_PORT("object-group ip port"),
-  OSPF_AREA("router ospf area"),
   POLICY_MAP_CONTROL_PLANE("policy-map type control-plane"),
   POLICY_MAP_NETWORK_QOS("policy-map type network-qos"),
   POLICY_MAP_QOS("policy-map type qos"),

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -3086,16 +3086,6 @@
         }
       },
       {
-        "Structure_Type" : "router ospf area",
-        "Structure_Name" : "1",
-        "Source_Lines" : {
-          "filename" : "configs/nxos/nxos_ospf",
-          "lines" : [
-            40
-          ]
-        }
-      },
-      {
         "Structure_Type" : "vrf",
         "Structure_Name" : "foo",
         "Source_Lines" : {
@@ -3749,10 +3739,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 248 results",
+      "notes" : "Found 247 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 248
+      "numResults" : 247
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -73377,12 +73377,6 @@
               "numReferrers" : 2
             }
           },
-          "router ospf area" : {
-            "1" : {
-              "definitionLines" : "40",
-              "numReferrers" : 0
-            }
-          },
           "vrf" : {
             "OTHER" : {
               "definitionLines" : "6",


### PR DESCRIPTION
It's never referenced, so always shows as unused.