### PR TITLE
Move deny-all BGP redistribution policy init function to common

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Common.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Common.java
@@ -107,18 +107,18 @@ public final class Common {
   }
 
   /**
-   * If the given {@link Configuration} does not already have a deny-all policy, creates and adds
-   * one. Returns the policy name for convenience.
+   * If the given {@link Configuration} does not already have a deny-all BGP redistribution policy,
+   * creates and adds one. Returns the policy name for convenience.
    */
-  public static @Nonnull String initDenyAllPolicy(Configuration c) {
-    if (!c.getRoutingPolicies().containsKey(DENY_ALL_POLICY_NAME)) {
+  public static @Nonnull String initDenyAllBgpRedistributionPolicy(Configuration c) {
+    if (!c.getRoutingPolicies().containsKey(DENY_ALL_BGP_REDISTRIBUTION_POLICY_NAME)) {
       RoutingPolicy.builder()
-          .setName(DENY_ALL_POLICY_NAME)
+          .setName(DENY_ALL_BGP_REDISTRIBUTION_POLICY_NAME)
           .setOwner(c)
           .addStatement(Statements.ExitReject.toStaticStatement())
           .build();
     }
-    return DENY_ALL_POLICY_NAME;
+    return DENY_ALL_BGP_REDISTRIBUTION_POLICY_NAME;
   }
 
   /**
@@ -166,7 +166,8 @@ public final class Common {
   @VisibleForTesting
   public static String SUMMARY_ONLY_SUPPRESSION_POLICY_NAME = "~suppress~rp~summary-only~";
 
-  private static String DENY_ALL_POLICY_NAME = "~deny~all~";
+  private static String DENY_ALL_BGP_REDISTRIBUTION_POLICY_NAME =
+      "~deny~all~bgp~redistribution~policy~";
 
   // Private implementation details
   private Common() {} // prevent instantiation of utility class

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Common.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/Common.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.LineAction;
@@ -106,6 +107,21 @@ public final class Common {
   }
 
   /**
+   * If the given {@link Configuration} does not already have a deny-all policy, creates and adds
+   * one. Returns the policy name for convenience.
+   */
+  public static @Nonnull String initDenyAllPolicy(Configuration c) {
+    if (!c.getRoutingPolicies().containsKey(DENY_ALL_POLICY_NAME)) {
+      RoutingPolicy.builder()
+          .setName(DENY_ALL_POLICY_NAME)
+          .setOwner(c)
+          .addStatement(Statements.ExitReject.toStaticStatement())
+          .build();
+    }
+    return DENY_ALL_POLICY_NAME;
+  }
+
+  /**
    * Generates and returns a {@link Statement} that suppresses routes that are summarized by the
    * given set of {@link Prefix prefixes} configured as {@code summary-only}.
    *
@@ -149,6 +165,8 @@ public final class Common {
 
   @VisibleForTesting
   public static String SUMMARY_ONLY_SUPPRESSION_POLICY_NAME = "~suppress~rp~summary-only~";
+
+  private static String DENY_ALL_POLICY_NAME = "~deny~all~";
 
   // Private implementation details
   private Common() {} // prevent instantiation of utility class

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -13,9 +13,9 @@ import static org.batfish.datamodel.Names.generatedBgpRedistributionPolicyName;
 import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.SOURCE_ORIGINATING_FROM_DEVICE;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.routing_policy.Common.generateGenerationPolicy;
+import static org.batfish.datamodel.routing_policy.Common.initDenyAllPolicy;
 import static org.batfish.datamodel.routing_policy.Common.matchDefaultRoute;
 import static org.batfish.datamodel.routing_policy.Common.suppressSummarizedPrefixes;
-import static org.batfish.representation.cisco.CiscoConversions.DENY_ALL_REDIST_POLICY_NAME;
 import static org.batfish.representation.cisco.CiscoConversions.computeDistributeListPolicies;
 import static org.batfish.representation.cisco.CiscoConversions.convertCryptoMapSet;
 import static org.batfish.representation.cisco.CiscoConversions.convertVrfLeakingConfig;
@@ -24,7 +24,6 @@ import static org.batfish.representation.cisco.CiscoConversions.generateBgpImpor
 import static org.batfish.representation.cisco.CiscoConversions.generateEigrpPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.getIsakmpKeyGeneratedName;
 import static org.batfish.representation.cisco.CiscoConversions.getRsaPubKeyGeneratedName;
-import static org.batfish.representation.cisco.CiscoConversions.initBgpDenyAllRedistPolicy;
 import static org.batfish.representation.cisco.CiscoConversions.matchOwnAsn;
 import static org.batfish.representation.cisco.CiscoConversions.resolveIsakmpProfileIfaceNames;
 import static org.batfish.representation.cisco.CiscoConversions.resolveKeyringIfaceNames;
@@ -2878,12 +2877,12 @@ public final class CiscoConfiguration extends VendorConfiguration {
              * Despite no BGP config this vrf is leaked into. Make a dummy BGP process.
              */
             assert newVrf.getBgpProcess() == null;
-            initBgpDenyAllRedistPolicy(c);
+            String denyAllPolicyName = initDenyAllPolicy(c);
             newVrf.setBgpProcess(
                 org.batfish.datamodel.BgpProcess.builder()
                     .setRouterId(Ip.ZERO)
                     .setAdminCostsToVendorDefaults(c.getConfigurationFormat())
-                    .setRedistributionPolicy(DENY_ALL_REDIST_POLICY_NAME)
+                    .setRedistributionPolicy(denyAllPolicyName)
                     .build());
           }
         });

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -13,7 +13,7 @@ import static org.batfish.datamodel.Names.generatedBgpRedistributionPolicyName;
 import static org.batfish.datamodel.acl.SourcesReferencedByIpAccessLists.SOURCE_ORIGINATING_FROM_DEVICE;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.routing_policy.Common.generateGenerationPolicy;
