### PR TITLE
NXOS: exclude default-routes as in NHI resolution process

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Vrf.java
@@ -42,6 +42,7 @@ public class Vrf extends ComparableStructure<String> {
     @Nullable private String _name;
     @Nullable private Supplier<String> _nameGenerator;
     @Nullable private Configuration _owner;
+    @Nullable private String _resolutionPolicy;
     @Nonnull private Map<Long, EigrpProcess> _eigrpProcesses = ImmutableMap.of();
 
     @Nonnull
@@ -60,6 +61,7 @@ public class Vrf extends ComparableStructure<String> {
       }
       vrf.setEigrpProcesses(_eigrpProcesses);
       vrf.setVrfLeakConfigs(_vrfLeakingConfigs.build());
+      vrf.setResolutionPolicy(_resolutionPolicy);
       return vrf;
     }
 
@@ -75,6 +77,11 @@ public class Vrf extends ComparableStructure<String> {
 
     public Builder setOwner(@Nullable Configuration owner) {
       _owner = owner;
+      return this;
+    }
+
+    public Builder setResolutionPolicy(@Nullable String resolutionPolicy) {
+      _resolutionPolicy = resolutionPolicy;
       return this;
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1352,10 +1352,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
         .setStatements(
             ImmutableList.of(
                 new If(
-                    new MatchPrefixSet(
-                        DestinationNetwork.instance(),
-                        new ExplicitPrefixSet(
-                            new PrefixSpace(PrefixRange.fromPrefix(Prefix.parse("0.0.0.0/0"))))),
+                    matchDefaultRoute(),
                     ImmutableList.of(Statements.ReturnFalse.toStaticStatement()),
                     ImmutableList.of(Statements.ReturnTrue.toStaticStatement()))))
         .build();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -274,7 +274,9 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
    */
   public static final String DEFAULT_POLICY_MAP_OUT = "default-out-policy";
 
-  /** Name of the generated resolution policy, implementing NX-OS resolution filtering */
+  /**
+   * Name of the generated static route resolution policy, implementing NX-OS resolution filtering
+   */
   public static final String RESOLUTION_POLICY_NAME = "~RESOLUTION_POLICY~";
 
   private int _currentContextVrfId;
@@ -1345,7 +1347,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   }
 
   private void convertVrfs() {
-    // Build resolution policy used by VRFs; prevents resolution w/ default-routes
+    // Build static route resolution policy used by VRFs; prevents resolution w/ default-routes
     RoutingPolicy.builder()
         .setOwner(_c)
         .setName(RESOLUTION_POLICY_NAME)

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -274,6 +274,9 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
    */
   public static final String DEFAULT_POLICY_MAP_OUT = "default-out-policy";
 
+  /** Name of the generated resolution policy, implementing NX-OS resolution filtering */
+  public static final String RESOLUTION_POLICY_NAME = "~RESOLUTION_POLICY~";
+
   private int _currentContextVrfId;
 
   /** Returns canonical prefix of interface name if valid, else {@code null}. */
@@ -1342,6 +1345,21 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   }
 
   private void convertVrfs() {
+    // Build resolution policy used by VRFs; prevents resolution w/ default-routes
+    RoutingPolicy.builder()
+        .setOwner(_c)
+        .setName(RESOLUTION_POLICY_NAME)
+        .setStatements(
+            ImmutableList.of(
+                new If(
+                    new MatchPrefixSet(
+                        DestinationNetwork.instance(),
+                        new ExplicitPrefixSet(
+                            new PrefixSpace(PrefixRange.fromPrefix(Prefix.parse("0.0.0.0/0"))))),
+                    ImmutableList.of(Statements.ReturnFalse.toStaticStatement()),
+                    ImmutableList.of(Statements.ReturnTrue.toStaticStatement()))))
+        .build();
+
     _vrfs.forEach((name, vrf) -> _c.getVrfs().put(name, toVrf(vrf)));
   }
 
@@ -3709,7 +3727,9 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
   private @Nonnull org.batfish.datamodel.Vrf toVrf(Vrf vrf) {
     org.batfish.datamodel.Vrf.Builder newVrfBuilder =
-        org.batfish.datamodel.Vrf.builder().setName(vrf.getName());
+        org.batfish.datamodel.Vrf.builder()
+            .setName(vrf.getName())
+            .setResolutionPolicy(RESOLUTION_POLICY_NAME);
     return newVrfBuilder.build();
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -8577,9 +8577,7 @@ public final class CiscoNxosGrammarTest {
     // Policy should not accept default routes
     assertFalse(
         r.processReadOnly(
-            org.batfish.datamodel.StaticRoute.testBuilder()
-                .setNetwork(Prefix.create(ZERO, 0))
-                .build()));
+            org.batfish.datamodel.StaticRoute.testBuilder().setNetwork(Prefix.ZERO).build()));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -6441,7 +6441,8 @@ public final class CiscoNxosGrammarTest {
             computeRoutingPolicyName("continue_from_set_to_match_on_set_field", 20),
             "reach_continue_target_without_match",
             computeRoutingPolicyName("reach_continue_target_without_match", 10),
-            computeRoutingPolicyName("reach_continue_target_without_match", 30)));
+            computeRoutingPolicyName("reach_continue_target_without_match", 30),
+            RESOLUTION_POLICY_NAME));
     Ip origNextHopIp = Ip.parse("192.0.2.254");
     Bgpv4Route base =
         Bgpv4Route.testBuilder()

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -9,6 +9,7 @@ import static org.batfish.common.matchers.WarningsMatchers.hasRedFlags;
 import static org.batfish.common.util.Resources.readResource;
 import static org.batfish.datamodel.BgpRoute.DEFAULT_LOCAL_PREFERENCE;
 import static org.batfish.datamodel.Interface.NULL_INTERFACE_NAME;
