### PR TITLE
Clean up XR BGP default originate policy

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -288,12 +288,6 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
 
   private static final int VLAN_NORMAL_MIN_CISCO = 2;
 
-  public static String computeBgpDefaultRouteExportPolicyName(
-      boolean ipv4, String vrf, String peer) {
-    return String.format(
-        "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv%s:%s:%s~", ipv4 ? "4" : "6", vrf, peer);
-  }
-
   public static @Nonnull String computeCommunitySetMatchAnyName(String name) {
     return String.format("~MATCH_ANY~%s~", name);
   }


### PR DESCRIPTION
* Generate one default-originate policy per config (technically up to 2, for IPv4 & IPv6)
* Use standard default-originate policy name from `Names`