-import static org.batfish.datamodel.routing_policy.Common.initDenyAllPolicy;
+import static org.batfish.datamodel.routing_policy.Common.initDenyAllBgpRedistributionPolicy;
 import static org.batfish.datamodel.routing_policy.Common.matchDefaultRoute;
 import static org.batfish.datamodel.routing_policy.Common.suppressSummarizedPrefixes;
 import static org.batfish.representation.cisco.CiscoConversions.computeDistributeListPolicies;
@@ -2881,7 +2881,7 @@ public final class CiscoConfiguration extends VendorConfiguration {
                 org.batfish.datamodel.BgpProcess.builder()
                     .setRouterId(Ip.ZERO)
                     .setAdminCostsToVendorDefaults(c.getConfigurationFormat())
-                    .setRedistributionPolicy(initDenyAllPolicy(c))
+                    .setRedistributionPolicy(initDenyAllBgpRedistributionPolicy(c))
                     .build());
           }
         });

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -2877,12 +2877,11 @@ public final class CiscoConfiguration extends VendorConfiguration {
              * Despite no BGP config this vrf is leaked into. Make a dummy BGP process.
              */
             assert newVrf.getBgpProcess() == null;
-            String denyAllPolicyName = initDenyAllPolicy(c);
             newVrf.setBgpProcess(
                 org.batfish.datamodel.BgpProcess.builder()
                     .setRouterId(Ip.ZERO)
                     .setAdminCostsToVendorDefaults(c.getConfigurationFormat())
-                    .setRedistributionPolicy(denyAllPolicyName)
+                    .setRedistributionPolicy(initDenyAllPolicy(c))
                     .build());
           }
         });

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConversions.java
@@ -154,8 +154,6 @@ public class CiscoConversions {
   static int DEFAULT_OSPF_DEAD_INTERVAL =
       OSPF_DEAD_INTERVAL_HELLO_MULTIPLIER * DEFAULT_OSPF_HELLO_INTERVAL;
 
-  static final String DENY_ALL_REDIST_POLICY_NAME = "~DENY_ALL_REDISTRIBUTION_POLICY~";
-
   static Ip getHighestIp(Map<String, Interface> allInterfaces) {
     Map<String, Interface> interfacesToCheck;
     Map<String, Interface> loopbackInterfaces = new HashMap<>();
@@ -479,20 +477,6 @@ public class CiscoConversions {
                 defaultRouteExportStatements))
         .addStatement(Statements.ReturnFalse.toStaticStatement())
         .build();
-  }
-
-  /**
-   * Initializes dummy BGP redistribution policy that denies everything, for VRFs that are set up to
-   * receive leaked routes from other VRFs but have no BGP configuration themselves.
-   */
-  static void initBgpDenyAllRedistPolicy(Configuration c) {
-    if (!c.getRoutingPolicies().containsKey(DENY_ALL_REDIST_POLICY_NAME)) {
-      RoutingPolicy.builder()
-          .setOwner(c)
-          .setName(DENY_ALL_REDIST_POLICY_NAME)
-          .addStatement(Statements.ExitReject.toStaticStatement())
-          .build();
-    }
   }
 
   /**


### PR DESCRIPTION
No real need to have separate generated deny-all policies for separate contexts that need them. This PR utilizes the new function in one context; can update more contexts to use it as we find/create them.