### PR TITLE
FlowTracer: intern Breadcrumbs

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -35,6 +35,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import java.util.ArrayList;
@@ -219,6 +221,17 @@ class FlowTracer {
   private final int _origNewSessionsSize; // size of _newSessions at construction
   private final Flow _originalFlow;
   private final @Nonnull String _vrfName;
+  /** Only create one in-memory instance of the same breadcrumb. */
+  private final @Nonnull Interner<Breadcrumb> _breadcrumbInterner;
+
+  private @Nonnull Breadcrumb newBreadcrumb(
+      @Nonnull String currentNodeName,
+      @Nonnull String vrfName,
+      @Nullable String ingressInterface,
+      @Nonnull Flow currentFlow) {
+    return _breadcrumbInterner.intern(
+        new Breadcrumb(currentNodeName, vrfName, ingressInterface, currentFlow));
+  }
 
   // Mutable list of hops in the current trace
   private final List<HopInfo> _hops;
@@ -268,7 +281,8 @@ class FlowTracer {
         new Stack<>(),
         originalFlow,
         0,
-        0);
+        0,
+        Interners.newStrongInterner());
   }
 
   /**
@@ -300,7 +314,8 @@ class FlowTracer {
         _breadcrumbs,
         _currentFlow,
         _newSessions.size(),
-        _breadcrumbs.size());
+        _breadcrumbs.size(),
+        _breadcrumbInterner);
   }
 
   private static @Nonnull String initVrfName(
@@ -335,7 +350,8 @@ class FlowTracer {
       Stack<Breadcrumb> breadcrumbs,
       Flow currentFlow,
       int origNewSessionsSize,
-      int origBreadcrumbsSize) {
+      int origBreadcrumbsSize,
+      @Nonnull Interner<Breadcrumb> breadcrumbInterner) {
     assert originalFlow.equals(currentFlow)
             || steps.stream()
                 .anyMatch(step -> step instanceof TransformationStep || step instanceof PolicyStep)
@@ -356,6 +372,7 @@ class FlowTracer {
     _currentFlow = currentFlow;
     _origNewSessionsSize = origNewSessionsSize;
     _origBreadcrumbsSize = origBreadcrumbsSize;
+    _breadcrumbInterner = breadcrumbInterner;
   }
 
   @Nullable
@@ -408,7 +425,8 @@ class FlowTracer {
         _breadcrumbs,
         _currentFlow,
         _newSessions.size(),
-        _breadcrumbs.size());
+        _breadcrumbs.size(),
+        _breadcrumbInterner);
   }
 
   /** Return forked {@link FlowTracer} on same node and VRF. Used for taking ECMP actions. */
@@ -441,7 +459,8 @@ class FlowTracer {
         _breadcrumbs,
         _currentFlow,
         _origNewSessionsSize,
-        _origBreadcrumbsSize);
+        _origBreadcrumbsSize,
+        _breadcrumbInterner);
   }
 
   private void processOutgoingInterfaceEdges(
@@ -773,7 +792,7 @@ class FlowTracer {
       Stack<Breadcrumb> intraHopBreadcrumbs) {
     // Loop detection
     Breadcrumb breadcrumb =
-        new Breadcrumb(currentNodeName, _vrfName, _ingressInterface, _currentFlow);
+        newBreadcrumb(currentNodeName, _vrfName, _ingressInterface, _currentFlow);
     if (_breadcrumbs.contains(breadcrumb)) {
       buildLoopTrace(breadcrumb);
       return;
@@ -1009,7 +1028,7 @@ class FlowTracer {
                 }
                 // cycle detection
                 Breadcrumb breadcrumb =
-                    new Breadcrumb(currentNodeName, _vrfName, _ingressInterface, originalFlow);
+                    newBreadcrumb(currentNodeName, _vrfName, _ingressInterface, originalFlow);
                 if (_breadcrumbs.contains(breadcrumb)) {
                   buildLoopTrace(breadcrumb);
                   return null;

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -43,6 +43,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Interners;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -199,7 +200,8 @@ public final class FlowTracerTest {
             new Stack<>(),
             flow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
     flowTracer.buildAcceptTrace();
     return Iterables.getOnlyElement(traces);
   }
@@ -345,7 +347,8 @@ public final class FlowTracerTest {
             new Stack<>(),
             flow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
 
     flowTracer.buildAcceptTrace();
     TraceAndReverseFlow traceAndReverseFlow = Iterables.getOnlyElement(traces);
@@ -436,7 +439,8 @@ public final class FlowTracerTest {
               new Stack<>(),
               returnFlow,
               0,
-              0);
+              0,
+              Interners.newStrongInterner());
       flowTracer.processHop();
 
       // Reverse trace should match session and get forwarded out original ingress interface
@@ -467,7 +471,8 @@ public final class FlowTracerTest {
               new Stack<>(),
               nonMatchingReturnFlow,
               0,
-              0);
+              0,
+              Interners.newStrongInterner());
       flowTracer.processHop();
 
       // Reverse trace should not match session, so should be dropped (FIB has no routes)
@@ -582,7 +587,8 @@ public final class FlowTracerTest {
               new Stack<>(),
               returnFlow,
               0,
-              0);
+              0,
+              Interners.newStrongInterner());
       flowTracer.processHop();
 
       // Reverse trace should match session and get accepted.
@@ -630,7 +636,8 @@ public final class FlowTracerTest {
               new Stack<>(),
               nonMatchingReturnFlow,
               0,
-              0);
+              0,
+              Interners.newStrongInterner());
       flowTracer.processHop();
 
       // Reverse trace should not match session, so should be dropped (FIB has no routes)
@@ -779,7 +786,8 @@ public final class FlowTracerTest {
             new Stack<>(),
             returnFlow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
     flowTracer.processHop();
 
     TraceAndReverseFlow traceAndReverseFlow = Iterables.getOnlyElement(traces);
@@ -932,7 +940,8 @@ public final class FlowTracerTest {
             new Stack<>(),
             flow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
     flowTracer.processHop();
     return !Iterables.getOnlyElement(traces).getNewFirewallSessions().isEmpty();
   }
@@ -1708,7 +1717,8 @@ public final class FlowTracerTest {
             new Stack<>(),
             flow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
 
     {
       FlowDisposition disposition = FlowDisposition.INSUFFICIENT_INFO;
@@ -1925,7 +1935,8 @@ public final class FlowTracerTest {
             breadcrumbs,
             flow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
 
     Ip dstIp2 = Ip.parse("2.2.2.2");
     flowTracer.applyTransformation(
@@ -2065,7 +2076,8 @@ public final class FlowTracerTest {
               new Stack<>(),
               flowWithPermittedSrc, // current flow
               0,
-              0);
+              0,
+              Interners.newStrongInterner());
 
       flowTracer.forwardOutInterface(iface, dstIp, null);
       assertThat(traces, hasSize(1));
@@ -2093,7 +2105,8 @@ public final class FlowTracerTest {
               new Stack<>(),
               flowWithBlockedSrc, // current flow
               0,
-              0);
+              0,
+              Interners.newStrongInterner());
 
       flowTracer.forwardOutInterface(iface, dstIp, null);
       assertThat(traces, hasSize(1));


### PR DESCRIPTION
Under ECMP, the same breadcrumb may be generated many times. TraceDAG
compressions makes the redundancy less, but interning Breadcrumbs is still
faster and uses less RAM.

We only intern at the FlowTracer level, so that the reference dies after the
traces are completed.