### PR TITLE
Traceroute: include admin and metric in RouteInfo 

### DIFF
--- a/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/RouteInfo.java
+++ b/projects/batfish-common-protocol/src/main/java/org/batfish/datamodel/flow/RouteInfo.java
@@ -21,6 +21,8 @@ public final class RouteInfo {
   private static final String PROP_NETWORK = "network";
   private static final String PROP_NEXT_HOP_IP = "nextHopIp";
   private static final String PROP_NEXT_VRF = "nextVrf";
+  private static final String PROP_ADMIN_DISTANCE = "admin";
+  private static final String PROP_METRIC = "metric";
 
   /** Protocol of the route like bgp, ospf etc. */
   private @Nonnull final RoutingProtocol _protocol;
@@ -34,12 +36,25 @@ public final class RouteInfo {
   /** Next VRF for this route */
   private @Nullable final String _nextVrf;
 
+  /** Administrative distance for this route */
+  private final int _adminDistance;
+
+  /** Metric for this route */
+  private final long _metric;
+
   public RouteInfo(
-      RoutingProtocol protocol, Prefix network, @Nullable Ip nextHopIp, @Nullable String nextVrf) {
+      RoutingProtocol protocol,
+      Prefix network,
+      @Nullable Ip nextHopIp,
+      @Nullable String nextVrf,
+      int adminDistance,
+      long metric) {
     _protocol = protocol;
     _network = network;
     _nextHopIp = nextHopIp;
     _nextVrf = nextVrf;
+    _adminDistance = adminDistance;
+    _metric = metric;
   }
 
   @JsonCreator
@@ -47,10 +62,14 @@ public final class RouteInfo {
       @JsonProperty(PROP_PROTOCOL) @Nullable RoutingProtocol protocol,
       @JsonProperty(PROP_NETWORK) @Nullable Prefix network,
       @JsonProperty(PROP_NEXT_HOP_IP) @Nullable Ip nextHopIp,
-      @JsonProperty(PROP_NEXT_VRF) @Nullable String nextVrf) {
+      @JsonProperty(PROP_NEXT_VRF) @Nullable String nextVrf,
+      @JsonProperty(PROP_ADMIN_DISTANCE) @Nullable Integer adminDistance,
+      @JsonProperty(PROP_METRIC) @Nullable Long metric) {
     checkArgument(protocol != null, "Missing %s", PROP_PROTOCOL);
     checkArgument(network != null, "Missing %s", PROP_NETWORK);
-    return new RouteInfo(protocol, network, nextHopIp, nextVrf);
+    checkArgument(adminDistance != null, "Missing %s", PROP_ADMIN_DISTANCE);
+    checkArgument(metric != null, "Missing %s", PROP_METRIC);
+    return new RouteInfo(protocol, network, nextHopIp, nextVrf, adminDistance, metric);
   }
 
   @Override
@@ -64,12 +83,14 @@ public final class RouteInfo {
     return _protocol.equals(other._protocol)
         && _network.equals(other._network)
         && Objects.equals(_nextHopIp, other._nextHopIp)
-        && Objects.equals(_nextVrf, other._nextVrf);
+        && Objects.equals(_nextVrf, other._nextVrf)
+        && _adminDistance == other._adminDistance
+        && _metric == other._metric;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_protocol, _network, _nextHopIp, _nextVrf);
+    return Objects.hash(_protocol, _network, _nextHopIp, _nextVrf, _adminDistance, _metric);
   }
 
   @JsonProperty(PROP_PROTOCOL)
@@ -94,5 +115,15 @@ public final class RouteInfo {
   @Nullable
   public String getNextVrf() {
     return _nextVrf;
+  }
+
+  @JsonProperty(PROP_ADMIN_DISTANCE)
+  public int getAdminDistance() {
+    return _adminDistance;
+  }
+
+  @JsonProperty(PROP_METRIC)
+  public long getMetric() {
+    return _metric;
   }
 }

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/RouteInfoTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/RouteInfoTest.java
@@ -1,0 +1,49 @@
+package org.batfish.datamodel.flow;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.testing.EqualsTester;
+import org.batfish.common.util.BatfishObjectMapper;
+import org.batfish.datamodel.Ip;
+import org.batfish.datamodel.Prefix;
+import org.batfish.datamodel.RoutingProtocol;
+import org.junit.Test;
+
+/** Tests of {@link RouteInfo}. */
+public class RouteInfoTest {
+  @Test
+  public void testJsonSerialization() {
+    RouteInfo orig =
+        new RouteInfo(RoutingProtocol.BGP, Prefix.parse("1.1.1.1/30"), null, null, 0, 1);
+    RouteInfo clone = BatfishObjectMapper.clone(orig, RouteInfo.class);
+    assertEquals(orig, clone);
+  }
+
+  @Test
+  public void testEquals() {
+    RoutingProtocol proto1 = RoutingProtocol.BGP;
+    RoutingProtocol proto2 = RoutingProtocol.STATIC;
+    Prefix p1 = Prefix.parse("1.1.1.1/32");
+    Prefix p2 = Prefix.parse("2.2.2.2/32");
+    Ip nhip1 = null;
+    Ip nhip2 = Ip.parse("3.3.3.3");
+    String nextVrf1 = null;
+    String nextVrf2 = "nextVrf";
+    int ad1 = 0;
+    int ad2 = 1;
+    int met1 = 0;
+    int met2 = 1;
+
+    new EqualsTester()
+        .addEqualityGroup(
+            new RouteInfo(proto1, p1, nhip1, nextVrf1, ad1, met1),
+            new RouteInfo(proto1, p1, nhip1, nextVrf1, ad1, met1))
+        .addEqualityGroup(new RouteInfo(proto2, p1, nhip1, nextVrf1, ad1, met1))
+        .addEqualityGroup(new RouteInfo(proto1, p2, nhip1, nextVrf1, ad1, met1))
+        .addEqualityGroup(new RouteInfo(proto1, p1, nhip2, nextVrf1, ad1, met1))
+        .addEqualityGroup(new RouteInfo(proto1, p1, nhip1, nextVrf2, ad1, met1))
+        .addEqualityGroup(new RouteInfo(proto1, p1, nhip1, nextVrf1, ad2, met1))
+        .addEqualityGroup(new RouteInfo(proto1, p1, nhip1, nextVrf1, ad1, met2))
+        .testEquals();
+  }
+}

--- a/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/RoutingStepTest.java
+++ b/projects/batfish-common-protocol/src/test/java/org/batfish/datamodel/flow/RoutingStepTest.java
@@ -21,8 +21,10 @@ public class RoutingStepTest {
         RoutingStepDetail.builder()
             .setRoutes(
                 ImmutableList.of(
-                    new RouteInfo(RoutingProtocol.BGP, Prefix.parse("1.1.1.1/30"), null, null),
-                    new RouteInfo(RoutingProtocol.STATIC, Prefix.parse("2.1.1.3/30"), null, null)))
+                    new RouteInfo(
+                        RoutingProtocol.BGP, Prefix.parse("1.1.1.1/30"), null, null, 0, 1),
+                    new RouteInfo(
+                        RoutingProtocol.STATIC, Prefix.parse("2.1.1.3/30"), null, null, 1, 0)))
             .setOutputInterface("iface")
             .setArpIp(Ip.parse("2.3.4.5"))
             .build();
