### PR TITLE
BGP: use CommunitySet for intermediate state and parameters

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Bgpv4Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Bgpv4Route.java
@@ -1,5 +1,6 @@
 package org.batfish.datamodel;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -11,9 +12,9 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 
 /**
  * A BGP Route. Captures attributes of both iBGP and eBGP routes.
@@ -79,7 +80,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
       @Nullable @JsonProperty(PROP_NEXT_HOP_IP) Ip nextHopIp,
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
       @Nullable @JsonProperty(PROP_AS_PATH) AsPath asPath,
-      @Nullable @JsonProperty(PROP_COMMUNITIES) Set<Community> communities,
+      @Nullable @JsonProperty(PROP_COMMUNITIES) CommunitySet communities,
       @JsonProperty(PROP_LOCAL_PREFERENCE) long localPreference,
       @JsonProperty(PROP_METRIC) long med,
       @Nullable @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface,
@@ -101,7 +102,7 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
         NextHop.legacyConverter(nextHopInterface, nextHopIp),
         admin,
         asPath,
-        communities,
+        firstNonNull(communities, CommunitySet.empty()),
         localPreference,
         med,
         originatorIp,
@@ -122,11 +123,11 @@ public final class Bgpv4Route extends BgpRoute<Bgpv4Route.Builder, Bgpv4Route> {
       @Nonnull NextHop nextHop,
       int admin,
       @Nullable AsPath asPath,
-      @Nullable Set<Community> communities,
+      CommunitySet communities,
       long localPreference,
       long med,
       Ip originatorIp,
-      @Nullable Set<Long> clusterList,
+      Set<Long> clusterList,
       boolean receivedFromRouteReflectorClient,
       OriginType originType,
       RoutingProtocol protocol,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnRoute.java
@@ -9,9 +9,9 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.BgpRoute.Builder;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
-import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 
 /**
  * A generic EVPN route containing the common properties among the different types of EVPN routes
@@ -50,7 +50,7 @@ public abstract class EvpnRoute<B extends Builder<B, R>, R extends BgpRoute<B, R
       NextHop nextHop,
       int admin,
       AsPath asPath,
-      Set<Community> communities,
+      CommunitySet communities,
       long localPreference,
       long med,
       Ip originatorIp,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType2Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType2Route.java
@@ -12,8 +12,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
-import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 
 /** An EVPN type 2 route */
 @ParametersAreNonnullByDefault
@@ -107,7 +107,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
       @Nullable @JsonProperty(PROP_AS_PATH) AsPath asPath,
       @Nullable @JsonProperty(PROP_CLUSTER_LIST) Set<Long> clusterList,
-      @Nullable @JsonProperty(PROP_COMMUNITIES) Set<Community> communities,
+      @Nullable @JsonProperty(PROP_COMMUNITIES) CommunitySet communities,
       @Nullable @JsonProperty(PROP_IP) Ip ip,
       @JsonProperty(PROP_LOCAL_PREFERENCE) long localPreference,
       @Nullable @JsonProperty(PROP_MAC_ADDRESS) MacAddress macAddress,
@@ -133,7 +133,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
         admin,
         firstNonNull(asPath, AsPath.empty()),
         firstNonNull(clusterList, ImmutableSet.of()),
-        firstNonNull(communities, ImmutableSet.of()),
+        firstNonNull(communities, CommunitySet.empty()),
         ip,
         localPreference,
         macAddress,
@@ -156,7 +156,7 @@ public final class EvpnType2Route extends EvpnRoute<EvpnType2Route.Builder, Evpn
       int admin,
       AsPath asPath,
       Set<Long> clusterList,
-      Set<Community> communities,
+      CommunitySet communities,
       Ip ip,
       long localPreference,
       @Nullable MacAddress macAddress,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType3Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType3Route.java
@@ -12,8 +12,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
-import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 
 /** An EVPN type 3 route */
 @ParametersAreNonnullByDefault
@@ -93,7 +93,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
       @Nullable @JsonProperty(PROP_AS_PATH) AsPath asPath,
       @Nullable @JsonProperty(PROP_CLUSTER_LIST) Set<Long> clusterList,
