### PR TITLE
FRR: Add support for ospf hello and dead interval timers 

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -130,6 +130,8 @@ CRITICAL: 'critical';
 
 DATACENTER: 'datacenter';
 
+DEAD_INTERVAL: 'dead-interval';
+
 DEBUGGING: 'debugging';
 
 DEFAULT: 'default';
@@ -193,6 +195,8 @@ FRR: 'frr';
 GE: 'ge';
 
 GOTO: 'goto';
+
+HELLO_INTERVAL: 'hello-interval';
 
 HOSTNAME
 :

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_interface.g4
@@ -69,6 +69,8 @@ siip_ospf
     | siipo_message_digest_key
     | siipo_network_p2p
     | siipo_cost
+    | siipo_hello_interval
+    | siipo_dead_interval
   )
   NEWLINE
 ;
@@ -98,7 +100,22 @@ siipo_cost
   COST interface_ospf_cost
 ;
 
+siipo_hello_interval
+:
+  HELLO_INTERVAL interface_ospf_interval
+;
+
+siipo_dead_interval
+:
+  DEAD_INTERVAL interface_ospf_interval
+;
+
 interface_ospf_cost
+:
+  uint16
+;
+
+interface_ospf_interval
 :
   uint16
 ;

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -67,6 +67,7 @@ import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Bgp_redist_typeContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Icl_expandedContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Icl_standardContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Interface_ospf_costContext;
+import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Interface_ospf_intervalContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Ip_addressContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Ip_as_pathContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Ip_community_list_nameContext;
@@ -166,6 +167,8 @@ import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Siip_addressContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Siipo_areaContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Siipo_costContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Siipo_network_p2pContext;
+import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Siipo_hello_intervalContext;
+import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Siipo_dead_intervalContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Snoip_forwardingContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Standard_communityContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Sv_routeContext;
@@ -413,6 +416,10 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   }
 
   private Integer toInteger(Interface_ospf_costContext ctx) {
+    return Integer.parseInt(ctx.getText());
+  }
+
+  private Integer toInteger(Interface_ospf_intervalContext ctx) {
     return Integer.parseInt(ctx.getText());
   }
 
@@ -1070,6 +1077,16 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   @Override
   public void exitSiipo_cost(Siipo_costContext ctx) {
     _currentInterface.getOrCreateOspf().setCost(toInteger(ctx.interface_ospf_cost()));
+  }
+
+  @Override
+  public void exitSiipo_hello_interval(Siipo_hello_intervalContext ctx) {
+    _currentInterface.getOrCreateOspf().setHelloInterval(toInteger(ctx.interface_ospf_interval()));
+  }
+
+  @Override
+  public void exitSiipo_dead_interval(Siipo_dead_intervalContext ctx) {
+    _currentInterface.getOrCreateOspf().setDeadInterval(toInteger(ctx.interface_ospf_interval()));
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -2100,6 +2100,20 @@ public class CumulusFrrGrammarTest {
   }
 
   @Test
+  public void testOspfIntervals() {
+    parseLines("interface swp1", "ip ospf hello-interval 755", "ip ospf dead-interval 999");
+    assertThat(Objects.requireNonNull(_frr.getInterfaces().get("swp1").getOspf()).getHelloInterval(), equalTo(755));
+    assertThat(Objects.requireNonNull(_frr.getInterfaces().get("swp1").getOspf()).getDeadInterval(), equalTo(999));
+  }
+
+  @Test
+  public void testOspfIntervalsNoValue() {
+    parseLines("interface swp1", "ip ospf area 0.0.0.0");
+    assertThat(_frr.getInterfaces().get("swp1").getOspf().getHelloInterval(), equalTo(null));
+    assertThat(_frr.getInterfaces().get("swp1").getOspf().getDeadInterval(), equalTo(null));
+  }
+
+  @Test
   public void testOspfRedistributeBgpSetMetric_behavior() throws IOException {
     /*
       Three nodes in a line - frr-originator spawns a route into BGP, redistributor redistributes this route into OSPF and sets metric of 10k


### PR DESCRIPTION
added support for OSPF hello and dead interval timers for FRR configs
 the support in vendor independent model for OSPF already exists. This PR provides the support specifically for FRR (vendor specific configs).