### PR TITLE
Cumulus FRR only assign duplicated addresses to single interface per vrf

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -264,6 +264,8 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   private @Nullable FrrInterface _currentInterface;
   private OspfArea _currentOspfArea;
   private OspfVrf _currentOspfVrf;
+  // Interfaces in the frr file are initialized from bottom to top, where bottommost occurrence of a
+  // given interface is the only one that matters for determining order.
   private Set<String> _reverseInterfaceInitOrder;
 
   public CumulusFrrConfigurationBuilder(

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_frr/CumulusFrrConfigurationBuilder.java
@@ -32,8 +32,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,6 +66,7 @@ import org.batfish.grammar.BatfishCombinedParser;
 import org.batfish.grammar.SilentSyntaxListener;
 import org.batfish.grammar.UnrecognizedLineToken;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Bgp_redist_typeContext;
+import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Cumulus_frr_configurationContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Icl_expandedContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Icl_standardContext;
 import org.batfish.grammar.cumulus_frr.CumulusFrrParser.Interface_ospf_costContext;
@@ -261,6 +264,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
   private @Nullable FrrInterface _currentInterface;
   private OspfArea _currentOspfArea;
   private OspfVrf _currentOspfVrf;
+  private Set<String> _reverseInterfaceInitOrder;
 
   public CumulusFrrConfigurationBuilder(
       CumulusConcatenatedConfiguration configuration,
@@ -274,6 +278,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
     _w = w;
     _text = fullText;
     _silentSyntax = silentSyntax;
+    _reverseInterfaceInitOrder = new LinkedHashSet<>();
   }
 
   @Override
@@ -788,7 +793,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
         return;
       }
 
-      _currentInterface = _frr.getInterfaces().get(name);
+      setRealCurrentInterface(_frr.getInterfaces().get(name));
       return;
     }
 
@@ -811,7 +816,7 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
           _currentInterface = new FrrInterface("dummy", "dummy");
           return;
         }
-        _currentInterface = _frr.getOrCreateInterface(name, vrfName);
+        setRealCurrentInterface(_frr.getOrCreateInterface(name, vrfName));
         return;
       }
 
@@ -824,12 +829,24 @@ public class CumulusFrrConfigurationBuilder extends CumulusFrrParserBaseListener
         _currentInterface = new FrrInterface("dummy", "dummy");
         return;
       }
-      _currentInterface = _frr.getOrCreateInterface(name, vrfName);
+      setRealCurrentInterface(_frr.getOrCreateInterface(name, vrfName));
       return;
     }
 
     // interface with default vrf and defined for the first time in FRR
