### PR TITLE
NX-OS: stop warning on hsrp priority forwarding-threshold

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -1931,10 +1931,6 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   public void exitIhg_priority(Ihg_priorityContext ctx) {
     int priority = toInteger(ctx.priority);
     _currentInterfaces.forEach(iface -> _currentHsrpGroupGetter.apply(iface).setPriority(priority));
-    if (ctx.FORWARDING_THRESHOLD() != null) {
-      // TODO: forwarding-threshold for HSRP priority
-      todo(ctx);
-    }
   }
 
   @Override


### PR DESCRIPTION
Interface priority changing during dataplane run doesn't happen in our model.