### PR TITLE
IOS XR: fix loopback OSPF cost calculation

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -141,7 +141,6 @@ import org.batfish.datamodel.ospf.OspfAreaSummary;
 import org.batfish.datamodel.ospf.OspfDefaultOriginateType;
 import org.batfish.datamodel.ospf.OspfInterfaceSettings;
 import org.batfish.datamodel.ospf.OspfMetricType;
-import org.batfish.datamodel.ospf.OspfNetworkType;
 import org.batfish.datamodel.ospf.StubType;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.expr.BooleanExpr;
@@ -1850,9 +1849,7 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
     org.batfish.datamodel.ospf.OspfNetworkType networkType = toOspfNetworkType(vsNetworkType, _w);
 
     ospfSettings.setNetworkType(networkType);
-    if (vsIface.getOspfCost() == null
-        && iface.isLoopback()
-        && networkType != OspfNetworkType.POINT_TO_POINT) {
+    if (vsIface.getOspfCost() == null && iface.isLoopback()) {
       ospfSettings.setCost(DEFAULT_LOOPBACK_OSPF_COST);
     } else {
       ospfSettings.setCost(vsIface.getOspfCost());

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -1129,6 +1129,34 @@ public final class XrGrammarTest {
   }
 
   @Test
+  public void testOspfInterfaceCost() {
+    Configuration c = parseConfig("ospf-interface-cost");
+    String ifaceEth1Name = "GigabitEthernet0/0/0/1";
+    String ifaceEth2Name = "GigabitEthernet0/0/0/2";
+    String ifaceLoop1Name = "Loopback1";
+    String ifaceLoop2Name = "Loopback2";
+    String ifaceLoop3Name = "Loopback3";
+    Map<String, Interface> ifaces = c.getAllInterfaces();
+    assertThat(
+        ifaces.keySet(),
+        contains(ifaceEth1Name, ifaceEth2Name, ifaceLoop1Name, ifaceLoop2Name, ifaceLoop3Name));
+    Interface ifaceEth1 = ifaces.get(ifaceEth1Name);
+    Interface ifaceEth2 = ifaces.get(ifaceEth2Name);
+    Interface ifaceLoop1 = ifaces.get(ifaceLoop1Name);
+    Interface ifaceLoop2 = ifaces.get(ifaceLoop2Name);
+    Interface ifaceLoop3 = ifaces.get(ifaceLoop3Name);
+
+    // Confirm explicitly configured costs are applied
+    assertThat(ifaceEth1.getOspfCost(), equalTo(1));
+    assertThat(ifaceLoop3.getOspfCost(), equalTo(12));
+
+    // Confirm other costs are calculated correctly
+    assertThat(ifaceEth2.getOspfCost(), equalTo(400));
+    assertThat(ifaceLoop1.getOspfCost(), equalTo(1));
+    assertThat(ifaceLoop2.getOspfCost(), equalTo(1));
+  }
+
+  @Test
   public void testOspfInterface() {
     Configuration c = parseConfig("ospf-interface");
     String ifaceName = "Bundle-Ether201";

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-interface-cost
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-interface-cost
@@ -1,0 +1,28 @@
+!RANCID-CONTENT-TYPE: cisco-xr
+hostname ospf-interface-cost
+!
+interface GigabitEthernet0/0/0/1
+ no shutdown
+!
+interface GigabitEthernet0/0/0/2
+ no shutdown
+!
+router ospf 2
+ router-id 10.10.10.10
+ auto-cost reference-bandwidth 400000
+ area 0
+  interface GigabitEthernet0/0/0/1
+   cost 1
+  !
+  interface GigabitEthernet0/0/0/2
+  !
+  interface Loopback1
+  !
+  interface Loopback2
+   network point-to-point
+  !
+  interface Loopback3
+   cost 12
+  !
+ !
+!


### PR DESCRIPTION
For XR loopback interfaces, the OSPF cost is set to `1` unless explicitly configured. This also applies with set network type / `loopback stub-network enable`.
