### PR TITLE
NXOS: parse unsupported track methods

### DIFF
--- a/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosParser.g4
+++ b/projects/batfish/src/main/antlr4/org/batfish/grammar/cisco_nxos/CiscoNxosParser.g4
@@ -512,15 +512,15 @@ sysvlan_reserve
   first = vlan_id RESERVE NEWLINE
 ;
 
-s_track: TRACK num = track_object_id track_definition NEWLINE;
+s_track: TRACK num = track_object_id track_definition;
 
 track_definition
 :
   track_interface
-  // | track_ip
+  | track_ip
 ;
 
-track_interface: INTERFACE interface_name track_interface_mode;
+track_interface: INTERFACE interface_name track_interface_mode NEWLINE;
 
 track_interface_mode
 :
@@ -530,26 +530,29 @@ track_interface_mode
 ;
 
 // Currently unsupported tracking structures
-//track_ip
-//:
-//  IP
-//  (
-//    track_ip_route
-//    | track_ip_sla
-//  )
-//;
-//track_ip_route
-//:
-//  ROUTE null_rest_of_line tir_vrf*
-//;
-//tir_vrf
-//:
-//  VRF MEMBER name = vrf_name NEWLINE
-//;
-//track_ip_sla
-//:
-//  SLA null_rest_of_line
-//;
+track_ip
+:
+  IP
+  (
+    track_ip_route
+    | track_ip_sla
+  )
+;
+
+track_ip_route
+:
+  ROUTE null_rest_of_line tir_vrf*
+;
+
+tir_vrf
+:
+  VRF MEMBER name = vrf_name NEWLINE
+;
+
+track_ip_sla
+:
+  SLA null_rest_of_line
+;
 
 s_version
 :

--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco_nxos/CiscoNxosControlPlaneExtractor.java
@@ -4827,8 +4827,11 @@ public final class CiscoNxosControlPlaneExtractor extends CiscoNxosParserBaseLis
 
   private Optional<Track> toTrack(Track_definitionContext ctx) {
     // Interface tracking is the only method Batfish currently parses and extracts
-    assert ctx.track_interface() != null;
-    return toTrack(ctx.track_interface());
+    if (ctx.track_interface() != null) {
+      return toTrack(ctx.track_interface());
+    }
+    warn(ctx, "This track method is not yet supported and will be ignored.");
+    return Optional.empty();
   }
 
   private Optional<Track> toTrack(Track_interfaceContext ctx) {

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco_nxos/CiscoNxosConfiguration.java
@@ -1818,16 +1818,18 @@ public final class CiscoNxosConfiguration extends VendorConfiguration {
 
   private static @Nonnull Optional<org.batfish.datamodel.tracking.TrackMethod> toTrackMethod(
       @Nonnull Track track, @Nonnull Warnings w) {
-    assert track instanceof TrackInterface;
-    TrackInterface trackInterface = (TrackInterface) track;
-    if (trackInterface.getMode() == Mode.LINE_PROTOCOL) {
-      return Optional.of(
-          new org.batfish.datamodel.tracking.TrackInterface(trackInterface.getInterface()));
+    if (track instanceof TrackInterface) {
+      TrackInterface trackInterface = (TrackInterface) track;
+      if (trackInterface.getMode() == Mode.LINE_PROTOCOL) {
+        return Optional.of(
+            new org.batfish.datamodel.tracking.TrackInterface(trackInterface.getInterface()));
+      }
+      w.redFlag(
+          String.format(
+              "Interface track mode %s is not yet supported and will be ignored.",
+              trackInterface.getMode()));
     }
-    w.redFlag(
-        String.format(
-            "Interface track mode %s is not yet supported and will be ignored.",
-            trackInterface.getMode()));
+    // Warnings for unsupported track methods should be handled by parse warnings
     return Optional.empty();
   }
 

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -392,6 +392,7 @@ import org.batfish.representation.cisco_nxos.TcpOptions;
 import org.batfish.representation.cisco_nxos.Track;
 import org.batfish.representation.cisco_nxos.TrackInterface;
 import org.batfish.representation.cisco_nxos.TrackInterface.Mode;
+import org.batfish.representation.cisco_nxos.TrackUnsupported;
 import org.batfish.representation.cisco_nxos.UdpOptions;
 import org.batfish.representation.cisco_nxos.Vlan;
 import org.batfish.representation.cisco_nxos.Vrf;
@@ -1550,7 +1551,7 @@ public final class CiscoNxosGrammarTest {
     String hostname = "nxos_track";
     CiscoNxosConfiguration vc = parseVendorConfig(hostname);
 
-    assertThat(vc.getTracks(), hasKeys(1, 2, 500));
+    assertThat(vc.getTracks(), hasKeys(1, 2, 100, 101, 500));
 
     {
       Track track = vc.getTracks().get(1);
@@ -1575,6 +1576,10 @@ public final class CiscoNxosGrammarTest {
       assertThat(trackInterface.getInterface(), equalTo("loopback1"));
       assertThat(trackInterface.getMode(), equalTo(Mode.IPV6_ROUTING));
     }
+
+    // Should have placeholders for unsupported track types in the VS model
+    assertThat(vc.getTracks().get(100), instanceOf(TrackUnsupported.class));
+    assertThat(vc.getTracks().get(101), instanceOf(TrackUnsupported.class));
   }
 
   @Test
@@ -1589,6 +1594,12 @@ public final class CiscoNxosGrammarTest {
                 "Unsupported interface type: mgmt, expected [ETHERNET, PORT_CHANNEL, LOOPBACK]"),
             hasComment(
                 "Unsupported interface type: Vlan, expected [ETHERNET, PORT_CHANNEL, LOOPBACK]"),
+            allOf(
+                hasComment("This track method is not yet supported and will be ignored."),
+                ParseWarningMatchers.hasText(containsString("ip route 192.0.2.1/32 reachability"))),
+            allOf(
+                hasComment("This track method is not yet supported and will be ignored."),
+                ParseWarningMatchers.hasText(containsString("ip sla 1 reachability"))),
             hasComment("Expected track object-id in range 1-500, but got '0'"),
             hasComment("Expected track object-id in range 1-500, but got '501'"),
             // Undefined references are not accepted by the CLI
@@ -8762,6 +8773,8 @@ public final class CiscoNxosGrammarTest {
     assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.TRACK, "1", 2));
     assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.TRACK, "2", 1));
     assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.TRACK, "3", 0));
