### PR TITLE
Arista: implement interface ip nat source static

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationStep.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/transformation/TransformationStep.java
@@ -23,12 +23,16 @@ public interface TransformationStep {
 
   <T> T accept(TransformationStepVisitor<T> visitor);
 
-  static AssignIpAddressFromPool assignDestinationIp(Ip poolStart) {
-    return new AssignIpAddressFromPool(DEST_NAT, DESTINATION, poolStart, poolStart);
+  static AssignIpAddressFromPool assignDestinationIp(Ip ip) {
+    return assignDestinationIp(ip, ip);
   }
 
   static AssignIpAddressFromPool assignDestinationIp(Ip poolStart, Ip poolEnd) {
     return new AssignIpAddressFromPool(DEST_NAT, DESTINATION, poolStart, poolEnd);
+  }
+
+  static AssignIpAddressFromPool assignSourceIp(Ip ip) {
+    return assignSourceIp(ip, ip);
   }
 
   static AssignIpAddressFromPool assignSourceIp(Ip poolStart, Ip poolEnd) {
@@ -43,8 +47,16 @@ public interface TransformationStep {
     return new ShiftIpAddressIntoSubnet(SOURCE_NAT, SOURCE, subnet);
   }
 
+  static AssignPortFromPool assignSourcePort(int port) {
+    return assignSourcePort(port, port);
+  }
+
   static AssignPortFromPool assignSourcePort(int poolStart, int poolEnd) {
     return new AssignPortFromPool(SOURCE_NAT, PortField.SOURCE, poolStart, poolEnd);
+  }
+
+  static AssignPortFromPool assignDestinationPort(int port) {
+    return assignDestinationPort(port, port);
   }
 
   static AssignPortFromPool assignDestinationPort(int poolStart, int poolEnd) {

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/Arista_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/Arista_common.g4
@@ -27,6 +27,12 @@ ospf_area
   | id = uint32
 ;
 
+port_number
+:
+// 1-65535
+  uint16
+;
+
 uint8: UINT8;
 uint16: UINT8 | UINT16;
 uint32: UINT8 | UINT16 | UINT32;

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/Legacy_interface.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/arista/Legacy_interface.g4
@@ -424,7 +424,7 @@ ifipn_source
    SOURCE
    (
      ifipns_dynamic
-     // | ifipns_static
+     | ifipns_static
    )
 ;
 
@@ -437,10 +437,15 @@ ifipns_dynamic
    ) NEWLINE
 ;
 
-//ifipns_static
-//:
-//   STATIC
-//;
+ifipns_static
+:
+   STATIC
+   original_ip = IP_ADDRESS (original_port = port_number)?
+   (ACCESS_LIST acl = variable)?
+   tx_ip = IP_ADDRESS (tx_port = port_number)?
+   (PROTOCOL (TCP | UDP))?
+   NEWLINE
+;
 
 if_ip_nbar
 :

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AnyAddressSpecifier.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AnyAddressSpecifier.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.UniverseIpSpace;
 
+/** Used iff a user specifies the address {@code any} for an IPv4 address in an ACL. */
 public final class AnyAddressSpecifier implements AccessListAddressSpecifier {
 
   public static final AnyAddressSpecifier INSTANCE = new AnyAddressSpecifier();

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AnyAddressSpecifier.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AnyAddressSpecifier.java
@@ -1,0 +1,28 @@
+package org.batfish.representation.arista;
+
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.UniverseIpSpace;
+
+public final class AnyAddressSpecifier implements AccessListAddressSpecifier {
+
+  public static final AnyAddressSpecifier INSTANCE = new AnyAddressSpecifier();
+
+  private AnyAddressSpecifier() {} // prevent instantiation
+
+  @Override
+  public boolean equals(Object o) {
+    return this == o || o instanceof AnyAddressSpecifier;
+  }
+
+  @Override
+  public int hashCode() {
+    /* Randomly generated. */
+    return 0xA840F6CD;
+  }
+
+  @Override
+  public @Nonnull IpSpace toIpSpace() {
+    return UniverseIpSpace.INSTANCE;
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -1261,7 +1261,6 @@ public final class AristaConfiguration extends VendorConfiguration {
      * following Cisco behavior. TODO(https://github.com/batfish/batfish/issues/7047)
      */
     generateDynamicSourceNats(newIface, iface.getDynamicSourceNats());
-    // Only extended ACLs are suitable for static source NAT (filtering on destination IP).
     generateStaticSourceNats(newIface, iface.getStaticSourceNats(), c);
 
     String routingPolicyName = iface.getRoutingPolicy();

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaDynamicSourceNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaDynamicSourceNat.java
@@ -14,7 +14,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.transformation.Transformation;
 
-/** Representation of a Arista dynamic source NAT. */
+/** Interface-level configuration of {@code ip nat source dynamic}. */
 @ParametersAreNonnullByDefault
 public final class AristaDynamicSourceNat implements Serializable {
 
@@ -32,7 +32,7 @@ public final class AristaDynamicSourceNat implements Serializable {
   }
 
   public Optional<Transformation> toTransformation(
-      Ip interfaceIp, Map<String, NatPool> natPools, Transformation orElse) {
+      Ip interfaceIp, Map<String, NatPool> natPools, @Nullable Transformation orElse) {
     NatPool natPool =
         _overload ? new NatPool(interfaceIp, interfaceIp) : natPools.get(_natPoolName);
     if (natPool == null) {

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaStaticSourceNat.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaStaticSourceNat.java
@@ -1,0 +1,133 @@
+package org.batfish.representation.arista;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstPort;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchIpProtocol;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcPort;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
+import static org.batfish.datamodel.transformation.Transformation.when;
+import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp;
+import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationPort;
+import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
+import static org.batfish.datamodel.transformation.TransformationStep.assignSourcePort;
+import static org.batfish.representation.arista.Conversions.nameOfSourceNatIpSpaceFromAcl;
+
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.IpSpace;
+import org.batfish.datamodel.IpSpaceReference;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.transformation.Transformation;
+import org.batfish.datamodel.transformation.TransformationStep;
+
+/** Interface-level configuration of {@code ip nat source static}. */
+@ParametersAreNonnullByDefault
+public final class AristaStaticSourceNat implements Serializable {
+  /** The protocol filter on the static source NAT, if applicable. */
+  public enum Protocol {
+    ANY,
+    TCP,
+    UDP
+  }
+
+  private final @Nonnull Ip _originalIp;
+  private final @Nullable Integer _originalPort;
+  private final @Nonnull Ip _translatedIp;
+  private final @Nullable Integer _translatedPort;
+  private final @Nullable String _extendedAclName;
+  private final @Nonnull Protocol _protocol;
+
+  public AristaStaticSourceNat(
+      Ip originalIp,
+      @Nullable Integer originalPort,
+      Ip translatedIp,
+      @Nullable Integer translatedPort,
+      @Nullable String extendedAclName,
+      Protocol protocol) {
+    checkArgument(
+        (originalPort == null) == (translatedPort == null),
+        "Must have translated ports for both original and translated traffic.");
+    _originalIp = originalIp;
+    _originalPort = originalPort;
+    _translatedIp = translatedIp;
+    _translatedPort = translatedPort;
+    _extendedAclName = extendedAclName;
+    _protocol = protocol;
+  }
+
+  public @Nullable String getExtendedAclName() {
+    return _extendedAclName;
+  }
+
+  public @Nonnull Ip getOriginalIp() {
+    return _originalIp;
+  }
+
+  public @Nullable Integer getOriginalPort() {
+    return _originalPort;
+  }
+
+  public @Nonnull Protocol getProtocol() {
+    return _protocol;
+  }
+
+  public @Nonnull Ip getTranslatedIp() {
+    return _translatedIp;
+  }
+
+  public @Nullable Integer getTranslatedPort() {
+    return _translatedPort;
+  }
+
+  private Transformation toTransformation(@Nullable Transformation orElse, boolean forward) {
+    assert (_originalPort == null) == (_translatedPort == null); // invariant
+    ImmutableList.Builder<AclLineMatchExpr> conditions = ImmutableList.builder();
+    conditions.add(forward ? matchSrc(_originalIp) : matchDst(_translatedIp));
+    if (_originalPort != null) {
+      conditions.add(forward ? matchSrcPort(_originalPort) : matchDstPort(_translatedPort));
+    }
+    switch (_protocol) {
+      case TCP:
+        conditions.add(matchIpProtocol(IpProtocol.TCP));
+        break;
+      case UDP:
+        conditions.add(matchIpProtocol(IpProtocol.UDP));
+        break;
+      default:
+        if (_originalPort != null) {
+          // Matching and translating port, treat "ANY" as TCP or UDP.
+          conditions.add(or(matchIpProtocol(IpProtocol.TCP), matchIpProtocol(IpProtocol.UDP)));
+        }
+        break;
+    }
+    if (_extendedAclName != null) {
+      IpSpace space = new IpSpaceReference(nameOfSourceNatIpSpaceFromAcl(_extendedAclName));
+      conditions.add(forward ? matchDst(space) : matchSrc(space));
+    }
+    ImmutableList.Builder<TransformationStep> steps = ImmutableList.builder();
+    steps.add(
+        forward ? assignSourceIp(_translatedIp, _translatedIp) : assignDestinationIp(_originalIp));
+    if (_originalPort != null) {
+      steps.add(forward ? assignSourcePort(_translatedPort) : assignDestinationPort(_originalPort));
+    }
+    return when(and(conditions.build())).apply(steps.build()).setOrElse(orElse).build();
+  }
+
+  /** Translate from original source IP when sending. */
+  public Transformation toOutgoingTransformation(@Nullable Transformation orElse) {
+    return toTransformation(orElse, true);
+  }
+
+  /** Translate back to original source IP when receiving. */
+  public Transformation toIncomingTransformation(@Nullable Transformation orElse) {
+    return toTransformation(orElse, false);
+  }
+}

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaStructureUsage.java
@@ -63,6 +63,7 @@ public enum AristaStructureUsage implements StructureUsage {
   IP_ROUTE_NHINT("ip route next-hop interface"),
   IP_NAT_DESTINATION_ACCESS_LIST("ip nat destination acl"),
   IP_NAT_SOURCE_ACCESS_LIST("ip nat source dynamic access-list"),
+  IP_NAT_SOURCE_STATIC_ACCESS_LIST("ip nat source static access-list"),
   IP_NAT_SOURCE_POOL("ip nat source pool"),
   IP_TACACS_SOURCE_INTERFACE("ip tacacs source-interface"),
   IPSEC_PROFILE_ISAKMP_PROFILE("ipsec profile set isakmp-profile"),

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/Interface.java
@@ -76,7 +76,9 @@ public class Interface implements Serializable {
 
   @Nullable private IntegerSpace _allowedVlans;
 
-  private List<AristaDynamicSourceNat> _aristaNats;
+  private List<AristaDynamicSourceNat> _dynamicSourceNats;
+
+  private List<AristaStaticSourceNat> _staticSourceNats;
 
   private boolean _autoState;
 
@@ -236,10 +238,6 @@ public class Interface implements Serializable {
     return allAddresses;
   }
 
-  public List<AristaDynamicSourceNat> getAristaNats() {
-    return _aristaNats;
-  }
-
   public boolean getAutoState() {
     return _autoState;
   }
@@ -266,6 +264,10 @@ public class Interface implements Serializable {
 
   public boolean getDhcpRelayClient() {
     return _dhcpRelayClient;
+  }
+
+  public List<AristaDynamicSourceNat> getDynamicSourceNats() {
+    return _dynamicSourceNats;
   }
 
   public @Nullable Integer getEncapsulationVlan() {
@@ -383,6 +385,14 @@ public class Interface implements Serializable {
     return _speed;
   }
 
+  public List<AristaStaticSourceNat> getStaticSourceNats() {
+    return _staticSourceNats;
+  }
+
+  public void setStaticSourceNats(List<AristaStaticSourceNat> staticSourceNats) {
+    _staticSourceNats = staticSourceNats;
+  }
+
   public Boolean getSwitchport() {
     return _switchport;
   }
@@ -431,8 +441,8 @@ public class Interface implements Serializable {
     _shutdown = shutdown;
   }
 
-  public void setAristaNats(List<AristaDynamicSourceNat> aristaNats) {
-    _aristaNats = aristaNats;
+  public void setDynamicSourceNats(List<AristaDynamicSourceNat> dynamicSourceNats) {
+    _dynamicSourceNats = dynamicSourceNats;
   }
 
   public void setAutoState(boolean autoState) {

--- a/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/arista/AristaGrammarTest.java
@@ -9,6 +9,9 @@ import static org.batfish.datamodel.ConfigurationFormat.ARISTA;
 import static org.batfish.datamodel.Names.generatedBgpPeerEvpnExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpPeerExportPolicyName;
 import static org.batfish.datamodel.Route.UNSET_ROUTE_NEXT_HOP_IP;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
 import static org.batfish.datamodel.acl.AclLineMatchExprs.permittedByAcl;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.matchers.AddressFamilyCapabilitiesMatchers.hasAllowRemoteAsOut;
@@ -31,6 +34,8 @@ import static org.batfish.datamodel.matchers.DataModelMatchers.hasBandwidth;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasNoUndefinedReferences;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasNumReferrers;
 import static org.batfish.datamodel.matchers.DataModelMatchers.hasRedFlagWarning;
+import static org.batfish.datamodel.matchers.FlowMatchers.hasDstIp;
+import static org.batfish.datamodel.matchers.FlowMatchers.hasSrcIp;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllAddresses;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasAllowedVlans;
 import static org.batfish.datamodel.matchers.InterfaceMatchers.hasDescription;
@@ -56,12 +61,14 @@ import static org.batfish.datamodel.matchers.VrfMatchers.hasBgpProcess;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasL2VniSettings;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasName;
 import static org.batfish.datamodel.transformation.Transformation.when;
+import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp;
 import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
 import static org.batfish.main.BatfishTestUtils.TEST_SNAPSHOT;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
 import static org.batfish.representation.arista.AristaStructureType.INTERFACE;
 import static org.batfish.representation.arista.AristaStructureType.POLICY_MAP;
 import static org.batfish.representation.arista.AristaStructureType.VXLAN;
+import static org.batfish.representation.arista.Conversions.nameOfSourceNatIpSpaceFromAcl;
 import static org.batfish.representation.arista.OspfProcess.getReferenceOspfBandwidth;
 import static org.batfish.representation.arista.eos.AristaBgpProcess.DEFAULT_VRF;
 import static org.batfish.representation.arista.eos.AristaRedistributeType.OSPF;
@@ -110,6 +117,7 @@ import org.apache.commons.lang3.SerializationUtils;
 import org.batfish.common.BatfishLogger;
 import org.batfish.common.NetworkSnapshot;
 import org.batfish.common.Warnings;
+import org.batfish.common.matchers.WarningMatchers;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.AbstractRoute;
@@ -130,6 +138,8 @@ import org.batfish.datamodel.BumTransportMethod;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.DataPlane;
+import org.batfish.datamodel.Flow;
+import org.batfish.datamodel.FlowDisposition;
 import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.GenericRib;
 import org.batfish.datamodel.IntegerSpace;
@@ -137,6 +147,7 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Interface.Dependency;
 import org.batfish.datamodel.Interface.DependencyType;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpSpaceReference;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
 import org.batfish.datamodel.LongSpace;
@@ -153,6 +164,7 @@ import org.batfish.datamodel.SnmpCommunity;
 import org.batfish.datamodel.SnmpServer;
 import org.batfish.datamodel.SwitchportMode;
 import org.batfish.datamodel.VrrpGroup;
+import org.batfish.datamodel.acl.AclLineMatchExprs;
 import org.batfish.datamodel.answers.ConvertConfigurationAnswerElement;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.bgp.BgpConfederation;
@@ -163,6 +175,7 @@ import org.batfish.datamodel.bgp.Layer3VniConfig;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.ExtendedCommunity;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
+import org.batfish.datamodel.flow.TraceAndReverseFlow;
 import org.batfish.datamodel.matchers.ConfigurationMatchers;
 import org.batfish.datamodel.matchers.MlagMatchers;
 import org.batfish.datamodel.route.nh.NextHopDiscard;
@@ -175,6 +188,7 @@ import org.batfish.datamodel.routing_policy.communities.CommunityMatchExprEvalua
 import org.batfish.datamodel.routing_policy.communities.CommunitySet;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExpr;
 import org.batfish.datamodel.routing_policy.communities.CommunitySetMatchExprEvaluator;
+import org.batfish.datamodel.transformation.Transformation;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.datamodel.vxlan.Layer3Vni;
 import org.batfish.grammar.silent_syntax.SilentSyntaxCollection;
@@ -182,6 +196,8 @@ import org.batfish.main.Batfish;
 import org.batfish.main.BatfishTestUtils;
 import org.batfish.main.TestrigText;
 import org.batfish.representation.arista.AristaConfiguration;
+import org.batfish.representation.arista.AristaStaticSourceNat;
+import org.batfish.representation.arista.AristaStaticSourceNat.Protocol;
 import org.batfish.representation.arista.ExpandedCommunityList;
 import org.batfish.representation.arista.ExpandedCommunityListLine;
 import org.batfish.representation.arista.IpAsPathAccessList;
@@ -795,6 +811,54 @@ public class AristaGrammarTest {
                 // overload rule, so use the interface IP
                 .apply(assignSourceIp(Ip.parse("8.8.8.8"), Ip.parse("8.8.8.8")))
                 .build()));
+  }
+
+  /**
+   * Test that static source NAT works as expected. A flow originates from r1[loopback0] with srcIp
+   * 8.8.8.8, gets routed towards r2[Ethernet1] via connected route, is src-natted to 9.9.9.9 on the
+   * way out. It should be accepted at r2[Ethernet1].
+   *
+   * <p>The reverse flow should start out from 1.0.0.1 -> 9.9.9.9, be dest-natted on the way back
+   * in, rewritten to 8.8.8.8 at r1[Ethernet1], and then accepted.
+   */
+  @Test
+  public void testStaticSourceNatE2e() throws IOException {
+    Batfish batfish =
+        BatfishTestUtils.getBatfishFromTestrigText(
+            TestrigText.builder()
+                .setConfigurationFiles(
+                    TESTRIGS_PREFIX + "nat-source-static", ImmutableList.of("r1", "r2"))
+                .build(),
+            _folder);
+    NetworkSnapshot snapshot = batfish.getSnapshot();
+    assertThat(batfish.loadConfigurations(snapshot), hasKeys("r1", "r2"));
+
+    batfish.computeDataPlane(snapshot);
+
+    Flow testFlow =
+        Flow.builder()
+            .setIngressNode("r1")
+            .setIngressVrf("default")
+            .setSrcIp(Ip.parse("8.8.8.8"))
+            .setDstIp(Ip.parse("1.0.0.1"))
+            .build();
+    TraceAndReverseFlow tarf =
+        getOnlyElement(
+            batfish
+                .getTracerouteEngine(snapshot)
+                .computeTracesAndReverseFlows(ImmutableSet.of(testFlow), false)
+                .get(testFlow));
+    assertThat(tarf.getTrace().getDisposition(), equalTo(FlowDisposition.ACCEPTED));
+    assertThat(tarf.getReverseFlow(), hasDstIp(Ip.parse("9.9.9.9")));
+
+    TraceAndReverseFlow reverseTarf =
+        getOnlyElement(
+            batfish
+                .getTracerouteEngine(snapshot)
+                .computeTracesAndReverseFlows(ImmutableSet.of(tarf.getReverseFlow()), false)
+                .get(tarf.getReverseFlow()));
+    assertThat(reverseTarf.getTrace().getDisposition(), equalTo(FlowDisposition.ACCEPTED));
+    assertThat(reverseTarf.getReverseFlow(), hasSrcIp(Ip.parse("8.8.8.8")));
   }
 
   @Test
@@ -2680,6 +2744,133 @@ public class AristaGrammarTest {
         policy.processBgpRoute(acceptRoute, Bgpv4Route.testBuilder(), null, Direction.IN, null));
     assertFalse(
         policy.processBgpRoute(denyRoute, Bgpv4Route.testBuilder(), null, Direction.IN, null));
+  }
+
+  @Test
+  public void testIpNatSourceStaticExtraction() {
+    AristaConfiguration c = parseVendorConfig("ip-nat-source-static");
+    assertThat(c.getExtendedAcls(), hasKeys("ACL", "INVALID_ACL"));
+    assertThat(c.getInterfaces(), hasKeys("Ethernet1", "Ethernet2"));
+    {
+      org.batfish.representation.arista.Interface ethernet1 = c.getInterfaces().get("Ethernet1");
+      assertThat(ethernet1.getStaticSourceNats(), hasSize(4));
+      Iterator<AristaStaticSourceNat> nats = ethernet1.getStaticSourceNats().iterator();
+      {
+        AristaStaticSourceNat nat = nats.next();
+        assertThat(nat.getOriginalIp(), equalTo(Ip.parse("1.1.1.1")));
+        assertThat(nat.getOriginalPort(), nullValue());
+        assertThat(nat.getExtendedAclName(), nullValue());
+        assertThat(nat.getTranslatedIp(), equalTo(Ip.parse("2.2.2.2")));
+        assertThat(nat.getTranslatedPort(), nullValue());
+        assertThat(nat.getProtocol(), equalTo(Protocol.ANY));
+      }
+      {
+        AristaStaticSourceNat nat = nats.next();
+        assertThat(nat.getOriginalIp(), equalTo(Ip.parse("3.3.3.3")));
+        assertThat(nat.getOriginalPort(), equalTo(33));
+        assertThat(nat.getExtendedAclName(), nullValue());
+        assertThat(nat.getTranslatedIp(), equalTo(Ip.parse("4.4.4.4")));
+        assertThat(nat.getTranslatedPort(), equalTo(44));
+        assertThat(nat.getProtocol(), equalTo(Protocol.ANY));
+      }
+      {
+        AristaStaticSourceNat nat = nats.next();
+        assertThat(nat.getOriginalIp(), equalTo(Ip.parse("5.5.5.5")));
+        assertThat(nat.getOriginalPort(), equalTo(55));
+        assertThat(nat.getExtendedAclName(), equalTo("ACL"));
+        assertThat(nat.getTranslatedIp(), equalTo(Ip.parse("6.6.6.6")));
+        assertThat(nat.getTranslatedPort(), equalTo(66));
+        assertThat(nat.getProtocol(), equalTo(Protocol.TCP));
+      }
+      {
+        AristaStaticSourceNat nat = nats.next();
+        assertThat(nat.getOriginalIp(), equalTo(Ip.parse("7.7.7.7")));
+        assertThat(nat.getOriginalPort(), equalTo(77));
+        assertThat(nat.getExtendedAclName(), equalTo("ACL"));
+        assertThat(nat.getTranslatedIp(), equalTo(Ip.parse("8.8.8.8")));
+        assertThat(nat.getTranslatedPort(), equalTo(88));
+        assertThat(nat.getProtocol(), equalTo(Protocol.UDP));
+      }
+    }
+    {
+      // Shallow test of Ethernet2, since we did extraction tests above.
+      org.batfish.representation.arista.Interface ethernet2 = c.getInterfaces().get("Ethernet2");
+      assertThat(ethernet2.getStaticSourceNats(), hasSize(2));
+    }
+  }
+
+  @Test
+  public void testIpNatSourceStaticConversion() {
+    AristaConfiguration vendor = parseVendorConfig("ip-nat-source-static");
+    Warnings w = new Warnings(true, true, true);
+    vendor.setWarnings(w);
+    Configuration c = Iterables.getOnlyElement(vendor.toVendorIndependentConfigurations());
+    // Check that IP Spaces are extracted, and warnings are appropriate.
+    assertThat(
+        c.getIpSpaces(),
+        hasKeys(
+            nameOfSourceNatIpSpaceFromAcl("ACL"), nameOfSourceNatIpSpaceFromAcl("INVALID_ACL")));
+    assertThat(
+        c.getIpSpaces().get(nameOfSourceNatIpSpaceFromAcl("ACL")),
+        equalTo(
+            AclIpSpace.builder()
+                .thenPermitting(IpWildcard.parse("9.9.9.9").toIpSpace())
+                .thenRejecting(IpWildcard.parse("10.10.10.0/24").toIpSpace())
+                .thenPermitting(IpWildcard.parse("11.11.11.11").toIpSpace())
+                .build()));
+    assertThat(
+        c.getIpSpaces().get(nameOfSourceNatIpSpaceFromAcl("INVALID_ACL")),
+        equalTo(AclIpSpace.builder().build()));
+    assertThat(
+        w.getRedFlagWarnings(),
+        containsInAnyOrder(
+            WarningMatchers.hasText(
+                "INVALID_ACL line permit ip any any: destination address cannot be 'any'"),
+            WarningMatchers.hasText(
+                "INVALID_ACL line permit ip host 1.2.3.4 host 9.9.9.9: source address must be"
+                    + " 'any'"),
+            WarningMatchers.hasText(
+                "INVALID_ACL line permit tcp any host 10.10.10.10: cannot filter on anything but"
+                    + " destination address"),
+            WarningMatchers.hasText(
+                "INVALID_ACL line permit ip any host 11.11.11.11 fragments: cannot filter on"
+                    + " anything but destination address"),
+            WarningMatchers.hasText(
+                "ip nat source commands referencing nonexistent ACL UNDEFINED_ACL are not installed"
+                    + " until the ACL is created")));
+    // Check that applied transformations are correct.
+    {
+      Transformation e1out = c.getAllInterfaces().get("Ethernet1").getOutgoingTransformation();
+      assertThat(e1out.getGuard(), equalTo(AclLineMatchExprs.and(matchSrc(Ip.parse("1.1.1.1")))));
+      assertThat(e1out.getTransformationSteps(), contains(assignSourceIp(Ip.parse("2.2.2.2"))));
+      assertThat(e1out.getAndThen(), nullValue());
+      assertThat(e1out.getOrElse(), notNullValue());
+      // We do deep testing of the conversion to Transformation elsewhere.
+    }
+    {
+      Transformation e1in = c.getAllInterfaces().get("Ethernet1").getIncomingTransformation();
+      assertThat(e1in.getGuard(), equalTo(AclLineMatchExprs.and(matchDst(Ip.parse("2.2.2.2")))));
+      assertThat(e1in.getTransformationSteps(), contains(assignDestinationIp(Ip.parse("1.1.1.1"))));
+      assertThat(e1in.getAndThen(), nullValue());
+      assertThat(e1in.getOrElse(), notNullValue());
+      // We do deep testing of the conversion to Transformation elsewhere.
+    }
+    assertThat(
+        c.getAllInterfaces().get("Ethernet2").getIncomingTransformation(),
+        equalTo(
+            when(and(
+                    matchDst(Ip.parse("2.2.2.2")),
+                    matchSrc(new IpSpaceReference(nameOfSourceNatIpSpaceFromAcl("INVALID_ACL")))))
+                .apply(assignDestinationIp(Ip.parse("1.1.1.1")))
+                .build()));
+    assertThat(
+        c.getAllInterfaces().get("Ethernet2").getOutgoingTransformation(),
+        equalTo(
+            when(and(
+                    matchSrc(Ip.parse("1.1.1.1")),
+                    matchDst(new IpSpaceReference(nameOfSourceNatIpSpaceFromAcl("INVALID_ACL")))))
+                .apply(assignSourceIp(Ip.parse("2.2.2.2")))
+                .build()));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/arista/AristaStaticSourceNatTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/arista/AristaStaticSourceNatTest.java
@@ -1,0 +1,115 @@
+package org.batfish.representation.arista;
+
+import static org.batfish.datamodel.acl.AclLineMatchExprs.TRUE;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.and;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDst;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchDstPort;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchIpProtocol;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrc;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.matchSrcPort;
+import static org.batfish.datamodel.acl.AclLineMatchExprs.or;
+import static org.batfish.datamodel.transformation.Transformation.when;
+import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationIp;
+import static org.batfish.datamodel.transformation.TransformationStep.assignDestinationPort;
+import static org.batfish.datamodel.transformation.TransformationStep.assignSourceIp;
+import static org.batfish.datamodel.transformation.TransformationStep.assignSourcePort;
+import static org.batfish.representation.arista.Conversions.nameOfSourceNatIpSpaceFromAcl;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.IpProtocol;
+import org.batfish.datamodel.IpSpaceReference;
+import org.batfish.datamodel.acl.AclLineMatchExpr;
+import org.batfish.datamodel.acl.AndMatchExpr;
+import org.batfish.datamodel.transformation.Transformation;
+import org.batfish.representation.arista.AristaStaticSourceNat.Protocol;
+import org.junit.Test;
+
+public class AristaStaticSourceNatTest {
+  private final AristaStaticSourceNat _nat =
+      new AristaStaticSourceNat(
+          Ip.parse("1.1.1.1"), 11, Ip.parse("2.2.2.2"), 22, "someAcl", Protocol.ANY);
+  private final Transformation _orElse = when(TRUE).apply(assignDestinationPort(74, 1000)).build();
+
+  /** All fields, in direction. */
+  @Test
+  public void testConversionIn() {
+    Transformation trans = _nat.toIncomingTransformation(_orElse);
+    // Test guard
+    AclLineMatchExpr guard = trans.getGuard();
+    assertThat(guard, instanceOf(AndMatchExpr.class));
+    assertThat(
+        ((AndMatchExpr) guard).getConjuncts(),
+        containsInAnyOrder(
+            matchDst(Ip.parse("2.2.2.2")),
+            matchDstPort(22),
+            matchSrc(new IpSpaceReference(nameOfSourceNatIpSpaceFromAcl("someAcl"))),
+            or(matchIpProtocol(IpProtocol.TCP), matchIpProtocol(IpProtocol.UDP))));
+    // Test apply
+    assertThat(
+        trans.getTransformationSteps(),
+        containsInAnyOrder(assignDestinationIp(Ip.parse("1.1.1.1")), assignDestinationPort(11)));
+    // Test andThen
+    assertThat(trans.getAndThen(), nullValue());
+    // Test orElse
+    assertThat(trans.getOrElse(), sameInstance(_orElse));
+  }
+
+  /** All fields, out direction. */
+  @Test
+  public void testConversionOut() {
+    Transformation trans = _nat.toOutgoingTransformation(_orElse);
+    // Test guard
+    AclLineMatchExpr guard = trans.getGuard();
+    assertThat(guard, instanceOf(AndMatchExpr.class));
+    assertThat(
+        ((AndMatchExpr) guard).getConjuncts(),
+        containsInAnyOrder(
+            matchSrc(Ip.parse("1.1.1.1")),
+            matchSrcPort(11),
+            matchDst(new IpSpaceReference(nameOfSourceNatIpSpaceFromAcl("someAcl"))),
+            or(matchIpProtocol(IpProtocol.TCP), matchIpProtocol(IpProtocol.UDP))));
+    // Test apply
+    assertThat(
+        trans.getTransformationSteps(),
+        containsInAnyOrder(assignSourceIp(Ip.parse("2.2.2.2")), assignSourcePort(22)));
+    // Test andThen
+    assertThat(trans.getAndThen(), nullValue());
+    // Test orElse
+    assertThat(trans.getOrElse(), sameInstance(_orElse));
+  }
+
+  /** Test presence and absence of protocol with and without ports. */
+  @Test
+  public void testProtocolGuard() {
+    AristaStaticSourceNat anyNoPorts =
+        new AristaStaticSourceNat(
+            Ip.parse("1.1.1.1"), null, Ip.parse("2.2.2.2"), null, null, Protocol.ANY);
+    assertThat(
+        anyNoPorts.toOutgoingTransformation(_orElse).getGuard(),
+        equalTo(matchSrc(Ip.parse("1.1.1.1"))));
+    assertThat(
+        anyNoPorts.toIncomingTransformation(_orElse).getGuard(),
+        equalTo(matchDst(Ip.parse("2.2.2.2"))));
+
+    AristaStaticSourceNat tcpNoPorts =
+        new AristaStaticSourceNat(
+            Ip.parse("1.1.1.1"), null, Ip.parse("2.2.2.2"), null, null, Protocol.TCP);
+    assertThat(
+        tcpNoPorts.toOutgoingTransformation(_orElse).getGuard(),
+        equalTo(and(matchSrc(Ip.parse("1.1.1.1")), matchIpProtocol(IpProtocol.TCP))));
+
+    AristaStaticSourceNat tcpPorts =
+        new AristaStaticSourceNat(
+            Ip.parse("1.1.1.1"), 11, Ip.parse("2.2.2.2"), 22, null, Protocol.TCP);
+    assertThat(
+        tcpPorts.toOutgoingTransformation(_orElse).getGuard(),
+        equalTo(
+            and(matchSrc(Ip.parse("1.1.1.1")), matchSrcPort(11), matchIpProtocol(IpProtocol.TCP))));
+  }
+}

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/ip-nat-source-static
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/ip-nat-source-static
@@ -1,0 +1,37 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname ip-nat-source-static
+!
+ip access-list ACL
+  permit ip any host 9.9.9.9
+  ! TODO(https://github.com/batfish/batfish/issues/7047) are these semantics honored?
+  deny ip any 10.10.10.0/24
+  permit ip any host 11.11.11.11
+ip access-list INVALID_ACL
+  ! invalid: dest ip cannot be any
+  permit ip any any
+  ! invalid: src IP must be any
+  permit ip host 1.2.3.4 host 9.9.9.9
+  ! invalid: cannot match on protocol
+  permit tcp any host 10.10.10.10
+  ! believed invalid: cannot match on anything but dstIp
+  permit ip any host 11.11.11.11 fragments
+!
+interface Ethernet1
+  ! lots of valid configurations
+  ip address 1.0.0.0/31
+  ip nat source static 1.1.1.1 2.2.2.2
+  ip nat source static 3.3.3.3 33 4.4.4.4 44
+  ip nat source static 5.5.5.5 55 access-list ACL 6.6.6.6 66 protocol tcp
+  ip nat source static 7.7.7.7 77 access-list ACL 8.8.8.8 88 protocol udp
+!
+interface Ethernet2
+  ip address 2.0.0.0/31
+  ip nat source static 1.1.1.1 access-list INVALID_ACL 2.2.2.2
+  ip nat source static 3.3.3.3 access-list UNDEFINED_ACL 4.4.4.4
+  ! Next 2 lines invalid b/c only one port provided
+  ip nat source static 5.5.5.5 55 6.6.6.6
+  ip nat source static 7.7.7.7 8.8.8.8 88
+  ! Next line invalid b/c port 0 used
+  ip nat source static 9.9.9.9 99 10.10.10.10 0
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testrigs/nat-source-static/configs/r1
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testrigs/nat-source-static/configs/r1
@@ -1,0 +1,10 @@
+!RANCID-CONTENT-TYPE: arista
+!
+interface Loopback0
+  ip address 8.8.8.8/32
+!
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 1.0.0.0/31
+  ip nat source static 8.8.8.8 9.9.9.9

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testrigs/nat-source-static/configs/r2
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testrigs/nat-source-static/configs/r2
@@ -1,0 +1,9 @@
+!RANCID-CONTENT-TYPE: arista
+!
+interface Ethernet1
+  no switchport
+  no shutdown
+  ip address 1.0.0.1/31
+!
+ip route 9.9.9.9/32 1.0.0.0
+ip route 8.8.8.8/32 null0

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -19213,8 +19213,7 @@
                     ],
                     "negate" : false,
                     "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                      "ipWildcard" : "0.0.0.0/0"
+                      "class" : "org.batfish.datamodel.UniverseIpSpace"
                     }
                   }
                 },
@@ -19248,8 +19247,7 @@
                     ],
                     "negate" : false,
                     "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                      "ipWildcard" : "0.0.0.0/0"
+                      "class" : "org.batfish.datamodel.UniverseIpSpace"
                     },
                     "tcpFlagsMatchConditions" : [
                       {
@@ -19292,13 +19290,11 @@
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
                     "dstIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                      "ipWildcard" : "0.0.0.0/0"
+                      "class" : "org.batfish.datamodel.UniverseIpSpace"
                     },
                     "negate" : false,
                     "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                      "ipWildcard" : "0.0.0.0/0"
+                      "class" : "org.batfish.datamodel.UniverseIpSpace"
                     }
                   }
                 },
@@ -20059,13 +20055,11 @@
                   "class" : "org.batfish.datamodel.acl.MatchHeaderSpace",
                   "headerSpace" : {
                     "dstIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                      "ipWildcard" : "0.0.0.0/0"
+                      "class" : "org.batfish.datamodel.UniverseIpSpace"
                     },
                     "negate" : false,
                     "srcIps" : {
-                      "class" : "org.batfish.datamodel.IpWildcardIpSpace",
-                      "ipWildcard" : "0.0.0.0/0"
+                      "class" : "org.batfish.datamodel.UniverseIpSpace"
                     }
                   }
                 },


### PR DESCRIPTION
* Make extended ACLs distinguish between ANY and 0.0.0.0/0.
* Parse and extract AristaStaticSourceNat
* Extract IPs used for source NAT from an extended ACL. Since the IPs must be
  destination IPs, only extended ACLs can be used. Include some of the expected
  error handling during conversion.
* Install forward and reverse static rules on the interfaces.
* Tests.

Fix #7032 .