### PR TITLE
SearchRoutePolicies: Output route constraints are incompatible with the DENY action

### DIFF
--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/BgpRouteConstraints.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/BgpRouteConstraints.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Range;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -165,6 +166,27 @@ public class BgpRouteConstraints {
     }
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null) {
+      return false;
+    }
+    if (getClass() != o.getClass()) {
+      return false;
+    }
+    BgpRouteConstraints other = (BgpRouteConstraints) o;
+    return Objects.equals(_prefix, other._prefix)
+        && _complementPrefix == other._complementPrefix
+        && Objects.equals(_localPreference, other._localPreference)
+        && Objects.equals(_med, other._med)
+        && Objects.equals(_tag, other._tag)
+        && Objects.equals(_communities, other._communities)
+        && Objects.equals(_asPath, other._asPath);
+  }
+
   @JsonProperty(PROP_PREFIX)
   @Nonnull
   public PrefixSpace getPrefix() {
@@ -204,5 +226,11 @@ public class BgpRouteConstraints {
   @Nonnull
   public RegexConstraints getAsPath() {
     return _asPath;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        _prefix, _complementPrefix, _localPreference, _med, _tag, _communities, _asPath);
   }
 }

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/RegexConstraints.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/RegexConstraints.java
@@ -34,6 +34,21 @@ public class RegexConstraints {
     _regexConstraints = firstNonNull(regexConstraints, ImmutableList.of());
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null) {
+      return false;
+    }
+    if (getClass() != o.getClass()) {
+      return false;
+    }
+    RegexConstraints other = (RegexConstraints) o;
+    return _regexConstraints.equals(other._regexConstraints);
+  }
+
   @JsonValue
   public List<RegexConstraint> getRegexConstraints() {
     return _regexConstraints;
@@ -55,6 +70,11 @@ public class RegexConstraints {
     return _regexConstraints.stream()
         .map(RegexConstraint::getRegex)
         .collect(ImmutableList.toImmutableList());
+  }
+
+  @Override
+  public int hashCode() {
+    return _regexConstraints.hashCode();
   }
 
   public boolean isEmpty() {

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/RegexConstraints.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/RegexConstraints.java
@@ -1,11 +1,11 @@
 package org.batfish.minesweeper.question.searchroutepolicies;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class RegexConstraints {
 
-  @Nonnull private final List<RegexConstraint> _regexConstraints;
+  @Nonnull private final Set<RegexConstraint> _regexConstraints;
 
   public RegexConstraints() {
     this(ImmutableList.of());
@@ -31,7 +31,10 @@ public class RegexConstraints {
 
   @JsonCreator
   public RegexConstraints(@Nullable List<RegexConstraint> regexConstraints) {
-    _regexConstraints = firstNonNull(regexConstraints, ImmutableList.of());
+    _regexConstraints =
+        regexConstraints == null
+            ? ImmutableSet.of()
+            : regexConstraints.stream().collect(ImmutableSet.toImmutableSet());
   }
 
   @Override
@@ -50,7 +53,7 @@ public class RegexConstraints {
   }
 
   @JsonValue
-  public List<RegexConstraint> getRegexConstraints() {
+  public Set<RegexConstraint> getRegexConstraints() {
     return _regexConstraints;
   }
 

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/RegexConstraints.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/RegexConstraints.java
@@ -32,9 +32,7 @@ public class RegexConstraints {
   @JsonCreator
   public RegexConstraints(@Nullable List<RegexConstraint> regexConstraints) {
     _regexConstraints =
-        regexConstraints == null
-            ? ImmutableSet.of()
-            : regexConstraints.stream().collect(ImmutableSet.toImmutableSet());
+        regexConstraints == null ? ImmutableSet.of() : ImmutableSet.copyOf(regexConstraints);
   }
 
   @Override

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -1,5 +1,6 @@
 package org.batfish.minesweeper.question.searchroutepolicies;
 
+import static com.google.common.base.Preconditions.checkState;
 import static org.batfish.datamodel.answers.Schema.BGP_ROUTE;
 import static org.batfish.datamodel.answers.Schema.BGP_ROUTE_DIFFS;
 import static org.batfish.datamodel.answers.Schema.NODE;
@@ -10,7 +11,6 @@ import static org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePo
 import static org.batfish.specifier.NameRegexRoutingPolicySpecifier.ALL_ROUTING_POLICIES;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultiset;
@@ -159,11 +159,11 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
         Automaton a = apAutomata.get(i);
         // community atomic predicates should always be non-empty;
         // see RegexAtomicPredicates::initAtomicPredicates
-        Preconditions.checkState(!a.isEmpty(), "Cannot produce example string for empty automaton");
+        checkState(!a.isEmpty(), "Cannot produce example string for empty automaton");
         String str = a.getShortestExample(true);
         // community automata should only accept strings with this property;
         // see CommunityVar::toAutomaton
-        Preconditions.checkState(
+        checkState(
             str.startsWith("^") && str.endsWith("$"),
             "Community example %s has an unexpected format",
             str);
@@ -203,7 +203,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
             .collect(Collectors.toList());
 
     // since atomic predicates are disjoint, at most one of them should be true in the model
-    Preconditions.checkState(
+    checkState(
         trueAPs.size() <= 1,
         "Error in symbolic AS-path analysis: at most one atomic predicate should be true");
 
@@ -216,7 +216,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
     String asPathStr = asPathRegexAutomaton.getShortestExample(true);
     // As-path regex automata should only accept strings with this property;
     // see SymbolicAsPathRegex::toAutomaton
-    Preconditions.checkState(
+    checkState(
         asPathStr.startsWith("^") && asPathStr.endsWith("$"),
         "AS-path example %s has an unexpected format",
         asPathStr);

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesAnswerer.java
@@ -1,6 +1,5 @@
 package org.batfish.minesweeper.question.searchroutepolicies;
 
-import static com.google.common.base.Preconditions.checkState;
 import static org.batfish.datamodel.answers.Schema.BGP_ROUTE;
 import static org.batfish.datamodel.answers.Schema.BGP_ROUTE_DIFFS;
 import static org.batfish.datamodel.answers.Schema.NODE;
@@ -11,6 +10,7 @@ import static org.batfish.minesweeper.question.searchroutepolicies.SearchRoutePo
 import static org.batfish.specifier.NameRegexRoutingPolicySpecifier.ALL_ROUTING_POLICIES;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultiset;
@@ -159,11 +159,11 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
         Automaton a = apAutomata.get(i);
         // community atomic predicates should always be non-empty;
         // see RegexAtomicPredicates::initAtomicPredicates
-        checkState(!a.isEmpty(), "Cannot produce example string for empty automaton");
+        Preconditions.checkState(!a.isEmpty(), "Cannot produce example string for empty automaton");
         String str = a.getShortestExample(true);
         // community automata should only accept strings with this property;
         // see CommunityVar::toAutomaton
-        checkState(
+        Preconditions.checkState(
             str.startsWith("^") && str.endsWith("$"),
             "Community example %s has an unexpected format",
             str);
@@ -203,7 +203,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
             .collect(Collectors.toList());
 
     // since atomic predicates are disjoint, at most one of them should be true in the model
-    checkState(
+    Preconditions.checkState(
         trueAPs.size() <= 1,
         "Error in symbolic AS-path analysis: at most one atomic predicate should be true");
 
@@ -216,7 +216,7 @@ public final class SearchRoutePoliciesAnswerer extends Answerer {
     String asPathStr = asPathRegexAutomaton.getShortestExample(true);
     // As-path regex automata should only accept strings with this property;
     // see SymbolicAsPathRegex::toAutomaton
-    checkState(
+    Preconditions.checkState(
         asPathStr.startsWith("^") && asPathStr.endsWith("$"),
         "AS-path example %s has an unexpected format",
         asPathStr);

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesQuestion.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesQuestion.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -47,6 +48,9 @@ public final class SearchRoutePoliciesQuestion extends Question {
       @Nullable String nodes,
       @Nullable String policies,
       Action action) {
+    Preconditions.checkArgument(
+        action == Action.PERMIT || outputConstraints.equals(DEFAULT_ROUTE_CONSTRAINTS),
+        "Output route constraints can only be provided when the action is 'permit'");
     _nodes = nodes;
     _policies = policies;
     _inputConstraints = inputConstraints;

--- a/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesQuestion.java
+++ b/projects/minesweeper/src/main/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesQuestion.java
@@ -1,12 +1,12 @@
 package org.batfish.minesweeper.question.searchroutepolicies;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -48,7 +48,7 @@ public final class SearchRoutePoliciesQuestion extends Question {
       @Nullable String nodes,
       @Nullable String policies,
       Action action) {
-    Preconditions.checkArgument(
+    checkArgument(
         action == Action.PERMIT || outputConstraints.equals(DEFAULT_ROUTE_CONSTRAINTS),
         "Output route constraints can only be provided when the action is 'permit'");
     _nodes = nodes;

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/BgpRouteConstraintsTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/BgpRouteConstraintsTest.java
@@ -5,13 +5,43 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
+import com.google.common.testing.EqualsTester;
 import org.batfish.datamodel.LongSpace;
 import org.batfish.datamodel.LongSpace.Builder;
 import org.junit.Test;
 
 /** Tests for {@link BgpRouteConstraints}. */
 public class BgpRouteConstraintsTest {
+
+  @Test
+  public void testEquals() {
+    BgpRouteConstraints c1 = BgpRouteConstraints.builder().build();
+    BgpRouteConstraints c2 =
+        BgpRouteConstraints.builder().setLocalPreference(LongSpace.of(3)).build();
+    BgpRouteConstraints c3 =
+        BgpRouteConstraints.builder()
+            .setLocalPreference(LongSpace.of(3))
+            .setMed(LongSpace.of(3))
+            .build();
+    BgpRouteConstraints c4 =
+        BgpRouteConstraints.builder()
+            .setMed(LongSpace.of(3))
+            .setLocalPreference(LongSpace.of(3))
+            .build();
+    BgpRouteConstraints c5 =
+        BgpRouteConstraints.builder()
+            .setCommunities(
+                new RegexConstraints(ImmutableList.of(new RegexConstraint("foo", true))))
+            .build();
+    new EqualsTester()
+        .addEqualityGroup(c1)
+        .addEqualityGroup(c2)
+        .addEqualityGroup(c3, c4)
+        .addEqualityGroup(c5)
+        .testEquals();
+  }
 
   @Test
   public void testProcessBuilder() {

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/RegexConstraintTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/RegexConstraintTest.java
@@ -3,6 +3,7 @@ package org.batfish.minesweeper.question.searchroutepolicies;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import com.google.common.testing.EqualsTester;
 import org.batfish.common.BatfishException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,6 +12,17 @@ import org.junit.rules.ExpectedException;
 public class RegexConstraintTest {
 
   @Rule public ExpectedException _exception = ExpectedException.none();
+
+  @Test
+  public void testEquals() {
+    String r1 = "foo";
+    String r2 = "bar";
+    new EqualsTester()
+        .addEqualityGroup(new RegexConstraint(r1, true), new RegexConstraint(r1, true))
+        .addEqualityGroup(new RegexConstraint(r1, false))
+        .addEqualityGroup(new RegexConstraint(r2, true))
+        .testEquals();
+  }
 
   @Test
   public void testParse() {

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/RegexConstraintsTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/RegexConstraintsTest.java
@@ -1,0 +1,25 @@
+package org.batfish.minesweeper.question.searchroutepolicies;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+public class RegexConstraintsTest {
+
+  @Test
+  public void testEquals() {
+    RegexConstraint r1 = new RegexConstraint("foo", true);
+    RegexConstraint r2 = new RegexConstraint("bar", false);
+    RegexConstraints c1 = new RegexConstraints();
+    RegexConstraints c2 = new RegexConstraints(ImmutableList.of(r1));
+    RegexConstraints c3 = new RegexConstraints(ImmutableList.of(r1, r2));
+    RegexConstraints c4 = new RegexConstraints(ImmutableList.of(r2, r1));
+    RegexConstraints c5 = new RegexConstraints(ImmutableList.of(r2));
+    new EqualsTester()
+        .addEqualityGroup(c1)
+        .addEqualityGroup(c2)
+        .addEqualityGroup(c3, c4)
+        .addEqualityGroup(c5)
+        .testEquals();
+  }
+}

--- a/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesQuestionTest.java
+++ b/projects/minesweeper/src/test/java/org/batfish/minesweeper/question/searchroutepolicies/SearchRoutePoliciesQuestionTest.java
@@ -1,0 +1,22 @@
+package org.batfish.minesweeper.question.searchroutepolicies;
+
+import org.batfish.datamodel.LongSpace;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SearchRoutePoliciesQuestionTest {
+
+  @Rule public ExpectedException _exception = ExpectedException.none();
+
+  @Test
+  public void testDenyWithOutputConstraints() {
+    _exception.expect(IllegalArgumentException.class);
+    new SearchRoutePoliciesQuestion(
+        SearchRoutePoliciesQuestion.DEFAULT_ROUTE_CONSTRAINTS,
+        BgpRouteConstraints.builder().setMed(LongSpace.of(3)).build(),
+        null,
+        null,
+        SearchRoutePoliciesQuestion.Action.DENY);
+  }
+}


### PR DESCRIPTION
Updated SearchRoutePolicies to signal an error if the question is using the action DENY but also specifies constraints on the expected output route.  There are no output routes when the goal is to find input routes that are denied, so specifying both is likely an error on the part of the user.  Previously we silently ignored the output route constraints.