### PR TITLE
OSPF addresses datamodel and FRR conversion

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfAddresses.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfAddresses.java
@@ -9,12 +9,14 @@ import java.io.Serializable;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 
 /**
  * Describes the {@link org.batfish.datamodel.ConcreteInterfaceAddress}es that may be used for OSPF
  * point-to-point session establishment.
  */
+@ParametersAreNonnullByDefault
 public class OspfAddresses implements Serializable {
 
   public static @Nonnull OspfAddresses of(Iterable<ConcreteInterfaceAddress> addresses) {
@@ -22,7 +24,7 @@ public class OspfAddresses implements Serializable {
   }
 
   @JsonProperty(PROP_ADDRESSES)
-  public @Nullable List<ConcreteInterfaceAddress> getAddresses() {
+  public @Nonnull List<ConcreteInterfaceAddress> getAddresses() {
     return _addresses;
   }
 
@@ -50,7 +52,7 @@ public class OspfAddresses implements Serializable {
     return of(ImmutableList.copyOf(firstNonNull(addresses, ImmutableList.of())));
   }
 
-  private final @Nullable List<ConcreteInterfaceAddress> _addresses;
+  private final @Nonnull List<ConcreteInterfaceAddress> _addresses;
 
   private OspfAddresses(List<ConcreteInterfaceAddress> addresses) {
     _addresses = addresses;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfAddresses.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfAddresses.java
@@ -1,0 +1,58 @@
+package org.batfish.datamodel.ospf;
+
+import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+
+/**
+ * Describes the {@link org.batfish.datamodel.ConcreteInterfaceAddress}es that may be used for OSPF
+ * point-to-point session establishment.
+ */
+public class OspfAddresses implements Serializable {
+
+  public static @Nonnull OspfAddresses of(Iterable<ConcreteInterfaceAddress> addresses) {
+    return new OspfAddresses(ImmutableList.copyOf(addresses));
+  }
+
+  @JsonProperty(PROP_ADDRESSES)
+  public @Nullable List<ConcreteInterfaceAddress> getAddresses() {
+    return _addresses;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof OspfAddresses)) {
+      return false;
+    }
+    OspfAddresses that = (OspfAddresses) o;
+    return _addresses.equals(that._addresses);
+  }
+
+  @Override
+  public int hashCode() {
+    return _addresses.hashCode();
+  }
+
+  private static final String PROP_ADDRESSES = "addresses";
+
+  @JsonCreator
+  private static @Nonnull OspfAddresses create(
+      @JsonProperty(PROP_ADDRESSES) @Nullable List<ConcreteInterfaceAddress> addresses) {
+    return of(ImmutableList.copyOf(firstNonNull(addresses, ImmutableList.of())));
+  }
+
+  private final @Nullable List<ConcreteInterfaceAddress> _addresses;
+
+  private OspfAddresses(List<ConcreteInterfaceAddress> addresses) {
+    _addresses = addresses;
+  }
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfAddresses.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfAddresses.java
@@ -29,7 +29,7 @@ public class OspfAddresses implements Serializable {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     } else if (!(o instanceof OspfAddresses)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfInterfaceSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfInterfaceSettings.java
@@ -35,6 +35,7 @@ public final class OspfInterfaceSettings implements Serializable {
   }
 
   public static final class Builder {
+    private @Nullable OspfAddresses _ospfAddresses;
     private Long _ospfAreaName;
     private Integer _ospfCost;
     private int _ospfDeadInterval;
@@ -49,6 +50,11 @@ public final class OspfInterfaceSettings implements Serializable {
 
     public Builder() {
       _ospfEnabled = true;
+    }
+
+    public @Nonnull Builder setOspfAddresses(@Nullable OspfAddresses ospfAddresses) {
+      _ospfAddresses = ospfAddresses;
+      return this;
     }
 
     public Builder setAreaName(@Nullable Long ospfAreaName) {
@@ -108,6 +114,7 @@ public final class OspfInterfaceSettings implements Serializable {
 
     public OspfInterfaceSettings build() {
       return create(
+          _ospfAddresses,
           _ospfAreaName,
           _ospfCost,
           _ospfDeadInterval,
@@ -122,6 +129,7 @@ public final class OspfInterfaceSettings implements Serializable {
     }
   }
 
+  @Nullable private OspfAddresses _ospfAddresses;
   @Nullable private Long _ospfAreaName;
   @Nullable private Integer _ospfCost;
   private int _ospfDeadInterval;
@@ -143,11 +151,13 @@ public final class OspfInterfaceSettings implements Serializable {
   private static final String PROP_INBOUND_DISTRIBUTE_LIST_POLICY = "inboundDistributeListPolicy";
   private static final String PROP_NBMA_NEIGHBORS = "nbmaNeighbors";
   private static final String PROP_NETWORK_TYPE = "networkType";
+  private static final String PROP_OSPF_ADDRESSES = "ospfAddresses";
   private static final String PROP_PASSIVE = "passive";
   private static final String PROP_PROCESS = "process";
 
   @JsonCreator
   private static OspfInterfaceSettings create(
+      @Nullable @JsonProperty(PROP_OSPF_ADDRESSES) OspfAddresses addresses,
       @Nullable @JsonProperty(PROP_AREA) Long area,
       @Nullable @JsonProperty(PROP_COST) Integer cost,
       @Nullable @JsonProperty(PROP_DEAD_INTERVAL) Integer deadInterval,
@@ -165,6 +175,7 @@ public final class OspfInterfaceSettings implements Serializable {
     checkArgument(helloInterval != null, "OSPF hello interval must be specified");
     checkArgument(deadInterval != null, "OSPF dead interval must be specified");
     return new OspfInterfaceSettings(
+        addresses,
         area,
         cost,
         deadInterval,
@@ -179,6 +190,7 @@ public final class OspfInterfaceSettings implements Serializable {
   }
 
   private OspfInterfaceSettings(
+      @Nullable OspfAddresses addresses,
       @Nullable Long area,
       @Nullable Integer cost,
       int deadInterval,
@@ -190,6 +202,7 @@ public final class OspfInterfaceSettings implements Serializable {
       @Nullable OspfNetworkType networkType,
       boolean passive,
       @Nullable String process) {
+    _ospfAddresses = addresses;
     _ospfAreaName = area;
     _ospfCost = cost;
     _ospfDeadInterval = deadInterval;
@@ -206,6 +219,7 @@ public final class OspfInterfaceSettings implements Serializable {
   @Override
   public int hashCode() {
     return Objects.hash(
+        _ospfAddresses,
         _ospfAreaName,
         _ospfCost,
         _ospfDeadInterval,
@@ -227,7 +241,8 @@ public final class OspfInterfaceSettings implements Serializable {
       return false;
     }
     OspfInterfaceSettings other = (OspfInterfaceSettings) o;
-    return Objects.equals(_ospfAreaName, other._ospfAreaName)
+    return Objects.equals(_ospfAddresses, other._ospfAddresses)
+        && Objects.equals(_ospfAreaName, other._ospfAreaName)
         && Objects.equals(_ospfCost, other._ospfCost)
         && _ospfDeadInterval == other._ospfDeadInterval
         && _ospfEnabled == other._ospfEnabled
@@ -305,6 +320,12 @@ public final class OspfInterfaceSettings implements Serializable {
   @Nullable
   public OspfNetworkType getNetworkType() {
     return _ospfNetworkType;
+  }
+
+  @JsonProperty(PROP_OSPF_ADDRESSES)
+  @Nullable
+  public OspfAddresses getOspfAddresses() {
+    return _ospfAddresses;
   }
 
   /**

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfAddressesTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfAddressesTest.java
@@ -1,0 +1,41 @@
+package org.batfish.datamodel.ospf;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import org.apache.commons.lang3.SerializationUtils;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.junit.Test;
+
+/** Test of {@link OspfAddresses}. */
+public final class OspfAddressesTest {
+  @Test
+  public void testJsonSerialization() {
+    OspfAddresses obj =
+        OspfAddresses.of(ImmutableList.of(ConcreteInterfaceAddress.parse("1.1.1.1/32")));
+
+    // test (de)serialization
+    assertThat(obj, equalTo(BatfishObjectMapper.clone(obj, OspfAddresses.class)));
+  }
+
+  @Test
+  public void testJavaSerialization() {
+    OspfAddresses obj =
+        OspfAddresses.of(ImmutableList.of(ConcreteInterfaceAddress.parse("1.1.1.1/32")));
+
+    assertThat(SerializationUtils.clone(obj), equalTo(obj));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            OspfAddresses.of(ImmutableList.of()), OspfAddresses.of(ImmutableList.of()))
+        .addEqualityGroup(
+            OspfAddresses.of(ImmutableList.of(ConcreteInterfaceAddress.parse("1.1.1.1/32"))))
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfInterfaceSettingsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfInterfaceSettingsTest.java
@@ -3,10 +3,12 @@ package org.batfish.datamodel.ospf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
 import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.junit.Test;
 
@@ -25,6 +27,8 @@ public class OspfInterfaceSettingsTest {
             .setHelloMultiplier(55)
             .setNbmaNeighbors(ImmutableSet.of(Ip.parse("1.2.3.4")))
             .setNetworkType(OspfNetworkType.POINT_TO_POINT)
+            .setOspfAddresses(
+                OspfAddresses.of(ImmutableList.of(ConcreteInterfaceAddress.parse("1.1.1.1/32"))))
             .build();
 
     // test (de)serialization
@@ -45,6 +49,8 @@ public class OspfInterfaceSettingsTest {
             .setHelloMultiplier(55)
             .setNbmaNeighbors(ImmutableSet.of(Ip.parse("1.2.3.4")))
             .setNetworkType(OspfNetworkType.POINT_TO_POINT)
+            .setOspfAddresses(
+                OspfAddresses.of(ImmutableList.of(ConcreteInterfaceAddress.parse("1.1.1.1/32"))))
             .build();
 
     assertThat(SerializationUtils.clone(s), equalTo(s));
@@ -77,6 +83,11 @@ public class OspfInterfaceSettingsTest {
         .addEqualityGroup(s.setNetworkType(OspfNetworkType.NON_BROADCAST_MULTI_ACCESS).build())
         .addEqualityGroup(s.setPassive(false).build())
         .addEqualityGroup(s.setProcess("proc").build())
+        .addEqualityGroup(
+            s.setOspfAddresses(
+                    OspfAddresses.of(
+                        ImmutableList.of(ConcreteInterfaceAddress.parse("1.1.1.1/32"))))
+                .build())
         .testEquals();
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
@@ -47,6 +47,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.VendorConversionException;
 import org.batfish.common.runtime.InterfaceRuntimeData;
 import org.batfish.common.runtime.SnapshotRuntimeData;
+import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
@@ -292,7 +293,8 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration {
     for (ConcreteInterfaceAddress address : iface.getIpAddresses()) {
       Prefix prefix = address.getPrefix();
       if (ownedPrefixesByVrf().containsEntry(vrf, prefix)) {
-        // TODO: store shadowed interface address in VI somewhere for e.g. OSPF unnumbered
+        viIface.setAdditionalArpIps(
+            AclIpSpace.union(viIface.getAdditionalArpIps(), address.getIp().toIpSpace()));
         continue;
       }
       ownedPrefixesByVrf().put(vrf, prefix);
@@ -465,7 +467,8 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration {
       for (ConcreteInterfaceAddress address : addresses) {
         Prefix prefix = address.getPrefix();
         if (ownedPrefixesByVrf().containsEntry(vrf, prefix)) {
-          // TODO: store shadowed interface address in VI somewhere for e.g. OSPF unnumbered
+          viIface.setAdditionalArpIps(
+              AclIpSpace.union(viIface.getAdditionalArpIps(), address.getIp().toIpSpace()));
           continue;
         }
         ownedPrefixesByVrf().put(vrf, prefix);

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
@@ -24,9 +24,12 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.ValueGraph;
 import java.io.IOException;
@@ -40,9 +43,12 @@ import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.Warnings;
+import org.batfish.common.bdd.IpSpaceToBDD;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.config.Settings;
+import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.AsPath;
+import org.batfish.datamodel.BddTestbed;
 import org.batfish.datamodel.BgpActivePeerConfig;
 import org.batfish.datamodel.BgpPeerConfigId;
 import org.batfish.datamodel.BgpProcess;
@@ -51,6 +57,7 @@ import org.batfish.datamodel.Bgpv4Route;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConnectedRoute;
+import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
@@ -90,6 +97,9 @@ public class CumulusConcatenatedGrammarTest {
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
   @Rule public ExpectedException _thrown = ExpectedException.none();
+
+  private final BddTestbed _bddTestbed = new BddTestbed(ImmutableMap.of(), ImmutableMap.of());
+  private final IpSpaceToBDD _dstIpBdd = _bddTestbed.getDstIpBdd();
 
   private static CumulusConcatenatedConfiguration parseFromTextWithSettings(
       String src, Settings settings) {
@@ -839,26 +849,94 @@ public class CumulusConcatenatedGrammarTest {
           contains(
               ConcreteInterfaceAddress.parse("10.0.0.2/32"),
               ConcreteInterfaceAddress.parse("10.1.1.2/32")));
+      assertThat(
+          iface.getAdditionalArpIps().accept(_dstIpBdd),
+          equalTo(
+              AclIpSpace.union(Ip.parse("10.0.0.1").toIpSpace(), Ip.parse("10.1.1.1").toIpSpace())
+                  .accept(_dstIpBdd)));
     }
     {
       Interface iface = c.getAllInterfaces().get("swp2");
       assertThat(iface.getAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.0.1/32")));
       assertThat(iface.getAllAddresses(), contains(ConcreteInterfaceAddress.parse("10.0.0.1/32")));
+      assertThat(
+          iface.getAdditionalArpIps().accept(_dstIpBdd),
+          equalTo(
+              AclIpSpace.union(Ip.parse("10.1.1.1").toIpSpace(), Ip.parse("10.1.1.2").toIpSpace())
+                  .accept(_dstIpBdd)));
     }
     {
       Interface iface = c.getAllInterfaces().get("swp3");
       assertThat(iface.getAddress(), equalTo(ConcreteInterfaceAddress.parse("10.1.1.1/32")));
       assertThat(iface.getAllAddresses(), contains(ConcreteInterfaceAddress.parse("10.1.1.1/32")));
+      assertThat(
+          iface.getAdditionalArpIps().accept(_dstIpBdd),
+          equalTo(
+              AclIpSpace.union(Ip.parse("10.0.0.1").toIpSpace(), Ip.parse("10.0.0.2").toIpSpace())
+                  .accept(_dstIpBdd)));
     }
     {
       Interface iface = c.getAllInterfaces().get("swp4");
       assertThat(iface.getAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.0.1/32")));
       assertThat(iface.getAllAddresses(), contains(ConcreteInterfaceAddress.parse("10.0.0.1/32")));
+      assertThat(
+          iface.getAdditionalArpIps().accept(_dstIpBdd),
+          equalTo(EmptyIpSpace.INSTANCE.accept(_dstIpBdd)));
     }
     {
       Interface iface = c.getAllInterfaces().get("swp5");
       assertThat(iface.getAddress(), equalTo(ConcreteInterfaceAddress.parse("10.1.1.1/32")));
       assertThat(iface.getAllAddresses(), contains(ConcreteInterfaceAddress.parse("10.1.1.1/32")));
+      assertThat(
+          iface.getAdditionalArpIps().accept(_dstIpBdd),
+          equalTo(EmptyIpSpace.INSTANCE.accept(_dstIpBdd)));
+    }
+  }
+
+  @Test
+  public void testOspfAddresses() throws IOException {
+    Configuration c = parseConfig("ip_reuse");
+    assertThat(
+        c.getAllInterfaces(), hasKeys("swp1", "swp2", "swp3", "swp4", "swp5", "lo", "v1", "v2"));
+    {
+      Interface iface = c.getAllInterfaces().get("swp1");
+      assertNotNull(iface.getOspfSettings());
+      assertThat(
+          iface.getOspfSettings().getOspfAddresses().getAddresses(),
+          contains(
+              ConcreteInterfaceAddress.parse("10.0.0.1/32"),
+              ConcreteInterfaceAddress.parse("10.0.0.2/32"),
+              ConcreteInterfaceAddress.parse("10.1.1.1/32"),
+              ConcreteInterfaceAddress.parse("10.1.1.2/32")));
+    }
+    {
+      Interface iface = c.getAllInterfaces().get("swp2");
+      assertNotNull(iface.getOspfSettings());
+      assertThat(
+          iface.getOspfSettings().getOspfAddresses().getAddresses(),
+          contains(
+              ConcreteInterfaceAddress.parse("10.0.0.1/32"),
+              ConcreteInterfaceAddress.parse("10.1.1.1/32"),
+              ConcreteInterfaceAddress.parse("10.1.1.2/32")));
+    }
+    {
+      Interface iface = c.getAllInterfaces().get("swp3");
+      assertNotNull(iface.getOspfSettings());
+      assertThat(
+          iface.getOspfSettings().getOspfAddresses().getAddresses(),
+          contains(
+              ConcreteInterfaceAddress.parse("10.0.0.1/32"),
+              ConcreteInterfaceAddress.parse("10.0.0.2/32"),
+              ConcreteInterfaceAddress.parse("10.1.1.1/32")));
+    }
+    {
+      Interface iface = c.getAllInterfaces().get("swp4");
+      assertNull(iface.getOspfSettings());
+    }
+    {
+      Interface iface = c.getAllInterfaces().get("swp5");
+      // TODO: support OSPF in another VRF
+      assertNull(iface.getOspfSettings());
     }
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/ip_reuse
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/ip_reuse
@@ -61,25 +61,33 @@ log syslog informational
 interface swp2
   ip address 10.1.1.1/32
   ip address 10.1.1.2/32
+  ip ospf area 0
 !
 ! Should own 10.1.1.1/32, since this interface is initialized first.
 interface swp3
  ip address 10.1.1.1/32
+ ip ospf area 0
 !
 ! Should own this address, since it is in a distinct vrf from other owner.
 interface swp5 vrf v2
  ip address 10.1.1.1/32
+ ip ospf area 0
 !
 ! Should own 10.1.1.2/32, since this is the latest declared interface that assigns it.
 interface swp1
  ip address 10.1.1.1/32
  ip address 10.1.1.2/32
+ ip ospf area 0
 !
 ! Should be first to be initialized since it appears last, independently of earlier declaration.
 ! Should have neither of thse addresses, since they were assigned to other interfaces in interfaces file.
 interface swp3
   ip address 10.0.0.1/32
   ip address 10.0.0.2/32
+  ip ospf area 0
+!
+router ospf
+  ospf router-id 1.1.1.1
 !
 line vty
 !


### PR DESCRIPTION
- add getOspfAddresses() to OspfInterfaceSettings

  intent:
  - if non-null, gives list of addresses to be used for establishing
OSPF sessions
  - if null, should use Interface::getAllAddresses

- follow-on: actually use getOspfAddresses when establishing sessions
- populate ospfAddresses for Cumulus FRR
- also populate additionalArpIps for FRR using the difference between
ospfAddresses and surviving addresses assigned to Interface allAddresses