### PR TITLE
FortiOS: Convert bgp

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RoutingProtocol.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RoutingProtocol.java
@@ -129,6 +129,7 @@ public enum RoutingProtocol {
           case CUMULUS_CONCATENATED:
           case CUMULUS_NCLU:
           case FORCE10:
+          case FORTIOS:
           case FOUNDRY:
           case F5:
           case F5_BIGIP_STRUCTURED:
@@ -257,6 +258,7 @@ public enum RoutingProtocol {
           case CUMULUS_CONCATENATED:
           case CUMULUS_NCLU:
           case FORCE10:
+          case FORTIOS:
           case FOUNDRY:
           case F5:
           case F5_BIGIP_STRUCTURED:

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/FortiosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/FortiosLexer.g4
@@ -144,6 +144,7 @@ UDP_PORTRANGE: 'udp-portrange';
 UNSELECT: 'unselect';
 UNSET: 'unset';
 UP: 'up';
+UPDATE_SOURCE: 'update-source' -> pushMode(M_Str);
 UTM: 'utm';
 UUID: 'uuid' -> pushMode(M_Str);
 VDOM: 'vdom' -> pushMode(M_Str);

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_bgp.g4
@@ -44,7 +44,7 @@ crbcne
 
 crbcne_set_remote_as: REMOTE_AS bgp_remote_as newline;
 
-crbcne_set_update_source: UPDATE_SOURCE interface_name;
+crbcne_set_update_source: UPDATE_SOURCE interface_name newline;
 
 crbc_redistribute: REDISTRIBUTE bgp_redist_protocol newline crbcr*;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_bgp.g4
@@ -36,12 +36,17 @@ crbcn_edit: EDIT bgp_neighbor_id newline crbcne* NEXT newline;
 
 crbcne
 :
-    SET crbcne_set_remote_as
+    SET (
+        crbcne_set_remote_as
+        | crbcne_set_update_source
+    )
 ;
 
 crbcne_set_remote_as: REMOTE_AS bgp_remote_as newline;
 
-crbc_redistribute: REDISTRIBUTE protocol = str newline crbcr*;
+crbcne_set_update_source: UPDATE_SOURCE interface_name;
+
+crbc_redistribute: REDISTRIBUTE bgp_redist_protocol newline crbcr*;
 
 crbcr
 :
@@ -58,3 +63,5 @@ bgp_remote_as: str;
 
 // An IP (but not using ip_address rule because EDIT pushes str mode)
 bgp_neighbor_id: str;
+
+bgp_redist_protocol: str;

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.batfish.grammar.fortios;
 
 import static org.batfish.grammar.fortios.FortiosLexer.UNQUOTED_WORD_CHARS;
+import static org.batfish.representation.fortios.FortiosStructureUsage.BGP_UPDATE_SOURCE_INTERFACE;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -776,6 +777,12 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
   @Override
   public void exitCrbcne_set_remote_as(Crbcne_set_remote_asContext ctx) {
     toLong(ctx, ctx.bgp_remote_as()).ifPresent(_currentBgpNeighbor::setRemoteAs);
+  }
+
+  @Override
+  public void exitCrbcne_set_update_source(FortiosParser.Crbcne_set_update_sourceContext ctx) {
+    toInterface(ctx, ctx.interface_name(), BGP_UPDATE_SOURCE_INTERFACE)
+        .ifPresent(_currentBgpNeighbor::setUpdateSource);
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/BgpNeighbor.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/BgpNeighbor.java
@@ -19,10 +19,19 @@ public class BgpNeighbor implements Serializable {
     return _remoteAs;
   }
 
+  public @Nullable String getUpdateSource() {
+    return _updateSource;
+  }
+
   public void setRemoteAs(Long remoteAs) {
     _remoteAs = remoteAs;
   }
 
+  public void setUpdateSource(String updateSource) {
+    _updateSource = updateSource;
+  }
+
   private final @Nonnull Ip _ip;
   private @Nullable Long _remoteAs;
+  private @Nullable String _updateSource;
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/BgpProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/BgpProcess.java
@@ -1,5 +1,7 @@
 package org.batfish.representation.fortios;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +19,10 @@ public final class BgpProcess implements Serializable {
     return _as;
   }
 
+  public long getAsEffective() {
+    return firstNonNull(_as, DEFAULT_AS);
+  }
+
   public @Nonnull Map<Ip, BgpNeighbor> getNeighbors() {
     return _neighbors;
   }
@@ -32,6 +38,8 @@ public final class BgpProcess implements Serializable {
   public void setRouterId(Ip routerId) {
     _routerId = routerId;
   }
+
+  public static long DEFAULT_AS = 0L;
 
   private @Nullable Long _as;
   private @Nullable Ip _routerId;

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
@@ -1,0 +1,137 @@
+package org.batfish.representation.fortios;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.batfish.common.Warnings;
+import org.batfish.datamodel.BgpActivePeerConfig;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.RoutingProtocol;
+
+/** Helper functions for generating VI BGP structures for {@link FortiosConfiguration}. */
+public final class FortiosBgpConversions {
+
+  /**
+   * Infer the interface that the given {@link BgpNeighbor} will use as its update source. If none
+   * can be inferred, returns an empty optional.
+   */
+  private static Optional<Interface> getUpdateSource(
+      BgpNeighbor neighbor, Configuration c, Warnings w) {
+    String updateSource = neighbor.getUpdateSource();
+    if (updateSource != null) {
+      Interface viUpdateSourceIface = c.getAllInterfaces().get(updateSource);
+      if (viUpdateSourceIface == null) {
+        // Conversion issue with the update-source interface. Better to ignore the neighbor than try
+        // to infer a different update-source.
+        return Optional.empty();
+      } else if (!viUpdateSourceIface.getActive()) {
+        // TODO Check behavior if BGP neighbor's configured update-source is an inactive interface
+        w.redFlag(
+            String.format(
+                "BGP neighbor %s has an inactive update-source interface %s. Attempting to infer"
+                    + " another update-source for this neighbor",
+                neighbor.getIp(), updateSource));
+      } else {
+        // Configured update-source is viable
+        return Optional.of(viUpdateSourceIface);
+      }
+    }
+
+    // Either no update-source is configured or the configured update-source is inactive.
+    // Infer an interface based on iface address.
+    return c.getActiveInterfaces().values().stream()
+        .filter(
+            iface ->
+                iface.getConcreteAddress() != null
+                    && iface.getConcreteAddress().getPrefix().containsIp(neighbor.getIp()))
+        .findFirst();
+  }
+
+  /** Returns the VRFs in which the given {@link BgpProcess} is active. */
+  public static Set<String> getVrfs(BgpProcess bgpProcess, Configuration c, Warnings w) {
+    return bgpProcess.getNeighbors().values().stream()
+        .map(neighbor -> getUpdateSource(neighbor, c, w))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .map(Interface::getVrfName)
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  public static void convertBgp(BgpProcess bgpProcess, Configuration c, Warnings w) {
+    // TODO Infer router-id if not explicitly configured
+    Ip routerId = bgpProcess.getRouterId();
+    if (routerId == null) {
+      w.redFlag("Ignoring BGP process: No router ID configured");
+      return;
+    }
+    Map<Ip, Interface> updateSources = new HashMap<>();
+    Map<String, Set<Ip>> neighborsByVrf = new HashMap<>();
+    for (BgpNeighbor neighbor : bgpProcess.getNeighbors().values()) {
+      Optional<Interface> updateSource = getUpdateSource(neighbor, c, w);
+      if (!updateSource.isPresent()) {
+        w.redFlag(
+            String.format(
+                "Ignoring BGP neighbor %s: Unable to infer its update source", neighbor.getIp()));
+        continue;
+      }
+      updateSources.put(neighbor.getIp(), updateSource.get());
+      neighborsByVrf
+          .computeIfAbsent(updateSource.get().getVrfName(), k -> new HashSet<>())
+          .add(neighbor.getIp());
+    }
+
+    for (Map.Entry<String, Set<Ip>> e : neighborsByVrf.entrySet()) {
+      convertBgpProcessForVrf(bgpProcess, routerId, e.getKey(), e.getValue(), updateSources, c, w);
+    }
+  }
+
+  private static void convertBgpProcessForVrf(
+      BgpProcess bgpProcess,
+      Ip routerId,
+      String vrf,
+      Set<Ip> neighborIdsInVrf,
+      Map<Ip, Interface> updateSources,
+      Configuration c,
+      Warnings w) {
+    // TODO Admin distances can be explicitly configured on the process level
+    int ebgpAdmin = RoutingProtocol.BGP.getDefaultAdministrativeCost(c.getConfigurationFormat());
+    int ibgpAdmin = RoutingProtocol.IBGP.getDefaultAdministrativeCost(c.getConfigurationFormat());
+    org.batfish.datamodel.BgpProcess viProc =
+        new org.batfish.datamodel.BgpProcess(routerId, ebgpAdmin, ibgpAdmin);
+
+    // Convert neighbors
+    long localAs = bgpProcess.getAsEffective();
+    for (Ip remoteIp : neighborIdsInVrf) {
+      BgpNeighbor neighbor = bgpProcess.getNeighbors().get(remoteIp);
+      Interface updateSource = updateSources.get(remoteIp);
+      Ip localIp =
+          Optional.ofNullable(updateSource.getConcreteAddress())
+              .map(ConcreteInterfaceAddress::getIp)
+              .orElse(null);
+      if (localIp == null) {
+        w.redFlag(
+            String.format(
+                "Ignoring BGP neighbor %s: Update-source %s has no address",
+                remoteIp, updateSource.getName()));
+        continue;
+      }
+      BgpActivePeerConfig.builder()
+          .setLocalIp(localIp)
+          .setLocalAs(localAs)
+          .setPeerAddress(neighbor.getIp())
+          .setRemoteAs(neighbor.getRemoteAs())
+          .setBgpProcess(viProc)
+          .build();
+    }
+
+    // TODO: Redistribution policy, import/export policies
+
+    c.getVrfs().get(vrf).setBgpProcess(viProc);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
@@ -64,8 +64,12 @@ public final class FortiosBgpConversions {
   }
 
   public static void convertBgp(BgpProcess bgpProcess, Configuration c, Warnings w) {
-    if (bgpProcess.getAsEffective() == 0) {
+    long as = bgpProcess.getAsEffective();
+    if (as == 0L) {
       w.redFlag("Ignoring BGP process: No AS configured");
+      return;
+    } else if (as == 65535L || as == 4294967295L) {
+      w.redFlag(String.format("Ignoring BGP process: AS %s is proscribed by RFC 7300", as));
       return;
     }
     // TODO Infer router-id if not explicitly configured

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
@@ -64,6 +64,10 @@ public final class FortiosBgpConversions {
   }
 
   public static void convertBgp(BgpProcess bgpProcess, Configuration c, Warnings w) {
+    if (bgpProcess.getAsEffective() == 0) {
+      w.redFlag("Ignoring BGP process: No AS configured");
+      return;
+    }
     // TODO Infer router-id if not explicitly configured
     Ip routerId = bgpProcess.getRouterId();
     if (routerId == null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosConfiguration.java
@@ -1,5 +1,6 @@
 package org.batfish.representation.fortios;
 
+import static org.batfish.representation.fortios.FortiosBgpConversions.convertBgp;
 import static org.batfish.representation.fortios.FortiosPolicyConversions.computeOutgoingFilterName;
 import static org.batfish.representation.fortios.FortiosPolicyConversions.convertPolicies;
 import static org.batfish.representation.fortios.FortiosPolicyConversions.generateCrossZoneFilters;
@@ -175,6 +176,11 @@ public class FortiosConfiguration extends VendorConfiguration {
         _zones.values().stream()
             .collect(
                 ImmutableMap.toImmutableMap(Zone::getName, FortiosConfiguration::convertZone)));
+
+    // Convert BGP. Must happen after interface conversion
+    if (_bgpProcess != null) {
+      convertBgp(_bgpProcess, c, _w);
+    }
 
     // TODO Are FortiOS static routes really global? Can't set their VRFs. Perhaps they should
     //  only exist in their device's VRF.

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosStructureUsage.java
@@ -5,6 +5,7 @@ import org.batfish.vendor.StructureUsage;
 public enum FortiosStructureUsage implements StructureUsage {
   ADDRGRP_EXCLUDE_MEMBER("addrgrp exclude-member"),
   ADDRGRP_MEMBER("addrgrp member"),
+  BGP_UPDATE_SOURCE_INTERFACE("bgp update-source"),
   INTERFACE_SELF_REF("system interface"),
   POLICY_DSTADDR("firewall policy dstaddr"),
   POLICY_DSTINTF("firewall policy dstintf"),

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -620,7 +620,7 @@ public final class FortiosGrammarTest {
 
     BgpProcess bgpProcess = vc.getBgpProcess();
     assert bgpProcess != null;
-    assertThat(bgpProcess.getAs(), equalTo(0L));
+    assertThat(bgpProcess.getAs(), equalTo(4294967295L));
     assertThat(bgpProcess.getRouterId(), equalTo(Ip.parse("1.1.1.1")));
 
     Map<Ip, BgpNeighbor> neighbors = bgpProcess.getNeighbors();
@@ -661,7 +661,7 @@ public final class FortiosGrammarTest {
         bgpProcessDefaultVrf.getActiveNeighbors();
     assertThat(defaultVrfNeighbors, hasKeys(ip1.toPrefix()));
     BgpActivePeerConfig neighbor1 = defaultVrfNeighbors.get(ip1.toPrefix());
-    assertThat(neighbor1.getLocalAs(), equalTo(0L));
+    assertThat(neighbor1.getLocalAs(), equalTo(4294967295L));
     // port1 is the explicit update-source
     assertThat(neighbor1.getLocalIp(), equalTo(Ip.parse("10.10.10.1")));
     assertThat(neighbor1.getPeerAddress(), equalTo(ip1));
@@ -675,7 +675,7 @@ public final class FortiosGrammarTest {
     Map<Prefix, BgpActivePeerConfig> vrf5Neighbors = bgpProcessVrf5.getActiveNeighbors();
     assertThat(defaultVrfNeighbors, hasKeys(ip1.toPrefix()));
     BgpActivePeerConfig neighbor2 = vrf5Neighbors.get(ip2.toPrefix());
-    assertThat(neighbor2.getLocalAs(), equalTo(0L));
+    assertThat(neighbor2.getLocalAs(), equalTo(4294967295L));
     // port2 is the inferred update-source (its network includes ip2)
     assertThat(neighbor2.getLocalIp(), equalTo(Ip.parse("11.11.11.1")));
     assertThat(neighbor2.getPeerAddress(), equalTo(ip2));
@@ -727,6 +727,20 @@ public final class FortiosGrammarTest {
                 "Ignoring BGP neighbor 3.3.3.3: Unable to infer its update source"),
             WarningMatchers.hasText(
                 "Ignoring BGP neighbor 4.4.4.4: Unable to infer its update source")));
+  }
+
+  @Test
+  public void testBgpConversionNoAs() throws IOException {
+    String hostname = "bgp_no_as";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    Warnings warnings =
+        batfish
+            .loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot())
+            .getWarnings()
+            .get(hostname);
+    assertThat(
+        warnings.getRedFlagWarnings(),
+        contains(WarningMatchers.hasText("Ignoring BGP process: No AS configured")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -620,7 +620,7 @@ public final class FortiosGrammarTest {
 
     BgpProcess bgpProcess = vc.getBgpProcess();
     assert bgpProcess != null;
-    assertThat(bgpProcess.getAs(), equalTo(4294967295L));
+    assertThat(bgpProcess.getAs(), equalTo(1L));
     assertThat(bgpProcess.getRouterId(), equalTo(Ip.parse("1.1.1.1")));
 
     Map<Ip, BgpNeighbor> neighbors = bgpProcess.getNeighbors();
@@ -661,7 +661,7 @@ public final class FortiosGrammarTest {
         bgpProcessDefaultVrf.getActiveNeighbors();
     assertThat(defaultVrfNeighbors, hasKeys(ip1.toPrefix()));
     BgpActivePeerConfig neighbor1 = defaultVrfNeighbors.get(ip1.toPrefix());
-    assertThat(neighbor1.getLocalAs(), equalTo(4294967295L));
+    assertThat(neighbor1.getLocalAs(), equalTo(1L));
     // port1 is the explicit update-source
     assertThat(neighbor1.getLocalIp(), equalTo(Ip.parse("10.10.10.1")));
     assertThat(neighbor1.getPeerAddress(), equalTo(ip1));
@@ -675,7 +675,7 @@ public final class FortiosGrammarTest {
     Map<Prefix, BgpActivePeerConfig> vrf5Neighbors = bgpProcessVrf5.getActiveNeighbors();
     assertThat(defaultVrfNeighbors, hasKeys(ip1.toPrefix()));
     BgpActivePeerConfig neighbor2 = vrf5Neighbors.get(ip2.toPrefix());
-    assertThat(neighbor2.getLocalAs(), equalTo(4294967295L));
+    assertThat(neighbor2.getLocalAs(), equalTo(1L));
     // port2 is the inferred update-source (its network includes ip2)
     assertThat(neighbor2.getLocalIp(), equalTo(Ip.parse("11.11.11.1")));
     assertThat(neighbor2.getPeerAddress(), equalTo(ip2));
@@ -741,6 +741,22 @@ public final class FortiosGrammarTest {
     assertThat(
         warnings.getRedFlagWarnings(),
         contains(WarningMatchers.hasText("Ignoring BGP process: No AS configured")));
+  }
+
+  @Test
+  public void testBgpConversionInvalidAs() throws IOException {
+    String hostname = "bgp_invalid_as";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    Warnings warnings =
+        batfish
+            .loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot())
+            .getWarnings()
+            .get(hostname);
+    assertThat(
+        warnings.getRedFlagWarnings(),
+        contains(
+            WarningMatchers.hasText(
+                "Ignoring BGP process: AS 4294967295 is proscribed by RFC 7300")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -728,7 +728,7 @@ public final class FortiosGrammarTest {
             WarningMatchers.hasText(
                 "Ignoring BGP neighbor 4.4.4.4: Unable to infer its update source"),
             WarningMatchers.hasText(
-                "Interface port3 has unsupported type AGGREGATE and will not be converted"),
+                "Interface port3 has unsupported type WL_MESH and will not be converted"),
             WarningMatchers.hasText(
                 "Ignoring BGP neighbor 5.5.5.5: Unable to infer its update source")));
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -8,6 +8,7 @@ import static org.batfish.common.matchers.WarningsMatchers.hasParseWarning;
 import static org.batfish.common.matchers.WarningsMatchers.hasParseWarnings;
 import static org.batfish.common.matchers.WarningsMatchers.hasRedFlags;
 import static org.batfish.common.util.Resources.readResource;
+import static org.batfish.datamodel.matchers.BgpProcessMatchers.hasRouterId;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasHostname;
 import static org.batfish.datamodel.matchers.ConfigurationMatchers.hasInterface;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasDefinedStructure;
@@ -67,6 +68,7 @@ import org.batfish.config.Settings;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AclLine;
 import org.batfish.datamodel.BddTestbed;
+import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Flow;
@@ -622,19 +624,66 @@ public final class FortiosGrammarTest {
     assertThat(bgpProcess.getRouterId(), equalTo(Ip.parse("1.1.1.1")));
 
     Map<Ip, BgpNeighbor> neighbors = bgpProcess.getNeighbors();
-    Ip ip2222 = Ip.parse("2.2.2.2");
-    Ip ip3333 = Ip.parse("3.3.3.3");
-    assertThat(neighbors.keySet(), containsInAnyOrder(ip2222, ip3333));
-    BgpNeighbor neighbor2222 = neighbors.get(ip2222);
-    BgpNeighbor neighbor3333 = neighbors.get(ip3333);
-    assertThat(neighbor2222.getIp(), equalTo(ip2222));
-    assertThat(neighbor3333.getIp(), equalTo(ip3333));
-    assertThat(neighbor2222.getRemoteAs(), equalTo(1L));
-    assertThat(neighbor3333.getRemoteAs(), equalTo(4294967295L));
+    Ip ip1 = Ip.parse("2.2.2.2");
+    Ip ip2 = Ip.parse("11.11.11.2");
+    assertThat(neighbors.keySet(), containsInAnyOrder(ip1, ip2));
+    BgpNeighbor neighbor1 = neighbors.get(ip1);
+    BgpNeighbor neighbor2 = neighbors.get(ip2);
+    assertThat(neighbor1.getIp(), equalTo(ip1));
+    assertThat(neighbor2.getIp(), equalTo(ip2));
+    assertThat(neighbor1.getRemoteAs(), equalTo(1L));
+    assertThat(neighbor2.getRemoteAs(), equalTo(4294967295L));
+    assertThat(neighbor1.getUpdateSource(), equalTo("port1"));
+    assertNull(neighbor2.getUpdateSource());
   }
 
   @Test
-  public void testBgpWarnings() throws IOException {
+  public void testBgpConversion() throws IOException {
+    String hostname = "bgp";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    Configuration c = batfish.loadConfigurations(batfish.getSnapshot()).get(hostname);
+
+    // Ensure no warnings were generated
+    assertThat(
+        batfish.loadParseVendorConfigurationAnswerElement(batfish.getSnapshot()).getWarnings(),
+        anEmptyMap());
+
+    // Neighbor IDs
+    Ip ip1 = Ip.parse("2.2.2.2");
+    Ip ip2 = Ip.parse("11.11.11.2");
+
+    // Default VRF BGP process: should only have neighbor 1
+    org.batfish.datamodel.BgpProcess bgpProcessDefaultVrf =
+        c.getVrfs().get(computeVrfName("root", 0)).getBgpProcess();
+    assertThat(bgpProcessDefaultVrf, hasRouterId(Ip.parse("1.1.1.1")));
+
+    Map<Prefix, BgpActivePeerConfig> defaultVrfNeighbors =
+        bgpProcessDefaultVrf.getActiveNeighbors();
+    assertThat(defaultVrfNeighbors, hasKeys(ip1.toPrefix()));
+    BgpActivePeerConfig neighbor1 = defaultVrfNeighbors.get(ip1.toPrefix());
+    assertThat(neighbor1.getLocalAs(), equalTo(0L));
+    // port1 is the explicit update-source
+    assertThat(neighbor1.getLocalIp(), equalTo(Ip.parse("10.10.10.1")));
+    assertThat(neighbor1.getPeerAddress(), equalTo(ip1));
+    assertThat(neighbor1.getRemoteAsns().enumerate(), contains(1L));
+
+    // VRF 5 BGP process: should only have neighbor 2
+    org.batfish.datamodel.BgpProcess bgpProcessVrf5 =
+        c.getVrfs().get(computeVrfName("root", 5)).getBgpProcess();
+    assertThat(bgpProcessVrf5, hasRouterId(Ip.parse("1.1.1.1")));
+
+    Map<Prefix, BgpActivePeerConfig> vrf5Neighbors = bgpProcessVrf5.getActiveNeighbors();
+    assertThat(defaultVrfNeighbors, hasKeys(ip1.toPrefix()));
+    BgpActivePeerConfig neighbor2 = vrf5Neighbors.get(ip2.toPrefix());
+    assertThat(neighbor2.getLocalAs(), equalTo(0L));
+    // port2 is the inferred update-source (its network includes ip2)
+    assertThat(neighbor2.getLocalIp(), equalTo(Ip.parse("11.11.11.1")));
+    assertThat(neighbor2.getPeerAddress(), equalTo(ip2));
+    assertThat(neighbor2.getRemoteAsns().enumerate(), contains(4294967295L));
+  }
+
+  @Test
+  public void testBgpExtractionWarnings() throws IOException {
     String hostname = "bgp_warnings";
     Batfish batfish = getBatfishForConfigurationNames(hostname);
     Warnings parseWarnings =
@@ -655,6 +704,43 @@ public final class FortiosGrammarTest {
             hasComment("Expected BGP remote AS in range 1-4294967295, but got 'hello'"),
             hasComment("BGP neighbor edit block ignored: remote-as must be set"),
             hasComment("Redistribution into BGP is not yet supported")));
+  }
+
+  @Test
+  public void testBgpConversionWarnings() throws IOException {
+    String hostname = "bgp_conversion_warnings";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    Warnings warnings =
+        batfish
+            .loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot())
+            .getWarnings()
+            .get(hostname);
+    assertThat(
+        warnings.getRedFlagWarnings(),
+        containsInAnyOrder(
+            WarningMatchers.hasText(
+                "Ignoring BGP neighbor 2.2.2.2: Update-source port1 has no address"),
+            WarningMatchers.hasText(
+                "BGP neighbor 3.3.3.3 has an inactive update-source interface port2. Attempting to"
+                    + " infer another update-source for this neighbor"),
+            WarningMatchers.hasText(
+                "Ignoring BGP neighbor 3.3.3.3: Unable to infer its update source"),
+            WarningMatchers.hasText(
+                "Ignoring BGP neighbor 4.4.4.4: Unable to infer its update source")));
+  }
+
+  @Test
+  public void testBgpConversionNoRouterId() throws IOException {
+    String hostname = "bgp_no_router_id";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    Warnings warnings =
+        batfish
+            .loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot())
+            .getWarnings()
+            .get(hostname);
+    assertThat(
+        warnings.getRedFlagWarnings(),
+        contains(WarningMatchers.hasText("Ignoring BGP process: No router ID configured")));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -726,7 +726,11 @@ public final class FortiosGrammarTest {
             WarningMatchers.hasText(
                 "Ignoring BGP neighbor 3.3.3.3: Unable to infer its update source"),
             WarningMatchers.hasText(
-                "Ignoring BGP neighbor 4.4.4.4: Unable to infer its update source")));
+                "Ignoring BGP neighbor 4.4.4.4: Unable to infer its update source"),
+            WarningMatchers.hasText(
+                "Interface port3 has unsupported type AGGREGATE and will not be converted"),
+            WarningMatchers.hasText(
+                "Ignoring BGP neighbor 5.5.5.5: Unable to infer its update source")));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp
@@ -15,9 +15,9 @@ config system interface
     next
 end
 config router bgp
-    # Test min and max AS (`set as 0` effectively clears the process AS)
+    # `set as 0` effectively clears the process AS
     set as 0
-    set as 4294967295
+    set as 1
     set router-id 1.1.1.1
     config neighbor
         edit "2.2.2.2"

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp
@@ -15,9 +15,9 @@ config system interface
     next
 end
 config router bgp
-    # Test max and min AS
-    set as 4294967295
+    # Test min and max AS (`set as 0` effectively clears the process AS)
     set as 0
+    set as 4294967295
     set router-id 1.1.1.1
     config neighbor
         edit "2.2.2.2"

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_conversion_warnings
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_conversion_warnings
@@ -1,30 +1,32 @@
 config system global
-    set hostname "bgp"
+    set hostname "bgp_conversion_warnings"
 end
 config system interface
     edit "port1"
         set vdom "root"
-        set ip 10.10.10.1 255.255.255.0
         set type physical
     next
     edit "port2"
         set vdom "root"
-        set ip 11.11.11.1 255.255.255.0
         set type physical
-        set vrf 5
+        set status down
     next
 end
 config router bgp
-    # Test max and min AS
-    set as 4294967295
-    set as 0
     set router-id 1.1.1.1
     config neighbor
         edit "2.2.2.2"
+            # Update-source with no concrete address
             set remote-as 1
             set update-source port1
         next
-        edit "11.11.11.2"
+        edit "3.3.3.3"
+            # Inactive update-source
+            set remote-as 4294967295
+            set update-source port2
+        next
+        edit "4.4.4.4"
+            # No update-source
             set remote-as 4294967295
         next
     end

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_conversion_warnings
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_conversion_warnings
@@ -13,7 +13,7 @@ config system interface
     next
     edit "port3"
         set vdom "root"
-        set type aggregate
+        set type wl-mesh
     next
 end
 config router bgp

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_conversion_warnings
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_conversion_warnings
@@ -11,6 +11,10 @@ config system interface
         set type physical
         set status down
     next
+    edit "port3"
+        set vdom "root"
+        set type aggregate
+    next
 end
 config router bgp
     set router-id 1.1.1.1
@@ -23,12 +27,17 @@ config router bgp
         next
         edit "3.3.3.3"
             # Inactive update-source
-            set remote-as 4294967295
+            set remote-as 1
             set update-source port2
         next
         edit "4.4.4.4"
             # No update-source
-            set remote-as 4294967295
+            set remote-as 1
+        next
+        edit "5.5.5.5"
+            # Update-source that is not converted
+            set remote-as 1
+            set update-source port3
         next
     end
 end

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_conversion_warnings
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_conversion_warnings
@@ -14,6 +14,7 @@ config system interface
 end
 config router bgp
     set router-id 1.1.1.1
+    set as 1
     config neighbor
         edit "2.2.2.2"
             # Update-source with no concrete address

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_invalid_as
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_invalid_as
@@ -1,0 +1,14 @@
+config system global
+    set hostname "bgp_invalid_as"
+end
+config router bgp
+    set as 4294967295
+    config neighbor
+        edit "2.2.2.2"
+            # No update source, but warning shouldn't show up because
+            # without a valid AS, the neighbor won't be converted.
+            set remote-as 1
+            set update-source port1
+        next
+    end
+end

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_no_as
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_no_as
@@ -1,12 +1,11 @@
 config system global
-    set hostname "bgp_no_router_id"
+    set hostname "bgp_no_as"
 end
 config router bgp
-    set as 1
     config neighbor
         edit "2.2.2.2"
             # No update source, but warning shouldn't show up because
-            # without a router ID, the neighbor won't be converted.
+            # without an AS, the neighbor won't be converted.
             set remote-as 1
             set update-source port1
         next

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_no_router_id
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/bgp_no_router_id
@@ -1,0 +1,13 @@
+config system global
+    set hostname "bgp_no_router_id"
+end
+config router bgp
+    config neighbor
+        edit "2.2.2.2"
+            # No update source, but warning shouldn't show up because
+            # without a router ID, the neighbor won't be converted.
+            set remote-as 1
+            set update-source port1
+        next
+    end
+end


### PR DESCRIPTION
For now, the conversion process is fairly limited. It:
- Requires BGP router-id to be set (otherwise no BGP will convert)
- Ignores filtering (route-maps) and redistribution
- Will attempt to infer neighbors' update sources if not explicitly configured by finding an interface whose address includes the neighbor ID