### PR TITLE
Make OSPF routes non-recursive by including next-hop interface

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteBuilder.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRouteBuilder.java
@@ -101,6 +101,8 @@ public abstract class AbstractRouteBuilder<
     if (_nextHop instanceof NextHopIp) {
       // Merge NH INT + NH IP
       _nextHop = NextHopInterface.of(iface, ((NextHopIp) _nextHop).getIp());
+    } else if (_nextHop instanceof NextHopInterface) {
+      _nextHop = NextHopInterface.of(iface, ((NextHopInterface) _nextHop).getIp());
     } else {
       _nextHop = NextHopInterface.of(iface);
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfRoute.java
@@ -1,10 +1,14 @@
 package org.batfish.datamodel;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.route.nh.NextHopInterface;
+import org.batfish.datamodel.route.nh.NextHopIp;
 
 /** A generic OSPF route */
 @ParametersAreNonnullByDefault
@@ -28,6 +32,12 @@ public abstract class OspfRoute extends AbstractRoute {
       boolean nonRouting,
       boolean nonForwarding) {
     super(network, admin, tag, nonRouting, nonForwarding);
+    checkArgument(
+        nonRouting || !(nextHop instanceof NextHopIp),
+        "OSPF routes cannot only have next-hop IP unless they are non-routing.");
+    checkArgument(
+        !(nextHop instanceof NextHopInterface) || ((NextHopInterface) nextHop).getIp() != null,
+        "OSPF routes with next-hop interface must have next-hop IP.");
     _metric = metric;
     _nextHop = nextHop;
     _area = area;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfSessionProperties.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfSessionProperties.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.ospf;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
@@ -22,10 +24,11 @@ public final class OspfSessionProperties {
   @JsonCreator
   private static @Nonnull OspfSessionProperties create(
       @JsonProperty(PROP_AREA) long area, @JsonProperty(PROP_IP_LINK) @Nullable IpLink ipLink) {
+    checkArgument(ipLink != null, "Missing %s", PROP_IP_LINK);
     return new OspfSessionProperties(area, ipLink);
   }
 
-  public OspfSessionProperties(long area, @Nullable IpLink ipLink) {
+  public OspfSessionProperties(long area, IpLink ipLink) {
     _area = area;
     _ipLink = ipLink;
   }
@@ -36,7 +39,7 @@ public final class OspfSessionProperties {
   }
 
   @JsonProperty(PROP_IP_LINK)
-  public @Nullable IpLink getIpLink() {
+  public IpLink getIpLink() {
     return _ipLink;
   }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfInterAreaRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfInterAreaRouteTest.java
@@ -7,6 +7,7 @@ import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
+import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.junit.Test;
 
 /** Tests of {@link OspfInterAreaRoute} */
@@ -26,7 +27,8 @@ public class OspfInterAreaRouteTest {
         .addEqualityGroup(builder.setAdmin(1000).build())
         .addEqualityGroup(builder.setArea(2L).build())
         .addEqualityGroup(builder.setMetric(20L).build())
-        .addEqualityGroup(builder.setNextHopIp(Ip.parse("8.8.8.8")).build())
+        .addEqualityGroup(
+            builder.setNextHop(NextHopInterface.of("e0", Ip.parse("8.8.8.8"))).build())
         .addEqualityGroup(new Object())
         .testEquals();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfIntraAreaRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfIntraAreaRouteTest.java
@@ -7,6 +7,7 @@ import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
+import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.junit.Test;
 
 /** Tests of {@link OspfIntraAreaRoute} */
@@ -26,7 +27,8 @@ public class OspfIntraAreaRouteTest {
         .addEqualityGroup(builder.setAdmin(1000).build())
         .addEqualityGroup(builder.setArea(2L).build())
         .addEqualityGroup(builder.setMetric(20L).build())
-        .addEqualityGroup(builder.setNextHopIp(Ip.parse("8.8.8.8")).build())
+        .addEqualityGroup(
+            builder.setNextHop(NextHopInterface.of("e0", Ip.parse("8.8.8.8"))).build())
         .addEqualityGroup(new Object())
         .testEquals();
   }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfRouteTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/OspfRouteTest.java
@@ -1,0 +1,47 @@
+package org.batfish.datamodel;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.batfish.datamodel.route.nh.NextHopDiscard;
+import org.batfish.datamodel.route.nh.NextHopInterface;
+import org.batfish.datamodel.route.nh.NextHopIp;
+import org.batfish.datamodel.route.nh.NextHopVrf;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Tests of {@link OspfRoute} */
+public final class OspfRouteTest {
+
+  @Rule public ExpectedException _thrown = ExpectedException.none();
+
+  @Test
+  public void testOspfRouteValid() {
+    assertNotNull(testBuilder().setNextHop(NextHopDiscard.instance()).build());
+    assertNotNull(
+        testBuilder().setNextHop(NextHopInterface.of("e0", Ip.parse("192.0.2.1"))).build());
+    assertNotNull(testBuilder().setNextHop(NextHopVrf.of("v1")).build());
+
+    // non-routing
+    assertNotNull(
+        testBuilder().setNextHop(NextHopIp.of(Ip.parse("192.0.2.1"))).setNonRouting(true).build());
+  }
+
+  @Test
+  public void testOspfRouteInvalidNextHopIpRouting() {
+    _thrown.expect(IllegalArgumentException.class);
+    _thrown.expectMessage("OSPF routes cannot only have next-hop IP unless they are non-routing.");
+    testBuilder().setNextHop(NextHopIp.of(Ip.parse("192.0.2.1"))).build();
+  }
+
+  @Test
+  public void testOspfRouteInvalidNextHopInterfaceWithoutNextHopIp() {
+    _thrown.expect(IllegalArgumentException.class);
+    _thrown.expectMessage("OSPF routes with next-hop interface must have next-hop IP.");
+    testBuilder().setNextHop(NextHopInterface.of("e0")).build();
+  }
+
+  private static OspfIntraAreaRoute.Builder testBuilder() {
+    return OspfIntraAreaRoute.builder().setArea(0).setNetwork(Prefix.ZERO);
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteDecoratorMatchers.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/matchers/AbstractRouteDecoratorMatchers.java
@@ -166,8 +166,8 @@ public final class AbstractRouteDecoratorMatchers {
    * Provides a matcher that matches when the supplied {@code nonRouting} is equal to the {@link
    * AbstractRouteDecorator}'s nonRouting.
    */
-  public static IsNonRouting isNonRouting(boolean nonForwarding) {
-    return new IsNonRouting(equalTo(nonForwarding));
+  public static IsNonRouting isNonRouting(boolean nonRouting) {
+    return new IsNonRouting(equalTo(nonRouting));
   }
 
   private AbstractRouteDecoratorMatchers() {}

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/OspfRoutingProcessTest.java
@@ -842,18 +842,19 @@ public class OspfRoutingProcessTest {
             .setAdvertiser("someNode")
             .setArea(1L)
             .setAdmin(0)
-            .setNonRouting(true)
-            .setNextHopIp(Ip.parse("1.1.1.1"));
-    Stream<RouteAdvertisement<OspfExternalType1Route>> routes =
-        Stream.of(new RouteAdvertisement<>((OspfExternalType1Route) builder.build()));
+            .setNextHop(NextHopInterface.of("e0", Ip.parse("1.1.1.1")));
     final OspfArea ospfArea = OspfArea.builder().setNumber(33).build();
 
     // Going to area 0
+    // routing -> non-routing
     assertThat(
-        _routingProcess.transformType1RoutesOnExport(routes, AREA0_CONFIG),
-        contains(new RouteAdvertisement<>(builder.setArea(0).build())));
+        _routingProcess.transformType1RoutesOnExport(
+            Stream.of(new RouteAdvertisement<>((OspfExternalType1Route) builder.build())),
+            AREA0_CONFIG),
+        contains(new RouteAdvertisement<>(builder.setArea(0).setNonRouting(true).build())));
 
     // Going from area 0 to some area
+    // non-routing -> non-routing from here on
     assertThat(
         _routingProcess.transformType1RoutesOnExport(
             Stream.of(
@@ -947,13 +948,14 @@ public class OspfRoutingProcessTest {
             .setAdvertiser("someNode")
             .setArea(1L)
             .setAdmin(0)
-            .setNonRouting(true)
-            .setNextHopIp(Ip.parse("1.1.1.1"));
-    Stream<RouteAdvertisement<OspfExternalType2Route>> routes =
-        Stream.of(new RouteAdvertisement<>((OspfExternalType2Route) builder.build()));
+            .setNextHop(NextHopInterface.of("e0", Ip.parse("1.1.1.1")));
+    // routing -> non-routing
     assertThat(
-        OspfRoutingProcess.transformType2RoutesOnExport(routes, AREA0_CONFIG),
-        contains(new RouteAdvertisement<>(builder.setArea(1).build())));
+        OspfRoutingProcess.transformType2RoutesOnExport(
+            Stream.of(new RouteAdvertisement<>((OspfExternalType2Route) builder.build())),
+            AREA0_CONFIG),
+        contains(new RouteAdvertisement<>(builder.setArea(1).setNonRouting(true).build())));
+    // non-routing -> non-routing
     assertThat(
         OspfRoutingProcess.transformType2RoutesOnExport(
             Stream.of(

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -167,6 +167,7 @@ import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.matchers.ConfigurationMatchers;
 import org.batfish.datamodel.matchers.MlagMatchers;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
+import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.communities.CommunityContext;
@@ -645,7 +646,7 @@ public class AristaGrammarTest {
         hasItem(
             OspfExternalType2Route.builder()
                 .setNetwork(Prefix.ZERO)
-                .setNextHopIp(Ip.parse("1.2.3.5"))
+                .setNextHop(NextHopInterface.of("GigabitEthernet1/0", Ip.parse("1.2.3.5")))
                 .setArea(1)
                 .setCostToAdvertiser(1)
                 .setAdvertiser(advertiser)

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco/CiscoGrammarTest.java
@@ -359,6 +359,7 @@ import org.batfish.datamodel.ospf.OspfDefaultOriginateType;
 import org.batfish.datamodel.ospf.OspfProcess;
 import org.batfish.datamodel.ospf.StubType;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
+import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.route.nh.NextHopVrf;
 import org.batfish.datamodel.routing_policy.Environment.Direction;
@@ -1233,7 +1234,7 @@ public final class CiscoGrammarTest {
     assertTrue(
         routingPolicy.process(
             OspfIntraAreaRoute.builder()
-                .setNextHop(NextHopIp.of(Ip.parse("5.5.5.5")))
+                .setNextHop(NextHopInterface.of("dummyInterface", Ip.parse("5.5.5.5")))
                 .setNetwork(Prefix.parse("4.4.4.4/32"))
                 .setAdmin(1)
                 .setMetric(1)

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -410,16 +410,20 @@ public final class CiscoNxosGrammarTest {
         .setAdvertiser("dummy")
         .setArea(0L)
         .setCostToAdvertiser(0L)
-        .setNextHop(NextHopIp.of(Ip.parse("3.3.3.3")))
+        .setNextHop(NextHopInterface.of("dummyInt", Ip.parse("3.3.3.3")))
         .setLsaMetric(0L);
   }
 
   private static @Nonnull OspfIntraAreaRoute.Builder ospfRouteBuilder() {
-    return OspfIntraAreaRoute.builder().setNextHop(NextHopIp.of(Ip.parse("3.3.3.3"))).setArea(0L);
+    return OspfIntraAreaRoute.builder()
+        .setNextHop(NextHopInterface.of("dummyInterface", Ip.parse("3.3.3.3")))
+        .setArea(0L);
   }
 
   private static @Nonnull OspfInterAreaRoute.Builder ospfIARouteBuilder() {
-    return OspfInterAreaRoute.builder().setNextHop(NextHopIp.of(Ip.parse("3.3.3.3"))).setArea(0L);
+    return OspfInterAreaRoute.builder()
+        .setNextHop(NextHopInterface.of("dummyInterface", Ip.parse("3.3.3.3")))
+        .setArea(0L);
   }
 
   private @Nonnull BDD toBDD(AclLineMatchExpr aclLineMatchExpr) {
@@ -530,7 +534,7 @@ public final class CiscoNxosGrammarTest {
     OspfExternalRoute.Builder builder =
         OspfExternalRoute.builder()
             .setNetwork(route.getNetwork())
-            .setNextHop(NextHopIp.of(Ip.parse("3.3.3.3")))
+            .setNextHop(NextHopInterface.of("dummyInterface", Ip.parse("3.3.3.3")))
             .setLsaMetric(123L)
             .setArea(456L)
             .setCostToAdvertiser(789L)

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -88,6 +88,7 @@ import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.ospf.OspfAreaSummary;
 import org.batfish.datamodel.ospf.OspfAreaSummary.SummaryRouteBehavior;
 import org.batfish.datamodel.ospf.OspfProcess;
+import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.batfish.datamodel.routing_policy.RoutingPolicy;
 import org.batfish.datamodel.routing_policy.expr.LiteralLong;
 import org.batfish.grammar.BatfishParseTreeWalker;
@@ -2127,7 +2128,7 @@ public class CumulusFrrGrammarTest {
             equalTo(
                 OspfExternalType2Route.builder()
                     .setNetwork(Prefix.parse("10.2.2.2/32"))
-                    .setNextHopIp(Ip.parse("10.1.1.2"))
+                    .setNextHop(NextHopInterface.of("swp1", Ip.parse("10.1.1.2")))
                     .setAdvertiser("frr-redistributor")
                     .setAdmin(110)
                     .setLsaMetric(10000L)

--- a/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
+++ b/projects/question/src/test/java/org/batfish/question/routes/RoutesAnswererUtilTest.java
@@ -66,13 +66,13 @@ import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.OspfExternalType2Route;
 import org.batfish.datamodel.Prefix;
-import org.batfish.datamodel.Route;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.answers.Schema;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
 import org.batfish.datamodel.ospf.OspfMetricType;
 import org.batfish.datamodel.pojo.Node;
+import org.batfish.datamodel.route.nh.NextHopInterface;
 import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.table.Row;
 import org.batfish.question.routes.DiffRoutesOutput.KeyPresenceStatus;
@@ -179,7 +179,7 @@ public class RoutesAnswererUtilTest {
                     ImmutableSet.of(
                         OspfExternalType2Route.builder()
                             .setNetwork(Prefix.parse("1.1.1.0/24"))
-                            .setNextHopIp(Ip.parse("1.1.1.2"))
+                            .setNextHop(NextHopInterface.of("e0", Ip.parse("1.1.1.2")))
                             .setAdmin(10)
                             .setMetric(2L << 34)
                             .setLsaMetric(2)
@@ -206,7 +206,7 @@ public class RoutesAnswererUtilTest {
                 hasColumn(COL_VRF_NAME, Configuration.DEFAULT_VRF_NAME, Schema.STRING),
                 hasColumn(COL_NETWORK, Prefix.parse("1.1.1.0/24"), Schema.PREFIX),
                 hasColumn(COL_NEXT_HOP_IP, Ip.parse("1.1.1.2"), Schema.IP),
-                hasColumn(COL_NEXT_HOP_INTERFACE, "dynamic", Schema.STRING),
+                hasColumn(COL_NEXT_HOP_INTERFACE, "e0", Schema.STRING),
                 hasColumn(COL_NEXT_HOP, nullValue(), Schema.STRING),
                 hasColumn(COL_PROTOCOL, "ospfE2", Schema.STRING),
                 hasColumn(COL_TAG, equalTo(2L << 35), Schema.LONG),
@@ -474,7 +474,7 @@ public class RoutesAnswererUtilTest {
                     ImmutableSet.of(
                         OspfExternalType2Route.builder()
                             .setNetwork(Prefix.parse("1.1.1.0/24"))
-                            .setNextHopIp(Ip.parse("1.1.1.2"))
+                            .setNextHop(NextHopInterface.of("e0", Ip.parse("1.1.1.2")))
                             .setAdmin(10)
                             .setMetric(30L)
                             .setLsaMetric(2)
@@ -485,7 +485,7 @@ public class RoutesAnswererUtilTest {
                             .build(),
                         OspfExternalType2Route.builder()
                             .setNetwork(Prefix.parse("1.1.1.0/24"))
-                            .setNextHopIp(Ip.parse("1.1.1.3"))
+                            .setNextHop(NextHopInterface.of("e0", Ip.parse("1.1.1.3")))
                             .setAdmin(10)
                             .setMetric(20L)
                             .setLsaMetric(2)
@@ -519,14 +519,14 @@ public class RoutesAnswererUtilTest {
                 RouteRowAttribute.builder()
                     .setAdminDistance(10)
                     .setMetric(30L)
-                    .setNextHopInterface(Route.UNSET_NEXT_HOP_INTERFACE)
+                    .setNextHopInterface("e0")
                     .build()),
             new RouteRowSecondaryKey(Ip.parse("1.1.1.3"), "ospfE2"),
             ImmutableSortedSet.of(
                 RouteRowAttribute.builder()
                     .setAdminDistance(10)
                     .setMetric(20L)
-                    .setNextHopInterface(Route.UNSET_NEXT_HOP_INTERFACE)
+                    .setNextHopInterface("e0")
                     .build()));
     // matching the secondary key
     assertThat(innerGroup, equalTo(expectedInnerMap));

--- a/tests/basic/routes.ref
+++ b/tests/basic/routes.ref
@@ -94,18 +94,33 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
+          "id" : "node-as2border1",
+          "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "2.12.11.0/24",
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Network" : "2.23.11.0/24",
+        "Next_Hop_IP" : "2.12.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Next_Hop" : "as2core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.3.1/32",
+        "Next_Hop_IP" : "2.23.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
       },
       {
         "Node" : {
@@ -124,6 +139,21 @@
       },
       {
         "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "2.12.22.0/24",
+        "Next_Hop_IP" : "2.23.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
           "id" : "node-as2dept1",
           "name" : "as2dept1"
         },
@@ -136,6 +166,21 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
+        "VRF" : "default",
+        "Network" : "2.12.12.0/24",
+        "Next_Hop_IP" : "2.12.11.1",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2border1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -169,21 +214,6 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
-        },
-        "VRF" : "default",
-        "Network" : "2.23.22.0/24",
-        "Next_Hop_IP" : "2.23.12.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
           "id" : "node-as2border1",
           "name" : "as2border1"
         },
@@ -211,21 +241,6 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "2.34.201.0/24",
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
       },
       {
         "Node" : {
@@ -289,18 +304,33 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
         },
         "VRF" : "default",
-        "Network" : "2.1.1.1/32",
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
+        "Network" : "2.1.1.2/32",
+        "Next_Hop_IP" : "2.23.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core2",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as1border1",
+          "name" : "as1border1"
+        },
+        "VRF" : "default",
+        "Network" : "10.14.22.0/24",
+        "Next_Hop_IP" : "1.0.1.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as1core1",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -323,10 +353,10 @@
           "name" : "as1core1"
         },
         "VRF" : "default",
-        "Network" : "10.14.22.0/24",
-        "Next_Hop_IP" : "1.0.2.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1border2",
+        "Network" : "10.12.11.0/24",
+        "Next_Hop_IP" : "1.0.1.1",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as1border1",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -340,57 +370,12 @@
         "VRF" : "default",
         "Network" : "2.1.3.2/32",
         "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Next_Hop" : "as2core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 3
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "10.23.21.0/24",
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.2.2/32",
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as3border1",
-          "name" : "as3border1"
-        },
-        "VRF" : "default",
-        "Network" : "10.13.22.0/24",
-        "Next_Hop_IP" : "3.0.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as3core1",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
       },
       {
         "Node" : {
@@ -409,14 +394,44 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
+          "id" : "node-as2core1",
+          "name" : "as2core1"
         },
         "VRF" : "default",
-        "Network" : "2.34.101.0/24",
-        "Next_Hop_IP" : "2.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist1",
+        "Network" : "2.23.22.0/24",
+        "Next_Hop_IP" : "2.23.12.3",
+        "Next_Hop_Interface" : "GigabitEthernet3/0",
+        "Next_Hop" : "as2dist2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.2.1/32",
+        "Next_Hop_IP" : "2.23.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "10.12.11.0/24",
+        "Next_Hop_IP" : "2.23.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -424,18 +439,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
+          "id" : "node-as2border2",
+          "name" : "as2border2"
         },
         "VRF" : "default",
-        "Network" : "2.12.21.0/24",
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Network" : "2.34.201.0/24",
+        "Next_Hop_IP" : "2.12.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
+        "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 2
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -451,36 +466,6 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.34.101.0/24",
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.23.21.0/24",
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
       },
       {
         "Node" : {
@@ -496,6 +481,21 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 0
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.3.2/32",
+        "Next_Hop_IP" : "2.23.22.3",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2dist2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -511,21 +511,6 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
-        },
-        "VRF" : "default",
-        "Network" : "10.23.21.0/24",
-        "Next_Hop_IP" : "2.12.21.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
       },
       {
         "Node" : {
@@ -559,29 +544,14 @@
       },
       {
         "Node" : {
-          "id" : "node-as1border1",
-          "name" : "as1border1"
-        },
-        "VRF" : "default",
-        "Network" : "1.0.2.0/24",
-        "Next_Hop_IP" : "1.0.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
           "id" : "node-as2core2",
           "name" : "as2core2"
         },
         "VRF" : "default",
-        "Network" : "2.1.1.2/32",
-        "Next_Hop_IP" : "2.12.22.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
+        "Network" : "2.23.11.0/24",
+        "Next_Hop_IP" : "2.23.21.3",
+        "Next_Hop_Interface" : "GigabitEthernet3/0",
+        "Next_Hop" : "as2dist1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -589,63 +559,33 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
+          "id" : "node-as3border2",
+          "name" : "as3border2"
         },
         "VRF" : "default",
-        "Network" : "2.12.21.0/24",
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "10.23.21.0/24",
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
-        },
-        "VRF" : "default",
-        "Network" : "2.34.201.0/24",
-        "Next_Hop_IP" : "2.23.22.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist2",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.1.2/32",
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
+        "Network" : "3.1.1.1/32",
+        "Next_Hop_IP" : "3.0.2.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as3core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
+        "VRF" : "default",
+        "Network" : "2.23.22.0/24",
+        "Next_Hop_IP" : "2.12.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -728,6 +668,36 @@
           "name" : "as2core1"
         },
         "VRF" : "default",
+        "Network" : "2.1.1.1/32",
+        "Next_Hop_IP" : "2.12.11.1",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2border1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.1.1/32",
+        "Next_Hop_IP" : "2.12.12.1",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2border1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
+        "VRF" : "default",
         "Network" : "3.0.1.0/24",
         "Next_Hop_IP" : "10.23.21.3",
         "Next_Hop_Interface" : "dynamic",
@@ -788,36 +758,6 @@
           "name" : "as3border1"
         },
         "VRF" : "default",
-        "Network" : "3.10.1.1/32",
-        "Next_Hop_IP" : "3.0.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as3core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.3.1/32",
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
-          "id" : "node-as3border1",
-          "name" : "as3border1"
-        },
-        "VRF" : "default",
         "Network" : "2.128.0.0/16",
         "Next_Hop_IP" : "10.23.21.2",
         "Next_Hop_Interface" : "dynamic",
@@ -844,33 +784,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
+          "id" : "node-as2border2",
+          "name" : "as2border2"
         },
         "VRF" : "default",
-        "Network" : "10.12.11.0/24",
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Network" : "2.23.21.0/24",
+        "Next_Hop_IP" : "2.12.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Next_Hop" : "as2core2",
-        "Protocol" : "ospfE2",
+        "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.34.101.0/24",
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -901,6 +826,21 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "10.12.11.0/24",
+        "Next_Hop_IP" : "2.23.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -964,6 +904,51 @@
       },
       {
         "Node" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.2.2/32",
+        "Next_Hop_IP" : "2.12.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as3border2",
+          "name" : "as3border2"
+        },
+        "VRF" : "default",
+        "Network" : "3.10.1.1/32",
+        "Next_Hop_IP" : "3.0.2.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as3core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as1core1",
+          "name" : "as1core1"
+        },
+        "VRF" : "default",
+        "Network" : "10.14.22.0/24",
+        "Next_Hop_IP" : "1.0.2.1",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as1border2",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
           "id" : "node-host1",
           "name" : "host1"
         },
@@ -976,6 +961,21 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.2.2/32",
+        "Next_Hop_IP" : "2.23.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -998,51 +998,6 @@
           "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "2.1.2.2/32",
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.1.1/32",
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.1.2/32",
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
         "Network" : "2.12.12.0/24",
         "Next_Hop_IP" : "AUTO/NONE(-1l)",
         "Next_Hop_Interface" : "GigabitEthernet2/0",
@@ -1051,21 +1006,6 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as1border2",
-          "name" : "as1border2"
-        },
-        "VRF" : "default",
-        "Network" : "1.10.1.1/32",
-        "Next_Hop_IP" : "1.0.2.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
       },
       {
         "Node" : {
@@ -1118,14 +1058,14 @@
           "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "2.34.101.0/24",
+        "Network" : "2.1.3.1/32",
         "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Next_Hop" : "as2core2",
-        "Protocol" : "ospfE2",
+        "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 3
       },
       {
         "Node" : {
@@ -1144,6 +1084,36 @@
       },
       {
         "Node" : {
+          "id" : "node-as1core1",
+          "name" : "as1core1"
+        },
+        "VRF" : "default",
+        "Network" : "1.1.1.1/32",
+        "Next_Hop_IP" : "1.0.1.1",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as1border1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
+        "VRF" : "default",
+        "Network" : "2.12.22.0/24",
+        "Next_Hop_IP" : "2.12.21.1",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2border2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
           "id" : "node-as1border1",
           "name" : "as1border1"
         },
@@ -1159,14 +1129,14 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
+          "id" : "node-as2core2",
+          "name" : "as2core2"
         },
         "VRF" : "default",
-        "Network" : "2.23.22.0/24",
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
+        "Network" : "2.1.1.2/32",
+        "Next_Hop_IP" : "2.12.22.1",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2border2",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1174,18 +1144,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
+          "id" : "node-as3border2",
+          "name" : "as3border2"
         },
         "VRF" : "default",
-        "Network" : "2.34.101.0/24",
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospfE2",
+        "Network" : "3.0.1.0/24",
+        "Next_Hop_IP" : "3.0.2.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as3core1",
+        "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -1234,93 +1204,63 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.3.2/32",
-        "Next_Hop_IP" : "2.23.22.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.23.11.0/24",
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.23.22.0/24",
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.2.1/32",
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "2.23.12.0/24",
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
           "id" : "node-as1core1",
           "name" : "as1core1"
         },
         "VRF" : "default",
         "Network" : "1.2.2.2/32",
         "Next_Hop_IP" : "1.0.2.1",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Next_Hop" : "as1border2",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.2.2/32",
+        "Next_Hop_IP" : "2.23.12.3",
+        "Next_Hop_Interface" : "GigabitEthernet3/0",
+        "Next_Hop" : "as2dist2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
+        "VRF" : "default",
+        "Network" : "2.34.201.0/24",
+        "Next_Hop_IP" : "2.23.22.3",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2dist2",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
+        "VRF" : "default",
+        "Network" : "2.34.201.0/24",
+        "Next_Hop_IP" : "2.12.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -1354,18 +1294,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
+          "id" : "node-as2border1",
+          "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "2.23.12.0/24",
-        "Next_Hop_IP" : "2.23.22.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist2",
-        "Protocol" : "ospf",
+        "Network" : "10.23.21.0/24",
+        "Next_Hop_IP" : "2.12.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 2
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -1373,29 +1313,14 @@
           "name" : "as2border2"
         },
         "VRF" : "default",
-        "Network" : "2.23.11.0/24",
+        "Network" : "2.1.3.1/32",
         "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Next_Hop" : "as2core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "10.12.11.0/24",
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 3
       },
       {
         "Node" : {
@@ -1429,36 +1354,6 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.1.1/32",
-        "Next_Hop_IP" : "2.12.12.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.2.1/32",
-        "Next_Hop_IP" : "2.12.22.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
           "id" : "node-as1core1",
           "name" : "as1core1"
         },
@@ -1486,6 +1381,21 @@
         "Tag" : null,
         "Admin_Distance" : 20,
         "Metric" : 50
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.3.2/32",
+        "Next_Hop_IP" : "2.12.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
       },
       {
         "Node" : {
@@ -1549,14 +1459,29 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
         },
         "VRF" : "default",
-        "Network" : "10.23.21.0/24",
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Network" : "2.23.21.0/24",
+        "Next_Hop_IP" : "2.23.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
+        "VRF" : "default",
+        "Network" : "2.34.101.0/24",
+        "Next_Hop_IP" : "2.23.11.3",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2dist1",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1579,14 +1504,74 @@
       },
       {
         "Node" : {
-          "id" : "node-as1border1",
-          "name" : "as1border1"
+          "id" : "node-as2core1",
+          "name" : "as2core1"
         },
         "VRF" : "default",
-        "Network" : "10.14.22.0/24",
-        "Next_Hop_IP" : "1.0.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1core1",
+        "Network" : "2.1.3.2/32",
+        "Next_Hop_IP" : "2.23.12.3",
+        "Next_Hop_Interface" : "GigabitEthernet3/0",
+        "Next_Hop" : "as2dist2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
+        "VRF" : "default",
+        "Network" : "2.34.201.0/24",
+        "Next_Hop_IP" : "2.23.12.3",
+        "Next_Hop_Interface" : "GigabitEthernet3/0",
+        "Next_Hop" : "as2dist2",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "2.12.21.0/24",
+        "Next_Hop_IP" : "2.23.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.1.2/32",
+        "Next_Hop_IP" : "2.23.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as3border1",
+          "name" : "as3border1"
+        },
+        "VRF" : "default",
+        "Network" : "10.13.22.0/24",
+        "Next_Hop_IP" : "3.0.1.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as3core1",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -1606,6 +1591,21 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
+      },
+      {
+        "Node" : {
+          "id" : "node-as1core1",
+          "name" : "as1core1"
+        },
+        "VRF" : "default",
+        "Network" : "10.13.22.0/24",
+        "Next_Hop_IP" : "1.0.2.1",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as1border2",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -1639,18 +1639,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
+          "id" : "node-as2border2",
+          "name" : "as2border2"
         },
         "VRF" : "default",
-        "Network" : "10.12.11.0/24",
-        "Next_Hop_IP" : "2.12.12.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border1",
-        "Protocol" : "ospfE2",
+        "Network" : "2.1.3.2/32",
+        "Next_Hop_IP" : "2.12.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 3
       },
       {
         "Node" : {
@@ -1699,6 +1699,36 @@
       },
       {
         "Node" : {
+          "id" : "node-as3core1",
+          "name" : "as3core1"
+        },
+        "VRF" : "default",
+        "Network" : "3.1.1.1/32",
+        "Next_Hop_IP" : "3.0.1.1",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as3border1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "2.12.11.0/24",
+        "Next_Hop_IP" : "2.23.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
           "id" : "node-as2border1",
           "name" : "as2border1"
         },
@@ -1726,21 +1756,6 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as3border1",
-          "name" : "as3border1"
-        },
-        "VRF" : "default",
-        "Network" : "3.0.2.0/24",
-        "Next_Hop_IP" : "3.0.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as3core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
       },
       {
         "Node" : {
@@ -1789,6 +1804,21 @@
       },
       {
         "Node" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
+        "VRF" : "default",
+        "Network" : "2.34.201.0/24",
+        "Next_Hop_IP" : "2.12.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
           "id" : "node-as3border2",
           "name" : "as3border2"
         },
@@ -1801,21 +1831,6 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "10.12.11.0/24",
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
       },
       {
         "Node" : {
@@ -1834,18 +1849,108 @@
       },
       {
         "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.1.1/32",
+        "Next_Hop_IP" : "2.23.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
           "id" : "node-as3border2",
           "name" : "as3border2"
         },
         "VRF" : "default",
         "Network" : "10.23.21.0/24",
         "Next_Hop_IP" : "3.0.2.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Next_Hop" : "as3core1",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.1.2/32",
+        "Next_Hop_IP" : "2.23.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
+        "VRF" : "default",
+        "Network" : "2.34.101.0/24",
+        "Next_Hop_IP" : "2.23.21.3",
+        "Next_Hop_Interface" : "GigabitEthernet3/0",
+        "Next_Hop" : "as2dist1",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
+        "VRF" : "default",
+        "Network" : "2.34.101.0/24",
+        "Next_Hop_IP" : "2.12.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as3border1",
+          "name" : "as3border1"
+        },
+        "VRF" : "default",
+        "Network" : "3.2.2.2/32",
+        "Next_Hop_IP" : "3.0.1.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as3core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
+        "VRF" : "default",
+        "Network" : "2.23.12.0/24",
+        "Next_Hop_IP" : "2.12.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -1861,21 +1966,6 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as3border2",
-          "name" : "as3border2"
-        },
-        "VRF" : "default",
-        "Network" : "3.1.1.1/32",
-        "Next_Hop_IP" : "3.0.2.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as3core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
       },
       {
         "Node" : {
@@ -1936,6 +2026,21 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 50
+      },
+      {
+        "Node" : {
+          "id" : "node-as3border1",
+          "name" : "as3border1"
+        },
+        "VRF" : "default",
+        "Network" : "3.0.2.0/24",
+        "Next_Hop_IP" : "3.0.1.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as3core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -2029,6 +2134,21 @@
       },
       {
         "Node" : {
+          "id" : "node-as1border2",
+          "name" : "as1border2"
+        },
+        "VRF" : "default",
+        "Network" : "1.0.1.0/24",
+        "Next_Hop_IP" : "1.0.2.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as1core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
           "id" : "node-as3core1",
           "name" : "as3core1"
         },
@@ -2044,48 +2164,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
+          "id" : "node-as3core1",
+          "name" : "as3core1"
         },
         "VRF" : "default",
-        "Network" : "2.1.1.1/32",
-        "Next_Hop_IP" : "2.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
-        },
-        "VRF" : "default",
-        "Network" : "2.34.201.0/24",
-        "Next_Hop_IP" : "2.23.12.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist2",
+        "Network" : "10.13.22.0/24",
+        "Next_Hop_IP" : "3.0.2.1",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as3border2",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.2.1/32",
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
       },
       {
         "Node" : {
@@ -2104,21 +2194,6 @@
       },
       {
         "Node" : {
-          "id" : "node-as1core1",
-          "name" : "as1core1"
-        },
-        "VRF" : "default",
-        "Network" : "10.13.22.0/24",
-        "Next_Hop_IP" : "1.0.2.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1border2",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
-      },
-      {
-        "Node" : {
           "id" : "node-as2core2",
           "name" : "as2core2"
         },
@@ -2134,14 +2209,14 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
         },
         "VRF" : "default",
-        "Network" : "2.1.2.1/32",
-        "Next_Hop_IP" : "2.12.12.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border1",
+        "Network" : "2.1.1.1/32",
+        "Next_Hop_IP" : "2.23.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2191,36 +2266,6 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.2.2/32",
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.1.1/32",
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
       },
       {
         "Node" : {
@@ -2239,59 +2284,14 @@
       },
       {
         "Node" : {
-          "id" : "node-as3border2",
-          "name" : "as3border2"
+          "id" : "node-as2border1",
+          "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "3.10.1.1/32",
-        "Next_Hop_IP" : "3.0.2.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as3core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.3.2/32",
-        "Next_Hop_IP" : "2.23.12.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "2.12.22.0/24",
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Network" : "2.1.1.2/32",
+        "Next_Hop_IP" : "2.12.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.3.1/32",
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2311,6 +2311,21 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 50
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.2.1/32",
+        "Next_Hop_IP" : "2.23.21.3",
+        "Next_Hop_Interface" : "GigabitEthernet3/0",
+        "Next_Hop" : "as2dist1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
       },
       {
         "Node" : {
@@ -2344,14 +2359,14 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
         },
         "VRF" : "default",
-        "Network" : "2.12.11.0/24",
-        "Next_Hop_IP" : "2.12.12.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border1",
+        "Network" : "2.23.11.0/24",
+        "Next_Hop_IP" : "2.23.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -2389,33 +2404,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
+          "id" : "node-as2border2",
+          "name" : "as2border2"
         },
         "VRF" : "default",
-        "Network" : "2.12.12.0/24",
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
+        "Network" : "2.23.11.0/24",
+        "Next_Hop_IP" : "2.12.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.2.2/32",
-        "Next_Hop_IP" : "2.12.21.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
       },
       {
         "Node" : {
@@ -2479,36 +2479,6 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.1.2/32",
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
-        },
-        "VRF" : "default",
-        "Network" : "2.12.22.0/24",
-        "Next_Hop_IP" : "2.12.21.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
           "id" : "node-as2core1",
           "name" : "as2core1"
         },
@@ -2521,36 +2491,6 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.1.1/32",
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
-          "id" : "node-as3border1",
-          "name" : "as3border1"
-        },
-        "VRF" : "default",
-        "Network" : "3.2.2.2/32",
-        "Next_Hop_IP" : "3.0.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as3core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
       },
       {
         "Node" : {
@@ -2584,13 +2524,28 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
+          "id" : "node-as2core1",
+          "name" : "as2core1"
         },
         "VRF" : "default",
-        "Network" : "10.12.11.0/24",
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Network" : "2.1.1.2/32",
+        "Next_Hop_IP" : "2.12.21.1",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2border2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "10.23.21.0/24",
+        "Next_Hop_IP" : "2.23.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Next_Hop" : "as2core1",
         "Protocol" : "ospfE2",
         "Tag" : null,
@@ -2663,21 +2618,6 @@
           "name" : "as2core2"
         },
         "VRF" : "default",
-        "Network" : "2.1.2.1/32",
-        "Next_Hop_IP" : "2.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
-        },
-        "VRF" : "default",
         "Network" : "2.1.2.2/32",
         "Next_Hop_IP" : "AUTO/NONE(-1l)",
         "Next_Hop_Interface" : "Loopback0",
@@ -2734,13 +2674,13 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
+          "id" : "node-as2border2",
+          "name" : "as2border2"
         },
         "VRF" : "default",
