### PR TITLE
Clean up FRR BGP conversion

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
@@ -8,6 +8,10 @@ import static org.batfish.common.util.CollectionUtil.toImmutableSortedMap;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.EXACT_PATH;
 import static org.batfish.datamodel.MultipathEquivalentAsPathMatchMode.PATH_LENGTH;
+import static org.batfish.datamodel.Names.generatedBgpCommonExportPolicyName;
+import static org.batfish.datamodel.Names.generatedBgpDefaultRouteExportPolicyName;
+import static org.batfish.datamodel.Names.generatedBgpPeerExportPolicyName;
+import static org.batfish.datamodel.Names.generatedBgpPeerImportPolicyName;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.bgp.VniConfig.importRtPatternForAnyAs;
 import static org.batfish.representation.cumulus_nclu.BgpProcess.BGP_UNNUMBERED_IP;
@@ -117,7 +121,6 @@ import org.batfish.datamodel.routing_policy.expr.NamedPrefixSet;
 import org.batfish.datamodel.routing_policy.expr.Not;
 import org.batfish.datamodel.routing_policy.expr.SelfNextHop;
 import org.batfish.datamodel.routing_policy.expr.WithEnvironmentExpr;
-import org.batfish.datamodel.routing_policy.statement.CallStatement;
 import org.batfish.datamodel.routing_policy.statement.If;
 import org.batfish.datamodel.routing_policy.statement.SetMetric;
 import org.batfish.datamodel.routing_policy.statement.SetNextHop;
