### PR TITLE
AbstractRoute: unbox metric

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/AbstractRoute.java
@@ -74,7 +74,7 @@ public abstract class AbstractRoute implements AbstractRouteDecorator, Serializa
   }
 
   @JsonIgnore
-  public abstract Long getMetric();
+  public abstract long getMetric();
 
   /** IPV4 network of this route */
   @JsonProperty(PROP_NETWORK)

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/BgpRoute.java
@@ -391,7 +391,7 @@ public abstract class BgpRoute<B extends Builder<B, R>, R extends BgpRoute<B, R>
   @JsonIgnore(false)
   @JsonProperty(PROP_METRIC)
   @Override
-  public Long getMetric() {
+  public long getMetric() {
     return _med;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/ConnectedRoute.java
@@ -58,7 +58,7 @@ public final class ConnectedRoute extends AbstractRoute {
   }
 
   @Override
-  public Long getMetric() {
+  public long getMetric() {
     return 0L;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/EigrpRoute.java
@@ -59,7 +59,7 @@ public abstract class EigrpRoute extends AbstractRoute {
   }
 
   @Override
-  public final Long getMetric() {
+  public final long getMetric() {
     return _metric.ribMetric(_metricVersion);
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/GeneratedRoute.java
@@ -337,7 +337,7 @@ public final class GeneratedRoute extends AbstractRoute
   @JsonIgnore(false)
   @JsonProperty(PROP_METRIC)
   @Override
-  public Long getMetric() {
+  public long getMetric() {
     return _metric;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/IsisRoute.java
@@ -213,7 +213,7 @@ public class IsisRoute extends AbstractRoute {
   @JsonIgnore(false)
   @JsonProperty(PROP_METRIC)
   @Override
-  public @Nonnull Long getMetric() {
+  public @Nonnull long getMetric() {
     return _metric;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/KernelRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/KernelRoute.java
@@ -80,7 +80,7 @@ public final class KernelRoute extends AbstractRoute implements Comparable<Kerne
   }
 
   @Override
-  public Long getMetric() {
+  public long getMetric() {
     return 0L;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/LocalRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/LocalRoute.java
@@ -59,7 +59,7 @@ public final class LocalRoute extends AbstractRoute {
   }
 
   @Override
-  public Long getMetric() {
+  public long getMetric() {
     return 0L;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/OspfRoute.java
@@ -53,7 +53,7 @@ public abstract class OspfRoute extends AbstractRoute {
   @Nonnull
   @JsonIgnore(false)
   @JsonProperty(PROP_METRIC)
-  public final Long getMetric() {
+  public final long getMetric() {
     return _metric;
   }
 

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RipRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/RipRoute.java
@@ -29,7 +29,7 @@ public abstract class RipRoute extends AbstractRoute {
   @JsonIgnore(false)
   @JsonProperty(PROP_METRIC)
   @Override
-  public final Long getMetric() {
+  public final long getMetric() {
     return _metric;
   }
 }

--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/StaticRoute.java
@@ -75,7 +75,7 @@ public class StaticRoute extends AbstractRoute implements Comparable<StaticRoute
   @Override
   @JsonIgnore(false)
   @JsonProperty(PROP_METRIC)
-  public Long getMetric() {
+  public long getMetric() {
     return _metric;
   }
 


### PR DESCRIPTION
getMetric used to return a Long, but implementations never return null, and clients don't null-check. Now it returns a long.