@@ -40,8 +42,9 @@ public class RoutingStepTest {
         routingStepCloned.getDetail().getRoutes(),
         equalTo(
             ImmutableList.of(
-                new RouteInfo(RoutingProtocol.BGP, Prefix.parse("1.1.1.1/30"), null, null),
-                new RouteInfo(RoutingProtocol.STATIC, Prefix.parse("2.1.1.3/30"), null, null))));
+                new RouteInfo(RoutingProtocol.BGP, Prefix.parse("1.1.1.1/30"), null, null, 0, 1),
+                new RouteInfo(
+                    RoutingProtocol.STATIC, Prefix.parse("2.1.1.3/30"), null, null, 1, 0))));
     assertThat(routingStepCloned.getDetail().getArpIp(), equalTo(Ip.parse("2.3.4.5")));
     assertThat(routingStepCloned.getDetail().getOutputInterface(), equalTo("iface"));
     assertThat(routingStep.getAction(), equalTo(StepAction.FORWARDED_TO_NEXT_VRF));
@@ -59,12 +62,19 @@ public class RoutingStepTest {
                         .setRoutes(
                             ImmutableList.of(
                                 new RouteInfo(
-                                    RoutingProtocol.BGP, Prefix.parse("1.1.1.1/30"), null, null),
+                                    RoutingProtocol.BGP,
+                                    Prefix.parse("1.1.1.1/30"),
+                                    null,
+                                    null,
+                                    0,
+                                    1),
                                 new RouteInfo(
                                     RoutingProtocol.STATIC,
                                     Prefix.parse("2.1.1.3/30"),
                                     null,
-                                    null)))
+                                    null,
+                                    1,
+                                    0)))
                         .setOutputInterface("iface")
                         .setArpIp(Ip.parse("2.3.4.5"))
                         .build())