@@ -170,25 +173,6 @@ public final class CumulusConversions {
    * value in absence of explicit information.
    */
   public static final double DEFAULT_PORT_BANDWIDTH = 10E9D;
-
-  public static @Nonnull String computeBgpCommonExportPolicyName(String vrfName) {
-    return String.format("~BGP_COMMON_EXPORT_POLICY:%s~", vrfName);
-  }
-
-  @VisibleForTesting
-  public static @Nonnull String computeBgpPeerExportPolicyName(
-      String vrfName, String peerInterface) {
-    return String.format("~BGP_PEER_EXPORT_POLICY:%s:%s~", vrfName, peerInterface);
-  }
-
-  static String computeBgpDefaultRouteExportPolicyName(boolean ipv4, String vrf, String peer) {
-    return String.format(
-        "~BGP_DEFAULT_ROUTE_PEER_EXPORT_POLICY:IPv%s:%s:%s~", ipv4 ? "4" : "6", vrf, peer);
-  }
-
-  public static @Nonnull String computeBgpPeerImportPolicyName(String vrf, String peer) {
-    return String.format("~BGP_PEER_IMPORT_POLICY:%s:%s~", vrf, peer);
-  }
 
   public static String computeBgpGenerationPolicyName(boolean ipv4, String vrfName, String prefix) {
     return String.format("~AGGREGATE_ROUTE%s_GEN:%s:%s~", ipv4 ? "" : "6", vrfName, prefix);
@@ -665,17 +649,16 @@ public final class CumulusConversions {
     RoutingPolicy.Builder peerExportPolicy =
         RoutingPolicy.builder()
             .setOwner(c)
-            .setName(computeBgpPeerExportPolicyName(vrfName, neighbor.getName()));
+            .setName(generatedBgpPeerExportPolicyName(vrfName, neighbor.getName()));
 
     // If default originate is set for a neighbor, we will send it a "fresh" default route is not
     // subjected to the neighbor's outgoing route map. We will drop other default routes.
     if (bgpDefaultOriginate(neighbor)) {
-      initBgpDefaultRouteExportPolicy(vrfName, neighbor.getName(), true, null, c);
+      initBgpDefaultRouteExportPolicy(c);
       peerExportPolicy.addStatement(
           new If(
               "Export default route from peer with default-originate configured",
-              new CallExpr(
-                  computeBgpDefaultRouteExportPolicyName(true, vrfName, neighbor.getName())),
+              new CallExpr(generatedBgpDefaultRouteExportPolicyName(true)),
               singletonList(Statements.ReturnTrue.toStaticStatement()),
               ImmutableList.of()));
 
@@ -696,51 +679,26 @@ public final class CumulusConversions {
   }
 
   /**
-   * Initializes export policy for IPv4 or IPv6 default routes if it doesn't already exist. This
-   * policy is the same across BGP processes, so only one is created for each configuration.
-   *
-   * @param ipv4 Whether to initialize the IPv4 or IPv6 default route export policy
-   * @param defaultOriginateExportMapName Name of route-map to apply to generated route before
-   *     export.
+   * Initializes export policy for IPv4 default routes if it doesn't already exist. This policy is
+   * the same across BGP processes, so only one is created for each configuration.
    */
-  // TODO: This function is copied verbatim from CiscoConversations. Refactor after we've verified
-  // the right behavior for default-originate.
-  private static void initBgpDefaultRouteExportPolicy(
-      String vrfName,
-      String peerName,
-      boolean ipv4,
-      @Nullable String defaultOriginateExportMapName,
-      Configuration c) {
-    SetOrigin setOrigin =
-        new SetOrigin(
-            new LiteralOrigin(
-                c.getConfigurationFormat() == ConfigurationFormat.CISCO_IOS
-                    ? OriginType.IGP
-                    : OriginType.INCOMPLETE,
-                null));
-    List<Statement> defaultRouteExportStatements;
-    if (defaultOriginateExportMapName == null
-        || !c.getRoutingPolicies().containsKey(defaultOriginateExportMapName)) {
-      defaultRouteExportStatements =
-          ImmutableList.of(setOrigin, Statements.ReturnTrue.toStaticStatement());
-    } else {
-      defaultRouteExportStatements =
-          ImmutableList.of(
-              setOrigin,
-              new CallStatement(defaultOriginateExportMapName),
-              Statements.ReturnTrue.toStaticStatement());
+  private static void initBgpDefaultRouteExportPolicy(Configuration c) {
+    String policyName = generatedBgpDefaultRouteExportPolicyName(true);
+    if (c.getRoutingPolicies().containsKey(policyName)) {
+      return;
     }
 
+    // TODO Check if this is the correct origin type
+    SetOrigin setOrigin = new SetOrigin(new LiteralOrigin(OriginType.INCOMPLETE, null));
     RoutingPolicy.builder()
         .setOwner(c)
-        .setName(computeBgpDefaultRouteExportPolicyName(ipv4, vrfName, peerName))
+        .setName(policyName)
         .addStatement(
             new If(
                 new Conjunction(
                     ImmutableList.of(
-                        ipv4 ? Common.matchDefaultRoute() : Common.matchDefaultRouteV6(),
-                        new MatchProtocol(RoutingProtocol.AGGREGATE))),
-                defaultRouteExportStatements))
+                        Common.matchDefaultRoute(), new MatchProtocol(RoutingProtocol.AGGREGATE))),
+                ImmutableList.of(setOrigin, Statements.ReturnTrue.toStaticStatement())))
         .addStatement(Statements.ReturnFalse.toStaticStatement())
         .build();
   }
@@ -759,7 +717,7 @@ public final class CumulusConversions {
     RoutingPolicy.Builder peerImportPolicy =
         RoutingPolicy.builder()
             .setOwner(c)
-            .setName(computeBgpPeerImportPolicyName(vrfName, neighbor.getName()));
+            .setName(generatedBgpPeerImportPolicyName(vrfName, neighbor.getName()));
 
     peerImportPolicy.addStatement(
         new If(
@@ -773,7 +731,7 @@ public final class CumulusConversions {
 
   private static BooleanExpr computePeerExportConditions(BgpNeighbor neighbor, BgpVrf bgpVrf) {
     BooleanExpr commonCondition =
-        new CallExpr(computeBgpCommonExportPolicyName(bgpVrf.getVrfName()));
+        new CallExpr(generatedBgpCommonExportPolicyName(bgpVrf.getVrfName()));
     BooleanExpr peerCondition = getBgpNeighborExportPolicyCallExpr(neighbor);
 
     return peerCondition == null
@@ -933,7 +891,7 @@ public final class CumulusConversions {
     RoutingPolicy bgpCommonExportPolicy =
         RoutingPolicy.builder()
             .setOwner(c)
-            .setName(computeBgpCommonExportPolicyName(vrfName))
+            .setName(generatedBgpCommonExportPolicyName(vrfName))
             .build();
 
     List<Statement> statements = new ArrayList<>();

--- a/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
+++ b/projects/batfish/src/test/java/org/batfish/grammar/cumulus_nclu/CumulusNcluGrammarTest.java
@@ -4,6 +4,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.batfish.common.util.Resources.readResource;
 import static org.batfish.datamodel.BgpPeerConfig.ALL_AS_NUMBERS;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
+import static org.batfish.datamodel.Names.generatedBgpCommonExportPolicyName;
+import static org.batfish.datamodel.Names.generatedBgpPeerExportPolicyName;
 import static org.batfish.datamodel.matchers.AbstractRouteDecoratorMatchers.hasPrefix;
 import static org.batfish.datamodel.matchers.AddressFamilyCapabilitiesMatchers.hasSendCommunity;
 import static org.batfish.datamodel.matchers.AddressFamilyMatchers.hasAddressFamilyCapabilites;
@@ -48,8 +50,6 @@ import static org.batfish.datamodel.matchers.VniSettingsMatchers.hasVni;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasBgpProcess;
 import static org.batfish.datamodel.matchers.VrfMatchers.hasStaticRoutes;
 import static org.batfish.main.BatfishTestUtils.TEST_SNAPSHOT;
-import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeBgpCommonExportPolicyName;
-import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeBgpPeerExportPolicyName;
 import static org.batfish.representation.cumulus_nclu.CumulusNcluConfiguration.CUMULUS_CLAG_DOMAIN_ID;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
@@ -272,7 +272,7 @@ public final class CumulusNcluGrammarTest {
                                 allOf(
                                     hasAddressFamilyCapabilites(hasSendCommunity(true)),
                                     hasExportPolicy(
-                                        computeBgpPeerExportPolicyName(
+                                        generatedBgpPeerExportPolicyName(
                                             DEFAULT_VRF_NAME, iface))))))))));
     assertThat(
         configs.get(node2),
@@ -291,7 +291,7 @@ public final class CumulusNcluGrammarTest {
                                 allOf(
                                     hasAddressFamilyCapabilites(hasSendCommunity(true)),
                                     hasExportPolicy(
-                                        computeBgpPeerExportPolicyName(
+                                        generatedBgpPeerExportPolicyName(
                                             DEFAULT_VRF_NAME, iface))))))))));
 
     // Ensure reachability between nodes
