### PR TITLE
FortiOS: Anticipate unset lines in route-maps, services

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_route_map.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_route_map.g4
@@ -20,7 +20,9 @@ crrmec_rule: RULE newline crrmecr_edit* END newline;
 
 crrmecr_edit: EDIT route_map_rule_number newline crrmecre* NEXT newline;
 
-crrmecre: crrmecre_set;
+crrmecre: crrmecre_set | crrme_unset;
+
+crrme_unset: UNSET unimplemented;
 
 crrmecre_set: SET (crrmecre_set_action | crrmecre_set_match_ip_address);
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_route_map.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_route_map.g4
@@ -20,7 +20,11 @@ crrmec_rule: RULE newline crrmecr_edit* END newline;
 
 crrmecr_edit: EDIT route_map_rule_number newline crrmecre* NEXT newline;
 
-crrmecre: crrmecre_set | unimplemented_edit_stanza;
+crrmecre
+:
+    crrmecre_set
+    | (UNSET | SELECT | UNSELECT | APPEND | CLEAR) unimplemented
+;
 
 crrmecre_set: SET (crrmecre_set_action | crrmecre_set_match_ip_address);
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_route_map.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_route_map.g4
@@ -20,9 +20,7 @@ crrmec_rule: RULE newline crrmecr_edit* END newline;
 
 crrmecr_edit: EDIT route_map_rule_number newline crrmecre* NEXT newline;
 
-crrmecre: crrmecre_set | crrme_unset;
-
-crrme_unset: UNSET unimplemented;
+crrmecre: crrmecre_set | unimplemented_edit_stanza;
 
 crrmecre_set: SET (crrmecre_set_action | crrmecre_set_match_ip_address);
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_service.g4
@@ -18,7 +18,7 @@ cfsc_edit: EDIT service_name newline cfsce* NEXT newline;
 cfsce
 :
     SET cfsc_set_singletons
-    | unimplemented_edit_stanza
+    | (UNSET | SELECT | UNSELECT | APPEND | CLEAR) unimplemented
 ;
 
 cfsc_set_singletons:

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_service.g4
@@ -15,7 +15,13 @@ cfsc_rename: RENAME current_name = service_name TO new_name = service_name newli
 
 cfsc_edit: EDIT service_name newline cfsce* NEXT newline;
 
-cfsce: SET cfsc_set_singletons;
+cfsce
+:
+    SET cfsc_set_singletons
+    | cfsc_unset
+;
+
+cfsc_unset: UNSET unimplemented;
 
 cfsc_set_singletons:
     cfsc_set_comment

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_service.g4
@@ -18,10 +18,8 @@ cfsc_edit: EDIT service_name newline cfsce* NEXT newline;
 cfsce
 :
     SET cfsc_set_singletons
-    | cfsc_unset
+    | unimplemented_edit_stanza
 ;
-
-cfsc_unset: UNSET unimplemented;
 
 cfsc_set_singletons:
     cfsc_set_comment

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/service_custom
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/service_custom
@@ -38,8 +38,8 @@ config firewall service custom
         set protocol IP
         set protocol-number 254
         set protocol ICMP
-        set icmpcode 254
         set icmptype 254
+        set icmpcode 254
         set protocol TCP/UDP/SCTP
         set tcp-portrange 254
         set udp-portrange 254


### PR DESCRIPTION
Does not extract unset, but saves the parser from losing context.