-        "Network" : "2.1.1.2/32",
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Network" : "2.1.3.1/32",
+        "Next_Hop_IP" : "2.12.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Next_Hop" : "as2core2",
         "Protocol" : "ospf",
         "Tag" : null,
@@ -2779,6 +2719,36 @@
       },
       {
         "Node" : {
+          "id" : "node-as1border1",
+          "name" : "as1border1"
+        },
+        "VRF" : "default",
+        "Network" : "1.10.1.1/32",
+        "Next_Hop_IP" : "1.0.1.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as1core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as1border2",
+          "name" : "as1border2"
+        },
+        "VRF" : "default",
+        "Network" : "1.10.1.1/32",
+        "Next_Hop_IP" : "1.0.2.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as1core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
           "id" : "node-host1",
           "name" : "host1"
         },
@@ -2798,6 +2768,21 @@
           "name" : "as2core2"
         },
         "VRF" : "default",
+        "Network" : "2.1.2.1/32",
+        "Next_Hop_IP" : "2.12.12.1",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2border1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
+        "VRF" : "default",
         "Network" : "2.23.21.2/32",
         "Next_Hop_IP" : "AUTO/NONE(-1l)",
         "Next_Hop_Interface" : "GigabitEthernet3/0",
@@ -2809,18 +2794,48 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
+          "id" : "node-as2core2",
+          "name" : "as2core2"
         },
         "VRF" : "default",
