### PR TITLE
Cumulus: Fix incorrect VNI condition

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus/CumulusConversions.java
@@ -16,6 +16,7 @@ import static org.batfish.datamodel.Names.generatedBgpRedistributionPolicyName;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.bgp.VniConfig.importRtPatternForAnyAs;
 import static org.batfish.datamodel.routing_policy.Common.generateSuppressionPolicy;
+import static org.batfish.datamodel.routing_policy.Common.initDenyAllBgpRedistributionPolicy;
 import static org.batfish.representation.cumulus.BgpProcess.BGP_UNNUMBERED_IP;
 import static org.batfish.representation.cumulus.CumulusConcatenatedConfiguration.CUMULUS_CLAG_DOMAIN_ID;
 import static org.batfish.representation.cumulus.CumulusConcatenatedConfiguration.LOOPBACK_INTERFACE_NAME;
@@ -321,14 +322,15 @@ public final class CumulusConversions {
     c.getVrfs()
         .forEach(
             (vrfName, vrf) -> {
-              if (!vrf.getLayer2Vnis().isEmpty()
-                  || !vrf.getLayer3Vnis().isEmpty() // VRF has some VNI
-                      && vrf.getBgpProcess() == null // process does not already exist
-                      && c.getDefaultVrf().getBgpProcess() != null) { // there is a default BGP proc
+              if ((!vrf.getLayer2Vnis().isEmpty()
+                      || !vrf.getLayer3Vnis().isEmpty()) // VRF has some VNI
+                  && vrf.getBgpProcess() == null // process does not already exist
+                  && c.getDefaultVrf().getBgpProcess() != null) { // there is a default BGP proc
                 vrf.setBgpProcess(
                     org.batfish.datamodel.BgpProcess.builder()
                         .setRouterId(c.getDefaultVrf().getBgpProcess().getRouterId())
                         .setAdminCostsToVendorDefaults(ConfigurationFormat.CUMULUS_CONCATENATED)
+                        .setRedistributionPolicy(initDenyAllBgpRedistributionPolicy(c))
                         .build());
               }
             });

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
@@ -351,10 +351,10 @@ public final class CumulusConversions {
     c.getVrfs()
         .forEach(
             (vrfName, vrf) -> {
-              if (!vrf.getLayer2Vnis().isEmpty()
-                  || !vrf.getLayer3Vnis().isEmpty() // VRF has some VNI
-                      && vrf.getBgpProcess() == null // process does not already exist
-                      && c.getDefaultVrf().getBgpProcess() != null) { // there is a default BGP proc
+              if ((!vrf.getLayer2Vnis().isEmpty()
+                      || !vrf.getLayer3Vnis().isEmpty()) // VRF has some VNI
+                  && vrf.getBgpProcess() == null // process does not already exist
+                  && c.getDefaultVrf().getBgpProcess() != null) { // there is a default BGP proc
                 vrf.setBgpProcess(
                     org.batfish.datamodel.BgpProcess.builder()
                         .setRouterId(c.getDefaultVrf().getBgpProcess().getRouterId())

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/bgp_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/bgp_vnis
@@ -20,4 +20,3 @@ vrf vrf2
 exit-vrf
 router bgp 65000
   address-family l2vpn evpn
-    advertise-all-vni

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/bgp_vnis
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cumulus_concatenated/testconfigs/bgp_vnis
@@ -1,0 +1,23 @@
+bgp_vnis
+# This file describes the network interfaces
+iface vlan1
+  vlan-id 1000
+  vrf vrf1
+iface swp1
+  vxlan-id 123
+  vxlan-local-tunnelip 1.1.1.1
+  bridge-access 1000
+iface swp2
+  vxlan-id 2000
+  vxlan-local-tunnelip 2.2.2.2
+  bridge-access 456
+iface vrf3
+  vrf-table auto
+# ports.conf --
+frr version test
+vrf vrf2
+  vni 2000
+exit-vrf
+router bgp 65000
+  address-family l2vpn evpn
+    advertise-all-vni


### PR DESCRIPTION
Two changes:
1. FRR and NCLU: Fix a bug in the condition for generating a dummy BGP process. Needed more parentheses.
2. FRR only: Include a reject-all redistribution policy in dummy BGP processes (this was already done for NCLU).