### PR TITLE
NCLU: Fix BGP aggregate route conversion

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
@@ -221,7 +221,7 @@ public final class CumulusConversions {
     return Optional.empty();
   }
 
-  /** Creates BGP aggregates aggregate routes for the given {@link BgpProcess}. */
+  /** Creates BGP aggregates for the given {@link BgpProcess}. */
   static void generateBgpAggregates(
       Configuration c,
       org.batfish.datamodel.BgpProcess proc,

--- a/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cumulus_nclu/CumulusConversions.java
@@ -15,6 +15,7 @@ import static org.batfish.datamodel.Names.generatedBgpPeerImportPolicyName;
 import static org.batfish.datamodel.Names.generatedBgpRedistributionPolicyName;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.bgp.VniConfig.importRtPatternForAnyAs;
+import static org.batfish.datamodel.routing_policy.Common.generateSuppressionPolicy;
 import static org.batfish.datamodel.routing_policy.Common.initDenyAllBgpRedistributionPolicy;
 import static org.batfish.representation.cumulus_nclu.BgpProcess.BGP_UNNUMBERED_IP;
 import static org.batfish.representation.cumulus_nclu.CumulusNcluConfiguration.CUMULUS_CLAG_DOMAIN_ID;
@@ -32,7 +33,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -79,6 +79,7 @@ import org.batfish.datamodel.RouteFilterLine;
 import org.batfish.datamodel.RouteFilterList;
 import org.batfish.datamodel.RoutingProtocol;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
+import org.batfish.datamodel.bgp.BgpAggregate;
 import org.batfish.datamodel.bgp.BgpConfederation;
 import org.batfish.datamodel.bgp.EvpnAddressFamily;
 import org.batfish.datamodel.bgp.Ipv4UnicastAddressFamily;
@@ -135,8 +136,6 @@ import org.batfish.datamodel.vxlan.Vni;
 /** Utilities that convert Cumulus-specific representations to vendor-independent model. */
 @ParametersAreNonnullByDefault
 public final class CumulusConversions {
-  private static final int AGGREGATE_ROUTE_ADMIN_COST = 200; // TODO verify this
-
   private static final Prefix LOOPBACK_PREFIX = Prefix.parse("127.0.0.0/8");
 
   public static final int DEFAULT_STATIC_ROUTE_ADMINISTRATIVE_DISTANCE = 1;
@@ -173,10 +172,6 @@ public final class CumulusConversions {
    * value in absence of explicit information.
    */
   public static final double DEFAULT_PORT_BANDWIDTH = 10E9D;
-
-  public static String computeBgpGenerationPolicyName(boolean ipv4, String vrfName, String prefix) {
-    return String.format("~AGGREGATE_ROUTE%s_GEN:%s:%s~", ipv4 ? "" : "6", vrfName, prefix);
-  }
 
   public static String computeMatchSuppressedSummaryOnlyPolicyName(String vrfName) {
     return String.format("~MATCH_SUPPRESSED_SUMMARY_ONLY:%s~", vrfName);
@@ -226,76 +221,25 @@ public final class CumulusConversions {
     return Optional.empty();
   }
 
-  static BooleanExpr generateRedistributeAggregateConditions(
-      Map<Prefix, BgpVrfAddressFamilyAggregateNetworkConfiguration> aggregateNetworks) {
-    return new Disjunction(
-        aggregateNetworks.entrySet().stream()
-            .map(
-                entry -> {
-                  Prefix prefix = entry.getKey();
-
-                  // Conditions to generate this route
-                  List<BooleanExpr> exportAggregateConjuncts = new ArrayList<>();
-                  exportAggregateConjuncts.add(
-                      new MatchPrefixSet(
-                          DestinationNetwork.instance(),
-                          new ExplicitPrefixSet(new PrefixSpace(PrefixRange.fromPrefix(prefix)))));
-                  exportAggregateConjuncts.add(new MatchProtocol(RoutingProtocol.AGGREGATE));
-
-                  // TODO consider attribute map
-
-                  // Do export a generated aggregate.
-                  return new Conjunction(exportAggregateConjuncts);
-                })
-            .collect(ImmutableList.toImmutableList()));
-  }
-
-  /**
-   * Creates generated routes and route generation policies for aggregate routes for the input vrf.
-   */
-  static void generateGeneratedRoutes(
+  /** Creates BGP aggregates aggregate routes for the given {@link BgpProcess}. */
+  static void generateBgpAggregates(
       Configuration c,
-      org.batfish.datamodel.Vrf vrf,
+      org.batfish.datamodel.BgpProcess proc,
       Map<Prefix, BgpVrfAddressFamilyAggregateNetworkConfiguration> aggregateNetworks) {
-    aggregateNetworks.forEach(
-        (prefix, agg) -> {
-          generateGenerationPolicy(c, vrf.getName(), prefix);
-
-          // TODO generate attribute policy
-          GeneratedRoute gr =
-              GeneratedRoute.builder()
-                  .setNetwork(prefix)
-                  .setAdmin(AGGREGATE_ROUTE_ADMIN_COST)
-                  .setGenerationPolicy(
-                      computeBgpGenerationPolicyName(true, vrf.getName(), prefix.toString()))
-                  .setDiscard(true)
-                  .build();
-
-          vrf.getGeneratedRoutes().add(gr);
-        });
+    aggregateNetworks.entrySet().stream()
+        .map(
+            aggregateByPrefixEntry ->
+                toBgpAggregate(
+                    aggregateByPrefixEntry.getKey(), aggregateByPrefixEntry.getValue(), c))
+        .forEach(proc::addAggregate);
   }
 
-  /**
-   * Creates a generation policy for the aggregate network with the given {@link Prefix}. The
-   * generation policy matches any route with a destination more specific than {@code prefix}.
-   *
-   * @param c {@link Configuration} in which to create the generation policy
-   * @param vrfName Name of VRF in which the aggregate network exists
-   * @param prefix The aggregate network prefix
-   */
-  static void generateGenerationPolicy(Configuration c, String vrfName, Prefix prefix) {
-    RoutingPolicy.builder()
-        .setOwner(c)
-        .setName(computeBgpGenerationPolicyName(true, vrfName, prefix.toString()))
-        .addStatement(
-            new If(
-                // Match routes with destination networks more specific than prefix.
-                new MatchPrefixSet(
-                    DestinationNetwork.instance(),
-                    new ExplicitPrefixSet(new PrefixSpace(PrefixRange.moreSpecificThan(prefix)))),
-                ImmutableList.of(Statements.ReturnTrue.toStaticStatement()),
-                ImmutableList.of(Statements.ReturnFalse.toStaticStatement())))
-        .build();
+  private static @Nonnull BgpAggregate toBgpAggregate(
+      Prefix prefix,
+      BgpVrfAddressFamilyAggregateNetworkConfiguration vsAggregate,
+      Configuration c) {
+    return BgpAggregate.of(
+        prefix, generateSuppressionPolicy(vsAggregate.isSummaryOnly(), c), null, null);
   }
 
   /**
@@ -426,7 +370,7 @@ public final class CumulusConversions {
           .forEach(newProc::addToOriginationSpace);
 
       // Generate aggregate routes
-      generateGeneratedRoutes(c, c.getVrfs().get(vrfName), ipv4Unicast.getAggregateNetworks());
+      generateBgpAggregates(c, newProc, ipv4Unicast.getAggregateNetworks());
     }
 
     generateBgpCommonExportPolicy(c, vrfName, bgpVrf);
@@ -888,7 +832,6 @@ public final class CumulusConversions {
    * <ul>
    *   <li>routes whose network matches a configured network statement
    *   <li>routes that match a configured redistribution statement
-   *   <li>active BGP aggregate routes (TODO: remove this part once aggregates are in BGP process)
    * </ul>
    *
    * <p>All other routes are denied.
@@ -904,20 +847,8 @@ public final class CumulusConversions {
     // TODO Does NCLU clear next hop info when redistributing a route into BGP? If so, do:
     //     bgpRedistributionPolicy.addStatement(new SetNextHop(DiscardNextHop.INSTANCE));
 
-    // Add redistribution conditions for non-aggregate routes
+    // Add redistribution conditions
     addRedistributionAndNetworkStatements(bgpVrf, routeMaps, bgpRedistributionPolicy);
-
-    // Nothing will be redistributed unless the v4 address family is active
-    if (bgpVrf.getIpv4Unicast() != null) {
-      // Add redistribution conditions for aggregate routes
-      bgpRedistributionPolicy.addStatement(
-          new If(
-              generateRedistributeAggregateConditions(
-                  bgpVrf.getIpv4Unicast().getAggregateNetworks()),
-              ImmutableList.of(
-                  new SetOrigin(new LiteralOrigin(OriginType.IGP, null)),
-                  Statements.ExitAccept.toStaticStatement())));
-    }
 
     // Reject all other routes
     bgpRedistributionPolicy.addStatement(Statements.ExitReject.toStaticStatement()).build();

--- a/projects/batfish/src/test/java/org/batfish/representation/cumulus_nclu/CumulusConversionsTest.java
+++ b/projects/batfish/src/test/java/org/batfish/representation/cumulus_nclu/CumulusConversionsTest.java
@@ -13,13 +13,13 @@ import static org.batfish.datamodel.RoutingProtocol.BGP;
 import static org.batfish.datamodel.RoutingProtocol.IBGP;
 import static org.batfish.datamodel.bgp.AllowRemoteAsOutMode.ALWAYS;
 import static org.batfish.datamodel.matchers.BgpRouteMatchers.hasCommunities;
+import static org.batfish.datamodel.routing_policy.Common.SUMMARY_ONLY_SUPPRESSION_POLICY_NAME;
 import static org.batfish.datamodel.routing_policy.statement.Statements.ExitAccept;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.DEFAULT_MAX_MED;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.GENERATED_DEFAULT_ROUTE;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.REJECT_DEFAULT_ROUTE;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.addBgpNeighbor;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.addOspfInterfaces;
-import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeBgpGenerationPolicyName;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeBgpNeighborImportRoutingPolicy;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeLocalIpForBgpNeighbor;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.computeMatchSuppressedSummaryOnlyPolicyName;
@@ -29,9 +29,6 @@ import static org.batfish.representation.cumulus_nclu.CumulusConversions.convert
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.convertOspfRedistributionPolicy;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.convertVxlans;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.generateBgpCommonPeerConfig;
-import static org.batfish.representation.cumulus_nclu.CumulusConversions.generateGeneratedRoutes;
-import static org.batfish.representation.cumulus_nclu.CumulusConversions.generateGenerationPolicy;
-import static org.batfish.representation.cumulus_nclu.CumulusConversions.generateRedistributeAggregateConditions;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.getSetMaxMedMetric;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.getSetNextHop;
 import static org.batfish.representation.cumulus_nclu.CumulusConversions.inferClusterId;
@@ -49,7 +46,6 @@ import static org.batfish.representation.cumulus_nclu.CumulusNcluConfiguration.L
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -83,7 +79,6 @@ import org.batfish.datamodel.ConcreteInterfaceAddress;
 import org.batfish.datamodel.Configuration;
 import org.batfish.datamodel.ConfigurationFormat;
 import org.batfish.datamodel.ConnectedRoute;
-import org.batfish.datamodel.GeneratedRoute;
 import org.batfish.datamodel.InterfaceAddress;
 import org.batfish.datamodel.Ip;
 import org.batfish.datamodel.LineAction;
@@ -98,6 +93,7 @@ import org.batfish.datamodel.StaticRoute;
 import org.batfish.datamodel.SubRange;
 import org.batfish.datamodel.Vrf;
 import org.batfish.datamodel.bgp.AddressFamilyCapabilities;
+import org.batfish.datamodel.bgp.BgpAggregate;
 import org.batfish.datamodel.bgp.Layer2VniConfig;
 import org.batfish.datamodel.bgp.RouteDistinguisher;
 import org.batfish.datamodel.bgp.community.StandardCommunity;
@@ -131,7 +127,6 @@ import org.batfish.datamodel.routing_policy.statement.Statement;
 import org.batfish.datamodel.routing_policy.statement.Statements;
 import org.batfish.datamodel.vxlan.Layer2Vni;
 import org.batfish.representation.cumulus_nclu.BgpNeighbor.RemoteAs;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -197,81 +192,6 @@ public final class CumulusConversionsTest {
                     StaticRoute.testBuilder().setAdministrativeCost(0).setNetwork(network).build())
                 .build())
         .getBooleanValue();
-  }
-
-  @Test
-  public void testGenerateRedistributeAggregateConditions() {
-    BooleanExpr booleanExpr =
-        generateRedistributeAggregateConditions(
-            ImmutableMap.of(
-                Prefix.parse("1.2.3.0/24"),
-                new BgpVrfAddressFamilyAggregateNetworkConfiguration()));
-
-    // longer not exported
-    {
-      Environment env =
-          Environment.builder(_c)
-              .setOriginalRoute(
-                  GeneratedRoute.builder().setNetwork(Prefix.parse("1.2.3.4/32")).build())
-              .build();
-      assertFalse(value(booleanExpr, env));
-    }
-
-    // shorter not exported
-    {
-      Environment env =
-          Environment.builder(_c)
-              .setOriginalRoute(
-                  GeneratedRoute.builder().setNetwork(Prefix.parse("1.2.0.0/16")).build())
-              .build();
-      assertFalse(value(booleanExpr, env));
-    }
-
-    // exact match exported
-    {
-      Environment env =
-          Environment.builder(_c)
-              .setOriginalRoute(
-                  GeneratedRoute.builder().setNetwork(Prefix.parse("1.2.3.0/24")).build())
-              .build();
-      assertTrue(value(booleanExpr, env));
-    }
-  }
-
-  @Test
-  public void testGenerateGeneratedRoutes() {
-    Prefix prefix = Prefix.parse("1.2.3.0/24");
-    generateGeneratedRoutes(
-        _c, _v, ImmutableMap.of(prefix, new BgpVrfAddressFamilyAggregateNetworkConfiguration()));
-    String policyName = computeBgpGenerationPolicyName(true, _v.getName(), prefix.toString());
-
-    // configuration has the generation policy
-    assertThat(_c.getRoutingPolicies(), Matchers.hasKey(policyName));
-
-    // vrf has generated route
-    ImmutableList<GeneratedRoute> grs =
-        _v.getGeneratedRoutes().stream()
-            .filter(gr -> gr.getNetwork().equals(prefix))
-            .collect(ImmutableList.toImmutableList());
-    assertThat(grs, hasSize(1));
-
-    GeneratedRoute gr = grs.get(0);
-    assertTrue(gr.getDiscard());
-    assertThat(gr.getGenerationPolicy(), equalTo(policyName));
-  }
-
-  @Test
-  public void testGenerateGenerationPolicy() {
-    Prefix prefix = Prefix.parse("1.2.3.0/24");
-    generateGenerationPolicy(_c, _v.getName(), prefix);
-
-    RoutingPolicy policy =
-        _c.getRoutingPolicies()
-            .get(computeBgpGenerationPolicyName(true, _v.getName(), prefix.toString()));
-
-    assertTrue(value(policy, "1.2.3.4/32"));
-    assertFalse(value(policy, "1.2.3.0/24"));
-    assertFalse(value(policy, "1.2.0.0/16"));
   }
 
   @Test
@@ -491,26 +411,21 @@ public final class CumulusConversionsTest {
     vrf.setIpv4Unicast(ipv4Unicast);
 
     // the method under test
-    toBgpProcess(viConfig, vsConfig, DEFAULT_VRF_NAME, vrf);
+    viVrf.setBgpProcess(toBgpProcess(viConfig, vsConfig, DEFAULT_VRF_NAME, vrf));
 
-    // generation policy exists
-    assertThat(
-        viConfig.getRoutingPolicies(),
-        hasKey(computeBgpGenerationPolicyName(true, DEFAULT_VRF_NAME, prefix.toString())));
+    // aggregate route exists with expected suppression policy (if any)
+    String suppressionPolicyName = summaryOnly ? SUMMARY_ONLY_SUPPRESSION_POLICY_NAME : null;
+    BgpAggregate viAgg = viVrf.getBgpProcess().getAggregates().get(prefix);
+    assertThat(viAgg, equalTo(BgpAggregate.of(prefix, suppressionPolicyName, null, null)));
 
-    // generated route exists
-    assertTrue(viVrf.getGeneratedRoutes().stream().anyMatch(gr -> gr.getNetwork().equals(prefix)));
-
+    String summaryOnlyRouteFilterName =
+        computeMatchSuppressedSummaryOnlyPolicyName(viVrf.getName());
     if (summaryOnly) {
       // suppress summary only filter list exists
-      assertThat(
-          viConfig.getRouteFilterLists(),
-          hasKey(computeMatchSuppressedSummaryOnlyPolicyName(viVrf.getName())));
+      assertThat(viConfig.getRouteFilterLists(), hasKey(summaryOnlyRouteFilterName));
     } else {
       // suppress summary only filter list does not exist
-      assertThat(
-          viConfig.getRouteFilterLists(),
-          not(hasKey(computeMatchSuppressedSummaryOnlyPolicyName(viVrf.getName()))));
+      assertThat(viConfig.getRouteFilterLists(), not(hasKey(summaryOnlyRouteFilterName)));
     }
   }
 

--- a/tests/parsing-tests/unit-tests-vimodel.ref
+++ b/tests/parsing-tests/unit-tests-vimodel.ref
@@ -43657,25 +43657,6 @@
                 ]
               },
               {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction"
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
-                    "originType" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
-                      "originType" : "igp"
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitAccept"
-                  }
-                ]
-              },
-              {
                 "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
                 "type" : "ExitReject"
               }
@@ -43715,25 +43696,6 @@
               {
                 "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "comment" : "Add network statement routes to BGP",
-                "guard" : {
-                  "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction"
-                },
-                "trueStatements" : [
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.SetOrigin",
-                    "originType" : {
-                      "class" : "org.batfish.datamodel.routing_policy.expr.LiteralOrigin",
-                      "originType" : "igp"
-                    }
-                  },
-                  {
-                    "class" : "org.batfish.datamodel.routing_policy.statement.Statements$StaticStatement",
-                    "type" : "ExitAccept"
-                  }
-                ]
-              },
-              {
-                "class" : "org.batfish.datamodel.routing_policy.statement.If",
                 "guard" : {
                   "class" : "org.batfish.datamodel.routing_policy.expr.Disjunction"
                 },


### PR DESCRIPTION
BGP aggregates are now activated based on routes in the BGP RIB instead of the main RIB. (However, there's still no parsing or extraction of any aggregate-related grammar in NCLU.)