-        "Network" : "2.1.2.2/32",
-        "Next_Hop_IP" : "2.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border1",
+        "Network" : "2.1.3.1/32",
+        "Next_Hop_IP" : "2.23.21.3",
+        "Next_Hop_Interface" : "GigabitEthernet3/0",
+        "Next_Hop" : "as2dist1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 3
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
+        "VRF" : "default",
+        "Network" : "2.23.12.0/24",
+        "Next_Hop_IP" : "2.12.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
+        "VRF" : "default",
+        "Network" : "2.23.22.0/24",
+        "Next_Hop_IP" : "2.12.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -2828,14 +2843,14 @@
           "name" : "as2dist1"
         },
         "VRF" : "default",
-        "Network" : "2.1.1.1/32",
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
+        "Network" : "2.12.12.0/24",
+        "Next_Hop_IP" : "2.23.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 3
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -2869,36 +2884,6 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.3.2/32",
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.1.2/32",
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
           "id" : "node-host2",
           "name" : "host2"
         },
@@ -2911,51 +2896,6 @@
         "Tag" : null,
         "Admin_Distance" : 1,
         "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as1border2",
-          "name" : "as1border2"
-        },
-        "VRF" : "default",
-        "Network" : "1.0.1.0/24",
-        "Next_Hop_IP" : "1.0.2.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.3.1/32",
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
-          "id" : "node-as3core1",
-          "name" : "as3core1"
-        },
-        "VRF" : "default",
-        "Network" : "3.2.2.2/32",
-        "Next_Hop_IP" : "3.0.2.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as3border2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
       },
       {
         "Node" : {
@@ -2989,18 +2929,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as3core1",
-          "name" : "as3core1"
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
         },
         "VRF" : "default",
-        "Network" : "10.23.21.0/24",
-        "Next_Hop_IP" : "3.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as3border1",
-        "Protocol" : "ospfE2",
+        "Network" : "2.1.2.1/32",
+        "Next_Hop_IP" : "2.23.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -3016,36 +2956,6 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.3.2/32",
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.12.22.0/24",
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
       },
       {
         "Node" : {
@@ -3079,63 +2989,33 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
+          "id" : "node-as2core1",
+          "name" : "as2core1"
         },
         "VRF" : "default",
-        "Network" : "2.12.12.0/24",
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
+        "Network" : "10.12.11.0/24",
+        "Next_Hop_IP" : "2.12.11.1",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2border1",
+        "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 2
+        "Metric" : 20
       },
       {
         "Node" : {
-          "id" : "node-as1border1",
-          "name" : "as1border1"
+          "id" : "node-as2core2",
+          "name" : "as2core2"
         },
         "VRF" : "default",
-        "Network" : "1.2.2.2/32",
-        "Next_Hop_IP" : "1.0.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1core1",
-        "Protocol" : "ospf",
+        "Network" : "10.12.11.0/24",
+        "Next_Hop_IP" : "2.12.12.1",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2border1",
+        "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.0.0/24",
-        "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dept1",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.128.0.0/24",
-        "Next_Hop_IP" : "2.34.201.4",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dept1",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -3143,10 +3023,85 @@
           "name" : "as2border2"
         },
         "VRF" : "default",
