### PR TITLE
NXOS fix aggregate-address implementation

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosLexer.g4
@@ -110,7 +110,7 @@ ADMINISTRATIVELY_PROHIBITED: 'administratively-prohibited';
 
 ADVERTISE: 'advertise';
 
-ADVERTISE_MAP: 'advertise-map';
+ADVERTISE_MAP: 'advertise-map' -> pushMode(M_Word);
 
 ADVERTISEMENT_INTERVAL: 'advertisement-interval';
 
@@ -2171,7 +2171,7 @@ SUPPRESS_FIB_PENDING: 'suppress-fib-pending';
 
 SUPPRESS_INACTIVE: 'suppress-inactive';
 
-SUPPRESS_MAP: 'suppress-map';
+SUPPRESS_MAP: 'suppress-map' -> pushMode(M_Word);
 
 SUPPRESS_RA: 'suppress-ra';
 
@@ -2404,7 +2404,7 @@ UNREACHABLE: 'unreachable';
 
 UNREACHABLES: 'unreachables';
 
-UNSUPPRESS_MAP: 'unsuppress-map';
+UNSUPPRESS_MAP: 'unsuppress-map' -> pushMode(M_Word);
 
 UPDATE: 'update';
 

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -3730,6 +3730,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
   public void exitRb_afip_aa_tail(Rb_afip_aa_tailContext ctx) {
     int line = ctx.getStart().getLine();
     if (ctx.ADVERTISE_MAP() != null) {
+      todo(ctx);
       Optional<String> nameOrError = toString(ctx, ctx.mapname);
       if (!nameOrError.isPresent()) {
         return;
@@ -3738,6 +3739,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
       _c.referenceStructure(ROUTE_MAP, name, BGP_ADVERTISE_MAP, line);
       _currentBgpVrfAddressFamilyAggregateNetwork.setAdvertiseMap(name);
     } else if (ctx.AS_SET() != null) {
+      todo(ctx);
       _currentBgpVrfAddressFamilyAggregateNetwork.setAsSet(true);
     } else if (ctx.ATTRIBUTE_MAP() != null) {
       Optional<String> nameOrError = toString(ctx, ctx.mapname);
@@ -3750,6 +3752,7 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
     } else if (ctx.SUMMARY_ONLY() != null) {
       _currentBgpVrfAddressFamilyAggregateNetwork.setSummaryOnly(true);
     } else if (ctx.SUPPRESS_MAP() != null) {
+      todo(ctx);
       Optional<String> nameOrError = toString(ctx, ctx.mapname);
       if (!nameOrError.isPresent()) {
         return;

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/BgpVrfAddressFamilyAggregateNetworkConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/BgpVrfAddressFamilyAggregateNetworkConfiguration.java
@@ -1,6 +1,9 @@
 package org.batfish.representation.cisco_nxos;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+
 import java.io.Serializable;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -15,6 +18,53 @@ public class BgpVrfAddressFamilyAggregateNetworkConfiguration implements Seriali
   public BgpVrfAddressFamilyAggregateNetworkConfiguration() {
     _asSet = false;
     _summaryOnly = false;
+  }
+
+  public BgpVrfAddressFamilyAggregateNetworkConfiguration(
+      @Nullable String advertiseMap,
+      boolean asSet,
+      @Nullable String attributeMap,
+      boolean summaryOnly,
+      @Nullable String suppressMap) {
+    _advertiseMap = advertiseMap;
+    _asSet = asSet;
+    _attributeMap = attributeMap;
+    _summaryOnly = summaryOnly;
+    _suppressMap = suppressMap;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BgpVrfAddressFamilyAggregateNetworkConfiguration)) {
+      return false;
+    }
+    BgpVrfAddressFamilyAggregateNetworkConfiguration that =
+        (BgpVrfAddressFamilyAggregateNetworkConfiguration) o;
+    return Objects.equals(_advertiseMap, that._advertiseMap)
+        && _asSet == that._asSet
+        && Objects.equals(_attributeMap, that._attributeMap)
+        && _summaryOnly == that._summaryOnly
+        && Objects.equals(_suppressMap, that._suppressMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_advertiseMap, _asSet, _attributeMap, _summaryOnly, _suppressMap);
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .omitNullValues()
+        .add("_asSet", _asSet)
+        .add("_advertiseMap", _advertiseMap)
+        .add("_attributeMap", _attributeMap)
+        .add("_summaryOnly", _summaryOnly)
+        .add("_suppressMap", _suppressMap)
+        .toString();
   }
 
   @Nullable

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -566,7 +566,7 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
           .map(
               aggregateByPrefixEntry ->
                   toBgpAggregate(
-                      aggregateByPrefixEntry.getKey(), aggregateByPrefixEntry.getValue(), c))
+                      aggregateByPrefixEntry.getKey(), aggregateByPrefixEntry.getValue(), c, _w))
           .forEach(newBgpProcess::addAggregate);
     }
 

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -9,6 +9,7 @@ import static org.batfish.datamodel.Names.generatedBgpPeerEvpnExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpPeerEvpnImportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpPeerExportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpPeerImportPolicyName;
+import static org.batfish.datamodel.routing_policy.Common.generateSuppressionPolicy;
 import static org.batfish.datamodel.routing_policy.statement.Statements.RemovePrivateAs;
 import static org.batfish.representation.cisco_nxos.Vrf.MAC_VRF_OFFSET;
 