-      @Nullable @JsonProperty(PROP_COMMUNITIES) Set<Community> communities,
+      @Nullable @JsonProperty(PROP_COMMUNITIES) CommunitySet communities,
       @JsonProperty(PROP_LOCAL_PREFERENCE) long localPreference,
       @JsonProperty(PROP_METRIC) long med,
       @Nullable @JsonProperty(PROP_NEXT_HOP_INTERFACE) String nextHopInterface,
@@ -118,7 +118,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
         admin,
         firstNonNull(asPath, AsPath.empty()),
         firstNonNull(clusterList, ImmutableSet.of()),
-        firstNonNull(communities, ImmutableSet.of()),
+        firstNonNull(communities, CommunitySet.empty()),
         localPreference,
         med,
         NextHop.legacyConverter(nextHopInterface, nextHopIp),
@@ -140,7 +140,7 @@ public final class EvpnType3Route extends EvpnRoute<EvpnType3Route.Builder, Evpn
       int admin,
       AsPath asPath,
       Set<Long> clusterList,
-      Set<Community> communities,
+      CommunitySet communities,
       long localPreference,
       long med,
       NextHop nextHop,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType5Route.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EvpnType5Route.java
@@ -12,8 +12,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
-import org.batfish.datamodel.bgp.community.Community;
 import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 
 /** An EVPN type 5 route */
 @ParametersAreNonnullByDefault
@@ -77,7 +77,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
       @JsonProperty(PROP_ADMINISTRATIVE_COST) int admin,
       @Nullable @JsonProperty(PROP_AS_PATH) AsPath asPath,
       @Nullable @JsonProperty(PROP_CLUSTER_LIST) Set<Long> clusterList,
-      @Nullable @JsonProperty(PROP_COMMUNITIES) Set<Community> communities,
+      @Nullable @JsonProperty(PROP_COMMUNITIES) CommunitySet communities,
       @JsonProperty(PROP_LOCAL_PREFERENCE) long localPreference,
       @JsonProperty(PROP_METRIC) long med,
       @Nullable @JsonProperty(PROP_NETWORK) Prefix network,
@@ -102,7 +102,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
         admin,
         firstNonNull(asPath, AsPath.empty()),
         firstNonNull(clusterList, ImmutableSet.of()),
-        firstNonNull(communities, ImmutableSet.of()),
+        firstNonNull(communities, CommunitySet.empty()),
         localPreference,
         med,
         network,
@@ -124,7 +124,7 @@ public final class EvpnType5Route extends EvpnRoute<EvpnType5Route.Builder, Evpn
       int admin,
       AsPath asPath,
       Set<Long> clusterList,
