### PR TITLE
JunOS: routing-instance should never be unused

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -89,6 +89,7 @@ import static org.batfish.representation.juniper.JuniperStructureUsage.POLICY_ST
 import static org.batfish.representation.juniper.JuniperStructureUsage.POLICY_STATEMENT_THEN_SET_COMMUNITY;
 import static org.batfish.representation.juniper.JuniperStructureUsage.RESOLUTION_RIB_IMPORT_POLICY;
 import static org.batfish.representation.juniper.JuniperStructureUsage.ROUTING_INSTANCE_INTERFACE;
+import static org.batfish.representation.juniper.JuniperStructureUsage.ROUTING_INSTANCE_SELF_REFERENCE;
 import static org.batfish.representation.juniper.JuniperStructureUsage.ROUTING_INSTANCE_VRF_EXPORT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.ROUTING_INSTANCE_VRF_IMPORT;
 import static org.batfish.representation.juniper.JuniperStructureUsage.ROUTING_OPTIONS_INSTANCE_IMPORT;
@@ -2895,6 +2896,8 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
         _currentLogicalSystem.getRoutingInstances().computeIfAbsent(name, RoutingInstance::new);
     _currentRoutingInstance.getGlobalMasterInterface().setParent(_currentMasterInterface);
     _configuration.defineFlattenedStructure(ROUTING_INSTANCE, name, ctx, _parser);
+    _configuration.referenceStructure(
+        ROUTING_INSTANCE, name, ROUTING_INSTANCE_SELF_REFERENCE, getLine(ctx.name.getStart()));
   }
 
   @Override
@@ -3873,7 +3876,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void enterBfiu_rib_group(Bfiu_rib_groupContext ctx) {
     String groupName = unquote(ctx.name.getText());
     _configuration.referenceStructure(
-        RIB_GROUP, groupName, BGP_FAMILY_INET_UNICAST_RIB_GROUP, ctx.name.getStart().getLine());
+        RIB_GROUP, groupName, BGP_FAMILY_INET_UNICAST_RIB_GROUP, getLine(ctx.name.getStart()));
     _currentBgpGroup.setRibGroup(groupName);
   }
 
@@ -4221,7 +4224,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
     _currentFwTerm.getThens().add(new FwThenRoutingInstance(name));
     _currentFilter.setUsedForFBF(true);
     _configuration.referenceStructure(
-        ROUTING_INSTANCE, name, FIREWALL_FILTER_THEN_ROUTING_INSTANCE, ctx.getStart().getLine());
+        ROUTING_INSTANCE, name, FIREWALL_FILTER_THEN_ROUTING_INSTANCE, getLine(ctx.getStart()));
   }
 
   @Override
