### PR TITLE
Cumulus FRR assign LLAs to point-to-point OSPF interfaces without addresses

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
@@ -406,6 +406,7 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration {
   @VisibleForTesting
   static void populateLoopbackProperties(
       @Nullable InterfacesInterface vsLoopback, org.batfish.datamodel.Interface viLoopback) {
+    viLoopback.setInterfaceType(InterfaceType.LOOPBACK);
     if (vsLoopback != null && vsLoopback.getClagVxlanAnycastIp() != null) {
       // Just assume CLAG is correctly configured and comes up
       viLoopback.setAllAddresses(

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConcatenatedConfiguration.java
@@ -223,12 +223,21 @@ public class CumulusConcatenatedConfiguration extends VendorConfiguration {
     c.getAllInterfaces()
         .forEach(
             (iname, iface) -> {
-              if (iface.getAllAddresses().size() == 0
+              if (iface.getInterfaceType() != InterfaceType.LOOPBACK
                   && iface.getOspfEnabled()
                   && !iface.getOspfPassive()
-                  && iface.getOspfSettings().getNetworkType() == OspfNetworkType.POINT_TO_POINT) {
-                iface.setAddress(LINK_LOCAL_ADDRESS);
-                iface.setAllAddresses(ImmutableSet.of(LINK_LOCAL_ADDRESS));
+                  && iface.getOspfSettings().getNetworkType() == OspfNetworkType.POINT_TO_POINT
+                  && !iface.getOspfSettings().getOspfAddresses().getAddresses().isEmpty()
+                  && iface.getAllLinkLocalAddresses().isEmpty()) {
+                if (iface.getAddress() == null) {
+                  iface.setAddress(LINK_LOCAL_ADDRESS);
+                }
+                iface.setAllAddresses(
+                    ImmutableSet.<InterfaceAddress>builderWithExpectedSize(
+                            iface.getAllAddresses().size() + 1)
+                        .addAll(iface.getAllAddresses())
+                        .add(LINK_LOCAL_ADDRESS)
+                        .build());
               }
             });
   }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
@@ -945,11 +945,15 @@ public class CumulusConcatenatedGrammarTest {
   @Test
   public void testOspfUnnumberedLLAs() throws IOException {
     Configuration c = parseConfig("ospf_link_local");
-    assertThat(c.getAllInterfaces(), hasKeys("swp1", "swp2", "swp3", "swp4", "swp5", "lo"));
+    assertThat(c.getAllInterfaces(), hasKeys("swp1", "swp2", "swp3", "swp4", "swp5", "swp6", "lo"));
     {
       Interface iface = c.getAllInterfaces().get("swp1");
       assertThat(iface.getAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.0.1/32")));
-      assertThat(iface.getAllAddresses(), contains(ConcreteInterfaceAddress.parse("10.0.0.1/32")));
+      assertThat(
+          iface.getAllAddresses(),
+          containsInAnyOrder(
+              equalTo(ConcreteInterfaceAddress.parse("10.0.0.1/32")),
+              instanceOf(LinkLocalAddress.class)));
     }
     {
       Interface iface = c.getAllInterfaces().get("swp2");
@@ -968,6 +972,16 @@ public class CumulusConcatenatedGrammarTest {
     }
     {
       Interface iface = c.getAllInterfaces().get("swp5");
+      assertNull(iface.getAddress());
+      assertThat(iface.getAllAddresses(), empty());
+    }
+    {
+      Interface iface = c.getAllInterfaces().get("swp6");
+      assertNull(iface.getAddress());
+      assertThat(iface.getAllAddresses(), empty());
+    }
+    {
+      Interface iface = c.getAllInterfaces().get("lo");
       assertNull(iface.getAddress());
       assertThat(iface.getAllAddresses(), empty());
     }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -61,6 +62,7 @@ import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.LinkLocalAddress;
 import org.batfish.datamodel.OriginType;
 import org.batfish.datamodel.OspfExternalType2Route;
 import org.batfish.datamodel.Prefix;
@@ -937,6 +939,37 @@ public class CumulusConcatenatedGrammarTest {
       Interface iface = c.getAllInterfaces().get("swp5");
       // TODO: support OSPF in another VRF
       assertNull(iface.getOspfSettings());
+    }
+  }
+
+  @Test
+  public void testOspfUnnumberedLLAs() throws IOException {
+    Configuration c = parseConfig("ospf_link_local");
+    assertThat(c.getAllInterfaces(), hasKeys("swp1", "swp2", "swp3", "swp4", "swp5", "lo"));
+    {
+      Interface iface = c.getAllInterfaces().get("swp1");
+      assertThat(iface.getAddress(), equalTo(ConcreteInterfaceAddress.parse("10.0.0.1/32")));
+      assertThat(iface.getAllAddresses(), contains(ConcreteInterfaceAddress.parse("10.0.0.1/32")));
+    }
+    {
+      Interface iface = c.getAllInterfaces().get("swp2");
+      assertThat(iface.getAddress(), instanceOf(LinkLocalAddress.class));
+      assertThat(iface.getAllAddresses(), contains(instanceOf(LinkLocalAddress.class)));
+    }
+    {
+      Interface iface = c.getAllInterfaces().get("swp3");
+      assertNull(iface.getAddress());
+      assertThat(iface.getAllAddresses(), empty());
+    }
+    {
+      Interface iface = c.getAllInterfaces().get("swp4");
+      assertNull(iface.getAddress());
+      assertThat(iface.getAllAddresses(), empty());
+    }
+    {
+      Interface iface = c.getAllInterfaces().get("swp5");
+      assertNull(iface.getAddress());
+      assertThat(iface.getAllAddresses(), empty());
     }
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
@@ -61,6 +61,7 @@ import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.EmptyIpSpace;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.Interface;
+import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LinkLocalAddress;
 import org.batfish.datamodel.OriginType;
@@ -985,5 +986,12 @@ public class CumulusConcatenatedGrammarTest {
       assertNull(iface.getAddress());
       assertThat(iface.getAllAddresses(), empty());
     }
+  }
+
+  @Test
+  public void testLoopbackInterfaceType() throws IOException {
+    Configuration c = parseConfig("loopback");
+    assertThat(c.getAllInterfaces(), hasKeys("lo"));
+    assertThat(c.getAllInterfaces().get("lo").getInterfaceType(), equalTo(InterfaceType.LOOPBACK));
   }
 }

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/loopback
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/loopback
@@ -1,0 +1,19 @@
+loopback
+# This file describes the network interfaces
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+auto lo
+iface lo
+
+# ports.conf --
+# ports.conf --
+#
+#   configure port speed, aggregation, and subdivision.
+#
+#   The ports in Cumulus VX are not configurable from here.
+#frr version
+frr version 4.0+cl3u8
+frr defaults datacenter
+hostname loopback
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/ospf_link_local
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/ospf_link_local
@@ -1,0 +1,74 @@
+ospf_link_local
+# This file describes the network interfaces
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+auto swp1
+iface swp1
+  # Should own 10.0.0.1/32, since this is the earliest declared interface that assigns it.
+  # Should not receive an LLA, since it already has an address.
+  address 10.0.0.1/32
+
+auto swp2
+iface swp2
+  # Should not own 10.0.0.1/32.
+  # Instead should receive LLA, since OSPF is enabled on this interface and the network type is point-to-point.
+  address 10.0.0.1/32
+
+auto swp3
+iface swp3
+  # Should not own 10.0.0.1/32.
+  # Since OSPF is passive on this interface, should not receive LLA.
+  address 10.0.0.1/32
+
+auto swp4
+iface swp4
+  # Should not own 10.0.0.1/32.
+  # Since the OSPF network type is not point-to-point on this interface, should not receive LLA.
+  address 10.0.0.1/32
+
+auto swp5
+iface swp5
+  # Should not own 10.0.0.1/32.
+  # Since OSPF is not enabled on this interface, should not receive LLA.
+  address 10.0.0.1/32
+
+# ports.conf --
+# ports.conf --
+#
+#   configure port speed, aggregation, and subdivision.
+#
+#   The ports in Cumulus VX are not configurable from here.
+#frr version
+frr version 4.0+cl3u8
+frr defaults datacenter
+hostname ip_reuse
+username cumulus nopassword
+!
+service integrated-vtysh-config
+!
+log syslog informational
+!
+interface swp1
+ ip ospf area 0
+ ip ospf network point-to-point
+!
+interface swp2
+ ip ospf area 0
+ ip ospf network point-to-point
+!
+interface swp3
+ ip ospf area 0
+ ip ospf network point-to-point
+!
+interface swp4
+ ip ospf area 0
+!
+interface swp5
+!
+router ospf
+  ospf router-id 1.1.1.1
+  passive-interface swp3
+!
+line vty
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/ospf_link_local
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/ospf_link_local
@@ -6,31 +6,34 @@ ospf_link_local
 auto swp1
 iface swp1
   # Should own 10.0.0.1/32, since this is the earliest declared interface that assigns it.
-  # Should not receive an LLA, since it already has an address.
   address 10.0.0.1/32
 
 auto swp2
 iface swp2
   # Should not own 10.0.0.1/32.
-  # Instead should receive LLA, since OSPF is enabled on this interface and the network type is point-to-point.
   address 10.0.0.1/32
 
 auto swp3
 iface swp3
-  # Should not own 10.0.0.1/32.
-  # Since OSPF is passive on this interface, should not receive LLA.
-  address 10.0.0.1/32
 
 auto swp4
 iface swp4
   # Should not own 10.0.0.1/32.
-  # Since the OSPF network type is not point-to-point on this interface, should not receive LLA.
   address 10.0.0.1/32
 
 auto swp5
 iface swp5
   # Should not own 10.0.0.1/32.
-  # Since OSPF is not enabled on this interface, should not receive LLA.
+  address 10.0.0.1/32
+
+auto swp6
+iface swp6
+  # Should not own 10.0.0.1/32.
+  address 10.0.0.1/32
+
+auto lo
+iface lo
+  # Should not own 10.0.0.1/32.
   address 10.0.0.1/32
 
 # ports.conf --
@@ -42,7 +45,7 @@ iface swp5
 #frr version
 frr version 4.0+cl3u8
 frr defaults datacenter
-hostname ip_reuse
+hostname ospf_link_local
 username cumulus nopassword
 !
 service integrated-vtysh-config
@@ -50,25 +53,43 @@ service integrated-vtysh-config
 log syslog informational
 !
 interface swp1
+ ! Should receive LLA, since OSPF is enabled on this interface and the network type is point-to-point.
+ ! Even though it already has an address, it needs an LLA to ensure L3 edge can come up.
  ip ospf area 0
  ip ospf network point-to-point
 !
 interface swp2
+ ! Should receive LLA, since OSPF is enabled on this interface and the network type is point-to-point.
  ip ospf area 0
  ip ospf network point-to-point
 !
 interface swp3
+ ! Even though OSPF is enabled on this interface and the network type is point-to-point, should
+ ! not receive LLA since it was never assigned any addresses.
  ip ospf area 0
  ip ospf network point-to-point
 !
 interface swp4
+ ! Since OSPF is passive on this interface, should not receive LLA.
  ip ospf area 0
+ ip ospf network point-to-point
 !
 interface swp5
+ ! Since the OSPF network type is not point-to-point on this interface, should not receive LLA.
+ ip ospf area 0
+!
+interface swp6
+ ! Since OSPF is not enabled on this interface, should not receive LLA.
+!
+interface lo
+ ! Should not receive LLA since this is a loopback, even though OSPF is enabled on this interface
+ ! and the network type is point-to-point.
+ ip ospf area 0
+ ip ospf network point-to-point
 !
 router ospf
   ospf router-id 1.1.1.1
-  passive-interface swp3
+  passive-interface swp4
 !
 line vty
 !


### PR DESCRIPTION
- enables forwarding across unnumbered links