### PR TITLE
Arista: fix handling of undefined continue targets

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/arista/AristaControlPlaneExtractor.java
@@ -36,6 +36,7 @@ import static org.batfish.representation.arista.AristaStructureType.POLICY_MAP;
 import static org.batfish.representation.arista.AristaStructureType.PREFIX6_LIST;
 import static org.batfish.representation.arista.AristaStructureType.PREFIX_LIST;
 import static org.batfish.representation.arista.AristaStructureType.ROUTE_MAP;
+import static org.batfish.representation.arista.AristaStructureType.ROUTE_MAP_ENTRY;
 import static org.batfish.representation.arista.AristaStructureType.SERVICE_TEMPLATE;
 import static org.batfish.representation.arista.AristaStructureType.TRACK;
 import static org.batfish.representation.arista.AristaStructureType.VXLAN;
@@ -135,6 +136,8 @@ import static org.batfish.representation.arista.AristaStructureUsage.POLICY_MAP_
 import static org.batfish.representation.arista.AristaStructureUsage.RIP_DISTRIBUTE_LIST;
 import static org.batfish.representation.arista.AristaStructureUsage.ROUTER_ISIS_DISTRIBUTE_LIST_ACL;
 import static org.batfish.representation.arista.AristaStructureUsage.ROUTER_VRRP_INTERFACE;
+import static org.batfish.representation.arista.AristaStructureUsage.ROUTE_MAP_CONTINUE;
+import static org.batfish.representation.arista.AristaStructureUsage.ROUTE_MAP_ENTRY_AUTO_REF;
 import static org.batfish.representation.arista.AristaStructureUsage.ROUTE_MAP_MATCH_AS_PATH_ACCESS_LIST;
 import static org.batfish.representation.arista.AristaStructureUsage.ROUTE_MAP_MATCH_COMMUNITY_LIST;
 import static org.batfish.representation.arista.AristaStructureUsage.ROUTE_MAP_MATCH_IPV4_ACCESS_LIST;
@@ -938,6 +941,10 @@ import org.batfish.vendor.VendorConfiguration;
 
 public class AristaControlPlaneExtractor extends AristaParserBaseListener
     implements SilentSyntaxListener, ControlPlaneExtractor {
+
+  public static @Nonnull String computeRouteMapEntryName(String routeMapName, int sequence) {
+    return String.format("%s %d", routeMapName, sequence);
+  }
 
   private static final int DEFAULT_STATIC_ROUTE_DISTANCE = 1;
 
@@ -3540,6 +3547,11 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
     }
     _currentRouteMapClause = clause;
     _configuration.defineStructure(ROUTE_MAP, name, ctx);
+    // Declare and auto-reference the entry too.
+    String entryName = computeRouteMapEntryName(name, num);
+    _configuration.defineStructure(ROUTE_MAP_ENTRY, entryName, ctx);
+    _configuration.referenceStructure(
+        ROUTE_MAP_ENTRY, entryName, ROUTE_MAP_ENTRY_AUTO_REF, ctx.name.getStart().getLine());
   }
 
   @Override
@@ -4073,12 +4085,22 @@ public class AristaControlPlaneExtractor extends AristaParserBaseListener
 
   @Override
   public void exitContinue_rm_stanza(Continue_rm_stanzaContext ctx) {
-    int statementLine = ctx.getStart().getLine();
     Integer target = null;
     if (ctx.dec() != null) {
       target = toInteger(ctx.dec());
+      if (_currentRouteMapClause.getSeqNum() >= target) {
+        warn(
+            ctx,
+            String.format(
+                "Route-map %s entry %d: continue %d introduces a loop",
+                _currentRouteMap.getName(), _currentRouteMapClause.getSeqNum(), target));
+        return;
+      }
+      String targetName = computeRouteMapEntryName(_currentRouteMap.getName(), target);
+      _configuration.referenceStructure(
+          ROUTE_MAP_ENTRY, targetName, ROUTE_MAP_CONTINUE, ctx.getStart().getLine());
     }
-    RouteMapContinue continueLine = new RouteMapContinue(target, statementLine);
+    RouteMapContinue continueLine = new RouteMapContinue(target);
     _currentRouteMapClause.setContinueLine(continueLine);
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -1813,10 +1813,17 @@ public final class AristaConfiguration extends VendorConfiguration {
                     // Naked continue on last line.
                     return null;
                   }
+                  if (!routeMap.getClauses().containsKey(effectiveTarget)) {
+                    // On Arista, an undefined continue target is just treated as not a continue.
+                    _w.redFlag(
+                        String.format(
+                            "route-map %s entry %d: ignoring continue to missing entry %d",
+                            routeMap.getName(), clause.getSeqNum(), effectiveTarget));
+                    return null;
+                  }
                   return new SimpleEntry<>(clause.getSeqNum(), effectiveTarget);
                 })
             .filter(Objects::nonNull)
