### PR TITLE
FRR fix aggregate-address implementation

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrrLexer.g4
@@ -57,6 +57,8 @@ AS_PATH
   }
 ;
 
+AS_SET: 'as-set';
+
 AUTHENTICATION: 'authentication';
 
 
@@ -152,6 +154,8 @@ DOUBLE_QUOTE
   '"' -> pushMode ( M_DoubleQuote )
 ;
 
+EGP: 'egp';
+
 EIGRP: 'eigrp';
 
 EMERGENCIES: 'emergencies';
@@ -201,12 +205,16 @@ HOSTNAME
 
 IDENTIFIER: 'identifier';
 
+IGP: 'igp';
+
 IMPORT
 :
    'import' -> pushMode(M_Import)
 ;
 
 IN: 'in';
+
+INCOMPLETE: 'incomplete';
 
 INFORMATIONAL: 'informational';
 
@@ -412,6 +420,8 @@ STATIC: 'static';
 
 SUMMARY_ONLY: 'summary-only';
 
+SUPPRESS_MAP: 'suppress-map' -> pushMode(M_Word);
+
 SUPPRESS_RA: 'suppress-ra';
 
 SYSLOG: 'syslog';
@@ -427,6 +437,8 @@ WARNINGS: 'warnings';
 
 MATCH: 'match';
 
+MATCHING_MED_ONLY: 'matching-' [Mm][Ee][Dd] '-only';
+
 METRIC: 'metric';
 
 METRIC_TYPE: 'metric-type';
@@ -437,6 +449,8 @@ NEWLINE
 ;
 
 NEXT_HOP: 'next-hop';
+
+ORIGIN: 'origin';
 
 ROUTE_REFLECTOR_CLIENT: 'route-reflector-client';
 

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_bgp.g4
@@ -185,8 +185,30 @@ sbafl_neighbor
 
 sbafi_aggregate_address
 :
-  AGGREGATE_ADDRESS IP_PREFIX SUMMARY_ONLY? NEWLINE
+  AGGREGATE_ADDRESS IP_PREFIX agg_feature* NEWLINE
 ;
+
+agg_feature
+:
+  agg_feature_as_set
+  | agg_feature_matching_med_only
+  | agg_feature_origin
+  | agg_feature_route_map
+  | agg_feature_summary_only
+  | agg_feature_suppress_map
+;
+
+agg_feature_as_set: AS_SET;
+
+agg_feature_matching_med_only: MATCHING_MED_ONLY;
+
+agg_feature_origin: ORIGIN origin_type;
+
+agg_feature_route_map: ROUTE_MAP mapname = route_map_name;
+
+agg_feature_summary_only: SUMMARY_ONLY;
+
+agg_feature_suppress_map: SUPPRESS_MAP mapname = route_map_name;
 
 sbafi_import
 :

--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_common.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cumulus_frr/CumulusFrr_common.g4
@@ -79,6 +79,13 @@ ospf_redist_type
   STATIC | CONNECTED | BGP
 ;
 