@@ -76,12 +86,19 @@ public class RoutingStepTest {
                         .setRoutes(
                             ImmutableList.of(
                                 new RouteInfo(
-                                    RoutingProtocol.BGP, Prefix.parse("1.1.1.1/30"), null, null),
+                                    RoutingProtocol.BGP,
+                                    Prefix.parse("1.1.1.1/30"),
+                                    null,
+                                    null,
+                                    0,
+                                    1),
                                 new RouteInfo(
                                     RoutingProtocol.STATIC,
                                     Prefix.parse("2.1.1.3/30"),
                                     null,
-                                    null)))
+                                    null,
+                                    1,
+                                    0)))
                         .setOutputInterface("iface")
                         .setArpIp(Ip.parse("2.3.4.5"))
                         .build())
@@ -94,12 +111,19 @@ public class RoutingStepTest {
                         .setRoutes(
                             ImmutableList.of(
                                 new RouteInfo(
-                                    RoutingProtocol.BGP, Prefix.parse("1.1.1.1/30"), null, null),
+                                    RoutingProtocol.BGP,
+                                    Prefix.parse("1.1.1.1/30"),
+                                    null,
+                                    null,
+                                    0,
+                                    1),
                                 new RouteInfo(
                                     RoutingProtocol.STATIC,
                                     Prefix.parse("2.1.1.3/30"),
                                     null,
-                                    null)))
+                                    null,
+                                    1,
+                                    0)))
                         .setOutputInterface("iface")
                         .setArpIp(Ip.parse("2.3.4.5"))
                         .build())
@@ -115,7 +139,9 @@ public class RoutingStepTest {
                                     RoutingProtocol.STATIC,
                                     Prefix.parse("2.1.1.3/30"),
                                     null,
-                                    null)))
+                                    null,
+                                    0,
+                                    1)))
                         .setOutputInterface("iface")
                         .setArpIp(Ip.parse("2.3.4.5"))
                         .build())
@@ -131,7 +157,9 @@ public class RoutingStepTest {
                                     RoutingProtocol.STATIC,
                                     Prefix.parse("2.1.1.3/30"),
                                     null,
-                                    null)))
+                                    null,
+                                    0,
+                                    1)))
                         .setOutputInterface("iface1")
                         .setArpIp(Ip.parse("2.3.4.5"))
                         .build())
@@ -147,7 +175,9 @@ public class RoutingStepTest {
                                     RoutingProtocol.STATIC,
                                     Prefix.parse("2.1.1.3/30"),
                                     null,
-                                    null)))
+                                    null,
+                                    0,
+                                    1)))
                         .setOutputInterface("iface1")
                         .setArpIp(Ip.parse("2.3.4.6"))
                         .build())

--- a/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
+++ b/projects/batfish/src/main/java/org/batfish/dataplane/traceroute/TracerouteUtils.java
@@ -95,7 +95,9 @@ public final class TracerouteUtils {
                     route.getProtocol(),
                     route.getNetwork(),
                     route.getNextHopIp(),
-                    AbstractRoute.NEXT_VRF_EXTRACTOR.visit(route.getNextHop())))
+                    AbstractRoute.NEXT_VRF_EXTRACTOR.visit(route.getNextHop()),
+                    route.getAdministrativeCost(),
+                    route.getMetric()))
         .sorted(
             comparing(RouteInfo::getNetwork)
                 .thenComparing(RouteInfo::getNextHopIp)

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -1377,9 +1377,9 @@ public final class FlowTracerTest {
                 .setRoutes(
                     ImmutableList.of(
                         new RouteInfo(
-                            RoutingProtocol.STATIC, Prefix.ZERO, Ip.parse("1.2.3.4"), null),
+                            RoutingProtocol.STATIC, Prefix.ZERO, Ip.parse("1.2.3.4"), null, 0, 0),
                         new RouteInfo(
-                            RoutingProtocol.STATIC, Prefix.ZERO, Ip.parse("2.3.4.5"), null)))
+                            RoutingProtocol.STATIC, Prefix.ZERO, Ip.parse("2.3.4.5"), null, 0, 0)))
                 .build()));
   }
 
