### PR TITLE
FortiOS: support address associated zones

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -427,6 +427,17 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
     }
 
     if (_c.getInterfaces().containsKey(name)) {
+      // Zoned interfaces can't be referenced in this context
+      ImmutableSet<String> zonedIfaceNames =
+          _c.getZones().values().stream()
+              .map(Zone::getInterface)
+              .flatMap(Collection::stream)
+              .collect(ImmutableSet.toImmutableSet());
+      if (zonedIfaceNames.contains(name)) {
+        warn(ctx, "Cannot reference zoned interface " + name);
+        return;
+      }
+
       // TODO Add structure reference for interface
       todo(ctx);
       _currentAddress.setAssociatedInterface(name);

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -289,6 +289,13 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
       group.setExcludeMember(toNames(group.getExcludeMemberUUIDs()));
       group.setMember(toNames(group.getMemberUUIDs()));
     }
+
+    for (Address address : _c.getAddresses().values()) {
+      BatfishUUID uuid = address.getAssociatedZoneUUID();
+      if (uuid != null) {
+        address.setAssociatedZone(toName(uuid));
+      }
+    }
   }
 
   /**
@@ -296,9 +303,11 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
    * org.batfish.representation.fortios.FortiosRenameableObject} names
    */
   private Set<String> toNames(Set<BatfishUUID> uuids) {
-    return uuids.stream()
-        .map(u -> _c.getRenameableObjects().get(u).getName())
-        .collect(ImmutableSet.toImmutableSet());
+    return uuids.stream().map(this::toName).collect(ImmutableSet.toImmutableSet());
+  }
+
+  private String toName(BatfishUUID uuid) {
+    return _c.getRenameableObjects().get(uuid).getName();
   }
 
   @Override
@@ -410,17 +419,22 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
     // the name is a valid zone name, but it may or may not be a valid interface name.
     String name = optName.get();
 
-    // TODO after zone support: If zone exists, set _currentAddress's associatedZone and return.
-
-    if (!_c.getInterfaces().containsKey(name)) {
-      warn(ctx, "No interface or zone named " + name);
-      // TODO File undefined reference to zone, or INTERFACE_OR_ZONE if it's a valid interface name
+    if (_c.getZones().containsKey(name)) {
+      // TODO Add structure reference for zone
+      todo(ctx);
+      _currentAddress.setAssociatedZoneUUID(_c.getZones().get(name).getBatfishUUID());
       return;
     }
 
-    // TODO Add structure reference for interface
-    todo(ctx);
-    _currentAddress.setAssociatedInterface(name);
+    if (_c.getInterfaces().containsKey(name)) {
+      // TODO Add structure reference for interface
+      todo(ctx);
+      _currentAddress.setAssociatedInterface(name);
+      return;
+    }
+
+    warn(ctx, "No interface or zone named " + name);
+    // TODO File undefined reference to zone, or INTERFACE_OR_ZONE if it's a valid interface name
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/fortios/FortiosConfigurationBuilder.java
@@ -291,9 +291,9 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
     }
 
     for (Address address : _c.getAddresses().values()) {
-      BatfishUUID uuid = address.getAssociatedZoneUUID();
+      BatfishUUID uuid = address.getAssociatedInterfaceZoneUUID();
       if (uuid != null) {
-        address.setAssociatedZone(toName(uuid));
+        address.setAssociatedInterfaceZone(toName(uuid));
       }
     }
   }
