### PR TITLE
IOS-XR various BGP parsing

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
@@ -7586,8 +7586,7 @@ M_RdSetMatchExpr_WS: F_Whitespace+ -> channel(HIDDEN);
 
 mode M_Rd;
 
-M_Rd_IN: 'in' -> type(IN), popMode;
-M_Rd_NOT: 'not' -> type(NOT), popMode;
+M_Rd_IN: 'in' -> type(IN), mode(M_RdMatchExpr);
 
 M_Rd_COLON: ':' -> type(COLON);
 M_Rd_IP_ADDRESS: F_IpAddress -> type(IP_ADDRESS);
@@ -7597,3 +7596,12 @@ M_Rd_UINT32: F_Uint16 -> type(UINT16);
 M_Rd_NEWLINE: F_Newline -> type(NEWLINE), popMode;
 M_Rd_WS: F_Whitespace+ -> channel(HIDDEN);
 
+mode M_RdMatchExpr;
+
+// TODO: support inline `rd in (...)` expression
+M_RdMatchExpr_PAREN_LEFT: '(' -> type(PAREN_LEFT), popMode;
+
+M_RdMatchExpr_PARAMETER: F_Parameter -> type(PARAMETER), popMode;
+M_RdMatchExpr_WORD: F_Word -> type(WORD), popMode;
+M_RdMatchExpr_NEWLINE: F_Newline -> type(NEWLINE), popMode;
+M_RdMatchExpr_WS: F_Whitespace+ -> channel(HIDDEN);

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
@@ -3823,6 +3823,12 @@ PERMIT: 'permit';
 
 PERMIT_HOSTDOWN: 'permit-hostdown';
 
+PER_CE: 'per-ce';
+
+PER_PREFIX: 'per-prefix';
+
+PER_VRF: 'per-vrf';
+
 PERSISTENT: 'persistent';
 
 PFC: 'pfc';
@@ -4150,7 +4156,7 @@ RCP: 'rcp';
 
 RCV_QUEUE: 'rcv-queue';
 
-RD: 'rd';
+RD: 'rd' -> pushMode(M_Rd);
 
 RD_SET: 'rd-set' -> pushMode(M_RdSet);
 
@@ -7577,3 +7583,17 @@ M_RdSetMatchExpr_PARAMETER: F_Parameter -> type(PARAMETER), popMode;
 M_RdSetMatchExpr_WORD: F_Word -> type(WORD), popMode;
 M_RdSetMatchExpr_NEWLINE: F_Newline -> type(NEWLINE), popMode;
 M_RdSetMatchExpr_WS: F_Whitespace+ -> channel(HIDDEN);
+
+mode M_Rd;
+
+M_Rd_IN: 'in' -> type(IN), popMode;
+M_Rd_NOT: 'not' -> type(NOT), popMode;
+
+M_Rd_COLON: ':' -> type(COLON);
+M_Rd_IP_ADDRESS: F_IpAddress -> type(IP_ADDRESS);
+M_Rd_PERIOD: '.' -> type(PERIOD);
+M_Rd_UINT16: F_Uint16 -> type(UINT16);
+M_Rd_UINT32: F_Uint16 -> type(UINT16);
+M_Rd_NEWLINE: F_Newline -> type(NEWLINE), popMode;
+M_Rd_WS: F_Whitespace+ -> channel(HIDDEN);
+

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_bgp.g4
@@ -6,6 +6,42 @@ options {
    tokenVocab = CiscoXrLexer;
 }
 
+// new grammar
+bgp_vrf_rd: RD route_distinguisher NEWLINE;
+
+bgp_vrf_address_family
+:
+   address_family_header
+   (
+      // new grammar
+      bgp_vrf_af_label_mode
+
+      // legacy grammar
+      | additional_paths_receive_xr_rb_stanza
+      | additional_paths_selection_xr_rb_stanza
+      | additional_paths_send_xr_rb_stanza
+      | aggregate_address_rb_stanza
+      | bgp_tail
+      | no_neighbor_activate_rb_stanza
+      | no_neighbor_shutdown_rb_stanza
+      | null_no_neighbor_rb_stanza
+      | peer_group_assignment_rb_stanza
+      | peer_group_creation_rb_stanza
+   )* address_family_footer
+;
+
+bgp_vrf_af_label_mode
+:
+  LABEL MODE
+  (
+    PER_CE
+    | PER_PREFIX
+    | PER_VRF
+    | ROUTE_POLICY name = route_policy_name
+  ) NEWLINE
+;
+
+// legacy grammar
 activate_bgp_tail
 :
    ACTIVATE NEWLINE
