### PR TITLE
IOS XR: fix OSPF router network type

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_ospf.g4
@@ -183,16 +183,7 @@ ro_maximum_paths
    ) uint_legacy NEWLINE
 ;
 
-ro_network
-:
-   NETWORK
-   (
-     BROADCAST
-     | NON_BROADCAST
-     | POINT_TO_MULTIPOINT NON_BROADCAST?
-     | POINT_TO_POINT
-   ) NEWLINE
-;
+ro_network: NETWORK ospf_network_type NEWLINE;
 
 ro_nssa
 :

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -6063,7 +6063,7 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitRo_network(Ro_networkContext ctx) {
-    todo(ctx);
+    _currentOspfProcess.setDefaultNetworkType(toOspfNetworkType(ctx.ospf_network_type()));
   }
 
   @Override
@@ -6220,7 +6220,7 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
 
   @Override
   public void exitRoa_network(Roa_networkContext ctx) {
-    _currentOspfProcess.setDefaultNetworkType(toOspfNetworkType(ctx.ospf_network_type()));
+    todo(ctx);
   }
 
   @Override

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-network-type-override
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-network-type-override
@@ -17,4 +17,7 @@ router ospf 65100
   interface GigabitEthernet0/0/0/2
   !
  !
+ area 1
+  network non-broadcast
+ !
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-network-type-override
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-network-type-override
@@ -11,9 +11,10 @@ router ospf 65100
  router-id 10.0.0.1
  network point-to-point
  area 0
- interface GigabitEthernet0/0/0/1
-  network broadcast
- !
- interface GigabitEthernet0/0/0/2
+  interface GigabitEthernet0/0/0/1
+   network broadcast
+  !
+  interface GigabitEthernet0/0/0/2
+  !
  !
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-network-type-override
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-network-type-override
@@ -9,8 +9,8 @@ interface GigabitEthernet0/0/0/2
 !
 router ospf 65100
  router-id 10.0.0.1
- area 0
  network point-to-point
+ area 0
  interface GigabitEthernet0/0/0/1
   network broadcast
  !


### PR DESCRIPTION
https://github.com/batfish/batfish/pull/7016 incorrectly set the process-level network type for area-level settings. This PR correctly handles setting network type at the top OSPF router/process level.

Area-level network type settings are not included in this PR and will require a bit more work.
