### PR TITLE
NXOS route-map: match undefined prefix-list matches all

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -3360,9 +3360,16 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
           @Override
           public BooleanExpr visitRouteMapMatchIpAddressPrefixList(
               RouteMapMatchIpAddressPrefixList routeMapMatchIpAddressPrefixList) {
+            if (!_ipPrefixLists.keySet().containsAll(routeMapMatchIpAddressPrefixList.getNames())) {
+              // Lab tests show that this permits all routes:
+              //   route-map RM permit 10
+              //    match ip address prefix-list UNDEFINED
+              // TODO: Explore behavior with multiple prefix-lists configured
+              // TODO: Check that match behavior is the same if the term denies
+              return BooleanExprs.TRUE;
+            }
             return new Disjunction(
                 routeMapMatchIpAddressPrefixList.getNames().stream()
-                    .filter(_ipPrefixLists::containsKey)
                     .map(
                         name ->
                             new MatchPrefixSet(

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -6729,8 +6729,9 @@ public final class CiscoNxosGrammarTest {
       assertRoutingPolicyDeniesRoute(rp, base);
     }
     {
+      // when the prefix-list is undefined, the term matches all routes
       RoutingPolicy rp = c.getRoutingPolicies().get("match_undefined_prefix_list");
-      assertRoutingPolicyDeniesRoute(rp, base);
+      assertRoutingPolicyPermitsRoute(rp, base);
     }
 
     // continue route-maps


### PR DESCRIPTION
cc: @chiragvyas50

Lab tests found that this route-map would permit all routes:
```
route-map RM permit 10
  match ip address prefix-list UNDEFINED
```
Batfish's behavior in this situation was for the route-map to match nothing, and thus default deny all routes.