### PR TITLE
Map null remote AS to EMPTY, not ALL

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpPeerConfig.java
@@ -1,6 +1,7 @@
 package org.batfish.datamodel;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -418,16 +419,15 @@ public abstract class BgpPeerConfig implements Serializable {
       return getThis();
     }
 
-    /**
-     * Sets space of acceptable remote AS numbers to singleton of {@code remoteAs} if non-null, or
-     * else {@link BgpPeerConfig#ALL_AS_NUMBERS}.
-     */
-    public S setRemoteAs(@Nullable Long remoteAs) {
-      _remoteAsns = remoteAs != null ? LongSpace.of(remoteAs) : ALL_AS_NUMBERS;
+    /** Sets space of acceptable remote AS numbers to singleton of {@code remoteAs}. */
+    public S setRemoteAs(long remoteAs) {
+      checkArgument(ALL_AS_NUMBERS.contains(remoteAs), "Invalid remote-as value: %s", remoteAs);
+      _remoteAsns = LongSpace.of(remoteAs);
       return getThis();
     }
 
     public S setRemoteAsns(LongSpace remoteAs) {
+      checkArgument(ALL_AS_NUMBERS.contains(remoteAs), "Invalid remote-as space: %s", remoteAs);
       _remoteAsns = remoteAs;
       return getThis();
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConversions.java
@@ -378,7 +378,10 @@ final class AristaConversions {
     } else {
       newNeighborBuilder =
           BgpActivePeerConfig.builder()
-              .setRemoteAs(neighbor.getRemoteAs())
+              .setRemoteAsns(
+                  Optional.ofNullable(neighbor.getRemoteAs())
+                      .map(LongSpace::of)
+                      .orElse(LongSpace.EMPTY))
               .setPeerAddress(prefix.getStartIp());
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -49,6 +50,7 @@ import org.batfish.datamodel.IpsecPhase2Policy;
 import org.batfish.datamodel.IpsecPhase2Proposal;
 import org.batfish.datamodel.IpsecProtocol;
 import org.batfish.datamodel.IpsecStaticPeerConfig;
+import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
@@ -499,18 +501,22 @@ final class VpnConnection implements AwsVpcEntity, Serializable {
 
       // configure BGP peering
       if (_isBgpConnection) {
-        BgpActivePeerConfig.builder()
-            .setPeerAddress(ipsecTunnel.getCgwInsideAddress())
-            .setRemoteAs(ipsecTunnel.getCgwBgpAsn())
-            .setBgpProcess(tunnelVrf.getBgpProcess())
-            .setLocalAs(ipsecTunnel.getVgwBgpAsn())
-            .setLocalIp(ipsecTunnel.getVgwInsideAddress())
-            .setIpv4UnicastAddressFamily(
-                Ipv4UnicastAddressFamily.builder()
-                    .setExportPolicy(exportPolicyName)
-                    .setImportPolicy(importPolicyName)
-                    .build())
-            .build();
+        BgpActivePeerConfig activePeerConfig =
+            BgpActivePeerConfig.builder()
+                .setPeerAddress(ipsecTunnel.getCgwInsideAddress())
+                .setRemoteAsns(
+                    Optional.ofNullable(ipsecTunnel.getCgwBgpAsn())
+                        .map(LongSpace::of)
+                        .orElse(LongSpace.EMPTY))
+                .setBgpProcess(tunnelVrf.getBgpProcess())
+                .setLocalAs(ipsecTunnel.getVgwBgpAsn())
+                .setLocalIp(ipsecTunnel.getVgwInsideAddress())
+                .setIpv4UnicastAddressFamily(
+                    Ipv4UnicastAddressFamily.builder()
+                        .setExportPolicy(exportPolicyName)
+                        .setImportPolicy(importPolicyName)
+                        .build())
+                .build();
       }
 
       // configure static routes -- this list of routes should be empty in case of transit gateway

--- a/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/aws/VpnConnection.java
@@ -501,22 +501,21 @@ final class VpnConnection implements AwsVpcEntity, Serializable {
 
       // configure BGP peering
       if (_isBgpConnection) {
-        BgpActivePeerConfig activePeerConfig =
-            BgpActivePeerConfig.builder()
-                .setPeerAddress(ipsecTunnel.getCgwInsideAddress())
-                .setRemoteAsns(
-                    Optional.ofNullable(ipsecTunnel.getCgwBgpAsn())
-                        .map(LongSpace::of)
-                        .orElse(LongSpace.EMPTY))
-                .setBgpProcess(tunnelVrf.getBgpProcess())
-                .setLocalAs(ipsecTunnel.getVgwBgpAsn())
-                .setLocalIp(ipsecTunnel.getVgwInsideAddress())
-                .setIpv4UnicastAddressFamily(
-                    Ipv4UnicastAddressFamily.builder()
-                        .setExportPolicy(exportPolicyName)
-                        .setImportPolicy(importPolicyName)
-                        .build())
-                .build();
+        BgpActivePeerConfig.builder()
+            .setPeerAddress(ipsecTunnel.getCgwInsideAddress())
+            .setRemoteAsns(
+                Optional.ofNullable(ipsecTunnel.getCgwBgpAsn())
+                    .map(LongSpace::of)
+                    .orElse(LongSpace.EMPTY))
+            .setBgpProcess(tunnelVrf.getBgpProcess())
+            .setLocalAs(ipsecTunnel.getVgwBgpAsn())
+            .setLocalIp(ipsecTunnel.getVgwInsideAddress())
+            .setIpv4UnicastAddressFamily(
+                Ipv4UnicastAddressFamily.builder()
+                    .setExportPolicy(exportPolicyName)
+                    .setImportPolicy(importPolicyName)
+                    .build())
+            .build();
       }
 
       // configure static routes -- this list of routes should be empty in case of transit gateway

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1374,7 +1374,10 @@ public final class CiscoConfiguration extends VendorConfiguration {
         newNeighborBuilder =
             BgpActivePeerConfig.builder()
                 .setPeerAddress(ipg.getIp())
-                .setRemoteAs(lpg.getRemoteAs());
+                .setRemoteAsns(
+                    Optional.ofNullable(lpg.getRemoteAs())
+                        .map(LongSpace::of)
+                        .orElse(LongSpace.EMPTY));
       } else if (lpg instanceof DynamicIpBgpPeerGroup) {
         DynamicIpBgpPeerGroup dpg = (DynamicIpBgpPeerGroup) lpg;
         LongSpace.Builder asns = LongSpace.builder().including(dpg.getRemoteAs());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -1554,7 +1554,10 @@ public final class AsaConfiguration extends VendorConfiguration {
         newNeighborBuilder =
             BgpActivePeerConfig.builder()
                 .setPeerAddress(ipg.getIp())
-                .setRemoteAs(lpg.getRemoteAs());
+                .setRemoteAsns(
+                    Optional.ofNullable(lpg.getRemoteAs())
+                        .map(LongSpace::of)
+                        .orElse(LongSpace.EMPTY));
       } else if (lpg instanceof DynamicIpBgpPeerGroup) {
         DynamicIpBgpPeerGroup dpg = (DynamicIpBgpPeerGroup) lpg;
         LongSpace.Builder asns = LongSpace.builder().including(dpg.getRemoteAs());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -353,7 +353,10 @@ final class Conversions {
     } else {
       newNeighborBuilder =
           BgpActivePeerConfig.builder()
-              .setRemoteAs(neighbor.getRemoteAs())
+              .setRemoteAsns(
+                  Optional.ofNullable(neighbor.getRemoteAs())
+                      .map(LongSpace::of)
+                      .orElse(LongSpace.EMPTY))
               .setPeerAddress(prefix.getStartIp());
       // No remote AS set.
       if (neighbor.getRemoteAs() == null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -1209,7 +1209,10 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
         newNeighborBuilder =
             BgpActivePeerConfig.builder()
                 .setPeerAddress(ipg.getIp())
-                .setRemoteAs(lpg.getRemoteAs());
+                .setRemoteAsns(
+                    Optional.ofNullable(lpg.getRemoteAs())
+                        .map(LongSpace::of)
+                        .orElse(LongSpace.EMPTY));
       } else if (lpg instanceof DynamicIpBgpPeerGroup) {
         DynamicIpBgpPeerGroup dpg = (DynamicIpBgpPeerGroup) lpg;
         LongSpace.Builder asns = LongSpace.builder().including(dpg.getRemoteAs());

--- a/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/fortios/FortiosBgpConversions.java
@@ -17,6 +17,7 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.PrefixRange;
 import org.batfish.datamodel.PrefixSpace;
@@ -244,7 +245,10 @@ public final class FortiosBgpConversions {
           .setLocalIp(localIp)
           .setLocalAs(localAs)
           .setPeerAddress(neighbor.getIp())
-          .setRemoteAs(neighbor.getRemoteAs())
+          .setRemoteAsns(
+              Optional.ofNullable(neighbor.getRemoteAs())
+                  .map(LongSpace::of)
+                  .orElse(LongSpace.EMPTY))
           .setBgpProcess(viProc)
           .setIpv4UnicastAddressFamily(
               Ipv4UnicastAddressFamily.builder()

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -91,6 +91,7 @@ import org.batfish.datamodel.IpsecPhase2Proposal;
 import org.batfish.datamodel.IpsecStaticPeerConfig;
 import org.batfish.datamodel.IsoAddress;
 import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.MultipathEquivalentAsPathMatchMode;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
@@ -453,12 +454,18 @@ public final class JuniperConfiguration extends VendorConfiguration {
       IpBgpGroup ig = e.getValue();
       Builder<?, ?> neighbor;
       Ipv4UnicastAddressFamily.Builder ipv4AfBuilder = Ipv4UnicastAddressFamily.builder();
-      Long remoteAs = ig.getType() == BgpGroupType.INTERNAL ? ig.getLocalAs() : ig.getPeerAs();
+      LongSpace remoteAs =
+          Optional.ofNullable(
+                  ig.getType() == BgpGroupType.INTERNAL ? ig.getLocalAs() : ig.getPeerAs())
+              .map(LongSpace::of)
+              .orElse(LongSpace.EMPTY);
       if (ig.getDynamic()) {
-        neighbor = BgpPassivePeerConfig.builder().setPeerPrefix(prefix).setRemoteAs(remoteAs);
+        neighbor = BgpPassivePeerConfig.builder().setPeerPrefix(prefix).setRemoteAsns(remoteAs);
       } else {
         neighbor =
-            BgpActivePeerConfig.builder().setPeerAddress(prefix.getStartIp()).setRemoteAs(remoteAs);
+            BgpActivePeerConfig.builder()
+                .setPeerAddress(prefix.getStartIp())
+                .setRemoteAsns(remoteAs);
       }
       neighbor.setDescription(ig.getDescription());
 

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -2,6 +2,7 @@ package org.batfish.representation.juniper;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.stream.Collectors.groupingBy;
+import static org.batfish.datamodel.BgpPeerConfig.ALL_AS_NUMBERS;
 import static org.batfish.datamodel.Names.zoneToZoneFilter;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcInterface;
@@ -454,18 +455,19 @@ public final class JuniperConfiguration extends VendorConfiguration {
       IpBgpGroup ig = e.getValue();
       Builder<?, ?> neighbor;
       Ipv4UnicastAddressFamily.Builder ipv4AfBuilder = Ipv4UnicastAddressFamily.builder();
-      LongSpace remoteAs =
-          Optional.ofNullable(
-                  ig.getType() == BgpGroupType.INTERNAL ? ig.getLocalAs() : ig.getPeerAs())
-              .map(LongSpace::of)
-              .orElse(LongSpace.EMPTY);
+      Long remoteAs = ig.getType() == BgpGroupType.INTERNAL ? ig.getLocalAs() : ig.getPeerAs();
       if (ig.getDynamic()) {
-        neighbor = BgpPassivePeerConfig.builder().setPeerPrefix(prefix).setRemoteAsns(remoteAs);
+        neighbor =
+            BgpPassivePeerConfig.builder()
+                .setPeerPrefix(prefix)
+                .setRemoteAsns(
+                    Optional.ofNullable(remoteAs).map(LongSpace::of).orElse(ALL_AS_NUMBERS));
       } else {
         neighbor =
             BgpActivePeerConfig.builder()
                 .setPeerAddress(prefix.getStartIp())
-                .setRemoteAsns(remoteAs);
+                .setRemoteAsns(
+                    Optional.ofNullable(remoteAs).map(LongSpace::of).orElse(LongSpace.EMPTY));
       }
       neighbor.setDescription(ig.getDescription());
 

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -114,6 +114,7 @@ import org.batfish.datamodel.IpRange;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.IpSpaceMetadata;
 import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SwitchportMode;
@@ -2401,7 +2402,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
             // "number + 2" computation
             // See https://knowledgebase.paloaltonetworks.com/KCSArticleDetail?id=kA10g000000ClKkCAK
             .setEbgpMultihop(true)
-            .setRemoteAs(peerAs);
+            .setRemoteAsns(Optional.ofNullable(peerAs).map(LongSpace::of).orElse(LongSpace.EMPTY));
     if (peer.getLocalAddress() != null) {
       peerB.setLocalIp(peer.getLocalAddress());
     } else {


### PR DESCRIPTION
Semantics change is only for active peers. 

Real-networks and labs pass with this change.