+import static org.batfish.datamodel.Ip.ZERO;
 import static org.batfish.datamodel.IpWildcard.ipWithWildcardMask;
 import static org.batfish.datamodel.Names.generatedBgpCommonExportPolicyName;
 import static org.batfish.datamodel.Route.UNSET_NEXT_HOP_INTERFACE;
@@ -92,6 +93,7 @@ import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.DEFAULT_VRF_ID;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.DEFAULT_VRF_NAME;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.MANAGEMENT_VRF_NAME;
+import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.RESOLUTION_POLICY_NAME;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.computeRoutingPolicyName;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.eigrpNeighborExportPolicyName;
 import static org.batfish.representation.cisco_nxos.CiscoNxosConfiguration.eigrpNeighborImportPolicyName;
@@ -119,6 +121,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -144,6 +147,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -174,6 +178,7 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.ConnectedRouteMetadata;
+import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.DscpType;
 import org.batfish.datamodel.EigrpExternalRoute;
 import org.batfish.datamodel.EigrpInternalRoute;
@@ -829,7 +834,7 @@ public final class CiscoNxosGrammarTest {
                   .setLocalPreference(DEFAULT_LOCAL_PREFERENCE)
                   .setMetric(matchEigrp.getMetric())
                   .setNextHopIp(nextHopIp)
-                  .setReceivedFromIp(Ip.ZERO)
+                  .setReceivedFromIp(ZERO)
                   .setOriginatorIp(bgpRouterId)
                   .setOriginType(OriginType.INCOMPLETE)
                   .setSrcProtocol(RoutingProtocol.EIGRP)
@@ -860,7 +865,7 @@ public final class CiscoNxosGrammarTest {
                   .setLocalPreference(DEFAULT_LOCAL_PREFERENCE)
                   .setMetric(matchEigrp.getMetric())
                   .setNextHopIp(nextHopIp)
-                  .setReceivedFromIp(Ip.ZERO)
+                  .setReceivedFromIp(ZERO)
                   .setOriginatorIp(bgpRouterId)
                   .setOriginType(OriginType.INCOMPLETE)
                   .setSrcProtocol(RoutingProtocol.EIGRP)
@@ -902,7 +907,7 @@ public final class CiscoNxosGrammarTest {
                   .setLocalPreference(DEFAULT_LOCAL_PREFERENCE)
                   .setMetric(matchEigrpEx.getMetric())
                   .setNextHopIp(nextHopIp)
-                  .setReceivedFromIp(Ip.ZERO)
+                  .setReceivedFromIp(ZERO)
                   .setOriginatorIp(bgpRouterId)
                   .setOriginType(OriginType.INCOMPLETE)
                   .setSrcProtocol(RoutingProtocol.EIGRP_EX)
@@ -6441,7 +6446,7 @@ public final class CiscoNxosGrammarTest {
     Bgpv4Route base =
         Bgpv4Route.testBuilder()
             .setAsPath(AsPath.ofSingletonAsSets(2L))
-            .setOriginatorIp(Ip.ZERO)
+            .setOriginatorIp(ZERO)
             .setOriginType(OriginType.INCOMPLETE)
             .setProtocol(RoutingProtocol.BGP)
             .setNextHopIp(origNextHopIp)
@@ -6633,7 +6638,7 @@ public final class CiscoNxosGrammarTest {
           org.batfish.datamodel.StaticRoute.testBuilder()
               .setAdmin(1)
               .setNetwork(Prefix.ZERO)
-              .setNextHopIp(Ip.ZERO)
+              .setNextHopIp(ZERO)
               .build());
       assertRoutingPolicyPermitsRoute(rp, new ConnectedRoute(Prefix.ZERO, "dummy"));
     }
@@ -6645,7 +6650,7 @@ public final class CiscoNxosGrammarTest {
           org.batfish.datamodel.StaticRoute.testBuilder()
               .setAdmin(1)
               .setNetwork(Prefix.ZERO)
-              .setNextHopIp(Ip.ZERO)
+              .setNextHopIp(ZERO)
               .build());
     }
     {
@@ -6787,7 +6792,7 @@ public final class CiscoNxosGrammarTest {
                   .setAsNumber(1L)
                   .setMode(EigrpProcessMode.CLASSIC)
                   .setMetricVersion(EigrpMetricVersion.V2)
-                  .setRouterId(Ip.ZERO)
+                  .setRouterId(ZERO)
                   .build(),
               Direction.IN));
       EigrpExternalRoute routAfter = builder.build();
@@ -7473,7 +7478,7 @@ public final class CiscoNxosGrammarTest {
             .setSrcProtocol(RoutingProtocol.BGP)
             .setMetric(0L) // 30 match metric 3
             .setAsPath(AsPath.ofSingletonAsSets(2L))
-            .setOriginatorIp(Ip.ZERO)
+            .setOriginatorIp(ZERO)
             .setOriginType(OriginType.INCOMPLETE)
             .setProtocol(RoutingProtocol.BGP)
             .setNextHopIp(Ip.parse("192.0.2.254"))
@@ -8551,5 +8556,47 @@ public final class CiscoNxosGrammarTest {
               EigrpInternalRoute.testBuilder().setEigrpMetricVersion(EigrpMetricVersion.V2),
               Direction.OUT));
     }
+  }
+
+  @Test
+  public void testResolutionPolicyFiltering() throws IOException {
+    String hostname = "resolution_policy";
+    Configuration c = parseConfig(hostname);
+    assertThat(c.getDefaultVrf().getResolutionPolicy(), equalTo(RESOLUTION_POLICY_NAME));
+    assertThat(c.getRoutingPolicies(), hasKey(RESOLUTION_POLICY_NAME));
+    RoutingPolicy r = c.getRoutingPolicies().get(RESOLUTION_POLICY_NAME);
+
+    // Policy should accept non-default routes
+    assertTrue(
+        r.processReadOnly(
+            org.batfish.datamodel.StaticRoute.testBuilder()
+                .setNetwork(Prefix.create(Ip.parse("10.10.10.10"), 24))
+                .build()));
+
+    // Policy should not accept default routes
+    assertFalse(
+        r.processReadOnly(
+            org.batfish.datamodel.StaticRoute.testBuilder()
+                .setNetwork(Prefix.create(ZERO, 0))
+                .build()));
+  }
+
+  @Test
+  public void testResolutionPolicyRibRoutes() throws IOException {
+    String hostname = "resolution_policy";
+    Batfish batfish = getBatfishForConfigurationNames(hostname);
+    batfish.loadConfigurations(batfish.getSnapshot());
+    batfish.computeDataPlane(batfish.getSnapshot());
+    DataPlane dp = batfish.loadDataPlane(batfish.getSnapshot());
+    Set<AbstractRoute> routes = dp.getRibs().get(hostname).get("default").getRoutes();
+
+    // Rib should have the static route whose NHI is determined from a non-default route
+    assertThat(
+        routes,
+        hasItem(
+            allOf(hasPrefix(Prefix.parse("10.101.1.1/32")), hasNextHopIp(Ip.parse("10.0.1.100")))));
+
+    // Rib should NOT have the static route whose NHI is determined from the default route
+    assertThat(routes, not(hasItem(hasPrefix(Prefix.parse("10.103.3.1/32")))));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/resolution_policy
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/resolution_policy
@@ -1,0 +1,16 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname resolution_policy
+!
+interface Ethernet1/1
+  no switchport
+  no shutdown
+  ip address 10.0.1.1/24
+!
+!
+ip route 0.0.0.0/0 Ethernet1/1
+!
+! NHI determined from default-route
+ip route 10.103.3.1/32 10.0.3.100
+! NHI determined from non-default-route
+ip route 10.101.1.1/32 10.0.1.100

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -74669,6 +74669,7 @@
                 ],
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
                   "prefix" : {
                     "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                   },
@@ -74844,6 +74845,7 @@
                 ],
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
                   "prefix" : {
                     "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                   },
@@ -74903,6 +74905,7 @@
                 ],
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
                   "prefix" : {
                     "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                   },
@@ -74965,6 +74968,7 @@
                 ],
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
                   "prefix" : {
                     "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                   },
@@ -75070,6 +75074,7 @@
                 ],
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
                   "prefix" : {
                     "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                   },
@@ -75302,6 +75307,7 @@
                 ],
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
                   "prefix" : {
                     "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                   },
@@ -77195,6 +77201,7 @@
                 ],
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
                   "prefix" : {
                     "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                   },
@@ -77254,6 +77261,7 @@
                 ],
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
                   "prefix" : {
                     "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                   },
@@ -77313,6 +77321,7 @@
                 ],
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "comment" : "match default route",
                   "prefix" : {
                     "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
                   },

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -74655,6 +74655,38 @@
                 "type" : "ExitReject"
               }
             ]
