### PR TITLE
HSRP: priority-update support

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
@@ -32,6 +32,7 @@ import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.hsrp.HsrpGroup;
 import org.batfish.datamodel.tracking.HsrpPriorityEvaluator;
+import org.batfish.datamodel.tracking.PredicateTrackMethodEvaluator;
 import org.batfish.datamodel.tracking.TrackMethod;
 
 /** A utility class for working with IPs owned by network devices. */
@@ -358,17 +359,18 @@ public final class IpOwners {
   static int computeHsrpPriority(Interface iface, HsrpGroup group) {
     Configuration c = iface.getOwner();
     Map<String, TrackMethod> trackMethods = c.getTrackingGroups();
-    HsrpPriorityEvaluator evaluator = new HsrpPriorityEvaluator(group.getPriority());
+    PredicateTrackMethodEvaluator trackMethodEvaluator = new PredicateTrackMethodEvaluator(c);
+    HsrpPriorityEvaluator hsrpEvaluator = new HsrpPriorityEvaluator(group.getPriority());
     group
         .getTrackActions()
         .forEach(
             (trackName, action) -> {
               TrackMethod trackMethod = trackMethods.get(trackName);
-              if (trackMethod != null && trackMethod.evaluate(c)) {
-                action.accept(evaluator);
+              if (trackMethod != null && trackMethod.accept(trackMethodEvaluator)) {
+                action.accept(hsrpEvaluator);
               }
             });
-    return evaluator.getPriority();
+    return hsrpEvaluator.getPriority();
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
@@ -22,6 +22,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
@@ -356,7 +357,7 @@ public final class IpOwners {
   }
 
   /** Compute HSRP priority for a given HSRP group and the interface it is associated with. */
-  static int computeHsrpPriority(Interface iface, HsrpGroup group) {
+  static int computeHsrpPriority(@Nonnull Interface iface, @Nonnull HsrpGroup group) {
     Configuration c = iface.getOwner();
     Map<String, TrackMethod> trackMethods = c.getTrackingGroups();
     PredicateTrackMethodEvaluator trackMethodEvaluator = new PredicateTrackMethodEvaluator(c);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/common/topology/IpOwners.java
@@ -22,6 +22,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.batfish.datamodel.AclIpSpace;
 import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
@@ -30,6 +31,9 @@ import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.IpSpace;
 import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.hsrp.HsrpGroup;
+import org.batfish.datamodel.tracking.HsrpPriorityEvaluator;
+import org.batfish.datamodel.tracking.TrackMethod;
 
 /** A utility class for working with IPs owned by network devices. */
 public final class IpOwners {
@@ -341,13 +345,31 @@ public final class IpOwners {
                   Collections.max(
                       candidates,
                       Comparator.comparingInt(
-                              (Interface i) -> i.getHsrpGroups().get(groupNum).getPriority())
+                              (Interface i) ->
+                                  computeHsrpPriority(i, i.getHsrpGroups().get(groupNum)))
                           .thenComparing(i -> i.getConcreteAddress().getIp()));
               ipOwners
                   .computeIfAbsent(ip, k -> new HashMap<>())
                   .computeIfAbsent(hsrpMaster.getOwner().getHostname(), k -> new HashSet<>())
                   .add(hsrpMaster.getName());
             });
+  }
+
+  /** Compute HSRP priority for a given HSRP group and the interface it is associated with. */
+  static int computeHsrpPriority(Interface iface, HsrpGroup group) {
+    AtomicInteger priority = new AtomicInteger(group.getPriority());
+    Configuration c = iface.getOwner();
+    Map<String, TrackMethod> trackMethods = c.getTrackingGroups();
+    group
+        .getTrackActions()
+        .forEach(
+            (trackName, action) -> {
+              TrackMethod trackMethod = trackMethods.get(trackName);
+              if (trackMethod != null && trackMethod.evaluate(c)) {
+                priority.set(action.apply(new HsrpPriorityEvaluator(priority.get())));
+              }
+            });
+    return priority.get();
   }
 
   /**

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/DecrementPriority.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/DecrementPriority.java
@@ -42,4 +42,9 @@ public class DecrementPriority implements TrackAction {
   public String toString() {
     return toStringHelper(getClass()).add(PROP_SUBTRAHEND, _subtrahend).toString();
   }
+
+  @Override
+  public <R> R apply(GenericTrackActionVisitor<R> visitor) {
+    return visitor.visitDecrementPriority(this);
+  }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/DecrementPriority.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/DecrementPriority.java
@@ -44,7 +44,7 @@ public class DecrementPriority implements TrackAction {
   }
 
   @Override
-  public <R> R accept(GenericTrackActionVisitor<R> visitor) {
-    return visitor.visitDecrementPriority(this);
+  public void accept(GenericTrackActionVisitor visitor) {
+    visitor.visitDecrementPriority(this);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/DecrementPriority.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/DecrementPriority.java
@@ -44,7 +44,7 @@ public class DecrementPriority implements TrackAction {
   }
 
   @Override
-  public <R> R apply(GenericTrackActionVisitor<R> visitor) {
+  public <R> R accept(GenericTrackActionVisitor<R> visitor) {
     return visitor.visitDecrementPriority(this);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/GenericTrackActionVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/GenericTrackActionVisitor.java
@@ -1,0 +1,11 @@
+package org.batfish.datamodel.tracking;
+
+/** Visitor for {@link TrackAction} */
+public interface GenericTrackActionVisitor<R> {
+
+  default R visit(TrackAction trackAction) {
+    return trackAction.apply(this);
+  }
+
+  R visitDecrementPriority(DecrementPriority decrementPriority);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/GenericTrackActionVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/GenericTrackActionVisitor.java
@@ -1,6 +1,6 @@
 package org.batfish.datamodel.tracking;
 
 /** Visitor for {@link TrackAction} */
-public interface GenericTrackActionVisitor<R> {
-  R visitDecrementPriority(DecrementPriority decrementPriority);
+public interface GenericTrackActionVisitor {
+  void visitDecrementPriority(DecrementPriority decrementPriority);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/GenericTrackActionVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/GenericTrackActionVisitor.java
@@ -2,10 +2,5 @@ package org.batfish.datamodel.tracking;
 
 /** Visitor for {@link TrackAction} */
 public interface GenericTrackActionVisitor<R> {
-
-  default R visit(TrackAction trackAction) {
-    return trackAction.apply(this);
-  }
-
   R visitDecrementPriority(DecrementPriority decrementPriority);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/GenericTrackMethodVisitor.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/GenericTrackMethodVisitor.java
@@ -1,0 +1,6 @@
+package org.batfish.datamodel.tracking;
+
+/** Visitor for {@link TrackMethod} */
+public interface GenericTrackMethodVisitor<R> {
+  R visitTrackInterface(TrackInterface trackInterface);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluator.java
@@ -4,7 +4,7 @@ package org.batfish.datamodel.tracking;
  * Evaluates the action of a {@link TrackAction} on a given HSRP {@code priority}. Visiting an
  * action returns the updated priority value after applying the action.
  */
-public class HsrpPriorityEvaluator implements GenericTrackActionVisitor<Integer> {
+public class HsrpPriorityEvaluator implements GenericTrackActionVisitor {
 
   public final int MAX_PRIORITY = 255;
   public final int MIN_PRIORITY = 0;
@@ -18,12 +18,10 @@ public class HsrpPriorityEvaluator implements GenericTrackActionVisitor<Integer>
   }
 
   @Override
-  public Integer visitDecrementPriority(DecrementPriority decrementPriority) {
+  public void visitDecrementPriority(DecrementPriority decrementPriority) {
     _priority =
         Math.min(
             Math.max(_priority - decrementPriority.getSubtrahend(), MIN_PRIORITY), MAX_PRIORITY);
-
-    return _priority;
   }
 
   private int _priority;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluator.java
@@ -13,11 +13,18 @@ public class HsrpPriorityEvaluator implements GenericTrackActionVisitor<Integer>
     _priority = priority;
   }
 
-  @Override
-  public Integer visitDecrementPriority(DecrementPriority decrementPriority) {
-    int priority = _priority - decrementPriority.getSubtrahend();
-    return Math.min(Math.max(priority, MIN_PRIORITY), MAX_PRIORITY);
+  public int getPriority() {
+    return _priority;
   }
 
-  private final int _priority;
+  @Override
+  public Integer visitDecrementPriority(DecrementPriority decrementPriority) {
+    _priority =
+        Math.min(
+            Math.max(_priority - decrementPriority.getSubtrahend(), MIN_PRIORITY), MAX_PRIORITY);
+
+    return _priority;
+  }
+
+  private int _priority;
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluator.java
@@ -1,0 +1,23 @@
+package org.batfish.datamodel.tracking;
+
+/**
+ * Evaluates the action of a {@link TrackAction} on a given HSRP {@code priority}. Visiting an
+ * action returns the priority value after applying the action.
+ */
+public class HsrpPriorityEvaluator implements GenericTrackActionVisitor<Integer> {
+
+  public final int MAX_PRIORITY = 255;
+  public final int MIN_PRIORITY = 0;
+
+  public HsrpPriorityEvaluator(int priority) {
+    _priority = priority;
+  }
+
+  @Override
+  public Integer visitDecrementPriority(DecrementPriority decrementPriority) {
+    int priority = _priority - decrementPriority.getSubtrahend();
+    return Math.min(Math.max(priority, MIN_PRIORITY), MAX_PRIORITY);
+  }
+
+  private final int _priority;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluator.java
@@ -1,9 +1,12 @@
 package org.batfish.datamodel.tracking;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
 /**
  * Evaluates the action of a {@link TrackAction} on a given HSRP {@code priority}. Visiting an
  * action updates evaluator's priority value according to the action.
  */
+@ParametersAreNonnullByDefault
 public class HsrpPriorityEvaluator implements GenericTrackActionVisitor {
 
   public final int MAX_PRIORITY = 255;

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluator.java
@@ -2,7 +2,7 @@ package org.batfish.datamodel.tracking;
 
 /**
  * Evaluates the action of a {@link TrackAction} on a given HSRP {@code priority}. Visiting an
- * action returns the updated priority value after applying the action.
+ * action updates evaluator's priority value according to the action.
  */
 public class HsrpPriorityEvaluator implements GenericTrackActionVisitor {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluator.java
@@ -2,7 +2,7 @@ package org.batfish.datamodel.tracking;
 
 /**
  * Evaluates the action of a {@link TrackAction} on a given HSRP {@code priority}. Visiting an
- * action returns the priority value after applying the action.
+ * action returns the updated priority value after applying the action.
  */
 public class HsrpPriorityEvaluator implements GenericTrackActionVisitor<Integer> {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/PredicateTrackMethodEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/PredicateTrackMethodEvaluator.java
@@ -1,5 +1,7 @@
 package org.batfish.datamodel.tracking;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.Interface;
 
@@ -8,6 +10,7 @@ import org.batfish.datamodel.Interface;
  * {@link TrackMethod} would be triggered and execute associated {@link TrackAction}s and {@code
  * false} otherwise.
  */
+@ParametersAreNonnullByDefault
 public class PredicateTrackMethodEvaluator implements GenericTrackMethodVisitor<Boolean> {
   public PredicateTrackMethodEvaluator(Configuration configuration) {
     _configuration = configuration;
@@ -24,5 +27,5 @@ public class PredicateTrackMethodEvaluator implements GenericTrackMethodVisitor<
     return !trackedInterface.getActive() || trackedInterface.getBlacklisted();
   }
 
-  private final Configuration _configuration;
+  @Nonnull private final Configuration _configuration;
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/PredicateTrackMethodEvaluator.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/PredicateTrackMethodEvaluator.java
@@ -1,0 +1,28 @@
+package org.batfish.datamodel.tracking;
+
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
+
+/**
+ * Evaluates a {@link TrackMethod} as a predicate. Visiting the method returns {@code true} if the
+ * {@link TrackMethod} would be triggered and execute associated {@link TrackAction}s and {@code
+ * false} otherwise.
+ */
+public class PredicateTrackMethodEvaluator implements GenericTrackMethodVisitor<Boolean> {
+  public PredicateTrackMethodEvaluator(Configuration configuration) {
+    _configuration = configuration;
+  }
+
+  @Override
+  public Boolean visitTrackInterface(TrackInterface trackInterface) {
+    Interface trackedInterface =
+        _configuration.getAllInterfaces().get(trackInterface.getTrackedInterface());
+    if (trackedInterface == null) {
+      // Assume an undefined interface cannot trigger this track methood
+      return false;
+    }
+    return !trackedInterface.getActive() || trackedInterface.getBlacklisted();
+  }
+
+  private final Configuration _configuration;
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackAction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackAction.java
@@ -6,5 +6,5 @@ import java.io.Serializable;
 /** An action to take when a {@link TrackMethod} has been triggered (is down). */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 public interface TrackAction extends Serializable {
-  <R> R accept(GenericTrackActionVisitor<R> visitor);
+  void accept(GenericTrackActionVisitor visitor);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackAction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackAction.java
@@ -3,7 +3,7 @@ package org.batfish.datamodel.tracking;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
 
-/** An action to take when a tracking-group is down */
+/** An action to take when a {@link TrackMethod} has been triggered (is down). */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 public interface TrackAction extends Serializable {
   <R> R apply(GenericTrackActionVisitor<R> visitor);

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackAction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackAction.java
@@ -5,4 +5,6 @@ import java.io.Serializable;
 
 /** An action to take when a tracking-group is down */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
-public interface TrackAction extends Serializable {}
+public interface TrackAction extends Serializable {
+  <R> R apply(GenericTrackActionVisitor<R> visitor);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackAction.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackAction.java
@@ -6,5 +6,5 @@ import java.io.Serializable;
 /** An action to take when a {@link TrackMethod} has been triggered (is down). */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 public interface TrackAction extends Serializable {
-  <R> R apply(GenericTrackActionVisitor<R> visitor);
+  <R> R accept(GenericTrackActionVisitor<R> visitor);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackInterface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackInterface.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.Configuration;
-import org.batfish.datamodel.Interface;
 
 /** Tracks whether a specified interface is active or not */
 public class TrackInterface implements TrackMethod {
@@ -47,12 +45,7 @@ public class TrackInterface implements TrackMethod {
   }
 
   @Override
-  public boolean evaluate(Configuration configuration) {
-    Interface trackedInterface = configuration.getAllInterfaces().get(this.getTrackedInterface());
-    if (trackedInterface == null) {
-      // Assume an undefined interface cannot trigger this track methood
-      return false;
-    }
-    return !trackedInterface.getActive() || trackedInterface.getBlacklisted();
+  public <R> R accept(GenericTrackMethodVisitor<R> visitor) {
+    return visitor.visitTrackInterface(this);
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackInterface.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackInterface.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.Interface;
 
 /** Tracks whether a specified interface is active or not */
 public class TrackInterface implements TrackMethod {
@@ -42,5 +44,15 @@ public class TrackInterface implements TrackMethod {
   @Override
   public String toString() {
     return toStringHelper(getClass()).add(PROP_TRACKED_INTERFACE, _trackedInterface).toString();
+  }
+
+  @Override
+  public boolean evaluate(Configuration configuration) {
+    Interface trackedInterface = configuration.getAllInterfaces().get(this.getTrackedInterface());
+    if (trackedInterface == null) {
+      // Assume an undefined interface cannot trigger this track methood
+      return false;
+    }
+    return !trackedInterface.getActive() || trackedInterface.getBlacklisted();
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackMethod.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackMethod.java
@@ -13,5 +13,4 @@ public interface TrackMethod extends Serializable {
 
   /** Evaluate if this track method is triggered on the specified {@link Configuration}. */
   <R> R accept(GenericTrackMethodVisitor<R> visitor);
-  // boolean evaluate(Configuration configuration);
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackMethod.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackMethod.java
@@ -2,6 +2,11 @@ package org.batfish.datamodel.tracking;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
+import org.batfish.datamodel.Configuration;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
-public interface TrackMethod extends Serializable {}
+public interface TrackMethod extends Serializable {
+
+  /** Evaluate if this track method is triggered on the specified {@link Configuration}. */
+  boolean evaluate(Configuration configuration);
+}

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackMethod.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackMethod.java
@@ -4,6 +4,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
 import org.batfish.datamodel.Configuration;
 
+/**
+ * An object "monitor" which can be used to trigger one or more {@link TrackAction} when the tracked
+ * object state changes. Can track things like interface active state or ICMP reachability.
+ */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 public interface TrackMethod extends Serializable {
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackMethod.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/tracking/TrackMethod.java
@@ -12,5 +12,6 @@ import org.batfish.datamodel.Configuration;
 public interface TrackMethod extends Serializable {
 
   /** Evaluate if this track method is triggered on the specified {@link Configuration}. */
-  boolean evaluate(Configuration configuration);
+  <R> R accept(GenericTrackMethodVisitor<R> visitor);
+  // boolean evaluate(Configuration configuration);
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/common/topology/IpOwnersTest.java
@@ -1,5 +1,6 @@
 package org.batfish.common.topology;
 
+import static org.batfish.common.topology.IpOwners.computeHsrpPriority;
 import static org.batfish.common.topology.IpOwners.computeInterfaceHostSubnetIps;
 import static org.batfish.common.topology.IpOwners.computeIpIfaceOwners;
 import static org.batfish.common.topology.IpOwners.computeIpVrfOwners;
@@ -253,76 +254,145 @@ public class IpOwnersTest {
   }
 
   @Test
-  public void testProcessHsrpGroupTracking() {
+  public void testProcessHsrpGroupPriorityTie() {
     Map<Ip, Map<String, Set<String>>> ipOwners = new HashMap<>();
+    Table<Ip, Integer, Set<Interface>> groups = HashBasedTable.create();
+    Ip hsrpIp = Ip.parse("1.1.1.1");
+    HsrpGroup hsrpGroup =
+        HsrpGroup.builder().setPriority(100).setGroupNumber(1).setIp(hsrpIp).build();
+
     Configuration c1 =
         Configuration.builder()
             .setHostname("c1")
             .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
             .build();
-    c1.setTrackingGroups(ImmutableMap.of("1", new TrackInterface("i1tracked")));
+    Interface i1 =
+        Interface.builder()
+            .setOwner(c1)
+            .setName("i1")
+            .setAddress(ConcreteInterfaceAddress.parse("1.1.1.2/24"))
+            .build();
+    i1.setHsrpGroups(ImmutableMap.of(1, hsrpGroup));
 
     Configuration c2 =
         Configuration.builder()
             .setHostname("c2")
             .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
             .build();
-    c2.setTrackingGroups(ImmutableMap.of("1", new TrackInterface("i2tracked")));
+    Interface i2 =
+        Interface.builder()
+            .setOwner(c2)
+            .setName("i2")
+            .setAddress(ConcreteInterfaceAddress.parse("1.1.1.4/24"))
+            .build();
+    i2.setHsrpGroups(ImmutableMap.of(1, hsrpGroup));
 
-    Table<Ip, Integer, Set<Interface>> groups = HashBasedTable.create();
+    Configuration c3 =
+        Configuration.builder()
+            .setHostname("c3")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    Interface i3 =
+        Interface.builder()
+            .setOwner(c3)
+            .setName("i3")
+            .setAddress(ConcreteInterfaceAddress.parse("1.1.1.3/24"))
+            .build();
+    i3.setHsrpGroups(ImmutableMap.of(1, hsrpGroup));
+
+    extractHsrp(groups, i1);
+    extractHsrp(groups, i2);
+    extractHsrp(groups, i3);
+
+    // Expect c2/i2 to win
+    // Since priority is identical, highest IP address wins
+    processHsrpGroups(ipOwners, groups);
+    assertThat(ipOwners.get(hsrpIp).get(c2.getHostname()), equalTo(ImmutableSet.of(i2.getName())));
+  }
+
+  @Test
+  public void testComputeHsrpPriority() {
+    int basePriority = 100;
+    int track1Decrement = 50;
+    int track2Decrement = 25;
+
+    Configuration c1 =
+        Configuration.builder()
+            .setHostname("c1")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    HsrpGroup hsrpGroup =
+        HsrpGroup.builder()
+            .setPriority(basePriority)
+            .setTrackActions(
+                ImmutableSortedMap.of(
+                    "1",
+                    new DecrementPriority(track1Decrement),
+                    "2",
+                    new DecrementPriority(track2Decrement)))
+            .setGroupNumber(1)
+            .setIp(Ip.parse("10.10.10.1"))
+            .build();
     Interface i1 =
         Interface.builder()
             .setOwner(c1)
             .setName("i1")
-            .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
+            .setAddress(ConcreteInterfaceAddress.parse("10.10.10.2/24"))
             .build();
-    // Tracked by track "1" on c1
+    i1.setHsrpGroups(ImmutableMap.of(1, hsrpGroup));
+
+    c1.setTrackingGroups(
+        ImmutableMap.of(
+            "1", new TrackInterface("i1tracked"), "2", new TrackInterface("i1trackedAlso")));
+    // Tracked by track "1"
     Interface.builder()
         .setOwner(c1)
         .setName("i1tracked")
         .setAddress(ConcreteInterfaceAddress.parse("10.0.1.1/24"))
         .setActive(true)
         .build();
-
-    Interface i2 =
-        Interface.builder()
-            .setOwner(c2)
-            .setName("i2")
-            .setAddress(ConcreteInterfaceAddress.parse("2.3.4.5/24"))
-            .build();
-    // Tracked by track "1" on c2
+    // Tracked by track "2"
     Interface.builder()
-        .setOwner(c2)
-        .setName("i2tracked")
+        .setOwner(c1)
+        .setName("i1trackedAlso")
         .setAddress(ConcreteInterfaceAddress.parse("10.0.2.1/24"))
         .setActive(false)
         .build();
 
-    Ip ip = Ip.parse("1.1.1.1");
-    i1.setHsrpGroups(
-        ImmutableMap.of(
-            1,
-            HsrpGroup.builder()
-                .setPriority(100)
-                .setTrackActions(ImmutableSortedMap.of("1", new DecrementPriority(99)))
-                .setGroupNumber(1)
-                .setIp(ip)
-                .build()));
-    i2.setHsrpGroups(
-        ImmutableMap.of(
-            1,
-            HsrpGroup.builder()
-                .setPriority(200)
-                .setTrackActions(ImmutableSortedMap.of("1", new DecrementPriority(101)))
-                .setGroupNumber(1)
-                .setIp(ip)
-                .build()));
-    extractHsrp(groups, i1);
-    extractHsrp(groups, i2);
+    // Only track 2 is triggered, so only track 2 decrement is applied
+    assertThat(computeHsrpPriority(i1, hsrpGroup), equalTo(basePriority - track2Decrement));
+  }
 
-    // Expect c1/i1 to win
-    // Since track action decrement is not triggered for c1/i1, but it is triggered for c2/i2
-    processHsrpGroups(ipOwners, groups);
-    assertThat(ipOwners.get(ip).get(c1.getHostname()), equalTo(ImmutableSet.of(i1.getName())));
+  @Test
+  public void testComputeHsrpPriorityUndefinedTrack() {
+    int basePriority = 100;
+    int track1Decrement = 50;
+
+    Configuration c1 =
+        Configuration.builder()
+            .setHostname("c1")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    HsrpGroup hsrpGroup =
+        HsrpGroup.builder()
+            .setPriority(basePriority)
+            // Reference to undefined track method
+            .setTrackActions(ImmutableSortedMap.of("1", new DecrementPriority(track1Decrement)))
+            .setGroupNumber(1)
+            .setIp(Ip.parse("10.10.10.1"))
+            .build();
+    Interface i1 =
+        Interface.builder()
+            .setOwner(c1)
+            .setName("i1")
+            .setAddress(ConcreteInterfaceAddress.parse("10.10.10.2/24"))
+            .build();
+    i1.setHsrpGroups(ImmutableMap.of(1, hsrpGroup));
+
+    // Empty map of tracking methods
+    c1.setTrackingGroups(ImmutableMap.of());
+    // If VI model doesn't have references to undefined track groups we shouldn't crash
+    // Also skip applying track action if that happens
+    assertThat(computeHsrpPriority(i1, hsrpGroup), equalTo(basePriority));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluatorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluatorTest.java
@@ -15,10 +15,10 @@ public class HsrpPriorityEvaluatorTest {
     DecrementPriority decrement125 = new DecrementPriority(125);
     DecrementPriority decrementNegative200 = new DecrementPriority(-200);
 
-    assertThat(evaluator.visit(decrement25), equalTo(75));
+    assertThat(evaluator.visitDecrementPriority(decrement25), equalTo(75));
 
     // Final priority must be between 0 and 255
-    assertThat(evaluator.visit(decrement125), equalTo(0));
-    assertThat(evaluator.visit(decrementNegative200), equalTo(255));
+    assertThat(evaluator.visitDecrementPriority(decrement125), equalTo(0));
+    assertThat(evaluator.visitDecrementPriority(decrementNegative200), equalTo(255));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluatorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluatorTest.java
@@ -1,0 +1,24 @@
+package org.batfish.datamodel.tracking;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.Test;
+
+/** Tests of {@link HsrpPriorityEvaluator} */
+public class HsrpPriorityEvaluatorTest {
+
+  @Test
+  public void testVisitDecrementPriority() {
+    HsrpPriorityEvaluator evaluator = new HsrpPriorityEvaluator(100);
+    DecrementPriority decrement25 = new DecrementPriority(25);
+    DecrementPriority decrement125 = new DecrementPriority(125);
+    DecrementPriority decrementNegative200 = new DecrementPriority(-200);
+
+    assertThat(evaluator.visit(decrement25), equalTo(75));
+
+    // Final priority must be between 0 and 255
+    assertThat(evaluator.visit(decrement125), equalTo(0));
+    assertThat(evaluator.visit(decrementNegative200), equalTo(255));
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluatorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/HsrpPriorityEvaluatorTest.java
@@ -10,15 +10,39 @@ public class HsrpPriorityEvaluatorTest {
 
   @Test
   public void testVisitDecrementPriority() {
-    HsrpPriorityEvaluator evaluator = new HsrpPriorityEvaluator(100);
     DecrementPriority decrement25 = new DecrementPriority(25);
     DecrementPriority decrement125 = new DecrementPriority(125);
     DecrementPriority decrementNegative200 = new DecrementPriority(-200);
 
-    assertThat(evaluator.visitDecrementPriority(decrement25), equalTo(75));
+    {
+      HsrpPriorityEvaluator evaluator = new HsrpPriorityEvaluator(100);
+      evaluator.visitDecrementPriority(decrement25);
+      assertThat(evaluator.getPriority(), equalTo(75));
+    }
 
     // Final priority must be between 0 and 255
-    assertThat(evaluator.visitDecrementPriority(decrement125), equalTo(0));
-    assertThat(evaluator.visitDecrementPriority(decrementNegative200), equalTo(255));
+    {
+      HsrpPriorityEvaluator evaluator = new HsrpPriorityEvaluator(100);
+      evaluator.visitDecrementPriority(decrement125);
+      assertThat(evaluator.getPriority(), equalTo(0));
+    }
+    {
+      HsrpPriorityEvaluator evaluator = new HsrpPriorityEvaluator(100);
+      evaluator.visitDecrementPriority(decrementNegative200);
+      assertThat(evaluator.getPriority(), equalTo(255));
+    }
+  }
+
+  @Test
+  public void testVisitDecrementPriorityCumulative() {
+    HsrpPriorityEvaluator evaluator = new HsrpPriorityEvaluator(250);
+    DecrementPriority decrement25 = new DecrementPriority(25);
+    DecrementPriority decrement125 = new DecrementPriority(125);
+
+    evaluator.visitDecrementPriority(decrement25);
+    assertThat(evaluator.getPriority(), equalTo(225));
+
+    evaluator.visitDecrementPriority(decrement125);
+    assertThat(evaluator.getPriority(), equalTo(100));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/PredicateTrackMethodEvaluatorTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/PredicateTrackMethodEvaluatorTest.java
@@ -10,10 +10,10 @@ import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Interface;
 import org.junit.Test;
 
-/** Tests of {@link TrackInterface} */
-public class TrackInterfaceTest {
+/** Tests of {@link PredicateTrackMethodEvaluator} */
+public class PredicateTrackMethodEvaluatorTest {
   @Test
-  public void testEvaluate() {
+  public void testVisitTrackInterface() {
     Configuration c1 =
         Configuration.builder()
             .setHostname("c1")
@@ -43,20 +43,21 @@ public class TrackInterfaceTest {
         .setBlacklisted(true)
         .build();
 
+    PredicateTrackMethodEvaluator evaluator = new PredicateTrackMethodEvaluator(c1);
     // Iface is active
     TrackInterface trackInterface1 = new TrackInterface("i1");
-    assertFalse(trackInterface1.evaluate(c1));
+    assertFalse(trackInterface1.accept(evaluator));
 
     // Iface is not active
     TrackInterface trackInterface2 = new TrackInterface("i2");
-    assertTrue(trackInterface2.evaluate(c1));
+    assertTrue(trackInterface2.accept(evaluator));
 
     // Iface is active, but blacklisted
     TrackInterface trackInterface3 = new TrackInterface("i3");
-    assertTrue(trackInterface3.evaluate(c1));
+    assertTrue(trackInterface3.accept(evaluator));
 
     // Non-existent iface
     TrackInterface trackInterface4 = new TrackInterface("i4");
-    assertFalse(trackInterface4.evaluate(c1));
+    assertFalse(trackInterface4.accept(evaluator));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/TrackInterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/TrackInterfaceTest.java
@@ -34,6 +34,14 @@ public class TrackInterfaceTest {
         .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
         .setActive(false)
         .build();
+    // i3: active, but blacklisted
+    Interface.builder()
+        .setOwner(c1)
+        .setName("i3")
+        .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
+        .setActive(true)
+        .setBlacklisted(true)
+        .build();
 
     // Iface is active
     TrackInterface trackInterface1 = new TrackInterface("i1");
@@ -43,8 +51,12 @@ public class TrackInterfaceTest {
     TrackInterface trackInterface2 = new TrackInterface("i2");
     assertTrue(trackInterface2.evaluate(c1));
 
-    // Non-existent iface
+    // Iface is active, but blacklisted
     TrackInterface trackInterface3 = new TrackInterface("i3");
-    assertFalse(trackInterface3.evaluate(c1));
+    assertTrue(trackInterface3.evaluate(c1));
+
+    // Non-existent iface
+    TrackInterface trackInterface4 = new TrackInterface("i4");
+    assertFalse(trackInterface4.evaluate(c1));
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/TrackInterfaceTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/tracking/TrackInterfaceTest.java
@@ -1,0 +1,50 @@
+package org.batfish.datamodel.tracking;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import org.batfish.datamodel.ConcreteInterfaceAddress;
+import org.batfish.datamodel.Configuration;
+import org.batfish.datamodel.ConfigurationFormat;
+import org.batfish.datamodel.Interface;
+import org.junit.Test;
+
+/** Tests of {@link TrackInterface} */
+public class TrackInterfaceTest {
+  @Test
+  public void testEvaluate() {
+    Configuration c1 =
+        Configuration.builder()
+            .setHostname("c1")
+            .setConfigurationFormat(ConfigurationFormat.CISCO_IOS)
+            .build();
+    c1.setTrackingGroups(ImmutableMap.of("1", new TrackInterface("i1tracked")));
+    // i1: active
+    Interface.builder()
+        .setOwner(c1)
+        .setName("i1")
+        .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
+        .setActive(true)
+        .build();
+    // i2: not active
+    Interface.builder()
+        .setOwner(c1)
+        .setName("i2")
+        .setAddress(ConcreteInterfaceAddress.parse("1.2.3.4/24"))
+        .setActive(false)
+        .build();
+
+    // Iface is active
+    TrackInterface trackInterface1 = new TrackInterface("i1");
+    assertFalse(trackInterface1.evaluate(c1));
+
+    // Iface is not active
+    TrackInterface trackInterface2 = new TrackInterface("i2");
+    assertTrue(trackInterface2.evaluate(c1));
+
+    // Non-existent iface
+    TrackInterface trackInterface3 = new TrackInterface("i3");
+    assertFalse(trackInterface3.evaluate(c1));
+  }
+}


### PR DESCRIPTION
Add initial VI support for updating Hot Standby Router Protocol (HSRP) priority based on tracking interface active status.
