### PR TITLE
NX-OS: no switchport access vlan optional id

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxos_interface.g4
@@ -1126,7 +1126,7 @@ i_no_switchport
 
 inos_access
 :
-  ACCESS VLAN NEWLINE
+  ACCESS VLAN (vlan = unreserved_vlan_id)? NEWLINE
 ;
 
 inos_block

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -396,6 +396,7 @@ import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Inherit_sequence_numberCon
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Inoip_forwardContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Inoip_proxy_arpContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Inoipo_passive_interfaceContext;
+import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Inos_accessContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Inos_switchportContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.InoshutContext;
 import org.batfish.grammar.cisco_nxos.CiscoNxosParser.Interface_addressContext;
@@ -5489,6 +5490,16 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   @Override
   public void exitInoshut(InoshutContext ctx) {
     _currentInterfaces.forEach(iface -> iface.setShutdown(false));
+  }
+
+  @Override
+  public void exitInos_access(Inos_accessContext ctx) {
+    if (ctx.vlan != null && toVlanId(ctx, ctx.vlan) == null) {
+      // NX-OS rejects lines where vlan is invalid, even if it ignores vlan later.
+      return;
+    }
+    // Note: NX-OS does not care what vlan id you put, it clears access vlan regardless.
+    _currentInterfaces.forEach(iface -> iface.setAccessVlan(null));
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -2762,6 +2762,7 @@ public final class CiscoNxosGrammarTest {
       assertThat(iface.getEigrp(), nullValue());
       assertThat(iface.getIpForward(), equalTo(Boolean.FALSE));
       assertThat(iface.getIpProxyArp(), equalTo(Boolean.FALSE));
+      assertThat(iface.getAccessVlan(), nullValue());
     }
     {
       Interface iface = vc.getInterfaces().get("Ethernet1/3");

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_properties
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_properties
@@ -66,6 +66,9 @@ interface Ethernet1/2
   no snmp trap link-status
   udld disable
   no ip forward
+  switchport
+  switchport access vlan 5
+  no switchport access vlan 7
 
 interface Ethernet1/3
   autostate


### PR DESCRIPTION
NX-OS accepts a vlan ID, though it is ignored.