+          },
+          "~RESOLUTION_POLICY~" : {
+            "name" : "~RESOLUTION_POLICY~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ]
+              }
+            ]
           }
         },
         "vendorFamily" : {
@@ -74711,10 +74743,12 @@
               },
               "tieBreaker" : "ROUTER_ID"
             },
+            "resolutionPolicy" : "~RESOLUTION_POLICY~",
             "snmpServer" : { }
           },
           "management" : {
-            "name" : "management"
+            "name" : "management",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~"
           }
         }
       },
@@ -74796,6 +74830,40 @@
             "vrf" : "default"
           }
         },
+        "routingPolicies" : {
+          "~RESOLUTION_POLICY~" : {
+            "name" : "~RESOLUTION_POLICY~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ]
+              }
+            ]
+          }
+        },
         "vendorFamily" : {
           "cisco_nxos" : {
             "majorVersion" : "UNKNOWN",
@@ -74805,10 +74873,12 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~",
             "snmpServer" : { }
           },
           "management" : {
-            "name" : "management"
+            "name" : "management",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~"
           }
         }
       },
@@ -74819,6 +74889,40 @@
         "defaultInboundAction" : "PERMIT",
         "deviceModel" : "CISCO_UNSPECIFIED",
         "deviceType" : "SWITCH",
