### PR TITLE
InterfacesByVlanRange: canonicalize on the way in

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/InterfacesByVlanRange.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/InterfacesByVlanRange.java
@@ -51,11 +51,12 @@ class InterfacesByVlanRange {
    * of existing and provided interfaces.
    */
   public void add(Range<Integer> vlans, Collection<String> interfaces) {
-    if (vlans.isEmpty() || interfaces.isEmpty()) {
+    Range<Integer> canonical = vlans.canonical(DiscreteDomain.integers());
+    if (canonical.isEmpty() || interfaces.isEmpty()) {
       return;
     }
     _ranges.merge(
-        vlans,
+        canonical,
         ImmutableSet.copyOf(interfaces),
         (a, b) -> ImmutableSet.<String>builder().addAll(a).addAll(b).build());
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/InterfacesByVlanRangeTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/InterfacesByVlanRangeTest.java
@@ -33,9 +33,10 @@ public class InterfacesByVlanRangeTest {
   @Test
   public void testAddToEmpty() {
     Range<Integer> range = Range.closed(1, 2);
+    Range<Integer> canonical = Range.closedOpen(1, 3);
     ImmutableSet<String> interfaces = ImmutableSet.of("iface1", "iface2");
     _interfacesByVlanRange.add(range, interfaces);
-    assertThat(_interfacesByVlanRange.asMap(), hasEntry(range, interfaces));
+    assertThat(_interfacesByVlanRange.asMap(), hasEntry(canonical, interfaces));
   }
 
   @Test
@@ -50,8 +51,8 @@ public class InterfacesByVlanRangeTest {
         _interfacesByVlanRange.asMap(),
         allOf(
             hasEntry(Range.closedOpen(1, 5), set1),
-            hasEntry(Range.closed(5, 10), ImmutableSet.of("iface1", "iface2")),
-            hasEntry(Range.openClosed(10, 20), set2)));
+            hasEntry(Range.closedOpen(5, 11), ImmutableSet.of("iface1", "iface2")),
+            hasEntry(Range.closedOpen(11, 21), set2)));
   }
 
   @Test
@@ -69,10 +70,10 @@ public class InterfacesByVlanRangeTest {
         _interfacesByVlanRange.asMap(),
         allOf(
             hasEntry(Range.closedOpen(1, 5), set1),
-            hasEntry(Range.closed(5, 10), ImmutableSet.of("iface1", "iface3")),
-            hasEntry(Range.open(10, 20), set3),
-            hasEntry(Range.closed(20, 25), ImmutableSet.of("iface2", "iface3")),
-            hasEntry(Range.openClosed(25, 30), set2)));
+            hasEntry(Range.closedOpen(5, 11), ImmutableSet.of("iface1", "iface3")),
+            hasEntry(Range.closedOpen(11, 20), set3),
+            hasEntry(Range.closedOpen(20, 26), ImmutableSet.of("iface2", "iface3")),
+            hasEntry(Range.closedOpen(26, 31), set2)));
   }
 
   @Test
@@ -87,8 +88,8 @@ public class InterfacesByVlanRangeTest {
         _interfacesByVlanRange.asMap(),
         allOf(
             hasEntry(Range.closedOpen(1, 5), set1),
-            hasEntry(Range.closed(5, 10), ImmutableSet.of("iface1", "iface2")),
-            hasEntry(Range.openClosed(10, 20), set1)));
+            hasEntry(Range.closedOpen(5, 11), ImmutableSet.of("iface1", "iface2")),
+            hasEntry(Range.closedOpen(11, 21), set1)));
   }
 
   @Test
@@ -105,10 +106,11 @@ public class InterfacesByVlanRangeTest {
   @Test
   public void testGetRange() {
     Range<Integer> range = Range.closed(1, 10);
+    Range<Integer> canonicalRange = Range.closedOpen(1, 11);
     ImmutableSet<String> interfaces = ImmutableSet.of("iface1", "iface2");
     _interfacesByVlanRange.add(range, interfaces);
     for (int i = 1; i <= 10; i++) {
-      assertThat(_interfacesByVlanRange.getRange(i), equalTo(range));
+      assertThat(_interfacesByVlanRange.getRange(i), equalTo(canonicalRange));
     }
     assertThat(_interfacesByVlanRange.getRange(11), nullValue());
   }


### PR DESCRIPTION
This should not have any e2e functional changes, but it sure makes the output
easier to understand. It also makes the intersection operation never produce an
empty intersection, since two closedOpen ranges cannot produce one.