@@ -51,8 +87,7 @@ address_family_rb_stanza
 :
    address_family_header
    (
-      additional_paths_rb_stanza
-      | additional_paths_receive_xr_rb_stanza
+      additional_paths_receive_xr_rb_stanza
       | additional_paths_selection_xr_rb_stanza
       | additional_paths_send_xr_rb_stanza
       | aggregate_address_rb_stanza
@@ -90,17 +125,6 @@ aggregate_address_rb_stanza
     | summary_only = SUMMARY_ONLY
     | ROUTE_POLICY rp = route_policy_name
   )* NEWLINE
-;
-
-additional_paths_rb_stanza
-:
-   BGP ADDITIONAL_PATHS
-   (
-      INSTALL
-      | SELECT ALL
-      | SEND RECEIVE?
-      | RECEIVE SEND?
-   ) NEWLINE
 ;
 
 additional_paths_receive_xr_rb_stanza
@@ -433,7 +457,11 @@ vrf_block_rb_stanza
 :
    VRF name = vrf_name NEWLINE
    (
-      address_family_rb_stanza
+      // new grammar
+      bgp_vrf_rd
+      | bgp_vrf_address_family
+
+      // legacy grammar
       | aggregate_address_rb_stanza
       | always_compare_med_rb_stanza
       | as_path_multipath_relax_rb_stanza
@@ -785,8 +813,7 @@ router_bgp_stanza
 
 router_bgp_stanza_tail
 :
-   additional_paths_rb_stanza
-   | address_family_rb_stanza
+   address_family_rb_stanza
    | address_family_enable_rb_stanza
    | af_group_rb_stanza
    | aggregate_address_rb_stanza

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ignored.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ignored.g4
@@ -455,7 +455,6 @@ null_inner
       | PROVISION
       | RANDOM
       | RANDOM_DETECT
-      | RD
       | REACT
       | REAL
       | RECEIVE
@@ -858,7 +857,6 @@ null_single
       | QUIT
       | RADIUS_COMMON_PW
       | RADIUS_SERVER
-      | RD
       | RESOURCE
       | RESOURCE_POOL
       | NO ROUTE

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -334,7 +334,6 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Access_list_ip6_rangeContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Access_list_ip_rangeContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Access_list_nameContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Activate_bgp_tailContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.Additional_paths_rb_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Additional_paths_selection_xr_rb_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Address_family_headerContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Address_family_rb_stanzaContext;
@@ -356,6 +355,8 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Bgp_asnContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Bgp_confederation_rb_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Bgp_listen_range_rb_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Bgp_redistribute_internal_rb_stanzaContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Bgp_vrf_address_familyContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Bgp_vrf_rdContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Boolean_and_rp_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Boolean_apply_rp_stanzaContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Boolean_as_path_in_rp_stanzaContext;
@@ -2925,20 +2926,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   }
 
   @Override
-  public void exitAdditional_paths_rb_stanza(Additional_paths_rb_stanzaContext ctx) {
-    if (ctx.SELECT() != null && ctx.ALL() != null) {
-      _currentPeerGroup.setAdditionalPathsSelectAll(true);
-    } else {
-      if (ctx.RECEIVE() != null) {
-        _currentPeerGroup.setAdditionalPathsReceive(true);
-      }
-      if (ctx.SEND() != null) {
-        _currentPeerGroup.setAdditionalPathsSend(true);
-      }
-    }
-  }
-
-  @Override
   public void exitAdditional_paths_selection_xr_rb_stanza(
       Additional_paths_selection_xr_rb_stanzaContext ctx) {
     if (ctx.name != null) {
@@ -2954,6 +2941,16 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   @Override
   public void exitAddress_family_rb_stanza(Address_family_rb_stanzaContext ctx) {
     popPeer();
+  }
+
+  @Override
+  public void exitBgp_vrf_address_family(Bgp_vrf_address_familyContext ctx) {
+    popPeer();
+  }
+
+  @Override
+  public void exitBgp_vrf_rd(Bgp_vrf_rdContext ctx) {
+    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -1343,4 +1343,11 @@ public final class XrGrammarTest {
                   WildcardUint32RangeExpr.instance(), WildcardUint16RangeExpr.instance())));
     }
   }
