### PR TITLE
JunOS: robustness to misconfigured NAT rules

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPacketLocation.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/NatPacketLocation.java
@@ -1,8 +1,10 @@
 package org.batfish.representation.juniper;
 
+import com.google.common.collect.Ordering;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Represents how packets enter and exit a Nat */
@@ -38,7 +40,8 @@ public final class NatPacketLocation implements Serializable, Comparable<NatPack
   }
 
   private static final Comparator<NatPacketLocation> COMPARATOR =
-      Comparator.comparing(NatPacketLocation::getType).thenComparing(NatPacketLocation::getName);
+      Comparator.comparing(NatPacketLocation::getType, Comparator.nullsFirst(Ordering.natural()))
+          .thenComparing(NatPacketLocation::getName, Comparator.nullsFirst(Ordering.natural()));
 
   private String _name;
 
@@ -64,17 +67,17 @@ public final class NatPacketLocation implements Serializable, Comparable<NatPack
     return _type == Type.ZoneType ? _name : null;
   }
 
-  public void setInterface(@Nullable String interfaceName) {
+  public void setInterface(@Nonnull String interfaceName) {
     _name = interfaceName;
     _type = Type.InterfaceType;
   }
 
-  public void setRoutingInstance(@Nullable String routingInstance) {
+  public void setRoutingInstance(@Nonnull String routingInstance) {
     _name = routingInstance;
     _type = Type.RoutingInstanceType;
   }
 
-  public void setZone(@Nullable String zone) {
+  public void setZone(@Nonnull String zone) {
     _name = zone;
     _type = Type.ZoneType;
   }
@@ -101,7 +104,7 @@ public final class NatPacketLocation implements Serializable, Comparable<NatPack
   }
 
   @Override
-  public int compareTo(NatPacketLocation o) {
+  public int compareTo(@Nonnull NatPacketLocation o) {
     return COMPARATOR.compare(this, o);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/RoutingInstance.java
@@ -44,7 +44,7 @@ public class RoutingInstance implements Serializable {
   @Nonnull private final IsisSettings _isisSettings;
   @Nullable private Integer _loops;
   private BgpGroup _masterBgpGroup;
-  private String _name;
+  private final @Nonnull String _name;
   private Map<String, NamedBgpGroup> _namedBgpGroups;
   private final Map<String, NodeDevice> _nodeDevices;
   private Map<Long, OspfArea> _ospfAreas;
@@ -57,7 +57,7 @@ public class RoutingInstance implements Serializable {
   private final JuniperSystem _system;
   @Nullable private Resolution _resolution;
 
-  public RoutingInstance(String name) {
+  public RoutingInstance(@Nonnull String name) {
     _aggregateRouteDefaults = initAggregateRouteDefaults();
     _appliedRibGroups = new HashMap<>();
     _confederationMembers = new TreeSet<>();
@@ -173,7 +173,7 @@ public class RoutingInstance implements Serializable {
     return _masterBgpGroup;
   }
 
-  public String getName() {
+  public @Nonnull String getName() {
     return _name;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/Zone.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/Zone.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import javax.annotation.Nonnull;
 
 public final class Zone implements Serializable {
 
@@ -30,7 +31,7 @@ public final class Zone implements Serializable {
 
   private final List<String> _interfaces;
 
-  private final String _name;
+  private final @Nonnull String _name;
 
   private ConcreteFirewallFilter _toHostFilter;
 
@@ -38,7 +39,7 @@ public final class Zone implements Serializable {
 
   private final Set<String> _screens;
 
-  public Zone(String name, AddressBook globalAddressBook) {
+  public Zone(@Nonnull String name, AddressBook globalAddressBook) {
     _name = name;
     _addressBook = globalAddressBook;
     _addressBookType = AddressBookType.GLOBAL;

--- a/projects/batfish/src/test/java/org/batfish/representation/juniper/NatPacketLocationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/juniper/NatPacketLocationTest.java
@@ -2,8 +2,16 @@ package org.batfish.representation.juniper;
 
 import static org.batfish.representation.juniper.NatPacketLocation.interfaceLocation;
 import static org.batfish.representation.juniper.NatPacketLocation.zoneLocation;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Lists;
 import com.google.common.testing.EqualsTester;
+import java.util.List;
 import org.junit.Test;
 
 /** Tests for {@link NatPacketLocation}. */
@@ -15,5 +23,21 @@ public class NatPacketLocationTest {
         .addEqualityGroup(interfaceLocation("2"))
         .addEqualityGroup(zoneLocation("1"))
         .testEquals();
+  }
+
+  @Test
+  public void testComparator() {
+    List<NatPacketLocation> locs =
+        ImmutableList.of(
+            new NatPacketLocation(),
+            NatPacketLocation.interfaceLocation("i1"),
+            NatPacketLocation.interfaceLocation("i2"),
+            NatPacketLocation.zoneLocation("i1"),
+            NatPacketLocation.zoneLocation("z1"),
+            NatPacketLocation.routingInstanceLocation("i1"),
+            NatPacketLocation.routingInstanceLocation("ri1"));
+    assertThat(ImmutableSet.copyOf(locs), hasSize(locs.size()));
+    assertThat(
+        ImmutableSortedSet.copyOf(locs), equalTo(ImmutableSortedSet.copyOf(Lists.reverse(locs))));
   }
 }


### PR DESCRIPTION
Some misconfigured NAT rules can be missing fromLocation or toLocation. Fix comparator not to
crash in these cases, improve annotations.