### PR TITLE
XR: remove unused routing policy from VS ifaces

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/CiscoXrConfiguration.java
@@ -1351,11 +1351,6 @@ public final class CiscoXrConfiguration extends VendorConfiguration {
       }
     }
 
-    String routingPolicyName = iface.getRoutingPolicy();
-    if (routingPolicyName != null) {
-      newIface.setPacketPolicy(routingPolicyName);
-    }
-
     return newIface;
   }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/Interface.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_xr/Interface.java
@@ -174,8 +174,6 @@ public class Interface implements Serializable {
 
   private boolean _proxyArp;
 
-  private String _routingPolicy;
-
   private Set<ConcreteInterfaceAddress> _secondaryAddresses;
 
   private boolean _spanningTreePortfast;
@@ -392,10 +390,6 @@ public class Interface implements Serializable {
     return _proxyArp;
   }
 
-  public String getRoutingPolicy() {
-    return _routingPolicy;
-  }
-
   public Set<ConcreteInterfaceAddress> getSecondaryAddresses() {
     return _secondaryAddresses;
   }
@@ -554,10 +548,6 @@ public class Interface implements Serializable {
 
   public void setProxyArp(boolean proxyArp) {
     _proxyArp = proxyArp;
-  }
-
-  public void setRoutingPolicy(String routingPolicy) {
-    _routingPolicy = routingPolicy;
   }
 
   public void setSpanningTreePortfast(boolean spanningTreePortfast) {


### PR DESCRIPTION
Routing policy attached to XR interfaces isn't populated anywhere, I suspect it was just copied from IOS.

Remove it since it is unused (and if it were used in the future, it would conflict with ACL based forwarding policies).
