### PR TITLE
RoutesAnswererUtil.java

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Trace.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/Trace.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -82,9 +81,8 @@ public final class Trace {
       Hop h = hops.get(i);
       List<Step<?>> steps = h.getSteps();
       if (i > 0) {
-        Step<?> s = Iterables.getFirst(steps, null);
         checkArgument(
-            s instanceof EnterInputIfaceStep,
+            steps.get(0) instanceof EnterInputIfaceStep,
             "Hop %s/%s of trace does not begin with an %s: %s",
             i + 1,
             hops.size(),
@@ -92,9 +90,8 @@ public final class Trace {
             h);
       }
       if (i < hops.size() - 1) {
-        Step<?> s = Iterables.getLast(steps, null);
         checkArgument(
-            s instanceof ExitOutputIfaceStep,
+            steps.get(steps.size() - 1) instanceof ExitOutputIfaceStep,
             "Hop %s/%s of trace does not end with an %s: %s",
             i + 1,
             hops.size(),

--- a/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/TracerouteEngineImpl.java
@@ -37,10 +37,17 @@ public final class TracerouteEngineImpl implements TracerouteEngine {
       Set<Flow> flows, Set<FirewallSessionTraceInfo> sessions, boolean ignoreFilters) {
     return computeTraceDags(flows, sessions, ignoreFilters).entrySet().parallelStream()
         .map(
-            entry ->
-                new SimpleEntry<>(
-                    entry.getKey(),
-                    entry.getValue().getTraces().collect(ImmutableList.toImmutableList())))
+            entry -> {
+              TraceDag dag = entry.getValue();
+              System.err.println("Dag has size " + dag.size());
+              ImmutableList<TraceAndReverseFlow> traces =
+                  entry
+                      .getValue()
+                      .getTraces()
+                      .limit(16384)
+                      .collect(ImmutableList.toImmutableList());
+              return new SimpleEntry<>(entry.getKey(), traces);
+            })
         .collect(
             ImmutableSortedMap.toImmutableSortedMap(
                 Ordering.natural(), Entry::getKey, Entry::getValue));

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -45,6 +45,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Interners;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -219,7 +220,8 @@ public final class FlowTracerTest {
             new Stack<>(),
             flow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
 
     flowTracer.buildDeniedTrace(DENIED_IN);
     assertThat(
@@ -291,7 +293,8 @@ public final class FlowTracerTest {
             new Stack<>(),
             flow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
     flowTracer.buildAcceptTrace();
     return Iterables.getOnlyElement(traces);
   }
@@ -437,7 +440,8 @@ public final class FlowTracerTest {
             new Stack<>(),
             flow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
 
     flowTracer.buildAcceptTrace();
     TraceAndReverseFlow traceAndReverseFlow = Iterables.getOnlyElement(traces);
@@ -528,7 +532,8 @@ public final class FlowTracerTest {
               new Stack<>(),
               returnFlow,
               0,
-              0);
+              0,
+              Interners.newStrongInterner());
       flowTracer.processHop();
 
       // Reverse trace should match session and get forwarded out original ingress interface
@@ -559,7 +564,8 @@ public final class FlowTracerTest {
               new Stack<>(),
               nonMatchingReturnFlow,
               0,
-              0);
+              0,
+              Interners.newStrongInterner());
       flowTracer.processHop();
 
       // Reverse trace should not match session, so should be dropped (FIB has no routes)
@@ -674,7 +680,8 @@ public final class FlowTracerTest {
               new Stack<>(),
               returnFlow,
               0,
-              0);
+              0,
+              Interners.newStrongInterner());
       flowTracer.processHop();
 
       // Reverse trace should match session and get accepted.
@@ -722,7 +729,8 @@ public final class FlowTracerTest {
               new Stack<>(),
               nonMatchingReturnFlow,
               0,
-              0);
+              0,
+              Interners.newStrongInterner());
       flowTracer.processHop();
 
       // Reverse trace should not match session, so should be dropped (FIB has no routes)
@@ -871,7 +879,8 @@ public final class FlowTracerTest {
             new Stack<>(),
             returnFlow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
     flowTracer.processHop();
 
     TraceAndReverseFlow traceAndReverseFlow = Iterables.getOnlyElement(traces);
@@ -1024,7 +1033,8 @@ public final class FlowTracerTest {
             new Stack<>(),
             flow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
     flowTracer.processHop();
     return !Iterables.getOnlyElement(traces).getNewFirewallSessions().isEmpty();
   }
@@ -1800,7 +1810,8 @@ public final class FlowTracerTest {
             new Stack<>(),
             flow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
 
     {
       FlowDisposition disposition = FlowDisposition.INSUFFICIENT_INFO;
@@ -2017,7 +2028,8 @@ public final class FlowTracerTest {
             breadcrumbs,
             flow,
             0,
-            0);
+            0,
+            Interners.newStrongInterner());
 
     Ip dstIp2 = Ip.parse("2.2.2.2");
     flowTracer.applyTransformation(
@@ -2157,7 +2169,8 @@ public final class FlowTracerTest {
               new Stack<>(),
               flowWithPermittedSrc, // current flow
               0,
-              0);
+              0,
+              Interners.newStrongInterner());
 
       flowTracer.forwardOutInterface(iface, dstIp, null);
       assertThat(traces, hasSize(1));
@@ -2185,7 +2198,8 @@ public final class FlowTracerTest {
               new Stack<>(),
               flowWithBlockedSrc, // current flow
               0,
-              0);
+              0,
+              Interners.newStrongInterner());
 
       flowTracer.forwardOutInterface(iface, dstIp, null);
       assertThat(traces, hasSize(1));

--- a/projects/question/src/main/java/org/batfish/question/loop/DetectLoopsAnswerer.java
+++ b/projects/question/src/main/java/org/batfish/question/loop/DetectLoopsAnswerer.java
@@ -39,6 +39,8 @@ public final class DetectLoopsAnswerer extends Answerer {
             .map(Optional::get) // safe: the min here cannot be empty by construction.
             .collect(ImmutableSortedSet.toImmutableSortedSet(Ordering.natural()));
 
+    System.err.printf("Found %d flows that end in loops%n", flows.size());
+
     SortedMap<Flow, List<Trace>> flowTraces = _batfish.buildFlows(snapshot, flows, false);
     TableAnswerElement tableAnswer = new TableAnswerElement(TracerouteAnswerer.metadata(false));
     TracerouteAnswerer.flowTracesToRows(flowTraces, question.getMaxTraces())


### PR DESCRIPTION
While running checkstyle with some certain modules names, I found a few changes I would like to make in some files in the project.
the first change is in the file 
projects/question/src/main/java/org/batfish/question/routes/RoutesAnswererUtil.java
the first method I changed is populateBgpRouteAttributes. before the change the npathcomplexity was 24,576 (while the max value is 200).
the second method was populateRouteAttributes. before the change the npathxomplexity was 1,024.
my change includes some variable assignments and conditions which reduces the npathcomplexity of the methods. 
now, running the same checkstyle with the moudles doesn't return a npathcomplexity error.
I also run "question" tests and had now change.



[RoutesAnswererUtil.zip](https://github.com/batfish/batfish/files/6308756/RoutesAnswererUtil.zip)