-        "Network" : "2.34.101.0/24",
+        "Network" : "10.12.11.0/24",
         "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Next_Hop" : "as2core1",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
+        "VRF" : "default",
+        "Network" : "2.128.0.0/24",
+        "Next_Hop_IP" : "2.34.201.4",
+        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop" : "as2dept1",
+        "Protocol" : "ibgp",
+        "Tag" : null,
+        "Admin_Distance" : 200,
+        "Metric" : 50
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
+        "VRF" : "default",
+        "Network" : "2.128.0.0/24",
+        "Next_Hop_IP" : "2.34.201.4",
+        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop" : "as2dept1",
+        "Protocol" : "ibgp",
+        "Tag" : null,
+        "Admin_Distance" : 200,
+        "Metric" : 50
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.1.1/32",
+        "Next_Hop_IP" : "2.23.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
+        "VRF" : "default",
+        "Network" : "10.23.21.0/24",
+        "Next_Hop_IP" : "2.12.22.1",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2border2",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "2.34.201.0/24",
+        "Next_Hop_IP" : "2.23.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3184,18 +3139,33 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
+          "id" : "node-as2border2",
+          "name" : "as2border2"
         },
         "VRF" : "default",
-        "Network" : "10.12.11.0/24",
-        "Next_Hop_IP" : "2.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border1",
-        "Protocol" : "ospfE2",
+        "Network" : "2.12.11.0/24",
+        "Next_Hop_IP" : "2.12.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "2.23.12.0/24",
+        "Next_Hop_IP" : "2.23.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -3244,21 +3214,6 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.1.2/32",
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
           "id" : "node-as2core1",
           "name" : "as2core1"
         },