-      Set<Community> communities,
+      CommunitySet communities,
       long localPreference,
       long med,
       Prefix network,

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/communities/CommunitySet.java
@@ -61,29 +61,33 @@ public final class CommunitySet implements Serializable {
   }
 
   public @Nonnull Set<ExtendedCommunity> getExtendedCommunities() {
-    if (_communities.isEmpty()) {
-      return ImmutableSet.of();
-    }
-    ImmutableSet.Builder<ExtendedCommunity> ret = ImmutableSet.builder();
-    for (Community c : _communities) {
-      if (c instanceof ExtendedCommunity) {
-        ret.add((ExtendedCommunity) c);
+    Set<ExtendedCommunity> extended = _extendedCommunities;
+    if (extended == null) {
+      ImmutableSet.Builder<ExtendedCommunity> ret = ImmutableSet.builder();
+      for (Community c : _communities) {
+        if (c instanceof ExtendedCommunity) {
+          ret.add((ExtendedCommunity) c);
+        }
       }
+      extended = ret.build();
+      _extendedCommunities = extended;
     }
-    return ret.build();
+    return extended;
   }
 
   public @Nonnull Set<StandardCommunity> getStandardCommunities() {
-    if (_communities.isEmpty()) {
-      return ImmutableSet.of();
-    }
-    ImmutableSet.Builder<StandardCommunity> ret = ImmutableSet.builder();
-    for (Community c : _communities) {
-      if (c instanceof StandardCommunity) {
-        ret.add((StandardCommunity) c);
+    Set<StandardCommunity> standard = _standardCommunities;
+    if (standard == null) {
+      ImmutableSet.Builder<StandardCommunity> ret = ImmutableSet.builder();
+      for (Community c : _communities) {
+        if (c instanceof StandardCommunity) {
+          ret.add((StandardCommunity) c);
+        }
       }
+      standard = ret.build();
+      _standardCommunities = standard;
     }
-    return ret.build();
+    return standard;
   }
 
   @Override
@@ -148,4 +152,7 @@ public final class CommunitySet implements Serializable {
 
   /* Cache the hashcode */
   private transient int _hashCode = 0;
+  /* Cache conversions to _extendedCommunities and _standardCommunities. */
+  private transient @Nullable Set<ExtendedCommunity> _extendedCommunities;
+  private transient @Nullable Set<StandardCommunity> _standardCommunities;
 }

--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/BgpRoutingProcess.java
@@ -81,6 +81,7 @@ import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.route.nh.NextHopVrf;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.dataplane.ibdp.VirtualRouter.RibExprEvaluator;
 import org.batfish.dataplane.protocols.BgpProtocolHelper;
@@ -693,7 +694,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
     // Locally all routes start as eBGP routes in our own RIB
     EvpnType3Route.Builder type3RouteBuilder = EvpnType3Route.builder();
     type3RouteBuilder.setAdmin(ebgpAdmin);
-    type3RouteBuilder.setCommunities(ImmutableSet.of(routeTarget));
+    type3RouteBuilder.setCommunities(CommunitySet.of(routeTarget));
     type3RouteBuilder.setLocalPreference(DEFAULT_LOCAL_PREFERENCE);
     // so that this route is not installed back in the main RIB of any of the VRFs
     type3RouteBuilder.setNonRouting(true);
@@ -1535,7 +1536,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
           Bgpv4Route.testBuilder()
               .setAsPath(advert.getAsPath())
               .setClusterList(advert.getClusterList())
-              .setCommunities(ImmutableSortedSet.copyOf(advert.getCommunities()))
+              .setCommunities(advert.getCommunities())
               .setLocalPreference(localPreference)
               .setMetric(advert.getMed())
               .setNetwork(advert.getNetwork())
@@ -1552,7 +1553,7 @@ final class BgpRoutingProcess implements RoutingProcess<BgpTopology, BgpRoute<?,
               .setAdmin(admin)
               .setAsPath(transformedOutgoingRoute.getAsPath())
               .setClusterList(transformedOutgoingRoute.getClusterList())
-              .setCommunities(transformedOutgoingRoute.getCommunities().getCommunities())
+              .setCommunities(transformedOutgoingRoute.getCommunities())
               .setLocalPreference(transformedOutgoingRoute.getLocalPreference())
               .setMetric(transformedOutgoingRoute.getMetric())
               .setNetwork(transformedOutgoingRoute.getNetwork())

--- a/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/protocols/BgpProtocolHelper.java
@@ -34,6 +34,7 @@ import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
+import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 
 @ParametersAreNonnullByDefault
 public final class BgpProtocolHelper {
@@ -114,12 +115,15 @@ public final class BgpProtocolHelper {
     }
 
     // Set transformed route's communities
-    builder.setCommunities(ImmutableSet.of());
-    if (af.getAddressFamilyCapabilities().getSendCommunity()) {
-      builder.addCommunities(route.getStandardCommunities());
-    }
-    if (af.getAddressFamilyCapabilities().getSendExtendedCommunity()) {
-      builder.addCommunities(route.getExtendedCommunities());
+    if (af.getAddressFamilyCapabilities().getSendCommunity()
+        && af.getAddressFamilyCapabilities().getSendExtendedCommunity()) {
+      builder.setCommunities(route.getCommunities());
+    } else if (af.getAddressFamilyCapabilities().getSendCommunity()) {
+      builder.setCommunities(route.getStandardCommunities());
+    } else if (af.getAddressFamilyCapabilities().getSendExtendedCommunity()) {
+      builder.setCommunities(route.getExtendedCommunities());
+    } else {
+      builder.setCommunities(CommunitySet.empty());
     }
 
     /*


### PR DESCRIPTION
Rather than `Set<Community>`.