+origin_type
+:
+  EGP
+  | IGP
+  | INCOMPLETE
+;
+
 prefix
 :
   IP_PREFIX

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpVrfAddressFamilyAggregateNetworkConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/BgpVrfAddressFamilyAggregateNetworkConfiguration.java
@@ -1,6 +1,11 @@
 package org.batfish.representation.cumulus;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+
 import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.batfish.datamodel.OriginType;
 
 /**
  * Represents the BGP configuration for an aggregate network configured for an address family in a
@@ -9,7 +14,98 @@ import java.io.Serializable;
  * <p>Configured using the {@code aggregate-address} command in {@code /etc/frr/frr.conf}.
  */
 public final class BgpVrfAddressFamilyAggregateNetworkConfiguration implements Serializable {
+  private boolean _asSet;
+  private boolean _matchingMedOnly;
+  private @Nullable OriginType _origin;
+  private @Nullable String _routeMap;
   private boolean _summaryOnly;
+  private @Nullable String _suppressMap;
+
+  public BgpVrfAddressFamilyAggregateNetworkConfiguration() {}
+
+  public BgpVrfAddressFamilyAggregateNetworkConfiguration(
+      boolean asSet,
+      boolean matchingMedOnly,
+      @Nullable OriginType origin,
+      @Nullable String routeMap,
+      boolean summaryOnly,
+      @Nullable String suppressMap) {
+    _asSet = asSet;
+    _matchingMedOnly = matchingMedOnly;
+    _origin = origin;
+    _routeMap = routeMap;
+    _summaryOnly = summaryOnly;
+    _suppressMap = suppressMap;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof BgpVrfAddressFamilyAggregateNetworkConfiguration)) {
+      return false;
+    }
+    BgpVrfAddressFamilyAggregateNetworkConfiguration that =
+        (BgpVrfAddressFamilyAggregateNetworkConfiguration) o;
+    return _asSet == that._asSet
+        && _matchingMedOnly == that._matchingMedOnly
+        && _origin == that._origin
+        && Objects.equals(_routeMap, that._routeMap)
+        && _summaryOnly == that._summaryOnly
+        && Objects.equals(_suppressMap, that._suppressMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_asSet, _matchingMedOnly, _origin, _routeMap, _summaryOnly, _suppressMap);
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .omitNullValues()
+        .add("_asSet", _asSet)
+        .add("_matchingMedOnly", _matchingMedOnly)
+        .add("_origin", _origin)
+        .add("_routeMap", _routeMap)
+        .add("_summaryOnly", _summaryOnly)
+        .add("_suppressMap", _suppressMap)
+        .toString();
+  }
+
+  public boolean isAsSet() {
+    return _asSet;
+  }
+
+  public void setAsSet(boolean asSet) {
+    _asSet = asSet;
+  }
+
+  public boolean isMatchingMedOnly() {
+    return _matchingMedOnly;
+  }
+
+  public void setMatchingMedOnly(boolean matchingMedOnly) {
+    _matchingMedOnly = matchingMedOnly;
+  }
+
+  @Nullable
+  public OriginType getOrigin() {
+    return _origin;
+  }
+
+  public void setOrigin(@Nullable OriginType origin) {
+    _origin = origin;
+  }
+
+  @Nullable
+  public String getRouteMap() {
+    return _routeMap;
+  }
+
+  public void setRouteMap(@Nullable String routeMap) {
+    _routeMap = routeMap;
+  }
 
   public boolean isSummaryOnly() {
     return _summaryOnly;
@@ -17,5 +113,14 @@ public final class BgpVrfAddressFamilyAggregateNetworkConfiguration implements S
 
   public void setSummaryOnly(boolean summaryOnly) {
     _summaryOnly = summaryOnly;
+  }
+
+  @Nullable
+  public String getSuppressMap() {
+    return _suppressMap;
+  }
+
+  public void setSuppressMap(@Nullable String suppressMap) {
+    _suppressMap = suppressMap;
   }
 }

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -289,6 +289,7 @@ public final class CumulusConversions {
     // TODO: handle origin
     // TODO: handle suppress-map
     // TODO: verify undefined route-map can be treated as omitted
+    // TODO: verify route-map option is same as attribute-map
     String routeMap =
         Optional.ofNullable(vsAggregate.getRouteMap())
             .filter(c.getRoutingPolicies()::containsKey)

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusStructureUsage.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusStructureUsage.java
@@ -10,6 +10,8 @@ public enum CumulusStructureUsage implements StructureUsage {
       "bgp address-family l2vpn advertise ipv4 unicast"),
   BGP_ADDRESS_FAMILY_L2VPN_ADVERTISE_IPV6_UNICAST(
       "bgp address-family l2vpn advertise ipv6 unicast"),
+  BGP_AGGREGATE_ADDRESS_ROUTE_MAP("bgp address-family aggregate-address route-map"),
+  BGP_AGGREGATE_ADDRESS_SUPPRESS_MAP("bgp address-family aggregate-address suppress-map"),
   BGP_IPV4_UNICAST_REDISTRIBUTE_CONNECTED_ROUTE_MAP(
       "bgp ipv4 unicast redistribute connected route-map"),
   BGP_IPV4_UNICAST_REDISTRIBUTE_STATIC_ROUTE_MAP("bgp ipv4 unicast redistribute static route-map"),

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_concatenated/CumulusConcatenatedGrammarTest.java
@@ -15,8 +15,6 @@ import static org.batfish.main.BatfishTestUtils.TEST_SNAPSHOT;
 import static org.batfish.main.BatfishTestUtils.configureBatfishTestSettings;
 import static org.batfish.representation.cumulus.CumulusConversions.DEFAULT_LOOPBACK_MTU;
 import static org.batfish.representation.cumulus.CumulusConversions.DEFAULT_PORT_MTU;
-import static org.batfish.representation.cumulus.CumulusConversions.computeBgpGenerationPolicyName;
-import static org.batfish.representation.cumulus.CumulusConversions.computeMatchSuppressedSummaryOnlyPolicyName;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
@@ -26,7 +24,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -68,7 +65,6 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConnectedRoute;
 import org.batfish.datamodel.DataPlane;
 import org.batfish.datamodel.EmptyIpSpace;
-import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.InterfaceType;
 import org.batfish.datamodel.Ip;
@@ -78,7 +74,6 @@ import org.batfish.datamodel.OspfExternalType2Route;
 import org.batfish.datamodel.Prefix;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.StaticRoute;
-import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.answers.ParseVendorConfigurationAnswerElement;
 import org.batfish.datamodel.bgp.BgpAggregate;
 import org.batfish.datamodel.bgp.BgpConfederation;
@@ -222,40 +217,6 @@ public class CumulusConcatenatedGrammarTest {
     settings.setThrowOnParserError(false);
     CumulusConcatenatedConfiguration cfg = parseVendorConfig("ports_unrecognized", settings);
     assertThat(cfg.getHostname(), equalTo("hostname"));
-  }
-
-  @Test
-  public void testBgpAggregateAddress_e2e() {
-    CumulusConcatenatedConfiguration vsConfig = parseVendorConfig("bgp_aggregate_address");
-    Configuration viConfig = vsConfig.toVendorIndependentConfigurations().get(0);
-    Vrf vrf = viConfig.getDefaultVrf();
-
-    Prefix prefix1 = Prefix.parse("1.1.1.0/24");
-    Prefix prefix2 = Prefix.parse("2.2.0.0/16");
-
-    // Test that the expected routes maps were generated. We test their semantics elsewhere.
-    assertThat(
-        viConfig.getRoutingPolicies(),
-        hasKey(
-            computeBgpGenerationPolicyName(
-                true, Configuration.DEFAULT_VRF_NAME, prefix1.toString())));
-    assertThat(
-        viConfig.getRoutingPolicies(),
-        hasKey(
-            computeBgpGenerationPolicyName(
-                true, Configuration.DEFAULT_VRF_NAME, prefix2.toString())));
-
-    // Test that expected generated routes exist
-    assertThat(
-        vrf.getGeneratedRoutes().stream()
-            .map(GeneratedRoute::getNetwork)
-            .collect(ImmutableList.toImmutableList()),
-        containsInAnyOrder(prefix1, prefix2));
-
-    // suppression route map exists. Semantics tested elsewhere
-    assertThat(
-        viConfig.getRouteFilterLists(),
-        hasKey(computeMatchSuppressedSummaryOnlyPolicyName(vrf.getName())));
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -31,7 +31,6 @@ import static org.batfish.representation.cumulus.CumulusConversions.convertIpv4U
 import static org.batfish.representation.cumulus.CumulusConversions.convertOspfRedistributionPolicy;
 import static org.batfish.representation.cumulus.CumulusConversions.convertVxlans;
 import static org.batfish.representation.cumulus.CumulusConversions.generateBgpCommonPeerConfig;
-import static org.batfish.representation.cumulus.CumulusConversions.generateRedistributeAggregateConditions;
 import static org.batfish.representation.cumulus.CumulusConversions.getSetMaxMedMetric;
 import static org.batfish.representation.cumulus.CumulusConversions.getSetNextHop;
 import static org.batfish.representation.cumulus.CumulusConversions.inferClusterId;
@@ -81,7 +80,6 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.ConnectedRoute;
-import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
@@ -196,45 +194,6 @@ public final class CumulusConversionsTest {
                     StaticRoute.testBuilder().setAdministrativeCost(0).setNetwork(network).build())
                 .build())
         .getBooleanValue();
-  }
-
-  @Test
-  public void testGenerateExportAggregateConditions() {
-    BooleanExpr booleanExpr =
-        generateRedistributeAggregateConditions(
-            ImmutableMap.of(
-                Prefix.parse("1.2.3.0/24"),
-                new BgpVrfAddressFamilyAggregateNetworkConfiguration()));
-
-    // longer not exported
-    {
-      Environment env =
-          Environment.builder(_c)
-              .setOriginalRoute(
-                  GeneratedRoute.builder().setNetwork(Prefix.parse("1.2.3.4/32")).build())
-              .build();
-      assertFalse(value(booleanExpr, env));
-    }
-
-    // shorter not exported
-    {
-      Environment env =
-          Environment.builder(_c)
-              .setOriginalRoute(
-                  GeneratedRoute.builder().setNetwork(Prefix.parse("1.2.0.0/16")).build())
-              .build();
-      assertFalse(value(booleanExpr, env));
-    }
-
-    // exact match exported
-    {
-      Environment env =
-          Environment.builder(_c)
-              .setOriginalRoute(
-                  GeneratedRoute.builder().setNetwork(Prefix.parse("1.2.3.0/24")).build())
-              .build();
-      assertTrue(value(booleanExpr, env));
-    }
   }
 
   @Test

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -30,8 +30,8 @@ import static org.batfish.representation.cumulus.CumulusConversions.computeOspfE
 import static org.batfish.representation.cumulus.CumulusConversions.convertIpv4UnicastAddressFamily;
 import static org.batfish.representation.cumulus.CumulusConversions.convertOspfRedistributionPolicy;
 import static org.batfish.representation.cumulus.CumulusConversions.convertVxlans;