+        "routingPolicies" : {
+          "~RESOLUTION_POLICY~" : {
+            "name" : "~RESOLUTION_POLICY~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ]
+              }
+            ]
+          }
+        },
         "vendorFamily" : {
           "cisco_nxos" : {
             "majorVersion" : "UNKNOWN",
@@ -74828,10 +74932,12 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~",
             "snmpServer" : { }
           },
           "management" : {
-            "name" : "management"
+            "name" : "management",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~"
           }
         }
       },
@@ -74845,6 +74951,40 @@
         "ntpServers" : [
           "10.1.2.3"
         ],
+        "routingPolicies" : {
+          "~RESOLUTION_POLICY~" : {
+            "name" : "~RESOLUTION_POLICY~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ]
+              }
+            ]
+          }
+        },
         "vendorFamily" : {
           "cisco_nxos" : {
             "majorVersion" : "UNKNOWN",
@@ -74854,10 +74994,12 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~",
             "snmpServer" : { }
           },
           "management" : {
-            "name" : "management"
+            "name" : "management",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~"
           }
         }
       },
@@ -74912,6 +75054,40 @@
             "switchportTrunkEncapsulation" : "DOT1Q",
             "type" : "PHYSICAL",
             "vrf" : "OTHER"
+          }
+        },
+        "routingPolicies" : {
+          "~RESOLUTION_POLICY~" : {
+            "name" : "~RESOLUTION_POLICY~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ]
+              }
+            ]
           }
         },
         "vendorFamily" : {
@@ -74970,7 +75146,8 @@
                 "summaryAdminCost" : 254,
                 "summaryDiscardMetric" : 0
               }
-            }
+            },
+            "resolutionPolicy" : "~RESOLUTION_POLICY~"
           },
           "default" : {
             "name" : "default",
@@ -75018,6 +75195,7 @@
                 "summaryDiscardMetric" : 0
               }
             },
