### PR TITLE
FortiOS: Remove warning for BGP AS 0

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
@@ -78,7 +78,7 @@ public final class FortiosBgpConversions {
   public static void convertBgp(BgpProcess bgpProcess, Configuration c, Warnings w) {
     long as = bgpProcess.getAsEffective();
     if (as == 0L) {
-      w.redFlag("Ignoring BGP process: No AS configured");
+      // this is the standard way to disable BGP in FortiOS
       return;
     } else if (as == 65535L || as == 4294967295L) {
       w.redFlag(String.format("Ignoring BGP process: AS %s is proscribed by RFC 7300", as));

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -33,7 +33,9 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -747,14 +749,11 @@ public final class FortiosGrammarTest {
   public void testBgpConversionNoAs() throws IOException {
     String hostname = "bgp_no_as";
     Batfish batfish = getBatfishForConfigurationNames(hostname);
-    Warnings warnings =
-        batfish
-            .loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot())
-            .getWarnings()
-            .get(hostname);
+    // No warnings generated, indicating that BGP conversion was skipped (if it had attempted to
+    // convert the neighbor, it would have generated a warning)
     assertThat(
-        warnings.getRedFlagWarnings(),
-        contains(WarningMatchers.hasText("Ignoring BGP process: No AS configured")));
+        batfish.loadConvertConfigurationAnswerElementOrReparse(batfish.getSnapshot()).getWarnings(),
+        not(hasKey(hostname)));
   }
 
   @Test


### PR DESCRIPTION
Setting AS to 0 is the standard way to disable BGP in FortiOS (and it is set to 0 by default, so `show full-configuration` will often show `set as 0`).