### PR TITLE
XR: remove impossible OSPF configuration syntax

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_xr/CiscoXr_interface.g4
@@ -331,43 +331,6 @@ if_ip_nbar
    IP NBAR PROTOCOL_DISCOVERY (IPV4 | IPV6)? NEWLINE
 ;
 
-if_ip_ospf_area
-:
-   IP OSPF procname = variable AREA (area_ip = IP_ADDRESS | area_dec = uint_legacy) NEWLINE
-;
-
-if_ip_ospf_cost
-:
-   IP? OSPF COST cost = uint_legacy NEWLINE
-;
-
-if_ip_ospf_dead_interval
-:
-   IP OSPF DEAD_INTERVAL seconds = uint_legacy NEWLINE
-;
-
-if_ip_ospf_dead_interval_minimal
-:
-   IP OSPF DEAD_INTERVAL MINIMAL HELLO_MULTIPLIER mult = uint_legacy NEWLINE
-;
-
-if_ip_ospf_hello_interval
-:
-   IP OSPF HELLO_INTERVAL seconds = uint_legacy NEWLINE
-;
-
-if_ip_ospf_network: IP OSPF NETWORK ospf_network_type NEWLINE;
-
-if_ip_ospf_passive_interface
-:
-   NO? IP OSPF PASSIVE_INTERFACE NEWLINE
-;
-
-if_ip_ospf_shutdown
-:
-   NO? IP OSPF SHUTDOWN NEWLINE
-;
-
 if_ip_passive_interface_eigrp
 :
    NO? IP PASSIVE_INTERFACE EIGRP tag = uint_legacy NEWLINE
@@ -1666,14 +1629,6 @@ if_inner
    | if_ip_nat_inside
    | if_ip_nat_outside
    | if_ip_nbar
-   | if_ip_ospf_area
-   | if_ip_ospf_cost
-   | if_ip_ospf_dead_interval
-   | if_ip_ospf_dead_interval_minimal
-   | if_ip_ospf_hello_interval
-   | if_ip_ospf_network
-   | if_ip_ospf_passive_interface
-   | if_ip_ospf_shutdown
    | if_ip_passive_interface_eigrp
    | if_ip_pim_neighbor_filter
    | if_ip_router_isis

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_xr/CiscoXrControlPlaneExtractor.java
@@ -527,14 +527,6 @@ import org.batfish.grammar.cisco_xr.CiscoXrParser.If_flowContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_forwardContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_helper_addressContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_igmpContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_ospf_areaContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_ospf_costContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_ospf_dead_intervalContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_ospf_dead_interval_minimalContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_ospf_hello_intervalContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_ospf_networkContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_ospf_passive_interfaceContext;
-import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_ospf_shutdownContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_pim_neighbor_filterContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_proxy_arpContext;
 import org.batfish.grammar.cisco_xr.CiscoXrParser.If_ip_router_isisContext;
@@ -1091,13 +1083,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
     } else {
       warn(ctx, "Cannot determine OSPF network type.");
       return null;
-    }
-  }
-
-  @Override
-  public void exitIf_ip_ospf_network(If_ip_ospf_networkContext ctx) {
-    for (Interface iface : _currentInterfaces) {
-      iface.setOspfNetworkType(toOspfNetworkType(ctx.ospf_network_type()));
     }
   }
 