@@ -422,7 +422,7 @@ public final class FortiosConfigurationBuilder extends FortiosParserBaseListener
     if (_c.getZones().containsKey(name)) {
       // TODO Add structure reference for zone
       todo(ctx);
-      _currentAddress.setAssociatedZoneUUID(_c.getZones().get(name).getBatfishUUID());
+      _currentAddress.setAssociatedInterfaceZoneUUID(_c.getZones().get(name).getBatfishUUID());
       return;
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
@@ -87,8 +87,8 @@ public class Address extends AddrgrpMember implements Serializable {
 
   @Nullable private Boolean _allowRouting;
   @Nullable private String _associatedInterface;
-  @Nullable private String _associatedZone;
-  @Nullable private BatfishUUID _associatedZoneUuid;
+  @Nullable private String _associatedInterfaceZone;
+  @Nullable private BatfishUUID _associatedInterfaceZoneUuid;
   @Nonnull private String _name;
   @Nonnull private final BatfishUUID _uuid;
   @Nullable private Type _type;
@@ -118,15 +118,15 @@ public class Address extends AddrgrpMember implements Serializable {
 
   /**
    * Name of zone referenced in associated-interface field in this address. Should be derived from
-   * {@link this#getAssociatedZoneUUID} when finishing building the VS model.
+   * {@link this#getAssociatedInterfaceZoneUUID} when finishing building the VS model.
    */
-  public @Nullable String getAssociatedZone() {
-    return _associatedZone;
+  public @Nullable String getAssociatedInterfaceZone() {
+    return _associatedInterfaceZone;
   }
 
-  /** Batfish-internal UUID ccorresponding to associated zone */
-  public @Nullable BatfishUUID getAssociatedZoneUUID() {
-    return _associatedZoneUuid;
+  /** Batfish-internal UUID ccorresponding to the zone in associated-interface */
+  public @Nullable BatfishUUID getAssociatedInterfaceZoneUUID() {
+    return _associatedInterfaceZoneUuid;
   }
 
   @Override
@@ -167,12 +167,12 @@ public class Address extends AddrgrpMember implements Serializable {
     _associatedInterface = associatedInterface;
   }
 
-  public void setAssociatedZone(String associatedZone) {
-    _associatedZone = associatedZone;
+  public void setAssociatedInterfaceZone(String associatedZone) {
+    _associatedInterfaceZone = associatedZone;
   }
 
-  public void setAssociatedZoneUUID(BatfishUUID uuid) {
-    _associatedZoneUuid = uuid;
+  public void setAssociatedInterfaceZoneUUID(BatfishUUID uuid) {
+    _associatedInterfaceZoneUuid = uuid;
   }
 
   public void setType(Type type) {

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Address.java
@@ -87,6 +87,8 @@ public class Address extends AddrgrpMember implements Serializable {
 
   @Nullable private Boolean _allowRouting;
   @Nullable private String _associatedInterface;
+  @Nullable private String _associatedZone;
+  @Nullable private BatfishUUID _associatedZoneUuid;
   @Nonnull private String _name;
   @Nonnull private final BatfishUUID _uuid;
   @Nullable private Type _type;
@@ -112,6 +114,19 @@ public class Address extends AddrgrpMember implements Serializable {
   /** Interface or zone associated with this address */
   public @Nullable String getAssociatedInterface() {
     return _associatedInterface;
+  }
+
+  /**
+   * Name of zone referenced in associated-interface field in this address. Should be derived from
+   * {@link this#getAssociatedZoneUUID} when finishing building the VS model.
+   */
+  public @Nullable String getAssociatedZone() {
+    return _associatedZone;
+  }
+
+  /** Batfish-internal UUID ccorresponding to associated zone */
+  public @Nullable BatfishUUID getAssociatedZoneUUID() {
+    return _associatedZoneUuid;
   }
 
   @Override
@@ -150,6 +165,14 @@ public class Address extends AddrgrpMember implements Serializable {
 
   public void setAssociatedInterface(String associatedInterface) {
     _associatedInterface = associatedInterface;
+  }
+
+  public void setAssociatedZone(String associatedZone) {
+    _associatedZone = associatedZone;
+  }
+
+  public void setAssociatedZoneUUID(BatfishUUID uuid) {
+    _associatedZoneUuid = uuid;
   }
 
   public void setType(Type type) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -323,7 +323,7 @@ public final class FortiosGrammarTest {
     assertThat(ipmask.getAssociatedInterface(), equalTo("port1"));
     assertThat(ipmask.getComment(), equalTo("Hello world"));
     assertThat(ipmask.getFabricObject(), equalTo(true));
-    assertThat(iprange.getAssociatedZone(), equalTo("zoneA"));
+    assertThat(iprange.getAssociatedInterfaceZone(), equalTo("zoneA"));
 
     // Test default values
     assertThat(longName.getTypeEffective(), equalTo(Address.Type.IPMASK));

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -420,6 +420,7 @@ public final class FortiosGrammarTest {
 
     // Expect warnings for each undefined reference in the config (in an otherwise legal context)
     warningMatchers.add(hasComment("No interface or zone named undefined_iface"));
+    warningMatchers.add(hasComment("Cannot reference zoned interface zoned_iface"));
     warningMatchers.add(hasComment("No interface named undefined_iface"));
 
     warningMatchers.add(

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -323,6 +323,7 @@ public final class FortiosGrammarTest {
     assertThat(ipmask.getAssociatedInterface(), equalTo("port1"));
     assertThat(ipmask.getComment(), equalTo("Hello world"));
     assertThat(ipmask.getFabricObject(), equalTo(true));
+    assertThat(iprange.getAssociatedZone(), equalTo("zoneA"));
 
     // Test default values
     assertThat(longName.getTypeEffective(), equalTo(Address.Type.IPMASK));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/address
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/address
@@ -7,6 +7,16 @@ config system interface
         set type physical
         set ip 1.1.1.1 255.255.255.0
     next
+    edit "port2"
+        set vdom "root"
+        set type physical
+        set ip 2.1.1.1 255.255.255.0
+    next
+end
+config system zone
+    edit "zoneA"
+        set interface port2
+    next
 end
 config firewall address
     edit "ipmask"
@@ -32,6 +42,7 @@ config firewall address
         set type iprange
         set start-ip 1.1.1.0
         set end-ip 1.1.1.255
+        set associated-interface zoneA
     next
     edit "dynamic"
         set type dynamic

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/address_warnings
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/address_warnings
@@ -1,6 +1,19 @@
 config system global
     set hostname "address_warnings"
 end
+
+config system interface
+    edit "zoned_iface"
+        set vdom "root"
+        set ip 192.168.10.1 255.255.255.0
+        set type physical
+    next
+end
+config system zone
+    edit "zone1"
+        set interface zoned_iface
+    next
+end
 config firewall address
     # Name is too long
     edit "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz"
@@ -11,6 +24,7 @@ config firewall address
         set interface "abcdefghijklmnop"
         # Undefined references
         set associated-interface "undefined_iface"
+        set associated-interface "zoned_iface"
         set interface "undefined_iface"
         # Invalid for this type
         set start-ip 1.1.1.0


### PR DESCRIPTION
Under `address` objects, `associated-interface` can also point to zones. This PR adds support for that.