-    _currentInterface = _frr.getOrCreateInterface(name, DEFAULT_VRF_NAME);
+    setRealCurrentInterface(_frr.getOrCreateInterface(name, DEFAULT_VRF_NAME));
+  }
+
+  private void setRealCurrentInterface(FrrInterface newCurrentInterface) {
+    _currentInterface = newCurrentInterface;
+    String name = newCurrentInterface.getName();
+    _reverseInterfaceInitOrder.remove(name);
+    _reverseInterfaceInitOrder.add(name);
+  }
+
+  @Override
+  public void exitCumulus_frr_configuration(Cumulus_frr_configurationContext ctx) {
+    _frr.setInterfaceInitOrder(Lists.reverse(ImmutableList.copyOf(_reverseInterfaceInitOrder)));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesConfigurationBuilder.java
@@ -4,9 +4,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -25,6 +28,7 @@ import org.batfish.grammar.BatfishCombinedParser;
 import org.batfish.grammar.SilentSyntaxListener;
 import org.batfish.grammar.UnrecognizedLineToken;
 import org.batfish.grammar.cumulus_interfaces.CumulusInterfacesParser.AddressContext;
+import org.batfish.grammar.cumulus_interfaces.CumulusInterfacesParser.Cumulus_interfaces_configurationContext;
 import org.batfish.grammar.cumulus_interfaces.CumulusInterfacesParser.I_addressContext;
 import org.batfish.grammar.cumulus_interfaces.CumulusInterfacesParser.I_address_virtualContext;
 import org.batfish.grammar.cumulus_interfaces.CumulusInterfacesParser.I_aliasContext;
@@ -81,6 +85,7 @@ public final class CumulusInterfacesConfigurationBuilder extends CumulusInterfac
   private final Warnings _w;
   private InterfacesInterface _currentIface;
   private @Nullable String _currentIfaceName;
+  private final @Nonnull Set<String> _interfaceInitOrder;
   private @Nonnull SilentSyntaxCollection _silentSyntax;
 
   public CumulusInterfacesConfigurationBuilder(
@@ -94,6 +99,7 @@ public final class CumulusInterfacesConfigurationBuilder extends CumulusInterfac
     _text = text;
     _w = w;
     _silentSyntax = silentSyntax;
+    _interfaceInitOrder = new LinkedHashSet<>(); // order matters
   }
 
   @Nonnull
@@ -166,6 +172,14 @@ public final class CumulusInterfacesConfigurationBuilder extends CumulusInterfac
   @Override
   public void enterS_iface(S_ifaceContext ctx) {
     _currentIfaceName = ctx.interface_name().getText();
+    _interfaceInitOrder.add(_currentIfaceName);
+  }
+
+  @Override
+  public void exitCumulus_interfaces_configuration(Cumulus_interfaces_configurationContext ctx) {
+    _config
+        .getInterfacesConfiguration()
+        .setInterfaceInitOrder(ImmutableList.copyOf(_interfaceInitOrder));
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesConfigurationBuilder.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesConfigurationBuilder.java
@@ -172,6 +172,7 @@ public final class CumulusInterfacesConfigurationBuilder extends CumulusInterfac
   @Override
   public void enterS_iface(S_ifaceContext ctx) {
     _currentIfaceName = ctx.interface_name().getText();
+    // Duplicates are ignored and do not change the order, since this is a LinkedHashSet.
     _interfaceInitOrder.add(_currentIfaceName);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
@@ -125,8 +125,6 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration {
     return ImmutableList.of(toVendorIndependentConfiguration());
   }
 
-  private void initializeVrfIpOwners() {}
-
   @Nonnull
   @VisibleForTesting
   Configuration toVendorIndependentConfiguration() {
@@ -138,7 +136,6 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration {
     // create default VRF
     getOrCreateVrf(c, DEFAULT_VRF_NAME);
 
-    initializeVrfIpOwners();
     initializeAllInterfaces(c);
     populateInterfacesInterfaceProperties(c);
     populatePortsInterfaceProperties(c);

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusFrrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusFrrConfiguration.java
@@ -1,6 +1,11 @@
 package org.batfish.representation.cumulus;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -19,6 +24,7 @@ public class CumulusFrrConfiguration implements Serializable {
   private @Nullable BgpProcess _bgpProcess;
   private @Nullable OspfProcess _ospfProcess;
   private @Nonnull Map<String, FrrInterface> _interfaces;
+  private List<String> _interfaceInitOrder;
   private final @Nonnull List<Ip> _ipv4Nameservers;
   private final @Nonnull List<Ip6> _ipv6Nameservers;
   private final @Nonnull Map<String, RouteMap> _routeMaps;
@@ -123,5 +129,17 @@ public class CumulusFrrConfiguration implements Serializable {
   @Nonnull
   public Map<String, FrrInterface> getInterfaces() {
     return _interfaces;
+  }
+
+  @Nonnull
+  public Collection<String> getInterfaceInitOrder() {
+    return firstNonNull(
+        _interfaceInitOrder,
+        // for ease of testing
+        Collections.unmodifiableSet(_interfaces.keySet()));
+  }
+
+  public void setInterfaceInitOrder(List<String> interfaceInitOrder) {
+    _interfaceInitOrder = ImmutableList.copyOf(interfaceInitOrder);
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusInterfacesConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusInterfacesConfiguration.java
@@ -1,10 +1,15 @@
 package org.batfish.representation.cumulus;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.batfish.representation.cumulus.InterfaceConverter.isVrf;
 
+import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -15,6 +20,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public final class CumulusInterfacesConfiguration implements Serializable {
   @Nonnull private final Set<String> _autoIfaces;
   @Nonnull private final Map<String, InterfacesInterface> _interfaces;
+  private List<String> _interfaceInitOrder;
 
   public CumulusInterfacesConfiguration() {
     _autoIfaces = new HashSet<>();
@@ -50,5 +56,17 @@ public final class CumulusInterfacesConfiguration implements Serializable {
   @Nonnull
   public Map<String, InterfacesInterface> getInterfaces() {
     return _interfaces;
+  }
+
+  @Nonnull
+  public Collection<String> getInterfaceInitOrder() {
+    return firstNonNull(
+        _interfaceInitOrder,
+        // for ease of testing
+        Collections.unmodifiableSet(_interfaces.keySet()));
+  }
+
+  public void setInterfaceInitOrder(Iterable<String> interfaceInitOrder) {
+    _interfaceInitOrder = ImmutableList.copyOf(interfaceInitOrder);
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_frr/CumulusFrrGrammarTest.java
@@ -2502,4 +2502,25 @@ public class CumulusFrrGrammarTest {
         dp.getRibs().get("frr-t2-r2").get(DEFAULT_VRF_NAME).getRoutes(),
         hasItem(isBgpv4RouteThat(hasPrefix(Prefix.parse("99.8.0.0/20")))));
   }
+
+  @Test
+  public void testInterfaceInitOrderNoVrfs() {
+    parseLines("interface swp1", "interface swp2", "interface swp1", "interface swp3");
+
+    // init from the back
+    assertThat(_frr.getInterfaceInitOrder(), contains("swp3", "swp1", "swp2"));
+  }
+
+  @Test
+  public void testInterfaceInitOrderVrfs() {
+    _frr.getVrfs().put("v1", new Vrf("v1"));
+    parseLines(
+        "interface swp1 vrf v1",
+        "interface swp2 vrf v1",
+        "interface swp1 vrf v1",
+        "interface swp3 vrf v1");
+
+    // init from the back
+    assertThat(_frr.getInterfaceInitOrder(), contains("swp3", "swp1", "swp2"));
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_interfaces/CumulusInterfacesGrammarTest.java
@@ -596,4 +596,12 @@ public class CumulusInterfacesGrammarTest {
     // assert we can parse the input text
     parse(input);
   }
+
+  @Test
+  public void testInterfaceInitOrderSimple() {
+    String input = "iface swp1\n iface swp3\n iface swp1\n iface swp2\n";
+    CumulusInterfacesConfiguration interfaces = parse(input);
+
+    assertThat(interfaces.getInterfaceInitOrder(), contains("swp1", "swp3", "swp2"));
+  }
 }

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConcatenatedConfigurationTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConcatenatedConfigurationTest.java
@@ -5,7 +5,6 @@ import static org.batfish.datamodel.Interface.DEFAULT_MTU;
 import static org.batfish.representation.cumulus.CumulusConcatenatedConfiguration.LINK_LOCAL_ADDRESS;
 import static org.batfish.representation.cumulus.CumulusConcatenatedConfiguration.LOOPBACK_INTERFACE_NAME;
 import static org.batfish.representation.cumulus.CumulusConcatenatedConfiguration.isValidVIInterface;
-import static org.batfish.representation.cumulus.CumulusConcatenatedConfiguration.populateCommonInterfaceProperties;
 import static org.batfish.representation.cumulus.CumulusConcatenatedConfiguration.populateLoopbackProperties;
 import static org.batfish.representation.cumulus.CumulusConversions.DEFAULT_LOOPBACK_BANDWIDTH;
 import static org.batfish.representation.cumulus.CumulusConversions.DEFAULT_PORT_BANDWIDTH;
@@ -329,17 +328,18 @@ public class CumulusConcatenatedConfigurationTest {
   @Test
   public void testPopulateCommonProperties_mtu() {
     Configuration c = new Configuration("c", ConfigurationFormat.CUMULUS_CONCATENATED);
+    CumulusConcatenatedConfiguration vc = new CumulusConcatenatedConfiguration();
     InterfacesInterface vsIface = new InterfacesInterface("iface");
     Interface viIface =
         org.batfish.datamodel.Interface.builder().setName("iface").setOwner(c).build();
 
     // unset means default
-    populateCommonInterfaceProperties(vsIface, viIface);
+    vc.populateCommonInterfaceProperties(vsIface, viIface);
     assertEquals(viIface.getMtu(), DEFAULT_MTU);
 
     // should get the set value
     vsIface.setMtu(42);
-    populateCommonInterfaceProperties(vsIface, viIface);
+    vc.populateCommonInterfaceProperties(vsIface, viIface);
     assertEquals(viIface.getMtu(), 42);
   }
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/ip_reuse
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/ip_reuse
@@ -1,0 +1,85 @@
+ip_reuse
+# This file describes the network interfaces
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+iface v1
+  vrf-table auto
+iface v2
+  vrf-table auto
+
+
+# Should be first to be initialized since it appears first, independently of re-entry at bottom.
+auto swp2
+iface swp2
+
+# Should own 10.0.0.2/32, since this is the earliest declared interface that assigns it.
+auto swp1
+iface swp1
+  address 10.0.0.1/32
+  address 10.0.0.2/32
+
+# Should own this address, since it is in a distinct vrf from other owner.
+auto swp4
+iface swp4
+  vrf v1
+  address 10.0.0.1/32
+
+auto swp5
+iface swp5
+  vrf v2
+
+# Should own 10.0.0.1/32, since this interface is initialized first.
+auto swp2
+iface swp2
+  address 10.0.0.1/32
+
+# Should have neither of these IP addresses, since the assignments are all shadowed by other interfaces.
+auto swp3
+iface swp3
+  address 10.0.0.1/32
+  address 10.0.0.2/32
+
+
+# ports.conf --
+# ports.conf --
+#
+#   configure port speed, aggregation, and subdivision.
+#
+#   The ports in Cumulus VX are not configurable from here.
+#frr version
+frr version 4.0+cl3u8
+frr defaults datacenter
+hostname ip_reuse
+username cumulus nopassword
+!
+service integrated-vtysh-config
+!
+log syslog informational
+!
+! Should have neither of these IP addresses, since the assignments are all shadowed by other interfaces.
+interface swp2
+  ip address 10.1.1.1/32
+  ip address 10.1.1.2/32
+!
+! Should own 10.1.1.1/32, since this interface is initialized first.
+interface swp3
+ ip address 10.1.1.1/32
+!
+! Should own this address, since it is in a distinct vrf from other owner.
+interface swp5 vrf v2
+ ip address 10.1.1.1/32
+!
+! Should own 10.1.1.2/32, since this is the latest declared interface that assigns it.
+interface swp1
+ ip address 10.1.1.1/32
+ ip address 10.1.1.2/32
+!
+! Should be first to be initialized since it appears last, independently of earlier declaration.
+! Should have neither of thse addresses, since they were assigned to other interfaces in interfaces file.
+interface swp3
+  ip address 10.0.0.1/32
+  ip address 10.0.0.2/32
+!
+line vty
+!


### PR DESCRIPTION
- First assign addresses from interfaces file
  - interface init order is from top to bottom, considering only first declaration of each interface
  - all of an interface's addresses are assigned on init
    - previously assigned addresses in the same VRF are skipped
- Now assign addresses from frr file
  - interface init order is from bottom to top, considering only last declaration of each interface
  - all of an interface's addresses are assigned on init
    - previously assigned addresses in the same VRF are skipped,
      including those from interfaces file