### PR TITLE
IOS XR: update route-policy default action

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import java.util.Objects;
@@ -13,7 +12,6 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.route.nh.NextHop;
-import org.batfish.datamodel.route.nh.NextHopDiscard;
 
 /** Base class for OSPF external routes */
 @ParametersAreNonnullByDefault
@@ -129,18 +127,6 @@ public abstract class OspfExternalRoute extends OspfRoute {
   @Nonnull
   public static Builder builder() {
     return new Builder();
-  }
-
-  /** Return a route builder with pre-filled mandatory values. To be used in tests only */
-  @VisibleForTesting
-  public static Builder testBuilder() {
-    return builder()
-        .setOspfMetricType(OspfMetricType.E1)
-        .setLsaMetric(10L)
-        .setArea(11L)
-        .setCostToAdvertiser(12L)
-        .setAdvertiser("advertiser")
-        .setNextHop(NextHopDiscard.instance());
   }
 
   OspfExternalRoute(

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfExternalRoute.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import java.util.Objects;
@@ -12,6 +13,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.route.nh.NextHopDiscard;
 
 /** Base class for OSPF external routes */
 @ParametersAreNonnullByDefault
@@ -127,6 +129,18 @@ public abstract class OspfExternalRoute extends OspfRoute {
   @Nonnull
   public static Builder builder() {
     return new Builder();
+  }
+
+  /** Return a route builder with pre-filled mandatory values. To be used in tests only */
+  @VisibleForTesting
+  public static Builder testBuilder() {
+    return builder()
+        .setOspfMetricType(OspfMetricType.E1)
+        .setLsaMetric(10L)
+        .setArea(11L)
+        .setCostToAdvertiser(12L)
+        .setAdvertiser("advertiser")
+        .setNextHop(NextHopDiscard.instance());
   }
 
   OspfExternalRoute(

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyPrependAsPath.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyPrependAsPath.java
@@ -2,7 +2,6 @@ package org.batfish.representation.cisco_xr;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
-import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.common.Warnings;
@@ -13,9 +12,8 @@ import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.datamodel.routing_policy.expr.MultipliedAs;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.Statement;
-import org.batfish.datamodel.routing_policy.statement.Statements;
 
-public class RoutePolicyPrependAsPath extends RoutePolicyStatement {
+public class RoutePolicyPrependAsPath extends RoutePolicySetStatement {
 
   @Nonnull private AsExpr _expr;
   @Nullable private IntExpr _number;
@@ -26,12 +24,8 @@ public class RoutePolicyPrependAsPath extends RoutePolicyStatement {
   }
 
   @Override
-  public void applyTo(
-      List<Statement> statements, CiscoXrConfiguration cc, Configuration c, Warnings w) {
-    statements.add(
-        // prepend once by default, unless number modifier is present. TODO: verify this is correct
-        new PrependAsPath(new MultipliedAs(_expr, firstNonNull(_number, new LiteralInt(1)))));
-    // Modified routes are not subject to default-drop disposition
-    statements.add(Statements.SetDefaultActionAccept.toStaticStatement());
+  public Statement toSetStatement(CiscoXrConfiguration cc, Configuration c, Warnings w) {
+    // prepend once by default, unless number modifier is present. TODO: verify this is correct
+    return new PrependAsPath(new MultipliedAs(_expr, firstNonNull(_number, new LiteralInt(1))));
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyPrependAsPath.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicyPrependAsPath.java
@@ -13,6 +13,7 @@ import org.batfish.datamodel.routing_policy.expr.LiteralInt;
 import org.batfish.datamodel.routing_policy.expr.MultipliedAs;
 import org.batfish.datamodel.routing_policy.statement.PrependAsPath;
 import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.batfish.datamodel.routing_policy.statement.Statements;
 
 public class RoutePolicyPrependAsPath extends RoutePolicyStatement {
 
@@ -30,5 +31,7 @@ public class RoutePolicyPrependAsPath extends RoutePolicyStatement {
     statements.add(
         // prepend once by default, unless number modifier is present. TODO: verify this is correct
         new PrependAsPath(new MultipliedAs(_expr, firstNonNull(_number, new LiteralInt(1)))));
+    // Modified routes are not subject to default-drop disposition
+    statements.add(Statements.SetDefaultActionAccept.toStaticStatement());
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicySetIsisMetricType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicySetIsisMetricType.java
@@ -6,6 +6,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.isis.IsisMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetIsisMetricType;
 import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.batfish.datamodel.routing_policy.statement.Statements;
 
 public class RoutePolicySetIsisMetricType extends RoutePolicyStatement {
 
@@ -19,5 +20,7 @@ public class RoutePolicySetIsisMetricType extends RoutePolicyStatement {
   public void applyTo(
       List<Statement> statements, CiscoXrConfiguration cc, Configuration c, Warnings w) {
     statements.add(new SetIsisMetricType(_type));
+    // Modified routes are not subject to default-drop disposition
+    statements.add(Statements.SetDefaultActionAccept.toStaticStatement());
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicySetIsisMetricType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicySetIsisMetricType.java
@@ -1,14 +1,12 @@
 package org.batfish.representation.cisco_xr;
 
-import java.util.List;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.isis.IsisMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetIsisMetricType;
 import org.batfish.datamodel.routing_policy.statement.Statement;
-import org.batfish.datamodel.routing_policy.statement.Statements;
 
-public class RoutePolicySetIsisMetricType extends RoutePolicyStatement {
+public class RoutePolicySetIsisMetricType extends RoutePolicySetStatement {
 
   private IsisMetricType _type;
 
@@ -17,10 +15,7 @@ public class RoutePolicySetIsisMetricType extends RoutePolicyStatement {
   }
 
   @Override
-  public void applyTo(
-      List<Statement> statements, CiscoXrConfiguration cc, Configuration c, Warnings w) {
-    statements.add(new SetIsisMetricType(_type));
-    // Modified routes are not subject to default-drop disposition
-    statements.add(Statements.SetDefaultActionAccept.toStaticStatement());
+  public Statement toSetStatement(CiscoXrConfiguration cc, Configuration c, Warnings w) {
+    return new SetIsisMetricType(_type);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicySetOspfMetricType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicySetOspfMetricType.java
@@ -1,14 +1,12 @@
 package org.batfish.representation.cisco_xr;
 
-import java.util.List;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
 import org.batfish.datamodel.routing_policy.statement.Statement;
-import org.batfish.datamodel.routing_policy.statement.Statements;
 
-public class RoutePolicySetOspfMetricType extends RoutePolicyStatement {
+public class RoutePolicySetOspfMetricType extends RoutePolicySetStatement {
 
   private OspfMetricType _type;
 
@@ -17,10 +15,7 @@ public class RoutePolicySetOspfMetricType extends RoutePolicyStatement {
   }
 
   @Override
-  public void applyTo(
-      List<Statement> statements, CiscoXrConfiguration cc, Configuration c, Warnings w) {
-    statements.add(new SetOspfMetricType(_type));
-    // Modified routes are not subject to default-drop disposition
-    statements.add(Statements.SetDefaultActionAccept.toStaticStatement());
+  public Statement toSetStatement(CiscoXrConfiguration cc, Configuration c, Warnings w) {
+    return new SetOspfMetricType(_type);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicySetOspfMetricType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicySetOspfMetricType.java
@@ -6,6 +6,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.routing_policy.statement.SetOspfMetricType;
 import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.batfish.datamodel.routing_policy.statement.Statements;
 
 public class RoutePolicySetOspfMetricType extends RoutePolicyStatement {
 
@@ -19,5 +20,7 @@ public class RoutePolicySetOspfMetricType extends RoutePolicyStatement {
   public void applyTo(
       List<Statement> statements, CiscoXrConfiguration cc, Configuration c, Warnings w) {
     statements.add(new SetOspfMetricType(_type));
+    // Modified routes are not subject to default-drop disposition
+    statements.add(Statements.SetDefaultActionAccept.toStaticStatement());
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicySetVarMetricType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicySetVarMetricType.java
@@ -1,13 +1,11 @@
 package org.batfish.representation.cisco_xr;
 
-import java.util.List;
 import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.routing_policy.statement.SetVarMetricType;
 import org.batfish.datamodel.routing_policy.statement.Statement;
-import org.batfish.datamodel.routing_policy.statement.Statements;
 
-public class RoutePolicySetVarMetricType extends RoutePolicyStatement {
+public class RoutePolicySetVarMetricType extends RoutePolicySetStatement {
 
   private String _var;
 
@@ -16,10 +14,7 @@ public class RoutePolicySetVarMetricType extends RoutePolicyStatement {
   }
 
   @Override
-  public void applyTo(
-      List<Statement> statements, CiscoXrConfiguration cc, Configuration c, Warnings w) {
-    statements.add(new SetVarMetricType(_var));
-    // Modified routes are not subject to default-drop disposition
-    statements.add(Statements.SetDefaultActionAccept.toStaticStatement());
+  public Statement toSetStatement(CiscoXrConfiguration cc, Configuration c, Warnings w) {
+    return new SetVarMetricType(_var);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicySetVarMetricType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/RoutePolicySetVarMetricType.java
@@ -5,6 +5,7 @@ import org.batfish.common.Warnings;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.routing_policy.statement.SetVarMetricType;
 import org.batfish.datamodel.routing_policy.statement.Statement;
+import org.batfish.datamodel.routing_policy.statement.Statements;
 
 public class RoutePolicySetVarMetricType extends RoutePolicyStatement {
 
@@ -18,5 +19,7 @@ public class RoutePolicySetVarMetricType extends RoutePolicyStatement {
   public void applyTo(
       List<Statement> statements, CiscoXrConfiguration cc, Configuration c, Warnings w) {
     statements.add(new SetVarMetricType(_var));
+    // Modified routes are not subject to default-drop disposition
+    statements.add(Statements.SetDefaultActionAccept.toStaticStatement());
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -617,32 +617,33 @@ public final class XrGrammarTest {
     Prefix prefixLocalPrefThenDrop = Prefix.parse("10.10.10.0/24");
     Prefix prefixAsPath = Prefix.parse("192.168.2.0/24");
     Prefix prefixOspfMetricType = Prefix.parse("192.168.1.0/24");
-    Bgpv4Route.Builder baseBgp = Bgpv4Route.testBuilder();
-    OspfExternalRoute.Builder baseOspf =
-        OspfExternalRoute.testBuilder()
-            .setOspfMetricType(OspfMetricType.E1)
-            .setNetwork(prefixOspfMetricType);
+    Bgpv4Route.Builder bgpLocalPref = Bgpv4Route.testBuilder().setNetwork(prefixLocalPref);
+    Bgpv4Route.Builder bgpLocalPrefThenDrop =
+        Bgpv4Route.testBuilder().setNetwork(prefixLocalPrefThenDrop);
+    Bgpv4Route.Builder bgpNoMatch = Bgpv4Route.testBuilder().setNetwork(prefixNoMatch);
+    Bgpv4Route.Builder bgpAsPath = Bgpv4Route.testBuilder().setNetwork(prefixAsPath);
+    OspfExternalRoute.Builder ospfMetricType =
+        OspfExternalType1Route.testBuilder().setNetwork(prefixOspfMetricType);
 
     assertThat(c.getRoutingPolicies(), hasKeys("implicit-actions"));
     RoutingPolicy rp = c.getRoutingPolicies().get("implicit-actions");
 
     // If routes are updated, default-deny doesn't apply
     // Confirm default is accept when local-pref is updated
-    assertRoutingPolicyPermitsRoute(rp, baseBgp.setNetwork(prefixLocalPref).build(), baseBgp);
-    assertThat(baseBgp.build().getLocalPreference(), equalTo(100L));
+    assertRoutingPolicyPermitsRoute(rp, bgpLocalPref.build(), bgpLocalPref);
+    assertThat(bgpLocalPref.build().getLocalPreference(), equalTo(100L));
     // Confirm default is pass when as-path is updated
-    assertRoutingPolicyPermitsRoute(rp, baseBgp.setNetwork(prefixAsPath).build(), baseBgp);
-    assertThat(baseBgp.build().getAsPath(), equalTo(AsPath.ofSingletonAsSets(65432L)));
+    assertRoutingPolicyPermitsRoute(rp, bgpAsPath.build(), bgpAsPath);
+    assertThat(bgpAsPath.build().getAsPath(), equalTo(AsPath.ofSingletonAsSets(65432L)));
     // Confirm default is pass when OSPF metric type is updated
-    assertRoutingPolicyPermitsRoute(rp, baseOspf.build(), baseOspf);
-    assertThat(baseOspf.build().getOspfMetricType(), equalTo(OspfMetricType.E2));
+    assertRoutingPolicyPermitsRoute(rp, ospfMetricType.build(), ospfMetricType);
+    assertThat(ospfMetricType.build().getOspfMetricType(), equalTo(OspfMetricType.E2));
 
     // Even if default is pass, explicit drop should still take effect
-    assertRoutingPolicyDeniesRoute(rp, baseBgp.setNetwork(prefixLocalPrefThenDrop).build());
+    assertRoutingPolicyDeniesRoute(rp, bgpLocalPrefThenDrop.build());
 
     // No match / no route update should use default-deny
-    Bgpv4Route bgpNoMatch = baseBgp.setNetwork(prefixNoMatch).build();
-    assertRoutingPolicyDeniesRoute(rp, bgpNoMatch);
+    assertRoutingPolicyDeniesRoute(rp, bgpNoMatch.build());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/route-policy-implicit-actions
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/route-policy-implicit-actions
@@ -1,0 +1,29 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+!
+hostname route-policy-implicit-actions
+!
+prefix-set DEST_A
+  10.10.0.0/16 le 32
+end-set
+prefix-set DEST_B
+  10.10.10.0/24
+end-set
+prefix-set DEST_C
+  192.168.1.0/24
+end-set
+prefix-set DEST_D
+  192.168.2.0/24
+end-set
+!
+route-policy implicit-actions
+  if destination in DEST_A and not destination in DEST_B then
+    set local-preference 100
+  elseif destination in DEST_C then
+    set metric-type type-2
+  endif
+  if destination in DEST_D then
+    prepend as-path 65432
+  endif
+end-policy
+!
+end

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/route-policy-implicit-actions
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/route-policy-implicit-actions
@@ -23,7 +23,7 @@ route-policy implicit-actions
   elseif destination in DEST_C then
     prepend as-path 65432
   endif
-  ! Even through SUB_DEST_A is covered above / default-pass
+  ! Even though SUB_DEST_A is covered above / default-pass
   ! It should still be dropped
   if destination in SUB_DEST_A then
     drop

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/route-policy-implicit-actions
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/route-policy-implicit-actions
@@ -5,24 +5,28 @@ hostname route-policy-implicit-actions
 prefix-set DEST_A
   10.10.0.0/16 le 32
 end-set
-prefix-set DEST_B
+prefix-set SUB_DEST_A
   10.10.10.0/24
 end-set
-prefix-set DEST_C
+prefix-set DEST_B
   192.168.1.0/24
 end-set
-prefix-set DEST_D
+prefix-set DEST_C
   192.168.2.0/24
 end-set
 !
 route-policy implicit-actions
-  if destination in DEST_A and not destination in DEST_B then
+  if destination in DEST_A then
     set local-preference 100
-  elseif destination in DEST_C then
+  elseif destination in DEST_B then
     set metric-type type-2
-  endif
-  if destination in DEST_D then
+  elseif destination in DEST_C then
     prepend as-path 65432
+  endif
+  ! Even through SUB_DEST_A is covered above / default-pass
+  ! It should still be dropped
+  if destination in SUB_DEST_A then
+    drop
   endif
 end-policy
 !

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -79096,6 +79096,10 @@
                     "metricType" : "INTERNAL"
                   },
                   {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "SetDefaultActionAccept"
+                  },
+                  {
                     "class" : "org.batfish.datamodel.routing_policy.statement.BufferedStatement",
                     "statement" : {
                       "class" : "org.batfish.datamodel.routing_policy.communities.SetCommunities",
@@ -79489,6 +79493,10 @@
                         "value" : 3
                       }
                     }
+                  },
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "SetDefaultActionAccept"
                   }
                 ]
               },
@@ -81378,6 +81386,10 @@
                                     "value" : 3
                                   }
                                 }
+                              },
+                              {
+                                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                                "type" : "SetDefaultActionAccept"
                               },
                               {
                                 "class" : "org.batfish.datamodel.routing_policy.statement.BufferedStatement",

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -79092,12 +79092,30 @@
                 },
                 "trueStatements" : [
                   {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetIsisMetricType",
-                    "metricType" : "INTERNAL"
+                    "class" : "org.batfish.datamodel.routing_policy.statement.BufferedStatement",
+                    "statement" : {
+                      "class" : "org.batfish.datamodel.routing_policy.statement.SetIsisMetricType",
+                      "metricType" : "INTERNAL"
+                    }
                   },
                   {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetDefaultActionAccept"
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "SetDefaultActionAccept"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                      "type" : "CallExprContext"
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "SetLocalDefaultActionAccept"
+                      }
+                    ]
                   },
                   {
                     "class" : "org.batfish.datamodel.routing_policy.statement.BufferedStatement",
@@ -79481,22 +79499,40 @@
                 },
                 "trueStatements" : [
                   {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.PrependAsPath",
-                    "expr" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.MultipliedAs",
+                    "class" : "org.batfish.datamodel.routing_policy.statement.BufferedStatement",
+                    "statement" : {
+                      "class" : "org.batfish.datamodel.routing_policy.statement.PrependAsPath",
                       "expr" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitAs",
-                        "as" : 2152
-                      },
-                      "number" : {
-                        "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
-                        "value" : 3
+                        "class" : "org.batfish.datamodel.routing_policy.expr.MultipliedAs",
+                        "expr" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitAs",
+                          "as" : 2152
+                        },
+                        "number" : {
+                          "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                          "value" : 3
+                        }
                       }
                     }
                   },
                   {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "SetDefaultActionAccept"
+                    "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                    "falseStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "SetDefaultActionAccept"
+                      }
+                    ],
+                    "guard" : {
+                      "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                      "type" : "CallExprContext"
+                    },
+                    "trueStatements" : [
+                      {
+                        "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                        "type" : "SetLocalDefaultActionAccept"
+                      }
+                    ]
                   }
                 ]
               },
@@ -81374,22 +81410,40 @@
                             },
                             "trueStatements" : [
                               {
-                                "class" : "org.batfish.datamodel.routing_policy.statement.PrependAsPath",
-                                "expr" : {
-                                  "class" : "org.batfish.datamodel.routing_policy.expr.MultipliedAs",
+                                "class" : "org.batfish.datamodel.routing_policy.statement.BufferedStatement",
+                                "statement" : {
+                                  "class" : "org.batfish.datamodel.routing_policy.statement.PrependAsPath",
                                   "expr" : {
-                                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitAs",
-                                    "as" : 2152
-                                  },
-                                  "number" : {
-                                    "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
-                                    "value" : 3
+                                    "class" : "org.batfish.datamodel.routing_policy.expr.MultipliedAs",
+                                    "expr" : {
+                                      "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitAs",
+                                      "as" : 2152
+                                    },
+                                    "number" : {
+                                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralInt",
+                                      "value" : 3
+                                    }
                                   }
                                 }
                               },
                               {
-                                "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                                "type" : "SetDefaultActionAccept"
+                                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                                "falseStatements" : [
+                                  {
+                                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                                    "type" : "SetDefaultActionAccept"
+                                  }
+                                ],
+                                "guard" : {
+                                  "class" : "org.batfish.datamodel.routing_policy.expr.BooleanExprs$StaticBooleanExpr",
+                                  "type" : "CallExprContext"
+                                },
+                                "trueStatements" : [
+                                  {
+                                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                                    "type" : "SetLocalDefaultActionAccept"
+                                  }
+                                ]
                               },
                               {
                                 "class" : "org.batfish.datamodel.routing_policy.statement.BufferedStatement",


### PR DESCRIPTION
Routes that are modified in route-policies are treated as default-pass instead of default-drop. From [Cisco docs](https://www.cisco.com/c/en/us/td/docs/routers/xr12000/software/xr12k_r4-0/routing/configuration/guide/rc40xr12k_chapter7.html#con_1118699):

> Default Drop Disposition
> All route policies have a default action to drop the route under evaluation unless the route has been modified by a policy action or explicitly passed. Applied (nested) policies implement this disposition as though the applied policy were pasted into the point where it is applied.
