### PR TITLE
Interface: rename routing policy to packet policy

### DIFF
--- a/projects/allinone/src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java
@@ -51,7 +51,7 @@ import org.junit.rules.TemporaryFolder;
 /** End-to-end-ish tests of traceroute with policy-based routing */
 public class TraceroutePolicyBasedRoutingTest {
 
-  private static final String ROUTING_POLICY_NAME = "packetPolicy";
+  private static final String PACKET_POLICY_NAME = "packetPolicy";
   private static final String SOURCE_LOCATION_STR = "enter(c1[ingressInterface])";
   @Rule public TemporaryFolder _folder = new TemporaryFolder();
 
@@ -85,14 +85,14 @@ public class TraceroutePolicyBasedRoutingTest {
             .build();
 
     if (withPolicy) {
-      ingressIface.setPacketPolicy(ROUTING_POLICY_NAME);
+      ingressIface.setPacketPolicy(PACKET_POLICY_NAME);
       // If IP protocol is TCP use PBR to do a lookup in V2, which will cause the packet to
       // take a different exit interface
       c1.setPacketPolicies(
           ImmutableSortedMap.of(
-              ROUTING_POLICY_NAME,
+              PACKET_POLICY_NAME,
               new PacketPolicy(
-                  ROUTING_POLICY_NAME,
+                  PACKET_POLICY_NAME,
                   ImmutableList.of(
                       new If(
                           new PacketMatchExpr(
@@ -106,7 +106,7 @@ public class TraceroutePolicyBasedRoutingTest {
                                   HeaderSpace.builder().setIpProtocols(IpProtocol.UDP).build())),
                           ImmutableList.of(new Return(Drop.instance())))),
                   new Return(new FibLookup(new LiteralVrfName(v1.getName()))))));
-      ingressIface.setPacketPolicy(ROUTING_POLICY_NAME);
+      ingressIface.setPacketPolicy(PACKET_POLICY_NAME);
     }
 
     Interface i1 =

--- a/projects/allinone/src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java
+++ b/projects/allinone/src/test/java/org/batfish/question/traceroute/TraceroutePolicyBasedRoutingTest.java
@@ -85,7 +85,7 @@ public class TraceroutePolicyBasedRoutingTest {
             .build();
 
     if (withPolicy) {
-      ingressIface.setRoutingPolicy(ROUTING_POLICY_NAME);
+      ingressIface.setPacketPolicy(ROUTING_POLICY_NAME);
       // If IP protocol is TCP use PBR to do a lookup in V2, which will cause the packet to
       // take a different exit interface
       c1.setPacketPolicies(
@@ -106,7 +106,7 @@ public class TraceroutePolicyBasedRoutingTest {
                                   HeaderSpace.builder().setIpProtocols(IpProtocol.UDP).build())),
                           ImmutableList.of(new Return(Drop.instance())))),
                   new Return(new FibLookup(new LiteralVrfName(v1.getName()))))));