@@ -3274,29 +3229,14 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
+          "id" : "node-as3core1",
+          "name" : "as3core1"
         },
         "VRF" : "default",
-        "Network" : "2.12.11.0/24",
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.2.1/32",
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
+        "Network" : "3.2.2.2/32",
+        "Next_Hop_IP" : "3.0.2.1",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as3border2",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3364,14 +3304,29 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
         },
         "VRF" : "default",
         "Network" : "2.1.1.2/32",
-        "Next_Hop_IP" : "2.12.21.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
+        "Next_Hop_IP" : "2.23.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
+        "VRF" : "default",
+        "Network" : "2.12.11.0/24",
+        "Next_Hop_IP" : "2.12.12.1",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2border1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3379,18 +3334,33 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
+          "id" : "node-as1border2",
+          "name" : "as1border2"
         },
         "VRF" : "default",
-        "Network" : "2.34.201.0/24",
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospfE2",
+        "Network" : "1.1.1.1/32",
+        "Next_Hop_IP" : "1.0.2.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as1core1",
+        "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
+        "VRF" : "default",
+        "Network" : "2.12.22.0/24",
+        "Next_Hop_IP" : "2.12.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -3439,18 +3409,78 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
         },
         "VRF" : "default",
-        "Network" : "2.1.3.1/32",
-        "Next_Hop_IP" : "2.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist1",
-        "Protocol" : "ospf",
+        "Network" : "2.34.201.0/24",
+        "Next_Hop_IP" : "2.23.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 2
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "10.12.11.0/24",
+        "Next_Hop_IP" : "2.23.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
+        "VRF" : "default",
+        "Network" : "2.34.101.0/24",
+        "Next_Hop_IP" : "2.12.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "2.34.101.0/24",
+        "Next_Hop_IP" : "2.23.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "10.23.21.0/24",
+        "Next_Hop_IP" : "2.23.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -3466,21 +3496,6 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as1border1",
-          "name" : "as1border1"
-        },
-        "VRF" : "default",
-        "Network" : "10.13.22.0/24",
-        "Next_Hop_IP" : "1.0.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1core1",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
       },
       {
         "Node" : {
@@ -3511,6 +3526,36 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 50
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.2.1/32",
+        "Next_Hop_IP" : "2.12.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.2.2/32",
+        "Next_Hop_IP" : "2.23.11.3",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2dist1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
       },
       {
         "Node" : {
@@ -3548,6 +3593,21 @@
           "name" : "as2core2"
         },
         "VRF" : "default",
+        "Network" : "2.23.12.0/24",
+        "Next_Hop_IP" : "2.23.22.3",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2dist2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
+        "VRF" : "default",
         "Network" : "2.12.12.2/32",
         "Next_Hop_IP" : "AUTO/NONE(-1l)",
         "Next_Hop_Interface" : "GigabitEthernet1/0",
@@ -3563,10 +3623,55 @@
           "name" : "as2core2"
         },
         "VRF" : "default",
-        "Network" : "2.12.21.0/24",
+        "Network" : "2.1.2.1/32",
         "Next_Hop_IP" : "2.12.22.1",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Next_Hop" : "as2border2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
+        "VRF" : "default",
+        "Network" : "1.0.1.0/24",
+        "Next_Hop_IP" : "10.12.11.1",
+        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop" : "as1border1",
+        "Protocol" : "ibgp",
+        "Tag" : null,
+        "Admin_Distance" : 200,
+        "Metric" : 50
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
+        "VRF" : "default",
+        "Network" : "1.0.1.0/24",
+        "Next_Hop_IP" : "10.12.11.1",
+        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop" : "as1border1",
+        "Protocol" : "ibgp",
+        "Tag" : null,
+        "Admin_Distance" : 200,
+        "Metric" : 50
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "2.23.22.0/24",
+        "Next_Hop_IP" : "2.23.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3574,48 +3679,33 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "1.0.1.0/24",
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1border1",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "1.0.1.0/24",
-        "Next_Hop_IP" : "10.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1border1",
-        "Protocol" : "ibgp",
-        "Tag" : null,
-        "Admin_Distance" : 200,
-        "Metric" : 50
-      },
-      {
-        "Node" : {
           "id" : "node-as2border1",
           "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "2.34.201.0/24",
+        "Network" : "2.1.3.1/32",
         "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Next_Hop" : "as2core1",
-        "Protocol" : "ospfE2",
+        "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.1.1/32",
+        "Next_Hop_IP" : "2.12.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
       },
       {
         "Node" : {
@@ -3634,6 +3724,21 @@
       },
       {
         "Node" : {
+          "id" : "node-as1border1",
+          "name" : "as1border1"
+        },
+        "VRF" : "default",
+        "Network" : "1.0.2.0/24",
+        "Next_Hop_IP" : "1.0.1.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as1core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
           "id" : "node-as2border1",
           "name" : "as2border1"
         },
@@ -3691,6 +3796,21 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 50
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.3.1/32",
+        "Next_Hop_IP" : "2.23.11.3",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2dist1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -3784,43 +3904,28 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "10.12.11.0/24",
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "2.12.11.0/24",
-        "Next_Hop_IP" : "2.12.21.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
           "id" : "node-as2core1",
           "name" : "as2core1"
         },
         "VRF" : "default",
         "Network" : "2.1.2.2/32",
-        "Next_Hop_IP" : "2.23.12.3",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_IP" : "2.12.21.1",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2border2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core2",
+          "name" : "as2core2"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.2.1/32",
+        "Next_Hop_IP" : "2.23.22.3",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Next_Hop" : "as2dist2",
         "Protocol" : "ospf",
         "Tag" : null,
@@ -3829,78 +3934,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
+          "id" : "node-as2border1",
+          "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "10.23.21.0/24",
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.3.2/32",
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Network" : "2.34.201.0/24",
+        "Next_Hop_IP" : "2.12.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
-          "id" : "node-as3core1",
-          "name" : "as3core1"
-        },
-        "VRF" : "default",
-        "Network" : "10.13.22.0/24",
-        "Next_Hop_IP" : "3.0.2.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as3border2",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.2.1/32",
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as1core1",
-          "name" : "as1core1"
-        },
-        "VRF" : "default",
-        "Network" : "1.1.1.1/32",
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1border1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
       },
       {
         "Node" : {
@@ -3919,14 +3964,14 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
+          "id" : "node-as1border1",
+          "name" : "as1border1"
         },
         "VRF" : "default",
-        "Network" : "2.1.3.1/32",
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
+        "Network" : "1.2.2.2/32",
+        "Next_Hop_IP" : "1.0.1.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as1core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -3938,29 +3983,14 @@
           "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "2.23.21.0/24",
+        "Network" : "10.23.21.0/24",
         "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
+        "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "2.23.12.0/24",
-        "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -3994,18 +4024,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
+          "id" : "node-as2border1",
+          "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "2.34.201.0/24",
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Network" : "2.1.3.2/32",
+        "Next_Hop_IP" : "2.12.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Next_Hop" : "as2core2",
-        "Protocol" : "ospfE2",
+        "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 3
       },
       {
         "Node" : {
@@ -4024,14 +4054,14 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
         },
         "VRF" : "default",
-        "Network" : "2.23.12.0/24",
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
+        "Network" : "2.12.12.0/24",
+        "Next_Hop_IP" : "2.23.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core2",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4066,6 +4096,21 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 50
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "2.12.21.0/24",
+        "Next_Hop_IP" : "2.23.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -4099,51 +4144,6 @@
       },
       {
         "Node" : {
-          "id" : "node-as1border2",
-          "name" : "as1border2"
-        },
-        "VRF" : "default",
-        "Network" : "10.12.11.0/24",
-        "Next_Hop_IP" : "1.0.2.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1core1",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as1core1",
-          "name" : "as1core1"
-        },
-        "VRF" : "default",
-        "Network" : "10.12.11.0/24",
-        "Next_Hop_IP" : "1.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1border1",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
-        },
-        "VRF" : "default",
-        "Network" : "2.23.21.0/24",
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
           "id" : "node-as2border1",
           "name" : "as2border1"
         },
