### PR TITLE
fix static route activation condition

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/StaticRouteHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/StaticRouteHelper.java
@@ -50,7 +50,7 @@ public class StaticRouteHelper {
     //   longest prefix match upon activation, creating a loop.
     Prefix network = route.getNetwork();
     int prefixLength = network.getPrefixLength();
-    boolean containsOwnNextHop = network.containsIp(route.getNextHopIp());
+    boolean containsOwnNextHop = network.containsIp(nextHopIp);
     return matchingRoutes.stream()
         .map(AbstractRouteDecorator::getAbstractRoute)
         .anyMatch(


### PR DESCRIPTION
- if a static route matches its own next-hop, a matching route must be
more specific