### PR TITLE
StreamUtil: add toListInRandomOrder

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/StreamUtil.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/util/StreamUtil.java
@@ -1,0 +1,29 @@
+package org.batfish.common.util;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** Utility functions for dealing with streams. */
+public final class StreamUtil {
+  /** Returns a list of the items in the given stream, but in random order. */
+  public static <T> List<T> toListInRandomOrder(Stream<T> in) {
+    return toListInRandomOrder(in, ThreadLocalRandom.current());
+  }
+
+  /**
+   * Returns a list of the items in the given stream, but in random order controlled by the given
+   * {@link Random}.
+   */
+  public static <T> List<T> toListInRandomOrder(Stream<T> in, Random random) {
+    List<T> collected = in.collect(Collectors.toList());
+    Collections.shuffle(collected, random);
+    return ImmutableList.copyOf(collected);
+  }
+
+  private StreamUtil() {} // prevent instantiation
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/StreamUtilTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/util/StreamUtilTest.java
@@ -1,0 +1,32 @@
+package org.batfish.common.util;
+
+import static org.batfish.common.util.StreamUtil.toListInRandomOrder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class StreamUtilTest {
+  @Test
+  public void testToListInRandomOrder() {
+    int num = 10;
+    Random r = new Random(5);
+    List<Integer> ints = IntStream.range(0, num).boxed().collect(Collectors.toList());
+    List<Integer> afterwards = toListInRandomOrder(IntStream.range(0, num).boxed(), r);
+    assertThat(afterwards, not(equalTo(ints))); // Guaranteed given fixed seed.
+    assertThat(ImmutableSet.copyOf(afterwards), equalTo(ImmutableSet.copyOf(ints)));
+
+    // Without fixed seed, just check that the sets are the same.
+    List<Integer> afterwardsRandomSeed = toListInRandomOrder(IntStream.range(0, num).boxed());
+    assertThat(ImmutableSet.copyOf(afterwardsRandomSeed), equalTo(ImmutableSet.copyOf(ints)));
+  }
+}


### PR DESCRIPTION
There are many times where we have streams on sorted items that we'd
really rather process in random order. The easiest way to do this that I
can find is to materialize and then randomize the stream. Since these
streams are typically O(# nodes) or O(# vrfs) materialization should not
be so bad.