### PR TITLE
IOS XR: handle setting OSPF router network type

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
@@ -22,7 +22,7 @@ ro_area_inner
   | roa_cost
   | roa_interface
   | roa_mpls
-  | roa_network_null
+  | roa_network
   | roa_range
 ;
 
@@ -427,9 +427,9 @@ roa_mpls
 
 roampls_traffic_eng: TRAFFIC_ENG NEWLINE;
 
-roa_network_null
+roa_network
 :
-   NETWORK POINT_TO_POINT NEWLINE
+   NETWORK ospf_network_type NEWLINE
 ;
 
 roi_cost

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -745,6 +745,7 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.Ro_rfc1583_compatibilityContex
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Ro_router_idContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Ro_vrfContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Roa_interfaceContext;
+import org.batfish.grammar.cisco_xr.CiscoXrParser.Roa_networkContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Roa_rangeContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Rodl_aclContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.Rodl_route_policyContext;
@@ -6215,6 +6216,11 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   @Override
   public void exitRoa_interface(Roa_interfaceContext ctx) {
     _currentOspfInterface = null;
+  }
+
+  @Override
+  public void exitRoa_network(Roa_networkContext ctx) {
+    _currentOspfProcess.setDefaultNetworkType(toOspfNetworkType(ctx.ospf_network_type()));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -1840,8 +1840,15 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
 
     ospfSettings.setAreaName(areaNum);
     ospfSettings.setEnabled(proc != null && areaNum != null && !vsIface.getOspfShutdown());
-    org.batfish.datamodel.ospf.OspfNetworkType networkType =
-        toOspfNetworkType(vsIface.getOspfNetworkType(), _w);
+
+    org.batfish.representation.cisco_xr.OspfNetworkType vsNetworkType =
+        vsIface.getOspfNetworkType();
+    // Use default from process if it exists and no type is already set
+    if (vsNetworkType == null && proc != null) {
+      vsNetworkType = proc.getDefaultNetworkType();
+    }
+    org.batfish.datamodel.ospf.OspfNetworkType networkType = toOspfNetworkType(vsNetworkType, _w);
+
     ospfSettings.setNetworkType(networkType);
     if (vsIface.getOspfCost() == null
         && iface.isLoopback()

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/OspfProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/OspfProcess.java
@@ -48,6 +48,8 @@ public class OspfProcess implements Serializable {
 
   private Long _defaultMetric;
 
+  @Nullable private OspfNetworkType _defaultNetworkType;
+
   @Nullable private DistributeList _inboundGlobalDistributeList;
 
   private Long _maxMetricExternalLsa;
@@ -164,6 +166,11 @@ public class OspfProcess implements Serializable {
   }
 
   @Nullable
+  public OspfNetworkType getDefaultNetworkType() {
+    return _defaultNetworkType;
+  }
+
+  @Nullable
   public DistributeList getInboundGlobalDistributeList() {
     return _inboundGlobalDistributeList;
   }
@@ -263,6 +270,10 @@ public class OspfProcess implements Serializable {
 
   public void setDefaultMetric(Long metric) {
     _defaultMetric = metric;
+  }
+
+  public void setDefaultNetworkType(@Nullable OspfNetworkType networkType) {
+    _defaultNetworkType = networkType;
   }
 
   public void setInboundGlobalDistributeList(@Nullable DistributeList inboundGlobalDistributeList) {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-network-type-override
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-network-type-override
@@ -1,0 +1,19 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+hostname ospf-network-type-override
+!
+interface GigabitEthernet0/0/0/1
+ ipv4 address 10.0.1.1 255.255.255.252
+!
+interface GigabitEthernet0/0/0/2
+ ipv4 address 10.0.2.1 255.255.255.252
+!
+router ospf 65100
+ router-id 10.0.0.1
+ area 0
+ network point-to-point
+ interface GigabitEthernet0/0/0/1
+  network broadcast
+ !
+ interface GigabitEthernet0/0/0/2
+ !
+!


### PR DESCRIPTION
Handle setting OSPF network type at OSPF router level. This value is used when no network type is set at the OSPF interface level.
