### PR TITLE
NXOS: HSRP secondary ip

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -1903,7 +1903,10 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
               ((HsrpGroupIpv4) group).setIp(ip);
             }
           } else {
-            warn(ctx, "HSRP IP must be contained by its interface subnets.");
+            warn(
+                ctx,
+                "HSRP IP must be contained by its interface subnets. This HSRP IP will be"
+                    + " ignored.");
           }
         });
   }

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -222,11 +222,13 @@ import org.batfish.datamodel.DscpType;
 import org.batfish.datamodel.IcmpCode;
 import org.batfish.datamodel.IcmpType;
 import org.batfish.datamodel.IntegerSpace;
+import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6;
 import org.batfish.datamodel.IpProtocol;
 import org.batfish.datamodel.IpWildcard;
 import org.batfish.datamodel.LineAction;
+import org.batfish.datamodel.LinkLocalAddress;
 import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.NamedPort;
 import org.batfish.datamodel.OriginType;
@@ -1856,6 +1858,29 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
         .forEach(iface -> iface.setSwitchportMode(SwitchportMode.ACCESS));
   }
 
+  /**
+   * Returns boolean indicating if the interface's configured IP subnet(s) contain the specified IP
+   * address.
+   */
+  private boolean ifaceContainsIp(Interface iface, Ip ip) {
+    return ifaceAddrContainsIp(iface.getAddress(), ip)
+        || iface.getSecondaryAddresses().stream().anyMatch(a -> ifaceAddrContainsIp(a, ip));
+  }
+
+  private boolean ifaceAddrContainsIp(
+      @Nullable InterfaceAddressWithAttributes ifaceAddrWithAttributes, Ip ip) {
+    if (ifaceAddrWithAttributes == null) {
+      return false;
+    }
+
+    InterfaceAddress addr = ifaceAddrWithAttributes.getAddress();
+    if (addr instanceof ConcreteInterfaceAddress) {
+      return ((ConcreteInterfaceAddress) addr).getPrefix().containsIp(ip);
+    }
+    assert addr instanceof LinkLocalAddress;
+    return ((LinkLocalAddress) addr).getPrefix().containsIp(ip);
+  }
+
   @Override
   public void exitIhg4_ip(Ihg4_ipContext ctx) {
     if (ctx.prefix != null) {
@@ -1864,21 +1889,23 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     }
     assert ctx.ip != null;
     Ip ip = toIp(ctx.ip);
-    if (ctx.SECONDARY() != null) {
-      _currentInterfaces.forEach(
-          iface -> {
+    _currentInterfaces.forEach(
+        iface -> {
+          // Device allows configuring HSRP IPs if either:
+          // 1. No interface IPs are configured yet OR
+          // 2. HSRP IPs are in the subnet(s) associated with the interface
+          if (iface.getAddress() == null || ifaceContainsIp(iface, ip)) {
             HsrpGroup group = _currentHsrpGroupGetter.apply(iface);
             assert group instanceof HsrpGroupIpv4;
-            ((HsrpGroupIpv4) group).getIpSecondaries().add(ip);
-          });
-    } else {
-      _currentInterfaces.forEach(
-          iface -> {
-            HsrpGroup group = _currentHsrpGroupGetter.apply(iface);
-            assert group instanceof HsrpGroupIpv4;
-            ((HsrpGroupIpv4) group).setIp(ip);
-          });
-    }
+            if (ctx.SECONDARY() != null) {
+              ((HsrpGroupIpv4) group).getIpSecondaries().add(ip);
+            } else {
+              ((HsrpGroupIpv4) group).setIp(ip);
+            }
+          } else {
+            warn(ctx, "HSRP IP must be contained by its interface subnets.");
+          }
+        });
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1832,11 +1832,16 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
   }
 
   private static @Nonnull org.batfish.datamodel.hsrp.HsrpGroup toHsrpGroup(HsrpGroupIpv4 group) {
-    Ip groupIp = group.getIp();
+    Optional<Ip> groupIp = Optional.ofNullable(group.getIp());
+    Set<Ip> groupIpSecondary = group.getIpSecondaries();
+    ImmutableSet.Builder<Ip> hsrpIps = ImmutableSet.builder();
+    groupIp.ifPresent(hsrpIps::add);
+    groupIpSecondary.forEach(hsrpIps::add);
+
     org.batfish.datamodel.hsrp.HsrpGroup.Builder builder =
         org.batfish.datamodel.hsrp.HsrpGroup.builder()
             .setGroupNumber(group.getGroup())
-            .setIps(groupIp == null ? ImmutableSet.of() : ImmutableSet.of(groupIp))
+            .setIps(hsrpIps.build())
             .setPreempt(group.getPreempt());
     if (group.getHelloIntervalMs() != null) {
       builder.setHelloTime(group.getHelloIntervalMs());

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -1988,8 +1988,9 @@ public final class CiscoNxosGrammarTest {
               allOf(
                   hasHelloTime(250),
                   hasHoldTime(750),
-                  // TODO secondary
-                  HsrpGroupMatchers.hasIps(contains(Ip.parse("192.0.2.1"))),
+                  HsrpGroupMatchers.hasIps(
+                      containsInAnyOrder(
+                          Ip.parse("192.0.2.1"), Ip.parse("192.168.0.1"), Ip.parse("192.168.1.1"))),
                   hasPreempt(),
                   hasPriority(105),
                   hasTrackActions(
@@ -2062,10 +2063,14 @@ public final class CiscoNxosGrammarTest {
         vc.getWarnings().getParseWarnings(),
         containsInAnyOrder(
             allOf(
-                hasComment("HSRP IP must be contained by its interface subnets."),
+                hasComment(
+                    "HSRP IP must be contained by its interface subnets. This HSRP IP will be"
+                        + " ignored."),
                 ParseWarningMatchers.hasText("ip 10.0.0.1")),
             allOf(
-                hasComment("HSRP IP must be contained by its interface subnets."),
+                hasComment(
+                    "HSRP IP must be contained by its interface subnets. This HSRP IP will be"
+                        + " ignored."),
                 ParseWarningMatchers.hasText("ip 10.0.0.2 secondary"))));
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -162,6 +162,7 @@ import org.batfish.common.BatfishLogger;
 import org.batfish.common.Warnings;
 import org.batfish.common.bdd.IpAccessListToBdd;
 import org.batfish.common.bdd.IpSpaceToBDD;
+import org.batfish.common.matchers.ParseWarningMatchers;
 import org.batfish.common.plugin.IBatfish;
 import org.batfish.config.Settings;
 import org.batfish.datamodel.AbstractRoute;
@@ -1987,6 +1988,7 @@ public final class CiscoNxosGrammarTest {
               allOf(
                   hasHelloTime(250),
                   hasHoldTime(750),
+                  // TODO secondary
                   HsrpGroupMatchers.hasIps(contains(Ip.parse("192.0.2.1"))),
                   hasPreempt(),
                   hasPriority(105),
@@ -2049,6 +2051,22 @@ public final class CiscoNxosGrammarTest {
         assertThat(group.getTracks(), anEmptyMap());
       }
     }
+  }
+
+  @Test
+  public void testInterfaceHsrpWarnings() {
+    String hostname = "nxos_interface_hsrp_warn";
+    CiscoNxosConfiguration vc = parseVendorConfig(hostname);
+
+    assertThat(
+        vc.getWarnings().getParseWarnings(),
+        containsInAnyOrder(
+            allOf(
+                hasComment("HSRP IP must be contained by its interface subnets."),
+                ParseWarningMatchers.hasText("ip 10.0.0.1")),
+            allOf(
+                hasComment("HSRP IP must be contained by its interface subnets."),
+                ParseWarningMatchers.hasText("ip 10.0.0.2 secondary"))));
   }
 
   @Test

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_hsrp_warn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_interface_hsrp_warn
@@ -1,0 +1,16 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos_interface_hsrp_warn
+!
+
+feature hsrp
+
+interface Ethernet1/1
+  no switchport
+  no shutdown
+  ip address 192.168.0.1/24
+  hsrp 1
+    ip 10.0.0.1
+  hsrp 2
+    ip 192.168.0.2
+    ip 10.0.0.2 secondary

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -93068,7 +93068,8 @@
                 "helloTime" : 0,
                 "holdTime" : 10000,
                 "ips" : [
-                  "1.1.1.1"
+                  "1.1.1.1",
+                  "2.2.2.2"
                 ],
                 "preempt" : false,
                 "priority" : 100


### PR DESCRIPTION
Support converting HSRP group secondary IPs and also enforce device's restrictions on what IPs can be used for HSRP groups.