@@ -47,6 +48,7 @@ import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
 import org.batfish.datamodel.bgp.AllowRemoteAsOutMode;
+import org.batfish.datamodel.bgp.BgpAggregate;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
 import org.batfish.datamodel.bgp.Layer2VniConfig;
@@ -187,6 +189,25 @@ final class Conversions {
     }
 
     return true;
+  }
+
+  static @Nonnull BgpAggregate toBgpAggregate(
+      Prefix prefix,
+      BgpVrfAddressFamilyAggregateNetworkConfiguration vsAggregate,
+      Configuration c) {
+    // TODO: handle as-set
+    // TODO: handle suppress-map
+    // TODO: verify undefined route-map can be treated as omitted
+    String attributeMap =
+        Optional.ofNullable(vsAggregate.getAttributeMap())
+            .filter(c.getRoutingPolicies()::containsKey)
+            .orElse(null);
+    return BgpAggregate.of(
+        prefix,
+        generateSuppressionPolicy(vsAggregate.getSummaryOnly(), c),
+        // TODO: put advertise-map here
+        null,
+        attributeMap);
   }
 
   @Nonnull

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/Conversions.java
@@ -194,14 +194,17 @@ final class Conversions {
   static @Nonnull BgpAggregate toBgpAggregate(
       Prefix prefix,
       BgpVrfAddressFamilyAggregateNetworkConfiguration vsAggregate,
-      Configuration c) {
+      Configuration c,
+      Warnings w) {
     // TODO: handle as-set
     // TODO: handle suppress-map
     // TODO: verify undefined route-map can be treated as omitted
-    String attributeMap =
-        Optional.ofNullable(vsAggregate.getAttributeMap())
-            .filter(c.getRoutingPolicies()::containsKey)
-            .orElse(null);
+    String attributeMap = vsAggregate.getAttributeMap();
+    if (attributeMap != null && !c.getRoutingPolicies().containsKey(attributeMap)) {
+      w.redFlag(
+          String.format("Ignoring undefined aggregate-address attribute-map %s", attributeMap));
+      attributeMap = null;
+    }
     return BgpAggregate.of(
         prefix,
         generateSuppressionPolicy(vsAggregate.getSummaryOnly(), c),

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos-aggregate-address
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos-aggregate-address
@@ -1,0 +1,40 @@
+!RANCID-CONTENT-TYPE: cisco-nx
+!
+hostname nxos-aggregate-address
+!
+route-map atm1 permit 100
+ set metric 50
+!
+route-map adm permit 100
+ match tag 5
+!
+route-map atm2 permit 100
+ set community 1:1
+!
+route-map sm1 permit 100
+ match tag 5
+!
+route-map sm2 permit 100
+ match tag 5
+!
+router bgp 1
+ address-family ipv4 unicast
+   ! no suppression, everything more specific contributes, no inheritance
+   aggregate-address 1.1.0.0/16
+   ! attribute-map should transform aggregate
+   aggregate-address 1.2.0.0/16 attribute-map atm1
+   ! inheritance
+   aggregate-address 2.1.0.0/16 as-set
+   ! inheritance and contributors are limited to routes passing advertise-map,
+   aggregate-address 2.2.0.0/16 as-set advertise-map adm
+   ! attribute-map applies after inheritance
+   aggregate-address 2.3.0.0/16 as-set attribute-map atm2
+   ! suppression everything more specific
+   aggregate-address 3.1.0.0/16 summary-only
+   ! suppress only routes passing suppress-map
+   aggregate-address 3.2.0.0/16 suppress-map sm1
+   ! suppress only routes passing suppress-map, completely ignoring summary-only
+   aggregate-address 3.3.0.0/16 summary-only suppress-map sm2
+   ! undefined route-maps
+   aggregate-address 4.0.0.0/16 advertise-map undefined attribute-map undefined suppress-map undefined
+!


### PR DESCRIPTION
- fix lexing for aggregate-address route-map keywords
- use BGP process-level aggregates instead of vrf-level following batfish/batfish#7067