-            .filter(e -> routeMap.getClauses().containsKey(e.getValue()))
             .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
     // sequences that are valid targets of a continue statement
     Set<Integer> continueTargets = ImmutableSet.copyOf(continues.values());
@@ -1893,9 +1900,9 @@ public final class AristaConfiguration extends VendorConfiguration {
 
     LineAction action = entry.getAction();
 
-    RouteMapContinue cont = entry.getContinueLine();
-    if (cont == null) {
-      // No continue: on match, return the action.
+    @Nullable Integer continueSeq = continues.get(entry.getSeqNum());
+    if (continueSeq == null) {
+      // No continue (after cleaning up invalid refs, etc.): on match, return the action.
       if (action == LineAction.PERMIT) {
         trueStatements.add(Statements.ReturnTrue.toStaticStatement());
       } else {
@@ -1910,21 +1917,7 @@ public final class AristaConfiguration extends VendorConfiguration {
         assert action == LineAction.DENY;
         trueStatements.add(Statements.SetLocalDefaultActionReject.toStaticStatement());
       }
-      Integer target = continues.get(entry.getSeqNum());
-      if (target != null) {
-        trueStatements.add(call(computeRoutingPolicyName(routeMapName, target)));
-      } else {
-        String targetName =
-            String.format("clause: '%s' in route-map: '%s'", cont.getTarget(), routeMapName);
-        undefined(
-            AristaStructureType.ROUTE_MAP_CLAUSE,
-            targetName,
-            AristaStructureUsage.ROUTE_MAP_CONTINUE,
-            cont.getStatementLine());
-        // invalid continue target, so just deny
-        // TODO: verify actual behavior
-        trueStatements.add(Statements.ReturnFalse.toStaticStatement());
-      }
+      trueStatements.add(call(computeRoutingPolicyName(routeMapName, continueSeq)));
     }
 
     // final action if not matched
@@ -2579,6 +2572,7 @@ public final class AristaConfiguration extends VendorConfiguration {
 
     // mark references to route-maps
     markConcreteStructure(AristaStructureType.ROUTE_MAP);
+    markConcreteStructure(AristaStructureType.ROUTE_MAP_ENTRY);
 
     // L2tp
     markConcreteStructure(AristaStructureType.L2TP_CLASS);

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaStructureType.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaStructureType.java
@@ -38,7 +38,7 @@ public enum AristaStructureType implements StructureType {
   PREFIX_LIST("ipv4 prefix-list"),
   PREFIX6_LIST("ipv6 prefix-list"),
   ROUTE_MAP("route-map"),
-  ROUTE_MAP_CLAUSE("route-map-clause"),
+  ROUTE_MAP_ENTRY("route-map entry"),
   SERVICE_TEMPLATE("service-template"),
   TRACK("track"),
   VXLAN("vxlan");

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaStructureUsage.java
@@ -124,10 +124,8 @@ public enum AristaStructureUsage implements StructureUsage {
   RIP_REDISTRIBUTE_BGP_MAP("router rip redistribute bgp route-map"),
   RIP_REDISTRIBUTE_CONNECTED_MAP("router rip redistribute connected route-map"),
   RIP_REDISTRIBUTE_STATIC_MAP("router rip redistribute static route-map"),
-  ROUTE_MAP_SET_COMMUNITY_COMMUNITY_LIST_ADDITIVE(
-      "route-map set community community-list additive"),
-  ROUTE_MAP_CONTINUE("route-map continue target clause"),
-  ROUTE_MAP_SET_COMMUNITY_COMMUNITY_LIST_DELETE("route-map set community community-list delete"),
+  ROUTE_MAP_CONTINUE("route-map continue"),
+  ROUTE_MAP_ENTRY_AUTO_REF("route-map entry"),
   ROUTE_MAP_MATCH_AS_PATH_ACCESS_LIST("route-map match as-path access-list"),
   ROUTE_MAP_MATCH_COMMUNITY_LIST("route-map match community-list"),
   ROUTE_MAP_MATCH_IPV4_ACCESS_LIST("route-map match ipv4 access-list"),
@@ -135,6 +133,9 @@ public enum AristaStructureUsage implements StructureUsage {
   ROUTE_MAP_MATCH_IPV6_ACCESS_LIST("route-map match ipv6 access-list"),
   ROUTE_MAP_MATCH_IPV6_PREFIX_LIST("route-map match ipv6 prefix-list"),
   ROUTE_MAP_SET_COMMUNITY_COMMUNITY_LIST("route-map set community community list"),
+  ROUTE_MAP_SET_COMMUNITY_COMMUNITY_LIST_ADDITIVE(
+      "route-map set community community-list additive"),
+  ROUTE_MAP_SET_COMMUNITY_COMMUNITY_LIST_DELETE("route-map set community community-list delete"),
   ROUTER_ISIS_DISTRIBUTE_LIST_ACL("router isis distribute-list acl"),
   ROUTER_STATIC_ROUTE("router static route"),
   ROUTER_VRRP_INTERFACE("router vrrp interface"),

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/RouteMapContinue.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/RouteMapContinue.java
@@ -4,17 +4,10 @@ import java.io.Serializable;
 
 public class RouteMapContinue implements Serializable {
 
-  private final int _statementLine;
-
   private final Integer _target;
 
-  public RouteMapContinue(Integer target, int statementLine) {
+  public RouteMapContinue(Integer target) {
     _target = target;
-    _statementLine = statementLine;
-  }
-
-  public int getStatementLine() {
-    return _statementLine;
   }
 
   public Integer getTarget() {

--- a/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_route_map_misconfigured
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/arista/testconfigs/arista_route_map_misconfigured
@@ -1,0 +1,16 @@
+!RANCID-CONTENT-TYPE: arista
+!
+hostname arista_route_map_misconfigured
+!
+route-map MAP permit 10
+  match tag 1
+  set local-preference 75
+  ! Continue to undefined target
+  continue 20
+route-map MAP deny 30
+  ! Introduce a loop
+  continue 10
+!
+route-map MAP permit 40
+  ! not reached
+!

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -70952,6 +70952,12 @@
               "definitionLines" : "16",
               "numReferrers" : 1
             }
+          },
+          "route-map entry" : {
+            "ROUTE_MAP 10" : {
+              "definitionLines" : "16",
+              "numReferrers" : 1
+            }
           }
         },
         "configs/arista_bgp_asn" : { },
@@ -70966,6 +70972,12 @@
             "TO_NEIGHBOR" : {
               "definitionLines" : "9-11",
               "numReferrers" : 0
+            }
+          },
+          "route-map entry" : {
+            "TO_NEIGHBOR 30" : {
+              "definitionLines" : "9-11",
+              "numReferrers" : 1
             }
           },
           "standard community-list" : {
@@ -75600,6 +75612,13 @@
                 14
               ]
             }
+          },
+          "route-map entry" : {
+            "ROUTE_MAP 10" : {
+              "route-map entry" : [
+                16
+              ]
+            }
           }
         },
         "configs/arista_community_list_named" : {
@@ -75614,6 +75633,13 @@
             "PFX_LIST" : {
               "route-map match ipv4 prefix-list" : [
                 10
+              ]
+            }
+          },
+          "route-map entry" : {
+            "TO_NEIGHBOR 30" : {
+              "route-map entry" : [
+                9
               ]
             }
           }


### PR DESCRIPTION
* If continue target is undefined, the continue line is ignored
* If the continue target is before this term, then the continue line is ignored
* Also move reference tracking to parser, and add warnings