@@ -1608,7 +1608,7 @@ public final class FlowTracerTest {
         routingStep.getDetail().getRoutes(),
         equalTo(
             ImmutableList.of(
-                new RouteInfo(RoutingProtocol.STATIC, prefix, Ip.parse("2.2.2.2"), null))));
+                new RouteInfo(RoutingProtocol.STATIC, prefix, Ip.parse("2.2.2.2"), null, 0, 0))));
     assertThat(routingStep.getDetail().getArpIp(), equalTo(Ip.parse("1.1.1.1")));
     assertThat(routingStep.getDetail().getOutputInterface(), equalTo("iface1"));
   }
@@ -1635,7 +1635,7 @@ public final class FlowTracerTest {
         routingStep.getDetail().getRoutes(),
         equalTo(
             ImmutableList.of(
-                new RouteInfo(RoutingProtocol.STATIC, prefix, Ip.parse("2.2.2.2"), null))));
+                new RouteInfo(RoutingProtocol.STATIC, prefix, Ip.parse("2.2.2.2"), null, 0, 0))));
     assertThat(routingStep.getDetail().getArpIp(), nullValue());
     assertThat(routingStep.getDetail().getOutputInterface(), nullValue());
   }
@@ -1662,7 +1662,7 @@ public final class FlowTracerTest {
         routingStep.getDetail().getRoutes(),
         equalTo(
             ImmutableList.of(
-                new RouteInfo(RoutingProtocol.STATIC, prefix, Ip.parse("2.2.2.2"), null))));
+                new RouteInfo(RoutingProtocol.STATIC, prefix, Ip.parse("2.2.2.2"), null, 0, 0))));
     assertThat(routingStep.getDetail().getArpIp(), nullValue());
     assertThat(routingStep.getDetail().getOutputInterface(), nullValue());
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -1608,7 +1608,7 @@ public final class FlowTracerTest {
         routingStep.getDetail().getRoutes(),
         equalTo(
             ImmutableList.of(
-                new RouteInfo(RoutingProtocol.STATIC, prefix, Ip.parse("2.2.2.2"), null, 0, 0))));
+                new RouteInfo(RoutingProtocol.STATIC, prefix, Ip.parse("2.2.2.2"), null, 1, 0))));
     assertThat(routingStep.getDetail().getArpIp(), equalTo(Ip.parse("1.1.1.1")));
     assertThat(routingStep.getDetail().getOutputInterface(), equalTo("iface1"));
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/FlowTracerTest.java
@@ -1377,9 +1377,9 @@ public final class FlowTracerTest {
                 .setRoutes(
                     ImmutableList.of(
                         new RouteInfo(
-                            RoutingProtocol.STATIC, Prefix.ZERO, Ip.parse("1.2.3.4"), null, 0, 0),
+                            RoutingProtocol.STATIC, Prefix.ZERO, Ip.parse("1.2.3.4"), null, 1, 0),
                         new RouteInfo(
-                            RoutingProtocol.STATIC, Prefix.ZERO, Ip.parse("2.3.4.5"), null, 0, 0)))
+                            RoutingProtocol.STATIC, Prefix.ZERO, Ip.parse("2.3.4.5"), null, 1, 0)))
                 .build()));
   }
 
@@ -1635,7 +1635,7 @@ public final class FlowTracerTest {
         routingStep.getDetail().getRoutes(),
         equalTo(
             ImmutableList.of(
-                new RouteInfo(RoutingProtocol.STATIC, prefix, Ip.parse("2.2.2.2"), null, 0, 0))));
+                new RouteInfo(RoutingProtocol.STATIC, prefix, Ip.parse("2.2.2.2"), null, 1, 0))));
     assertThat(routingStep.getDetail().getArpIp(), nullValue());
     assertThat(routingStep.getDetail().getOutputInterface(), nullValue());
   }