+    assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.TRACK, "100", 1));
+    assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.TRACK, "101", 1));
 
     assertThat(
         ans,

--- a/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cisco_nxos/CiscoNxosGrammarTest.java
@@ -8773,6 +8773,7 @@ public final class CiscoNxosGrammarTest {
     assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.TRACK, "1", 2));
     assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.TRACK, "2", 1));
     assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.TRACK, "3", 0));
+    // Unsupported track methods should still produce correct references
     assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.TRACK, "100", 1));
     assertThat(ans, hasNumReferrers(filename, CiscoNxosStructureType.TRACK, "101", 1));
 

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track
@@ -9,7 +9,7 @@ track 1 interface port-channel1 line-protocol
 track 2 interface Ethernet1/1 ip routing
 track 500 interface loopback1 ipv6 routing
 
-! Not yet supported
+! Not yet supported in VS model, but parsed
 track 100 ip route 192.0.2.1/32 reachability hmm
   vrf member v1
 track 101 ip sla 1 reachability

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track
@@ -9,8 +9,8 @@ track 1 interface port-channel1 line-protocol
 track 2 interface Ethernet1/1 ip routing
 track 500 interface loopback1 ipv6 routing
 
-! Syntax not yet supported
-!track 2 ip route 192.0.2.1/32 reachability hmm
-!  vrf member v1
-!track 3 ip sla 1 reachability
+! Not yet supported
+track 100 ip route 192.0.2.1/32 reachability hmm
+  vrf member v1
+track 101 ip sla 1 reachability
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion
@@ -4,3 +4,9 @@ hostname nxos_track_conversion
 !
 track 1 interface port-channel1 line-protocol
 track 500 interface Ethernet1/1 line-protocol
+
+! Don't yet convert these track types, but shouldn't crash
+track 100 ip route 192.0.2.1/32 reachability hmm
+  vrf member v1
+track 101 ip sla 1 reachability
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_conversion
@@ -5,7 +5,7 @@ hostname nxos_track_conversion
 track 1 interface port-channel1 line-protocol
 track 500 interface Ethernet1/1 line-protocol
 
-! Don't yet convert these track types, but shouldn't crash
+! We don't yet convert these track types, but shouldn't crash
 track 100 ip route 192.0.2.1/32 reachability hmm
   vrf member v1
 track 101 ip sla 1 reachability

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_refs
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_refs
@@ -6,6 +6,10 @@ hostname nxos_track_refs
 track 1 interface Ethernet1/1 line-protocol
 track 2 interface Ethernet1/2 line-protocol
 track 3 interface Ethernet1/3 line-protocol
+! Unsupported track types; should still be referenced
+track 100 ip route 192.0.2.1/32 reachability hmm
+  vrf member v1
+track 101 ip sla 1 reachability
 
 ip route 10.0.100.0/24 Ethernet1/1 10.255.1.254 track 1
 ipv6 route 1111::/24 Ethernet1/1 1110:: track 1
@@ -17,6 +21,8 @@ interface Ethernet1/1
   hsrp 2
     ip 192.0.2.1
     track 2
+    track 100
+    track 101
 
 ! Undefined track references are rejected by the CLI but should still report undefined references
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_refs
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_refs
@@ -6,7 +6,8 @@ hostname nxos_track_refs
 track 1 interface Ethernet1/1 line-protocol
 track 2 interface Ethernet1/2 line-protocol
 track 3 interface Ethernet1/3 line-protocol
-! Unsupported track types; should still be referenced
+! These are unsupported track types
+! But they should still support correct reference tracking
 track 100 ip route 192.0.2.1/32 reachability hmm
   vrf member v1
 track 101 ip sla 1 reachability

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_warn
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco_nxos/testconfigs/nxos_track_warn
@@ -7,6 +7,11 @@ track 2 interface Vlan1 line-protocol
 track 0 interface port-channel1 line-protocol
 track 501 interface port-channel2 line-protocol
 !
+! Not yet supported
+track 100 ip route 192.0.2.1/32 reachability hmm
+  vrf member v1
+track 101 ip sla 1 reachability
+!
 
 ! Undefined track references are rejected by the CLI
 !


### PR DESCRIPTION
Add parsing and reference tracking for other `track` methods.

We still don't support really extracting these into the VS model but this replaces false-positive undefined references to these structures with parse warnings (indicating the track method isn't supported and ignored).
