### PR TITLE
Arista BGP neighbor: Check null before using the address family variable

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
@@ -524,7 +524,7 @@ final class AristaConversions {
         firstNonNull(
             neighbor.getNextHopUnchanged(),
             firstNonNull(
-                af4.getNextHopUnchanged(),
+                af4 == null ? null : af4.getNextHopUnchanged(),
                 firstNonNull(vrfConfig.getNextHopUnchanged(), Boolean.FALSE))))) {
       exportStatements.add(new SetNextHop(UnchangedNextHop.getInstance()));
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -1365,6 +1365,22 @@ public class AristaGrammarTest {
     }
   }
 
+  /** Test that we convert properly when v4 family is completely absent */
+  @Test
+  public void testNeighborConversion_no_v4() {
+    Configuration c = parseConfig("arista_bgp_neighbors_no_v4");
+    assertThat(c.getDefaultVrf(), notNullValue());
+    BgpProcess proc = c.getDefaultVrf().getBgpProcess();
+    assertThat(proc, notNullValue());
+    {
+      Prefix neighborPrefix = Prefix.parse("10.0.0.11/32");
+      assertThat(proc.getActiveNeighbors(), hasKey(neighborPrefix));
+      BgpActivePeerConfig neighbor = proc.getActiveNeighbors().get(neighborPrefix);
+      assertThat(neighbor.getEvpnAddressFamily(), notNullValue());
+      assertThat(neighbor.getIpv4UnicastAddressFamily(), nullValue());
+    }
+  }
+
   @Test
   public void testVrfExtraction() {
     AristaConfiguration config = parseVendorConfig("arista_bgp_vrf");

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -1372,13 +1372,11 @@ public class AristaGrammarTest {
     assertThat(c.getDefaultVrf(), notNullValue());
     BgpProcess proc = c.getDefaultVrf().getBgpProcess();
     assertThat(proc, notNullValue());
-    {
-      Prefix neighborPrefix = Prefix.parse("10.0.0.11/32");
-      assertThat(proc.getActiveNeighbors(), hasKey(neighborPrefix));
-      BgpActivePeerConfig neighbor = proc.getActiveNeighbors().get(neighborPrefix);
-      assertThat(neighbor.getEvpnAddressFamily(), notNullValue());
-      assertThat(neighbor.getIpv4UnicastAddressFamily(), nullValue());
-    }
+    Prefix neighborPrefix = Prefix.parse("10.0.0.11/32");
+    assertThat(proc.getActiveNeighbors(), hasKey(neighborPrefix));
+    BgpActivePeerConfig neighbor = proc.getActiveNeighbors().get(neighborPrefix);
+    assertThat(neighbor.getEvpnAddressFamily(), notNullValue());
+    assertThat(neighbor.getIpv4UnicastAddressFamily(), nullValue());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_neighbors_no_v4
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_bgp_neighbors_no_v4
@@ -1,0 +1,18 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_bgp_neighbors_no_v4
+!
+interface Loopback0
+   ip address 10.0.0.21/32
+!
+router bgp 64520
+   router-id 10.0.0.21
+   no bgp default ipv4-unicast
+   neighbor RR peer group
+   neighbor RR remote-as 64520
+   neighbor 10.0.0.11 peer group RR
+   !
+   address-family evpn
+      neighbor 10.0.0.11 activate
+!
+end


### PR DESCRIPTION
Otherwise the attached config throws an NPE while processing neighbor 10.0.0.32.

[spine01.txt](https://github.com/batfish/batfish/files/6293034/spine01.txt)
