### PR TITLE
MemoizedIpSpaceToBDD: use identity equality for IpSpace equality

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MemoizedIpSpaceToBDD.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/bdd/MemoizedIpSpaceToBDD.java
@@ -11,10 +11,22 @@ import org.batfish.datamodel.IpSpace;
 
 /** An {@link IpSpaceToBDD} that memoizes its {@link IpSpaceToBDD#visit} method. */
 public final class MemoizedIpSpaceToBDD extends IpSpaceToBDD {
+  /**
+   * The cache used for memoizing BDD conversions. We use weak keys to make the equality check be
+   * based on object identity instead of deep equality. This strategy makes sense because:
+   *
+   * <ul>
+   *   <li>Most IpSpace objects are interned, so they will be == if they are .equals().
+   *   <li>Complex IpSpace objects (AclIpSpace, IpWildcardSetIpSpace) that are not interned have
+   *       expensive equals methods, especially compared to conversion of mostly-cached inner
+   *       objects. So it's much faster to use == and reconvert different equivalent objects.
+   * </ul>
+   */
   private final LoadingCache<IpSpace, BDD> _cache =
       CacheBuilder.newBuilder()
           .maximumSize(1_000_000)
-          .concurrencyLevel(1) // The underlying BDD is not threadsafe.
+          .weakKeys() // this makes equality check for keys be identity, not deep.
+          .concurrencyLevel(1) // super::visit is not threadsafe, don't allocate multiple locks
           .build(CacheLoader.from(super::visit));
 
   public MemoizedIpSpaceToBDD(BDDInteger var, Map<String, IpSpace> namedIpSpaces) {

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BUILD
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/BUILD
@@ -39,6 +39,7 @@ junit_tests(
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:junit_junit",
+        "@maven//:org_apache_commons_commons_lang3",
         "@maven//:org_hamcrest_hamcrest",
     ],
 )

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MemoizedIpSpaceToBDDTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/bdd/MemoizedIpSpaceToBDDTest.java
@@ -1,15 +1,18 @@
 package org.batfish.common.bdd;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Optional;
 import net.sf.javabdd.BDD;
+import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.Prefix;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,5 +46,38 @@ public class MemoizedIpSpaceToBDDTest {
     assertTrue("IP1_IP_SPACE should be memoized", _toBdd.getMemoizedBdd(IP1_IP_SPACE).isPresent());
     assertTrue("IP2_IP_SPACE should be memoized", _toBdd.getMemoizedBdd(IP2_IP_SPACE).isPresent());
     assertThat(_toBdd.getMemoizedBdd(ACL_IP_SPACE), equalTo(Optional.of(bdd)));
+  }
+
+  /**
+   * A test that {@link AclIpSpace} memoization is feasible. This test finishes in well under a
+   * second on a laptop (2017 Macbook Pro 13"), but times out in several prior implementations of
+   * {@link MemoizedIpSpaceToBDD}.
+   */
+  @Test(timeout = 60_000)
+  public void testDeepAclIpSpace() {
+    int depth = 15;
+    long ip = Ip.parse("1.2.3.3").asLong();
+    IpSpace current =
+        AclIpSpace.builder()
+            .thenRejecting(Ip.parse("1.2.3.4").toIpSpace())
+            .thenPermitting(Prefix.parse("1.0.0.0/8").toIpSpace())
+            .thenRejecting(Ip.parse("2.2.3.4").toIpSpace())
+            .thenPermitting(Prefix.parse("2.0.0.0/8").toIpSpace())
+            .build();
+    assertThat(current, instanceOf(AclIpSpace.class));
+    for (int i = 0; i < depth; ++i) {
+      current =
+          AclIpSpace.permitting(Ip.create(ip++).toIpSpace())
+              .thenRejecting(current)
+              .thenPermitting(current.complement())
+              .thenRejecting(current.complement())
+              .thenPermitting(current.complement())
+              .thenRejecting(current.complement())
+              .thenPermitting(current.complement())
+              .build();
+    }
+    _toBdd.visit(current);
+    IpSpace cloned = SerializationUtils.clone(current);
+    _toBdd.visit(cloned);
   }
 }


### PR DESCRIPTION
Complex IpSpace objects (Acl, IpWildcardSet) have an expensive equals method,
which can cause problems for memoization: we have seen cases where converting
ForwardingAnalysis into BDDs took 10s pre-caching, and then a (cloned via
serialization) copy of the same objects took nearly 15m.

However, avoiding memoizing IpSpace -> BDD conversions altogether also causes
performance problems.

Instead, cache IpSpace objects with identity equality, so that multiple
conversions of the same object are remembered, but different equal objects are
converted redundantly.

Note that most IpSpace types are interned, so that `a != b` should imply
`!a.equals(b)` anyway.