### PR TITLE
Trace: improve performance in sanity checks

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Trace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Trace.java
@@ -80,6 +80,7 @@ public final class Trace {
     for (int i = 0; i < hops.size(); ++i) {
       Hop h = hops.get(i);
       List<Step<?>> steps = h.getSteps();
+      checkArgument(!steps.isEmpty(), "Invalid hop with no steps: %s", h);
       if (i > 0) {
         checkArgument(
             steps.get(0) instanceof EnterInputIfaceStep,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Trace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Trace.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -82,9 +81,8 @@ public final class Trace {
       Hop h = hops.get(i);
       List<Step<?>> steps = h.getSteps();
       if (i > 0) {
-        Step<?> s = Iterables.getFirst(steps, null);
         checkArgument(
-            s instanceof EnterInputIfaceStep,
+            steps.get(0) instanceof EnterInputIfaceStep,
             "Hop %s/%s of trace does not begin with an %s: %s",
             i + 1,
             hops.size(),
@@ -92,9 +90,8 @@ public final class Trace {
             h);
       }
       if (i < hops.size() - 1) {
-        Step<?> s = Iterables.getLast(steps, null);
         checkArgument(
-            s instanceof ExitOutputIfaceStep,
+            steps.get(steps.size() - 1) instanceof ExitOutputIfaceStep,
             "Hop %s/%s of trace does not end with an %s: %s",
             i + 1,
             hops.size(),

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/TracePrunerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/TracePrunerTest.java
@@ -14,6 +14,7 @@ import org.batfish.datamodel.flow.EnterInputIfaceStep.EnterInputIfaceStepDetail;
 import org.batfish.datamodel.flow.ExitOutputIfaceStep;
 import org.batfish.datamodel.flow.ExitOutputIfaceStep.ExitOutputIfaceStepDetail;
 import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.LoopStep;
 import org.batfish.datamodel.flow.StepAction;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.pojo.Node;
@@ -43,7 +44,7 @@ public class TracePrunerTest {
                           .setInputInterface(NodeInterfacePair.of("B", "in"))
                           .build())
                   .build()));
-  private static final Hop HOP_C = new Hop(new Node("C"), ImmutableList.of());
+  private static final Hop HOP_C = new Hop(new Node("C"), ImmutableList.of(LoopStep.INSTANCE));
 
   private static final Trace TRACE_A_ACCEPTED = new Trace(ACCEPTED, ImmutableList.of(HOP_A));
   private static final Trace TRACE_A_B_ACCEPTED =

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTracePrunerTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/BidirectionalTracePrunerTest.java
@@ -29,9 +29,9 @@ public class BidirectionalTracePrunerTest {
     FLOW3 = fb.setIngressNode("flow3").build();
   }
 
-  private static final Hop HOP1 = new Hop(new Node("hop1"), ImmutableList.of());
-  private static final Hop HOP2 = new Hop(new Node("hop2"), ImmutableList.of());
-  private static final Hop HOP3 = new Hop(new Node("hop3"), ImmutableList.of());
+  private static final Hop HOP1 = new Hop(new Node("hop1"), ImmutableList.of(LoopStep.INSTANCE));
+  private static final Hop HOP2 = new Hop(new Node("hop2"), ImmutableList.of(LoopStep.INSTANCE));
+  private static final Hop HOP3 = new Hop(new Node("hop3"), ImmutableList.of(LoopStep.INSTANCE));
 
   /** Test that forward flow values are covered before reverse flow, dispositions, or hops. */
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/TraceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/TraceTest.java
@@ -54,21 +54,26 @@ public class TraceTest {
               InboundStep.builder().setDetail(new InboundStepDetail("Loopback0")).build()));
 
   @Test
+  public void validateHopRejectsEmptyHops() {
+    _thrown.expectMessage("Invalid hop with no steps:");
+    Trace.validateHops(ImmutableList.of(_emptyHop));
+  }
+
+  @Test
   public void validateHopBeginsWithEnterInputInterface() {
     _thrown.expectMessage("Hop 2/2 of trace does not begin with an EnterInputIfaceStep:");
-    Trace.validateHops(ImmutableList.of(_hopWithOnlyExit, _emptyHop));
+    Trace.validateHops(ImmutableList.of(_hopWithOnlyExit, _hopWithOnlyExit));
   }
 
   @Test
   public void validateHopEndsWithExitOutputInterface() {
     _thrown.expectMessage("Hop 1/2 of trace does not end with an ExitOutputIfaceStep:");
-    Trace.validateHops(ImmutableList.of(_emptyHop, _hopWithOnlyEnter));
+    Trace.validateHops(ImmutableList.of(_hopWithOnlyEnter, _hopWithOnlyEnter));
   }
 
   @Test
   public void validateValidHops() {
     Trace.validateHops(ImmutableList.of());
-    Trace.validateHops(ImmutableList.of(_emptyHop));
     Trace.validateHops(ImmutableList.of(_hopWithOnlyEnter));
     Trace.validateHops(ImmutableList.of(_hopWithOnlyExit));
     Trace.validateHops(ImmutableList.of(_hopWithOnlyExit, _hopWithOnlyEnter));

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/vxlan/VxlanTopologyUtilsTest.java
@@ -49,6 +49,7 @@ import org.batfish.datamodel.NetworkFactory;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.flow.FirewallSessionTraceInfo;
 import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.LoopStep;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.flow.TraceAndReverseFlow;
 import org.batfish.datamodel.pojo.Node;
@@ -69,7 +70,8 @@ public final class VxlanTopologyUtilsTest {
           new Trace(
               result._accept ? FlowDisposition.ACCEPTED : FlowDisposition.DENIED_OUT,
               result._addHop
-                  ? ImmutableList.of(new Hop(new Node(result._receivingNode), ImmutableList.of()))
+                  ? ImmutableList.of(
+                      new Hop(new Node(result._receivingNode), ImmutableList.of(LoopStep.INSTANCE)))
                   : ImmutableList.of());
       return new TraceAndReverseFlow(
           forwardTrace,

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -1390,8 +1390,7 @@ class FlowTracer {
     return filterStep.getAction();
   }
 
-  @VisibleForTesting
-  void buildDeniedTrace(FlowDisposition disposition) {
+  private void buildDeniedTrace(FlowDisposition disposition) {
     _hops.add(
         failureHop(
             new Hop(_currentNode, _steps),

--- a/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
+++ b/projects/coordinator/src/test/java/org/batfish/coordinator/WorkMgrTest.java
@@ -96,6 +96,7 @@ import org.batfish.datamodel.answers.SelfDescribingObject;
 import org.batfish.datamodel.answers.StringAnswerElement;
 import org.batfish.datamodel.collections.NodeInterfacePair;
 import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.LoopStep;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.pojo.Node;
 import org.batfish.datamodel.pojo.Topology;
@@ -2584,7 +2585,7 @@ public final class WorkMgrTest {
             col,
             new Trace(
                 FlowDisposition.ACCEPTED,
-                ImmutableList.of(new Hop(new Node("a"), ImmutableList.of()))));
+                ImmutableList.of(new Hop(new Node("a"), ImmutableList.of(LoopStep.INSTANCE)))));
     Row r3 = Row.of(col, new Trace(FlowDisposition.DELIVERED_TO_SUBNET, ImmutableList.of()));
 
     assertThat(comparator.compare(r1, r2), lessThan(0));

--- a/projects/question/src/test/java/org/batfish/question/traceroute/TracerouteAnswererTest.java
+++ b/projects/question/src/test/java/org/batfish/question/traceroute/TracerouteAnswererTest.java
@@ -30,6 +30,7 @@ import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.flow.Hop;
+import org.batfish.datamodel.flow.LoopStep;
 import org.batfish.datamodel.flow.Trace;
 import org.batfish.datamodel.matchers.TraceMatchers;
 import org.batfish.datamodel.pojo.Node;
@@ -108,10 +109,12 @@ public class TracerouteAnswererTest {
             ImmutableList.of(
                 new Trace(
                     FlowDisposition.DENIED_OUT,
-                    ImmutableList.of(new Hop(new Node("node1"), ImmutableList.of()))),
+                    ImmutableList.of(
+                        new Hop(new Node("node1"), ImmutableList.of(LoopStep.INSTANCE)))),
                 new Trace(
                     FlowDisposition.DENIED_IN,
-                    ImmutableList.of(new Hop(new Node("node2"), ImmutableList.of())))));
+                    ImmutableList.of(
+                        new Hop(new Node("node2"), ImmutableList.of(LoopStep.INSTANCE))))));
 
     SortedMap<Flow, List<Trace>> deltaFlowTraces =
         ImmutableSortedMap.of(


### PR DESCRIPTION
Iterables.getLast is an iteration, but since we have a list we can just get
the index.

Notice this only affects development runs or runs with `-ea` set.