+            "resolutionPolicy" : "~RESOLUTION_POLICY~",
             "snmpServer" : { }
           },
           "foo" : {
@@ -75040,10 +75218,12 @@
                 "summaryAdminCost" : 254,
                 "summaryDiscardMetric" : 0
               }
-            }
+            },
+            "resolutionPolicy" : "~RESOLUTION_POLICY~"
           },
           "management" : {
-            "name" : "management"
+            "name" : "management",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~"
           }
         }
       },
@@ -75104,6 +75284,38 @@
                         "type" : "ReturnTrue"
                       }
                     ]
+                  }
+                ]
+              }
+            ]
+          },
+          "~RESOLUTION_POLICY~" : {
+            "name" : "~RESOLUTION_POLICY~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
                   }
                 ]
               }
@@ -76953,10 +77165,12 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~",
             "snmpServer" : { }
           },
           "management" : {
-            "name" : "management"
+            "name" : "management",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~"
           }
         }
       },
@@ -76967,6 +77181,40 @@
         "defaultInboundAction" : "PERMIT",
         "deviceModel" : "CISCO_UNSPECIFIED",
         "deviceType" : "SWITCH",
+        "routingPolicies" : {
+          "~RESOLUTION_POLICY~" : {
+            "name" : "~RESOLUTION_POLICY~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ]
+              }
+            ]
+          }
+        },
         "vendorFamily" : {
           "cisco_nxos" : {
             "majorVersion" : "UNKNOWN",
@@ -76976,10 +77224,12 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~",
             "snmpServer" : { }
           },
           "management" : {
-            "name" : "management"
+            "name" : "management",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~"
           }
         }
       },
@@ -76990,6 +77240,40 @@
         "defaultInboundAction" : "PERMIT",
         "deviceModel" : "CISCO_UNSPECIFIED",
         "deviceType" : "SWITCH",
+        "routingPolicies" : {
+          "~RESOLUTION_POLICY~" : {
+            "name" : "~RESOLUTION_POLICY~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ]
+              }
+            ]
+          }
+        },
         "vendorFamily" : {
           "cisco_nxos" : {
             "majorVersion" : "UNKNOWN",
@@ -76999,10 +77283,12 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~",
             "snmpServer" : { }
           },
           "management" : {
-            "name" : "management"
+            "name" : "management",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~"
           }
         }
       },
@@ -77013,6 +77299,40 @@
         "defaultInboundAction" : "PERMIT",
         "deviceModel" : "CISCO_UNSPECIFIED",
         "deviceType" : "ROUTER",
+        "routingPolicies" : {
+          "~RESOLUTION_POLICY~" : {
+            "name" : "~RESOLUTION_POLICY~",
+            "statements" : [
+              {
+                "class" : "org.batfish.datamodel.routing_policy.statement.If",
+                "falseStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnTrue"
+                  }
+                ],
+                "guard" : {
+                  "class" : "org.batfish.datamodel.routing_policy.expr.MatchPrefixSet",
+                  "prefix" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.DestinationNetwork"
+                  },
+                  "prefixSet" : {
+                    "class" : "org.batfish.datamodel.routing_policy.expr.ExplicitPrefixSet",
+                    "prefixSpace" : [
+                      "0.0.0.0/0"
+                    ]
+                  }
+                },
+                "trueStatements" : [
+                  {
+                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
+                    "type" : "ReturnFalse"
+                  }
+                ]
+              }
+            ]
+          }
+        },
         "vendorFamily" : {
           "cisco_nxos" : {
             "majorVersion" : "UNKNOWN",
@@ -77022,10 +77342,12 @@
         "vrfs" : {
           "default" : {
             "name" : "default",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~",
             "snmpServer" : { }
           },
           "management" : {
             "name" : "management",
+            "resolutionPolicy" : "~RESOLUTION_POLICY~",
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",
@@ -77049,6 +77371,7 @@
               "multipathIbgp" : false,
               "tieBreaker" : "ARRIVAL_ORDER"
             },
+            "resolutionPolicy" : "~RESOLUTION_POLICY~",
             "staticRoutes" : [
               {
                 "class" : "org.batfish.datamodel.StaticRoute",


### PR DESCRIPTION
Similar to https://github.com/batfish/batfish/issues/6785, NXOS doesn't permit resolving next hop interfaces through default-routes.

This PR adds a fixed resolution policy for NXOS VRFs that prevents this.