@@ -1662,7 +1662,7 @@ public final class FlowTracerTest {
         routingStep.getDetail().getRoutes(),
         equalTo(
             ImmutableList.of(
-                new RouteInfo(RoutingProtocol.STATIC, prefix, Ip.parse("2.2.2.2"), null, 0, 0))));
+                new RouteInfo(RoutingProtocol.STATIC, prefix, Ip.parse("2.2.2.2"), null, 1, 0))));
     assertThat(routingStep.getDetail().getArpIp(), nullValue());
     assertThat(routingStep.getDetail().getOutputInterface(), nullValue());
   }

--- a/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
+++ b/projects/batfish/src/test/java/org/batfish/dataplane/traceroute/TracerouteEngineImplTest.java
@@ -647,7 +647,8 @@ public class TracerouteEngineImplTest {
     assertThat(step1.getDetail().getRoutes(), hasSize(1));
     assertThat(
         step1.getDetail().getRoutes(),
-        contains(new RouteInfo(RoutingProtocol.STATIC, Prefix.parse("0.0.0.0/0"), Ip.AUTO, null)));
+        contains(
+            new RouteInfo(RoutingProtocol.STATIC, Prefix.parse("0.0.0.0/0"), Ip.AUTO, null, 1, 0)));
 
     FilterStep step2 = (FilterStep) steps.get(2);
     assertThat(step2.getAction(), equalTo(StepAction.PERMITTED));

--- a/tests/basic/traceroute-1-2.ref
+++ b/tests/basic/traceroute-1-2.ref
@@ -81,6 +81,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "ibgp"
@@ -125,6 +127,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "bgp"
@@ -201,11 +205,15 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
                         },
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
@@ -250,6 +258,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
@@ -294,6 +304,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "bgp"
@@ -338,6 +350,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 0,
+                          "metric" : 0,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "AUTO/NONE(-1l)",
                           "protocol" : "connected"
@@ -438,6 +452,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "ibgp"
@@ -482,6 +498,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "bgp"
@@ -558,11 +576,15 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
                         },
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
@@ -607,6 +629,8 @@
                       "outputInterface" : "GigabitEthernet3/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
@@ -651,6 +675,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "bgp"
@@ -695,6 +721,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 0,
+                          "metric" : 0,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "AUTO/NONE(-1l)",
                           "protocol" : "connected"
@@ -795,6 +823,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "ibgp"
@@ -839,6 +869,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "bgp"
@@ -915,11 +947,15 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
                         },
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
@@ -964,6 +1000,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
@@ -1008,6 +1046,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "bgp"
@@ -1052,6 +1092,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 0,
+                          "metric" : 0,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "AUTO/NONE(-1l)",
                           "protocol" : "connected"
@@ -1152,6 +1194,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "ibgp"
@@ -1196,6 +1240,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "bgp"
@@ -1272,11 +1318,15 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
                         },
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
@@ -1321,6 +1371,8 @@
                       "outputInterface" : "GigabitEthernet3/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
@@ -1365,6 +1417,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "bgp"
@@ -1409,6 +1463,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 0,
+                          "metric" : 0,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "AUTO/NONE(-1l)",
                           "protocol" : "connected"
@@ -1537,6 +1593,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "ibgp"
@@ -1581,6 +1639,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "bgp"
@@ -1657,11 +1717,15 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
                         },
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
@@ -1706,6 +1770,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
@@ -1750,6 +1816,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "bgp"
@@ -1794,6 +1862,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 0,
+                          "metric" : 0,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "AUTO/NONE(-1l)",
                           "protocol" : "connected"
@@ -1894,6 +1964,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "ibgp"
@@ -1938,6 +2010,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "bgp"
@@ -2014,11 +2088,15 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
                         },
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
@@ -2063,6 +2141,8 @@
                       "outputInterface" : "GigabitEthernet3/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
@@ -2107,6 +2187,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "bgp"
@@ -2151,6 +2233,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 0,
+                          "metric" : 0,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "AUTO/NONE(-1l)",
                           "protocol" : "connected"
@@ -2251,6 +2335,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "ibgp"
@@ -2295,6 +2381,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "bgp"
@@ -2371,11 +2459,15 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
                         },
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
@@ -2420,6 +2512,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
@@ -2464,6 +2558,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "bgp"
@@ -2508,6 +2604,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 0,
+                          "metric" : 0,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "AUTO/NONE(-1l)",
                           "protocol" : "connected"
