### PR TITLE
TransferBDD: Avoid crashing on common idioms for setting communities

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/SetCommunitiesVarCollector.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/SetCommunitiesVarCollector.java
@@ -34,7 +34,14 @@ public class SetCommunitiesVarCollector
   @Override
   public Set<CommunityVar> visitCommunitySetDifference(
       CommunitySetDifference communitySetDifference, Configuration arg) {
-    throw new UnsupportedOperationException("Community set differences are not supported");
+    if (communitySetDifference.getInitial().equals(InputCommunities.instance())) {
+      // a common pattern is to remove specific input communities (e.g. all standard ones)
+      // before adding new ones.
+      // TODO: handle this idiom properly rather than just ignoring it
+      return ImmutableSet.of();
+    } else {
+      throw new UnsupportedOperationException("Community set differences are not supported");
+    }
   }
 
   @Override

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/SetCommunitiesVarCollectorTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/SetCommunitiesVarCollectorTest.java
@@ -9,11 +9,14 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.batfish.datamodel.routing_policy.communities.AllStandardCommunities;
 import org.batfish.datamodel.routing_policy.communities.CommunityExprsSet;
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
+import org.batfish.datamodel.routing_policy.communities.CommunitySetDifference;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetExprReference;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetReference;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetUnion;
+import org.batfish.datamodel.routing_policy.communities.InputCommunities;
 import org.batfish.datamodel.routing_policy.communities.LiteralCommunitySet;
 import org.batfish.datamodel.routing_policy.communities.StandardCommunityHighLowExprs;
 import org.batfish.datamodel.routing_policy.expr.LiteralInt;
@@ -53,6 +56,16 @@ public class SetCommunitiesVarCollectorTest {
     Set<CommunityVar> result = _varCollector.visitCommunityExprsSet(ces, _baseConfig);
 
     assertEquals(ImmutableSet.of(cvar1, cvar2), result);
+  }
+
+  @Test
+  public void testVisitCommunitySetDifference() {
+    CommunitySetDifference csd =
+        new CommunitySetDifference(InputCommunities.instance(), AllStandardCommunities.instance());
+
+    Set<CommunityVar> result = _varCollector.visitCommunitySetDifference(csd, _baseConfig);
+
+    assertEquals(ImmutableSet.of(), result);
   }
 
   @Test


### PR DESCRIPTION
Identifies expressions of the form (InputCommunities - E), which is common in the translation of config commands to set communities, and ignores them rather than crashing.