### PR TITLE
FortiOS: add lexer for entirely ignored configuration blocks

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/FortiosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/FortiosLexer.g4
@@ -5,6 +5,7 @@ options {
 }
 
 tokens {
+  IGNORED_CONFIG_BLOCK,
   QUOTED_TEXT,
   STR_SEPARATOR,
   UNIMPLEMENTED_PLACEHOLDER,
@@ -13,34 +14,94 @@ tokens {
 
 // Keyword Tokens
 
+ACCPROFILE: 'accprofile' {
+  // ignore config system accprofile
+  if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 ADMIN:
   'admin'
   {
     if (lastTokenType() == REPLACEMSG) {
       pushMode(M_Str);
+    } else if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+      // ignore config system admin
+      setType(IGNORED_CONFIG_BLOCK);
+      pushMode(M_IgnoredConfigBlock);
     }
   }
 ;
-
 ACCEPT: 'accept';
 ACCESS_LIST: 'access-list';
 ACTION: 'action';
 ADDRESS: 'address';
+ADDRESS6: 'address6' {
+  // ignore config firewall address6
+  if (lastTokenType() == FIREWALL && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 ADDRGRP: 'addrgrp';
 AFTER: 'after' -> pushMode(M_SingleStr);
 AGGREGATE: 'aggregate';
-ALERTMAIL: 'alertmail';
+ALERTMAIL: 'alertmail' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
 ALIAS: 'alias' -> pushMode(M_Str);
 ALLOW: 'allow';
 ALLOW_ROUTING: 'allow-routing';
 ANY: 'any';
+API_USER: 'api-user' {
+  if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+    // ignore config system api-user
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 APPEND: 'append';
 AS: 'as' -> pushMode(M_Str);
 ASSOCIATED_INTERFACE: 'associated-interface' -> pushMode(M_Str);
-AUTH: 'auth';
+AUTH: 'auth' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
+AUTOMATION_ACTION: 'automation-action' {
+  // ignore config system automation-action
+  if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
+AUTOMATION_STITCH: 'automation-stitch' {
+  // ignore config system automation-stitch
+  if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
+AUTOMATION_TRIGGER: 'automation-trigger' {
+  // ignore config system automation-trigger
+  if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 BEFORE: 'before' -> pushMode(M_SingleStr);
 BGP: 'bgp';
 BUFFER: 'buffer' -> pushMode(M_Str);
+CATEGORY: 'category' {
+  // ignore config firewall service category
+  if (lastTokenType() == SERVICE && secondToLastTokenType() == FIREWALL) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 CLEAR: 'clear';
 CLONE: 'clone' -> pushMode(M_SingleStr);
 COLOR: 'color';
@@ -49,6 +110,14 @@ COMMENTS: 'comments' -> pushMode(M_Str);
 CONFIG: 'config';
 COUNTRY: 'country';
 CUSTOM: 'custom';
+CUSTOM_LANGUAGE: 'custom-language' {
+  // ignore config system custom-language
+  if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
+
 DEFAULT: 'default';
 DELETE: 'delete' -> pushMode(M_Str);
 DENY: 'deny';
@@ -63,8 +132,15 @@ DSTINTF: 'dstintf' -> pushMode(M_Str);
 DYNAMIC: 'dynamic';
 EBGP_MULTIPATH: 'ebgp-multipath';
 EDIT: 'edit' -> pushMode(M_Str);
-EMAC_VLAN: 'emac-vlan';
 ENABLE: 'enable';
+EMAC_VLAN: 'emac-vlan';
+EMAIL_SERVER: 'email-server' {
+  // ignore config system email-server
+  if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 END: 'end';
 END_IP: 'end-ip';
 EXACT_MATCH: 'exact-match';
@@ -73,17 +149,33 @@ EXCLUDE_MEMBER: 'exclude-member' -> pushMode(M_Str);
 FABRIC_OBJECT: 'fabric-object';
 FIREWALL: 'firewall';
 FOLDER: 'folder';
-FORTIGUARD_WF: 'fortiguard-wf';
+FORTIGUARD_WF: 'fortiguard-wf' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
 FQDN: 'fqdn';
-FTP: 'ftp';
+FTP: 'ftp' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
 GATEWAY: 'gateway';
 GEOGRAPHY: 'geography';
 GLOBAL: 'global';
 GROUP: 'group';
 HOSTNAME: 'hostname' -> pushMode(M_Str);
-HTTP: 'http';
+HTTP: 'http' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
 IBGP_MULTIPATH: 'ibgp-multipath';
-ICAP: 'icap';
+ICAP: 'icap' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
 ICMP: 'ICMP';
 ICMP6: 'ICMP6';
 ICMPCODE: 'icmpcode';
@@ -101,17 +193,39 @@ IPSEC: 'ipsec';
 LOCATION: 'location';
 LOOPBACK: 'loopback';
 MAC: 'mac';
-MAIL: 'mail';
+MAIL: 'mail' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
 MATCH_IP_ADDRESS: 'match-ip-address' -> pushMode(M_Str);
 MEMBER: 'member' -> pushMode(M_Str);
 MOVE: 'move' -> pushMode(M_SingleStr);
 MTU: 'mtu';
 MTU_OVERRIDE: 'mtu-override';
-NAC_QUAR: 'nac-quar';
+MULTICAST_ADDRESS: 'multicast-address' {
+  // ignore config firewall multicast-address
+  if (lastTokenType() == FIREWALL && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
+NAC_QUAR: 'nac-quar' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
 NAME: 'name' -> pushMode(M_Str);
 NEIGHBOR: 'neighbor';
 NETWORK: 'network';
 NEXT: 'next';
+NP6: 'np6' {
+  // ignore config system np6
+  if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 PERMIT: 'permit';
 PHYSICAL: 'physical';
 POLICY: 'policy';
@@ -123,6 +237,13 @@ REDUNDANT: 'redundant';
 REMOTE_AS: 'remote-as' -> pushMode(M_Str);
 RENAME: 'rename' -> pushMode(M_SingleStr);
 REPLACEMSG: 'replacemsg';
+REPLACEMSG_IMAGE: 'replacemsg-image'{
+  // ignore config system replacemsg-image
+  if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 ROUTE_MAP: 'route-map';
 ROUTE_MAP_IN: 'route-map-in' -> pushMode(M_Str);
 ROUTE_MAP_OUT: 'route-map-out' -> pushMode(M_Str);
@@ -144,23 +265,63 @@ SERVICE:
     }
   }
 ;
+SESSION_HELPER: 'session-helper' {
+  // ignore config system session-helper
+  if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 SET: 'set';
 SNMP_INDEX: 'snmp-index';
-SPAM: 'spam';
+SPAM: 'spam' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
 SRCADDR: 'srcaddr' -> pushMode(M_Str);
 SRCINTF: 'srcintf' -> pushMode(M_Str);
-SSLVPN: 'sslvpn';
+SSLVPN: 'sslvpn' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
+SSO_ADMIN: 'sso-admin' {
+  if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+    // ignore config system sso-admin
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 START_IP: 'start-ip';
 STATIC: 'static';
 STATUS: 'status';
+STORAGE: 'storage' {
+  // ignore config system storage
+  if (lastTokenType() == SYSTEM && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 SUBNET: 'subnet';
 SUB_TYPE: 'sub-type';
+SWITCH_CONTROLLER: 'switch-controller' {
+  // ignore config switch-controller
+  if (lastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 SYSTEM: 'system';
 TAGGING: 'tagging';
 TCP_PORTRANGE: 'tcp-portrange';
 TCP_UDP_SCTP: 'TCP/UDP/SCTP';
 TO: 'to' -> pushMode(M_SingleStr);
-TRAFFIC_QUOTA: 'traffic-quota';
+TRAFFIC_QUOTA: 'traffic-quota' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
 TUNNEL: 'tunnel';
 TYPE: 'type';
 UDP_PORTRANGE: 'udp-portrange';
@@ -168,14 +329,36 @@ UNSELECT: 'unselect';
 UNSET: 'unset';
 UP: 'up';
 UPDATE_SOURCE: 'update-source' -> pushMode(M_Str);
-UTM: 'utm';
+UTM: 'utm' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
 UUID: 'uuid' -> pushMode(M_Str);
 VDOM: 'vdom' -> pushMode(M_Str);
 VLAN: 'vlan';
 VLANID: 'vlanid';
 VRF: 'vrf';
-WEBPROXY: 'webproxy';
+WANOPT: 'wanopt' {
+  // ignore config wanopt
+  if (lastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
+WEBPROXY: 'webproxy' {
+  if (lastTokenType() == REPLACEMSG) {
+    pushMode(M_Str);
+  }
+};
 WILDCARD: 'wildcard';
+WILDCARD_FQDN: 'wildcard-fqdn' {
+  // ignore config firewall wildcard-fqdn
+  if (lastTokenType() == FIREWALL && secondToLastTokenType() == CONFIG) {
+    setType(IGNORED_CONFIG_BLOCK);
+    pushMode(M_IgnoredConfigBlock);
+  }
+};
 WL_MESH: 'wl-mesh';
 ZONE: 'zone';
 
@@ -631,3 +814,49 @@ M_SingleStrValue_UNQUOTED_WORD_CHARS: (F_WordChar | F_UnquotedEscapedChar)+ -> t
 M_SingleStrValue_WS: F_Whitespace+ -> skip, popMode;
 
 M_SingleStrValue_NEWLINE: F_Newline -> type(NEWLINE), popMode;
+
+
+/////////////////////////////////////////////
+/// Mode to ignore an entire config block ///
+/////////////////////////////////////////////
+
+// This is the entrance, after `config <something we want to ignore> [maybe more]`. Eat rest of line,
+// then start ignoring inner lines.
+mode M_IgnoredConfigBlock;
+
+M_IgnoredConfigBlock_REST_OF_LINE: F_NonNewline* F_Newline -> more, mode(M_IgnoredConfigBlockInner);
+
+// We are on some line inside an ignored config block. Eat lines, push if we hit an inner stanza.
+mode M_IgnoredConfigBlockInner;
+
+M_IgnoredConfigBlockInner_EDIT: 'edit' F_NonNewline* F_Newline -> more, pushMode(M_IgnoredEditBlock);
+
+M_IgnoredConfigBlockInner_SINGLE_LINE: ('set' | 'unset') F_NonNewline* F_Newline -> more;
+
+M_IgnoredConfigBlockInner_END: 'end' -> type(END), popMode;
+
+M_IgnoredConfigBlockInner_WS: F_Whitespace+ -> more;
+
+// This is the entrance to an edit line
+mode M_IgnoredEditBlock;
+
+M_IgnoredEditBlock_CONFIG: 'config' F_NonNewline* F_Newline -> more, pushMode(M_IgnoredInteriorConfigBlockInner);
+
+M_IgnoredEditBlock_SINGLE_LINE: ('set' | 'unset') F_NonNewline* F_Newline -> more;
+
+M_IgnoredEditBlock_NEXT: 'next' F_Whitespace* F_Newline -> more, popMode;
+
+M_IgnoredEditBlock_WS: F_Whitespace+ -> more;
+
+// We are on some line inside an ignored config block (not the outermost on).
+// Eat lines, push if we hit an inner stanza.
+// This is the same as M_IgnoredConfigBlockInner, except that the END token is also skipped.
+mode M_IgnoredInteriorConfigBlockInner;
+
+M_IgnoredInteriorConfigBlockInner_EDIT: 'edit' F_NonNewline* F_Newline -> more, pushMode(M_IgnoredEditBlock);
+
+M_IgnoredInteriorConfigBlockInner_SINGLE_LINE: ('set' | 'unset') F_NonNewline* F_Newline -> more;
+
+M_IgnoredInteriorConfigBlockInner_END: 'end' F_Whitespace* F_Newline -> more, popMode;
+
+M_IgnoredInteriorConfigBlockInner_WS: F_Whitespace+ -> more;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/FortiosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/FortiosLexer.g4
@@ -132,7 +132,6 @@ DSTINTF: 'dstintf' -> pushMode(M_Str);
 DYNAMIC: 'dynamic';
 EBGP_MULTIPATH: 'ebgp-multipath';
 EDIT: 'edit' -> pushMode(M_Str);
-ENABLE: 'enable';
 EMAC_VLAN: 'emac-vlan';
 EMAIL_SERVER: 'email-server' {
   // ignore config system email-server
@@ -141,6 +140,7 @@ EMAIL_SERVER: 'email-server' {
     pushMode(M_IgnoredConfigBlock);
   }
 };
+ENABLE: 'enable';
 END: 'end';
 END_IP: 'end-ip';
 EXACT_MATCH: 'exact-match';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/FortiosParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/FortiosParser.g4
@@ -32,5 +32,6 @@ s_config
         c_system
         | c_firewall
         | c_router
+        | IGNORED_CONFIG_BLOCK
     ) END NEWLINE
 ;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_firewall.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_firewall.g4
@@ -10,4 +10,5 @@ c_firewall: FIREWALL (
   | cf_internet_service_name
   | cf_policy
   | cf_service
+  | IGNORED_CONFIG_BLOCK
 );

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_service.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_service.g4
@@ -4,7 +4,7 @@ options {
   tokenVocab = FortiosLexer;
 }
 
-cf_service: SERVICE (cfs_custom | cfs_group);
+cf_service: SERVICE (cfs_custom | cfs_group | IGNORED_CONFIG_BLOCK);
 
 // Service custom
 cfs_custom: CUSTOM newline cfsc*;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_system.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/fortios/Fortios_system.g4
@@ -9,6 +9,7 @@ c_system: SYSTEM (
   | cs_interface
   | cs_replacemsg
   | cs_zone
+  | IGNORED_CONFIG_BLOCK
 );
 
 cs_global: GLOBAL newline csg*;

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -137,7 +137,11 @@ public final class FortiosGrammarTest {
 
   @Test
   public void testIgnoredConfigBlocks() {
-    parseVendorConfig("fortios_ignored");
+    FortiosConfiguration c = parseVendorConfig("fortios_ignored");
+    // Valid syntax before ignored block is parsed
+    assertThat(c.getHostname(), equalTo("ignored"));
+    // Valid syntax after an ignored block is parsed (and before another one)
+    assertThat(c.getAddresses(), hasKeys("Extracted Address"));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -136,6 +136,11 @@ import org.junit.rules.TemporaryFolder;
 public final class FortiosGrammarTest {
 
   @Test
+  public void testIgnoredConfigBlocks() {
+    parseVendorConfig("fortios_ignored");
+  }
+
+  @Test
   public void testHostnameExtraction() {
     String filename = "fortios_hostname";
     String hostname = "my_fortios-hostname1";

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/fortios_ignored
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/fortios_ignored
@@ -317,6 +317,11 @@ config system storage
         set usage log
     next
 end
+config firewall address
+    edit "Extracted Address"
+        set subnet 1.1.1.0/24
+    next
+end
 config firewall address6
     edit "all"
         set uuid aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa

--- a/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/fortios_ignored
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/fortios/testconfigs/fortios_ignored
@@ -1,0 +1,383 @@
+config system global
+  set hostname ignored
+end
+config system accprofile
+    edit "prof_admin"
+        set secfabgrp read-write
+        set ftviewgrp read-write
+        set authgrp read-write
+        set sysgrp read-write
+        set netgrp read-write
+        set loggrp read-write
+        set fwgrp read-write
+        set vpngrp read-write
+        set utmgrp read-write
+        set wanoptgrp read-write
+        set wifi read-write
+    next
+    edit "monitoring"
+        set secfabgrp read
+        set ftviewgrp read
+        set authgrp read
+        set sysgrp read
+        set netgrp custom
+        set loggrp read
+        set fwgrp custom
+        set vpngrp read
+        set utmgrp read
+        set wanoptgrp read
+        set wifi read
+        set system-diagnostics disable
+        config netgrp-permission
+            set cfg read
+        end
+    next
+end
+config system admin
+    edit "admin"
+        set accprofile "super_admin"
+        set vdom "root"
+        config gui-dashboard
+            edit 12
+                set name "Status"
+                set vdom "root"
+                set permanent enable
+                config widget
+                    edit 1
+                        set width 1
+                        set height 1
+                    next
+                end
+            next
+        end
+    next
+end
+config system np6
+    edit "np6_0"
+    next
+end
+config system replacemsg-image
+    edit "logo_fnet"
+        set image-type gif
+    next
+    edit "logo_fguard_wf"
+        set image-type gif
+    next
+    edit "logo_v3_fguard_app"
+    next
+    edit "logo_fw_auth"
+        set image-base64 "<removed>"
+    next
+    edit "logo_v2_fnet"
+        set image-base64 "<removed>"
+    next
+    edit "logo_v2_fguard_wf"
+        set image-base64 "<removed>"
+    next
+    edit "logo_v2_fguard_app"
+        set image-base64 "<removed>"
+    next
+end
+config system replacemsg mail "partial"
+end
+config system replacemsg http "url-block"
+end
+config system replacemsg http "urlfilter-err"
+end
+config system replacemsg http "infcache-block"
+end
+config system replacemsg http "http-contenttypeblock"
+end
+config system replacemsg http "https-invalid-cert-block"
+end
+config system replacemsg http "https-untrusted-cert-block"
+end
+config system replacemsg http "https-blacklisted-cert-block"
+end
+config system replacemsg http "switching-protocols-block"
+end
+config system replacemsg http "http-antiphish-block"
+end
+config system replacemsg webproxy "deny"
+end
+config system replacemsg webproxy "user-limit"
+end
+config system replacemsg webproxy "auth-challenge"
+end
+config system replacemsg webproxy "auth-login-fail"
+end
+config system replacemsg webproxy "auth-group-info-fail"
+end
+config system replacemsg webproxy "http-err"
+end
+config system replacemsg webproxy "auth-ip-blackout"
+end
+config system replacemsg ftp "ftp-explicit-banner"
+end
+config system replacemsg fortiguard-wf "ftgd-block"
+end
+config system replacemsg fortiguard-wf "ftgd-ovrd"
+end
+config system replacemsg fortiguard-wf "ftgd-quota"
+end
+config system replacemsg fortiguard-wf "ftgd-warning"
+end
+config system replacemsg spam "ipblocklist"
+end
+config system replacemsg spam "smtp-spam-dnsbl"
+end
+config system replacemsg spam "smtp-spam-feip"
+end
+config system replacemsg spam "smtp-spam-helo"
+end
+config system replacemsg spam "smtp-spam-emailblack"
+end
+config system replacemsg spam "smtp-spam-mimeheader"
+end
+config system replacemsg spam "reversedns"
+end
+config system replacemsg spam "smtp-spam-ase"
+end
+config system replacemsg spam "submit"
+end
+config system replacemsg alertmail "alertmail-virus"
+end
+config system replacemsg alertmail "alertmail-block"
+end
+config system replacemsg alertmail "alertmail-nids-event"
+end
+config system replacemsg alertmail "alertmail-crit-event"
+end
+config system replacemsg alertmail "alertmail-disk-full"
+end
+config system replacemsg admin "pre_admin-disclaimer-text"
+end
+config system replacemsg admin "post_admin-disclaimer-text"
+end
+config system replacemsg auth "auth-disclaimer-page-1"
+end
+config system replacemsg auth "auth-disclaimer-page-2"
+end
+config system replacemsg auth "auth-disclaimer-page-3"
+end
+config system replacemsg auth "auth-reject-page"
+end
+config system replacemsg auth "auth-login-page"
+end
+config system replacemsg auth "auth-login-failed-page"
+end
+config system replacemsg auth "auth-token-login-page"
+end
+config system replacemsg auth "auth-token-login-failed-page"
+end
+config system replacemsg auth "auth-success-msg"
+end
+config system replacemsg auth "auth-challenge-page"
+end
+config system replacemsg auth "auth-keepalive-page"
+end
+config system replacemsg auth "auth-portal-page"
+end
+config system replacemsg auth "auth-password-page"
+end
+config system replacemsg auth "auth-fortitoken-page"
+end
+config system replacemsg auth "auth-next-fortitoken-page"
+end
+config system replacemsg auth "auth-email-token-page"
+end
+config system replacemsg auth "auth-sms-token-page"
+end
+config system replacemsg auth "auth-email-harvesting-page"
+end
+config system replacemsg auth "auth-email-failed-page"
+end
+config system replacemsg auth "auth-cert-passwd-page"
+end
+config system replacemsg auth "auth-guest-print-page"
+end
+config system replacemsg auth "auth-guest-email-page"
+end
+config system replacemsg auth "auth-success-page"
+end
+config system replacemsg auth "auth-block-notification-page"
+end
+config system replacemsg auth "auth-quarantine-page"
+end
+config system replacemsg auth "auth-qtn-reject-page"
+end
+config system replacemsg auth "auth-saml-page"
+end
+config system replacemsg sslvpn "sslvpn-login"
+end
+config system replacemsg sslvpn "sslvpn-header"
+end
+config system replacemsg sslvpn "sslvpn-limit"
+end
+config system replacemsg sslvpn "hostcheck-error"
+end
+config system replacemsg sslvpn "sslvpn-provision-user"
+end
+config system replacemsg sslvpn "sslvpn-provision-user-sms"
+end
+config system replacemsg nac-quar "nac-quar-virus"
+end
+config system replacemsg nac-quar "nac-quar-dos"
+end
+config system replacemsg nac-quar "nac-quar-ips"
+end
+config system replacemsg nac-quar "nac-quar-dlp"
+end
+config system replacemsg nac-quar "nac-quar-admin"
+end
+config system replacemsg nac-quar "nac-quar-app"
+end
+config system replacemsg traffic-quota "per-ip-shaper-block"
+end
+config system replacemsg utm "virus-html"
+end
+config system replacemsg utm "client-virus-html"
+end
+config system replacemsg utm "virus-text"
+end
+config system replacemsg utm "dlp-html"
+end
+config system replacemsg utm "dlp-text"
+end
+config system replacemsg utm "appblk-html"
+end
+config system replacemsg utm "ipsblk-html"
+end
+config system replacemsg utm "ipsfail-html"
+end
+config system replacemsg utm "exe-text"
+end
+config system replacemsg utm "waf-html"
+end
+config system replacemsg utm "outbreak-prevention-html"
+end
+config system replacemsg utm "outbreak-prevention-text"
+end
+config system replacemsg utm "file-filter-html"
+end
+config system replacemsg utm "file-filter-text"
+end
+config system replacemsg utm "file-size-text"
+end
+config system replacemsg utm "transfer-size-text"
+end
+config system replacemsg utm "internal-error-text"
+end
+config system replacemsg utm "archive-block-html"
+end
+config system replacemsg utm "archive-block-text"
+end
+config system replacemsg utm "file-av-fail-text"
+end
+config system replacemsg utm "transfer-av-fail-text"
+end
+config system replacemsg utm "banned-word-html"
+end
+config system replacemsg utm "banned-word-text"
+end
+config system replacemsg utm "block-html"
+end
+config system replacemsg utm "block-text"
+end
+config system replacemsg utm "decompress-limit-text"
+end
+config system replacemsg utm "dlp-subject-text"
+end
+config system replacemsg utm "file-size-html"
+end
+config system replacemsg utm "client-file-size-html"
+end
+config system replacemsg icap "icap-req-resp"
+end
+config system api-user
+    edit "monitoring"
+        set api-key ENC <removed>
+        set accprofile "monitoring"
+        set vdom "root"
+        config trusthost
+            edit 1
+                set ipv4-trusthost 1.2.3.4 255.255.255.255
+            next
+        end
+    next
+end
+config system storage
+    edit "SSD1"
+        set status enable
+        set media-status enable
+        set order 1
+        set partition "AAAAAAAA12345678"
+        set device "/dev/sdb1"
+        set size 1802680
+        set usage log
+    next
+end
+config firewall address6
+    edit "all"
+        set uuid aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+    next
+    edit "none"
+        set uuid aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+        set ip6 ::/128
+    next
+end
+config firewall multicast-address6
+    edit "all"
+        set ip6 ff00::/8
+    next
+end
+config firewall wildcard-fqdn custom
+    edit "adobe"
+        set uuid aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+        set wildcard-fqdn "*.adobe.com"
+    next
+end
+config firewall service category
+    edit "General"
+        set comment "General services."
+    next
+    edit "Web Access"
+        set comment "Web access."
+    next
+    edit "File Access"
+        set comment "File access."
+    next
+    edit "Email"
+        set comment "Email services."
+    next
+    edit "Network Services"
+        set comment "Network services."
+    next
+    edit "Authentication"
+        set comment "Authentication service."
+    next
+    edit "Remote Access"
+        set comment "Remote access."
+    next
+    edit "Tunneling"
+        set comment "Tunneling service."
+    next
+    edit "VoIP, Messaging & Other Applications"
+        set comment "VoIP, messaging, and other applications."
+    next
+    edit "Web Proxy"
+        set comment "Explicit web proxy."
+    next
+end
+config system session-helper
+    edit 1
+        set name pptp
+        set protocol 6
+        set port 1723
+    next
+end
+config system email-server
+    set server "notification.fortinet.net"
+    set port 465
+    set security smtps
+end


### PR DESCRIPTION
And ignore a few places.

Also fix modes in existing config system replacemsg.

The way this mode works is that it recursively ignores
all single lines (set and unset for now), and nested edit or config
blocks.

It emites all of the ignored text in the final END token.

It needs enhancement for multiline strings, so we can't yet handle
things like VPN certificates in here. It also also in general be less sloppy
about edit strings as well. But it gets us going for now.