### PR TITLE
FortiOS grammar: make rules more consistent

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_address.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_address.g4
@@ -12,9 +12,13 @@ cfa_rename: RENAME current_name = address_name TO new_name = address_name newlin
 
 cfa_edit: EDIT address_name newline cfae* NEXT newline;
 
-cfae: SET cfa_set_singletons | CONFIG cfae_config;
+cfae: cfa_set | cfae_config;
 
-cfae_config: TAGGING newline cfaec_tagging END newline;
+cfae_config: CONFIG cfaec_tagging;
+
+cfaec_tagging: TAGGING newline cfaect_edit END newline;
+
+cfa_set: SET cfa_set_singletons;
 
 cfa_set_singletons:
     cfa_set_allow_routing
@@ -62,7 +66,7 @@ cfa_set_null:
         | SUB_TYPE
     ) null_rest_of_line;
 
-cfaec_tagging: EDIT tagging_name newline unimplemented_edit_stanza* NEXT newline;
+cfaect_edit: EDIT tagging_name newline unimplemented_edit_stanza* NEXT newline;
 
 address_type:
     IPMASK

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_addrgrp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_addrgrp.g4
@@ -14,10 +14,14 @@ cfaddrgrp_edit: EDIT address_name newline cfaddrgrpe* NEXT newline;
 
 cfaddrgrpe
 :
-    SET (cfaddrgrp_set_singletons | cfaddrgrp_set_lists)
-    | SELECT cfaddrgrp_set_lists
-    | APPEND cfaddrgrp_append_lists
+    cfaddrgrp_set
+    | cfaddrgrp_select
+    | cfaddrgrp_append
 ;
+
+cfaddrgrp_set: SET (cfaddrgrp_set_singletons | cfaddrgrp_set_lists);
+
+cfaddrgrp_select: SELECT cfaddrgrp_set_lists;
 
 cfaddrgrp_set_singletons:
     cfaddrgrp_set_comment
@@ -52,6 +56,8 @@ cfaddrgrp_set_lists
 cfaddrgrp_set_exclude_member: EXCLUDE_MEMBER address_names newline;
 
 cfaddrgrp_set_member: MEMBER address_names newline;
+
+cfaddrgrp_append: APPEND cfaddrgrp_append_lists;
 
 cfaddrgrp_append_lists
 :

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_bgp.g4
@@ -8,9 +8,11 @@ cr_bgp: BGP newline crb*;
 
 crb
 :
-    SET crb_set_singletons
+    crb_set
     | crb_config
 ;
