### PR TITLE
extended communitities fix transitive check

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/bgp/community/ExtendedCommunity.java
@@ -194,7 +194,7 @@ public final class ExtendedCommunity extends Community {
   @Override
   public boolean isTransitive() {
     // Second most significant bit is set
-    return (_type & (byte) 0x40) != 0;
+    return (_type & (byte) 0x40) == 0;
   }
 
   /** Check whether this community is of type route-origin / site-of-origin */

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/ExtendedCommunityTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/bgp/community/ExtendedCommunityTest.java
@@ -131,8 +131,8 @@ public final class ExtendedCommunityTest {
 
   @Test
   public void testIsTransitive() {
-    assertFalse(ExtendedCommunity.parse("1:1:1").isTransitive());
-    assertTrue(ExtendedCommunity.parse("16384:1:1").isTransitive());
+    assertTrue(ExtendedCommunity.parse("1:1:1").isTransitive());
+    assertFalse(ExtendedCommunity.parse("16384:1:1").isTransitive());
   }
 
   @Test


### PR DESCRIPTION
- extended community is transitive when second-highest-order type bit is
UNSET, not when it is set
- see https://tools.ietf.org/html/rfc4360 Page 3