### PR TITLE
NXOS: track object conversion

### DIFF
--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion
@@ -1,0 +1,6 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_track_conversion
+!
+track 1 interface port-channel1 line-protocol
+track 500 interface Ethernet1/1 line-protocol

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion_warn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion_warn
@@ -1,0 +1,6 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_track_conversion_warn
+!
+track 1 interface port-channel1 ip routing
+track 500 interface Ethernet1/1 ipv6 routing


### PR DESCRIPTION
Convert NXOS track objects into VI model (currently, only interface line-protocol tracking is supported in the VI model).
