### PR TITLE
Support setting admin/weight for bgp-vrf-leaked IGP routes

### DIFF
--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfLeakingConfigTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/VrfLeakingConfigTest.java
@@ -20,7 +20,12 @@ public class VrfLeakingConfigTest {
         VrfLeakingConfig.builder()
             .setImportFromVrf("vrf1")
             .setImportPolicy("policy")
-            .setBgpLeakConfig(BgpLeakConfig.forRouteTargets(ExtendedCommunity.target(1, 2)))
+            .setBgpLeakConfig(
+                BgpLeakConfig.builder()
+                    .setAdmin(5)
+                    .setAttachRouteTargets(ExtendedCommunity.target(1, 2))
+                    .setWeight(3)
+                    .build())
             .build();
     assertThat(SerializationUtils.clone(val), equalTo(val));
   }
@@ -31,7 +36,12 @@ public class VrfLeakingConfigTest {
         VrfLeakingConfig.builder()
             .setImportFromVrf("vrf1")
             .setImportPolicy("policy")
-            .setBgpLeakConfig(BgpLeakConfig.forRouteTargets(ExtendedCommunity.target(1, 2)))
+            .setBgpLeakConfig(
+                BgpLeakConfig.builder()
+                    .setAdmin(5)
+                    .setAttachRouteTargets(ExtendedCommunity.target(1, 2))
+                    .setWeight(3)
+                    .build())
             .build();
     assertThat(BatfishObjectMapper.clone(val, VrfLeakingConfig.class), equalTo(val));
   }
@@ -39,14 +49,21 @@ public class VrfLeakingConfigTest {
   @Test
   public void testEquals() {
     Builder b = VrfLeakingConfig.builder().setImportFromVrf("vrf1").setImportPolicy("policy");
+    BgpLeakConfig.Builder bgpLeakConfigBuilder = BgpLeakConfig.builder();
     VrfLeakingConfig val = b.build();
     new EqualsTester()
         .addEqualityGroup(val, val, b.build())
         .addEqualityGroup(b.setImportFromVrf("vrf2").build())
         .addEqualityGroup(b.setImportPolicy("policy2").build())
+        .addEqualityGroup(b.setBgpLeakConfig(bgpLeakConfigBuilder.build()).build())
+        .addEqualityGroup(b.setBgpLeakConfig(bgpLeakConfigBuilder.setAdmin(5).build()).build())
         .addEqualityGroup(
-            b.setBgpLeakConfig(BgpLeakConfig.forRouteTargets(ExtendedCommunity.target(1, 2)))
+            b.setBgpLeakConfig(
+                    bgpLeakConfigBuilder
+                        .setAttachRouteTargets(ExtendedCommunity.target(1, 2))
+                        .build())
                 .build())
+        .addEqualityGroup(b.setBgpLeakConfig(bgpLeakConfigBuilder.setWeight(3).build()).build())
         .addEqualityGroup(new Object())
         .testEquals();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/BgpRouteMatchers.java
@@ -83,6 +83,14 @@ public final class BgpRouteMatchers {
   }
 
   /**
+   * Provides a matcher that matches when the {@link AbstractRoute}'s weight is matched by the
+   * provided {@code subMatcher}..
+   */
+  public static @Nonnull Matcher<HasReadableWeight> hasWeight(Matcher<? super Integer> subMatcher) {
+    return new HasWeight(subMatcher);
+  }
+
+  /**
    * Provides a matcher that matches when the {@link AbstractRoute} is a {@link Bgpv4Route} matched
    * by the provided {@code subMatcher}.
    */

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -1713,6 +1713,15 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
                   .setNonRouting(false)
                   .setNextHop(NextHopVrf.of(importFromVrf))
                   .addCommunities(bgpConfig.getAttachRouteTargets());
+          switch (route.getSrcProtocol()) {
+            case AGGREGATE: // local BGP route
+            case BGP:
+            case IBGP:
+              break;
+            default:
+              builder.setAdmin(bgpConfig.getAdmin()).setWeight(bgpConfig.getWeight());
+              break;
+          }
 
           // Process route through import policy, if one exists
           boolean accept = true;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConversions.java
@@ -1846,7 +1846,8 @@ public class AsaConversions {
           }
           viVrf.addVrfLeakingConfig(
               VrfLeakingConfig.builder()
-                  .setBgpLeakConfig(BgpLeakConfig.forRouteTargets(importRt))
+                  // TODO: VRF leaking even allowed? If so, write admin and weight.
+                  .setBgpLeakConfig(BgpLeakConfig.builder().setAttachRouteTargets(importRt).build())
                   .setImportFromVrf(exportingVrf)
                   .setImportPolicy(routeMapOrRejectAll(ipv4uaf.getImportMap(), c))
                   .build());
@@ -1860,7 +1861,8 @@ public class AsaConversions {
           }
           viVrf.addVrfLeakingConfig(
               VrfLeakingConfig.builder()
-                  .setBgpLeakConfig(BgpLeakConfig.forRouteTargets(importRt))
+                  // TODO: VRF leaking even allowed? If so, write admin and weight.
+                  .setBgpLeakConfig(BgpLeakConfig.builder().setAttachRouteTargets(importRt).build())
                   .setImportFromVrf(mapExportingVrf.getName())
                   .setImportPolicy(
                       vrfExportImportPolicy(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -168,6 +168,7 @@ import static org.batfish.representation.cisco.CiscoConfiguration.computeService
 import static org.batfish.representation.cisco.CiscoConfiguration.computeZonePairAclName;
 import static org.batfish.representation.cisco.CiscoConfiguration.eigrpNeighborExportPolicyName;
 import static org.batfish.representation.cisco.CiscoConfiguration.eigrpNeighborImportPolicyName;
+import static org.batfish.representation.cisco.CiscoConversions.BGP_VRF_LEAK_IGP_WEIGHT;
 import static org.batfish.representation.cisco.CiscoConversions.computeVrfExportImportPolicyName;
 import static org.batfish.representation.cisco.CiscoIosDynamicNat.computeDynamicDestinationNatAclName;
 import static org.batfish.representation.cisco.CiscoStructureType.ACCESS_LIST;
@@ -5703,7 +5704,14 @@ public final class CiscoGrammarTest {
     Configuration c = parseConfig(hostname);
     VrfLeakingConfig.Builder builder =
         VrfLeakingConfig.builder()
-            .setBgpLeakConfig(BgpLeakConfig.forRouteTargets(ExtendedCommunity.target(65003, 11)));
+            .setBgpLeakConfig(
+                BgpLeakConfig.builder()
+                    .setAdmin(
+                        RoutingProtocol.BGP.getDefaultAdministrativeCost(
+                            ConfigurationFormat.CISCO_IOS))
+                    .setAttachRouteTargets(ExtendedCommunity.target(65003, 11))
+                    .setWeight(BGP_VRF_LEAK_IGP_WEIGHT)
+                    .build());
     assertThat(
         c.getVrfs().get("DST_VRF").getVrfLeakConfigs(),
         containsInAnyOrder(


### PR DESCRIPTION
- do not adjust admin distance nor weight for leaked BGP routes