@@ -4132,71 +4117,6 @@ public class CiscoXrControlPlaneExtractor extends CiscoXrParserBaseListener
   @Override
   public void exitIf_ip_igmp(If_ip_igmpContext ctx) {
     _no = false;
-  }
-
-  @Override
-  public void exitIf_ip_ospf_area(If_ip_ospf_areaContext ctx) {
-    long area;
-    if (ctx.area_dec != null) {
-      area = toInteger(ctx.area_dec);
-    } else {
-      assert ctx.area_ip != null;
-      area = toIp(ctx.area_ip).asLong();
-    }
-    String ospfProcessName = ctx.procname.getText();
-    for (Interface iface : _currentInterfaces) {
-      iface.setOspfArea(area);
-      iface.setOspfProcess(ospfProcessName);
-    }
-  }
-
-  @Override
-  public void exitIf_ip_ospf_cost(If_ip_ospf_costContext ctx) {
-    int cost = toInteger(ctx.cost);
-    for (Interface currentInterface : _currentInterfaces) {
-      currentInterface.setOspfCost(cost);
-    }
-  }
-
-  @Override
-  public void exitIf_ip_ospf_dead_interval(If_ip_ospf_dead_intervalContext ctx) {
-    int seconds = toInteger(ctx.seconds);
-    for (Interface currentInterface : _currentInterfaces) {
-      currentInterface.setOspfDeadInterval(seconds);
-      currentInterface.setOspfHelloMultiplier(0);
-    }
-  }
-
-  @Override
-  public void exitIf_ip_ospf_dead_interval_minimal(If_ip_ospf_dead_interval_minimalContext ctx) {
-    int multiplier = toInteger(ctx.mult);
-    for (Interface currentInterface : _currentInterfaces) {
-      currentInterface.setOspfDeadInterval(1);
-      currentInterface.setOspfHelloMultiplier(multiplier);
-    }
-  }
-
-  @Override
-  public void exitIf_ip_ospf_hello_interval(If_ip_ospf_hello_intervalContext ctx) {
-    int seconds = toInteger(ctx.seconds);
-    for (Interface currentInterface : _currentInterfaces) {
-      currentInterface.setOspfHelloInterval(seconds);
-    }
-  }
-
-  @Override
-  public void exitIf_ip_ospf_passive_interface(If_ip_ospf_passive_interfaceContext ctx) {
-    boolean passive = ctx.NO() == null;
-    for (Interface iface : _currentInterfaces) {
-      iface.setOspfPassive(passive);
-    }
-  }
-
-  @Override
-  public void exitIf_ip_ospf_shutdown(If_ip_ospf_shutdownContext ctx) {
-    for (Interface iface : _currentInterfaces) {
-      iface.setOspfShutdown(ctx.NO() == null);
-    }
   }
 
   @Override

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -2761,12 +2761,7 @@ public final class XrGrammarTest {
             "GigabitEthernet0/0/0/2",
             "GigabitEthernet0/0/0/3",
             "GigabitEthernet0/0/0/4",
-            "GigabitEthernet0/0/0/5",
-            "GigabitEthernet0/0/0/6",
-            "GigabitEthernet0/0/0/7",
-            "GigabitEthernet0/0/0/8",
-            "GigabitEthernet0/0/0/9",
-            "GigabitEthernet0/0/0/10"));
+            "GigabitEthernet0/0/0/5"));
 
     // Configured in OSPF router
     assertThat(
@@ -2783,23 +2778,6 @@ public final class XrGrammarTest {
         equalTo(org.batfish.representation.cisco_xr.OspfNetworkType.POINT_TO_MULTIPOINT));
     assertThat(
         c.getInterfaces().get("GigabitEthernet0/0/0/5").getOspfNetworkType(),
-        equalTo(OspfNetworkType.POINT_TO_MULTIPOINT_NON_BROADCAST));
-
-    // Configured in interface under OSPF area
-    assertThat(
-        c.getInterfaces().get("GigabitEthernet0/0/0/6").getOspfNetworkType(),
-        equalTo(org.batfish.representation.cisco_xr.OspfNetworkType.POINT_TO_POINT));
-    assertThat(
-        c.getInterfaces().get("GigabitEthernet0/0/0/7").getOspfNetworkType(),
-        equalTo(org.batfish.representation.cisco_xr.OspfNetworkType.BROADCAST));
-    assertThat(
-        c.getInterfaces().get("GigabitEthernet0/0/0/8").getOspfNetworkType(),
-        equalTo(org.batfish.representation.cisco_xr.OspfNetworkType.NON_BROADCAST));
-    assertThat(
-        c.getInterfaces().get("GigabitEthernet0/0/0/9").getOspfNetworkType(),
-        equalTo(org.batfish.representation.cisco_xr.OspfNetworkType.POINT_TO_MULTIPOINT));
-    assertThat(
-        c.getInterfaces().get("GigabitEthernet0/0/0/10").getOspfNetworkType(),
         equalTo(OspfNetworkType.POINT_TO_MULTIPOINT_NON_BROADCAST));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -2785,7 +2785,7 @@ public final class XrGrammarTest {
         c.getInterfaces().get("GigabitEthernet0/0/0/5").getOspfNetworkType(),
         equalTo(OspfNetworkType.POINT_TO_MULTIPOINT_NON_BROADCAST));
 
-    // Configured in interface directly
+    // Configured in interface under OSPF area
     assertThat(
         c.getInterfaces().get("GigabitEthernet0/0/0/6").getOspfNetworkType(),
         equalTo(org.batfish.representation.cisco_xr.OspfNetworkType.POINT_TO_POINT));

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-network-type
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-network-type
@@ -18,23 +18,18 @@ interface GigabitEthernet0/0/0/5
 !
 interface GigabitEthernet0/0/0/6
  ipv4 address 10.0.6.1 255.255.255.252
- ip ospf network point-to-point
 !
 interface GigabitEthernet0/0/0/7
  ipv4 address 10.0.7.1 255.255.255.252
- ip ospf network broadcast
 !
 interface GigabitEthernet0/0/0/8
  ipv4 address 10.0.8.1 255.255.255.252
- ip ospf network non-broadcast
 !
 interface GigabitEthernet0/0/0/9
  ipv4 address 10.0.9.1 255.255.255.252
- ip ospf network point-to-multipoint
 !
 interface GigabitEthernet0/0/0/10
  ipv4 address 10.0.10.1 255.255.255.252
- ip ospf network point-to-multipoint non-broadcast
 !
 router ospf 65100
  router-id 10.0.0.1
@@ -55,13 +50,18 @@ router ospf 65100
    network point-to-multipoint non-broadcast
   !
   interface GigabitEthernet0/0/0/6
+   network point-to-point
   !
   interface GigabitEthernet0/0/0/7
+   network broadcast
   !
   interface GigabitEthernet0/0/0/8
+   network non-broadcast
   !
   interface GigabitEthernet0/0/0/9
+   network point-to-multipoint
   !
   interface GigabitEthernet0/0/0/10
+   network point-to-multipoint non-broadcast
  !
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-network-type
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_xr/testconfigs/ospf-network-type
@@ -16,21 +16,6 @@ interface GigabitEthernet0/0/0/4
 interface GigabitEthernet0/0/0/5
  ipv4 address 10.0.5.1 255.255.255.252
 !
-interface GigabitEthernet0/0/0/6
- ipv4 address 10.0.6.1 255.255.255.252
-!
-interface GigabitEthernet0/0/0/7
- ipv4 address 10.0.7.1 255.255.255.252
-!
-interface GigabitEthernet0/0/0/8
- ipv4 address 10.0.8.1 255.255.255.252
-!
-interface GigabitEthernet0/0/0/9
- ipv4 address 10.0.9.1 255.255.255.252
-!
-interface GigabitEthernet0/0/0/10
- ipv4 address 10.0.10.1 255.255.255.252
-!
 router ospf 65100
  router-id 10.0.0.1
  area 0
@@ -49,19 +34,5 @@ router ospf 65100
   interface GigabitEthernet0/0/0/5
    network point-to-multipoint non-broadcast
   !
-  interface GigabitEthernet0/0/0/6
-   network point-to-point
-  !
-  interface GigabitEthernet0/0/0/7
-   network broadcast
-  !
-  interface GigabitEthernet0/0/0/8
-   network non-broadcast
-  !
-  interface GigabitEthernet0/0/0/9
-   network point-to-multipoint
-  !
-  interface GigabitEthernet0/0/0/10
-   network point-to-multipoint non-broadcast
  !
 !


### PR DESCRIPTION
Remove parsing/extraction support for OSPF configuration under top-level interfaces. On XR, this syntax isn't supported and this kind of configuration is done under the `router ospf ...` context.
