### PR TITLE
Create neighbor even if local IP is null

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
@@ -236,9 +236,8 @@ public final class FortiosBgpConversions {
       if (localIp == null) {
         w.redFlag(
             String.format(
-                "Ignoring BGP neighbor %s: Update-source %s has no address",
-                remoteIp, updateSource.getName()));
-        continue;
+                "BGP neighbor %s in vrf %s: Update-source %s has no address",
+                remoteIp, vrf, updateSource.getName()));
       }
       BgpActivePeerConfig.builder()
           .setLocalIp(localIp)

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
@@ -231,19 +231,17 @@ public final class FortiosBgpConversions {
     for (Ip remoteIp : neighborIdsInVrf) {
       BgpNeighbor neighbor = bgpProcess.getNeighbors().get(remoteIp);
       @Nullable Interface updateSource = updateSources.get(remoteIp);
-      Ip localIp =
-          updateSource == null || updateSource.getConcreteAddress() == null
-              ? null
-              : updateSource.getConcreteAddress().getIp();
-      if (localIp == null) {
-        String warning =
-            updateSource == null
-                ? String.format(
-                    "BGP neighbor %s: Unable to infer its update source", neighbor.getIp())
-                : String.format(
-                    "BGP neighbor %s in vrf %s: Update-source %s has no address",
-                    remoteIp, vrf, updateSource.getName());
-        w.redFlag(warning);
+      @Nullable Ip localIp = null;
+      if (updateSource == null) {
+        w.redFlag(
+            String.format("BGP neighbor %s: Unable to infer its update source", neighbor.getIp()));
+      } else if (updateSource.getConcreteAddress() == null) {
+        w.redFlag(
+            String.format(
+                "BGP neighbor %s in vrf %s: Update-source %s has no address",
+                remoteIp, vrf, updateSource.getName()));
+      } else {
+        localIp = updateSource.getConcreteAddress().getIp();
       }
       BgpActivePeerConfig.builder()
           .setLocalIp(localIp)

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/Interface.java
@@ -46,6 +46,7 @@ public final class Interface implements InterfaceOrZone, Serializable {
   public static final int DEFAULT_INTERFACE_MTU = 1500;
   public static final boolean DEFAULT_SECONDARY_IP_ENABLED = false;
   public static final Speed DEFAULT_SPEED = Speed.AUTO;
+  public static final String DEFAULT_VDOM = "root";
   public static final int DEFAULT_VRF = 0;
   public static final Type DEFAULT_TYPE = Type.VLAN;
   public static final boolean DEFAULT_STATUS = true;

--- a/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/fortios/FortiosGrammarTest.java
@@ -908,18 +908,15 @@ public final class FortiosGrammarTest {
         warnings.getRedFlagWarnings(),
         containsInAnyOrder(
             WarningMatchers.hasText(
-                "Ignoring BGP neighbor 2.2.2.2: Update-source port1 has no address"),
+                "BGP neighbor 2.2.2.2 in vrf root:0: Update-source port1 has no address"),
             WarningMatchers.hasText(
                 "BGP neighbor 3.3.3.3 has an inactive update-source interface port2. Attempting to"
                     + " infer another update-source for this neighbor"),
-            WarningMatchers.hasText(
-                "Ignoring BGP neighbor 3.3.3.3: Unable to infer its update source"),
-            WarningMatchers.hasText(
-                "Ignoring BGP neighbor 4.4.4.4: Unable to infer its update source"),
+            WarningMatchers.hasText("BGP neighbor 3.3.3.3: Unable to infer its update source"),
+            WarningMatchers.hasText("BGP neighbor 4.4.4.4: Unable to infer its update source"),
             WarningMatchers.hasText(
                 "Interface port3 has unsupported type WL_MESH and will not be converted"),
-            WarningMatchers.hasText(
-                "Ignoring BGP neighbor 5.5.5.5: Unable to infer its update source")));
+            WarningMatchers.hasText("BGP neighbor 5.5.5.5: Unable to infer its update source")));
   }
 
   @Test


### PR DESCRIPTION
Mirror what is happening with other vendors (e.g., Arista). If local-ip/update-source is null, warn and create the VI neighbor anyway. That way, this neighbor will show up BgpPeer set of questions.