+
+crb_set: SET crb_set_singletons;
 
 crb_set_singletons
 :

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_bgp.g4
@@ -6,11 +6,7 @@ options {
 
 cr_bgp: BGP newline crb*;
 
-crb
-:
-    crb_set
-    | crb_config
-;
+crb: crb_set | crb_config;
 
 crb_set: SET crb_set_singletons;
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_interface.g4
@@ -8,7 +8,9 @@ cs_interface: INTERFACE newline csi_edit*;
 
 csi_edit: EDIT interface_name newline csie* NEXT newline;
 
-csie: SET csi_set_singletons;
+csie: csi_set;
+
+csi_set: SET csi_set_singletons;
 
 csi_set_singletons:
     csi_set_alias

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_policy.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_policy.g4
@@ -16,14 +16,11 @@ cfp_move: MOVE name = policy_number after_or_before pivot = policy_number newlin
 
 cfp_edit: EDIT policy_number newline cfpe* NEXT newline;
 
-cfpe
-:
-    (
-        SET (cfp_set_singletons | cfp_set_lists)
-        | APPEND cfp_append
-        | SELECT cfp_set_lists
-    )
-;
+cfpe: cfp_set | cfp_append | cfp_select;
+
+cfp_set: SET (cfp_set_singletons | cfp_set_lists);
+
+cfp_select: SELECT cfp_set_lists;
 
 cfp_set_singletons
 :
@@ -62,11 +59,13 @@ cfp_set_srcintf: SRCINTF interfaces = interface_or_zone_names newline;
 
 cfp_append
 :
-    cfp_append_dstaddr
-    | cfp_append_dstintf
-    | cfp_append_service
-    | cfp_append_srcaddr
-    | cfp_append_srcintf
+    APPEND (
+        cfp_append_dstaddr
+        | cfp_append_dstintf
+        | cfp_append_service
+        | cfp_append_srcaddr
+        | cfp_append_srcintf
+    )
 ;
 
 cfp_append_dstaddr: DSTADDR addresses = address_names newline;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_service.g4
@@ -17,9 +17,11 @@ cfsc_edit: EDIT service_name newline cfsce* NEXT newline;
 
 cfsce
 :
-    SET cfsc_set_singletons
+    cfsc_set
     | (UNSET | SELECT | UNSELECT | APPEND | CLEAR) unimplemented
 ;
+
+cfsc_set: SET cfsc_set_singletons;
 
 cfsc_set_singletons:
     cfsc_set_comment
@@ -57,19 +59,13 @@ cfsg_rename: RENAME current_name = service_name TO new_name = service_name newli
 
 cfsg_edit: EDIT service_name newline cfsge* NEXT newline;
 
-cfsge
-:
-    (
-        SET (cfsg_set_singletons | cfsg_set_member)
-        | APPEND cfsg_append_member
-        | SELECT cfsg_set_member
-    )
-;
+cfsge: cfsg_set | cfsg_append | cfsg_select;
 
-cfsg_set_singletons:
-    cfsg_set_comment
-    | cfsg_set_null
-;
+cfsg_set: SET (cfsg_set_singletons | cfsg_set_member);
+
+cfsg_select: SELECT cfsg_set_member;
+
+cfsg_set_singletons: cfsg_set_comment | cfsg_set_null;
 
 cfsg_set_comment: COMMENT comment = str newline;
 
@@ -77,7 +73,9 @@ cfsg_set_null: COLOR null_rest_of_line;
 
 cfsg_set_member: MEMBER service_names newline;
 
-cfsg_append_member: MEMBER service_names newline;
+cfsg_append: APPEND cfsga_member;
+
+cfsga_member: MEMBER service_names newline;
 
 service_protocol
 :

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_static.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_static.g4
@@ -8,7 +8,9 @@ cr_static: STATIC newline crs_edit*;
 
 crs_edit: EDIT route_num newline crse* NEXT newline;
 
-crse: SET crs_set_singletons;
+crse: crs_set;
+
+crs_set: SET crs_set_singletons;
 
 crs_set_singletons:
     crs_set_device

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_system.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_system.g4
@@ -13,11 +13,9 @@ c_system: SYSTEM (
 
 cs_global: GLOBAL newline csg*;
 
-csg:
-  SET (
-    csg_hostname
-  )
-;
+csg: csg_set;
+
+csg_set: SET csg_hostname;
 
 csg_hostname: HOSTNAME host=device_hostname newline;
 
@@ -48,15 +46,12 @@ replacemsg_minor_type:
          output they appear in quotes, but need not be entered that way. */
   word;
 
-csr:
-  SET (
-    csr_set_buffer
-  )
-  | UNSET (
-    csr_unset_buffer
-  )
-;
+csr: csr_set | csr_unset;
+
+csr_set: SET csr_set_buffer;
 
 csr_set_buffer: BUFFER buffer=str newline;
+
+csr_unset: UNSET csr_unset_buffer;
 
 csr_unset_buffer: BUFFER newline;

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -98,11 +98,11 @@ import org.batfish.grammar.fortios.FortiosParser.Cfsc_set_protocol_numberContext
 import org.batfish.grammar.fortios.FortiosParser.Cfsc_set_sctp_portrangeContext;
 import org.batfish.grammar.fortios.FortiosParser.Cfsc_set_tcp_portrangeContext;
 import org.batfish.grammar.fortios.FortiosParser.Cfsc_set_udp_portrangeContext;
-import org.batfish.grammar.fortios.FortiosParser.Cfsg_append_memberContext;
 import org.batfish.grammar.fortios.FortiosParser.Cfsg_editContext;
 import org.batfish.grammar.fortios.FortiosParser.Cfsg_renameContext;
 import org.batfish.grammar.fortios.FortiosParser.Cfsg_set_commentContext;
 import org.batfish.grammar.fortios.FortiosParser.Cfsg_set_memberContext;
+import org.batfish.grammar.fortios.FortiosParser.Cfsga_memberContext;
 import org.batfish.grammar.fortios.FortiosParser.Cr_bgpContext;
 import org.batfish.grammar.fortios.FortiosParser.Cral_editContext;
 import org.batfish.grammar.fortios.FortiosParser.Crale_set_commentsContext;
@@ -1372,7 +1372,7 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
   }
 
   @Override
-  public void exitCfsg_append_member(Cfsg_append_memberContext ctx) {
+  public void exitCfsga_member(Cfsga_memberContext ctx) {
     toServiceGroupMemberUUIDs(
             ctx.service_names(), FortiosStructureUsage.SERVICE_GROUP_MEMBER, false)
         .ifPresent(


### PR DESCRIPTION
Make main FortiOS grammar rules generally follow the pattern where rules ending in `_set`,  `_config`, `_rename` etc correspond to rules that start with the token `SET`,  `CONFIG`, `RENAME`

Also, inline a bit less.

No functional changes in this PR.