@@ -2608,6 +2706,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "ibgp"
@@ -2652,6 +2752,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/16",
                           "nextHopIp" : "10.12.11.2",
                           "protocol" : "bgp"
@@ -2728,11 +2830,15 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
                         },
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.201.4",
                           "protocol" : "ibgp"
@@ -2777,6 +2883,8 @@
                       "outputInterface" : "GigabitEthernet3/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "ibgp"
@@ -2821,6 +2929,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "2.34.101.4",
                           "protocol" : "bgp"
@@ -2865,6 +2975,8 @@
                       "outputInterface" : "GigabitEthernet2/0",
                       "routes" : [
                         {
+                          "admin" : 0,
+                          "metric" : 0,
                           "network" : "2.128.0.0/24",
                           "nextHopIp" : "AUTO/NONE(-1l)",
                           "protocol" : "connected"

--- a/tests/basic/traceroute-2-1.ref
+++ b/tests/basic/traceroute-2-1.ref
@@ -77,6 +77,8 @@
                       "outputInterface" : "eth0",
                       "routes" : [
                         {
+                          "admin" : 1,
+                          "metric" : 0,
                           "network" : "0.0.0.0/0",
                           "nextHopIp" : "2.128.1.1",
                           "protocol" : "static"
@@ -184,6 +186,8 @@
                       "outputInterface" : "GigabitEthernet0/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "2.34.101.3",
                           "protocol" : "bgp"
@@ -228,6 +232,8 @@
                       "outputInterface" : "GigabitEthernet0/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "ibgp"
@@ -304,6 +310,8 @@
                       "outputInterface" : "GigabitEthernet0/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "ibgp"
@@ -348,6 +356,8 @@
                       "outputInterface" : "GigabitEthernet0/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "bgp"
@@ -451,6 +461,8 @@
                       "outputInterface" : "eth0",
                       "routes" : [
                         {
+                          "admin" : 1,
+                          "metric" : 0,
                           "network" : "0.0.0.0/0",
                           "nextHopIp" : "2.128.1.1",
                           "protocol" : "static"
@@ -558,6 +570,8 @@
                       "outputInterface" : "GigabitEthernet0/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "2.34.101.3",
                           "protocol" : "bgp"
@@ -602,6 +616,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "ibgp"
@@ -646,6 +662,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "ibgp"
@@ -690,6 +708,8 @@
                       "outputInterface" : "GigabitEthernet0/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "bgp"
@@ -793,6 +813,8 @@
                       "outputInterface" : "eth0",
                       "routes" : [
                         {
+                          "admin" : 1,
+                          "metric" : 0,
                           "network" : "0.0.0.0/0",
                           "nextHopIp" : "2.128.1.1",
                           "protocol" : "static"
@@ -900,6 +922,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "2.34.201.3",
                           "protocol" : "bgp"
@@ -944,6 +968,8 @@
                       "outputInterface" : "GigabitEthernet0/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "ibgp"
@@ -988,6 +1014,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "ibgp"
@@ -1032,6 +1060,8 @@
                       "outputInterface" : "GigabitEthernet0/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "bgp"
@@ -1135,6 +1165,8 @@
                       "outputInterface" : "eth0",
                       "routes" : [
                         {
+                          "admin" : 1,
+                          "metric" : 0,
                           "network" : "0.0.0.0/0",
                           "nextHopIp" : "2.128.1.1",
                           "protocol" : "static"
@@ -1242,6 +1274,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "2.34.201.3",
                           "protocol" : "bgp"
@@ -1286,6 +1320,8 @@
                       "outputInterface" : "GigabitEthernet1/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "ibgp"
@@ -1362,6 +1398,8 @@
                       "outputInterface" : "GigabitEthernet0/0",
                       "routes" : [
                         {
+                          "admin" : 200,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "ibgp"
@@ -1406,6 +1444,8 @@
                       "outputInterface" : "GigabitEthernet0/0",
                       "routes" : [
                         {
+                          "admin" : 20,
+                          "metric" : 50,
                           "network" : "1.0.1.0/24",
                           "nextHopIp" : "10.12.11.1",
                           "protocol" : "bgp"


### PR DESCRIPTION
Include the administrative distance and metric route fields in the RouteInfo objects embedded in traceroute traces.