@@ -308,8 +308,8 @@ public final class CumulusNcluGrammarTest {
   public void testBgpConversion() throws IOException {
     Configuration c = parseConfig("cumulus_nclu_bgp");
     String peerInterface = "swp1";
-    String peerExportPolicyName = computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, peerInterface);
-    String commonExportPolicyName = computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME);
+    String peerExportPolicyName = generatedBgpPeerExportPolicyName(DEFAULT_VRF_NAME, peerInterface);
+    String commonExportPolicyName = generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME);
 
     assertThat(c, hasDefaultVrf(hasBgpProcess(hasRouterId(Ip.parse("192.0.2.2")))));
     assertThat(

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus/CumulusConversionsTest.java
@@ -7,6 +7,8 @@ import static org.batfish.common.matchers.WarningsMatchers.hasRedFlags;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.InterfaceType.LOOPBACK;
 import static org.batfish.datamodel.InterfaceType.PHYSICAL;
+import static org.batfish.datamodel.Names.generatedBgpCommonExportPolicyName;
+import static org.batfish.datamodel.Names.generatedBgpPeerExportPolicyName;
 import static org.batfish.datamodel.RoutingProtocol.BGP;
 import static org.batfish.datamodel.RoutingProtocol.IBGP;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
@@ -18,10 +20,8 @@ import static org.batfish.representation.cumulus.CumulusConversions.GENERATED_DE
 import static org.batfish.representation.cumulus.CumulusConversions.REJECT_DEFAULT_ROUTE;
 import static org.batfish.representation.cumulus.CumulusConversions.addBgpNeighbor;
 import static org.batfish.representation.cumulus.CumulusConversions.addOspfInterfaces;
-import static org.batfish.representation.cumulus.CumulusConversions.computeBgpCommonExportPolicyName;
 import static org.batfish.representation.cumulus.CumulusConversions.computeBgpGenerationPolicyName;
 import static org.batfish.representation.cumulus.CumulusConversions.computeBgpNeighborImportRoutingPolicy;
-import static org.batfish.representation.cumulus.CumulusConversions.computeBgpPeerExportPolicyName;
 import static org.batfish.representation.cumulus.CumulusConversions.computeLocalIpForBgpNeighbor;
 import static org.batfish.representation.cumulus.CumulusConversions.computeMatchSuppressedSummaryOnlyPolicyName;
 import static org.batfish.representation.cumulus.CumulusConversions.computeOspfAreas;
@@ -564,7 +564,7 @@ public final class CumulusConversionsTest {
     assertTrue(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
+            .get(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
             .process(
                 route, Bgpv4Route.testBuilder().setNetwork(route.getNetwork()), Direction.OUT));
   }
@@ -611,7 +611,7 @@ public final class CumulusConversionsTest {
     assertTrue(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
+            .get(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
             .process(route, builder.setNetwork(route.getNetwork()), Direction.OUT));
     assertThat(builder, hasCommunities(community));
   }
@@ -654,7 +654,7 @@ public final class CumulusConversionsTest {
     assertFalse(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
+            .get(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
             .process(
                 route, Bgpv4Route.testBuilder().setNetwork(route.getNetwork()), Direction.OUT));
   }
@@ -804,7 +804,7 @@ public final class CumulusConversionsTest {
     assertThat(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpPeerExportPolicyName("vrf", neighbor.getName()))
+            .get(generatedBgpPeerExportPolicyName("vrf", neighbor.getName()))
             .getStatements()
             .get(1),
         equalTo(REJECT_DEFAULT_ROUTE));
@@ -1586,7 +1586,7 @@ public final class CumulusConversionsTest {
     assertFalse(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
+            .get(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
             .process(
                 ospfExternalRouteBuilder.build(),
                 Bgpv4Route.testBuilder().setNetwork(Prefix.ZERO),
@@ -1595,7 +1595,7 @@ public final class CumulusConversionsTest {
     assertTrue(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
+            .get(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
             .process(
                 ospfExternalRouteBuilder2.build(),
                 Bgpv4Route.testBuilder().setNetwork(prefix),
@@ -2224,11 +2224,11 @@ public final class CumulusConversionsTest {
     assertEquals(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, bgpNeighbor.getName()))
+            .get(generatedBgpPeerExportPolicyName(DEFAULT_VRF_NAME, bgpNeighbor.getName()))
             .getStatements(),
         ImmutableList.of(
             new If(
-                new CallExpr(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME)),
+                new CallExpr(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME)),
                 ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
                 ImmutableList.of(Statements.ExitReject.toStaticStatement()))));
 
@@ -2240,11 +2240,11 @@ public final class CumulusConversionsTest {
     assertEquals(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, bgpNeighbor.getName()))
+            .get(generatedBgpPeerExportPolicyName(DEFAULT_VRF_NAME, bgpNeighbor.getName()))
             .getStatements(),
         ImmutableList.of(
             new If(
-                new CallExpr(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME)),
+                new CallExpr(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME)),
                 ImmutableList.of(
                     new SetMetric(new LiteralLong(DEFAULT_MAX_MED)),
                     Statements.ExitAccept.toStaticStatement()),

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus_nclu/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus_nclu/CumulusConversionsTest.java
@@ -6,6 +6,8 @@ import static org.batfish.common.matchers.WarningMatchers.hasText;
 import static org.batfish.common.matchers.WarningsMatchers.hasRedFlags;
 import static org.batfish.datamodel.Configuration.DEFAULT_VRF_NAME;
 import static org.batfish.datamodel.InterfaceType.PHYSICAL;
+import static org.batfish.datamodel.Names.generatedBgpCommonExportPolicyName;
+import static org.batfish.datamodel.Names.generatedBgpPeerExportPolicyName;
 import static org.batfish.datamodel.RoutingProtocol.BGP;
 import static org.batfish.datamodel.RoutingProtocol.IBGP;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
@@ -16,10 +18,8 @@ import static org.batfish.representation.cumulus_nclu.CumulusConversions.GENERAT
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.REJECT_DEFAULT_ROUTE;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.addBgpNeighbor;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.addOspfInterfaces;
-import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeBgpCommonExportPolicyName;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeBgpGenerationPolicyName;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeBgpNeighborImportRoutingPolicy;
-import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeBgpPeerExportPolicyName;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeLocalIpForBgpNeighbor;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeMatchSuppressedSummaryOnlyPolicyName;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeOspfAreas;
@@ -549,7 +549,7 @@ public final class CumulusConversionsTest {
     assertTrue(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
+            .get(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
             .process(
                 route, Bgpv4Route.testBuilder().setNetwork(route.getNetwork()), Direction.OUT));
   }
@@ -595,7 +595,7 @@ public final class CumulusConversionsTest {
     assertTrue(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
+            .get(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
             .process(route, builder.setNetwork(route.getNetwork()), Direction.OUT));
     assertThat(builder, hasCommunities(community));
   }
@@ -637,7 +637,7 @@ public final class CumulusConversionsTest {
     assertFalse(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
+            .get(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
             .process(
                 route, Bgpv4Route.testBuilder().setNetwork(route.getNetwork()), Direction.OUT));
   }
@@ -782,7 +782,7 @@ public final class CumulusConversionsTest {
     assertThat(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpPeerExportPolicyName("vrf", neighbor.getName()))
+            .get(generatedBgpPeerExportPolicyName("vrf", neighbor.getName()))
             .getStatements()
             .get(1),
         equalTo(REJECT_DEFAULT_ROUTE));
@@ -1518,7 +1518,7 @@ public final class CumulusConversionsTest {
     assertFalse(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
+            .get(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
             .process(
                 ospfExternalRouteBuilder.build(),
                 Bgpv4Route.testBuilder().setNetwork(Prefix.ZERO),
@@ -1527,7 +1527,7 @@ public final class CumulusConversionsTest {
     assertTrue(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
+            .get(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME))
             .process(
                 ospfExternalRouteBuilder2.build(),
                 Bgpv4Route.testBuilder().setNetwork(prefix),
@@ -2107,11 +2107,11 @@ public final class CumulusConversionsTest {
     assertEquals(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, bgpNeighbor.getName()))
+            .get(generatedBgpPeerExportPolicyName(DEFAULT_VRF_NAME, bgpNeighbor.getName()))
             .getStatements(),
         ImmutableList.of(
             new If(
-                new CallExpr(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME)),
+                new CallExpr(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME)),
                 ImmutableList.of(Statements.ExitAccept.toStaticStatement()),
                 ImmutableList.of(Statements.ExitReject.toStaticStatement()))));
 
@@ -2123,11 +2123,11 @@ public final class CumulusConversionsTest {
     assertEquals(
         viConfig
             .getRoutingPolicies()
-            .get(computeBgpPeerExportPolicyName(DEFAULT_VRF_NAME, bgpNeighbor.getName()))
+            .get(generatedBgpPeerExportPolicyName(DEFAULT_VRF_NAME, bgpNeighbor.getName()))
             .getStatements(),
         ImmutableList.of(
             new If(
-                new CallExpr(computeBgpCommonExportPolicyName(DEFAULT_VRF_NAME)),
+                new CallExpr(generatedBgpCommonExportPolicyName(DEFAULT_VRF_NAME)),
                 ImmutableList.of(
                     new SetMetric(new LiteralLong(DEFAULT_MAX_MED)),
                     Statements.ExitAccept.toStaticStatement()),


### PR DESCRIPTION
- Create at most 1 default-route export policy per config (as javadocs incorrectly already claimed)
- Use `Names` for policy name functions