@@ -4174,28 +4174,13 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
         },
         "VRF" : "default",
-        "Network" : "2.34.101.0/24",
-        "Next_Hop_IP" : "2.23.11.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist1",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.2.2/32",
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Network" : "2.12.22.0/24",
+        "Next_Hop_IP" : "2.23.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Next_Hop" : "as2core2",
         "Protocol" : "ospf",
         "Tag" : null,
@@ -4219,21 +4204,6 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.12.22.0/24",
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
           "id" : "node-as2dept1",
           "name" : "as2dept1"
         },
@@ -4246,21 +4216,6 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.23.11.0/24",
-        "Next_Hop_IP" : "2.12.11.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
       },
       {
         "Node" : {
@@ -4313,14 +4268,14 @@
           "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "2.34.201.0/24",
+        "Network" : "2.23.21.0/24",
         "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
         "Next_Hop" : "as2core2",
-        "Protocol" : "ospfE2",
+        "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -4369,18 +4324,33 @@
       },
       {
         "Node" : {
-          "id" : "node-as1border1",
-          "name" : "as1border1"
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
         },
         "VRF" : "default",
-        "Network" : "1.10.1.1/32",
-        "Next_Hop_IP" : "1.0.1.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1core1",
+        "Network" : "2.1.3.1/32",
+        "Next_Hop_IP" : "2.23.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core2",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 2
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "10.12.11.0/24",
+        "Next_Hop_IP" : "2.23.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -4388,14 +4358,14 @@
           "name" : "as2border2"
         },
         "VRF" : "default",
-        "Network" : "2.12.12.0/24",
+        "Network" : "10.12.11.0/24",
         "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
+        "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 2
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -4429,44 +4399,14 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
-        },
-        "VRF" : "default",
-        "Network" : "2.23.11.0/24",
-        "Next_Hop_IP" : "2.23.21.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
           "id" : "node-as2core1",
           "name" : "as2core1"
         },
         "VRF" : "default",
