### PR TITLE
AclTracer: do not include subtraces for NotMatchExpr

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/acl/AclTracer.java
@@ -321,11 +321,9 @@ public final class AclTracer extends AclLineEvaluator {
     setTraceElement(notMatchExpr.getTraceElement());
     _tracer.newSubTrace();
     boolean result = visit(notMatchExpr.getOperand());
-    if (result) {
-      _tracer.discardSubTrace();
-    } else {
-      _tracer.endSubTrace();
-    }
+    // TODO: how should we handle explaining "did not match"?
+    // Preserving the sub-trace for a BooleanExpr that returned false is misleading.
+    _tracer.discardSubTrace();
     return !result;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/AclTracerTest.java
@@ -613,13 +613,13 @@ public class AclTracerTest {
   @Test
   public void testNotMatchExpr_withoutTraceElement() {
     List<TraceTree> trace = trace(not(falseExpr("false")));
-    assertThat(trace, contains(isTraceTree("false")));
+    assertThat(trace, empty());
   }
 
   @Test
   public void testNotMatchExpr_withTraceElement() {
     List<TraceTree> trace = trace(not("not", falseExpr("false")));
-    assertThat(trace, contains(isTraceTree("not", isTraceTree("false"))));
+    assertThat(trace, contains(isTraceTree("not")));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/BUILD
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/acl/BUILD
@@ -1,0 +1,24 @@
+load("@batfish//skylark:junit.bzl", "junit_tests")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+junit_tests(
+    name = "tests",
+    srcs = glob([
+        "**/*Test.java",
+    ]),
+    deps = [
+        "//projects/batfish-common-protocol:common",
+        "//projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers",
+        "@maven//:com_fasterxml_jackson_core_jackson_core",
+        "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_guava_guava_testlib",
+        "@maven//:junit_junit",
+        "@maven//:org_apache_commons_commons_lang3",
+        "@maven//:org_hamcrest_hamcrest",
+    ],
+)

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoTraceElementCreators.java
@@ -130,8 +130,13 @@ public final class PaloAltoTraceElementCreators {
   }
 
   @VisibleForTesting
-  public static TraceElement matchNegatedAddressTraceElement() {
-    return TraceElement.of("Matched negated address");
+  public static TraceElement matchNegatedDestinationAddressTraceElement() {
+    return TraceElement.of("Matched negated destination address");
+  }
+
+  @VisibleForTesting
+  public static TraceElement matchNegatedSourceAddressTraceElement() {
+    return TraceElement.of("Matched negated source address");
   }
 
   @VisibleForTesting

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoSecurityRuleTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoSecurityRuleTest.java
@@ -17,7 +17,7 @@ import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchBuiltInApplicationTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchBuiltInServiceTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchDestinationAddressTraceElement;
-import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchNegatedAddressTraceElement;
+import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchNegatedDestinationAddressTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchSecurityRuleTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchServiceAnyTraceElement;
 import static org.batfish.representation.palo_alto.PaloAltoTraceElementCreators.matchServiceApplicationDefaultTraceElement;
@@ -412,14 +412,7 @@ public class PaloAltoSecurityRuleTest {
                   matchSecurityRuleTraceElement("RULE4", "vsys1", filename),
                   isTraceTree(
                       matchSourceAddressTraceElement(), isTraceTree(matchAddressAnyTraceElement())),
-                  isTraceTree(
-                      matchDestinationAddressTraceElement(),
-                      isTraceTree(
-                          matchNegatedAddressTraceElement(),
-                          isTraceTree(matchAddressValueTraceElement("10.11.12.13"))),
-                      isTraceTree(
-                          matchNegatedAddressTraceElement(),
-                          isTraceTree(matchAddressValueTraceElement("10.11.11.0/24")))),
+                  isTraceTree(matchNegatedDestinationAddressTraceElement()),
                   isTraceTree(matchApplicationAnyTraceElement()),
                   isTraceTree(matchServiceAnyTraceElement()))));
     }


### PR DESCRIPTION
Tracing does not make sense through Not, since the subtracers are not
aware that they have been negated. While we work out a better solution,
discard the child subtraces unconditionally.

Traces on the NotMatchExpr itself are still preserved.

Minor updates to the Palo Alto modeling for filters as a result.