### PR TITLE
FlowToBDD: include Packet Length in modeling

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowToBDD.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/FlowToBDD.java
@@ -39,7 +39,7 @@ public final class FlowToBDD {
         f.getIcmpCode() == null ? one : p.getIcmpCode().value(f.getIcmpCode()),
         f.getIcmpType() == null ? one : p.getIcmpType().value(f.getIcmpType()),
         p.getIpProtocol().value(f.getIpProtocol()),
-        // TODO: packet length
+        p.getPacketLength().value(f.getPacketLength()),
         p.getSrcIp().value(f.getSrcIp().asLong()),
         f.getSrcPort() == null ? one : p.getSrcPort().value(f.getSrcPort()),
         tcpFlags);

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FlowToBDDTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/FlowToBDDTest.java
@@ -35,7 +35,7 @@ public class FlowToBDDTest {
     assertThat(headerBdd.imp(_packet.getDscp().value(5)), isOne());
     assertThat(headerBdd.imp(_packet.getEcn().value(3)), isOne());
     assertThat(headerBdd.imp(_packet.getFragmentOffset().value(4)), isOne());
-    // TODO: packet length is not modeled in BDD
+    assertThat(headerBdd.imp(_packet.getPacketLength().value(71)), isOne());
     // Protocol-specific values are not constrained.
     assertThat(headerBdd.exist(_packet.getSrcPort().getVars()), equalTo(headerBdd));
     assertThat(headerBdd.exist(_packet.getDstPort().getVars()), equalTo(headerBdd));


### PR DESCRIPTION
At some earlier time, the packet length field was not modeled in BDD. When
we added it, we forgot to update this class.