### PR TITLE
NX-OS: don't double warn for track

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -4695,7 +4695,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     if (!iface.isPresent()) {
       return;
     }
-    todo(ctx);
+    // already warning at parent stanza
     _c.referenceStructure(INTERFACE, iface.get(), TRACK_INTERFACE, ctx.getStart().getLine());
   }
 


### PR DESCRIPTION
We warn at parent context, no need to warn for inner children.