@@ -5386,7 +5389,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
   public void exitRoi_rib_group(Roi_rib_groupContext ctx) {
     String groupName = unquote(ctx.name.getText());
     _configuration.referenceStructure(
-        RIB_GROUP, groupName, INTERFACE_ROUTING_OPTIONS, ctx.name.getStart().getLine());
+        RIB_GROUP, groupName, INTERFACE_ROUTING_OPTIONS, getLine(ctx.name.getStart()));
     if (ctx.INET() != null) {
       _currentRoutingInstance.applyRibGroup(RoutingProtocol.CONNECTED, groupName);
       _currentRoutingInstance.applyRibGroup(RoutingProtocol.LOCAL, groupName);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -3597,9 +3597,7 @@ public final class JuniperConfiguration extends VendorConfiguration {
         JuniperStructureUsage.NAT_SOURCE_RULE_SET_RULE_THEN,
         JuniperStructureUsage.NAT_STATIC_RULE_SET_RULE_THEN);
 
-    markConcreteStructure(
-        JuniperStructureType.ROUTING_INSTANCE,
-        JuniperStructureUsage.POLICY_STATEMENT_FROM_INSTANCE);
+    markConcreteStructure(JuniperStructureType.ROUTING_INSTANCE);
 
     markConcreteStructure(JuniperStructureType.SECURITY_POLICY);
     markConcreteStructure(JuniperStructureType.SECURITY_POLICY_TERM);

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperStructureUsage.java
@@ -58,6 +58,7 @@ public enum JuniperStructureUsage implements StructureUsage {
   POLICY_STATEMENT_THEN_SET_COMMUNITY("policy-statement then set community"),
   RESOLUTION_RIB_IMPORT_POLICY("routing-instance resolution rib import"),
   ROUTING_INSTANCE_INTERFACE("routing-instance interface"),
+  ROUTING_INSTANCE_SELF_REFERENCE("routing-instance"),
   ROUTING_INSTANCE_VRF_EXPORT("routing-instance vrf-export"),
   ROUTING_INSTANCE_VRF_IMPORT("routing-instance vrf-import"),
   ROUTING_OPTIONS_INSTANCE_IMPORT("routing-options instance-import"),

--- a/tests/parsing-tests/unit-tests-undefined.ref
+++ b/tests/parsing-tests/unit-tests-undefined.ref
@@ -3457,6 +3457,18 @@
         }
       },
       {
+        "File_Name" : "configs/juniper_firewall",
+        "Struct_Type" : "routing-instance",
+        "Ref_Name" : "OTHER_INSTANCE",
+        "Context" : "firewall filter then routing-instance",
+        "Lines" : {
+          "filename" : "configs/juniper_firewall",
+          "lines" : [
+            38
+          ]
+        }
+      },
+      {
         "File_Name" : "configs/juniper_forwarding_options",
         "Struct_Type" : "dhcp-relay server-group",
         "Ref_Name" : "site-dhcp",
@@ -4171,10 +4183,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 338 results",
+      "notes" : "Found 339 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 338
+      "numResults" : 339
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests-unused.ref
+++ b/tests/parsing-tests/unit-tests-unused.ref
@@ -1738,54 +1738,6 @@
         }
       },
       {
-        "Structure_Type" : "routing-instance",
-        "Structure_Name" : "fabric",
-        "Source_Lines" : {
-          "filename" : "configs/gh-2658-juniper-vrf-import-export.cfg",
-          "lines" : [
-            200,
-            201,
-            202,
-            203,
-            204,
-            205,
-            206,
-            207,
-            208,
-            209,
-            210,
-            211,
-            213,
-            214,
-            217,
-            218,
-            221,
-            222,
-            223,
-            224,
-            225,
-            226,
-            229,
-            230,
-            231,
-            232,
-            233
-          ]
-        }
-      },
-      {
-        "Structure_Type" : "routing-instance",
-        "Structure_Name" : "vr",
-        "Source_Lines" : {
-          "filename" : "configs/gh-2658-juniper-vrf-import-export.cfg",
-          "lines" : [
-            196,
-            197,
-            198
-          ]
-        }
-      },
-      {
         "Structure_Type" : "route-policy",
         "Structure_Name" : "FOO",
         "Source_Lines" : {
@@ -2704,16 +2656,6 @@
         }
       },
       {
-        "Structure_Type" : "routing-instance",
-        "Structure_Name" : "SOME_INSTANCE",
-        "Source_Lines" : {
-          "filename" : "configs/juniper_interfaces",
-          "lines" : [
-            24
-          ]
-        }
-      },
-      {
         "Structure_Type" : "vlan",
         "Structure_Name" : "unused-vlan",
         "Source_Lines" : {
@@ -2721,16 +2663,6 @@
           "lines" : [
             26,
             27
-          ]
-        }
-      },
-      {
-        "Structure_Type" : "routing-instance",
-        "Structure_Name" : "ROUTING_INSTANCE",
-        "Source_Lines" : {
-          "filename" : "configs/juniper_misc",
-          "lines" : [
-            9
           ]
         }
       },