-        "Network" : "2.23.21.0/24",
-        "Next_Hop_IP" : "2.23.11.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "10.12.11.0/24",
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
+        "Network" : "10.23.21.0/24",
+        "Next_Hop_IP" : "2.12.21.1",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2border2",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4489,18 +4429,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
+          "id" : "node-as2border1",
+          "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "2.1.2.1/32",
-        "Next_Hop_IP" : "2.23.22.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist2",
-        "Protocol" : "ospf",
+        "Network" : "2.34.101.0/24",
+        "Next_Hop_IP" : "2.12.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 3
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -4519,14 +4459,14 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
+          "id" : "node-as2border1",
+          "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "2.12.12.0/24",
-        "Next_Hop_IP" : "2.12.11.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border1",
+        "Network" : "2.12.21.0/24",
+        "Next_Hop_IP" : "2.12.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4534,33 +4474,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.1.1/32",
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
           "id" : "node-as2border2",
           "name" : "as2border2"
         },
         "VRF" : "default",
-        "Network" : "2.1.3.1/32",
+        "Network" : "2.1.2.2/32",
         "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Next_Hop" : "as2core2",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 3
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -4568,29 +4493,29 @@
           "name" : "as2dist2"
         },
         "VRF" : "default",
-        "Network" : "2.1.3.1/32",
+        "Network" : "2.12.11.0/24",
         "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Next_Hop" : "as2core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 3
+        "Metric" : 2
       },
       {
         "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
+          "id" : "node-as3core1",
+          "name" : "as3core1"
         },
         "VRF" : "default",
