### PR TITLE
Make extractors consistently implement BatfishListener

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishListener.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishListener.java
@@ -3,11 +3,12 @@ package org.batfish.grammar;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.batfish.common.Warnings;
 
 /** Interface providing common parse-tree listener utility methods with default implementations. */
 @ParametersAreNonnullByDefault
-public interface BatfishListener {
+public interface BatfishListener extends ParseTreeListener {
 
   default @Nonnull String getFullText(ParserRuleContext ctx) {
     int start = ctx.getStart().getStartIndex();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishListener.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/grammar/BatfishListener.java
@@ -10,26 +10,51 @@ import org.batfish.common.Warnings;
 @ParametersAreNonnullByDefault
 public interface BatfishListener extends ParseTreeListener {
 
+  /**
+   * Returns the full text of of the provided {@link ParserRuleContext}. If the parse tree has been
+   * preprocessed, a client may want to override this method to produce the correct text for each
+   * parse tree node.
+   */
   default @Nonnull String getFullText(ParserRuleContext ctx) {
     int start = ctx.getStart().getStartIndex();
     int end = ctx.getStop().getStopIndex();
     return getInputText().substring(start, end + 1);
   }
 
+  /**
+   * Returns a version of the text of the provided {@link ParserRuleContext} suitable for a warning.
+   * By default, just returns {@link #getFullText(ParserRuleContext)}. Clients may want to override
+   * this method to produce something more concise.
+   */
+  default @Nonnull String getWarningText(ParserRuleContext ctx) {
+    return getFullText(ctx);
+  }
+
+  /** Return the input text processed by this listener. */
   @Nonnull
   String getInputText();
 
+  /** Return the parser used to parse the input text. */
   @Nonnull
   BatfishCombinedParser<?, ?> getParser();
 
+  /** Return the {@link Warnings} this listener may want to update as it processes the input. */
   @Nonnull
   Warnings getWarnings();
 
+  /**
+   * Helper for adding todo warning for {@link ParserRuleContext}. Generally should not be
+   * overridden.
+   */
   default void todo(ParserRuleContext ctx) {
-    getWarnings().todo(ctx, getFullText(ctx), getParser());
+    getWarnings().todo(ctx, getWarningText(ctx), getParser());
   }
 
+  /**
+   * Helper for adding generic warning for {@link ParserRuleContext}. Generally should not be
+   * overridden.
+   */
   default void warn(ParserRuleContext ctx, String message) {
-    getWarnings().addWarning(ctx, getFullText(ctx), getParser(), message);
+    getWarnings().addWarning(ctx, getWarningText(ctx), getParser(), message);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -351,6 +351,8 @@ import org.batfish.datamodel.vendor_family.cisco_xr.Ntp;
 import org.batfish.datamodel.vendor_family.cisco_xr.NtpServer;
 import org.batfish.datamodel.vendor_family.cisco_xr.Service;
 import org.batfish.datamodel.vendor_family.cisco_xr.User;
+import org.batfish.grammar.BatfishCombinedParser;
+import org.batfish.grammar.BatfishListener;
 import org.batfish.grammar.BatfishParseTreeWalker;
 import org.batfish.grammar.ControlPlaneExtractor;
 import org.batfish.grammar.UnrecognizedLineToken;
@@ -1036,7 +1038,7 @@ import org.batfish.representation.cisco_xr.XrWildcardCommunitySetElem;
 import org.batfish.vendor.VendorConfiguration;
 
 public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
-    implements ControlPlaneExtractor {
+    implements ControlPlaneExtractor, BatfishListener {
 
   public static final IntegerSpace VLAN_RANGE = IntegerSpace.of(Range.closed(1, 4094));
 
@@ -6803,10 +6805,22 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
     return _configuration.canonicalizeInterfaceName(ifaceName);
   }
 
-  private String getFullText(ParserRuleContext ctx) {
-    int start = ctx.getStart().getStartIndex();
-    int end = ctx.getStop().getStopIndex();
-    return _text.substring(start, end + 1);
+  @Nonnull
+  @Override
+  public String getInputText() {
+    return _text;
+  }
+
+  @Nonnull
+  @Override
+  public BatfishCombinedParser<?, ?> getParser() {
+    return _parser;
+  }
+
+  @Nonnull
+  @Override
+  public Warnings getWarnings() {
+    return _w;
   }
 
   private String getLocation(ParserRuleContext ctx) {
@@ -7152,14 +7166,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   private static int toInteger(Uint16Context ctx) {
     return Integer.parseInt(ctx.getText());
-  }
-
-  private void todo(ParserRuleContext ctx) {
-    _w.todo(ctx, getFullText(ctx), _parser);
-  }
-
-  private void warn(ParserRuleContext ctx, String message) {
-    _w.addWarning(ctx, getFullText(ctx), _parser, message);
   }
 
   private DiffieHellmanGroup toDhGroup(Dh_groupContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -60,6 +60,8 @@ import org.batfish.datamodel.routing_policy.expr.DecrementMetric;
 import org.batfish.datamodel.routing_policy.expr.IncrementMetric;
 import org.batfish.datamodel.routing_policy.expr.LiteralLong;
 import org.batfish.datamodel.routing_policy.expr.LongExpr;
+import org.batfish.grammar.BatfishCombinedParser;
+import org.batfish.grammar.BatfishListener;
 import org.batfish.grammar.UnrecognizedLineToken;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Bgp_redist_typeContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Icl_expandedContext;
@@ -234,7 +236,8 @@ import org.batfish.representation.cumulus.RouteMapSetWeight;
 import org.batfish.representation.cumulus.StaticRoute;
 import org.batfish.representation.cumulus.Vrf;
 
-public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener {
+public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
+    implements BatfishListener {
   private static final IntegerSpace OSPF_AREA_RANGE_COST_SPACE =
       IntegerSpace.of(Range.closed(0, 16777215));
   private static final IntegerSpace PREFIX_LENGTH_SPACE =
@@ -335,20 +338,22 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     }
   }
 
-  /** Return the text of a given rule context */
   @Nonnull
-  String getFullText(ParserRuleContext ctx) {
-    int start = ctx.getStart().getStartIndex();
-    int end = ctx.getStop().getStopIndex();
-    return _text.substring(start, end + 1);
+  @Override
+  public String getInputText() {
+    return _text;
   }
 
-  private void todo(ParserRuleContext ctx) {
-    _w.todo(ctx, getFullText(ctx), _parser);
+  @Nonnull
+  @Override
+  public BatfishCombinedParser<?, ?> getParser() {
+    return _parser;
   }
 
-  private void warn(ParserRuleContext ctx, String message) {
-    _w.addWarning(ctx, getFullText(ctx), _parser, message);
+  @Nonnull
+  @Override
+  public Warnings getWarnings() {
+    return _w;
   }
 
   private LongExpr toMetricLongExpr(Int_exprContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesConfigurationBuilder.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ErrorNode;
@@ -21,6 +20,8 @@ import org.batfish.datamodel.IntegerSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.MacAddress;
 import org.batfish.datamodel.Prefix;
+import org.batfish.grammar.BatfishCombinedParser;
+import org.batfish.grammar.BatfishListener;
 import org.batfish.grammar.UnrecognizedLineToken;
 import org.batfish.grammar.cumulus_interfaces.CumulusInterfacesParser.AddressContext;
 import org.batfish.grammar.cumulus_interfaces.CumulusInterfacesParser.I_addressContext;
@@ -69,8 +70,8 @@ import org.batfish.representation.cumulus.StaticRoute;
  * Populates {@link CumulusInterfacesConfiguration} from a parse tree from {@link
  * org.batfish.grammar.cumulus_interfaces.CumulusInterfacesCombinedParser}.
  */
-public final class CumulusInterfacesConfigurationBuilder
-    extends CumulusInterfacesParserBaseListener {
+public final class CumulusInterfacesConfigurationBuilder extends CumulusInterfacesParserBaseListener
+    implements BatfishListener {
   private final CumulusConcatenatedConfiguration _config;
 
   private final CumulusInterfacesCombinedParser _parser;
@@ -90,10 +91,22 @@ public final class CumulusInterfacesConfigurationBuilder
     _w = w;
   }
 
-  private String getFullText(ParserRuleContext ctx) {
-    int start = ctx.getStart().getStartIndex();
-    int end = ctx.getStop().getStopIndex();
-    return _text.substring(start, end + 1);
+  @Nonnull
+  @Override
+  public String getInputText() {
+    return _text;
+  }
+
+  @Nonnull
+  @Override
+  public BatfishCombinedParser<?, ?> getParser() {
+    return _parser;
+  }
+
+  @Nonnull
+  @Override
+  public Warnings getWarnings() {
+    return _w;
   }
 
   @VisibleForTesting
@@ -266,7 +279,7 @@ public final class CumulusInterfacesConfigurationBuilder
   @Override
   public void exitI_bridge_vlan_aware(I_bridge_vlan_awareContext ctx) {
     if (ctx.NO() != null) {
-      _w.todo(ctx, getFullText(ctx), _parser);
+      todo(ctx);
     }
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_nclu/CumulusNcluConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_nclu/CumulusNcluConfigurationBuilder.java
@@ -47,6 +47,8 @@ import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.MacAddress;
 import org.batfish.datamodel.Prefix;
+import org.batfish.grammar.BatfishCombinedParser;
+import org.batfish.grammar.BatfishListener;
 import org.batfish.grammar.ParseTreePrettyPrinter;
 import org.batfish.grammar.UnrecognizedLineToken;
 import org.batfish.grammar.cumulus_nclu.CumulusNcluParser.A_bgpContext;
@@ -193,7 +195,8 @@ import org.batfish.representation.cumulus_nclu.Vxlan;
  * A listener that builds a {@link CumulusNcluConfiguration} while walking a parse tree produced by
  * {@link CumulusNcluCombinedParser#parse}.
  */
-public class CumulusNcluConfigurationBuilder extends CumulusNcluParserBaseListener {
+public class CumulusNcluConfigurationBuilder extends CumulusNcluParserBaseListener
+    implements BatfishListener {
 
   private static final Pattern NUMBERED_WORD_PATTERN = Pattern.compile("^(.*[^0-9])([0-9]+)$");
   private static final int MAX_VXLAN_ID = (1 << 24) - 1; // 24 bit number
@@ -1459,11 +1462,22 @@ public class CumulusNcluConfigurationBuilder extends CumulusNcluParserBaseListen
     return _c;
   }
 
-  private @Nonnull String getFullText(ParserRuleContext ctx) {
-    int start = ctx.getStart().getStartIndex();
-    int end = ctx.getStop().getStopIndex();
-    String text = _text.substring(start, end + 1);
-    return text;
+  @Nonnull
+  @Override
+  public String getInputText() {
+    return _text;
+  }
+
+  @Nonnull
+  @Override
+  public BatfishCombinedParser<?, ?> getParser() {
+    return _parser;
+  }
+
+  @Nonnull
+  @Override
+  public Warnings getWarnings() {
+    return _w;
   }
 
   /**
@@ -1613,11 +1627,6 @@ public class CumulusNcluConfigurationBuilder extends CumulusNcluParserBaseListen
     names.forEach(
         name -> _c.referenceStructure(CumulusStructureType.ABSTRACT_INTERFACE, name, usage, line));
     return true;
-  }
-
-  @SuppressWarnings("unused")
-  private void todo(ParserRuleContext ctx) {
-    _w.todo(ctx, getFullText(ctx), _parser);
   }
 
   private void unrecognized(ParserRuleContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishConfigurationBuilder.java
@@ -25,6 +25,8 @@ import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.batfish.grammar.BatfishCombinedParser;
+import org.batfish.grammar.BatfishListener;
 import org.batfish.grammar.UnrecognizedLineToken;
 import org.batfish.grammar.f5_bigip_imish.F5BigipImishParser.F5_bigip_imish_configurationContext;
 import org.batfish.grammar.f5_bigip_imish.F5BigipImishParser.Iipo_networkContext;
@@ -107,7 +109,8 @@ import org.batfish.representation.f5_bigip.RouteMapSetOrigin;
 import org.batfish.representation.f5_bigip.UpdateSourceInterface;
 import org.batfish.representation.f5_bigip.UpdateSourceIp;
 
-public class F5BigipImishConfigurationBuilder extends F5BigipImishParserBaseListener {
+public class F5BigipImishConfigurationBuilder extends F5BigipImishParserBaseListener
+    implements BatfishListener {
 
   private static int toInteger(Ip_prefix_lengthContext ctx) {
     return Integer.parseInt(ctx.getText(), 10);
@@ -759,11 +762,22 @@ public class F5BigipImishConfigurationBuilder extends F5BigipImishParserBaseList
     _currentBgpProcess = null;
   }
 
-  private @Nonnull String getFullText(ParserRuleContext ctx) {
-    int start = ctx.getStart().getStartIndex();
-    int end = ctx.getStop().getStopIndex();
-    String text = _text.substring(start, end + 1);
-    return text;
+  @Nonnull
+  @Override
+  public String getInputText() {
+    return _text;
+  }
+
+  @Nonnull
+  @Override
+  public BatfishCombinedParser<?, ?> getParser() {
+    return _parser;
+  }
+
+  @Nonnull
+  @Override
+  public Warnings getWarnings() {
+    return _w;
   }
 
   private @Nullable Long toLong(Standard_communityContext ctx) {
@@ -784,7 +798,8 @@ public class F5BigipImishConfigurationBuilder extends F5BigipImishParserBaseList
     }
   }
 
-  private void todo(ParserRuleContext ctx) {
+  @Override
+  public void todo(ParserRuleContext ctx) {
     _w.todo(ctx, getFullText(ctx).split("\\n", -1)[0], _parser);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishConfigurationBuilder.java
@@ -206,7 +206,7 @@ public class F5BigipImishConfigurationBuilder extends F5BigipImishParserBaseList
     if (ctx.NON_BROADCAST() != null) {
       return Optional.of(OspfNetworkType.NON_BROADCAST);
     }
-    warn(ctx, String.format("Unhandled OSPF network type: %s", ctx.getText()));
+    warn(messageCtx, String.format("Unhandled OSPF network type: %s", getFullText(ctx)));
     return Optional.empty();
   }
 
@@ -792,12 +792,6 @@ public class F5BigipImishConfigurationBuilder extends F5BigipImishParserBaseList
     } else {
       return convProblem(Prefix.class, ctx, null);
     }
-  }
-
-  @Nonnull
-  @Override
-  public String getWarningText(ParserRuleContext ctx) {
-    return getFullText(ctx).split("\\n", -1)[0];
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_imish/F5BigipImishConfigurationBuilder.java
@@ -206,11 +206,7 @@ public class F5BigipImishConfigurationBuilder extends F5BigipImishParserBaseList
     if (ctx.NON_BROADCAST() != null) {
       return Optional.of(OspfNetworkType.NON_BROADCAST);
     }
-    _w.addWarning(
-        ctx,
-        getFullText(messageCtx),
-        _parser,
-        String.format("Unhandled OSPF network type: %s", ctx.getText()));
+    warn(ctx, String.format("Unhandled OSPF network type: %s", ctx.getText()));
     return Optional.empty();
   }
 
@@ -798,9 +794,10 @@ public class F5BigipImishConfigurationBuilder extends F5BigipImishParserBaseList
     }
   }
 
+  @Nonnull
   @Override
-  public void todo(ParserRuleContext ctx) {
-    _w.todo(ctx, getFullText(ctx).split("\\n", -1)[0], _parser);
+  public String getWarningText(ParserRuleContext ctx) {
+    return getFullText(ctx).split("\\n", -1)[0];
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredConfigurationBuilder.java
@@ -3187,16 +3187,11 @@ public class F5BigipStructuredConfigurationBuilder extends F5BigipStructuredPars
     }
   }
 
+  @Nonnull
   @Override
-  public void todo(ParserRuleContext ctx) {
-    // Just print first line of unsupported feature
-    _w.todo(ctx, getFullText(ctx).split("\n", -1)[0], _parser);
-  }
-
-  @Override
-  public void warn(ParserRuleContext ctx, String message) {
-    // Just print first line of unsupported feature
-    _w.addWarning(ctx, getFullText(ctx).split("\n", -1)[0], _parser, message);
+  public String getWarningText(ParserRuleContext ctx) {
+    // Just print first line
+    return getFullText(ctx).split("\n", -1)[0];
   }
 
   private @Nullable IpProtocol toIpProtocol(Ip_protocolContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/f5_bigip_structured/F5BigipStructuredConfigurationBuilder.java
@@ -222,6 +222,8 @@ import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.vendor_family.f5_bigip.DeviceGroupType;
 import org.batfish.datamodel.vendor_family.f5_bigip.RouteAdvertisementMode;
+import org.batfish.grammar.BatfishCombinedParser;
+import org.batfish.grammar.BatfishListener;
 import org.batfish.grammar.ParseTreePrettyPrinter;
 import org.batfish.grammar.UnrecognizedLineToken;
 import org.batfish.grammar.f5_bigip_structured.F5BigipStructuredParser.Bundle_speedContext;
@@ -586,7 +588,8 @@ import org.batfish.representation.f5_bigip.Vlan;
 import org.batfish.representation.f5_bigip.VlanInterface;
 
 @ParametersAreNonnullByDefault
-public class F5BigipStructuredConfigurationBuilder extends F5BigipStructuredParserBaseListener {
+public class F5BigipStructuredConfigurationBuilder extends F5BigipStructuredParserBaseListener
+    implements BatfishListener {
 
   private static int toInteger(Ip_address_portContext ctx) {
     String text = ctx.getText();
@@ -3144,11 +3147,22 @@ public class F5BigipStructuredConfigurationBuilder extends F5BigipStructuredPars
     return _c;
   }
 
-  private @Nonnull String getFullText(ParserRuleContext ctx) {
-    int start = ctx.getStart().getStartIndex();
-    int end = ctx.getStop().getStopIndex();
-    String text = _text.substring(start, end + 1);
-    return text;
+  @Nonnull
+  @Override
+  public String getInputText() {
+    return _text;
+  }
+
+  @Nonnull
+  @Override
+  public BatfishCombinedParser<?, ?> getParser() {
+    return _parser;
+  }
+
+  @Nonnull
+  @Override
+  public Warnings getWarnings() {
+    return _w;
   }
 
   public @Nullable Integer getImishConfigurationLine() {
@@ -3173,12 +3187,14 @@ public class F5BigipStructuredConfigurationBuilder extends F5BigipStructuredPars
     }
   }
 
-  private void todo(ParserRuleContext ctx) {
+  @Override
+  public void todo(ParserRuleContext ctx) {
     // Just print first line of unsupported feature
     _w.todo(ctx, getFullText(ctx).split("\n", -1)[0], _parser);
   }
 
-  private void warn(ParserRuleContext ctx, String message) {
+  @Override
+  public void warn(ParserRuleContext ctx, String message) {
     // Just print first line of unsupported feature
     _w.addWarning(ctx, getFullText(ctx).split("\n", -1)[0], _parser, message);
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/flatvyos/FlatVyosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/flatvyos/FlatVyosControlPlaneExtractor.java
@@ -1,5 +1,6 @@
 package org.batfish.grammar.flatvyos;
 
+import javax.annotation.Nonnull;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
@@ -14,6 +15,8 @@ import org.batfish.datamodel.IkeAuthenticationMethod;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.Prefix;
+import org.batfish.grammar.BatfishCombinedParser;
+import org.batfish.grammar.BatfishListener;
 import org.batfish.grammar.BatfishParseTreeWalker;
 import org.batfish.grammar.ControlPlaneExtractor;
 import org.batfish.grammar.flatvyos.FlatVyosParser.Bnt_nexthop_selfContext;
@@ -93,7 +96,7 @@ import org.batfish.representation.vyos.VyosConfiguration;
 import org.batfish.vendor.VendorConfiguration;
 
 public class FlatVyosControlPlaneExtractor extends FlatVyosParserBaseListener
-    implements ControlPlaneExtractor {
+    implements ControlPlaneExtractor, BatfishListener {
 
   private static LineAction toAction(Line_actionContext ctx) {
     if (ctx.DENY() != null) {
@@ -693,7 +696,21 @@ public class FlatVyosControlPlaneExtractor extends FlatVyosParserBaseListener
     walker.walk(this, tree);
   }
 
-  private void todo(ParserRuleContext ctx) {
-    _w.todo(ctx, _text, _parser);
+  @Nonnull
+  @Override
+  public String getInputText() {
+    return _text;
+  }
+
+  @Nonnull
+  @Override
+  public BatfishCombinedParser<?, ?> getParser() {
+    return _parser;
+  }
+
+  @Nonnull
+  @Override
+  public Warnings getWarnings() {
+    return _w;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/grammar/mrv/MrvControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/mrv/MrvControlPlaneExtractor.java
@@ -1,9 +1,12 @@
 package org.batfish.grammar.mrv;
 
+import javax.annotation.Nonnull;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.Warnings;
+import org.batfish.grammar.BatfishCombinedParser;
+import org.batfish.grammar.BatfishListener;
 import org.batfish.grammar.BatfishParseTreeWalker;
 import org.batfish.grammar.ControlPlaneExtractor;
 import org.batfish.grammar.mrv.MrvParser.A_system_systemnameContext;
@@ -14,7 +17,7 @@ import org.batfish.representation.mrv.MrvConfiguration;
 import org.batfish.vendor.VendorConfiguration;
 
 public class MrvControlPlaneExtractor extends MrvParserBaseListener
-    implements ControlPlaneExtractor {
+    implements ControlPlaneExtractor, BatfishListener {
 
   private MrvConfiguration _configuration;
 
@@ -41,10 +44,22 @@ public class MrvControlPlaneExtractor extends MrvParserBaseListener
     _configuration.setHostname(hostname);
   }
 
-  private String getFullText(ParserRuleContext ctx) {
-    int start = ctx.getStart().getStartIndex();
-    int end = ctx.getStop().getStopIndex();
-    return _text.substring(start, end + 1);
+  @Nonnull
+  @Override
+  public String getInputText() {
+    return _text;
+  }
+
+  @Nonnull
+  @Override
+  public BatfishCombinedParser<?, ?> getParser() {
+    return _parser;
+  }
+
+  @Nonnull
+  @Override
+  public Warnings getWarnings() {
+    return _w;
   }
 
   private String getText(Quoted_stringContext ctx) {
@@ -64,11 +79,6 @@ public class MrvControlPlaneExtractor extends MrvParserBaseListener
   public void processParseTree(NetworkSnapshot snapshot, ParserRuleContext tree) {
     ParseTreeWalker walker = new BatfishParseTreeWalker(_parser);
     walker.walk(this, tree);
-  }
-
-  @SuppressWarnings("unused")
-  private void todo(ParserRuleContext ctx) {
-    _w.todo(ctx, getFullText(ctx), _parser);
   }
 
   private String toString(NsdeclContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/palo_alto/PaloAltoConfigurationBuilder.java
@@ -107,6 +107,8 @@ import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.SubRange;
+import org.batfish.grammar.BatfishCombinedParser;
+import org.batfish.grammar.BatfishListener;
 import org.batfish.grammar.UnrecognizedLineToken;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Bgp_asnContext;
 import org.batfish.grammar.palo_alto.PaloAltoParser.Bgp_enableContext;
@@ -445,7 +447,8 @@ import org.batfish.representation.palo_alto.Zone;
 import org.batfish.vendor.StructureType;
 import org.batfish.vendor.StructureUsage;
 
-public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
+public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener
+    implements BatfishListener {
 
   /** Indicates which rulebase that new rules go into. */
   private enum RulebaseId {
@@ -533,11 +536,22 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
     return defaultReturnValue;
   }
 
-  private String getFullText(ParserRuleContext ctx) {
-    int start = ctx.getStart().getStartIndex();
-    int end = ctx.getStop().getStopIndex();
-    String text = _text.substring(start, end + 1);
-    return text;
+  @Nonnull
+  @Override
+  public String getInputText() {
+    return _text;
+  }
+
+  @Nonnull
+  @Override
+  public BatfishCombinedParser<?, ?> getParser() {
+    return _parser;
+  }
+
+  @Nonnull
+  @Override
+  public Warnings getWarnings() {
+    return _w;
   }
 
   /** Return original line number for specified token */
@@ -3317,14 +3331,6 @@ public class PaloAltoConfigurationBuilder extends PaloAltoParserBaseListener {
           "Application definitions only affect App-ID, so Batfish ignores custom application"
               + " definitions.");
     }
-  }
-
-  private void todo(ParserRuleContext ctx) {
-    _w.todo(ctx, getFullText(ctx), _parser);
-  }
-
-  private void warn(ParserRuleContext ctx, String message) {
-    _w.addWarning(ctx, getFullText(ctx), _parser, message);
   }
 
   private void warn(ParserRuleContext ctx, ParserRuleContext warnCtx, String message) {


### PR DESCRIPTION
- Make final-stage xxxExtractor / xxxConfigurationBuilder
  consistently implement BatfishListener
  - remove duplicate code
  - prerequisite for planned warning functionality