### PR TITLE
SearchRoutePolicies: Better handling of conditionals

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/TransferParam.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/TransferParam.java
@@ -134,6 +134,12 @@ public class TransferParam<T extends IDeepCopy<T>> {
     return ret;
   }
 
+  public TransferParam<T> setDefaultsFrom(TransferParam<T> updatedParam) {
+    return setDefaultAccept(updatedParam._defaultAccept)
+        .setDefaultPolicy(updatedParam._defaultPolicy)
+        .setDefaultAcceptLocal(updatedParam._defaultAcceptLocal);
+  }
+
   public TransferParam<T> enterScope(String name) {
     TransferParam<T> ret = new TransferParam<>(this);
     ret._scopes = ret._scopes.plus(name);

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -510,7 +510,7 @@ public class TransferBDD {
       // Symbolically execute each branch if it is feasible.
       // Some guards are statically resolved (e.g. CallExprContext and StatementExprContext), which
       // means that only one branch will be analyzed.  Skipping analysis of the other branch avoids
-      // causing an error unnecessarily if we reach a route-map construct that is not currently
+      // signaling an error unnecessarily if we reach a route-map construct that is not currently
       // modelled.  It also allows us to properly account for updates to things like the default
       // action that occur within the one feasible branch (see below for more on this).
       if (!guard.isZero()) {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -504,10 +504,6 @@ public class TransferBDD {
       BDDRoute current = guardResult.getReturnValue().getFirst();
       curP.debug("guard: ");
 
-      // copy the current BDDRoute so we can separately track any updates on the two branches
-      TransferParam<BDDRoute> pTrue = curP.indent().setData(current.deepCopy());
-      TransferParam<BDDRoute> pFalse = curP.indent().setData(current.deepCopy());
-
       TransferBDDState trueState = null;
       TransferBDDState falseState = null;
 
@@ -519,6 +515,8 @@ public class TransferBDD {
       // action that occur within the one feasible branch (see below for more on this).
       if (!guard.isZero()) {
         curP.debug("True Branch");
+        // copy the current BDDRoute so we can separately track any updates on the two branches
+        TransferParam<BDDRoute> pTrue = curP.indent().setData(current.deepCopy());
         trueState =
             compute(
                 i.getTrueStatements(),
@@ -528,6 +526,7 @@ public class TransferBDD {
       }
       if (!guard.isOne()) {
         curP.debug("False Branch");
+        TransferParam<BDDRoute> pFalse = curP.indent().setData(current.deepCopy());
         falseState =
             compute(
                 i.getFalseStatements(),

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/bdd/TransferBDD.java
@@ -508,7 +508,7 @@ public class TransferBDD {
       TransferBDDState falseState = null;
 
       // Symbolically execute each branch if it is feasible.
-      // Some guards are statically resolved (e.g. CallExprContext and StatementExprContext), which
+      // Some guards are statically resolved (e.g. CallExprContext and CallStatementContext), which
       // means that only one branch will be analyzed.  Skipping analysis of the other branch avoids
       // signaling an error unnecessarily if we reach a route-map construct that is not currently
       // modelled.  It also allows us to properly account for updates to things like the default

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -1030,6 +1030,28 @@ public class TransferBDDTest {
   }
 
   @Test
+  public void testConditionalDefaultAction() {
+    RoutingPolicy policy =
+        _policyBuilder
+            .addStatement(
+                new If(
+                    BooleanExprs.CALL_EXPR_CONTEXT,
+                    ImmutableList.of(),
+                    ImmutableList.of(new StaticStatement(Statements.SetDefaultActionAccept))))
+            .addStatement(new StaticStatement(Statements.DefaultAction))
+            .build();
+    _g = new Graph(_batfish, _batfish.getSnapshot());
+
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
+    TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
+    BDD acceptedAnnouncements = result.getSecond();
+    BDDRoute outAnnouncements = result.getFirst();
+
+    assertTrue(acceptedAnnouncements.isOne());
+    assertEquals(_anyRoute, outAnnouncements);
+  }
+
+  @Test
   public void testBufferedStatement() {
     RoutingPolicy policy =
         _policyBuilder

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/bdd/TransferBDDTest.java
@@ -71,6 +71,7 @@ import org.batfish.datamodel.routing_policy.expr.Not;
 import org.batfish.datamodel.routing_policy.statement.BufferedStatement;
 import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.If;
+import org.batfish.datamodel.routing_policy.statement.SetDefaultTag;
 import org.batfish.datamodel.routing_policy.statement.SetLocalPreference;
 import org.batfish.datamodel.routing_policy.statement.SetMetric;
 import org.batfish.datamodel.routing_policy.statement.SetTag;
@@ -1039,6 +1040,28 @@ public class TransferBDDTest {
                     ImmutableList.of(),
                     ImmutableList.of(new StaticStatement(Statements.SetDefaultActionAccept))))
             .addStatement(new StaticStatement(Statements.DefaultAction))
+            .build();
+    _g = new Graph(_batfish, _batfish.getSnapshot());
+
+    TransferBDD tbdd = new TransferBDD(_g, _baseConfig, policy.getStatements());
+    TransferReturn result = tbdd.compute(ImmutableSet.of()).getReturnValue();
+    BDD acceptedAnnouncements = result.getSecond();
+    BDDRoute outAnnouncements = result.getFirst();
+
+    assertTrue(acceptedAnnouncements.isOne());
+    assertEquals(_anyRoute, outAnnouncements);
+  }
+
+  @Test
+  public void testUnreachableUnhandled() {
+    RoutingPolicy policy =
+        _policyBuilder
+            .addStatement(
+                new If(
+                    BooleanExprs.CALL_EXPR_CONTEXT,
+                    // currently we don't handle SetDefaultTag, but this branch is unreachable
+                    ImmutableList.of(new SetDefaultTag(new LiteralLong(0L))),
+                    ImmutableList.of(new StaticStatement(Statements.ExitAccept))))
             .build();
     _g = new Graph(_batfish, _batfish.getSnapshot());
 


### PR DESCRIPTION
Updates the handling of if statements in the symbolic route-map analysis so that it only analyzes feasible branches.  Some guards are statically resolved (notably CallExprContext and CallStatementContext), so analyzing both branches is unnecessary.  Skipping analysis of the infeasible branch also avoids a possible failure to answer the question due to reaching route-map features not currently supported.  Further, it allows us to properly account for updates to things like the default action within the one feasible branch, which previously were being ignored.