### PR TITLE
IOS-XR extract and refactor af-specific vrf configuration

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXrLexer.g4
@@ -2078,6 +2078,8 @@ FPD: 'fpd';
 
 FQDN: 'fqdn';
 
+FLOWSPEC: 'flowspec';
+
 FRAGMENTATION: 'fragmentation';
 
 FRAGMENTS: 'fragments';

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_vrf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_vrf.g4
@@ -15,21 +15,19 @@ vrf_inner
   | vrf_null
 ;
 
-vrf_address_family
+vrf_address_family: ADDRESS_FAMILY af = vrf_address_family_type NEWLINE vrf_af_inner*;
+
+vrf_address_family_type
 :
-   ADDRESS_FAMILY
-   (
-      IPV4
-      | IPV6
-   )
-   (
-      MULTICAST
-      | UNICAST
-   )?
-   (
-      MAX_ROUTE uint_legacy
-   )? NEWLINE
-   vrf_af_inner*
+  (
+    IPV4
+    | IPV6
+  )
+  (
+    FLOWSPEC
+    | MULTICAST
+    | UNICAST
+  )
 ;
 
 vrf_af_inner

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/AddressFamilyType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/AddressFamilyType.java
@@ -1,0 +1,11 @@
+package org.batfish.representation.cisco_xr;
+
+/** Allowed address families (e.g., in VRF config) for IOS-XR */
+public enum AddressFamilyType {
+  IPV4_FLOWSPEC,
+  IPV4_MULTICAST,
+  IPV4_UNICAST,
+  IPV6_FLOWSPEC,
+  IPV6_MULTICAST,
+  IPV6_UNICAST
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/Vrf.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/Vrf.java
@@ -1,20 +1,18 @@
 package org.batfish.representation.cisco_xr;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
-import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 
 public final class Vrf implements Serializable {
+  @Nonnull private final Map<AddressFamilyType, VrfAddressFamily> _addressFamilies;
   @Nonnull private final Map<Long, EigrpProcess> _eigrpProcesses;
   @Nullable private BgpProcess _bgpProcess;
   @Nullable private String _description;
@@ -23,26 +21,17 @@ public final class Vrf implements Serializable {
   @Nonnull private Map<String, OspfProcess> _ospfProcesses;
   @Nullable private RipProcess _ripProcess;
   @Nullable private RouteDistinguisher _routeDistinguisher;
-  @Nonnull private List<ExtendedCommunity> _routeTargetExport;
-  @Nonnull private List<ExtendedCommunity> _routeTargetImport;
   private boolean _shutdown;
   @Nonnull private final Set<StaticRoute> _staticRoutes;
   @Nullable private Integer _vni;
-  @Nullable private String _exportPolicy;
-  @Nullable private String _importPolicy;
-  @Nonnull private Map<String, String> _exportPolicyByVrf;
-  @Nonnull private Map<String, String> _importPolicyByVrf;
 
   public Vrf(@Nonnull String name) {
+    _addressFamilies = new HashMap<>();
     _eigrpProcesses = new TreeMap<>();
     _name = name;
     // Ensure that processes are in insertion order.
     _ospfProcesses = new LinkedHashMap<>(0);
     _staticRoutes = new HashSet<>();
-    _routeTargetExport = ImmutableList.of();
-    _routeTargetImport = ImmutableList.of();
-    _exportPolicyByVrf = ImmutableMap.of();
-    _importPolicyByVrf = ImmutableMap.of();
   }
 
   @Nullable
@@ -90,24 +79,6 @@ public final class Vrf implements Serializable {
     return _routeDistinguisher;
   }
 
-  /**
-   * The route target values to attach to VPN routes originating from this VRF. Will be empty if it
-   * must be auto-derived.
-   */
-  @Nonnull
-  public List<ExtendedCommunity> getRouteTargetExport() {
-    return _routeTargetExport;
-  }
-
-  /**
-   * Routes that contain any of these route target community should be merged into this VRF. Will be
-   * empty if it must be auto-derived.
-   */
-  @Nonnull
-  public List<ExtendedCommunity> getRouteTargetImport() {
-    return _routeTargetImport;
-  }
-
   /** Is this VRF shutdown (not used for routing/forwarding) */
   public boolean isShutdown() {
     return _shutdown;
@@ -144,22 +115,6 @@ public final class Vrf implements Serializable {
     _routeDistinguisher = routeDistinguisher;
   }
 
-  public void addRouteTargetExport(ExtendedCommunity routeTargetExport) {
-    _routeTargetExport =
-        ImmutableList.<ExtendedCommunity>builder()
-            .addAll(_routeTargetExport)
-            .add(routeTargetExport)
-            .build();
-  }
-
-  public void addRouteTargetImport(ExtendedCommunity routeTargetImport) {
-    _routeTargetImport =
-        ImmutableList.<ExtendedCommunity>builder()
-            .addAll(_routeTargetImport)
-            .add(routeTargetImport)
-            .build();
-  }
-
   public void setShutdown(boolean shutdown) {
     _shutdown = shutdown;
   }
@@ -168,41 +123,15 @@ public final class Vrf implements Serializable {
     _vni = vni;
   }
 
-  @Nullable
-  public String getExportPolicy() {
-    return _exportPolicy;
-  }
-
-  public void setExportPolicy(@Nullable String exportPolicy) {
-    _exportPolicy = exportPolicy;
-  }
-
+  /** Address-family specific configuration keyed by address-family type. */
   @Nonnull
-  public Map<String, String> getExportPolicyByVrf() {
-    return _exportPolicyByVrf;
+  public Map<AddressFamilyType, VrfAddressFamily> getAddressFamilies() {
+    return _addressFamilies;
   }
 
-  public void setExportPolicyForVrf(String vrf, String policy) {
-    _exportPolicyByVrf =
-        ImmutableMap.<String, String>builder().putAll(_exportPolicyByVrf).put(vrf, policy).build();
-  }
-
+  /** Configuration available under address-family ipv4 (unicast). */
   @Nullable
-  public String getImportPolicy() {
-    return _importPolicy;
-  }
-
-  public void setImportPolicy(@Nullable String importPolicy) {
-    _importPolicy = importPolicy;
-  }
-
-  @Nonnull
-  public Map<String, String> getImportPolicyByVrf() {
-    return _importPolicyByVrf;
-  }
-
-  public void setImportPolicyForVrf(String vrf, String policy) {
-    _importPolicyByVrf =
-        ImmutableMap.<String, String>builder().putAll(_importPolicyByVrf).put(vrf, policy).build();
+  public VrfAddressFamily getIpv4UnicastAddressFamily() {
+    return _addressFamilies.get(AddressFamilyType.IPV4_UNICAST);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/VrfAddressFamily.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/VrfAddressFamily.java
@@ -1,0 +1,102 @@
+package org.batfish.representation.cisco_xr;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.bgp.community.ExtendedCommunity;
+
+/** Address-family-specific configuration for a {@link Vrf}. */
+@ParametersAreNonnullByDefault
+public final class VrfAddressFamily implements Serializable {
+
+  public VrfAddressFamily() {
+    _routeTargetExport = ImmutableList.of();
+    _routeTargetImport = ImmutableList.of();
+    _exportPolicyByVrf = ImmutableMap.of();
+    _importPolicyByVrf = ImmutableMap.of();
+  }
+
+  @Nullable
+  public String getExportPolicy() {
+    return _exportPolicy;
+  }
+
+  public void setExportPolicy(@Nullable String exportPolicy) {
+    _exportPolicy = exportPolicy;
+  }
+
+  @Nonnull
+  public Map<String, String> getExportPolicyByVrf() {
+    return _exportPolicyByVrf;
+  }
+
+  public void setExportPolicyForVrf(String vrf, String policy) {
+    _exportPolicyByVrf =
+        ImmutableMap.<String, String>builder().putAll(_exportPolicyByVrf).put(vrf, policy).build();
+  }
+
+  @Nullable
+  public String getImportPolicy() {
+    return _importPolicy;
+  }
+
+  public void setImportPolicy(@Nullable String importPolicy) {
+    _importPolicy = importPolicy;
+  }
+
+  @Nonnull
+  public Map<String, String> getImportPolicyByVrf() {
+    return _importPolicyByVrf;
+  }
+
+  public void setImportPolicyForVrf(String vrf, String policy) {
+    _importPolicyByVrf =
+        ImmutableMap.<String, String>builder().putAll(_importPolicyByVrf).put(vrf, policy).build();
+  }
+
+  /**
+   * The route target values to attach to VPN routes originating from this VRF. Will be empty if it
+   * must be auto-derived.
+   */
+  @Nonnull
+  public List<ExtendedCommunity> getRouteTargetExport() {
+    return _routeTargetExport;
+  }
+
+  public void addRouteTargetExport(ExtendedCommunity routeTargetExport) {
+    _routeTargetExport =
+        ImmutableList.<ExtendedCommunity>builder()
+            .addAll(_routeTargetExport)
+            .add(routeTargetExport)
+            .build();
+  }
+
+  /**
+   * Routes that contain any of these route target community should be merged into this VRF. Will be
+   * empty if it must be auto-derived.
+   */
+  @Nonnull
+  public List<ExtendedCommunity> getRouteTargetImport() {
+    return _routeTargetImport;
+  }
+
+  public void addRouteTargetImport(ExtendedCommunity routeTargetImport) {
+    _routeTargetImport =
+        ImmutableList.<ExtendedCommunity>builder()
+            .addAll(_routeTargetImport)
+            .add(routeTargetImport)
+            .build();
+  }
+
+  @Nonnull private List<ExtendedCommunity> _routeTargetExport;
+  @Nonnull private List<ExtendedCommunity> _routeTargetImport;
+  @Nonnull private Map<String, String> _exportPolicyByVrf;
+  @Nonnull private Map<String, String> _importPolicyByVrf;
+  @Nullable private String _exportPolicy;
+  @Nullable private String _importPolicy;
+}

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -163,6 +163,7 @@ import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExpr;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
 import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
+import org.batfish.representation.cisco_xr.AddressFamilyType;
 import org.batfish.representation.cisco_xr.CiscoXrConfiguration;
 import org.batfish.representation.cisco_xr.DistributeList;
 import org.batfish.representation.cisco_xr.DistributeList.DistributeListFilterType;
@@ -1274,33 +1275,67 @@ public final class XrGrammarTest {
     assertThat(
         vc.getVrfs(),
         hasKeys(
-            Configuration.DEFAULT_VRF_NAME, "none", "single-oneline", "single-block", "multiple"));
+            Configuration.DEFAULT_VRF_NAME,
+            "none",
+            "single-oneline",
+            "single-block",
+            "multiple",
+            "multiple-af"));
     {
       Vrf v = vc.getVrfs().get("none");
-      assertThat(v.getRouteTargetExport(), empty());
-      assertThat(v.getRouteTargetImport(), empty());
+      assertThat(v.getIpv4UnicastAddressFamily().getRouteTargetExport(), empty());
+      assertThat(v.getIpv4UnicastAddressFamily().getRouteTargetImport(), empty());
     }
     {
       Vrf v = vc.getVrfs().get("single-oneline");
-      assertThat(v.getRouteTargetExport(), contains(ExtendedCommunity.target(1L, 1L)));
-      assertThat(v.getRouteTargetImport(), contains(ExtendedCommunity.target(2L, 2L)));
+      assertThat(
+          v.getIpv4UnicastAddressFamily().getRouteTargetExport(),
+          contains(ExtendedCommunity.target(1L, 1L)));
+      assertThat(
+          v.getIpv4UnicastAddressFamily().getRouteTargetImport(),
+          contains(ExtendedCommunity.target(2L, 2L)));
     }
     {
       Vrf v = vc.getVrfs().get("single-block");
-      assertThat(v.getRouteTargetExport(), contains(ExtendedCommunity.target(3L, 3L)));
-      assertThat(v.getRouteTargetImport(), contains(ExtendedCommunity.target(4L, 4L)));
+      assertThat(
+          v.getIpv4UnicastAddressFamily().getRouteTargetExport(),
+          contains(ExtendedCommunity.target(3L, 3L)));
+      assertThat(
+          v.getIpv4UnicastAddressFamily().getRouteTargetImport(),
+          contains(ExtendedCommunity.target(4L, 4L)));
     }
     {
       Vrf v = vc.getVrfs().get("multiple");
       assertThat(
-          v.getRouteTargetExport(),
+          v.getIpv4UnicastAddressFamily().getRouteTargetExport(),
           contains(ExtendedCommunity.target(5L, 5L), ExtendedCommunity.target(6L, 6L)));
       assertThat(
-          v.getRouteTargetImport(),
+          v.getIpv4UnicastAddressFamily().getRouteTargetImport(),
           contains(
               ExtendedCommunity.target(7L, 7L),
               ExtendedCommunity.target(8L, 9L),
               ExtendedCommunity.target(((10L << 16) + 11L), 12L)));
+    }
+    {
+      Vrf v = vc.getVrfs().get("multiple-af");
+      assertThat(
+          v.getAddressFamilies().get(AddressFamilyType.IPV4_UNICAST).getRouteTargetExport(),
+          contains(ExtendedCommunity.target(1L, 13L)));
+      assertThat(
+          v.getAddressFamilies().get(AddressFamilyType.IPV4_MULTICAST).getRouteTargetExport(),
+          contains(ExtendedCommunity.target(1L, 14L)));
+      assertThat(
+          v.getAddressFamilies().get(AddressFamilyType.IPV4_FLOWSPEC).getRouteTargetExport(),
+          contains(ExtendedCommunity.target(1L, 15L)));
+      assertThat(
+          v.getAddressFamilies().get(AddressFamilyType.IPV6_UNICAST).getRouteTargetExport(),
+          contains(ExtendedCommunity.target(1L, 16L)));
+      assertThat(
+          v.getAddressFamilies().get(AddressFamilyType.IPV6_MULTICAST).getRouteTargetExport(),
+          contains(ExtendedCommunity.target(1L, 17L)));
+      assertThat(
+          v.getAddressFamilies().get(AddressFamilyType.IPV6_FLOWSPEC).getRouteTargetExport(),
+          contains(ExtendedCommunity.target(1L, 18L)));
     }
   }
 
@@ -1308,24 +1343,28 @@ public final class XrGrammarTest {
   public void testVrfRoutePolicyExtraction() {
     String hostname = "xr-vrf-route-policy";
     CiscoXrConfiguration vc = parseVendorConfig(hostname);
-    assertThat(vc.getVrfs(), hasKeys(Configuration.DEFAULT_VRF_NAME, "v0", "v1"));
+    assertThat(vc.getVrfs(), hasKeys(Configuration.DEFAULT_VRF_NAME, "v0", "v1", "v2"));
     {
       Vrf v = vc.getVrfs().get("v0");
-      assertThat(v.getExportPolicy(), nullValue());
-      assertThat(v.getExportPolicyByVrf(), anEmptyMap());
-      assertThat(v.getImportPolicy(), nullValue());
-      assertThat(v.getImportPolicyByVrf(), anEmptyMap());
+      assertThat(v.getIpv4UnicastAddressFamily().getExportPolicy(), nullValue());
+      assertThat(v.getIpv4UnicastAddressFamily().getExportPolicyByVrf(), anEmptyMap());
+      assertThat(v.getIpv4UnicastAddressFamily().getImportPolicy(), nullValue());
+      assertThat(v.getIpv4UnicastAddressFamily().getImportPolicyByVrf(), anEmptyMap());
     }
     {
       Vrf v = vc.getVrfs().get("v1");
-      assertThat(v.getExportPolicy(), equalTo("p1"));
+      assertThat(v.getIpv4UnicastAddressFamily().getExportPolicy(), equalTo("p1"));
       assertThat(
-          v.getExportPolicyByVrf(),
+          v.getIpv4UnicastAddressFamily().getExportPolicyByVrf(),
           equalTo(ImmutableMap.of(Configuration.DEFAULT_VRF_NAME, "p2", "v0", "p3")));
-      assertThat(v.getImportPolicy(), equalTo("p4"));
+      assertThat(v.getIpv4UnicastAddressFamily().getImportPolicy(), equalTo("p4"));
       assertThat(
-          v.getImportPolicyByVrf(),
+          v.getIpv4UnicastAddressFamily().getImportPolicyByVrf(),
           equalTo(ImmutableMap.of(Configuration.DEFAULT_VRF_NAME, "p5", "v0", "p6")));
+    }
+    {
+      Vrf v = vc.getVrfs().get("v2");
+      assertThat(v.getIpv4UnicastAddressFamily(), nullValue());
     }
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/xr-vrf-route-policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/xr-vrf-route-policy
@@ -4,6 +4,8 @@ hostname xr-vrf-route-policy
 !
 
 vrf v0
+  address-family ipv4 unicast
+  !
 !
 
 vrf v1
@@ -15,4 +17,7 @@ vrf v1
     import from default-vrf route-policy p5
     import from v0 route-policy p6
   !
+!
+
+vrf v2
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/xr-vrf-route-target
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/xr-vrf-route-target
@@ -40,3 +40,24 @@ vrf multiple
     !
   !
 !
+
+vrf multiple-af
+  address-family ipv4 unicast
+    export route-target 1:13
+  !
+  address-family ipv4 multicast
+    export route-target 1:14
+  !
+  address-family ipv4 flowspec
+    export route-target 1:15
+  !
+  address-family ipv6 unicast
+    export route-target 1:16
+  !
+  address-family ipv6 multicast
+    export route-target 1:17
+  !
+  address-family ipv6 flowspec
+    export route-target 1:18
+  !
+!


### PR DESCRIPTION
- create VrfAddressFamily for address-family-specific information
- move route-target import/export configuration under VrfAddressFamily
- update vrf address-family parsing