+import static org.batfish.representation.cumulus.CumulusConversions.generateBgpAggregates;
 import static org.batfish.representation.cumulus.CumulusConversions.generateBgpCommonPeerConfig;
-import static org.batfish.representation.cumulus.CumulusConversions.generateGeneratedRoutes;
 import static org.batfish.representation.cumulus.CumulusConversions.generateGenerationPolicy;
 import static org.batfish.representation.cumulus.CumulusConversions.generateRedistributeAggregateConditions;
 import static org.batfish.representation.cumulus.CumulusConversions.getSetMaxMedMetric;
@@ -243,7 +243,7 @@ public final class CumulusConversionsTest {
   @Test
   public void testGenerateGeneratedRoutes() {
     Prefix prefix = Prefix.parse("1.2.3.0/24");
-    generateGeneratedRoutes(
+    generateBgpAggregates(
         _c, _v, ImmutableMap.of(prefix, new BgpVrfAddressFamilyAggregateNetworkConfiguration()));
     String policyName = computeBgpGenerationPolicyName(true, _v.getName(), prefix.toString());
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/bgp_aggregate_address
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/bgp_aggregate_address
@@ -1,9 +1,0 @@
-hostname
-# ports.conf --
-frr version asdf
-router bgp 1
-  bgp router-id 1.1.1.1
-  address-family ipv4 unicast
-    aggregate-address 1.1.1.0/24
-    aggregate-address 2.2.0.0/16 summary-only
-  exit-address-family

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/frr-aggregate-address
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/frr-aggregate-address
@@ -1,0 +1,52 @@
+frr-aggregate-address
+# This file describes the network interfaces
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+auto lo
+iface lo
+
+# ports.conf --
+# ports.conf --
+#
+#   configure port speed, aggregation, and subdivision.
+#
+#   The ports in Cumulus VX are not configurable from here.
+#frr version
+frr version 4.0+cl3u8
+frr defaults datacenter
+hostname frr-aggregate-address
+!
+route-map rm1 permit 100
+ set metric 50
+!
+route-map rm2 permit 100
+ set community 1:1
+!
+route-map sm1 permit 100
+ match tag 5
+!
+route-map sm2 permit 100
+ match tag 5
+!
+router bgp 1
+ address-family ipv4 unicast
+   ! no suppression, everything more specific contributes, no inheritance
+   aggregate-address 1.1.0.0/16
+   ! route-map should transform aggregate
+   aggregate-address 1.2.0.0/16 route-map rm1
+   ! inheritance
+   aggregate-address 2.1.0.0/16 as-set
+   ! route-map applies after inheritance
+   aggregate-address 2.2.0.0/16 as-set route-map rm2
+   ! suppression everything more specific
+   aggregate-address 3.1.0.0/16 summary-only
+   ! suppress only routes passing suppress-map
+   aggregate-address 3.2.0.0/16 suppress-map sm1
+   ! suppress only routes passing suppress-map, completely ignoring summary-only
+   aggregate-address 3.3.0.0/16 summary-only suppress-map sm2
+   ! undefined route-maps
+   aggregate-address 4.0.0.0/16 route-map undefined suppress-map undefined
+   ! unimplemented features
+   aggregate-address 5.0.0.0/16 matching-med-only origin incomplete
+!


### PR DESCRIPTION
- flesh out aggregate-address parsing
- use BGP process-level aggregates instead of vrf-level following batfish/batfish#7067