### PR TITLE
FortiOS: Default permit outgoing originated traffic

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosPolicyConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosPolicyConversions.java
@@ -84,9 +84,9 @@ public final class FortiosPolicyConversions {
       InterfaceOrZone to, List<InterfaceOrZone> zonesAndUnzonedInterfaces) {
     ImmutableList.Builder<AclLine> lines = ImmutableList.builder();
 
-    // TODO Should originated traffic always be rejected? Is it subject to intrazone policies or
+    // TODO Should originated traffic always be allowed out? Is it subject to intrazone policies or
     //  default intrazone action?
-    lines.add(ExprAclLine.rejecting().setMatchCondition(ORIGINATING_FROM_DEVICE).build());
+    lines.add(ExprAclLine.accepting().setMatchCondition(ORIGINATING_FROM_DEVICE).build());
 
     // Add lines for each possible source:
     // 1. If from that source and matching the associated cross-zone policy, permit

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -1934,7 +1934,8 @@ public final class FortiosGrammarTest {
     assertThat(aclToBdd.toBdd(zone1ToPort1), equalTo(_zero));
 
     // No policies apply to traffic leaving port1
-    assertThat(aclToBdd.toBdd(port1Outgoing), equalTo(_zero));
+    BDD originatedTraffic = srcMgr.getOriginatingFromDeviceBDD();
+    assertThat(aclToBdd.toBdd(port1Outgoing), equalTo(originatedTraffic));
 
     // Should reflect that policy 1 blocks traffic from port1 to addr1, and that traffic from zone1
     // to addr2 is permitted
@@ -1942,7 +1943,9 @@ public final class FortiosGrammarTest {
     BDD fromZone1 = srcMgr.getSourceInterfaceBDD("port2").or(srcMgr.getSourceInterfaceBDD("port3"));
     BDD permittedFromPort1 = fromPort1.and(addr2AsDst.diff(addr1AsDst));
     BDD permittedFromZone1 = fromZone1.and(addr2AsDst);
-    assertThat(aclToBdd.toBdd(zone1Outgoing), equalTo(permittedFromPort1.or(permittedFromZone1)));
+    assertThat(
+        aclToBdd.toBdd(zone1Outgoing),
+        equalTo(permittedFromPort1.or(permittedFromZone1).or(originatedTraffic)));
   }
 
   /**


### PR DESCRIPTION
Not clear that this is correct, but there's at least evidence that outgoing traffic shouldn't be unconditionally denied.