### PR TITLE
FortiOS: canonicalize hostname

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosConfiguration.java
@@ -69,7 +69,7 @@ public class FortiosConfiguration extends VendorConfiguration {
 
   @Override
   public void setHostname(String hostname) {
-    _hostname = hostname;
+    _hostname = hostname.toLowerCase();
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -141,6 +141,12 @@ public final class FortiosGrammarTest {
   }
 
   @Test
+  public void testCanonicalHostnameExtraction() {
+    String hostname = "fortios_UPPER_hostname";
+    assertThat(parseVendorConfig(hostname).getHostname(), equalTo(hostname.toLowerCase()));
+  }
+
+  @Test
   public void testHostnameConversion() throws IOException {
     String filename = "fortios_hostname";
     String hostname = "my_fortios-hostname1";

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/fortios_UPPER_hostname
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/fortios_UPPER_hostname
@@ -1,0 +1,3 @@
+config system global
+  set hostname fortios_UPPER_hostname
+end


### PR DESCRIPTION
Like we do for other vendors, save a lowercase version of hostname to the vendor configuration for FortiOS.
