### PR TITLE
NXOS: handle transient max-metric

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -2796,6 +2796,10 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
 
   @Override
   public void exitRo_max_metric(Ro_max_metricContext ctx) {
+    if (ctx.on_startup != null) {
+      return;
+    }
+
     @Nullable Integer externalLsa = null;
     if (ctx.external_lsa != null) {
       if (ctx.manual_external_lsa != null) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -6311,6 +6311,18 @@ public final class CiscoNxosGrammarTest {
   }
 
   @Test
+  public void testOspfMaxMetricOnStartup() {
+    String hostname = "ospf_max_metric_on_startup";
+    CiscoNxosConfiguration vc = parseVendorConfig(hostname);
+
+    // Max metric setting shouldn't stick if on-startup is specified
+    assertThat(vc.getOspfProcesses().get("65000").getMaxMetricRouterLsa(), nullValue());
+
+    // Otherwise, max metric setting should stick
+    assertThat(vc.getOspfProcesses().get("65001").getMaxMetricRouterLsa(), notNullValue());
+  }
+
+  @Test
   public void testRouteMapConversion() throws IOException {
     String hostname = "nxos_route_map";
     Configuration c = parseConfig(hostname);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -6311,15 +6311,15 @@ public final class CiscoNxosGrammarTest {
   }
 
   @Test
-  public void testOspfMaxMetricOnStartup() {
-    String hostname = "ospf_max_metric_on_startup";
+  public void testOspfMaxMetricTransient() {
+    String hostname = "ospf_max_metric_transient";
     CiscoNxosConfiguration vc = parseVendorConfig(hostname);
 
-    // Max metric setting shouldn't stick if on-startup is specified
-    assertThat(vc.getOspfProcesses().get("65000").getMaxMetricRouterLsa(), nullValue());
+    // Max metric setting should stick if there is no transient option specified
+    assertThat(vc.getOspfProcesses().get("65000").getMaxMetricRouterLsa(), notNullValue());
 
-    // Otherwise, max metric setting should stick
-    assertThat(vc.getOspfProcesses().get("65001").getMaxMetricRouterLsa(), notNullValue());
+    // Max metric setting shouldn't stick if transient option on-startup is specified
+    assertThat(vc.getOspfProcesses().get("65001").getMaxMetricRouterLsa(), nullValue());
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/ospf_max_metric_on_startup
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/ospf_max_metric_on_startup
@@ -1,0 +1,15 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname ospf_max_metric_on_startup
+!
+interface loopback0
+  ip address 10.0.0.1/32
+  ip router ospf 65000 area 0.0.0.0
+!
+router ospf 65000
+  router-id 10.0.0.1
+  max-metric router-lsa on-startup
+!
+router ospf 65001
+  router-id 10.0.0.1
+  max-metric router-lsa

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/ospf_max_metric_transient
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/ospf_max_metric_transient
@@ -1,6 +1,6 @@
 !RANCID-CONTENT-TYPE: cisco-nx
 !
-hostname ospf_max_metric_on_startup
+hostname ospf_max_metric_transient
 !
 interface loopback0
   ip address 10.0.0.1/32
@@ -8,8 +8,8 @@ interface loopback0
 !
 router ospf 65000
   router-id 10.0.0.1
-  max-metric router-lsa on-startup
+  max-metric router-lsa
 !
 router ospf 65001
   router-id 10.0.0.1
-  max-metric router-lsa
+  max-metric router-lsa on-startup

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -74946,8 +74946,6 @@
                     "stubType" : "STUB"
                   }
                 },
-                "maxMetricExternalNetworks" : 65535,
-                "maxMetricTransitLinks" : 65535,
                 "processId" : "1",
                 "referenceBandwidth" : 4.0E10,
                 "routerId" : "1.2.3.4",
@@ -74962,8 +74960,6 @@
                   "ospfIA" : 110,
                   "ospfIS" : 110
                 },
-                "maxMetricExternalNetworks" : 65535,
-                "maxMetricTransitLinks" : 65535,
                 "processId" : "ignored",
                 "referenceBandwidth" : 4.0E10,
                 "routerId" : "5.6.7.8",
@@ -75031,9 +75027,6 @@
                   "ospfIA" : 110,
                   "ospfIS" : 110
                 },
-                "maxMetricExternalNetworks" : 65535,
-                "maxMetricSummaryNetworks" : 65535,
-                "maxMetricTransitLinks" : 65535,
                 "processId" : "100",
                 "referenceBandwidth" : 4.0E10,
                 "routerId" : "0.0.0.0",


### PR DESCRIPTION
Don't apply `max-metric` when transient option `on-startup` is specified.
