### PR TITLE
TransferBDD: Handle community deletion/addition properly

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/SetCommunitiesVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/SetCommunitiesVarCollector.java
@@ -34,14 +34,7 @@ public class SetCommunitiesVarCollector
   @Override
   public Set<CommunityVar> visitCommunitySetDifference(
       CommunitySetDifference communitySetDifference, Configuration arg) {
-    Set<CommunityVar> s1 = communitySetDifference.getInitial().accept(this, arg);
-    // TODO: handle set differences; for now we handle the special case when the first
-    //  operand in the difference is empty, so that the second operand is irrelevant
-    if (s1.isEmpty()) {
-      return s1;
-    } else {
-      throw new BatfishException("Community set differences are not supported");
-    }
+    throw new UnsupportedOperationException("Community set differences are not supported");
   }
 
   @Override
@@ -72,7 +65,7 @@ public class SetCommunitiesVarCollector
   @Override
   public Set<CommunityVar> visitInputCommunities(
       InputCommunities inputCommunities, Configuration arg) {
-    return inputCommunities.accept(new CommunitySetExprVarCollector(), arg);
+    throw new UnsupportedOperationException("Input communities is not supported");
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -32,6 +32,8 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetDifference;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetUnion;
 import org.batfish.datamodel.routing_policy.communities.InputCommunities;
 import org.batfish.datamodel.routing_policy.communities.MatchCommunities;
 import org.batfish.datamodel.routing_policy.communities.SetCommunities;
@@ -627,18 +629,7 @@ public class TransferBDD {
       Set<CommunityVar> comms = collectCommunityVars(_conf, ac.getExpr());
       // set all atomic predicates associated with these communities to 1 if this statement
       // is reached
-      Set<Integer> commAPs = atomicPredicatesFor(comms, _communityAtomicPredicates);
-      BDD[] commAPBDDs = curP.getData().getCommunityAtomicPredicates();
-      for (int ap : commAPs) {
-        curP.indent().debug("Value: " + ap);
-        BDD comm = commAPBDDs[ap];
-        // on paths where the route policy has already hit a Return or Exit statement earlier,
-        // this AddCommunity statement will not be reached so the atomic predicate's value should
-        // be unchanged; otherwise it should be set to 1.
-        BDD newValue = ite(unreachable(result), comm, factory.one());
-        curP.indent().debug("New Value: " + newValue);
-        commAPBDDs[ap] = newValue;
-      }
+      addCommunities(comms, curP, result);
 
     } else if (stmt instanceof SetCommunity) {
       curP.debug("SetCommunity");
@@ -661,16 +652,38 @@ public class TransferBDD {
       SetCommunities sc = (SetCommunities) stmt;
       org.batfish.datamodel.routing_policy.communities.CommunitySetExpr setExpr =
           sc.getCommunitySetExpr();
-      /**
-       * TODO: the SetCommunitiesVarCollector does not support some kinds of expressions, such as
-       * set differences, for the same reason as described above regarding limitations of
-       * SetCommunity. again the right solution is to create a visitor to gather community atomic
-       * predicates. (note that SetCommunity and SetCommunities use two different data models for
-       * expressions, both named CommunitySetExpr but in different packages.)
-       */
-      Set<CommunityVar> comms = setExpr.accept(new SetCommunitiesVarCollector(), _conf);
-      setCommunities(comms, curP, result);
-
+      if (setExpr instanceof CommunitySetDifference
+          && ((CommunitySetDifference) setExpr).getInitial().equals(InputCommunities.instance())) {
+        // this SetCommunities expression has the form (InputCommunities - Expr)
+        // so we directly treat it as a deletion of communities
+        BDD toDelete =
+            ((CommunitySetDifference) setExpr)
+                .getRemovalCriterion()
+                .accept(new CommunityMatchExprToBDD(), new Arg(this, curP.getData()));
+        deleteCommunities(toDelete, curP, result);
+      } else if (setExpr instanceof CommunitySetUnion
+          && ((CommunitySetUnion) setExpr).getExprs().contains(InputCommunities.instance())) {
+        // this SetCommunities expression has the form (InputCommunities U Expr U ... U Expr)
+        // so we directly treat it as an addition of communities
+        Set<org.batfish.datamodel.routing_policy.communities.CommunitySetExpr> exprs =
+            ((CommunitySetUnion) setExpr).getExprs();
+        Set<CommunityVar> comms =
+            exprs.stream()
+                .filter(e -> !e.equals(InputCommunities.instance()))
+                .flatMap(e -> e.accept(new SetCommunitiesVarCollector(), _conf).stream())
+                .collect(ImmutableSet.toImmutableSet());
+        addCommunities(comms, curP, result);
+      } else {
+        /**
+         * TODO: the SetCommunitiesVarCollector does not support some kinds of expressions, such as
+         * set differences, for the same reason as described above regarding limitations of
+         * SetCommunity. again the right solution is to create a visitor to gather community atomic
+         * predicates. (note that SetCommunity and SetCommunities use two different data models for
+         * expressions, both named CommunitySetExpr but in different packages.)
+         */
+        Set<CommunityVar> comms = setExpr.accept(new SetCommunitiesVarCollector(), _conf);
+        setCommunities(comms, curP, result);
+      }
     } else if (stmt instanceof DeleteCommunity) {
       curP.debug("DeleteCommunity");
       DeleteCommunity ac = (DeleteCommunity) stmt;
@@ -685,7 +698,6 @@ public class TransferBDD {
         curP.indent().debug("New Value: " + newValue);
         commAPBDDs[ap] = newValue;
       }
-
     } else if (stmt instanceof CallStatement) {
 
       /*
@@ -1106,6 +1118,42 @@ public class TransferBDD {
       return x.getList().size();
     }
     throw new BatfishException("Error[prependLength]: unreachable");
+  }
+
+  /**
+   * A helper for route analysis of AddCommunity and uses of SetCommunities that add communities.
+   * Given a set of CommunityVars that are added by the statement, we set their BDDs to 1.
+   */
+  private void addCommunities(
+      Set<CommunityVar> comms, TransferParam<BDDRoute> curP, TransferResult result) {
+    Set<Integer> commAPs = atomicPredicatesFor(comms, _communityAtomicPredicates);
+    BDD[] commAPBDDs = curP.getData().getCommunityAtomicPredicates();
+    for (int ap : commAPs) {
+      curP.indent().debug("Value: " + ap);
+      BDD comm = commAPBDDs[ap];
+      BDD newValue = ite(unreachable(result), comm, factory.one());
+      curP.indent().debug("New Value: " + newValue);
+      commAPBDDs[ap] = newValue;
+    }
+  }
+
+  /**
+   * A helper for route analysis of DeleteCommunity and uses of SetCommunities that delete
+   * communities. Given a BDD representing the set of communities to be deleted, we set to 0 all
+   * community atomic predicates that are in the to-be-deleted set.
+   */
+  private void deleteCommunities(
+      BDD toDelete, TransferParam<BDDRoute> curP, TransferResult result) {
+    BDD[] commAPBDDs = curP.getData().getCommunityAtomicPredicates();
+    for (int ap = 0; ap < commAPBDDs.length; ap++) {
+      curP.indent().debug("Value: " + ap);
+      BDD comm = commAPBDDs[ap];
+      if (!comm.diffSat(toDelete)) {
+        BDD newValue = ite(unreachable(result), comm, factory.zero());
+        curP.indent().debug("New Value: " + newValue);
+        commAPBDDs[ap] = newValue;
+      }
+    }
   }
 
   /*

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/SetCommunitiesVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/SetCommunitiesVarCollectorTest.java
@@ -9,15 +9,11 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
-import org.batfish.datamodel.routing_policy.communities.ColonSeparatedRendering;
 import org.batfish.datamodel.routing_policy.communities.CommunityExprsSet;
-import org.batfish.datamodel.routing_policy.communities.CommunityMatchRegex;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
-import org.batfish.datamodel.routing_policy.communities.CommunitySetDifference;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetExprReference;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetReference;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetUnion;
-import org.batfish.datamodel.routing_policy.communities.InputCommunities;
 import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
 import org.batfish.datamodel.routing_policy.communities.StandardCommunityHighLowExprs;
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
@@ -57,18 +53,6 @@ public class SetCommunitiesVarCollectorTest {
     Set<CommunityVar> result = _varCollector.visitCommunityExprsSet(ces, _baseConfig);
 
     assertEquals(ImmutableSet.of(cvar1, cvar2), result);
-  }
-
-  @Test
-  public void testVisitCommunitySetDifference() {
-    CommunitySetDifference csd =
-        new CommunitySetDifference(
-            new InputCommunities(),
-            new CommunityMatchRegex(ColonSeparatedRendering.instance(), "^20:"));
-
-    Set<CommunityVar> result = _varCollector.visitCommunitySetDifference(csd, _baseConfig);
-
-    assertEquals(ImmutableSet.of(), result);
   }
 
   @Test


### PR DESCRIPTION
Updates the `TransferBDD` symbolic route analysis to identify `SetCommunities` expressions that are simply community deletions or additions, and treats them as such.  Previously they were not being handled properly, because the `InputCommunities` expression is not currently being modeled symbolically. 