@@ -2920,21 +2852,6 @@
             7,
             8,
             9
-          ]
-        }
-      },
-      {
-        "Structure_Type" : "routing-instance",
-        "Structure_Name" : "ROUTING_INSTANCE_NAME",
-        "Source_Lines" : {
-          "filename" : "configs/juniper_rib_groups",
-          "lines" : [
-            20,
-            21,
-            22,
-            23,
-            24,
-            25
           ]
         }
       },
@@ -3739,10 +3656,10 @@
       }
     ],
     "summary" : {
-      "notes" : "Found 247 results",
+      "notes" : "Found 242 results",
       "numFailed" : 0,
       "numPassed" : 0,
-      "numResults" : 247
+      "numResults" : 242
     }
   }
 ]

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -72039,11 +72039,11 @@
           "routing-instance" : {
             "fabric" : {
               "definitionLines" : "200-211,213-214,217-218,221-226,229-233",
-              "numReferrers" : 0
+              "numReferrers" : 17
             },
             "vr" : {
               "definitionLines" : "196-198",
-              "numReferrers" : 0
+              "numReferrers" : 2
             }
           }
         },
@@ -72749,7 +72749,7 @@
           "routing-instance" : {
             "SOME_INSTANCE" : {
               "definitionLines" : "24",
-              "numReferrers" : 0
+              "numReferrers" : 1
             }
           },
           "vlan" : {
@@ -72776,7 +72776,7 @@
           "routing-instance" : {
             "ROUTING_INSTANCE" : {
               "definitionLines" : "9",
-              "numReferrers" : 0
+              "numReferrers" : 1
             }
           }
         },
@@ -72922,7 +72922,7 @@
           "routing-instance" : {
             "ROUTING_INSTANCE_NAME" : {
               "definitionLines" : "20-25",
-              "numReferrers" : 0
+              "numReferrers" : 6
             }
           }
         },
@@ -77708,6 +77708,18 @@
                 112
               ]
             }
+          },
+          "routing-instance" : {
+            "fabric" : {
+              "routing-instance" : [
+                200
+              ]
+            },
+            "vr" : {
+              "routing-instance" : [
+                196
+              ]
+            }
           }
         },
         "configs/host2" : {
@@ -78668,6 +78680,13 @@
               ]
             }
           },
+          "routing-instance" : {
+            "SOME_INSTANCE" : {
+              "routing-instance" : [
+                24
+              ]
+            }
+          },
           "vlan" : {
             "bippetyboppety" : {
               "interface vlan" : [
@@ -78703,6 +78722,13 @@
           "interface" : {
             "lo0.0" : {
               "routing-instances vtep-source-interface" : [
+                9
+              ]
+            }
+          },
+          "routing-instance" : {
+            "ROUTING_INSTANCE" : {
+              "routing-instance" : [
                 9
               ]
             }
@@ -78887,6 +78913,18 @@
               "routing-options interface-routes" : [
                 3,
                 4
+              ]
+            }
+          },
+          "routing-instance" : {
+            "ROUTING_INSTANCE_NAME" : {
+              "routing-instance" : [
+                20,
+                21,
+                22,
+                23,
+                24,
+                25
               ]
             }
           }
@@ -82282,7 +82320,15 @@
         "configs/juniper_bgp_enforce_fist_as" : { },
         "configs/juniper_bgp_remove_private_as" : { },
         "configs/juniper_extended_community" : { },
-        "configs/juniper_firewall" : { },
+        "configs/juniper_firewall" : {
+          "routing-instance" : {
+            "OTHER_INSTANCE" : {
+              "firewall filter then routing-instance" : [
+                38
+              ]
+            }
+          }
+        },
         "configs/juniper_forwarding_options" : {
           "dhcp-relay server-group" : {
             "site-dhcp" : {


### PR DESCRIPTION
Also fixup a very small number of getLine mixups.