-        "Network" : "2.1.2.2/32",
-        "Next_Hop_IP" : "2.23.11.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist1",
-        "Protocol" : "ospf",
+        "Network" : "10.23.21.0/24",
+        "Next_Hop_IP" : "3.0.1.1",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as3border1",
+        "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 3
+        "Metric" : 20
       },
       {
         "Node" : {
@@ -4639,21 +4564,6 @@
       },
       {
         "Node" : {
-          "id" : "node-as3core1",
-          "name" : "as3core1"
-        },
-        "VRF" : "default",
-        "Network" : "3.1.1.1/32",
-        "Next_Hop_IP" : "3.0.1.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as3border1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
-      },
-      {
-        "Node" : {
           "id" : "node-as2dist1",
           "name" : "as2dist1"
         },
@@ -4681,21 +4591,6 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 50
-      },
-      {
-        "Node" : {
-          "id" : "node-as2core1",
-          "name" : "as2core1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.3.1/32",
-        "Next_Hop_IP" : "2.23.11.3",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2dist1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
       },
       {
         "Node" : {
@@ -4714,13 +4609,13 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist1",
-          "name" : "as2dist1"
+          "id" : "node-as2border2",
+          "name" : "as2border2"
         },
         "VRF" : "default",
-        "Network" : "2.23.22.0/24",
-        "Next_Hop_IP" : "2.23.21.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Network" : "2.12.12.0/24",
+        "Next_Hop_IP" : "2.12.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Next_Hop" : "as2core2",
         "Protocol" : "ospf",
         "Tag" : null,
@@ -4729,18 +4624,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
+          "id" : "node-as2core2",
+          "name" : "as2core2"
         },
         "VRF" : "default",
-        "Network" : "10.23.21.0/24",
-        "Next_Hop_IP" : "2.23.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospfE2",
+        "Network" : "2.12.21.0/24",
+        "Next_Hop_IP" : "2.12.22.1",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2border2",
+        "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 2
       },
       {
         "Node" : {
@@ -4756,6 +4651,66 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 50
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "10.23.21.0/24",
+        "Next_Hop_IP" : "2.23.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
+        "VRF" : "default",
+        "Network" : "2.34.101.0/24",
+        "Next_Hop_IP" : "2.12.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as1border2",
+          "name" : "as1border2"
+        },
+        "VRF" : "default",
+        "Network" : "10.12.11.0/24",
+        "Next_Hop_IP" : "1.0.2.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as1core1",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.2.2/32",
+        "Next_Hop_IP" : "2.12.11.1",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2border1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
       },
       {
         "Node" : {
@@ -4804,6 +4759,36 @@
       },
       {
         "Node" : {
+          "id" : "node-as1border1",
+          "name" : "as1border1"
+        },
+        "VRF" : "default",
+        "Network" : "10.13.22.0/24",
+        "Next_Hop_IP" : "1.0.1.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as1core1",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.2.2/32",
+        "Next_Hop_IP" : "2.23.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
           "id" : "node-as3border2",
           "name" : "as3border2"
         },
@@ -4834,14 +4819,14 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border2",
-          "name" : "as2border2"
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
         },
         "VRF" : "default",
         "Network" : "2.1.3.2/32",
-        "Next_Hop_IP" : "2.12.22.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
+        "Next_Hop_IP" : "2.23.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -4876,21 +4861,6 @@
         "Tag" : null,
         "Admin_Distance" : 0,
         "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "10.23.21.0/24",
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
       },
       {
         "Node" : {
@@ -4939,21 +4909,6 @@
       },
       {
         "Node" : {
-          "id" : "node-as2border1",
-          "name" : "as2border1"
-        },
-        "VRF" : "default",
-        "Network" : "2.1.3.2/32",
-        "Next_Hop_IP" : "2.12.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core2",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
-      },
-      {
-        "Node" : {
           "id" : "node-as2dist1",
           "name" : "as2dist1"
         },
@@ -4981,21 +4936,6 @@
         "Tag" : null,
         "Admin_Distance" : 200,
         "Metric" : 0
-      },
-      {
-        "Node" : {
-          "id" : "node-as1border2",
-          "name" : "as1border2"
-        },
-        "VRF" : "default",
-        "Network" : "1.1.1.1/32",
-        "Next_Hop_IP" : "1.0.2.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as1core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 3
       },
       {
         "Node" : {
@@ -5029,6 +4969,51 @@
       },
       {
         "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.1.1/32",
+        "Next_Hop_IP" : "2.23.12.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2border2",
+          "name" : "as2border2"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.1.1/32",
+        "Next_Hop_IP" : "2.12.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist2",
+          "name" : "as2dist2"
+        },
+        "VRF" : "default",
+        "Network" : "2.34.101.0/24",
+        "Next_Hop_IP" : "2.23.22.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospfE2",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 20
+      },
+      {
+        "Node" : {
           "id" : "node-as2dept1",
           "name" : "as2dept1"
         },
@@ -5059,14 +5044,14 @@
       },
       {
         "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
+          "id" : "node-as3border1",
+          "name" : "as3border1"
         },
         "VRF" : "default",
-        "Network" : "2.12.21.0/24",
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2core1",
+        "Network" : "3.10.1.1/32",
+        "Next_Hop_IP" : "3.0.1.2",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
+        "Next_Hop" : "as3core1",
         "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
@@ -5074,33 +5059,18 @@
       },
       {
         "Node" : {
-          "id" : "node-as2core2",
-          "name" : "as2core2"
+          "id" : "node-as2border1",
+          "name" : "as2border1"
         },
         "VRF" : "default",
-        "Network" : "10.23.21.0/24",
-        "Next_Hop_IP" : "2.12.22.1",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as2border2",
-        "Protocol" : "ospfE2",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as2dist2",
-          "name" : "as2dist2"
-        },
-        "VRF" : "default",
-        "Network" : "2.34.101.0/24",
-        "Next_Hop_IP" : "2.23.12.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Network" : "2.1.1.2/32",
+        "Next_Hop_IP" : "2.12.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
         "Next_Hop" : "as2core1",
-        "Protocol" : "ospfE2",
+        "Protocol" : "ospf",
         "Tag" : null,
         "Admin_Distance" : 110,
-        "Metric" : 20
+        "Metric" : 3
       },
       {
         "Node" : {
@@ -5119,6 +5089,21 @@
       },
       {
         "Node" : {
+          "id" : "node-as2core1",
+          "name" : "as2core1"
+        },
+        "VRF" : "default",
+        "Network" : "2.23.21.0/24",
+        "Next_Hop_IP" : "2.23.11.3",
+        "Next_Hop_Interface" : "GigabitEthernet2/0",
+        "Next_Hop" : "as2dist1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
           "id" : "node-as2border2",
           "name" : "as2border2"
         },
@@ -5134,33 +5119,48 @@
       },
       {
         "Node" : {
+          "id" : "node-as2border1",
+          "name" : "as2border1"
+        },
+        "VRF" : "default",
+        "Network" : "2.1.2.1/32",
+        "Next_Hop_IP" : "2.12.11.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core1",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 2
+      },
+      {
+        "Node" : {
           "id" : "node-as2dist1",
           "name" : "as2dist1"
         },
         "VRF" : "default",
-        "Network" : "2.34.201.0/24",
+        "Network" : "2.1.3.2/32",
+        "Next_Hop_IP" : "2.23.21.2",
+        "Next_Hop_Interface" : "GigabitEthernet1/0",
+        "Next_Hop" : "as2core2",
+        "Protocol" : "ospf",
+        "Tag" : null,
+        "Admin_Distance" : 110,
+        "Metric" : 3
+      },
+      {
+        "Node" : {
+          "id" : "node-as2dist1",
+          "name" : "as2dist1"
+        },
+        "VRF" : "default",
+        "Network" : "10.23.21.0/24",
         "Next_Hop_IP" : "2.23.11.2",
-        "Next_Hop_Interface" : "dynamic",
+        "Next_Hop_Interface" : "GigabitEthernet0/0",
         "Next_Hop" : "as2core1",
         "Protocol" : "ospfE2",
         "Tag" : null,
         "Admin_Distance" : 110,
         "Metric" : 20
-      },
-      {
-        "Node" : {
-          "id" : "node-as3border2",
-          "name" : "as3border2"
-        },
-        "VRF" : "default",
-        "Network" : "3.0.1.0/24",
-        "Next_Hop_IP" : "3.0.2.2",
-        "Next_Hop_Interface" : "dynamic",
-        "Next_Hop" : "as3core1",
-        "Protocol" : "ospf",
-        "Tag" : null,
-        "Admin_Distance" : 110,
-        "Metric" : 2
       }
     ],
     "summary" : {


### PR DESCRIPTION
- iBDP add next-hop interface to `OspfRoute`s
- require next-hop interface for `OspfRoute`s except when non-routing bit is set
  - next-hop interface not required for staging and export
  - set next-hop interface when imported