### PR TITLE
IOS-XR: remove u32 alternative for community-set

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_common.g4
@@ -40,7 +40,6 @@ community
    | NO_ADVERTISE
    | NO_EXPORT
    | hi = uint16 COLON lo = uint16
-   | u32 = uint32
 ;
 
 description_line

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -8114,8 +8114,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
     } else if (ctx.hi != null) {
       assert ctx.lo != null;
       return StandardCommunity.of(toInteger(ctx.hi), toInteger(ctx.lo)).asLong();
-    } else if (ctx.u32 != null) {
-      return toLong(ctx.u32);
     } else if (ctx.INTERNET() != null) {
       return WellKnownCommunity.INTERNET;
     } else if (ctx.GRACEFUL_SHUTDOWN() != null) {


### PR DESCRIPTION
> Integer community values must be split in half and expressed as two unsigned
> decimal integers in the range from 0 to 65535, separated by a colon. Single
> 32-bit community values are not allowed.

https://www.cisco.com/c/en/us/td/docs/routers/xr12000/software/xr12k_r4-0/routing/configuration/guide/rc40xr12k_chapter7.html#con_1115490