### PR TITLE
OSPF topology compute unnumbered sessions

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfInterfaceSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfInterfaceSettings.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
@@ -326,6 +327,11 @@ public final class OspfInterfaceSettings implements Serializable {
   @Nullable
   public OspfAddresses getOspfAddresses() {
     return _ospfAddresses;
+  }
+
+  @VisibleForTesting
+  void setOspfAddresses(@Nullable OspfAddresses ospfAddresses) {
+    _ospfAddresses = ospfAddresses;
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfInterfaceSettings.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfInterfaceSettings.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
@@ -327,11 +326,6 @@ public final class OspfInterfaceSettings implements Serializable {
   @Nullable
   public OspfAddresses getOspfAddresses() {
     return _ospfAddresses;
-  }
-
-  @VisibleForTesting
-  void setOspfAddresses(@Nullable OspfAddresses ospfAddresses) {
-    _ospfAddresses = ospfAddresses;
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfTopologyUtils.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ospf/OspfTopologyUtils.java
@@ -286,16 +286,16 @@ public final class OspfTopologyUtils {
     } else if (remoteNetworkType != null) {
       assumedNetworkType = remoteNetworkType;
     }
-    // - If P2P and prefixes do not match, the session is unnumbered.
-    // - If not P2P and prefixes do not match, the session should not come up. This can commonly
-    //   occur even when things are properly configured, so just silently throw out this edge with
-    //   NO_SESSION.
+    // Skip prefix check for P2P sessions
     if (assumedNetworkType != null
         && assumedNetworkType != OspfNetworkType.POINT_TO_POINT
         && !localConfigId
             .getAddress()
             .getPrefix()
             .equals(remoteConfigId.getAddress().getPrefix())) {
+      // If not P2P and prefixes do not match, the session should not come up. This can commonly
+      // occur even when things are properly configured, so just silently throw out this edge with
+      // NO_SESSION.
       return OspfSessionStatus.NO_SESSION;
     }
 

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfTopologyUtilsTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/ospf/OspfTopologyUtilsTest.java
@@ -604,11 +604,15 @@ public class OspfTopologyUtilsTest {
         buildNetworkConfigurations(
             LOCAL_CONFIG_ID_UNNUMBERED.getAddress().getIp(),
             OspfInterfaceSettings.defaultSettingsBuilder()
+                .setOspfAddresses(
+                    OspfAddresses.of(ImmutableList.of(LOCAL_CONFIG_ID_UNNUMBERED.getAddress())))
                 .setProcess(LOCAL_CONFIG_ID_UNNUMBERED.getProcName())
                 .setNetworkType(OspfNetworkType.POINT_TO_POINT)
                 .build(),
             REMOTE_CONFIG_ID_UNNUMBERED.getAddress().getIp(),
             OspfInterfaceSettings.defaultSettingsBuilder()
+                .setOspfAddresses(
+                    OspfAddresses.of(ImmutableList.of(REMOTE_CONFIG_ID_UNNUMBERED.getAddress())))
                 .setProcess(REMOTE_CONFIG_ID_UNNUMBERED.getProcName())
                 .setNetworkType(OspfNetworkType.POINT_TO_POINT)
                 .build(),
@@ -632,17 +636,9 @@ public class OspfTopologyUtilsTest {
   private static void updateConfigsForUnnumbered(NetworkConfigurations configs) {
     LinkLocalAddress lla = LinkLocalAddress.of(Ip.parse("169.254.0.1"));
     Interface iface1 = configs.getInterface("r1", "iface1").get();
-    iface1
-        .getOspfSettings()
-        .setOspfAddresses(
-            OspfAddresses.of(ImmutableList.of(LOCAL_CONFIG_ID_UNNUMBERED.getAddress())));
     iface1.setAddress(lla);
     iface1.setAllAddresses(ImmutableList.of(lla));
     Interface iface2 = configs.getInterface("r2", "iface2").get();
-    iface2
-        .getOspfSettings()
-        .setOspfAddresses(
-            OspfAddresses.of(ImmutableList.of(REMOTE_CONFIG_ID_UNNUMBERED.getAddress())));
     iface2.setAddress(lla);
     iface2.setAllAddresses(ImmutableList.of(lla));
   }
@@ -653,11 +649,15 @@ public class OspfTopologyUtilsTest {
         buildNetworkConfigurations(
             LOCAL_CONFIG_ID_UNNUMBERED.getAddress().getIp(),
             OspfInterfaceSettings.defaultSettingsBuilder()
+                .setOspfAddresses(
+                    OspfAddresses.of(ImmutableList.of(LOCAL_CONFIG_ID_UNNUMBERED.getAddress())))
                 .setProcess(LOCAL_CONFIG_ID_UNNUMBERED.getProcName())
                 .setNetworkType(OspfNetworkType.POINT_TO_POINT)
                 .build(),
             REMOTE_CONFIG_ID_UNNUMBERED.getAddress().getIp(),
             OspfInterfaceSettings.defaultSettingsBuilder()
+                .setOspfAddresses(
+                    OspfAddresses.of(ImmutableList.of(REMOTE_CONFIG_ID_UNNUMBERED.getAddress())))
                 .setProcess(REMOTE_CONFIG_ID_UNNUMBERED.getProcName())
                 .setNetworkType(OspfNetworkType.POINT_TO_POINT)
                 .build());
@@ -675,11 +675,15 @@ public class OspfTopologyUtilsTest {
         buildNetworkConfigurations(
             LOCAL_CONFIG_ID_UNNUMBERED.getAddress().getIp(),
             OspfInterfaceSettings.defaultSettingsBuilder()
+                .setOspfAddresses(
+                    OspfAddresses.of(ImmutableList.of(LOCAL_CONFIG_ID_UNNUMBERED.getAddress())))
                 .setProcess(LOCAL_CONFIG_ID_UNNUMBERED.getProcName())
                 .setNetworkType(OspfNetworkType.BROADCAST)
                 .build(),
             REMOTE_CONFIG_ID_UNNUMBERED.getAddress().getIp(),
             OspfInterfaceSettings.defaultSettingsBuilder()
+                .setOspfAddresses(
+                    OspfAddresses.of(ImmutableList.of(REMOTE_CONFIG_ID_UNNUMBERED.getAddress())))
                 .setProcess(REMOTE_CONFIG_ID_UNNUMBERED.getProcName())
                 .setNetworkType(OspfNetworkType.BROADCAST)
                 .build(),


### PR DESCRIPTION
- point-to-point links need not be on the same prefix
- use ospfAddresses to determine possible OspfConfigId source addresses
  over getAllConcreteAddresses when ospfAddresses is present, e.g. for
  unnumbered interfaces