+
+  @Test
+  public void testBgpParsing() {
+    String hostname = "xr-bgp";
+    // Do not crash
+    assertNotNull(parseVendorConfig(hostname));
+  }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/xr-bgp
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/xr-bgp
@@ -1,0 +1,143 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+!
+hostname xr-bgp
+!
+interface GigabitEthernet0/0/0/0
+ ipv4 address 10.1.0.0/31
+ ipv6 address dead:beef::/127
+!
+interface Loopback0
+ ipv4 address 10.0.0.1/32
+!
+route-policy rp1
+ set path-selection backup 1 install
+end-policy
+
+route-policy rp2
+ pass
+end-policy
+route-policy rp3
+ pass
+end-policy
+route-policy rp4
+ pass
+end-policy
+route-policy rp5
+ pass
+end-policy
+route-policy rp6
+ pass
+end-policy
+route-policy rp7
+ pass
+end-policy
+route-policy rp8
+ pass
+end-policy
+route-policy rp9
+ pass
+end-policy
+!
+router bgp 65500
+ nsr
+ bgp router-id 10.0.0.1
+ ! 1-4095
+ bgp graceful-restart restart-time 1
+ ! 1-4095
+ bgp graceful-restart stalepath-time 1
+ bgp graceful-restart
+ bgp log neighbor changes detail
+ address-family ipv4 unicast
+  additional-paths receive
+  additional-paths send
+  additional-paths selection route-policy rp1
+  aggregate-address 172.16.0.0/16
+  aggregate-address 192.168.0.0/16 summary-only
+ !
+ address-family vpnv4 unicast
+ !
+ address-family ipv6 unicast
+  redistribute connected
+ !
+ address-family vpnv6 unicast
+ !
+ neighbor-group ng1
+  remote-as 65500
+  description description1
+  update-source Loopback0
+  password encrypted xxxxxxxx
+  address-family ipv4 unicast
+   route-policy rp2 in
+   ! pint32, 1-100
+   maximum-prefix 1 1 warning-only
+   route-policy rp3 out
+   next-hop-self
+   soft-reconfiguration inbound always
+  !
+  address-family vpnv4 unicast
+   maximum-prefix 1 1 warning-only
+   route-policy rp4 out
+  !
+  address-family vpnv6 unicast
+   maximum-prefix 1 1 warning-only
+   route-policy rp5 out
+  !
+ !
+ neighbor 10.0.0.2
+  use neighbor-group ng1
+  description description2
+ !
+ neighbor 10.0.0.3
+  use neighbor-group ng1
+  shutdown
+ !
+ vrf v1
+  rd 10.0.0.1:1
+  address-family ipv4 unicast
+   label mode per-vrf
+   network 10.0.0.0/8
+   redistribute connected
+   redistribute static
+  !
+  address-family ipv6 unicast
+   redistribute connected
+  !
+  neighbor 10.1.0.1
+   remote-as 65501
+   bfd fast-detect
+   bfd fast-detect disable
+   ! 2-16
+   bfd multiplier 2
+   ! 3-30000
+   bfd minimum-interval 3
+   local-as 1 no-prepend replace-as
+   description description3
+   password encrypted xxxxxxxx
+   address-family ipv4 unicast
+    send-community-ebgp
+    route-policy rp6 in
+    ! pint32, 1-100, pint16
+    maximum-prefix 1 1 restart 1
+    route-policy rp7 out
+    remove-private-AS
+   !
+  !
+  neighbor 10.1.0.3
+   remote-as 65503
+   shutdown
+  !
+  neighbor dead:beef::1
+   remote-as 65504
+   local-as 1 no-prepend replace-as
+   password encrypted xxxxxxxx
+   description description4
+   address-family ipv6 unicast
+    send-community-ebgp
+    route-policy rp8 in
+    maximum-prefix 1 1
+    route-policy rp9 out
+    remove-private-AS
+   !
+  !
+ !
+!


### PR DESCRIPTION
- warn on `router bgp vrf rd`
- ignore `router bgp vrf address-family ipv4 label mode`
- add parsing test