-      ingressIface.setRoutingPolicy(ROUTING_POLICY_NAME);
+      ingressIface.setPacketPolicy(ROUTING_POLICY_NAME);
     }
 
     Interface i1 =

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -595,7 +595,7 @@ public final class Interface extends ComparableStructure<String> {
   private static final String PROP_PROXY_ARP = "proxyArp";
   private static final String PROP_RIP_ENABLED = "ripEnabled";
   private static final String PROP_RIP_PASSIVE = "ripPassive";
-  private static final String PROP_PACKET_POLICY = "packetPolicy";
+  private static final String PROP_ROUTING_POLICY = "routingPolicy";
   private static final String PROP_SPANNING_TREE_PORTFAST = "spanningTreePortfast";
   private static final String PROP_SPEED = "speed";
   private static final String PROP_SWITCHPORT = "switchport";
@@ -1443,7 +1443,7 @@ public final class Interface extends ComparableStructure<String> {
    * The name of the packet policy used on this interface for policy routing (as opposed to
    * destination-based routing).
    */
-  @JsonProperty(PROP_PACKET_POLICY)
+  @JsonProperty(PROP_ROUTING_POLICY)
   public String getPacketPolicyName() {
     return _packetPolicyName;
   }
@@ -1778,7 +1778,7 @@ public final class Interface extends ComparableStructure<String> {
     _ripPassive = ripPassive;
   }
 
-  @JsonProperty(PROP_PACKET_POLICY)
+  @JsonProperty(PROP_ROUTING_POLICY)
   public void setPacketPolicy(String packetPolicyName) {
     _packetPolicyName = packetPolicyName;
   }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -72,7 +72,7 @@ public final class Interface extends ComparableStructure<String> {
     @Nullable private IpAccessList _outgoingOriginalFlowFilter;
     private Transformation _outgoingTransformation;
     private Configuration _owner;
-    private String _routingPolicy;
+    private String _packetPolicy;
     private IpAccessList _postTransformationIncomingFilter;
     private boolean _proxyArp;
     private IpAccessList _preTransformationOutgoingFilter;
@@ -161,7 +161,7 @@ public final class Interface extends ComparableStructure<String> {
       iface.setPostTransformationIncomingFilter(_postTransformationIncomingFilter);
       iface.setPreTransformationOutgoingFilter(_preTransformationOutgoingFilter);
       iface.setProxyArp(_proxyArp);
-      iface.setPacketPolicy(_routingPolicy);
+      iface.setPacketPolicy(_packetPolicy);
       iface.setSpeed(_speed);
       if (_switchport != null) {
         iface.setSwitchport(_switchport);
@@ -411,8 +411,8 @@ public final class Interface extends ComparableStructure<String> {
     }
 
     /** Set the policy-based routing (PBR) policy */
-    public Builder setRoutingPolicy(String routingPolicy) {
-      _routingPolicy = routingPolicy;
+    public Builder setPacketPolicy(String packetPolicy) {
+      _packetPolicy = packetPolicy;
       return this;
     }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/Interface.java
@@ -161,7 +161,7 @@ public final class Interface extends ComparableStructure<String> {
       iface.setPostTransformationIncomingFilter(_postTransformationIncomingFilter);
       iface.setPreTransformationOutgoingFilter(_preTransformationOutgoingFilter);
       iface.setProxyArp(_proxyArp);
-      iface.setRoutingPolicy(_routingPolicy);
+      iface.setPacketPolicy(_routingPolicy);
       iface.setSpeed(_speed);
       if (_switchport != null) {
         iface.setSwitchport(_switchport);
@@ -595,7 +595,7 @@ public final class Interface extends ComparableStructure<String> {
   private static final String PROP_PROXY_ARP = "proxyArp";
   private static final String PROP_RIP_ENABLED = "ripEnabled";
   private static final String PROP_RIP_PASSIVE = "ripPassive";
-  private static final String PROP_ROUTING_POLICY = "routingPolicy";
+  private static final String PROP_PACKET_POLICY = "packetPolicy";
   private static final String PROP_SPANNING_TREE_PORTFAST = "spanningTreePortfast";
   private static final String PROP_SPEED = "speed";
   private static final String PROP_SWITCHPORT = "switchport";
@@ -889,7 +889,7 @@ public final class Interface extends ComparableStructure<String> {
   private transient String _preTransformationOutgoingFilterName;
   private boolean _ripEnabled;
   private boolean _ripPassive;
-  private String _routingPolicyName;
+  private String _packetPolicyName;
   private boolean _spanningTreePortfast;
   private @Nullable Double _speed;
   private boolean _switchport;
@@ -1016,7 +1016,7 @@ public final class Interface extends ComparableStructure<String> {
     if (!_proxyArp == other._proxyArp) {
       return false;
     }
-    if (!Objects.equals(_routingPolicyName, other._routingPolicyName)) {
+    if (!Objects.equals(_packetPolicyName, other._packetPolicyName)) {
       return false;
     }
     if (!Objects.equals(_speed, other._speed)) {
@@ -1440,12 +1440,12 @@ public final class Interface extends ComparableStructure<String> {
   }
 
   /**
-   * The name of the policy used on this interface for policy routing (as opposed to
+   * The name of the packet policy used on this interface for policy routing (as opposed to
    * destination-based routing).
    */
-  @JsonProperty(PROP_ROUTING_POLICY)
-  public String getRoutingPolicyName() {
-    return _routingPolicyName;
+  @JsonProperty(PROP_PACKET_POLICY)
+  public String getPacketPolicyName() {
+    return _packetPolicyName;
   }
 
   /** Whether or not spanning-tree portfast feature is enabled. */
@@ -1778,9 +1778,9 @@ public final class Interface extends ComparableStructure<String> {
     _ripPassive = ripPassive;
   }
 
-  @JsonProperty(PROP_ROUTING_POLICY)
-  public void setRoutingPolicy(String routingPolicyName) {
-    _routingPolicyName = routingPolicyName;
+  @JsonProperty(PROP_PACKET_POLICY)
+  public void setPacketPolicy(String packetPolicyName) {
+    _packetPolicyName = packetPolicyName;
   }
 
   @JsonProperty(PROP_SPANNING_TREE_PORTFAST)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/questions/InterfacePropertySpecifier.java
@@ -236,7 +236,7 @@ public class InterfacePropertySpecifier extends PropertySpecifier {
           .put(
               PBR_POLICY_NAME,
               new PropertyDescriptor<>(
-                  Interface::getRoutingPolicyName,
+                  Interface::getPacketPolicyName,
                   Schema.STRING,
                   "Name of policy-based routing (PBR) policy"))
           .put(

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InterfaceTest.java
@@ -58,7 +58,7 @@ public class InterfaceTest {
   public void testRoutingPolicySettingInBuilder() {
     String policy = "some_policy";
     Interface i = Interface.builder().setName("iface").setRoutingPolicy(policy).build();
-    assertThat(i.getRoutingPolicyName(), equalTo(policy));
+    assertThat(i.getPacketPolicyName(), equalTo(policy));
   }
 
   @Test

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/InterfaceTest.java
@@ -57,7 +57,7 @@ public class InterfaceTest {
   @Test
   public void testRoutingPolicySettingInBuilder() {
     String policy = "some_policy";
-    Interface i = Interface.builder().setName("iface").setRoutingPolicy(policy).build();
+    Interface i = Interface.builder().setName("iface").setPacketPolicy(policy).build();
     assertThat(i.getPacketPolicyName(), equalTo(policy));
   }
 

--- a/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
+++ b/projects/batfish/src/main/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactory.java
@@ -536,7 +536,7 @@ public final class BDDReachabilityAnalysisFactory {
                             .getActiveInterfaces(vrf.getName())
                             .values()
                             .stream()
-                            .filter(iface -> iface.getRoutingPolicyName() != null)
+                            .filter(iface -> iface.getPacketPolicyName() != null)
                             .map(
                                 iface ->
                                     Maps.immutableEntry(
@@ -545,7 +545,7 @@ public final class BDDReachabilityAnalysisFactory {
                                             configEntry
                                                 .getValue()
                                                 .getPacketPolicies()
-                                                .get(iface.getRoutingPolicyName()),
+                                                .get(iface.getPacketPolicyName()),
                                             ipAccessListToBdd(configEntry.getValue()),
                                             ipsRoutedOutInterfaces)));
                       })
@@ -900,7 +900,7 @@ public final class BDDReachabilityAnalysisFactory {
   @VisibleForTesting
   Stream<Edge> generateRules_PreInInterface_NodeDropAclIn() {
     return getInterfaces()
-        .filter(iface -> iface.getRoutingPolicyName() != null || iface.getIncomingFilter() != null)
+        .filter(iface -> iface.getPacketPolicyName() != null || iface.getIncomingFilter() != null)
         .map(
             i -> {
               String node = i.getOwner().getHostname();
@@ -909,7 +909,7 @@ public final class BDDReachabilityAnalysisFactory {
               // There are two ways to drop based on ACLs: incoming filter, or PBR.
               // PBR takes precedence (consistent with FlowTracer)
               Transition denyTransition =
-                  i.getRoutingPolicyName() != null
+                  i.getPacketPolicyName() != null
                       ? _convertedPacketPolicies.get(node).get(iface).getToDrop()
                       : constraint(ignorableAclDenyBDD(node, i.getIncomingFilter()));
 
@@ -929,7 +929,7 @@ public final class BDDReachabilityAnalysisFactory {
   @VisibleForTesting
   Stream<Edge> generateRules_PreInInterface_PbrFibLookup() {
     return getInterfaces()
-        .filter(iface -> iface.getRoutingPolicyName() != null)
+        .filter(iface -> iface.getPacketPolicyName() != null)
         .flatMap(
             iface -> {
               String nodeName = iface.getOwner().getHostname();
@@ -1045,7 +1045,7 @@ public final class BDDReachabilityAnalysisFactory {
   /** Returns {@link PbrFibLookup} states reachable by entering the given interface */
   @Nonnull
   private Stream<PbrFibLookup> interfaceToPbrFibLookups(Interface iface) {
-    if (iface.getRoutingPolicyName() == null) {
+    if (iface.getPacketPolicyName() == null) {
       // Interface does not have PBR
       return Stream.of();
     }
@@ -1081,7 +1081,7 @@ public final class BDDReachabilityAnalysisFactory {
   Stream<Edge> generateRules_PreInInterface_PostInInterface() {
     return getInterfaces()
         // Policy-based routing edges handled elsewhere
-        .filter(iface -> iface.getRoutingPolicyName() == null)
+        .filter(iface -> iface.getPacketPolicyName() == null)
         .map(
             iface -> {
               IpAccessList acl = iface.getIncomingFilter();

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/FlowTracer.java
@@ -599,7 +599,7 @@ class FlowTracer {
   private boolean processPBR(Interface incomingInterface) {
 
     // apply routing/packet policy applied to the interface, if defined.
-    String policyName = incomingInterface.getRoutingPolicyName();
+    String policyName = incomingInterface.getPacketPolicyName();
     if (policyName == null) {
       return false;
     }

--- a/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/arista/AristaConfiguration.java
@@ -1265,7 +1265,7 @@ public final class AristaConfiguration extends VendorConfiguration {
 
     String routingPolicyName = iface.getRoutingPolicy();
     if (routingPolicyName != null) {
-      newIface.setRoutingPolicy(routingPolicyName);
+      newIface.setPacketPolicy(routingPolicyName);
     }
 
     return newIface;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -1697,7 +1697,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
     String routingPolicyName = iface.getRoutingPolicy();
     if (routingPolicyName != null) {
-      newIface.setRoutingPolicy(routingPolicyName);
+      newIface.setPacketPolicy(routingPolicyName);
     }
 
     // For IOS and XR, FirewallSessionInterfaceInfo is created once for all NAT interfaces.

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_asa/AsaConfiguration.java
@@ -1866,7 +1866,7 @@ public final class AsaConfiguration extends VendorConfiguration {
 
     String routingPolicyName = iface.getRoutingPolicy();
     if (routingPolicyName != null) {
-      newIface.setRoutingPolicy(routingPolicyName);
+      newIface.setPacketPolicy(routingPolicyName);
     }
 
     newIface.setPostTransformationIncomingFilter(newIface.getIncomingFilter());

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1250,7 +1250,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
     // Find which route maps are used for PBR
     _c.getAllInterfaces().values().stream()
-        .map(org.batfish.datamodel.Interface::getRoutingPolicyName)
+        .map(org.batfish.datamodel.Interface::getPacketPolicyName)
         .filter(Objects::nonNull)
         .distinct()
         // Extract route map objects

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -2032,7 +2032,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
     String pbrPolicy = iface.getPbrPolicy();
     // Do not convert undefined references
     if (pbrPolicy != null && _routeMaps.get(pbrPolicy) != null) {
-      newIfaceBuilder.setRoutingPolicy(pbrPolicy);
+      newIfaceBuilder.setPacketPolicy(pbrPolicy);
     }
 
     org.batfish.datamodel.Interface newIface = newIfaceBuilder.build();

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -1332,7 +1332,7 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
       Ipv4AccessList incomingFilter = _ipv4Acls.get(incomingFilterName);
       if (incomingFilter != null) {
         if (isIpv4AclUsedForAbf(incomingFilter)) {
-          newIface.setRoutingPolicy(computeAbfIpv4PolicyName(incomingFilterName));
+          newIface.setPacketPolicy(computeAbfIpv4PolicyName(incomingFilterName));
         } else {
           newIface.setIncomingFilter(ipAccessLists.get(incomingFilterName));
         }
@@ -1353,7 +1353,7 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
 
     String routingPolicyName = iface.getRoutingPolicy();
     if (routingPolicyName != null) {
-      newIface.setRoutingPolicy(routingPolicyName);
+      newIface.setPacketPolicy(routingPolicyName);
     }
 
     return newIface;

--- a/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/juniper/JuniperConfiguration.java
@@ -1765,9 +1765,9 @@ public final class JuniperConfiguration extends VendorConfiguration {
         if (inFilter.isUsedForFBF()) {
           PacketPolicy routingPolicy = _c.getPacketPolicies().get(incomingFilterName);
           if (routingPolicy != null) {
-            newIface.setRoutingPolicy(incomingFilterName);
+            newIface.setPacketPolicy(incomingFilterName);
           } else {
-            newIface.setRoutingPolicy(null);
+            newIface.setPacketPolicy(null);
             _w.redFlag(
                 String.format(
                     "Interface %s: cannot resolve applied filter %s, defaulting to no filter",

--- a/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/palo_alto/PaloAltoConfiguration.java
@@ -2116,7 +2116,7 @@ public class PaloAltoConfiguration extends VendorConfiguration {
     // If there are NAT rules for packets entering this interface's zone, apply them
     String packetPolicyName = getPacketPolicyForZone(zone);
     if (packetPolicyName != null) {
-      newIface.setRoutingPolicy(packetPolicyName);
+      newIface.setPacketPolicy(packetPolicyName);
     }
 
     return newIface.build();

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -1979,7 +1979,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
             .setActive(true)
             .setAddress(ConcreteInterfaceAddress.create(Ip.parse("1.1.1.1"), 24))
             .setIncomingFilter(nf.aclBuilder().setOwner(n1).setLines(ACCEPT_ALL).build())
-            .setRoutingPolicy(pbr.getName())
+            .setPacketPolicy(pbr.getName())
             .build();
     SortedMap<String, Configuration> configs = ImmutableSortedMap.of(n1.getHostname(), n1);
     BDDReachabilityAnalysisFactory factory = makeBddReachabilityAnalysisFactory(configs);

--- a/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
+++ b/projects/batfish/src/test/java/org/batfish/bddreachability/BDDReachabilityAnalysisFactoryTest.java
@@ -1356,7 +1356,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
     Interface.Builder ib = nf.interfaceBuilder().setOwner(config).setVrf(vrf).setActive(true);
     Interface ingressIface =
         ib.setName(INGRESS_IFACE).setAddress(ConcreteInterfaceAddress.parse("1.1.1.0/24")).build();
-    ingressIface.setRoutingPolicy(packetPolicyName);
+    ingressIface.setPacketPolicy(packetPolicyName);
     Interface i1 =
         ib.setName("i1").setAddress(ConcreteInterfaceAddress.parse("2.2.2.0/24")).build();
 
@@ -1675,7 +1675,7 @@ public final class BDDReachabilityAnalysisFactoryTest {
     Interface.Builder ib = nf.interfaceBuilder().setOwner(config).setVrf(vrf).setActive(true);
     Interface ingressIface =
         ib.setName(INGRESS_IFACE).setAddress(ConcreteInterfaceAddress.parse("10.0.0.0/24")).build();
-    ingressIface.setRoutingPolicy(packetPolicyName);
+    ingressIface.setPacketPolicy(packetPolicyName);
     ib.setName("i1").setAddress(ConcreteInterfaceAddress.parse("1.1.1.1/24")).build();
     ib.setName("i2").setAddress(ConcreteInterfaceAddress.parse("2.2.2.1/24")).build();
 

--- a/projects/batfish/src/test/java/org/batfish/dataplane/PbrWithTracerouteTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/PbrWithTracerouteTest.java
@@ -151,7 +151,7 @@ public class PbrWithTracerouteTest {
         .setAddress(ConcreteInterfaceAddress.create(ingressIfaceIp, _subnetLength))
         .setOwner(c)
         .setVrf(vrf)
-        .setRoutingPolicy(policyName)
+        .setPacketPolicy(policyName)
         .build();
     nf.interfaceBuilder()
         .setName(_pbrOutIface)

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -2105,7 +2105,7 @@ public final class CiscoNxosGrammarTest {
     String policyName = "PBR_POLICY";
     PacketPolicy policy = c.getPacketPolicies().get(policyName);
     assertThat(policy, notNullValue());
-    assertThat(c.getAllInterfaces().get("Ethernet1/1").getRoutingPolicyName(), equalTo(policyName));
+    assertThat(c.getAllInterfaces().get("Ethernet1/1").getPacketPolicyName(), equalTo(policyName));
     Builder builder =
         Flow.builder()
             .setIngressNode(hostname)

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_xr/XrGrammarTest.java
@@ -3139,7 +3139,7 @@ public final class XrGrammarTest {
             .getAction(),
         equalTo(regularFibLookup));
 
-    assertThat(c.getAllInterfaces().get(gigE0).getRoutingPolicyName(), equalTo(abfPolicyName));
+    assertThat(c.getAllInterfaces().get(gigE0).getPacketPolicyName(), equalTo(abfPolicyName));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoNatTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/palo_alto/PaloAltoNatTest.java
@@ -297,7 +297,7 @@ public class PaloAltoNatTest {
         containsInAnyOrder("ethernet1/1", inside1Name, inside2Name, "ethernet1/2", outside1Name));
 
     Interface outside1 = c.getAllInterfaces().get(outside1Name);
-    String outside1Policy = outside1.getRoutingPolicyName();
+    String outside1Policy = outside1.getPacketPolicyName();
     // Interface in OUTSIDE zone has packet policy
     assertThat(outside1Policy, notNullValue());
 
@@ -379,7 +379,7 @@ public class PaloAltoNatTest {
         containsInAnyOrder("ethernet1/1", inside1Name, "ethernet1/2", outside1Name));
 
     Interface outside1 = c.getAllInterfaces().get(outside1Name);
-    String outside1Policy = outside1.getRoutingPolicyName();
+    String outside1Policy = outside1.getPacketPolicyName();
     // Interface in OUTSIDE zone has packet policy
     assertThat(outside1Policy, notNullValue());
 


### PR DESCRIPTION
Use a less ambiguous name for PBR/forwarding policies attached to interfaces.
