### PR TITLE
Clean up SetNextHop and next hop exprs

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/route/nh/NextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/route/nh/NextHop.java
@@ -5,7 +5,6 @@ import javax.annotation.Nullable;
 import org.batfish.datamodel.Interface;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Route;
-import org.batfish.datamodel.routing_policy.expr.DiscardNextHop;
 
 /**
  * Represent a generic routing next hop. There are many types of next hops: IPv4 concrete address,
@@ -16,8 +15,8 @@ public interface NextHop extends Serializable {
   <T> T accept(NextHopVisitor<T> visitor);
 
   /**
-   * Returns a {@link NextHop} based on next hop interface and next hop ip, both of which can be
-   * nullable. If both are null, a {@link DiscardNextHop} is returned
+   * Returns a {@link NextHop} based on next hop interface and next hop ip, one of which must be
+   * nonnull
    */
   static NextHop legacyConverter(@Nullable String nextHopInterface, @Nullable Ip nextHopIp) {
     if (nextHopInterface != null && !Route.UNSET_NEXT_HOP_INTERFACE.equals(nextHopInterface)) {

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BgpPeerAddressNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/BgpPeerAddressNextHop.java
@@ -2,9 +2,10 @@ package org.batfish.datamodel.routing_policy.expr;
 
 import static com.google.common.base.Preconditions.checkState;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import org.batfish.datamodel.BgpSessionProperties;
-import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.routing_policy.Environment;
 
 /** NextHopExpr that gets the peer address of the BGP peer where the policy is being evaluated. */
@@ -23,12 +24,11 @@ public class BgpPeerAddressNextHop extends NextHopExpr {
     return this == obj || obj instanceof BgpPeerAddressNextHop;
   }
 
-  @Nullable
   @Override
-  public Ip getNextHopIp(Environment environment) {
-    BgpSessionProperties sessionProps = environment.getBgpSessionProperties();
+  public @Nonnull NextHop evaluate(Environment env) {
+    BgpSessionProperties sessionProps = env.getBgpSessionProperties();
     checkState(sessionProps != null, "Expected BGP session properties");
-    return sessionProps.getTailIp();
+    return NextHopIp.of(sessionProps.getTailIp());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/DiscardNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/DiscardNextHop.java
@@ -1,6 +1,8 @@
 package org.batfish.datamodel.routing_policy.expr;
 
-import org.batfish.datamodel.Ip;
+import javax.annotation.Nonnull;
+import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.route.nh.NextHopDiscard;
 import org.batfish.datamodel.routing_policy.Environment;
 
 /**
@@ -14,21 +16,16 @@ public class DiscardNextHop extends NextHopExpr {
   private DiscardNextHop() {}
 
   @Override
+  public @Nonnull NextHop evaluate(Environment env) {
+    return NextHopDiscard.instance();
+  }
+
+  @Override
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
     }
     return obj instanceof DiscardNextHop;
-  }
-
-  @Override
-  public boolean getDiscard() {
-    return true;
-  }
-
-  @Override
-  public Ip getNextHopIp(Environment environment) {
-    return null;
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Ip6NextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/Ip6NextHop.java
@@ -9,8 +9,8 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Ip6;
+import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.routing_policy.Environment;
 
 @ParametersAreNonnullByDefault
@@ -46,8 +46,8 @@ public final class Ip6NextHop extends NextHopExpr {
   }
 
   @Override
-  public Ip getNextHopIp(Environment environment) {
-    throw new UnsupportedOperationException("no implementation for generated method");
+  public @Nonnull NextHop evaluate(Environment environment) {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/IpNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/IpNextHop.java
@@ -11,6 +11,8 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.batfish.common.BatfishException;
 import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.routing_policy.Environment;
 
 @ParametersAreNonnullByDefault
@@ -49,9 +51,9 @@ public final class IpNextHop extends NextHopExpr {
   }
 
   @Override
-  public Ip getNextHopIp(Environment environment) {
+  public @Nonnull NextHop evaluate(Environment env) {
     if (_ips.size() == 1) {
-      return _ips.get(0);
+      return NextHopIp.of(_ips.get(0));
     } else {
       throw new BatfishException("Do not currently support setting more than 1 next-hop-ip");
     }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NextHopExpr.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/NextHopExpr.java
@@ -1,29 +1,18 @@
 package org.batfish.datamodel.routing_policy.expr;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.Serializable;
 import javax.annotation.Nullable;
-import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.route.nh.NextHop;
 import org.batfish.datamodel.routing_policy.Environment;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 public abstract class NextHopExpr implements Serializable {
 
+  public abstract @Nullable NextHop evaluate(Environment env);
+
   @Override
   public abstract boolean equals(Object obj);
-
-  /**
-   * Whether to ignore the next-hop-ip and install as a discard route. Should only be true in
-   * context of import policy, as discard is non-transitive.
-   */
-  @JsonIgnore
-  public boolean getDiscard() {
-    return false;
-  }
-
-  @Nullable
-  public abstract Ip getNextHopIp(Environment environment);
 
   @Override
   public abstract int hashCode();

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/SelfNextHop.java
@@ -2,7 +2,8 @@ package org.batfish.datamodel.routing_policy.expr;
 
 import javax.annotation.Nullable;
 import org.batfish.datamodel.BgpSessionProperties;
-import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.routing_policy.Environment;
 
 /** Implements BGP next-hop-self semantics */
@@ -22,11 +23,10 @@ public class SelfNextHop extends NextHopExpr {
   }
 
   @Override
-  @Nullable
-  public Ip getNextHopIp(Environment environment) {
+  public @Nullable NextHop evaluate(Environment env) {
     // BgpSessionProperties are for session directed toward the node with the policy being executed
-    BgpSessionProperties sessionProperties = environment.getBgpSessionProperties();
-    return sessionProperties == null ? null : sessionProperties.getHeadIp();
+    BgpSessionProperties sessionProperties = env.getBgpSessionProperties();
+    return sessionProperties == null ? null : NextHopIp.of(sessionProperties.getHeadIp());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/UnchangedNextHop.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/expr/UnchangedNextHop.java
@@ -5,6 +5,8 @@ import org.batfish.datamodel.BgpRoute;
 import org.batfish.datamodel.BgpSessionProperties;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.Route;
+import org.batfish.datamodel.route.nh.NextHop;
+import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.routing_policy.Environment;
 
 /** Implements BGP next-hop unchanged semantics */
@@ -24,23 +26,22 @@ public class UnchangedNextHop extends NextHopExpr {
   }
 
   @Override
-  @Nullable
-  public Ip getNextHopIp(Environment environment) {
+  public @Nullable NextHop evaluate(Environment env) {
     // applies only to BGP-to-BGP transformations
-    if (!(environment.getOriginalRoute() instanceof BgpRoute<?, ?>)) {
+    if (!(env.getOriginalRoute() instanceof BgpRoute<?, ?>)) {
       return null;
     }
     // No operation for IBGP
-    BgpSessionProperties sessionProperties = environment.getBgpSessionProperties();
+    BgpSessionProperties sessionProperties = env.getBgpSessionProperties();
     if (sessionProperties == null || !sessionProperties.isEbgp()) {
       return null;
     }
     // Preserve original NHIP if present
-    Ip originalRouteNextHop = environment.getOriginalRoute().getNextHopIp();
+    Ip originalRouteNextHop = env.getOriginalRoute().getNextHopIp();
     if (originalRouteNextHop != null && originalRouteNextHop != Route.UNSET_ROUTE_NEXT_HOP_IP) {
-      return originalRouteNextHop;
+      return NextHopIp.of(originalRouteNextHop);
     }
-    return sessionProperties.getHeadIp();
+    return NextHopIp.of(sessionProperties.getHeadIp());
   }
 
   @Override

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/BgpPeerAddressNextHopTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/routing_policy/expr/BgpPeerAddressNextHopTest.java
@@ -8,6 +8,7 @@ import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.NetworkFactory;
+import org.batfish.datamodel.route.nh.NextHopIp;
 import org.batfish.datamodel.routing_policy.Environment;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,12 +36,12 @@ public class BgpPeerAddressNextHopTest {
             .setTailIp(tailIp)
             .build();
     Environment env = Environment.builder(C).setBgpSessionProperties(sessionProps).build();
-    assertThat(INSTANCE.getNextHopIp(env), equalTo(tailIp));
+    assertThat(INSTANCE.evaluate(env), equalTo(NextHopIp.of(tailIp)));
   }
 
   @Test
   public void testEvaluate_noBgpSessionProperties() {
     _thrown.expectMessage("Expected BGP session properties");
-    INSTANCE.getNextHopIp(Environment.builder(C).build());
+    INSTANCE.evaluate(Environment.builder(C).build());
   }
 }


### PR DESCRIPTION
- Make each NextHopExpr evaluate the environment itself
- Make SetNextHop modify intermediate BGP attributes if appropriate
- Update incorrect comment on NextHop legacy converter method

Inspired by an observation that the old version of `SetNextHop` fails to return [here](https://github.com/batfish/batfish/blob/161bb0fa512846d58ecfe6fdf745ac3835701c6c/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/routing_policy/statement/SetNextHop.java#L50) (confirmed as bug by ari).