### PR TITLE
ibdp/Node: use Optional#flatMap correctly

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/Node.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/ibdp/Node.java
@@ -80,6 +80,6 @@ public final class Node {
     if (!_c.getHostname().equals(ribId.getHostname())) {
       return Optional.empty();
     }
-    return getVirtualRouter(ribId.getVrfName()).map(vr -> vr.getRib(ribId)).get();
+    return getVirtualRouter(ribId.getVrfName()).flatMap(vr -> vr.getRib(ribId));
   }
 }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/NodeTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/ibdp/NodeTest.java
@@ -1,0 +1,39 @@
+package org.batfish.dataplane.ibdp;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Vrf;
+import org.batfish.datamodel.dataplane.rib.RibId;
+import org.junit.Test;
+
+public class NodeTest {
+  @Test
+  public void testGetRib() {
+    Configuration c =
+        Configuration.builder()
+            .setHostname("c")
+            .setConfigurationFormat(ConfigurationFormat.FLAT_JUNIPER)
+            .build();
+    Vrf v = Vrf.builder().setOwner(c).setName("v").build();
+    Node n = new Node(c);
+    // Right Vrf, right RIB -> present
+    assertThat(
+        n.getRib(new RibId(c.getHostname(), v.getName(), RibId.DEFAULT_RIB_NAME)).isPresent(),
+        equalTo(true));
+    // Right Vrf, wrong RIB -> absent
+    assertThat(
+        n.getRib(new RibId(c.getHostname(), v.getName(), "no-such-rib")).isPresent(),
+        equalTo(false));
+    // Wrong Vrf -> absent
+    assertThat(
+        n.getRib(new RibId(c.getHostname(), "no-such-vrf", RibId.DEFAULT_RIB_NAME)).isPresent(),
+        equalTo(false));
+    // Wrong Config -> absent
+    assertThat(
+        n.getRib(new RibId("no-such-host", v.getName(), RibId.DEFAULT_RIB_NAME)).isPresent(),
+        equalTo(false));
+  }
+}


### PR DESCRIPTION
We accidentally made an `Optional<Optional<Rib>>` that could be absent, or
present with a Rib, or present with an absent Rib. We meant to chain the
optionality, which is done with `flatMap`.